### PR TITLE
Error Handling 🔎

### DIFF
--- a/src/components/authentication/authentication.dto.ts
+++ b/src/components/authentication/authentication.dto.ts
@@ -1,3 +1,4 @@
+import { IsEmail } from 'class-validator';
 import { stripIndent } from 'common-tags';
 import { Field, InputType, ObjectType } from 'type-graphql';
 import { User } from '../user';
@@ -24,6 +25,7 @@ export abstract class SessionOutput {
 @InputType()
 export abstract class LoginInput {
   @Field()
+  @IsEmail()
   email: string;
 
   @Field()
@@ -32,14 +34,10 @@ export abstract class LoginInput {
 
 @ObjectType()
 export class LoginOutput {
-  @Field()
-  success: boolean;
-
   @Field({
-    nullable: true,
-    description: 'Only returned if login was successful',
+    description: 'The logged-in user',
   })
-  user?: User;
+  user: User;
 
   // TODO Global Permissions
 }

--- a/src/components/authentication/authentication.resolver.ts
+++ b/src/components/authentication/authentication.resolver.ts
@@ -71,14 +71,8 @@ export class AuthenticationResolver {
   ): Promise<LoginOutput> {
     const userId = await this.authService.login(input, session);
     const loggedInSession = await this.authService.createSession(session.token);
-    if (!userId) {
-      return { success: false };
-    }
     const user = await this.userService.readOne(userId, loggedInSession);
-    return {
-      success: true,
-      user,
-    };
+    return { user };
   }
 
   @Mutation(() => Boolean, {

--- a/src/components/authentication/authentication.service.ts
+++ b/src/components/authentication/authentication.service.ts
@@ -146,7 +146,7 @@ export class AuthenticationService {
       )
       .first();
 
-    if (result2 === undefined) {
+    if (!result2 || !result2.id) {
       throw new ServerException('Login failed');
     }
 

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -322,10 +322,11 @@ export class BudgetService {
       const result = await this.readOneRecord(id, session);
 
       return result;
-    } catch {
+    } catch (exception) {
       this.logger.error(`Could not create Budget Record`, {
         id,
         userId: session.userId,
+        exception,
       });
       throw new Error('Could not create Budget Record');
     }

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -1,5 +1,5 @@
 import { Global, Module } from '@nestjs/common';
-import { APP_FILTER } from '@nestjs/core';
+import { APP_FILTER, APP_PIPE } from '@nestjs/core';
 import { GraphQLModule } from '@nestjs/graphql';
 import { AwsS3Factory } from './aws-s3.factory';
 import { ConfigModule } from './config/config.module';
@@ -7,6 +7,7 @@ import { DatabaseModule } from './database/database.module';
 import { EmailModule } from './email';
 import { ExceptionFilter } from './exception.filter';
 import { GraphQLConfig } from './graphql.config';
+import { ValidationPipe } from './validation.pipe';
 
 @Global()
 @Module({
@@ -16,7 +17,11 @@ import { GraphQLConfig } from './graphql.config';
     EmailModule,
     GraphQLModule.forRootAsync({ useClass: GraphQLConfig }),
   ],
-  providers: [AwsS3Factory, { provide: APP_FILTER, useClass: ExceptionFilter }],
+  providers: [
+    AwsS3Factory,
+    { provide: APP_FILTER, useClass: ExceptionFilter },
+    { provide: APP_PIPE, useClass: ValidationPipe },
+  ],
   exports: [AwsS3Factory, ConfigModule, DatabaseModule, EmailModule],
 })
 export class CoreModule {}

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -1,9 +1,11 @@
 import { Global, Module } from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
 import { GraphQLModule } from '@nestjs/graphql';
 import { AwsS3Factory } from './aws-s3.factory';
 import { ConfigModule } from './config/config.module';
 import { DatabaseModule } from './database/database.module';
 import { EmailModule } from './email';
+import { ExceptionFilter } from './exception.filter';
 import { GraphQLConfig } from './graphql.config';
 
 @Global()
@@ -14,7 +16,7 @@ import { GraphQLConfig } from './graphql.config';
     EmailModule,
     GraphQLModule.forRootAsync({ useClass: GraphQLConfig }),
   ],
-  providers: [AwsS3Factory],
+  providers: [AwsS3Factory, { provide: APP_FILTER, useClass: ExceptionFilter }],
   exports: [AwsS3Factory, ConfigModule, DatabaseModule, EmailModule],
 })
 export class CoreModule {}

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -1,21 +1,10 @@
 import { Global, Module } from '@nestjs/common';
 import { GraphQLModule } from '@nestjs/graphql';
-import { ContextFunction } from 'apollo-server-core';
-import { Request, Response } from 'express';
-import { GqlContextType } from '../common';
 import { AwsS3Factory } from './aws-s3.factory';
 import { ConfigModule } from './config/config.module';
-import { ConfigService } from './config/config.service';
 import { DatabaseModule } from './database/database.module';
 import { EmailModule } from './email';
-
-const context: ContextFunction<
-  { req: Request; res: Response },
-  GqlContextType
-> = ({ req, res }) => ({
-  request: req,
-  response: res,
-});
+import { GraphQLConfig } from './graphql.config';
 
 @Global()
 @Module({
@@ -23,16 +12,7 @@ const context: ContextFunction<
     ConfigModule,
     DatabaseModule,
     EmailModule,
-    GraphQLModule.forRootAsync({
-      useFactory: (config: ConfigService) => ({
-        autoSchemaFile: 'schema.graphql',
-        context,
-        cors: config.cors,
-        playground: true, // enabled in all environments
-        introspection: true, // needed for playground
-      }),
-      inject: [ConfigService],
-    }),
+    GraphQLModule.forRootAsync({ useClass: GraphQLConfig }),
   ],
   providers: [AwsS3Factory],
   exports: [AwsS3Factory, ConfigModule, DatabaseModule, EmailModule],

--- a/src/core/exception.filter.ts
+++ b/src/core/exception.filter.ts
@@ -1,0 +1,47 @@
+import { ArgumentsHost, Catch, HttpException } from '@nestjs/common';
+import { GqlArgumentsHost, GqlExceptionFilter } from '@nestjs/graphql';
+
+@Catch()
+export class ExceptionFilter implements GqlExceptionFilter {
+  catch(exception: unknown, restHost: ArgumentsHost): any {
+    let ex;
+    try {
+      ex = this.catchGql(exception, GqlArgumentsHost.create(restHost));
+    } catch (e) {
+      throw exception;
+    }
+    throw Object.assign(new Error(), ex);
+  }
+
+  catchGql(ex: unknown, host: GqlArgumentsHost) {
+    if (ex instanceof HttpException) {
+      return this.httpException(ex, host);
+    }
+
+    return ex;
+  }
+
+  private httpException(ex: HttpException, _host: GqlArgumentsHost) {
+    const res = ex.getResponse();
+    const data =
+      typeof res === 'string'
+        ? { message: res, statusCode: ex.getResponse(), error: 'Unknown' }
+        : (res as {
+            statusCode: number;
+            error: string;
+            message?: string;
+          });
+
+    const message = data.message ?? data.error;
+    return {
+      message,
+      extensions: {
+        code: data.error.replace(/\s/g, ''),
+        status: data.statusCode,
+      },
+      stack: ex.stack
+        ? `Error: ${message}\n` + ex.stack.replace(/.+\n/, '')
+        : undefined,
+    };
+  }
+}

--- a/src/core/graphql.config.ts
+++ b/src/core/graphql.config.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { GqlModuleOptions, GqlOptionsFactory } from '@nestjs/graphql';
 import { ContextFunction } from 'apollo-server-core';
 import { Request, Response } from 'express';
+import { GraphQLError, GraphQLFormattedError } from 'graphql';
 import { GqlContextType } from '../common';
 import { ConfigService } from './config/config.service';
 
@@ -16,7 +17,13 @@ export class GraphQLConfig implements GqlOptionsFactory {
       cors: this.config.cors,
       playground: true, // enabled in all environments
       introspection: true, // needed for playground
+      formatError: this.formatError,
+      debug: this.debug,
     };
+  }
+
+  get debug() {
+    return true; // TODO
   }
 
   context: ContextFunction<{ req: Request; res: Response }, GqlContextType> = ({
@@ -26,4 +33,19 @@ export class GraphQLConfig implements GqlOptionsFactory {
     request: req,
     response: res,
   });
+
+  formatError = (error: GraphQLError): GraphQLFormattedError => {
+    const extensions = { ...error.extensions };
+
+    if (!this.debug) {
+      delete extensions.exception;
+    }
+
+    return {
+      message: error.message,
+      extensions,
+      locations: error.locations,
+      path: error.path,
+    };
+  };
 }

--- a/src/core/graphql.config.ts
+++ b/src/core/graphql.config.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { GqlModuleOptions, GqlOptionsFactory } from '@nestjs/graphql';
+import { ContextFunction } from 'apollo-server-core';
+import { Request, Response } from 'express';
+import { GqlContextType } from '../common';
+import { ConfigService } from './config/config.service';
+
+@Injectable()
+export class GraphQLConfig implements GqlOptionsFactory {
+  constructor(private readonly config: ConfigService) {}
+
+  async createGqlOptions(): Promise<GqlModuleOptions> {
+    return {
+      autoSchemaFile: 'schema.graphql',
+      context: this.context,
+      cors: this.config.cors,
+      playground: true, // enabled in all environments
+      introspection: true, // needed for playground
+    };
+  }
+
+  context: ContextFunction<{ req: Request; res: Response }, GqlContextType> = ({
+    req,
+    res,
+  }) => ({
+    request: req,
+    response: res,
+  });
+}

--- a/src/core/validation.pipe.ts
+++ b/src/core/validation.pipe.ts
@@ -1,6 +1,7 @@
 import {
   ValidationPipe as BaseValidationPipe,
   Injectable,
+  ValidationError,
 } from '@nestjs/common';
 
 @Injectable()
@@ -9,6 +10,13 @@ export class ValidationPipe extends BaseValidationPipe {
     super({
       transform: true,
       skipMissingProperties: true,
+      exceptionFactory: (es) => new ValidationException(es),
     });
+  }
+}
+
+export class ValidationException extends Error {
+  constructor(readonly errors: ValidationError[]) {
+    super();
   }
 }

--- a/src/core/validation.pipe.ts
+++ b/src/core/validation.pipe.ts
@@ -1,0 +1,14 @@
+import {
+  ValidationPipe as BaseValidationPipe,
+  Injectable,
+} from '@nestjs/common';
+
+@Injectable()
+export class ValidationPipe extends BaseValidationPipe {
+  constructor() {
+    super({
+      transform: true,
+      skipMissingProperties: true,
+    });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Logger, ValidationPipe } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import * as cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
@@ -13,12 +13,6 @@ async function bootstrap() {
   app.use(cookieParser());
 
   app.setGlobalPrefix(config.globalPrefix);
-  app.useGlobalPipes(
-    new ValidationPipe({
-      transform: true,
-      skipMissingProperties: true,
-    })
-  );
 
   app.enableShutdownHooks();
   await app.listen(config.port, () => {

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -13,6 +13,7 @@ import {
   createTestApp,
   createUser,
   createZone,
+  expectNotFound,
   fragments,
   login,
   TestApp,
@@ -267,8 +268,8 @@ describe('Engagement e2e', () => {
 
     const actual: boolean | undefined = result.deleteEngagement;
     expect(actual).toBeTruthy();
-    try {
-      await app.graphql.query(
+    await expectNotFound(
+      app.graphql.query(
         gql`
           query engagement($id: ID!) {
             engagement(id: $id) {
@@ -280,9 +281,7 @@ describe('Engagement e2e', () => {
         {
           id: languageEngagement.id,
         }
-      );
-    } catch (e) {
-      expect(e.response.statusCode).toBe(404);
-    }
+      )
+    );
   });
 });

--- a/test/file.e2e-spec.ts
+++ b/test/file.e2e-spec.ts
@@ -7,6 +7,7 @@ import {
   createSession,
   createTestApp,
   createUser,
+  expectNotFound,
   fragments,
   TestApp,
 } from './utility';
@@ -99,8 +100,8 @@ describe('File e2e', () => {
     );
 
     expect(result.deleteFile).toBeTruthy();
-    try {
-      await app.graphql.query(
+    await expectNotFound(
+      app.graphql.query(
         gql`
           query file($id: ID!) {
             file(id: $id) {
@@ -112,12 +113,8 @@ describe('File e2e', () => {
         {
           id: file.id,
         }
-      );
-    } catch (e) {
-      // we expect this to throw. the file should have been deleted, therefor a subsequent read should fail
-      expect(e.response.statusCode).toBe(404);
-    }
-    // expect(actual.id).toBe(file.id);
+      )
+    );
   });
 
   // LIST Files

--- a/test/language.e2e-spec.ts
+++ b/test/language.e2e-spec.ts
@@ -7,6 +7,7 @@ import {
   createSession,
   createTestApp,
   createUser,
+  expectNotFound,
   TestApp,
 } from './utility';
 import { fragments } from './utility/fragments';
@@ -104,8 +105,8 @@ describe('Language e2e', () => {
     );
 
     expect(result.deleteLanguage).toBeTruthy();
-    try {
-      await app.graphql.query(
+    await expectNotFound(
+      app.graphql.query(
         gql`
           query language($id: ID!) {
             language(id: $id) {
@@ -117,12 +118,8 @@ describe('Language e2e', () => {
         {
           id: language.id,
         }
-      );
-    } catch (e) {
-      // we expect this to throw. the language should have been deleted, therefor a subsequent read should fail
-      expect(e.response.statusCode).toBe(404);
-    }
-    // expect(actual.id).toBe(language.id);
+      )
+    );
   });
 
   // LIST Languages

--- a/test/partnership.e2e-spec.ts
+++ b/test/partnership.e2e-spec.ts
@@ -11,6 +11,7 @@ import {
   createSession,
   createTestApp,
   createUser,
+  expectNotFound,
   fragments,
   TestApp,
 } from './utility';
@@ -135,8 +136,8 @@ describe('Partnership e2e', () => {
 
     const actual: boolean | undefined = result.deletePartnership;
     expect(actual).toBeTruthy();
-    try {
-      await app.graphql.query(
+    await expectNotFound(
+      app.graphql.query(
         gql`
           query partnership($id: ID!) {
             partnership(id: $id) {
@@ -148,10 +149,8 @@ describe('Partnership e2e', () => {
         {
           id: partnership.id,
         }
-      );
-    } catch (e) {
-      expect(e.response.statusCode).toBe(404);
-    }
+      )
+    );
   });
 
   it('List view of partnerships', async () => {

--- a/test/product.e2e-spec.ts
+++ b/test/product.e2e-spec.ts
@@ -5,6 +5,7 @@ import {
   createSession,
   createTestApp,
   createUser,
+  expectNotFound,
   fragments,
   TestApp,
 } from './utility';
@@ -89,8 +90,8 @@ describe('Product e2e', () => {
 
     const actual: boolean | undefined = result.deleteProduct;
     expect(actual).toBeTruthy();
-    try {
-      await app.graphql.query(
+    await expectNotFound(
+      app.graphql.query(
         gql`
           query product($id: ID!) {
             product(id: $id) {
@@ -102,10 +103,8 @@ describe('Product e2e', () => {
         {
           id: product.id,
         }
-      );
-    } catch (e) {
-      expect(e.response.statusCode).toBe(404);
-    }
+      )
+    );
   });
 
   it('List view of products', async () => {

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -16,6 +16,7 @@ import {
   createTestApp,
   createUser,
   createZone,
+  expectNotFound,
   fragments,
   TestApp,
 } from './utility';
@@ -125,8 +126,8 @@ describe('Project e2e', () => {
 
     const actual: boolean | undefined = result.deleteProject;
     expect(actual).toBeTruthy();
-    try {
-      await app.graphql.query(
+    await expectNotFound(
+      app.graphql.query(
         gql`
           query project($id: ID!) {
             project(id: $id) {
@@ -138,10 +139,8 @@ describe('Project e2e', () => {
         {
           id: project.id,
         }
-      );
-    } catch (e) {
-      expect(e.response.statusCode).toBe(404);
-    }
+      )
+    );
   });
 
   it('List view of projects', async () => {

--- a/test/utility/create-app.ts
+++ b/test/utility/create-app.ts
@@ -1,10 +1,13 @@
 import { INestApplication } from '@nestjs/common';
+import { ApplicationConfig } from '@nestjs/core';
 import { GRAPHQL_MODULE_OPTIONS } from '@nestjs/graphql/dist/graphql.constants';
 import { Test } from '@nestjs/testing';
 import { SES } from 'aws-sdk';
+import { remove } from 'lodash';
 import { AppModule } from '../../src/app.module';
 import { LogLevel } from '../../src/core/logger';
 import { LevelMatcher } from '../../src/core/logger/level-matcher';
+import { ValidationPipe } from '../../src/core/validation.pipe';
 import { mockSES } from './aws';
 import {
   createGraphqlClient,
@@ -27,6 +30,12 @@ export const createTestApp = async () => {
     .overrideProvider(SES)
     .useValue(mockSES())
     .compile();
+
+  // Remove ValidationPipe for tests because of failures
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const appConfig: ApplicationConfig = moduleFixture.applicationConfig;
+  remove(appConfig.getGlobalPipes(), (p) => p instanceof ValidationPipe);
 
   const app: TestApp = moduleFixture.createNestApplication();
   await app.init();

--- a/test/utility/expect-not-found.ts
+++ b/test/utility/expect-not-found.ts
@@ -1,0 +1,10 @@
+export const expectNotFound = async (action: Promise<any>) => {
+  let thrown;
+  try {
+    await action;
+  } catch (e) {
+    thrown = e;
+  }
+  expect(thrown).toBeInstanceOf(Error);
+  expect(thrown.extensions.code).toEqual('NotFound');
+};

--- a/test/utility/index.ts
+++ b/test/utility/index.ts
@@ -16,4 +16,5 @@ export * from './create-state';
 export * from './create-security-group';
 export * from './create-permission';
 export * from './login';
+export * from './expect-not-found';
 export * from './fragments';

--- a/test/utility/login.ts
+++ b/test/utility/login.ts
@@ -3,23 +3,16 @@ import { LoginInput } from '../../src/components/authentication/authentication.d
 import { TestApp } from './create-app';
 
 export async function login(app: TestApp, input: Partial<LoginInput> = {}) {
-  const result = await app.graphql.mutate(
+  return app.graphql.mutate(
     gql`
       mutation login($input: LoginInput!) {
         login(input: $input) {
-          success
+          user {
+            id
+          }
         }
       }
     `,
-    {
-      input: {
-        email: input.email,
-        password: input.password,
-      },
-    }
+    { input }
   );
-
-  expect(result.login.success).toBeTruthy();
-
-  return result.login.success;
 }


### PR DESCRIPTION
We've been pretty loose with error handling so far. Now that are starting to exercise the API on the frontend we need to better about "what's gone wrong".

I've customized the error handling layer so more helpful for GraphQL responses.


# Usage
This should still be pretty painless. Let's look at some examples.

## Validation

As far as raw input goes, GraphQL's schema validation goes a long way in determining the request is well formed.

Decorators from the `class-validator` library can take it one step further. For rules that should always be applied and don't need extra info / business logic. 

Here's some examples:
```tsx
class DTO {
  @IsEmail()
  email: string;

  @MinLength(5)
  name: string;
}
```

These are encouraged as a first step for multiple reasons:
- They are simple one-liners
- They are ran automatically
- They inform the API consumer of which fields are invalid.
  This allows UI forms to show field errors from server easily.

## HTTP-Like Exceptions

The next most common case is exception handling. 
These are any class extending the NestJS `HttpException` class.
While we technically don't use the HTTP protocol directly, some of their error types are so common it's just easier to use them.

It's important to pick the right subclass. The subclass sets the correct `status` number. This will be used to determine if the error is a client error (`4xx`) or a server error (`5xx`).

They accept a `message` and an `error` parameter.
- The `message` should be a human readable, but maybe for developer eyes, string. These should **not** be programmed against.
- The `error` parameter can usually be left off (defaulted) but if given it should be a _PascalCase_ string (just like our enums). These communicate a more specific error type. These can and _should_ be programmed against.

Let's look at some common examples:

### Invalid Input / Bad Requests

```tsx
throw new BadRequestException('Token has expired', 'TokenExpired');
```
This outputs:
```
{
   status: 400,
   code: 'TokenExpired',
   message: 'Token has expired'
}
```

### Item Not Found

```tsx
throw new NotFoundException(`Could not find user`);
```
This outputs:
```
{
   status: 400,
   code: 'NotFound',
   message: 'Could not find user'
}
```

### Server Error

These should be vague and not expose too much information. Specific details should be logged.

```tsx
import { InternalServerErrorException as ServerException } from '@nestjs/common';

this.logger.error('Could not create token in database', { exception });
throw new ServerException('Failed to start session');
```
This outputs:
```
{
   status: 500,
   code: 'InternalServerError',
   message: 'Failed to start session'
}
```

### Unauthenticated (Can't identify requesting user)

This shouldn't be needed many places out of authorization service.

```tsx
// Renamed because HTTP name is confusing
import { UnauthorizedException as UnauthenticatedException } from '@nestjs/common';

throw new UnauthenticatedException('Session has not been established', 'NoSession');
```
This outputs:
```
{
   status: 401,
   code: 'NoSession',
   message: 'Session has not been established'
}
```

### Unauthorized (Does not have permission)

```tsx
// Renamed because HTTP name is confusing
import { ForbiddenException as UnauthorizedException } from '@nestjs/common';

throw new UnauthorizedException('Cannot modify project');
```
This outputs:
```
{
   status: 403,
   code: 'Forbidden',
   message: 'Cannot modify project'
}
```

## Custom Exceptions

If/when there's a case where `HttpException` classes do not cover the intent, we can make a custom exception.

First create the exception. 
```tsx
# common/custom.exception.ts

export class CustomException extends Error {
  readonly status = 400;
  constructor(message: string, readonly code: string) {
    super(message);
  }
}
```

Next add handling:
```tsx
# core/exception.filter.ts

class ExceptionFilter {
  ...

  catchGql(ex: unknown) {
    if (ex instance of CustomException) {
      return {
        message: ex.message,
        extensions: {
          code: ex.code,
          status: ex.status,
        },
      };
    }
    ...
  }

  ...
}
```

# What's next?

All errors that are not caught need to be changed to what's above.
See [`AuthenticationService`](https://github.com/SeedCompany/cord-api-v3/blob/master/src/components/authentication/authentication.service.ts) for examples in code.