### PR TITLE
Refactor create generic to use query builder

### DIFF
--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -113,7 +113,7 @@ export class PartnershipService {
         canEdit: !!result.canEditMouEnd,
       },
       types: {
-        value: result.types ? result.types.split(',') : [],
+        value: result.types ? result.types : [],
         canRead: !!result.canReadTypes,
         canEdit: !!result.canEditTypes,
       },
@@ -232,7 +232,7 @@ export class PartnershipService {
       changes: {
         ...input,
         // TODO: propertyService.update and propertyService.createNode appear to handle array types differently...
-        types: (input.types ? input.types.join(',') : undefined) as any,
+        types: (input.types ? input.types : undefined) as any,
       },
       nodevar: 'partnership',
     });

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -231,7 +231,6 @@ export class PartnershipService {
       props: ['agreementStatus', 'mouStatus', 'mouStart', 'mouEnd', 'types'],
       changes: {
         ...input,
-        // TODO: propertyService.update and propertyService.createNode appear to handle array types differently...
         types: (input.types ? input.types : undefined) as any,
       },
       nodevar: 'partnership',

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -113,7 +113,7 @@ export class PartnershipService {
         canEdit: !!result.canEditMouEnd,
       },
       types: {
-        value: result.types ? result.types : [],
+        value: result.types ?? [],
         canRead: !!result.canReadTypes,
         canEdit: !!result.canEditTypes,
       },
@@ -231,7 +231,7 @@ export class PartnershipService {
       props: ['agreementStatus', 'mouStatus', 'mouStart', 'mouEnd', 'types'],
       changes: {
         ...input,
-        types: (input.types ? input.types : undefined) as any,
+        types: input.types as any,
       },
       nodevar: 'partnership',
     });

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -84,9 +84,9 @@ export class ProductService {
       id,
       createdAt: result.createdAt.value,
       type: result.type.value,
-      books: result.books?.value?.split(',') || [],
-      mediums: result.mediums?.value?.split(',') || [],
-      purposes: result.purposes?.value?.split(',') || [],
+      books: result.books?.value || [],
+      mediums: result.mediums?.value || [],
+      purposes: result.purposes?.value || [],
       approach: result.approach.value,
       methodology: result.methodology.value,
     };

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -80,7 +80,7 @@ export class ProjectMemberService {
         canEdit: true,
       },
       roles: {
-        value: result.roles ? result.roles.split(',') : [],
+        value: result.roles || [],
         canEdit: true,
         canRead: true,
       },
@@ -179,7 +179,7 @@ export class ProjectMemberService {
       props: ['roles'],
       changes: {
         ...input,
-        roles: (input.roles ? input.roles.join(',') : undefined) as any,
+        roles: (input.roles ? input.roles : undefined) as any,
       },
       nodevar: 'projectMember',
     });

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -87,7 +87,7 @@ export class EducationService {
     await this.db
       .query()
       .raw(query, {
-        userId: session.userId,
+        userId,
         id,
       })
       .first();

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -43,7 +43,10 @@ export class EducationService {
     };
   }
 
