### PR TITLE
createNode infer generic with type param

### DIFF
--- a/src/components/file/dto/node.ts
+++ b/src/components/file/dto/node.ts
@@ -96,6 +96,9 @@ export class Directory extends FileNode {
   implements: [Resource],
 })
 export class FileVersion extends Resource {
+  /* TS wants a public constructor for "ClassType" */
+  static classType = (FileVersion as any) as Type<FileVersion>;
+
   @Field({
     description: 'The user who created this file version',
   })

--- a/src/components/language/dto/language.dto.ts
+++ b/src/components/language/dto/language.dto.ts
@@ -1,3 +1,4 @@
+import { Type } from '@nestjs/common';
 import { Field, ObjectType } from 'type-graphql';
 import {
   Resource,
@@ -11,6 +12,9 @@ import {
   implements: [Resource],
 })
 export class Language extends Resource {
+  /* TS wants a public constructor for "ClassType" */
+  static classType = (Language as any) as Type<Language>;
+
   @Field()
   readonly name: SecuredString;
 

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -44,9 +44,9 @@ export class LanguageService {
     try {
       await this.db.createNode({
         session,
+        type: Language.classType,
         input: { id, ...input },
         acls,
-        baseNodeLabel: 'Language',
         aclEditProp: 'canCreateLang',
       });
 

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -236,10 +236,9 @@ export class LocationService {
     try {
       await this.db.createNode({
         session,
+        type: Zone.classType,
         input: { id, ...input },
         acls,
-        baseNodeLabel: 'Zone',
-        aclEditProp: 'canCreateZone',
       });
 
       // connect director User to zone
@@ -383,10 +382,9 @@ export class LocationService {
     try {
       await this.db.createNode({
         session,
+        type: Region.classType,
         input: { id, ...input },
         acls,
-        baseNodeLabel: 'Region',
-        aclEditProp: 'canCreateRegion',
       });
 
       this.logger.info(`region created`);
@@ -532,10 +530,9 @@ export class LocationService {
     try {
       await this.db.createNode({
         session,
+        type: Country.classType,
         input: { id, ...input },
         acls,
-        baseNodeLabel: 'Country',
-        aclEditProp: 'canCreateCountry',
       });
 
       this.logger.info(`country created`);

--- a/src/components/organization/dto/organization.ts
+++ b/src/components/organization/dto/organization.ts
@@ -1,3 +1,4 @@
+import { Type } from '@nestjs/common';
 import { Field, ObjectType } from 'type-graphql';
 import { Resource, SecuredString } from '../../../common';
 
@@ -5,6 +6,9 @@ import { Resource, SecuredString } from '../../../common';
   implements: Resource,
 })
 export class Organization extends Resource {
+  /* TS wants a public constructor for "ClassType" */
+  static classType = (Organization as any) as Type<Organization>;
+
   @Field()
   readonly name: SecuredString;
 }

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -31,9 +31,9 @@ export class OrganizationService {
     try {
       await this.db.createNode({
         session,
+        type: Organization.classType,
         input: { id, ...input },
         acls,
-        baseNodeLabel: 'Organization',
         aclEditProp: 'canCreateOrg',
       });
     } catch {

--- a/src/components/partnership/dto/create-partnership.dto.ts
+++ b/src/components/partnership/dto/create-partnership.dto.ts
@@ -18,10 +18,10 @@ export class CreatePartnership {
   readonly mouStatus?: PartnershipAgreementStatus;
 
   @DateField({ nullable: true })
-  readonly mouStart?: CalendarDate | null;
+  readonly mouStart?: CalendarDate;
 
   @DateField({ nullable: true })
-  readonly mouEnd?: CalendarDate | null;
+  readonly mouEnd?: CalendarDate;
 
   @Field(() => [PartnershipType], { nullable: true })
   readonly types?: PartnershipType[];

--- a/src/components/partnership/dto/partnership.dto.ts
+++ b/src/components/partnership/dto/partnership.dto.ts
@@ -1,3 +1,4 @@
+import { Type } from '@nestjs/common';
 import { Field, ObjectType } from 'type-graphql';
 import {
   Resource,
@@ -27,6 +28,9 @@ export abstract class SecuredPartnershipTypes extends SecuredPropertyList(
   implements: [Resource],
 })
 export class Partnership extends Resource {
+  /* TS wants a public constructor for "ClassType" */
+  static classType = (Partnership as any) as Type<Partnership>;
+
   @Field()
   readonly agreementStatus: SecuredPartnershipAgreementStatus;
 

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -185,6 +185,7 @@ export class PartnershipService {
     try {
       await this.db.createNode({
         session,
+        type: Partnership.classType,
         input: {
           id,
           agreementStatus: PartnershipAgreementStatus.NotAttached,
@@ -192,8 +193,6 @@ export class PartnershipService {
           ...input,
         },
         acls,
-        baseNodeLabel: 'Partnership',
-        aclEditProp: 'canCreatePartnership',
       });
 
       // connect the Organization to the Partnership

--- a/src/components/product/dto/product.dto.ts
+++ b/src/components/product/dto/product.dto.ts
@@ -1,3 +1,4 @@
+import { Type } from '@nestjs/common';
 import { Field, ObjectType } from 'type-graphql';
 import { Resource } from '../../../common';
 import { BibleBook } from './bible-book';
@@ -11,6 +12,9 @@ import { ProductType } from './product-type';
   implements: [Resource],
 })
 export class Product extends Resource {
+  /* TS wants a public constructor for "ClassType" */
+  static classType = (Product as any) as Type<Product>;
+
   @Field(() => ProductType)
   readonly type: ProductType;
 

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -37,6 +37,7 @@ export class ProductService {
     try {
       await this.db.createNode({
         session,
+        type: Product.classType,
         input: {
           id,
           ...input,
@@ -45,8 +46,6 @@ export class ProductService {
             : {}),
         },
         acls,
-        baseNodeLabel: 'Product',
-        aclEditProp: 'canCreateProduct',
       });
     } catch (e) {
       this.logger.warning('Failed to create product', {

--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -28,6 +28,9 @@ export type AnyProject = MergeExclusive<TranslationProject, InternshipProject>;
   },
 })
 export class Project extends Resource {
+  /* TS wants a public constructor for "ClassType" */
+  static classType = (Project as any) as Type<Project>;
+
   @Field(() => ProjectType)
   readonly type: ProjectType;
 

--- a/src/components/project/project-member/dto/project-member.dto.ts
+++ b/src/components/project/project-member/dto/project-member.dto.ts
@@ -1,3 +1,4 @@
+import { Type } from '@nestjs/common';
 import { DateTime } from 'luxon';
 import { Field, ObjectType } from 'type-graphql';
 import { DateTimeField, Resource } from '../../../../common';
@@ -8,6 +9,9 @@ import { SecuredRoles } from './role.dto';
   implements: [Resource],
 })
 export class ProjectMember extends Resource {
+  /* TS wants a public constructor for "ClassType" */
+  static classType = (ProjectMember as any) as Type<ProjectMember>;
+
   @Field()
   readonly user: SecuredUser;
 

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -101,14 +101,13 @@ export class ProjectMemberService {
     try {
       await this.db.createNode({
         session,
+        type: ProjectMember.classType,
         input: {
           id,
           roles: [],
           ...input,
         },
         acls,
-        baseNodeLabel: 'ProjectMember',
-        aclEditProp: 'canCreateProjectMember',
       });
       //connect the User to the ProjectMember
       const query = `

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -312,10 +312,9 @@ export class ProjectService {
     try {
       await this.db.createNode({
         session,
+        type: Project.classType,
         input: createInput,
         acls,
-        baseNodeLabel: 'Project',
-        aclEditProp: 'canCreateProject',
       });
 
       // TODO: locations are not hooked up yet

--- a/src/components/user/education/dto/education.dto.ts
+++ b/src/components/user/education/dto/education.dto.ts
@@ -1,3 +1,4 @@
+import { Type } from '@nestjs/common';
 import { GraphQLString } from 'graphql';
 import { Field, ObjectType, registerEnumType } from 'type-graphql';
 import { Resource, SecuredProperty, SecuredString } from '../../../../common';
@@ -24,6 +25,9 @@ export abstract class SecuredDegree extends SecuredProperty<string>(
   implements: [Resource],
 })
 export class Education extends Resource {
+  /* TS wants a public constructor for "ClassType" */
+  static classType = (Education as any) as Type<Education>;
+
   @Field()
   readonly degree: SecuredDegree;
 

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -60,10 +60,9 @@ export class EducationService {
     try {
       await this.db.createNode({
         session,
+        type: Education.classType,
         input: { id, ...input },
         acls,
-        baseNodeLabel: 'Education',
-        aclEditProp: 'canCreateEducation',
       });
     } catch (e) {
       console.log(e);

--- a/src/components/user/unavailability/dto/unavailability.dto.ts
+++ b/src/components/user/unavailability/dto/unavailability.dto.ts
@@ -1,3 +1,4 @@
+import { Type } from '@nestjs/common';
 import { Field, ObjectType } from 'type-graphql';
 import {
   DateTimeField,
@@ -10,6 +11,9 @@ import {
   implements: [Resource],
 })
 export class Unavailability extends Resource {
+  /* TS wants a public constructor for "ClassType" */
+  static classType = (Unavailability as any) as Type<Unavailability>;
+
   @Field()
   readonly description: SecuredString;
 

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -33,10 +33,9 @@ export class UnavailabilityService {
     try {
       await this.db.createNode({
         session,
+        type: Unavailability.classType,
         input: { id, ...input },
         acls,
-        baseNodeLabel: 'Unavailability',
-        aclEditProp: 'canCreateUnavailability',
       });
     } catch {
       this.logger.error(`Could not create unavailability`, {

--- a/src/core/database/cypher.factory.ts
+++ b/src/core/database/cypher.factory.ts
@@ -45,7 +45,7 @@ export const CypherFactory: FactoryProvider<Connection> = {
       if (session) {
         const origRun = session.run;
         session.run = function(this: never, origStatement, parameters, conf) {
-          const statement = stripIndent(origStatement);
+          const statement = stripIndent(origStatement.slice(0, -1)) + ';';
           logger.debug('\n' + statement, parameters);
 
           const params = parameters


### PR DESCRIPTION
Previously the generic, `TObject`, was not inferred with `createNode`. So this generic was meaningless without explicitly defining it (`createNode<Foo>(...)`).

I changed it to pass in `type` so it can automatically be inferred.
We also use this `type` we also default the `baseNodeLabel` and `aclEditProp` (unless `false`)

---

I also abstracted the session matching query boilerplate to its own function