### PR TITLE
Avatar Letters for resources

### DIFF
--- a/src/common/firstLettersOfWords.test.ts
+++ b/src/common/firstLettersOfWords.test.ts
@@ -1,0 +1,31 @@
+import { firstLettersOfWords } from './firstLettersOfWords';
+
+describe('firstLettersOfWords', () => {
+  it.each([
+    // uppercase
+    [`Ma'di South 2`, 'MS2'],
+    [`2 Ma'di South`, '2MS'],
+    [`Ruruuli-Runyala`, 'RR'],
+    [`Ñandeva (Nandeva)`, 'ÑN'],
+    [`Pame, Ñorthern`, 'PÑ'],
+    [`Zapoteco de SBA`, 'ZS'],
+    [`New-Est Cluster`, 'NEC'],
+    [`Guina-ang Kalinga`, 'GK'],
+    [`Fa d'Ambu NT`, 'FAN'],
+    [`Aramaic M-South OT`, 'AMSO'],
+
+    // lowercase
+    [`ma'di south 2`, 'mds2'],
+    [`ruruuli-runyala`, 'rr'],
+    [`ñandeva (nandeva)`, 'ñn'],
+    [`pame, northern`, 'pn'],
+    [`zapoteco de sba`, 'zds'],
+    [`new-est cluster`, 'nec'],
+    [`guina-ang kalinga`, 'gak'],
+    [`fa d'ambu nt`, 'fdan'],
+    [`aramaic m-south ot`, 'amso'],
+    [`ḛramaic 2 ḛouth`, 'ḛ2ḛ'],
+  ])('%s -> %s', (words, letters) => {
+    expect(firstLettersOfWords(words, Infinity)).toEqual(letters);
+  });
+});

--- a/src/common/firstLettersOfWords.ts
+++ b/src/common/firstLettersOfWords.ts
@@ -1,0 +1,40 @@
+const hasUppercaseLettersPattern = /\p{Lu}/gu;
+
+// https://regex101.com/r/63P0Hw (make sure you are viewing the latest version)
+const uppercasePattern = RegExp(
+  // Match word-like boundaries
+  // \b fails in some cases, so also match start of string, and space before letter
+  '(?:^|\\b|\\s)' +
+    // Capture uppercase unicode letter or number
+    '([\\p{Lu}\\p{N}])',
+  'ug'
+);
+
+// https://regex101.com/r/t2xf5O (make sure you are viewing the latest version)
+const lowercasePattern = RegExp(
+  // Match word-like boundaries
+  // \b can't be used here has it will match lowercase char after a unicode lowercase char
+  // So match some punctuation, start of string, and spaces instead
+  `(?:^|'|\\(|-|\\s)` +
+    // Capture lower case unicode letter or number
+    '([\\p{Ll}\\p{N}])',
+  'ug'
+);
+
+export function firstLettersOfWords(
+  words: string,
+  limit: number | null = 3
+): string {
+  // If the string has uppercase characters we use the uppercase pattern which
+  // will ignore lowercase characters after word-like boundaries.
+  // If the string doesn't have any uppercase characters we fallback to the lowercase pattern
+  // which is less ideal but gives something instead of an empty string.
+  // See tests for differences in the two patterns.
+  const pattern = words.match(hasUppercaseLettersPattern)
+    ? uppercasePattern
+    : lowercasePattern;
+  const letters = Array.from(words.matchAll(pattern), (m) => m[1]).join('');
+  return limit === Infinity || limit == null
+    ? letters
+    : letters.substr(0, limit);
+}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -2,6 +2,7 @@ export * from './context.type';
 export * from './calendar-date';
 export * from './date-filter.input';
 export * from './editable.interface';
+export * from './firstLettersOfWords';
 export * from './id.arg';
 export { DateField, DateTimeField } from './luxon.graphql';
 export * from './not-implemented.error';

