### PR TITLE
GraphQL CORS & Tweaks

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,8 +1,4 @@
 import { Module } from '@nestjs/common';
-import { GraphQLModule } from '@nestjs/graphql';
-import { ContextFunction } from 'apollo-server-core';
-import { Request, Response } from 'express';
-import { GqlContextType } from './common';
 import { DateScalar, DateTimeScalar } from './common/luxon.graphql';
 import { AdminModule } from './components/admin';
 import { AuthenticationModule } from './components/authentication';
@@ -21,24 +17,10 @@ import { UserModule } from './components/user';
 import { WorkflowModule } from './components/workflow/workflow.module';
 import { CoreModule, LoggerModule } from './core';
 
-const context: ContextFunction<
-  { req: Request; res: Response },
-  GqlContextType
-> = ({ req, res }) => ({
-  request: req,
-  response: res,
-});
-
 @Module({
   imports: [
     LoggerModule.forRoot(),
     CoreModule,
-    GraphQLModule.forRoot({
-      autoSchemaFile: 'schema.gql',
-      context,
-      playground: true, // enabled in all environments
-      introspection: true, // needed for playground
-    }),
     AdminModule,
     AuthenticationModule,
     AuthorizationModule,

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -63,7 +63,9 @@ export class ConfigService {
     // `cf\.com$` matches both root cf.com and all subdomains
     // `\/\/cf\.com$` matches only root cf.com
     const rawOrigin = this.env.string('CORS_ORIGIN').optional('*');
-    const origin = rawOrigin === '*' ? rawOrigin : new RegExp(rawOrigin);
+    // Always use regex instead of literal `*` so the current origin is returned
+    // instead of `*`. fetch credentials="include" requires specific origin.
+    const origin = rawOrigin === '*' ? /.*/ : new RegExp(rawOrigin);
     return {
       origin,
       credentials: true,

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -5,6 +5,7 @@ import { Request, Response } from 'express';
 import { GqlContextType } from '../common';
 import { AwsS3Factory } from './aws-s3.factory';
 import { ConfigModule } from './config/config.module';
+import { ConfigService } from './config/config.service';
 import { DatabaseModule } from './database/database.module';
 import { EmailModule } from './email';
 
@@ -22,11 +23,15 @@ const context: ContextFunction<
     ConfigModule,
     DatabaseModule,
     EmailModule,
-    GraphQLModule.forRoot({
-      autoSchemaFile: 'schema.gql',
-      context,
-      playground: true, // enabled in all environments
-      introspection: true, // needed for playground
+    GraphQLModule.forRootAsync({
+      useFactory: (config: ConfigService) => ({
+        autoSchemaFile: 'schema.gql',
+        context,
+        cors: config.cors,
+        playground: true, // enabled in all environments
+        introspection: true, // needed for playground
+      }),
+      inject: [ConfigService],
     }),
   ],
   providers: [AwsS3Factory],

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -25,7 +25,7 @@ const context: ContextFunction<
     EmailModule,
     GraphQLModule.forRootAsync({
       useFactory: (config: ConfigService) => ({
-        autoSchemaFile: 'schema.gql',
+        autoSchemaFile: 'schema.graphql',
         context,
         cors: config.cors,
         playground: true, // enabled in all environments

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -1,12 +1,34 @@
 import { Global, Module } from '@nestjs/common';
+import { GraphQLModule } from '@nestjs/graphql';
+import { ContextFunction } from 'apollo-server-core';
+import { Request, Response } from 'express';
+import { GqlContextType } from '../common';
 import { AwsS3Factory } from './aws-s3.factory';
 import { ConfigModule } from './config/config.module';
 import { DatabaseModule } from './database/database.module';
 import { EmailModule } from './email';
 
+const context: ContextFunction<
+  { req: Request; res: Response },
+  GqlContextType
+> = ({ req, res }) => ({
+  request: req,
+  response: res,
+});
+
 @Global()
 @Module({
-  imports: [ConfigModule, DatabaseModule, EmailModule],
+  imports: [
+    ConfigModule,
+    DatabaseModule,
+    EmailModule,
+    GraphQLModule.forRoot({
+      autoSchemaFile: 'schema.gql',
+      context,
+      playground: true, // enabled in all environments
+      introspection: true, // needed for playground
+    }),
+  ],
   providers: [AwsS3Factory],
   exports: [AwsS3Factory, ConfigModule, DatabaseModule, EmailModule],
 })


### PR DESCRIPTION
- Move graphql setup to `CoreModule`
- Apply CORS config to Apollo server
  It was missed previously with the `express.use()` call in `main.ts`
- Always return current origin for CORS to comply with fetch credentials="include" mode
- Change the emitted schema file to the standard graphql extension.
  Will need to change frontend symlink to match.