-  async create(input: CreateEducation, session: ISession): Promise<Education> {
+  async create(
+    { userId, ...input }: CreateEducation,
+    session: ISession
+  ): Promise<Education> {
     const id = generate();
     const acls = {
       canReadDegree: true,
@@ -66,12 +69,12 @@ export class EducationService {
       console.log(e);
       this.logger.error(`Could not create education for user `, {
         id,
-        userId: input.userId,
+        userId,
       });
       throw new Error('Could not create education');
     }
 
-    this.logger.info(`Created user education`, { id, userId: input.userId });
+    this.logger.info(`Created user education`, { id, userId });
 
     // connect the Education to the User.
     const query = `

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -62,7 +62,7 @@ export class UnavailabilityService {
     await this.db
       .query()
       .raw(query, {
-        userId: session.userId,
+        userId,
         id,
       })
       .first();

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -18,7 +18,7 @@ export class UnavailabilityService {
   ) {}
 
   async create(
-    input: CreateUnavailability,
+    { userId, ...input }: CreateUnavailability,
     session: ISession
   ): Promise<Unavailability> {
     const id = generate();
@@ -41,14 +41,14 @@ export class UnavailabilityService {
     } catch {
       this.logger.error(`Could not create unavailability`, {
         id,
-        userId: input.userId,
+        userId,
       });
       throw new Error('Could not create unavailability');
     }
 
     this.logger.info(`Created user unavailability`, {
       id,
-      userId: input.userId,
+      userId,
     });
 
     // connect the Unavailability to the User.

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -1,5 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
-import { ForbiddenError } from 'apollo-server-core';
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import {
   Connection,
   contains,
@@ -590,7 +593,7 @@ export class DatabaseService {
     }
   }
 
-  private async createBaseNode<TObject extends Resource>({
+  async createBaseNode<TObject extends Resource>({
     session,
     baseNodeLabel,
     input,
@@ -634,7 +637,8 @@ export class DatabaseService {
         ])
         .run();
     } catch (e) {
-      // If there is no aclEditProp, then this is not an access-related issue and we can move forward with throwing
+      // If there is no aclEditProp, then this is not an access-related issue
+      // and we can move forward with throwing
       if (!aclEditProp) {
         throw e;
       }
@@ -654,13 +658,13 @@ export class DatabaseService {
           }),
         ])
         .return({
-          requestingUser: [{ aclEditProp: 'editProp' }],
+          requestingUser: [{ [aclEditProp]: 'editProp' }],
         })
         .first();
 
       // If the user doesn't have permission to perform the create action...
       if (!aclResult || !aclResult.editProp) {
-        throw new ForbiddenError(`${aclEditProp} missing or false`);
+        throw new ForbiddenException(`${aclEditProp} missing or false`);
       }
 
       this.logger.error(`createNode error`, {
@@ -671,7 +675,7 @@ export class DatabaseService {
     }
   }
 
-  private async createProperty({
+  async createProperty({
     session,
     key,
     value,
@@ -679,7 +683,7 @@ export class DatabaseService {
   }: {
     session: ISession;
     key: string;
-    value?: any;
+    value: any;
     id: string;
   }) {
     await this.db
@@ -707,7 +711,7 @@ export class DatabaseService {
       ])
       .create([
         node('item'),
-        relation('out', 'rel', `${key}`, {
+        relation('out', 'rel', key, {
           active: true,
           createdAt: DateTime.local(),
           owningOrgId: session.owningOrgId,

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -561,7 +561,7 @@ export class DatabaseService {
 
   async createNode<TObject extends Resource>({
     session,
-    input,
+    input: { id, ...propertyValues },
     acls,
     baseNodeLabel,
     aclEditProp,
@@ -575,21 +575,17 @@ export class DatabaseService {
     await this.createBaseNode<TObject>({
       session,
       baseNodeLabel,
-      input,
+      input: { id, ...propertyValues },
       acls,
       aclEditProp,
     });
 
-    for (const k in input) {
-      if (k === 'id') {
-        continue;
-      }
-
+    for (const k in propertyValues) {
       await this.createProperty({
         session,
         key: k,
-        value: input[k],
-        id: input.id,
+        value: propertyValues[k as keyof typeof propertyValues],
+        id,
       });
     }
   }

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -400,7 +400,7 @@ export class DatabaseService {
         const list = typeof prop === 'object' ? prop.list : false;
 
         if (list) {
-          const value = row[propName] ? row[propName] : [];
+          const value = row[propName] ?? [];
 
           if (secure) {
             item[propName] = {
@@ -667,7 +667,7 @@ export class DatabaseService {
         throw new ForbiddenError(`${aclEditProp} missing or false`);
       }
 
-      this.logger.error(`DatabaseService create error`, {
+      this.logger.error(`createNode error`, {
         exception: e,
       });
 

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -671,7 +671,7 @@ export class DatabaseService {
     }
   }
 
-  private async createProperty<TObject extends Resource>({
+  private async createProperty({
     session,
     key,
     value,


### PR DESCRIPTION
I apologize for sending a PR that has no direct issue. I was originally working on #178 and found myself working on this refactor as a precursor to that task.

## Breaking Changes
None

## API Updates
* The `DatabaseService.createNode` method (and all dependent methods) are now refactored to utilize the cypher query builder
* All dependent methods of `createNode` switched to `private`
* Eliminated `try / catch` in `createProperty` method that was swallowing DateTime errors which resulted in empty values for all DateTime fields in Neo4J
* ~Created `massagePropertyValue` private method for massaging values before sending them to Neo4J on update and create.~
  * This has been removed now that we have the `ParamaterTransformer`
* Eliminated casting of all values to strings in Neo4J. This resolves an issue where arrays were being saved as comma-delimited strings. We are now inserting and receiving raw JS arrays from Neo4J
