### PR TITLE
DB indexing lifecycle via decorator & discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:e2e": "jest --forceExit --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@golevelup/nestjs-discovery": "^2.2.3",
     "@nestjs/common": "^6.7.2",
     "@nestjs/core": "^6.7.2",
     "@nestjs/graphql": "^6.5.3",

--- a/src/components/auth/auth.service.ts
+++ b/src/components/auth/auth.service.ts
@@ -3,7 +3,13 @@ import * as argon2 from 'argon2';
 import { Connection } from 'cypher-query-builder';
 import { verify, sign } from 'jsonwebtoken';
 import { DateTime } from 'luxon';
-import { ConfigService, ILogger, Logger } from '../../core';
+import {
+  ConfigService,
+  ILogger,
+  Logger,
+  OnIndex,
+  OnIndexParams,
+} from '../../core';
 import { ISession } from './session';
 
 interface JwtPayload {
@@ -17,6 +23,9 @@ export class AuthService {
     private readonly config: ConfigService,
     @Logger('auth:service') private readonly logger: ILogger,
   ) {}
+
+  @OnIndex()
+  async createIndexes({ db, logger }: OnIndexParams) {}
 
   async createToken(): Promise<string> {
     const token = this.encodeJWT();

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -4,11 +4,13 @@ import { ConfigModule } from './config/config.module';
 import { CypherFactory } from './cypher.factory';
 import { DatabaseService } from './database.service';
 import { PropertyUpdaterService } from './database/property-updater.service';
+import { IndexerModule } from './database/indexer/indexer.module';
 
 @Global()
 @Module({
   imports: [
     ConfigModule,
+    IndexerModule,
   ],
   providers: [
     AwsS3Factory,

--- a/src/core/database/indexer/create-indexes.decorator.ts
+++ b/src/core/database/indexer/create-indexes.decorator.ts
@@ -1,0 +1,21 @@
+import { SetMetadata } from '@nestjs/common';
+import { Connection } from 'cypher-query-builder';
+import { ILogger } from '../../logger';
+import { DB_INDEX_KEY } from './indexer.constants';
+
+/**
+ * Hook into DB indexing lifecycle with this decorator.
+ *
+ * It should be used on a provider method.
+ * It's passed a db Connection for convenience.
+ */
+export const OnIndex = () => SetMetadata(DB_INDEX_KEY, true);
+
+export interface OnIndexParams {
+  db: Connection;
+  logger: ILogger;
+}
+
+export type Indexer = (
+  params: OnIndexParams,
+) => Promise<string | string[] | void>;

--- a/src/core/database/indexer/index.ts
+++ b/src/core/database/indexer/index.ts
@@ -1,0 +1,1 @@
+export * from './create-indexes.decorator';

--- a/src/core/database/indexer/indexer.constants.ts
+++ b/src/core/database/indexer/indexer.constants.ts
@@ -1,0 +1,1 @@
+export const DB_INDEX_KEY = 'ON_DB_INDEX';

--- a/src/core/database/indexer/indexer.module.ts
+++ b/src/core/database/indexer/indexer.module.ts
@@ -1,0 +1,48 @@
+import { DiscoveryModule, DiscoveryService } from '@golevelup/nestjs-discovery';
+import { Module, OnModuleInit } from '@nestjs/common';
+import { Connection } from 'cypher-query-builder';
+import { ILogger, Logger } from '../../logger';
+import { DB_INDEX_KEY } from './indexer.constants';
+
+@Module({
+  imports: [DiscoveryModule],
+})
+export class IndexerModule implements OnModuleInit {
+  constructor(
+    private readonly db: Connection,
+    private readonly discover: DiscoveryService,
+    @Logger('database:indexer') private readonly logger: ILogger,
+  ) {}
+
+  async onModuleInit() {
+    const discovered = await this.discover.providerMethodsWithMetaAtKey(
+      DB_INDEX_KEY,
+    );
+    this.logger.info('Discovered indexers', { count: discovered.length });
+
+    const indexers = discovered.map(h => h.discoveredMethod);
+    for (const { handler, methodName, parentClass } of indexers) {
+      this.logger.debug('Running indexer', {
+        class: parentClass.name,
+        method: methodName,
+      });
+      const maybeStatements = await handler({
+        db: this.db,
+        logger: this.logger,
+      });
+      const statements = maybeStatements
+        ? Array.isArray(maybeStatements)
+          ? maybeStatements
+          : [maybeStatements]
+        : [];
+      for (const statement of statements) {
+        await this.db
+          .query()
+          .raw(statement)
+          .run();
+      }
+    }
+
+    this.logger.info('Finished indexing');
+  }
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,3 +3,4 @@ export * from './config/config.service';
 export * from './core.module';
 export * from './database.service';
 export * from './database/property-updater.service';
+export * from './database/indexer';

--- a/yarn.lock
+++ b/yarn.lock
@@ -217,6 +217,13 @@
     is-absolute "^1.0.0"
     is-negated-glob "^1.0.0"
 
+"@golevelup/nestjs-discovery@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@golevelup/nestjs-discovery/-/nestjs-discovery-2.2.3.tgz#69584b15f21a15e1b70b00dd4ab598dea8b1225f"
+  integrity sha512-xT5VkyHtcFKG8k7P7HadsfAMJzdJeE0ujSgegszTVlGLAeg4pl2cxcroAitVf6T12IPd7Nju5gVFjL9HLTHBSg==
+  dependencies:
+    lodash "^4.17.15"
+
 "@graphql-toolkit/common@0.9.0":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@graphql-toolkit/common/-/common-0.9.0.tgz#24d1744fa0d6b9331e8032097fcebb74390bad92"


### PR DESCRIPTION
Indexing can be implemented via the `OnIndex` decorator
```ts
@Injectable()
class FooService {

  @OnIndex()
  createIndexes() {
    return [
      'CREATE CONSTRAINT userIdExists ON (n:User) ASSERT EXISTS(n.id)',
      'CREATE CONSTRAINT userIdUnique ON (n:User) ASSERT n.id IS UNIQUE',
    ];
  }

}
```

They can also run db queries directly
```ts
  @OnIndex()
  async createIndexes({ db }: OnIndexParams) {
    await db.query().raw('...').run();
  }
```