### PR TITLE
Move Session logic

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -13,3 +13,4 @@ export * from './resource.dto';
 export * from './secured-list';
 export * from './secured-property';
 export * from './sensitivity.enum';
+export { ISession, Session } from './session';

--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -1,0 +1,33 @@
+import {
+  ArgumentMetadata,
+  Inject,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
+import { Context } from '@nestjs/graphql';
+import { Request } from 'express';
+import { DateTime } from 'luxon';
+
+export const Session = () => Context('request', LazySessionPipe);
+
+// Prefixed with `I` so it can be used in conjunction with decorator
+// eslint-disable-next-line @typescript-eslint/interface-name-prefix
+export interface ISession {
+  token: string;
+  issuedAt: DateTime;
+  owningOrgId?: string;
+  userId?: string;
+}
+
+export const SESSION_PIPE_TOKEN = Symbol('SessionPipe');
+
+@Injectable()
+class LazySessionPipe implements PipeTransform<Request, Promise<ISession>> {
+  constructor(
+    @Inject(SESSION_PIPE_TOKEN) private readonly pipe: LazySessionPipe
+  ) {}
+
+  transform(request: Request, metadata: ArgumentMetadata): Promise<ISession> {
+    return this.pipe.transform(request, metadata);
+  }
+}

--- a/src/components/auth/auth.module.ts
+++ b/src/components/auth/auth.module.ts
@@ -1,13 +1,19 @@
-import { forwardRef, Global, Module } from '@nestjs/common';
+import { forwardRef, Global, Module, Provider } from '@nestjs/common';
+import { SESSION_PIPE_TOKEN } from '../../common/session';
 import { UserModule } from '../user';
 import { AuthResolver } from './auth.resolver';
 import { AuthService } from './auth.service';
-import { SessionPipe } from './session';
+import { SessionPipe } from './session.pipe';
+
+const ProvideSessionPipe: Provider = {
+  provide: SESSION_PIPE_TOKEN,
+  useExisting: SessionPipe,
+};
 
 @Global()
 @Module({
   imports: [forwardRef(() => UserModule)],
-  providers: [AuthResolver, AuthService, SessionPipe],
-  exports: [AuthService, SessionPipe],
+  providers: [AuthResolver, AuthService, SessionPipe, ProvideSessionPipe],
+  exports: [AuthService, SessionPipe, SESSION_PIPE_TOKEN],
 })
 export class AuthModule {}

--- a/src/components/auth/auth.resolver.ts
+++ b/src/components/auth/auth.resolver.ts
@@ -1,4 +1,5 @@
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { ISession, Session } from '../../common';
 import { UserService } from '../user';
 import {
   CreateSessionOutput,
@@ -7,7 +8,6 @@ import {
   ResetPasswordInput,
 } from './auth.dto';
 import { AuthService } from './auth.service';
-import { ISession, Session } from './session';
 
 @Resolver()
 export class AuthResolver {
@@ -32,9 +32,7 @@ export class AuthResolver {
     @Args('input') input: LoginInput
   ): Promise<LoginOutput> {
     const userId = await this.authService.login(input, session);
-    const loggedInSession = await this.authService.decodeAndVerifyToken(
-      session.token
-    );
+    const loggedInSession = await this.authService.createSession(session.token);
     if (!userId) {
       return { success: false };
     }

--- a/src/components/auth/auth.service.ts
+++ b/src/components/auth/auth.service.ts
@@ -3,9 +3,9 @@ import * as argon2 from 'argon2';
 import { SES } from 'aws-sdk';
 import { sign, verify } from 'jsonwebtoken';
 import { DateTime } from 'luxon';
+import { ISession } from '../../common';
 import { ConfigService, DatabaseService, ILogger, Logger } from '../../core';
 import { LoginInput, ResetPasswordInput } from './auth.dto';
-import { ISession } from './session';
 
 interface JwtPayload {
   iat: number;
@@ -144,7 +144,7 @@ export class AuthService {
       .run();
   }
 
-  async decodeAndVerifyToken(token: string): Promise<ISession> {
+  async createSession(token: string): Promise<ISession> {
     this.logger.debug('Decoding token', { token });
 
     const { iat } = this.decodeJWT(token);

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -1,3 +1,2 @@
-export * from './session';
 export * from './auth.service';
 export * from './auth.module';

--- a/src/components/budget/budget.resolver.ts
+++ b/src/components/budget/budget.resolver.ts
@@ -1,6 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg } from '../../common';
-import { ISession, Session } from '../auth';
+import { IdArg, ISession, Session } from '../../common';
 import { BudgetService } from './budget.service';
 import {
   Budget,

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -4,8 +4,8 @@ import {
   NotImplementedException,
 } from '@nestjs/common';
 import { generate } from 'shortid';
+import { ISession } from '../../common';
 import { DatabaseService, ILogger, Logger } from '../../core';
-import { ISession } from '../auth';
 import {
   Budget,
   BudgetListInput,

--- a/src/components/ceremony/ceremony.resolver.ts
+++ b/src/components/ceremony/ceremony.resolver.ts
@@ -1,6 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg } from '../../common';
-import { ISession, Session } from '../auth';
+import { IdArg, ISession, Session } from '../../common';
 import { CeremonyService } from './ceremony.service';
 import {
   Ceremony,

--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotImplementedException } from '@nestjs/common';
+import { ISession } from '../../common';
 import { DatabaseService, ILogger, Logger } from '../../core';
-import { ISession } from '../auth';
 import {
   Ceremony,
   CeremonyListInput,

--- a/src/components/engagement/engagement.resolver.ts
+++ b/src/components/engagement/engagement.resolver.ts
@@ -1,6 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg } from '../../common';
-import { ISession, Session } from '../auth';
+import { IdArg, ISession, Session } from '../../common';
 import {
   CreateInternshipEngagementInput,
   CreateInternshipEngagementOutput,

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotImplementedException } from '@nestjs/common';
-import { ISession } from '../auth';
+import { ISession } from '../../common';
 import { ProductListInput, SecuredProductList } from '../product';
 import {
   CreateInternshipEngagement,

--- a/src/components/engagement/language-engagement.resolver.ts
+++ b/src/components/engagement/language-engagement.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Parent, ResolveProperty, Resolver } from '@nestjs/graphql';
-import { ISession, Session } from '../auth';
+import { ISession, Session } from '../../common';
 import { ProductListInput, SecuredProductList } from '../product/dto';
 import { LanguageEngagement } from './dto';
 import { EngagementService } from './engagement.service';

--- a/src/components/file/directory.resolver.ts
+++ b/src/components/file/directory.resolver.ts
@@ -6,8 +6,7 @@ import {
   ResolveProperty,
   Resolver,
 } from '@nestjs/graphql';
-import { IdArg } from '../../common';
-import { ISession, Session } from '../auth';
+import { IdArg, ISession, Session } from '../../common';
 import { Directory, FileListInput, FileListOutput } from './dto';
 import { FileService } from './file.service';
 

--- a/src/components/file/file.resolver.ts
+++ b/src/components/file/file.resolver.ts
@@ -6,8 +6,7 @@ import {
   ResolveProperty,
   Resolver,
 } from '@nestjs/graphql';
-import { IdArg } from '../../common';
-import { ISession, Session } from '../auth';
+import { IdArg, ISession, Session } from '../../common';
 import {
   CreateFileInput,
   File,

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -1,10 +1,9 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { DateTime } from 'luxon';
 import { generate } from 'shortid';
-import { NotImplementedError } from '../../common';
+import { ISession, NotImplementedError } from '../../common';
 import { ILogger, Logger } from '../../core';
 import { DatabaseService } from '../../core/database/database.service';
-import { ISession } from '../auth';
 import { UserService } from '../user';
 import {
   CreateFileInput,

--- a/src/components/language/language.resolver.ts
+++ b/src/components/language/language.resolver.ts
@@ -1,6 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg } from '../../common';
-import { ISession, Session } from '../auth';
+import { IdArg, ISession, Session } from '../../common';
 import {
   CreateLanguageInput,
   CreateLanguageOutput,

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -1,8 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { generate } from 'shortid';
-import { Sensitivity } from '../../common';
+import { ISession, Sensitivity } from '../../common';
 import { DatabaseService, ILogger, Logger } from '../../core';
-import { ISession } from '../auth';
 import {
   CreateLanguage,
   Language,

--- a/src/components/location/location.resolver.ts
+++ b/src/components/location/location.resolver.ts
@@ -1,6 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg } from '../../common';
-import { ISession, Session } from '../auth';
+import { IdArg, ISession, Session } from '../../common';
 import {
   CreateCountryInput,
   CreateCountryOutput,

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -5,8 +5,8 @@ import {
 } from '@nestjs/common';
 import { DateTime } from 'luxon';
 import { generate } from 'shortid';
+import { ISession } from '../../common';
 import { DatabaseService, ILogger, Logger } from '../../core';
-import { ISession } from '../auth';
 import { RedactedUser, User, UserService } from '../user';
 import {
   Country,

--- a/src/components/organization/organization.resolver.ts
+++ b/src/components/organization/organization.resolver.ts
@@ -1,6 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg } from '../../common';
-import { ISession, Session } from '../auth/session'; // avoid cyclic dep (auth -> user -> org)
+import { IdArg, ISession, Session } from '../../common';
 import {
   CreateOrganizationInput,
   CreateOrganizationOutput,

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { generate } from 'shortid';
+import { ISession } from '../../common';
 import { DatabaseService, ILogger, Logger } from '../../core';
-import { ISession } from '../auth';
 import {
   CreateOrganization,
   Organization,

--- a/src/components/partnership/partnership.resolver.ts
+++ b/src/components/partnership/partnership.resolver.ts
@@ -1,6 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg } from '../../common';
-import { ISession, Session } from '../auth';
+import { IdArg, ISession, Session } from '../../common';
 import {
   CreatePartnershipInput,
   CreatePartnershipOutput,

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { generate } from 'shortid';
+import { ISession } from '../../common';
 import { DatabaseService, ILogger, Logger } from '../../core';
-import { ISession } from '../auth';
 import {
   CreatePartnership,
   Partnership,

--- a/src/components/product/product.resolver.ts
+++ b/src/components/product/product.resolver.ts
@@ -1,6 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg } from '../../common';
-import { ISession, Session } from '../auth';
+import { IdArg, ISession, Session } from '../../common';
 import {
   CreateProductInput,
   CreateProductOutput,

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { generate } from 'shortid';
+import { ISession } from '../../common';
 import { DatabaseService, ILogger, Logger } from '../../core';
-import { ISession } from '../auth';
 import {
   CreateProduct,
   MethodologyToApproach,

--- a/src/components/project/internship-project.resolver.ts
+++ b/src/components/project/internship-project.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Parent, ResolveProperty, Resolver } from '@nestjs/graphql';
-import { ISession, Session } from '../auth';
+import { ISession, Session } from '../../common';
 import {
   EngagementListInput,
   SecuredInternshipEngagementList,

--- a/src/components/project/project-member/project-member.resolver.ts
+++ b/src/components/project/project-member/project-member.resolver.ts
@@ -1,6 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg } from '../../../common';
-import { ISession, Session } from '../../auth';
+import { IdArg, ISession, Session } from '../../../common';
 import {
   CreateProjectMemberInput,
   CreateProjectMemberOutput,

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { generate } from 'shortid';
+import { ISession } from '../../../common';
 import { DatabaseService, ILogger, Logger } from '../../../core';
-import { ISession } from '../../auth';
 import { RedactedUser, User, UserService } from '../../user';
 import {
   CreateProjectMember,

--- a/src/components/project/project.resolver.ts
+++ b/src/components/project/project.resolver.ts
@@ -1,6 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg } from '../../common';
-import { ISession, Session } from '../auth';
+import { IdArg, ISession, Session } from '../../common';
 import {
   CreateProjectInput,
   CreateProjectOutput,

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -5,9 +5,8 @@ import {
 } from '@nestjs/common';
 import { DateTime } from 'luxon';
 import { generate } from 'shortid';
-import { Sensitivity } from '../../common';
+import { ISession, Sensitivity } from '../../common';
 import { DatabaseService, ILogger, Logger } from '../../core';
-import { ISession } from '../auth';
 import {
   EngagementListInput,
   SecuredInternshipEngagementList,

--- a/src/components/project/translation-project.resolver.ts
+++ b/src/components/project/translation-project.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Parent, ResolveProperty, Resolver } from '@nestjs/graphql';
-import { ISession, Session } from '../auth';
+import { ISession, Session } from '../../common';
 import {
   EngagementListInput,
   SecuredLanguageEngagementList,

--- a/src/components/user/education/education.resolver.ts
+++ b/src/components/user/education/education.resolver.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Args, Mutation, Query } from '@nestjs/graphql';
-import { IdArg } from '../../../common';
-import { ISession, Session } from '../../auth';
+import { IdArg, ISession, Session } from '../../../common';
 import {
   CreateEducationInput,
   CreateEducationOutput,

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { generate } from 'shortid';
+import { ISession } from '../../../common';
 import { DatabaseService, ILogger, Logger } from '../../../core';
-import { ISession } from '../../auth';
 import {
   CreateEducation,
   Education,

--- a/src/components/user/unavailability/unavailability.resolver.ts
+++ b/src/components/user/unavailability/unavailability.resolver.ts
@@ -1,6 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg } from '../../../common';
-import { ISession, Session } from '../../auth';
+import { IdArg, ISession, Session } from '../../../common';
 import {
   CreateUnavailabilityInput,
   CreateUnavailabilityOutput,

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { generate } from 'shortid';
+import { ISession } from '../../../common';
 import { DatabaseService, ILogger, Logger } from '../../../core';
-import { ISession } from '../../auth';
 import {
   CreateUnavailability,
   Unavailability,

--- a/src/components/user/user.resolver.ts
+++ b/src/components/user/user.resolver.ts
@@ -6,8 +6,7 @@ import {
   ResolveProperty,
   Resolver,
 } from '@nestjs/graphql';
-import { IdArg } from '../../common';
-import { ISession, Session } from '../auth';
+import { IdArg, ISession, Session } from '../../common';
 import {
   OrganizationListInput,
   SecuredOrganizationList,

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -3,8 +3,8 @@ import * as argon2 from 'argon2';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { generate } from 'shortid';
+import { ISession } from '../../common';
 import { DatabaseService, ILogger, Logger, OnIndex } from '../../core';
-import { ISession } from '../auth';
 import {
   OrganizationListInput,
   OrganizationService,

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -14,13 +14,13 @@ import {
 import { cloneDeep, Many, upperFirst } from 'lodash';
 import { DateTime, Duration } from 'luxon';
 import {
+  ISession,
   isSecured,
   Order,
   Resource,
   unwrapSecured,
   UnwrapSecured,
 } from '../../common';
-import { ISession } from '../../components/auth';
 import { ILogger, Logger } from '..';
 
 interface ReadPropertyResult {


### PR DESCRIPTION
- Move `Session` decorator & interface to _common_ module
- Create `LazySessionPipe` to lazily reference real `SessionPipe` (indirectly) which is injected via `SESSION_PIPE_TOKEN`
- Have the `AuthModule` _provide_ `SESSION_PIPE_TOKEN` via `SessionPipe`

This way everyone is referencing `Session` decorator and `ISession` interface from the _common_ module, but that module doesn't know anything about `AuthModule` or its `SessionPIpe`.
This fixes the circular dependency problem we were having with the decorator.

