### PR TITLE
Docker Compose Enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM node as dev
 # We copy the package.json and yarn.lock separately so node_modules
 # is cached in a separate docker layer from app code
 ADD package.json yarn.lock ./
-RUN yarn
+RUN yarn install --frozen-lockfile
 
 # Copy application code
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
   api:
     # Use dev target locally since there's no need to save space and contains everything
     image: cord-api-v3:dev
+    build:
+      context: .
+      target: dev
     # wait for db to be ready before running command
     entrypoint: [wait-for, -q, db:7687, --]
     command: yarn start:prod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,9 @@ services:
   api:
     # Use dev target locally since there's no need to save space and contains everything
     image: cord-api-v3:dev
-    command: wait-for db:7687 -- yarn start:prod
+    # wait for db to be ready before running command
+    entrypoint: [wait-for, -q, db:7687, --]
+    command: yarn start:prod
     ports:
       - 3000:80
     networks:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "nest build",
     "docker:build": "scripts/docker-build.sh",
     "docker:run": "scripts/docker-run.sh",
+    "docker:test": "scripts/docker-run.sh yarn test:e2e --runInBand",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prebuild": "rimraf dist",
     "build": "nest build",
     "docker:build": "scripts/docker-build.sh",
+    "docker:run": "scripts/docker-run.sh",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# This allows you to run any command inside of our built docker container with an ephemeral database
+# It ensures running code is fresh and cleaned up afterwards
+
+set -e
+
+function clear_lines() {
+  local end=$1
+  while [ $end -gt 0 ]; do
+    tput cuu 1
+    tput el
+    end=$(($end-1))
+  done
+}
+
+function compose() {
+  docker-compose -p cord "$@"
+}
+
+function pull() {
+  # shellcheck disable=SC2068
+  compose pull $@
+  clear_lines 1
+}
+
+function build() {
+  # Ensure there is 5 lines below
+  printf '\n\n\n\n\n' && tput cuu 5
+  # shellcheck disable=SC2068
+  compose build $@ | tail -n 5
+  clear_lines 6
+}
+
+function run() {
+  # shellcheck disable=SC2068
+  compose run --rm api $@ 2>/dev/null
+}
+
+function down() {
+  compose down --remove-orphans 2>/dev/null
+}
+
+pull db
+build api
+trap down EXIT
+run "${*:-yarn start:prod}"


### PR DESCRIPTION
- Ensure docker yarn install isn't modifying the lockfile
- Move wait for db command to entrypoint
  - This way it happens transparently and different commands can be given easily
- Make compose aware of how to build the cord-api-v3 image
  - Now `docker-compose up (--build)` will work without a previous build
- Created `yarn docker:run`
  - This allows you to run any command inside of our built docker container with an ephemeral database.
  - And it ensures images are pulled & built container is fresh and everything is cleaned up afterwards.
- Created `yarn docker:test` (`docker:run` with test command)
  - Which runs tests in docker container with clean db every time