--- a/src/components/language/language.resolver.ts
+++ b/src/components/language/language.resolver.ts
@@ -1,5 +1,12 @@
-import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import {
+  Args,
+  Mutation,
+  Parent,
+  Query,
+  ResolveField,
+  Resolver,
+} from '@nestjs/graphql';
+import { firstLettersOfWords, IdArg, ISession, Session } from '../../common';
 import {
   CreateLanguageInput,
   CreateLanguageOutput,
@@ -11,7 +18,7 @@ import {
 } from './dto';
 import { LanguageService } from './language.service';
 
-@Resolver()
+@Resolver(Language.classType)
 export class LanguageResolver {
   constructor(private readonly langService: LanguageService) {}
 
@@ -23,6 +30,13 @@ export class LanguageResolver {
     @IdArg() id: string
   ): Promise<Language> {
     return this.langService.readOne(id, session);
+  }
+
+  @ResolveField(() => String, { nullable: true })
+  avatarLetters(@Parent() language: Language): string | undefined {
+    return language.name.canRead && language.name.value
+      ? firstLettersOfWords(language.name.value)
+      : undefined;
   }
 
   @Query(() => LanguageListOutput, {

--- a/src/components/organization/organization.resolver.ts
+++ b/src/components/organization/organization.resolver.ts
@@ -1,5 +1,12 @@
-import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import {
+  Args,
+  Mutation,
+  Parent,
+  Query,
+  ResolveField,
+  Resolver,
+} from '@nestjs/graphql';
+import { firstLettersOfWords, IdArg, ISession, Session } from '../../common';
 import {
   CreateOrganizationInput,
   CreateOrganizationOutput,
@@ -11,7 +18,7 @@ import {
 } from './dto';
 import { OrganizationService } from './organization.service';
 
-@Resolver(Organization.name)
+@Resolver(Organization.classType)
 export class OrganizationResolver {
   constructor(private readonly orgs: OrganizationService) {}
 
@@ -34,6 +41,13 @@ export class OrganizationResolver {
     @IdArg() id: string
   ): Promise<Organization> {
     return this.orgs.readOne(id, session);
+  }
+
+  @ResolveField(() => String, { nullable: true })
+  avatarLetters(@Parent() org: Organization): string | undefined {
+    return org.name.canRead && org.name.value
+      ? firstLettersOfWords(org.name.value)
+      : undefined;
   }
 
   @Query(() => OrganizationListOutput, {

--- a/src/components/project/internship-project.resolver.ts
+++ b/src/components/project/internship-project.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { ISession, Session } from '../../common';
+import { firstLettersOfWords, ISession, Session } from '../../common';
 import {
   EngagementListInput,
   SecuredInternshipEngagementList,
@@ -14,6 +14,13 @@ import { ProjectService } from './project.service';
 @Resolver(InternshipProject.classType)
 export class InternshipProjectResolver {
   constructor(private readonly projects: ProjectService) {}
+
+  @ResolveField(() => String, { nullable: true })
+  avatarLetters(@Parent() project: InternshipProject): string | undefined {
+    return project.name.canRead && project.name.value
+      ? firstLettersOfWords(project.name.value)
+      : undefined;
+  }
 
   @ResolveField(() => SecuredInternshipEngagementList)
   async engagements(

--- a/src/components/project/translation-project.resolver.ts
+++ b/src/components/project/translation-project.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { ISession, Session } from '../../common';
+import { firstLettersOfWords, ISession, Session } from '../../common';
 import {
   EngagementListInput,
   SecuredLanguageEngagementList,
@@ -14,6 +14,13 @@ import { ProjectService } from './project.service';
 @Resolver(TranslationProject.classType)
 export class TranslationProjectResolver {
   constructor(private readonly projects: ProjectService) {}
+
+  @ResolveField(() => String, { nullable: true })
+  avatarLetters(@Parent() project: TranslationProject): string | undefined {
+    return project.name.canRead && project.name.value
+      ? firstLettersOfWords(project.name.value)
+      : undefined;
+  }
 
   @ResolveField(() => SecuredLanguageEngagementList)
   async engagements(


### PR DESCRIPTION
As a fallback to pictures, which haven't even been implemented yet, we want to show the first letters of words. Like _CF_ for _Carson Full_. This regex implementation is smarter than "first letter after space", as you can see in the tests. But it requires unicode property escapes which aren't supported in all browsers. The polyfill, [xregexp](https://github.com/slevithan/xregexp), is [127KB](https://bundlephobia.com/result?p=xregexp@4.3.0) which is huge. In short, it's much easier to do this server side with native implementation and provide via API.

# Resources
- [ ] Users
  - Need to determine how and when to combine the 4 name properties. There might be a discussion pending around that as well.
- [ ] Locations
  - Waiting on refactor. `Location` union needs to be converted to a `Locatable` interface and hopefully this lazy property can be applied once there.
- [x] Translation Projects / Internship Projects
- [x] Organizations
- [x] Languages
