### PR TITLE
Fix email validation

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -15,3 +15,4 @@ export * from './secured-property';
 export * from './sensitivity.enum';
 export * from './util';
 export { ISession, Session } from './session';
+export * from './validators';

--- a/src/common/validators/email.validator.ts
+++ b/src/common/validators/email.validator.ts
@@ -1,0 +1,23 @@
+import { ValidationOptions } from 'class-validator';
+import { isEmail } from 'validator';
+import { ValidateBy } from './validateBy';
+
+export const IsEmail = (
+  options?: ValidatorJS.IsEmailOptions,
+  validationOptions?: ValidationOptions
+) =>
+  ValidateBy(
+    {
+      name: 'isEmail',
+      constraints: [options],
+      validator: {
+        validate: (value, args) =>
+          typeof value === 'string' && isEmail(value, args?.constraints[0]),
+        defaultMessage: () =>
+          validationOptions?.each
+            ? 'Each value in $property must be a valid email'
+            : 'Invalid email',
+      },
+    },
+    validationOptions
+  );

--- a/src/common/validators/index.ts
+++ b/src/common/validators/index.ts
@@ -1,0 +1,1 @@
+export * from './email.validator';

--- a/src/common/validators/validateBy.ts
+++ b/src/common/validators/validateBy.ts
@@ -1,0 +1,27 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+export interface ValidateByOptions {
+  name: string;
+  constraints?: any[];
+  validator: ValidatorConstraintInterface | Function;
+  async?: boolean;
+}
+
+export const ValidateBy = (
+  options: ValidateByOptions,
+  validationOptions?: ValidationOptions
+): PropertyDecorator => (object: object, propertyName: string | symbol) => {
+  registerDecorator({
+    name: options.name,
+    target: object.constructor,
+    propertyName: propertyName as string,
+    options: validationOptions,
+    constraints: options.constraints,
+    validator: options.validator,
+    async: options.async,
+  });
+};

--- a/src/components/authentication/authentication.dto.ts
+++ b/src/components/authentication/authentication.dto.ts
@@ -1,6 +1,6 @@
 import { IsEmail } from 'class-validator';
 import { stripIndent } from 'common-tags';
-import { Field, InputType, ObjectType } from 'type-graphql';
+import { ArgsType, Field, InputType, ObjectType } from 'type-graphql';
 import { User } from '../user';
 
 @ObjectType()
@@ -49,4 +49,11 @@ export abstract class ResetPasswordInput {
 
   @Field()
   readonly password: string;
+}
+
+@ArgsType()
+export abstract class ForgotPasswordArgs {
+  @Field()
+  @IsEmail()
+  readonly email: string;
 }

--- a/src/components/authentication/authentication.dto.ts
+++ b/src/components/authentication/authentication.dto.ts
@@ -1,6 +1,6 @@
-import { IsEmail } from 'class-validator';
 import { stripIndent } from 'common-tags';
 import { ArgsType, Field, InputType, ObjectType } from 'type-graphql';
+import { IsEmail } from '../../common';
 import { User } from '../user';
 
 @ObjectType()

--- a/src/components/authentication/authentication.resolver.ts
+++ b/src/components/authentication/authentication.resolver.ts
@@ -6,6 +6,7 @@ import { ISession, Session } from '../../common';
 import { ConfigService, ILogger, Logger } from '../../core';
 import { UserService } from '../user';
 import {
+  ForgotPasswordArgs,
   LoginInput,
   LoginOutput,
   ResetPasswordInput,
@@ -102,7 +103,9 @@ export class AuthenticationResolver {
   @Mutation(() => Boolean, {
     description: 'Forgot password; send password reset email',
   })
-  async forgotPassword(@Args('email') email: string): Promise<boolean> {
+  async forgotPassword(
+    @Args() { email }: ForgotPasswordArgs
+  ): Promise<boolean> {
     await this.authService.forgotPassword(email);
     return true;
   }

--- a/src/components/user/dto/check-email.dto.ts
+++ b/src/components/user/dto/check-email.dto.ts
@@ -1,5 +1,5 @@
-import { IsEmail } from 'class-validator';
 import { Field, InputType } from 'type-graphql';
+import { IsEmail } from '../../../common';
 
 @InputType()
 export abstract class UserEmailInput {

--- a/src/components/user/dto/check-email.dto.ts
+++ b/src/components/user/dto/check-email.dto.ts
@@ -1,8 +1,8 @@
-import { Field, InputType } from 'type-graphql';
+import { ArgsType, Field } from 'type-graphql';
 import { IsEmail } from '../../../common';
 
-@InputType()
-export abstract class UserEmailInput {
+@ArgsType()
+export abstract class CheckEmailArgs {
   @Field()
   @IsEmail()
   readonly email: string;

--- a/src/components/user/dto/create-user.dto.ts
+++ b/src/components/user/dto/create-user.dto.ts
@@ -1,6 +1,7 @@
 import { Type } from 'class-transformer';
-import { IsEmail, MinLength, ValidateNested } from 'class-validator';
+import { MinLength, ValidateNested } from 'class-validator';
 import { Field, InputType, ObjectType } from 'type-graphql';
+import { IsEmail } from '../../../common';
 import { User } from './user.dto';
 
 @InputType()

--- a/src/components/user/user.resolver.ts
+++ b/src/components/user/user.resolver.ts
@@ -12,6 +12,7 @@ import {
   SecuredOrganizationList,
 } from '../organization';
 import {
+  CheckEmailArgs,
   CreateUserInput,
   CreateUserOutput,
   UpdateUserInput,
@@ -54,10 +55,9 @@ export class UserResolver {
   }
 
   @Query(() => Boolean, {
-    description:
-      'Check out whether a provided email exists or not in User Table',
+    description: 'Checks whether a provided email already exists',
   })
-  async checkEmail(@Args('email') email: string): Promise<boolean> {
+  async checkEmail(@Args() { email }: CheckEmailArgs): Promise<boolean> {
     return this.userService.checkEmail(email);
   }
 


### PR DESCRIPTION
- forgot password & check email resolvers were not checking for valid email address
- Switch to custom `IsEmail` decorator to change the default error message
- Added same `ValidateBy` helper that `class-validator` lib uses internally. This should help make more custom decorators in future
