### PR TITLE
DB Error Handling

### DIFF
--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -8,3 +8,8 @@ export const maybeMany = <T>(
 
 export const sleep = (milliseconds: number) =>
   new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+export const simpleSwitch = <T>(
+  key: string,
+  options: Record<string, T>
+): T | undefined => options[key];

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -9,13 +9,14 @@ import { node, relation } from 'cypher-query-builder';
 import { upperFirst } from 'lodash';
 import { DateTime } from 'luxon';
 import { generate } from 'shortid';
-import { ISession, Sensitivity } from '../../common';
+import { ISession, Sensitivity, simpleSwitch } from '../../common';
 import {
   DatabaseService,
   ILogger,
   Logger,
   matchSession,
   OnIndex,
+  UniquenessError,
 } from '../../core';
 import {
   CreateLanguage,
@@ -81,13 +82,11 @@ export class LanguageService {
     }
     const createdAt = DateTime.local();
     const propLabel =
-      prop === 'name'
-        ? 'LanguageName:Property'
-        : prop === 'displayName'
-        ? 'LanguageDisplayName:Property'
-        : prop === 'rodNumber'
-        ? 'LanguageRodNumber:Property'
-        : 'Property';
+      simpleSwitch(prop, {
+        name: ['LanguageName'],
+        displayName: ['LanguageDisplayName'],
+        rodNumber: ['LanguageRodNumber'],
+      }) ?? [];
     return [
       [
         node('newLang'),
@@ -95,7 +94,7 @@ export class LanguageService {
           active: true,
           createdAt,
         }),
-        node(prop, propLabel, {
+        node(prop, [...propLabel, 'Property'], {
           active: true,
           value,
         }),
@@ -229,23 +228,17 @@ export class LanguageService {
         .return('newLang.id as id');
       await createLanguage.first();
     } catch (e) {
-      // if fail to create, see if already exists
-      const lookup = this.db
-        .query()
-        .match([
-          node('lang', 'Language', { active: true }),
-          relation('out', 'name', 'name', { active: true }),
-          node('langName', 'LanguageName', { active: true, value: input.name }),
-        ])
-        .return({ lang: [{ id: 'langId' }] });
-
-      const lang = await lookup.first();
-      if (lang) {
-        this.logger.warning('Language name already exists', {
-          input,
-          userId: session.userId,
-        });
-        throw new BadRequestException('Language name already exists');
+      if (e instanceof UniquenessError) {
+        const prop =
+          simpleSwitch(e.label, {
+            LanguageName: 'name',
+            LanguageDisplayName: 'displayName',
+            LanguageRodNumber: 'rodNumber',
+          }) ?? e.label;
+        throw new BadRequestException(
+          `Language with ${prop}="${e.value}" already exists`,
+          'Duplicate'
+        );
       }
       // TODO permission error or no?
       this.logger.error(`Could not create`, { ...input, exception: e });

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -4,7 +4,6 @@ import {
   NotFoundException,
   InternalServerErrorException as ServerException,
 } from '@nestjs/common';
-import { ForbiddenError } from 'apollo-server-core';
 import { node, relation } from 'cypher-query-builder';
 import { upperFirst } from 'lodash';
 import { DateTime } from 'luxon';
@@ -240,9 +239,8 @@ export class LanguageService {
           'Duplicate'
         );
       }
-      // TODO permission error or no?
       this.logger.error(`Could not create`, { ...input, exception: e });
-      throw new ForbiddenError('Could not create language');
+      throw new ServerException('Could not create language');
     }
     const result = await this.readOne(id, session);
 

--- a/src/core/database/cypher.factory.ts
+++ b/src/core/database/cypher.factory.ts
@@ -5,7 +5,7 @@ import Session from 'neo4j-driver/types/v1/session';
 import { ConfigService } from '..';
 import { jestSkipFileInExceptionSource } from '../jest-skip-source-file';
 import { ILogger, LoggerToken, LogLevel } from '../logger';
-import { createBetterError } from './errors';
+import { createBetterError, isNeo4jError } from './errors';
 import { ParameterTransformer } from './parameter-transformer.service';
 import { MyTransformer } from './transformer';
 import './transaction'; // import our transaction augmentation
@@ -64,6 +64,9 @@ export const CypherFactory: FactoryProvider<Connection> = {
               observer.onError = (e) => {
                 const patched = jestSkipFileInExceptionSource(e, __filename);
                 const mapped = createBetterError(patched);
+                if (isNeo4jError(mapped) && mapped.logProps) {
+                  logger.log(mapped.logProps);
+                }
                 onError(mapped);
               };
             }

--- a/src/core/database/cypher.factory.ts
+++ b/src/core/database/cypher.factory.ts
@@ -5,6 +5,7 @@ import Session from 'neo4j-driver/types/v1/session';
 import { ConfigService } from '..';
 import { jestSkipFileInExceptionSource } from '../jest-skip-source-file';
 import { ILogger, LoggerToken, LogLevel } from '../logger';
+import { createBetterError } from './errors';
 import { ParameterTransformer } from './parameter-transformer.service';
 import { MyTransformer } from './transformer';
 import './transaction'; // import our transaction augmentation
@@ -62,7 +63,8 @@ export const CypherFactory: FactoryProvider<Connection> = {
               const onError = observer.onError;
               observer.onError = (e) => {
                 const patched = jestSkipFileInExceptionSource(e, __filename);
-                onError(patched);
+                const mapped = createBetterError(patched);
+                onError(mapped);
               };
             }
             origSubscribe.call(result, observer);

--- a/src/core/database/errors.ts
+++ b/src/core/database/errors.ts
@@ -1,0 +1,70 @@
+import { v1 as Neo } from 'neo4j-driver';
+
+export class ConstraintError extends Neo.Neo4jError {
+  readonly code = 'Neo.ClientError.Schema.ConstraintValidationFailed' as const;
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+
+  static fromNeo(e: Neo.Neo4jError) {
+    if (e instanceof ConstraintError) {
+      return e;
+    }
+    const ex = new this(e.message);
+    ex.stack = e.stack;
+    return ex;
+  }
+}
+
+export class UniquenessError extends ConstraintError {
+  constructor(
+    readonly node: number,
+    readonly label: string,
+    readonly value: string,
+    message: string
+  ) {
+    super(message);
+  }
+
+  static fromNeo(e: Neo.Neo4jError) {
+    if (e instanceof UniquenessError) {
+      return e;
+    }
+    const info = getUniqueFailureInfo(e);
+    const ex = new this(info.node, info.label, info.value, e.message);
+    ex.stack = e.stack;
+    return ex;
+  }
+}
+
+export const isNeo4jError = (e: unknown): e is Neo.Neo4jError =>
+  e instanceof Neo.Neo4jError;
+
+export const createBetterError = (e: Error) => {
+  if (!isNeo4jError(e)) {
+    return e;
+  }
+  if (e.code === 'Neo.ClientError.Schema.ConstraintValidationFailed') {
+    if (e.message.includes('already exists with label')) {
+      return UniquenessError.fromNeo(e);
+    }
+    return ConstraintError.fromNeo(e);
+  }
+  return e;
+};
+
+const uniqueMsgRegex = /^Node\((\d+)\) already exists with label `(\w+)` and property `value` = '(.+)'$/;
+const getUniqueFailureInfo = (e: Neo.Neo4jError) => {
+  const matches = uniqueMsgRegex.exec(e.message);
+  if (!matches) {
+    throw new Error(
+      'Could not determine uniqueness info from error. Are you sure this is a uniqueness constraint failure?'
+    );
+  }
+  return {
+    node: Number(matches[1]),
+    label: matches[2],
+    value: matches[3],
+  };
+};

--- a/src/core/database/errors.ts
+++ b/src/core/database/errors.ts
@@ -1,4 +1,11 @@
 import { v1 as Neo } from 'neo4j-driver';
+import { LogEntry, LogLevel } from '../logger';
+
+declare module 'neo4j-driver/types/v1' {
+  interface Neo4jError {
+    logProps?: LogEntry;
+  }
+}
 
 export class ConstraintError extends Neo.Neo4jError {
   readonly code = 'Neo.ClientError.Schema.ConstraintValidationFailed' as const;
@@ -36,6 +43,13 @@ export class UniquenessError extends ConstraintError {
     ex.stack = e.stack;
     return ex;
   }
+
+  logProps = {
+    level: LogLevel.WARNING,
+    message: 'Duplicate property',
+    label: this.label,
+    value: this.value,
+  };
 }
 
 export const isNeo4jError = (e: unknown): e is Neo.Neo4jError =>

--- a/src/core/database/index.ts
+++ b/src/core/database/index.ts
@@ -1,0 +1,2 @@
+export * from './database.service';
+export * from './errors';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -2,6 +2,6 @@ export * from './logger';
 export * from './config/config.service';
 export * from './core.module';
 export * from './deprecated-database.service';
-export * from './database/database.service';
+export * from './database';
 export * from './database/indexer';
 export * from './email';


### PR DESCRIPTION
Neo4j throws these generic errors which is super unhelpful for handling programmatically. 
This wraps it to provide a proper inheritance tree (incomplete) for the errors and stores dynamic data in properties of the error.

The first, biggest use case for this is uniqueness constraint failures. Previously we never even bothered to check the error message, which would've been really verbose anyways. Now it's really easy:
```tsx
if (e instanceof UniquenessError) {
  e.label // the label that failed
  e.value // the duplicated value
}
```
To take it a step further, these uniqueness errors automatically get logged so we don't have to do that in our concrete services.

I updated `LanguageService` to handle this error, as an example.