### PR TITLE
Convert createSession mutation to session query

### DIFF
--- a/src/components/authentication/authentication.dto.ts
+++ b/src/components/authentication/authentication.dto.ts
@@ -3,7 +3,7 @@ import { Field, InputType, ObjectType } from 'type-graphql';
 import { User } from '../user';
 
 @ObjectType()
-export abstract class CreateSessionOutput {
+export abstract class SessionOutput {
   @Field({
     nullable: true,
     description: stripIndent`
@@ -12,6 +12,13 @@ export abstract class CreateSessionOutput {
       This token is only returned when the \`browser\` argument is not set to \`true\`.`,
   })
   token?: string;
+
+  @Field(() => User, {
+    nullable: true,
+    description:
+      'Only returned if there is a logged-in user tied to the current session.',
+  })
+  user: User | null;
 }
 
 @InputType()

--- a/src/components/authentication/session.pipe.ts
+++ b/src/components/authentication/session.pipe.ts
@@ -60,6 +60,6 @@ export class SessionPipe implements PipeTransform<Request, Promise<ISession>> {
   }
 
   getTokenFromCookie(req: Request): string | null {
-    return req.cookies[this.config.session.cookieName] || null;
+    return req?.cookies?.[this.config.session.cookieName] || null;
   }
 }

--- a/test/utility/create-session.ts
+++ b/test/utility/create-session.ts
@@ -2,14 +2,14 @@ import { gql } from 'apollo-server-core';
 import { TestApp } from './create-app';
 
 export async function createSession(app: TestApp): Promise<string> {
-  const result = await app.graphql.mutate(gql`
-    mutation {
-      createSession {
+  const result = await app.graphql.query(gql`
+    query {
+      session {
         token
       }
     }
   `);
-  const token = result.createSession.token;
+  const token = result.session.token;
   expect(token).toBeTruthy();
   app.graphql.authToken = token;
   return token;


### PR DESCRIPTION
* Convert the `createSession` mutation to the `session` query
* Return a nullable `user` object in `session` query, for the currently-logged-in user