### PR TITLE
Session Refactor

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,8 +6,7 @@ import { GqlContextType } from './common';
 import { DateScalar, DateTimeScalar } from './common/luxon.graphql';
 import { AdminResolver } from './components/admin/admin.resolver';
 import { AdminService } from './components/admin/admin.service';
-import { AuthResolver } from './components/auth/auth.resolver';
-import { AuthService } from './components/auth/auth.service';
+import { AuthModule } from './components/auth';
 import { BudgetResolver } from './components/budget/budget.resolver';
 import { BudgetService } from './components/budget/budget.service';
 import { InternshipResolver } from './components/internship/internship.resolver';
@@ -28,11 +27,11 @@ import { ProjectService } from './components/project/project.service';
 import { UserModule } from './components/user';
 import { CoreModule, LoggerModule } from './core';
 
-const context: ContextFunction<{ req: Request; res: Response }, GqlContextType> = ({
-  req,
-  res,
-}) => ({
-  token: req.header('token'),
+const context: ContextFunction<
+  { req: Request; res: Response },
+  GqlContextType
+> = ({ req, res }) => ({
+  request: req,
 });
 
 @Module({
@@ -43,6 +42,7 @@ const context: ContextFunction<{ req: Request; res: Response }, GqlContextType> 
       autoSchemaFile: 'schema.gql',
       context,
     }),
+    AuthModule,
     LanguageModule,
     LocationModule,
     OrganizationModule,
@@ -52,8 +52,6 @@ const context: ContextFunction<{ req: Request; res: Response }, GqlContextType> 
   providers: [
     AdminResolver,
     AdminService,
-    AuthResolver,
-    AuthService,
     BudgetResolver,
     BudgetService,
     DateTimeScalar,

--- a/src/common/context.type.ts
+++ b/src/common/context.type.ts
@@ -1,6 +1,8 @@
+import { Request } from 'express';
+
 /**
  * The type for graphql @Context() decorator
  */
 export interface GqlContextType {
-  token?: string;
+  request: Request;
 }

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -9,5 +9,3 @@ export * from './readable.interface';
 export * from './resource.dto';
 export * from './secured-list';
 export * from './secured-property';
-export * from './request-user.decorator';
-export * from './request-user.interface';

--- a/src/common/request-user.interface.ts
+++ b/src/common/request-user.interface.ts
@@ -1,6 +1,0 @@
-export class IRequestUser {
-  token: string;
-  iat: number;
-  owningOrgId: string | null;
-  userId: string | null;
-}

--- a/src/components/auth/auth.dto.ts
+++ b/src/components/auth/auth.dto.ts
@@ -1,42 +1,36 @@
+import { stripIndent } from 'common-tags';
 import { InputType, Field, ObjectType } from 'type-graphql';
-
-// CREATE TOKEN
-@InputType()
-export class CreateTokenInputDto {
-  @Field(type => String)
-  header: string;
-}
+import { User } from '../user';
 
 @ObjectType()
-export class CreateTokenOutputDto {
-  @Field(type => String)
+export abstract class CreateSessionOutput {
+  @Field({
+    description: stripIndent`
+      Use this token in future requests in the Authorization header.
+      Authorization: Bearer {token}`,
+  })
   token: string;
 }
 
-// LOGIN USER
 @InputType()
-export class LoginUserInputDto {
+export abstract class LoginInput {
   @Field()
-  username: string;
+  email: string;
+
   @Field()
   password: string;
 }
 
 @ObjectType()
-export class LoginUserOutputDto {
+export class LoginOutput {
   @Field()
   success: boolean;
-}
 
-// LOGOUT USER
-@InputType()
-export class LogoutUserInputDto {
-  @Field()
-  token: string;
-}
+  @Field({
+    nullable: true,
+    description: 'Only returned if login was successful',
+  })
+  user?: User;
 
-@ObjectType()
-export class LogoutUserOutputDto {
-  @Field()
-  success: boolean;
+  // TODO Global Permissions
 }

--- a/src/components/auth/auth.module.ts
+++ b/src/components/auth/auth.module.ts
@@ -1,10 +1,12 @@
-import { Global, Module } from '@nestjs/common';
+import { forwardRef, Global, Module } from '@nestjs/common';
+import { UserModule } from '../user';
 import { AuthResolver } from './auth.resolver';
 import { AuthService } from './auth.service';
 import { SessionPipe } from './session';
 
 @Global()
 @Module({
+  imports: [forwardRef(() => UserModule)],
   providers: [AuthResolver, AuthService, SessionPipe],
   exports: [AuthService, SessionPipe],
 })

--- a/src/components/auth/auth.module.ts
+++ b/src/components/auth/auth.module.ts
@@ -1,0 +1,11 @@
+import { Global, Module } from '@nestjs/common';
+import { AuthResolver } from './auth.resolver';
+import { AuthService } from './auth.service';
+import { SessionPipe } from './session';
+
+@Global()
+@Module({
+  providers: [AuthResolver, AuthService, SessionPipe],
+  exports: [AuthService, SessionPipe],
+})
+export class AuthModule {}

--- a/src/components/auth/auth.resolver.ts
+++ b/src/components/auth/auth.resolver.ts
@@ -1,11 +1,11 @@
 import { Resolver, Mutation, Args } from '@nestjs/graphql';
-import { RequestUser } from '../../common';
 import { AuthService } from './auth.service';
 import {
   CreateTokenOutputDto,
   LoginUserOutputDto,
   LogoutUserOutputDto,
 } from './auth.dto';
+import { ISession, Session } from './session';
 
 @Resolver('Auth')
 export class AuthResolver {
@@ -22,16 +22,16 @@ export class AuthResolver {
     description: 'Login a user',
   })
   async loginUser(
-    @RequestUser() token: string,
+    @Session() session: ISession,
     @Args('password') password: string,
   ): Promise<LoginUserOutputDto> {
-    return await this.authService.login(password, token);
+    return await this.authService.login(password, session.token);
   }
 
   @Mutation(returns => LogoutUserOutputDto, {
     description: 'Logout a user',
   })
-  async logout(@RequestUser() token: string): Promise<LogoutUserOutputDto> {
-    return await this.authService.logout(token);
+  async logout(@Session() token: ISession): Promise<LogoutUserOutputDto> {
+    return await this.authService.logout(token.token);
   }
 }

--- a/src/components/auth/auth.resolver.ts
+++ b/src/components/auth/auth.resolver.ts
@@ -1,37 +1,55 @@
 import { Resolver, Mutation, Args } from '@nestjs/graphql';
+import { UserService } from '../user';
 import { AuthService } from './auth.service';
 import {
-  CreateTokenOutputDto,
-  LoginUserOutputDto,
-  LogoutUserOutputDto,
+  CreateSessionOutput,
+  LoginInput,
+  LoginOutput,
 } from './auth.dto';
 import { ISession, Session } from './session';
 
-@Resolver('Auth')
+@Resolver()
 export class AuthResolver {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly userService: UserService,
+  ) {}
 
-  @Mutation(returns => CreateTokenOutputDto, {
-    description: 'Create a token',
+  @Mutation(() => CreateSessionOutput, {
+    description: 'Create a session',
   })
-  async createToken(): Promise<CreateTokenOutputDto> {
-    return await this.authService.createToken();
+  async createSession(): Promise<CreateSessionOutput> {
+    const token = await this.authService.createToken();
+    return { token };
   }
 
-  @Mutation(returns => LoginUserOutputDto, {
+  @Mutation(() => LoginOutput, {
     description: 'Login a user',
   })
-  async loginUser(
+  async login(
     @Session() session: ISession,
-    @Args('password') password: string,
-  ): Promise<LoginUserOutputDto> {
-    return await this.authService.login(password, session.token);
+    @Args('input') input: LoginInput,
+  ): Promise<LoginOutput> {
+    const userId = await this.authService.login(
+      input.email,
+      input.password,
+      session.token,
+    );
+    if (!userId) {
+      return { success: false };
+    }
+    const user = await this.userService.readOne(userId, session);
+    return {
+      success: true,
+      user,
+    };
   }
 
-  @Mutation(returns => LogoutUserOutputDto, {
+  @Mutation(() => Boolean, {
     description: 'Logout a user',
   })
-  async logout(@Session() token: ISession): Promise<LogoutUserOutputDto> {
-    return await this.authService.logout(token.token);
+  async logout(@Session() session: ISession): Promise<boolean> {
+    await this.authService.logout(session.token);
+    return true;
   }
 }

--- a/src/components/auth/auth.service.ts
+++ b/src/components/auth/auth.service.ts
@@ -1,9 +1,19 @@
-import { Injectable } from '@nestjs/common';
-import { DatabaseService, ConfigService, ILogger, Logger } from '../../core';
-import { CreateTokenOutputDto, LoginUserOutputDto } from './auth.dto';
-import { generate } from 'shortid';
-import { decode, JsonWebTokenError, verify, sign } from 'jsonwebtoken';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import * as argon2 from 'argon2';
+import { verify, sign } from 'jsonwebtoken';
+import { DateTime } from 'luxon';
+import {
+  DatabaseService,
+  ConfigService,
+  ILogger,
+  ISession,
+  Logger,
+} from '../../core';
+import { CreateTokenOutputDto, LoginUserOutputDto } from './auth.dto';
+
+interface JwtPayload {
+  iat: number;
+}
 
 @Injectable()
 export class AuthService {
@@ -17,12 +27,7 @@ export class AuthService {
   async createToken(): Promise<CreateTokenOutputDto> {
     const response = new CreateTokenOutputDto();
 
-    const token = sign(
-      {
-        iat: Date.now(),
-      },
-      this.config.jwtKey,
-    );
+    const token = this.encodeJWT();
 
     const session = this.db.driver.session();
     const result = await session.run(
@@ -98,5 +103,68 @@ export class AuthService {
     response.success = result.records[0].get('token') === token;
     session.close();
     return response;
+  }
+
+  async decodeAndVerifyToken(token?: string): Promise<ISession> {
+    this.logger.debug('Decoding token', { token });
+
+    const { iat } = this.decodeJWT(token);
+
+    // check token in db to verify the user id and owning org id.
+    const result = await this.db
+      .query()
+      .raw(
+        `
+          MATCH
+            (token:Token {
+              active: true,
+              value: $token
+            })
+          OPTIONAL MATCH
+            (token)<-[:token {active: true}]-(user:User {active: true})
+          RETURN
+            token, user.owningOrgId AS owningOrgId, user.id AS userId
+        `,
+        {
+          token,
+        },
+      )
+      .first();
+    if (!result) {
+      this.logger.warning('Failed to find active token in database', { token });
+      throw new UnauthorizedException();
+    }
+
+    const session = {
+      token,
+      issuedAt: DateTime.fromMillis(iat),
+      owningOrgId: result.owningOrgId,
+      userId: result.userId,
+    };
+    this.logger.debug('Created session', session);
+    return session;
+  }
+
+  private encodeJWT() {
+    const payload: JwtPayload = {
+      iat: Date.now(),
+    };
+
+    return sign(payload, this.config.jwtKey);
+  }
+
+  private decodeJWT(token?: string) {
+    if (!token) {
+      throw new UnauthorizedException();
+    }
+
+    try {
+      return verify(token, this.config.jwtKey) as JwtPayload;
+    } catch (e) {
+      this.logger.warning('Failed to validate JWT', {
+        exception: e,
+      });
+      throw new UnauthorizedException();
+    }
   }
 }

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './session';

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -1,3 +1,3 @@
-export * from './auth.module';
-export * from './auth.service';
 export * from './session';
+export * from './auth.service';
+export * from './auth.module';

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -1,1 +1,3 @@
+export * from './auth.module';
+export * from './auth.service';
 export * from './session';

--- a/src/components/language/language.resolver.ts
+++ b/src/components/language/language.resolver.ts
@@ -1,5 +1,6 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg, RequestUser, IRequestUser } from '../../common';
+import { IdArg } from '../../common';
+import { ISession, Session } from '../auth';
 import {
   Language,
   LanguageListInput,
@@ -19,17 +20,17 @@ export class LanguageResolver {
     description: 'Look up a language by its ID',
   })
   async language(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @IdArg() id: string,
   ): Promise<Language> {
-    return await this.langService.readOne(id, token);
+    return await this.langService.readOne(id, session);
   }
 
   @Query(() => LanguageListOutput, {
     description: 'Look up languages',
   })
   async languages(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @Args({
       name: 'input',
       type: () => LanguageListInput,
@@ -37,17 +38,17 @@ export class LanguageResolver {
     })
     input: LanguageListInput,
   ): Promise<LanguageListOutput> {
-    return this.langService.list(input, token);
+    return this.langService.list(input, session);
   }
 
   @Mutation(() => CreateLanguageOutput, {
     description: 'Create a language',
   })
   async createLanguage(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @Args('input') { language: input }: CreateLanguageInput,
   ): Promise<CreateLanguageOutput> {
-    const language = await this.langService.create(input, token);
+    const language = await this.langService.create(input, session);
     return { language };
   }
 
@@ -55,10 +56,10 @@ export class LanguageResolver {
     description: 'Update a language',
   })
   async updateLanguage(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @Args('input') { language: input }: UpdateLanguageInput,
   ): Promise<UpdateLanguageOutput> {
-    const language = await this.langService.update(input, token);
+    const language = await this.langService.update(input, session);
     return { language };
   }
 
@@ -66,10 +67,10 @@ export class LanguageResolver {
     description: 'Delete a language',
   })
   async deleteLanguage(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @IdArg() id: string,
   ): Promise<boolean> {
-    await this.langService.delete(id, token);
+    await this.langService.delete(id, session);
     return true;
   }
 }

--- a/src/components/location/location.resolver.ts
+++ b/src/components/location/location.resolver.ts
@@ -1,5 +1,6 @@
 import { Resolver, Args, Query, Mutation } from '@nestjs/graphql';
-import { IdArg, RequestUser } from '../../common';
+import { IdArg } from '../../common';
+import { ISession, Session } from '../auth';
 import {
   CreateCountryInput,
   CreateCountryOutput,
@@ -27,17 +28,17 @@ export class LocationResolver {
     description: 'Read one Location by id',
   })
   async location(
-    @RequestUser() token: string,
+    @Session() session: ISession,
     @IdArg() id: string,
   ): Promise<Location> {
-    return this.locationService.readOne(id, token);
+    return this.locationService.readOne(id, session.token);
   }
 
   @Query(() => LocationListOutput, {
     description: 'Look up locations',
   })
   async locations(
-    @RequestUser() token: string,
+    @Session() session: ISession,
     @Args({
       name: 'input',
       type: () => LocationListInput,
@@ -45,17 +46,17 @@ export class LocationResolver {
     })
     input: LocationListInput,
   ): Promise<LocationListOutput> {
-    return this.locationService.list(input, token);
+    return this.locationService.list(input, session.token);
   }
 
   @Mutation(() => CreateZoneOutput, {
     description: 'Create a zone',
   })
   async createZone(
-    @RequestUser() token: string,
+    @Session() session: ISession,
     @Args('input') { zone: input }: CreateZoneInput,
   ): Promise<CreateZoneOutput> {
-    const zone = await this.locationService.createZone(input, token);
+    const zone = await this.locationService.createZone(input, session.token);
     return { zone };
   }
 
@@ -63,10 +64,10 @@ export class LocationResolver {
     description: 'Create a region',
   })
   async createRegion(
-    @RequestUser() token: string,
+    @Session() session: ISession,
     @Args('input') { region: input }: CreateRegionInput,
   ): Promise<CreateRegionOutput> {
-    const region = await this.locationService.createRegion(input, token);
+    const region = await this.locationService.createRegion(input, session.token);
     return { region };
   }
 
@@ -74,10 +75,10 @@ export class LocationResolver {
     description: 'Create a country',
   })
   async createCountry(
-    @RequestUser() token: string,
+    @Session() session: ISession,
     @Args('input') { country: input }: CreateCountryInput,
   ): Promise<CreateCountryOutput> {
-    const country = await this.locationService.createCountry(input, token);
+    const country = await this.locationService.createCountry(input, session.token);
     return { country };
   }
 
@@ -85,10 +86,10 @@ export class LocationResolver {
     description: 'Update a zone',
   })
   async updateZone(
-    @RequestUser() token: string,
+    @Session() session: ISession,
     @Args('input') { zone: input }: UpdateZoneInput,
   ): Promise<UpdateZoneOutput> {
-    const zone = await this.locationService.updateZone(input, token);
+    const zone = await this.locationService.updateZone(input, session.token);
     return { zone };
   }
 
@@ -96,10 +97,10 @@ export class LocationResolver {
     description: 'Update a region',
   })
   async updateRegion(
-    @RequestUser() token: string,
+    @Session() session: ISession,
     @Args('input') { region: input }: UpdateRegionInput,
   ): Promise<UpdateRegionOutput> {
-    const region = await this.locationService.updateRegion(input, token);
+    const region = await this.locationService.updateRegion(input, session.token);
     return { region };
   }
 
@@ -107,10 +108,10 @@ export class LocationResolver {
     description: 'Update a country',
   })
   async updateCountry(
-    @RequestUser() token: string,
+    @Session() session: ISession,
     @Args('input') { country: input }: UpdateCountryInput,
   ): Promise<UpdateCountryOutput> {
-    const country = await this.locationService.updateCountry(input, token);
+    const country = await this.locationService.updateCountry(input, session.token);
     return { country };
   }
 
@@ -118,10 +119,10 @@ export class LocationResolver {
     description: 'Delete a location',
   })
   async deleteLocation(
-    @RequestUser() token: string,
+    @Session() session: ISession,
     @IdArg() id: string,
   ): Promise<boolean> {
-    await this.locationService.delete(id, token);
+    await this.locationService.delete(id, session.token);
     return true;
   }
 }

--- a/src/components/organization/organization.resolver.ts
+++ b/src/components/organization/organization.resolver.ts
@@ -1,6 +1,6 @@
 import { Resolver, Args, Query, Mutation } from '@nestjs/graphql';
 import { IdArg } from '../../common';
-import { ISession, Session } from '../auth';
+import { ISession, Session } from '../auth/session'; // avoid cyclic dep (auth -> user -> org)
 import {
   CreateOrganizationInput,
   CreateOrganizationOutput,

--- a/src/components/organization/organization.resolver.ts
+++ b/src/components/organization/organization.resolver.ts
@@ -1,5 +1,6 @@
 import { Resolver, Args, Query, Mutation } from '@nestjs/graphql';
-import { IdArg, RequestUser, IRequestUser } from '../../common';
+import { IdArg } from '../../common';
+import { ISession, Session } from '../auth';
 import {
   CreateOrganizationInput,
   CreateOrganizationOutput,
@@ -19,10 +20,10 @@ export class OrganizationResolver {
     description: 'Create an organization',
   })
   async createOrganization(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @Args('input') { organization: input }: CreateOrganizationInput,
   ): Promise<CreateOrganizationOutput> {
-    const organization = await this.orgs.create(input, token);
+    const organization = await this.orgs.create(input, session);
     return { organization };
   }
 
@@ -30,17 +31,17 @@ export class OrganizationResolver {
     description: 'Look up an organization by its ID',
   })
   async organization(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @IdArg() id: string,
   ): Promise<Organization> {
-    return this.orgs.readOne(id, token);
+    return this.orgs.readOne(id, session);
   }
 
   @Query(() => OrganizationListOutput, {
     description: 'Look up organizations',
   })
   async organizations(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @Args({
       name: 'input',
       type: () => OrganizationListInput,
@@ -48,17 +49,17 @@ export class OrganizationResolver {
     })
     input: OrganizationListInput,
   ): Promise<OrganizationListOutput> {
-    return this.orgs.list(input, token);
+    return this.orgs.list(input, session);
   }
 
   @Mutation(() => UpdateOrganizationOutput, {
     description: 'Update an organization',
   })
   async updateOrganization(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @Args('input') { organization: input }: UpdateOrganizationInput,
   ): Promise<UpdateOrganizationOutput> {
-    const organization = await this.orgs.update(input, token);
+    const organization = await this.orgs.update(input, session);
     return { organization };
   }
 
@@ -66,10 +67,10 @@ export class OrganizationResolver {
     description: 'Delete an organization',
   })
   async deleteOrganization(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @IdArg() id: string,
   ): Promise<boolean> {
-    await this.orgs.delete(id, token);
+    await this.orgs.delete(id, session);
     return true;
   }
 }

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -1,4 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
+import { DatabaseService } from '../../core';
+import { ISession } from '../auth';
 import {
   CreateOrganization,
   Organization,
@@ -6,9 +8,7 @@ import {
   OrganizationListOutput,
   UpdateOrganization,
 } from './dto';
-import { DatabaseService } from '../../core';
 import { generate } from 'shortid';
-import { IRequestUser } from '../../common';
 
 @Injectable()
 export class OrganizationService {
@@ -16,7 +16,7 @@ export class OrganizationService {
 
   async create(
     { name }: CreateOrganization,
-    token: IRequestUser,
+    { token }: ISession,
   ): Promise<Organization> {
     const result = await this.db
       .query()
@@ -53,7 +53,7 @@ export class OrganizationService {
           user.canReadOrgs as canReadOrgs
       `,
         {
-          token: token.token,
+          token,
           name,
           id: generate(),
         },
@@ -75,7 +75,7 @@ export class OrganizationService {
     };
   }
 
-  async readOne(orgId: string, token: IRequestUser): Promise<Organization> {
+  async readOne(orgId: string, { token }: ISession): Promise<Organization> {
     const result = await this.db
       .query()
       .raw(
@@ -101,7 +101,7 @@ export class OrganizationService {
         `,
         {
           id: orgId,
-          token: token.token,
+          token,
         },
       )
       .first();
@@ -129,7 +129,7 @@ export class OrganizationService {
 
   async update(
     input: UpdateOrganization,
-    token: IRequestUser,
+    { token }: ISession,
   ): Promise<Organization> {
     const result = await this.db
       .query()
@@ -159,7 +159,7 @@ export class OrganizationService {
         {
           id: input.id,
           name: input.name,
-          token: token.token,
+          token,
         },
       )
       .first();
@@ -179,7 +179,7 @@ export class OrganizationService {
     };
   }
 
-  async delete(id: string, token: IRequestUser): Promise<void> {
+  async delete(id: string, { token }: ISession): Promise<void> {
     const result = await this.db
       .query()
       .raw(
@@ -201,7 +201,7 @@ export class OrganizationService {
         `,
         {
           id,
-          token: token.token,
+          token,
         },
       )
       .first();
@@ -213,7 +213,7 @@ export class OrganizationService {
 
   async list(
     { page, count, sort, order, filter }: OrganizationListInput,
-    token: IRequestUser,
+    { token }: ISession,
   ): Promise<OrganizationListOutput> {
     const result = await this.db
       .query()
@@ -254,7 +254,7 @@ export class OrganizationService {
           // filter: filter.name, // TODO Handle no filter
           skip: (page - 1) * count,
           count,
-          token: token.token,
+          token,
         },
       )
       .run();

--- a/src/components/user/education/education.resolver.ts
+++ b/src/components/user/education/education.resolver.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Args, Mutation, Query } from '@nestjs/graphql';
-import { IdArg, RequestUser, IRequestUser } from '../../../common';
+import { IdArg } from '../../../common';
+import { ISession, Session } from '../../auth';
 import {
   CreateEducationInput,
   CreateEducationOutput,
@@ -18,10 +19,10 @@ export class EducationResolver {
     description: 'Create an education entry',
   })
   async createEducation(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @Args('input') { education: input }: CreateEducationInput,
   ): Promise<CreateEducationOutput> {
-    const education = await this.service.create(input, token);
+    const education = await this.service.create(input, session);
     return { education };
   }
 
@@ -29,20 +30,20 @@ export class EducationResolver {
     description: 'Read an education entry by user id',
   })
   async education(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @IdArg() id: string,
   ): Promise<Education> {
-    return await this.service.readOne(id, token);
+    return await this.service.readOne(id, session);
   }
 
   @Mutation(() => UpdateEducationOutput, {
     description: 'Update an education entry',
   })
   async updateEducation(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @Args('input') { education: input }: UpdateEducationInput,
   ): Promise<UpdateEducationOutput> {
-    const education = await this.service.update(input, token);
+    const education = await this.service.update(input, session);
     return { education };
   }
 
@@ -50,10 +51,10 @@ export class EducationResolver {
     description: 'Delete an education entry',
   })
   async deleteEducation(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @IdArg() id: string,
   ): Promise<boolean> {
-    await this.service.delete(id, token);
+    await this.service.delete(id, session);
     return true;
   }
 }

--- a/src/components/user/unavailability/unavailability.resolver.ts
+++ b/src/components/user/unavailability/unavailability.resolver.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@nestjs/common';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg, RequestUser } from '../../../common';
+import { IdArg } from '../../../common';
+import { ISession, Session } from '../../auth';
 import {
   CreateUnavailabilityInput,
   CreateUnavailabilityOutput,
@@ -11,7 +11,6 @@ import {
   Unavailability,
 } from './dto';
 import { UnavailabilityService } from './unavailability.service';
-import { IRequestUser } from '../../../common/request-user.interface';
 
 @Resolver()
 export class UnavailabilityResolver {
@@ -21,10 +20,10 @@ export class UnavailabilityResolver {
     description: 'Look up a unavailability by its ID',
   })
   async unavailability(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @IdArg() id: string,
   ): Promise<Unavailability> {
-    return await this.service.readOne(id, token);
+    return await this.service.readOne(id, session);
   }
 
   // @Query(() => SecuredUnavailabilityList, {
@@ -46,10 +45,10 @@ export class UnavailabilityResolver {
     description: 'Create an unavailability',
   })
   async createUnavailability(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @Args('input') { unavailability: input }: CreateUnavailabilityInput,
   ): Promise<CreateUnavailabilityOutput> {
-    const unavailability = await this.service.create(input, token);
+    const unavailability = await this.service.create(input, session);
     return { unavailability };
   }
 
@@ -57,10 +56,10 @@ export class UnavailabilityResolver {
     description: 'Update an unavailability',
   })
   async updateUnavailability(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @Args('input') { unavailability: input }: UpdateUnavailabilityInput,
   ): Promise<UpdateUnavailabilityOutput> {
-    const unavailability = await this.service.update(input, token);
+    const unavailability = await this.service.update(input, session);
     return { unavailability };
   }
 
@@ -68,10 +67,10 @@ export class UnavailabilityResolver {
     description: 'Delete an unavailability',
   })
   async deleteUnavailability(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @IdArg() id: string,
   ): Promise<boolean> {
-    await this.service.delete(id, token);
+    await this.service.delete(id, session);
     return true;
   }
 }

--- a/src/components/user/user.resolver.ts
+++ b/src/components/user/user.resolver.ts
@@ -6,9 +6,8 @@ import {
   ResolveProperty,
   Parent,
 } from '@nestjs/graphql';
-import { IdArg, RequestUser } from '../../common';
-import { IRequestUser } from '../../common/request-user.interface';
-
+import { IdArg } from '../../common';
+import { ISession, Session } from '../auth';
 import {
   OrganizationListInput,
   SecuredOrganizationList,
@@ -45,19 +44,15 @@ export class UserResolver {
   @Query(() => User, {
     description: 'Look up a user by its ID',
   })
-  async user(
-    @RequestUser() token: IRequestUser,
-    @IdArg() id: string,
-    //
-  ): Promise<User> {
-    return this.userService.readOne(id, token);
+  async user(@Session() session: ISession, @IdArg() id: string): Promise<User> {
+    return this.userService.readOne(id, session);
   }
 
   @Query(() => UserListOutput, {
     description: 'Look up users',
   })
   async users(
-    @RequestUser() token: string,
+    @Session() session: ISession,
     @Args({
       name: 'input',
       type: () => UserListInput,
@@ -65,12 +60,12 @@ export class UserResolver {
     })
     input: UserListInput,
   ): Promise<UserListOutput> {
-    return this.userService.list(input, token);
+    return this.userService.list(input, session.token);
   }
 
   @ResolveProperty(() => SecuredUnavailabilityList)
   async unavailabilities(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @Parent() { id }: User,
     @Args({
       name: 'input',
@@ -79,12 +74,12 @@ export class UserResolver {
     })
     input: UnavailabilityListInput,
   ): Promise<SecuredUnavailabilityList> {
-    return this.unavailabilityService.list(id, input, token);
+    return this.unavailabilityService.list(id, input, session);
   }
 
   @ResolveProperty(() => SecuredOrganizationList)
   async organizations(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @Parent() { id }: User,
     @Args({
       name: 'input',
@@ -93,12 +88,12 @@ export class UserResolver {
     })
     input: OrganizationListInput,
   ): Promise<SecuredOrganizationList> {
-    return this.userService.listOrganizations(id, input, token);
+    return this.userService.listOrganizations(id, input, session);
   }
 
   @ResolveProperty(() => SecuredEducationList)
   async education(
-    @RequestUser() token: string,
+    @Session() session: ISession,
     @Parent() { id }: User,
     @Args({
       name: 'input',
@@ -107,17 +102,17 @@ export class UserResolver {
     })
     input: EducationListInput,
   ): Promise<SecuredEducationList> {
-    return this.educationService.list(id, input, token);
+    return this.educationService.list(id, input, session.token);
   }
 
   @Mutation(() => CreateUserOutput, {
     description: 'Create a user',
   })
   async createUser(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @Args('input') { user: input }: CreateUserInput,
   ): Promise<CreateUserOutput> {
-    const user = await this.userService.create(input, token);
+    const user = await this.userService.create(input, session);
     return { user };
   }
 
@@ -125,18 +120,18 @@ export class UserResolver {
     description: 'Update a user',
   })
   async updateUser(
-    @RequestUser() token: IRequestUser,
+    @Session() session: ISession,
     @Args('input') { user: input }: UpdateUserInput,
   ): Promise<UpdateUserOutput> {
-    const user = await this.userService.update(input, token);
+    const user = await this.userService.update(input, session);
     return { user };
   }
 
   @Mutation(() => Boolean, {
     description: 'Delete a user',
   })
-  async deleteUser(@RequestUser() token: IRequestUser, @IdArg() id: string) {
-    await this.userService.delete(id, token);
+  async deleteUser(@Session() session: ISession, @IdArg() id: string) {
+    await this.userService.delete(id, session);
     return true;
   }
 }

--- a/test/education.e2e-spec.ts
+++ b/test/education.e2e-spec.ts
@@ -3,7 +3,7 @@ import { isValid } from 'shortid';
 import {
   createEducation,
   createTestApp,
-  createToken,
+  createSession,
   createUser,
   fragments,
   TestApp,
@@ -17,7 +17,7 @@ describe('Education e2e', () => {
 
   beforeEach(async () => {
     app = await createTestApp();
-    await createToken(app);
+    await createSession(app);
   });
   afterAll(async () => {
     await app.close();

--- a/test/language.e2e-spec.ts
+++ b/test/language.e2e-spec.ts
@@ -4,7 +4,7 @@ import {
   TestApp,
   createLanguage,
   createTestApp,
-  createToken,
+  createSession,
   createUser,
 } from './utility';
 
@@ -19,7 +19,7 @@ describe('Language e2e', () => {
 
   beforeEach(async () => {
     app = await createTestApp();
-    await createToken(app);
+    await createSession(app);
     await createUser(app);
   });
 

--- a/test/organization.e2e-spec.ts
+++ b/test/organization.e2e-spec.ts
@@ -4,7 +4,7 @@ import {
   TestApp,
   createOrganization,
   createTestApp,
-  createToken,
+  createSession,
   createUser,
   fragments,
 } from './utility';
@@ -19,7 +19,7 @@ describe('Organization e2e', () => {
 
   beforeEach(async () => {
     app = await createTestApp();
-    await createToken(app);
+    await createSession(app);
     await createUser(app);
   });
 

--- a/test/unavailability.e2e-spec.ts
+++ b/test/unavailability.e2e-spec.ts
@@ -3,7 +3,7 @@ import * as faker from 'faker';
 import {
   TestApp,
   createTestApp,
-  createToken,
+  createSession,
   createUnavailability,
   createUser,
 } from './utility';
@@ -21,7 +21,7 @@ describe('Unavailability e2e', () => {
 
   beforeEach(async () => {
     app = await createTestApp();
-    await createToken(app);
+    await createSession(app);
     user = await createUser(app);
   });
 

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -1,9 +1,11 @@
-import * as request from 'supertest';
-
-import { CreateUser, User } from '../src/components/user';
-import { TestApp, createTestApp, createToken, createUser } from './utility';
-
-import { fragments } from './utility/fragments';
+import { User } from '../src/components/user';
+import {
+  TestApp,
+  createTestApp,
+  createSession,
+  createUser,
+  fragments,
+} from './utility';
 import { gql } from 'apollo-server-core';
 import { isValid } from 'shortid';
 
@@ -16,7 +18,7 @@ describe('User e2e', () => {
 
   it('read one user by id', async () => {
     // create user first
-    const token = await createToken(app);
+    const token = await createSession(app);
     const user = await createUser(app);
     const result = await app.graphql.query(
       gql`
@@ -43,14 +45,12 @@ describe('User e2e', () => {
 
   it('update user', async () => {
     // create user first
-    const token = await createToken(app);
+    const token = await createSession(app);
     const user = await createUser(app);
     const result = await app.graphql.mutate(
       gql`
         mutation updateUser($input: UpdateUserInput!) {
-          updateUser(
-            input: $input
-          ) {
+          updateUser(input: $input) {
             user {
               ...user
             }
@@ -79,7 +79,7 @@ describe('User e2e', () => {
 
   it('delete user', async () => {
     // create user first
-    const token = await createToken(app);
+    const token = await createSession(app);
     const user = await createUser(app);
     const result = await app.graphql.query(
       gql`

--- a/test/utility/create-education.ts
+++ b/test/utility/create-education.ts
@@ -7,7 +7,6 @@ import {
 import { TestApp } from './create-app';
 import * as faker from 'faker';
 import { fragments } from './fragments';
-import { IRequestUser } from '../../src/common';
 
 export async function createEducation(
   app: TestApp,

--- a/test/utility/create-graphql-client.ts
+++ b/test/utility/create-graphql-client.ts
@@ -75,9 +75,14 @@ const validateResult = (res: GraphQLResponse) => {
   expect(res.data).toBeTruthy();
 };
 
-const reportError = (e: GraphQLFormattedError & { originalError?: Error }) => {
+const reportError = (e: GraphQLFormattedError & { originalError?: Error & { response?: any } }) => {
   if (e.originalError instanceof Error) {
-    return e.originalError;
+    const e2 = e.originalError;
+    if (e2.response?.message && e2.stack?.startsWith('Error: [object Object]\n')) {
+      e2.stack = e2.stack.replace('[object Object]', e2.response.message);
+      e2.message = e2.response.message;
+    }
+    return e2;
   }
 
   let msg =

--- a/test/utility/create-session.ts
+++ b/test/utility/create-session.ts
@@ -1,15 +1,15 @@
 import { gql } from 'apollo-server-core';
 import { TestApp } from './create-app';
 
-export async function createToken(app: TestApp): Promise<string> {
+export async function createSession(app: TestApp): Promise<string> {
   const result = await app.graphql.mutate(gql`
     mutation {
-      createToken {
+      createSession {
         token
       }
     }
   `);
-  const token = result.createToken?.token;
+  const token = result.createSession?.token;
   expect(token).toBeTruthy();
   app.graphql.authToken = token;
   return token;

--- a/test/utility/index.ts
+++ b/test/utility/index.ts
@@ -3,7 +3,7 @@ export * from './create-education';
 export * from './create-graphql-client';
 export * from './create-language';
 export * from './create-organization';
-export * from './create-token';
+export * from './create-session';
 export * from './create-unavailability';
 export * from './create-user';
 export * from './fragments';


### PR DESCRIPTION
- Rename `RequestUser` to `Session`
- Move business logic to `AuthService`
- Use standard Authentication header
- Only create session once per request
- Update auth API