### PR TITLE
Various bugfixes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,19 @@
-.github/workflows/* @CarsonF
+# OPS
+/.github/workflows/ @CarsonF
+Dockerfile @CarsonF
+
+# Tooling
+tsconfig* @CarsonF
+.eslint* @CarsonF
+/eslint-local-rules.js @CarsonF
+/.prettierrc.yml @CarsonF
+/tools/ @CarsonF
+/scripts/ @CarsonF
+
+# API Schema
+*.dto.ts @CarsonF
+*.resolver.ts @CarsonF
+
+# Foundation
+/src/common/ @CarsonF
+/src/core/ @CarsonF

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --forceExit --config ./test/jest-e2e.json",
+    "test:e2e": "jest --config ./test/jest-e2e.json",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -1,4 +1,5 @@
-import { Global, Module } from '@nestjs/common';
+import { Global, Module, OnApplicationShutdown } from '@nestjs/common';
+import { Connection } from 'cypher-query-builder';
 import { AwsS3Factory } from './aws-s3.factory';
 import { AwsSESFactory } from './aws-ses.factory';
 import { ConfigModule } from './config/config.module';
@@ -26,4 +27,10 @@ import { DeprecatedDBService } from './deprecated-database.service';
     DatabaseService,
   ],
 })
-export class CoreModule {}
+export class CoreModule implements OnApplicationShutdown {
+  constructor(private readonly db: Connection) {}
+
+  async onApplicationShutdown() {
+    this.db.close();
+  }
+}

--- a/src/core/logger/formatters.ts
+++ b/src/core/logger/formatters.ts
@@ -71,10 +71,14 @@ export const formatException = () =>
       .map((t: StackFrame) => {
         const subject = t.getFunctionName();
 
-        const file = relative(`${__dirname}/../../..`, t.getFileName());
-        const location = file.startsWith('internal')
-          ? ''
-          : `${file}:${t.getLineNumber()}:${t.getColumnNumber()}`;
+        const absolute: string | null = t.getFileName();
+        const file = absolute
+          ? relative(`${__dirname}/../../..`, absolute)
+          : '';
+        const location =
+          !file || file.startsWith('internal')
+            ? ''
+            : `${file}:${t.getLineNumber()}:${t.getColumnNumber()}`;
 
         return (
           red(`    at`) +

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "test"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "tools"]
 }


### PR DESCRIPTION
- Fix db connections not being closed.
  There is logic builtin to `cypher-query-builder` will close db connections when node exits, but this wasn't doing anything for tests.
  Now we close db connections on a Nest Lifecycle.
  Now we don't have to `--forceExit` on Jest 🎉 
- Actually fix build location that I meant to fix in d6fa0d4
- Fix error formatter
  Stack frame doesn't always have a file name, even though it says it always should 🤦‍♂
  Accounting for null.
- Potentially fix db error handling
  I'm not convinced this was handling awaiting the error correctly.
https://github.com/SeedCompany/cord-api-v3/blob/8841f7110495c887e5afcb31e0f6459440205030/src/core/database/cypher.factory.ts#L49-L51
  Looking into driver code further, their [promise logic wraps their observer logic](https://github.com/neo4j/neo4j-javascript-driver/blob/1.7/src/v1/result.js#L71-L105).
  So I replaced our promise wrapping with subscribe wrapping.
  Bonus is if we ever stream/observe db results this will work for that as well.
