### PR TITLE
Prettier v2

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,2 +1,1 @@
-arrowParens: avoid
 singleQuote: true

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,2 +1,2 @@
-trailingComma: es5
+arrowParens: avoid
 singleQuote: true

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "jest": "^25.1.0",
     "lint-staged": "^10.0.8",
     "madge": "^3.8.0",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.4",
     "supertest": "^4.0.2",
     "ts-jest": "^25.2.1",
     "ts-loader": "^6.1.1",

--- a/src/common/calendar-date.ts
+++ b/src/common/calendar-date.ts
@@ -151,7 +151,9 @@ export class CalendarDate extends DateTime {
   }
 }
 
-(CalendarDate.prototype as any)[inspect.custom] = function(this: CalendarDate) {
+(CalendarDate.prototype as any)[inspect.custom] = function (
+  this: CalendarDate
+) {
   const str = this.toLocaleString(DateTime.DATE_SHORT);
   return `[Date] ${str}`;
 };

--- a/src/common/luxon.graphql.ts
+++ b/src/common/luxon.graphql.ts
@@ -14,7 +14,7 @@ Settings.throwOnInvalid = true;
 export const DateTimeField = (options?: AdvancedOptions) =>
   applyDecorators(
     Field(() => DateTime, options),
-    Transform(value => DateTime.fromISO(value), {
+    Transform((value) => DateTime.fromISO(value), {
       toClassOnly: true,
     }) as PropertyDecorator
   );
@@ -22,7 +22,7 @@ export const DateTimeField = (options?: AdvancedOptions) =>
 export const DateField = (options?: AdvancedOptions) =>
   applyDecorators(
     Field(() => CalendarDate, options),
-    Transform(value => CalendarDate.fromISO(value), {
+    Transform((value) => CalendarDate.fromISO(value), {
       toClassOnly: true,
     }) as PropertyDecorator
   );

--- a/src/common/luxon.neo4j.ts
+++ b/src/common/luxon.neo4j.ts
@@ -12,12 +12,12 @@ declare module 'luxon' {
 }
 
 // eslint-disable-next-line @typescript-eslint/unbound-method
-DateTime.prototype.toNeo4JDate = function(this: DateTime) {
+DateTime.prototype.toNeo4JDate = function (this: DateTime) {
   return new NeoDate(this.year, this.month, this.day);
 };
 
 // eslint-disable-next-line @typescript-eslint/unbound-method
-DateTime.prototype.toNeo4JDateTime = function(this: DateTime) {
+DateTime.prototype.toNeo4JDateTime = function (this: DateTime) {
   return new NeoDateTime(
     this.year,
     this.month,
@@ -31,7 +31,7 @@ DateTime.prototype.toNeo4JDateTime = function(this: DateTime) {
   );
 };
 
-(DateTime.prototype as any)[inspect.custom] = function(
+(DateTime.prototype as any)[inspect.custom] = function (
   this: DateTime,
   depth: number,
   _options: InspectOptions

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -176,7 +176,7 @@ export class BudgetService {
       .run();
 
     const items = await Promise.all(
-      projBudgets.map(async budget => this.readOne(budget.budgetId, session))
+      projBudgets.map(async (budget) => this.readOne(budget.budgetId, session))
     );
 
     return {
@@ -204,7 +204,7 @@ export class BudgetService {
     // cascade delete each budget record in this budget
     if (budget.records) {
       await Promise.all(
-        budget.records.map(async br => {
+        budget.records.map(async (br) => {
           if (br.value) {
             await this.deleteRecord(br.value, session);
           }
@@ -394,7 +394,7 @@ export class BudgetService {
       .run();
 
     const items = await Promise.all(
-      brs.map(async br => this.readOneRecord(br.budgetRecordId, session))
+      brs.map(async (br) => this.readOneRecord(br.budgetRecordId, session))
     );
 
     return {

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -40,10 +40,7 @@ export class EngagementService {
     MATCH (place {id: $id, active: true}) RETURN labels(place) as labels
     `;
 
-    const results = await this.db
-      .query()
-      .raw(qr, { id })
-      .first();
+    const results = await this.db.query().raw(qr, { id }).first();
     const label: string = results?.labels?.[0] ?? '';
 
     let query = `

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -454,7 +454,7 @@ export class EngagementService {
       .run();
 
     const items = await Promise.all(
-      result.map(row => this.readOne(row.id, session))
+      result.map((row) => this.readOne(row.id, session))
     );
 
     return {

--- a/src/components/file/dto/node.ts
+++ b/src/components/file/dto/node.ts
@@ -112,7 +112,7 @@ export const FileOrDirectory = createUnionType({
   name: 'FileOrDirectory',
   description: '',
   types: () => [File.classType, Directory.classType],
-  resolveType: value =>
+  resolveType: (value) =>
     value.type === FileNodeType.Directory
       ? Directory.classType
       : File.classType,

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -289,10 +289,7 @@ export class FileService {
         RETURN
           file, parent
       `;
-    await this.db
-      .query()
-      .raw(qryOne, { parentId })
-      .first();
+    await this.db.query().raw(qryOne, { parentId }).first();
 
     return this.getFile(fileId, session);
   }

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -57,10 +57,7 @@ export class LanguageService {
       //'CREATE CONSTRAINT ON (n:Property) ASSERT EXISTS(n.active)',
     ];
     for (const query of constraints) {
-      await this.db
-        .query()
-        .raw(query)
-        .run();
+      await this.db.query().raw(query).run();
     }
   }
 

--- a/src/components/location/dto/location.dto.ts
+++ b/src/components/location/dto/location.dto.ts
@@ -77,7 +77,7 @@ export class SecuredCountry extends SecuredProperty(Country) {}
 export const Location = createUnionType({
   name: 'Location',
   types: () => [Country.classType, Region.classType, Zone.classType],
-  resolveType: value => {
+  resolveType: (value) => {
     if ('region' in value) {
       return Country.classType;
     }

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -136,7 +136,7 @@ export class LocationService {
       .run();
 
     const items = await Promise.all(
-      result.map(row => this.readOne(row.id, session))
+      result.map((row) => this.readOne(row.id, session))
     );
 
     return {

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -80,10 +80,7 @@ export class LocationService {
       'CREATE CONSTRAINT ON (n:LocationName) ASSERT n.value IS UNIQUE',
     ];
     for (const query of constraints) {
-      await this.db
-        .query()
-        .raw(query)
-        .run();
+      await this.db.query().raw(query).run();
     }
   }
 
@@ -92,10 +89,7 @@ export class LocationService {
     MATCH (place {id: $id, active: true}) RETURN labels(place) as labels
     `;
 
-    const results = await this.db
-      .query()
-      .raw(query, { id })
-      .first();
+    const results = await this.db.query().raw(query, { id }).first();
     const label: string = results?.labels?.[0] ?? '';
     this.logger.info('Looking for ', { label, id, userId: session.userId });
     switch (label) {

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -33,10 +33,7 @@ export class OrganizationService {
       'CREATE CONSTRAINT ON (n:OrgName) ASSERT n.value IS UNIQUE',
     ];
     for (const query of constraints) {
-      await this.db
-        .query()
-        .raw(query)
-        .run();
+      await this.db.query().raw(query).run();
     }
   }
 

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -61,10 +61,7 @@ export class ProjectService {
       'CREATE CONSTRAINT ON (n:ProjectName) ASSERT n.value IS UNIQUE',
     ];
     for (const query of constraints) {
-      await this.db
-        .query()
-        .raw(query)
-        .run();
+      await this.db.query().raw(query).run();
     }
   }
 

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -243,7 +243,7 @@ export class ProjectService {
     });
 
     return {
-      items: result.items.map(item => ({
+      items: result.items.map((item) => ({
         ...item,
         location: {
           value: undefined,

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -67,10 +67,7 @@ export class UserService {
       'CREATE CONSTRAINT ON (n:Property) ASSERT EXISTS(n.active)',
     ];
     for (const query of constraints) {
-      await this.db
-        .query()
-        .raw(query)
-        .run();
+      await this.db.query().raw(query).run();
     }
   }
 

--- a/src/core/config/environment.service.ts
+++ b/src/core/config/environment.service.ts
@@ -26,7 +26,7 @@ export class EnvironmentService {
 
     const files = [`.env.${env}.local`, `.env.${env}`, `.env.local`, `.env`]
       .filter(isString)
-      .map(file => join(rootPath, file));
+      .map((file) => join(rootPath, file));
 
     for (const file of files) {
       if (!fs.existsSync(file)) {
@@ -57,15 +57,15 @@ export class EnvironmentService {
   }
 
   string(key: string) {
-    return this.wrap(key, raw => raw);
+    return this.wrap(key, (raw) => raw);
   }
 
   boolean(key: string) {
-    return this.wrap(key, raw => raw.toLowerCase() === 'true');
+    return this.wrap(key, (raw) => raw.toLowerCase() === 'true');
   }
 
   number(key: string) {
-    return this.wrap(key, raw => {
+    return this.wrap(key, (raw) => {
       const val = raw.toLowerCase();
       if (val === 'infinity') {
         return Infinity;

--- a/src/core/database/cypher.factory.ts
+++ b/src/core/database/cypher.factory.ts
@@ -40,11 +40,11 @@ export const CypherFactory: FactoryProvider<Connection> = {
     // wrap session.run calls to add logging
     /* eslint-disable @typescript-eslint/unbound-method */
     const origSession = conn.session;
-    conn.session = function(this: never) {
+    conn.session = function (this: never) {
       const session: Session | null = origSession.call(conn);
       if (session) {
         const origRun = session.run;
-        session.run = function(this: never, origStatement, parameters, conf) {
+        session.run = function (this: never, origStatement, parameters, conf) {
           const statement = stripIndent(origStatement.slice(0, -1)) + ';';
           logger.debug('\n' + statement, parameters);
 
@@ -54,7 +54,7 @@ export const CypherFactory: FactoryProvider<Connection> = {
           const result = origRun.call(session, statement, params, conf);
 
           const origSubscribe = result.subscribe;
-          result.subscribe = function(this: never, observer) {
+          result.subscribe = function (this: never, observer) {
             if (observer.onError) {
               const onError = observer.onError;
               observer.onError = e => {

--- a/src/core/database/cypher.factory.ts
+++ b/src/core/database/cypher.factory.ts
@@ -57,7 +57,7 @@ export const CypherFactory: FactoryProvider<Connection> = {
           result.subscribe = function (this: never, observer) {
             if (observer.onError) {
               const onError = observer.onError;
-              observer.onError = e => {
+              observer.onError = (e) => {
                 const patched = jestSkipFileInExceptionSource(e, __filename);
                 onError(patched);
               };

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -399,7 +399,7 @@ export class DatabaseService {
         },
 
         // return the rest of the requested properties
-        ...props.map(prop => {
+        ...props.map((prop) => {
           const propName = (typeof prop === 'object'
             ? prop.name
             : prop) as string;
@@ -418,7 +418,7 @@ export class DatabaseService {
     // if skip + count is less than total, there is more
     const hasMore = (input.page - 1) * input.count + input.count < total;
 
-    const items = result.map<TObject>(row => {
+    const items = result.map<TObject>((row) => {
       const item: any = {
         id: row.id,
         createdAt: row.createdAt,

--- a/src/core/database/indexer/indexer.module.ts
+++ b/src/core/database/indexer/indexer.module.ts
@@ -20,7 +20,7 @@ export class IndexerModule implements OnModuleInit {
     );
     this.logger.info('Discovered indexers', { count: discovered.length });
 
-    const indexers = discovered.map(h => h.discoveredMethod);
+    const indexers = discovered.map((h) => h.discoveredMethod);
     for (const { handler, methodName, parentClass } of indexers) {
       this.logger.debug('Running indexer', {
         class: parentClass.name,

--- a/src/core/database/indexer/indexer.module.ts
+++ b/src/core/database/indexer/indexer.module.ts
@@ -36,10 +36,7 @@ export class IndexerModule implements OnModuleInit {
           : [maybeStatements]
         : [];
       for (const statement of statements) {
-        await this.db
-          .query()
-          .raw(statement)
-          .run();
+        await this.db.query().raw(statement).run();
       }
     }
 

--- a/src/core/database/parameter-transformer.service.ts
+++ b/src/core/database/parameter-transformer.service.ts
@@ -46,11 +46,11 @@ export class ParameterTransformer {
     }
 
     if (Array.isArray(value)) {
-      return value.map(v => this.transformValue(v));
+      return value.map((v) => this.transformValue(v));
     }
 
     if (typeof value === 'object') {
-      return mapValues(value, v => this.transformValue(v));
+      return mapValues(value, (v) => this.transformValue(v));
     }
 
     throw new Error(`Could not determine how to transform value: ${value}`);

--- a/src/core/database/transaction.ts
+++ b/src/core/database/transaction.ts
@@ -91,7 +91,7 @@ export class Transaction implements QueryConnection {
    */
   async close() {
     if (this.session) {
-      await new Promise(resolve => this.session?.close(resolve));
+      await new Promise((resolve) => this.session?.close(resolve));
       this.session = null;
     }
   }

--- a/src/core/logger/formatters.ts
+++ b/src/core/logger/formatters.ts
@@ -13,7 +13,7 @@ export const metadata = () =>
   });
 
 export const maskSecrets = () =>
-  format(info => {
+  format((info) => {
     info.metadata = mapValues(info.metadata, (val: string, key) =>
       /(password|token|key)/i.exec(key)
         ? `${'*'.repeat(Math.min(val.slice(0, -3).length, 20)) + val.slice(-3)}`
@@ -22,14 +22,14 @@ export const maskSecrets = () =>
     return info;
   })();
 
-export const timestamp = format(info => {
+export const timestamp = format((info) => {
   info.timestamp = DateTime.local().toLocaleString(
     DateTime.DATETIME_SHORT_WITH_SECONDS
   );
   return info;
 });
 
-export const pid = format(info => {
+export const pid = format((info) => {
   info.pid = process.pid;
   return info;
 });
@@ -38,7 +38,7 @@ export const colorize = () =>
   colorsEnabled ? format.colorize({ message: true }) : format(identity)();
 
 export const exceptionInfo = () =>
-  format(info => {
+  format((info) => {
     if (!info.exception) {
       return info;
     }
@@ -61,7 +61,7 @@ export const exceptionInfo = () =>
   })();
 
 export const formatException = () =>
-  format(info => {
+  format((info) => {
     if (!info.exception) {
       return info;
     }
@@ -96,7 +96,7 @@ export const formatException = () =>
   })();
 
 export const printForCli = () =>
-  format.printf(info => {
+  format.printf((info) => {
     if (info[MESSAGE]) {
       return info[MESSAGE];
     }

--- a/src/core/logger/level-matcher.ts
+++ b/src/core/logger/level-matcher.ts
@@ -90,8 +90,8 @@ export class LevelMatcher {
     }
     for (const { include, exclude, level } of this.matchers) {
       const matched =
-        include.some(regex => regex.exec(name)) &&
-        !exclude.some(regex => regex.exec(name));
+        include.some((regex) => regex.exec(name)) &&
+        !exclude.some((regex) => regex.exec(name));
       if (matched) {
         this.cached[name] = level;
         return level;

--- a/src/core/logger/winston-logger.service.ts
+++ b/src/core/logger/winston-logger.service.ts
@@ -51,7 +51,7 @@ export class WinstonLoggerService extends AbstractLogger
   async onModuleDestroy() {
     const finish = Promise.all(
       this.logger.transports.map(
-        t => new Promise(resolve => t.on('finish', resolve))
+        (t) => new Promise((resolve) => t.on('finish', resolve))
       )
     );
     this.closing = true;

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,7 @@ async function bootstrap() {
       );
   });
 }
-bootstrap().catch(err => {
+bootstrap().catch((err) => {
   // eslint-disable-next-line no-console
   console.error(err);
   process.exit(1);

--- a/test/country.e2e-spec.ts
+++ b/test/country.e2e-spec.ts
@@ -180,7 +180,7 @@ describe('Country e2e', () => {
 
   it.skip('returns a list of countries', async () => {
     await Promise.all(
-      ['Arendale', 'South Arendale'].map(e => createCountry(app, { name: e }))
+      ['Arendale', 'South Arendale'].map((e) => createCountry(app, { name: e }))
     );
 
     const { locations } = await app.graphql.query(gql`

--- a/test/region.e2e-spec.ts
+++ b/test/region.e2e-spec.ts
@@ -224,7 +224,7 @@ describe('Region e2e', () => {
   it.skip('returns a list of regions', async () => {
     // create 2 regions with similar names
     await Promise.all(
-      ['Western Mainlandia', 'Eastern Mainlandia'].map(regionName =>
+      ['Western Mainlandia', 'Eastern Mainlandia'].map((regionName) =>
         createRegion(app, {
           name: regionName,
           directorId: director.id,

--- a/test/utility/create-graphql-client.ts
+++ b/test/utility/create-graphql-client.ts
@@ -104,7 +104,7 @@ const reportError = (
     msg += `\nPath: ${e.path}`;
   }
   const location = (e.locations || [])
-    .map(l => `  - line ${l.line}, column ${l.column}`)
+    .map((l) => `  - line ${l.line}, column ${l.column}`)
     .join('\n');
   if (location) {
     msg += `\nLocations:\n${location}`;

--- a/test/zone.e2e-spec.ts
+++ b/test/zone.e2e-spec.ts
@@ -155,7 +155,7 @@ describe('Zone e2e', () => {
   it.skip('returns a list of zones', async () => {
     // create 2 zones
     await Promise.all(
-      ['Asia1', 'Asia2'].map(e =>
+      ['Asia1', 'Asia2'].map((e) =>
         createZone(app, { name: e, directorId: director.id })
       )
     );

--- a/tools/eslint/no-unused-vars.ts
+++ b/tools/eslint/no-unused-vars.ts
@@ -37,7 +37,7 @@ export const noUnusedVars: RuleModule<string, any[]> = {
         return;
       }
 
-      descriptor.fix = fixer => {
+      descriptor.fix = (fixer) => {
         if (isImportDeclaration(node)) {
           return fixer.remove(node);
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3639,7 +3639,7 @@ __metadata:
     luxon: ^1.21.3
     madge: ^3.8.0
     neo4j-driver: 1.7.6
-    prettier: ^1.19.1
+    prettier: ^2.0.4
     reflect-metadata: ^0.1.13
     rimraf: ^3.0.0
     rxjs: ^6.5.3
@@ -9288,12 +9288,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^1.19.1":
-  version: 1.19.1
-  resolution: "prettier@npm:1.19.1"
+"prettier@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "prettier@npm:2.0.4"
   bin:
-    prettier: ./bin-prettier.js
-  checksum: 2/e5fcdfe5e159ef5c5480245353cf8fb5bbd1b8afff266f31f281641825238f8a645e58472f77cd75a09ccc45d44c335466e8d901ec138c2bda05e1bd6ea1077c
+    prettier: bin-prettier.js
+  checksum: 2/a43343ac00250ce239439a723e5b0860a46e4703542b925c962d8c3dfceab1f69a326ba4c8de2f24ad39c4daef07831439b0b237cda9c63e4981164075e7dc5a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# [Prettier 2.0 “2020”](https://prettier.io/blog/2020/03/21/2.0.0.html)

## Highlights:
- Support for new TS 3.8 syntax
- Improved method chain breaking heuristic ([example](https://github.com/SeedCompany/cord-api-v3/compare/prettier-v2?expand=1#diff-af9495af450c40fbc96f4780a03cb10cR292))
- `trailingComma` now defaults to `es5` 🎉 
- `arrowParens` now defaults to `always` - more below


## Arrow Parentheses: &nbsp;`(a) =>`

I typically think less chars is better, which is why I liked their former default of avoiding them.
But they've convinced me with this snippet from their blog post.

> At first glance, avoiding parentheses in the isolated example above may look like a better choice because it results in less visual noise. However, when Prettier removes parentheses, it becomes harder to add type annotations, extra arguments, default values, or a variety of other things. Consistent use of parentheses provides a better developer experience when editing real codebases, which justifies the change.

Also, this pic/tweet to drive it home:
[![](https://pbs.twimg.com/media/EGbiEVMWwAAzJwR?format=jpg&name=4096x4096)][tweet]

[tweet]: https://twitter.com/ManuelBieh/status/1181880524954050560