### PR TITLE
Event Handling

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -26,3 +26,8 @@ rules:
     - selector: parameter
       format: [camelCase]
       leadingUnderscore: allow
+  no-restricted-imports:
+    - error
+    - paths:
+        - name: '@nestjs/cqrs'
+          message: Import from our core module instead

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@golevelup/nestjs-discovery": "^2.2.3",
     "@nestjs/common": "^7.0.9",
     "@nestjs/core": "^7.0.9",
+    "@nestjs/cqrs": "^7.0.0",
     "@nestjs/graphql": "^7.3.7",
     "@nestjs/platform-express": "^7.0.9",
     "@patarapolw/prettyprint": "^1.0.3",

--- a/src/components/budget/budget.module.ts
+++ b/src/components/budget/budget.module.ts
@@ -8,6 +8,7 @@ import { UserModule } from '../user/user.module';
 import { BudgetRecordResolver } from './budget-record.resolver';
 import { BudgetResolver } from './budget.resolver';
 import { BudgetService } from './budget.service';
+import * as handlers from './handlers';
 
 @Module({
   imports: [
@@ -18,7 +19,12 @@ import { BudgetService } from './budget.service';
     UnavailabilityModule,
     UserModule,
   ],
-  providers: [BudgetResolver, BudgetRecordResolver, BudgetService],
+  providers: [
+    BudgetResolver,
+    BudgetRecordResolver,
+    BudgetService,
+    ...Object.values(handlers),
+  ],
   exports: [BudgetService],
 })
 export class BudgetModule {}

--- a/src/components/budget/budget.resolver.ts
+++ b/src/components/budget/budget.resolver.ts
@@ -14,6 +14,8 @@ import {
   Budget,
   BudgetListInput,
   BudgetListOutput,
+  CreateBudgetInput,
+  CreateBudgetOutput,
   UpdateBudgetInput,
   UpdateBudgetOutput,
 } from './dto';
@@ -50,6 +52,17 @@ export class BudgetResolver {
   @ResolveField(() => Int)
   async total(@Parent() budget: Budget): Promise<number> {
     return sumBy(budget.records, (record) => record.amount.value ?? 0);
+  }
+
+  @Mutation(() => CreateBudgetOutput, {
+    description: 'Create a budget',
+  })
+  async createBudget(
+    @Session() session: ISession,
+    @Args('input') { budget: input }: CreateBudgetInput
+  ): Promise<CreateBudgetOutput> {
+    const budget = await this.service.create(input, session);
+    return { budget };
   }
 
   @Mutation(() => UpdateBudgetOutput, {

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -209,6 +209,21 @@ export class BudgetService {
 
       await createBudget.first();
 
+      // connect budget to project
+      await this.db
+        .query()
+        .matchNode('project', 'Project', { id: projectId, active: true })
+        .matchNode('budget', 'Budget', { id, active: true })
+        .create([
+          node('project'),
+          relation('out', '', 'budget', {
+            active: true,
+            createdAt: DateTime.local(),
+          }),
+          node('budget'),
+        ])
+        .run();
+
       this.logger.info(`Created Budget`, {
         id,
         userId: session.userId,

--- a/src/components/budget/handlers/create-project-default-budget.handler.ts
+++ b/src/components/budget/handlers/create-project-default-budget.handler.ts
@@ -1,0 +1,13 @@
+import { EventsHandler, IEventHandler } from '../../../core';
+import { ProjectCreatedEvent } from '../../project/events';
+import { BudgetService } from '../budget.service';
+
+@EventsHandler(ProjectCreatedEvent)
+export class CreateProjectDefaultBudgetHandler
+  implements IEventHandler<ProjectCreatedEvent> {
+  constructor(private readonly budgets: BudgetService) {}
+
+  async handle({ project, session }: ProjectCreatedEvent) {
+    await this.budgets.create({ projectId: project.id }, session);
+  }
+}

--- a/src/components/budget/handlers/index.ts
+++ b/src/components/budget/handlers/index.ts
@@ -1,1 +1,2 @@
+export * from './create-project-default-budget.handler';
 export * from './sync-budget-records-to-funding-partners.handler';

--- a/src/components/budget/handlers/index.ts
+++ b/src/components/budget/handlers/index.ts
@@ -1,0 +1,1 @@
+export * from './sync-budget-records-to-funding-partners.handler';

--- a/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
+++ b/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
@@ -11,14 +11,17 @@ import {
   PartnershipDeletedEvent,
   PartnershipUpdatedEvent,
 } from '../../partnership/events';
+import { ProjectUpdatedEvent } from '../../project/events';
 import { BudgetService } from '../budget.service';
 
 type SubscribedEvent =
+  | ProjectUpdatedEvent
   | PartnershipCreatedEvent
   | PartnershipUpdatedEvent
   | PartnershipDeletedEvent;
 
 @EventsHandler(
+  ProjectUpdatedEvent,
   PartnershipCreatedEvent,
   PartnershipUpdatedEvent,
   PartnershipDeletedEvent
@@ -32,8 +35,9 @@ export class SyncBudgetRecordsToFundingPartners
   ) {}
 
   async handle(event: SubscribedEvent) {
-    this.logger.debug('Partnership mutation, syncing budget records', {
-      partnership: event.partnership,
+    this.logger.debug('Partnership/Project mutation, syncing budget records', {
+      ...event,
+      event: event.constructor.name,
     });
 
     if (

--- a/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
+++ b/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
@@ -1,0 +1,52 @@
+import {
+  DatabaseService,
+  EventsHandler,
+  IEventHandler,
+  ILogger,
+  Logger,
+} from '../../../core';
+import { PartnershipType } from '../../partnership/dto';
+import {
+  PartnershipCreatedEvent,
+  PartnershipDeletedEvent,
+  PartnershipUpdatedEvent,
+} from '../../partnership/events';
+import { BudgetService } from '../budget.service';
+
+type SubscribedEvent =
+  | PartnershipCreatedEvent
+  | PartnershipUpdatedEvent
+  | PartnershipDeletedEvent;
+
+@EventsHandler(
+  PartnershipCreatedEvent,
+  PartnershipUpdatedEvent,
+  PartnershipDeletedEvent
+)
+export class SyncBudgetRecordsToFundingPartners
+  implements IEventHandler<SubscribedEvent> {
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly budgets: BudgetService,
+    @Logger('budget:sync-partnerships') private readonly logger: ILogger
+  ) {}
+
+  async handle(event: SubscribedEvent) {
+    this.logger.debug('Partnership mutation, syncing budget records', {
+      partnership: event.partnership,
+    });
+
+    if (
+      event instanceof PartnershipCreatedEvent &&
+      !event.partnership.types.value.includes(PartnershipType.Funding)
+    ) {
+      // Partnership is not and never was funding, so do nothing.
+      return;
+    }
+
+    // TODO only continue if budget is pending
+    // TODO if partnership is deleted or no longer funding, then remove budget records
+    // TODO else if partnership is funding, then add budget records for its fiscal years.
+    // Fiscal years may need to be determined from project. See #596 for details
+  }
+}

--- a/src/components/file/file.module.ts
+++ b/src/components/file/file.module.ts
@@ -7,6 +7,7 @@ import { FileRepository } from './file.repository';
 import { FileResolver } from './file.resolver';
 import { FileService } from './file.service';
 import { FilesBucketFactory } from './files-bucket.factory';
+import * as handlers from './handlers';
 import { LocalBucketController } from './local-bucket.controller';
 
 @Module({
@@ -18,6 +19,7 @@ import { LocalBucketController } from './local-bucket.controller';
     FileResolver,
     FileVersionResolver,
     FileService,
+    ...Object.values(handlers),
   ],
   controllers: [LocalBucketController],
   exports: [FileService],

--- a/src/components/file/handlers/attach-project-root-directory.handler.ts
+++ b/src/components/file/handlers/attach-project-root-directory.handler.ts
@@ -1,0 +1,40 @@
+import { node, relation } from 'cypher-query-builder';
+import { DateTime } from 'luxon';
+import { DatabaseService, EventsHandler, IEventHandler } from '../../../core';
+import { ProjectCreatedEvent } from '../../project/events';
+import { FileService } from '../file.service';
+
+@EventsHandler(ProjectCreatedEvent)
+export class AttachProjectRootDirectoryHandler
+  implements IEventHandler<ProjectCreatedEvent> {
+  constructor(
+    private readonly files: FileService,
+    private readonly db: DatabaseService
+  ) {}
+
+  async handle({ project, session }: ProjectCreatedEvent) {
+    const { id } = project;
+
+    const rootDir = await this.files.createDirectory(
+      undefined,
+      `${id} root directory`,
+      session
+    );
+
+    await this.db
+      .query()
+      .match([
+        [node('project', 'Project', { id, active: true })],
+        [node('dir', 'Directory', { id: rootDir.id, active: true })],
+      ])
+      .create([
+        node('project'),
+        relation('out', '', 'rootDirectory', {
+          active: true,
+          createdAt: DateTime.local(),
+        }),
+        node('dir'),
+      ])
+      .run();
+  }
+}

--- a/src/components/file/handlers/detach-project-root-directory.handler.ts
+++ b/src/components/file/handlers/detach-project-root-directory.handler.ts
@@ -1,0 +1,10 @@
+import { EventsHandler, IEventHandler } from '../../../core';
+import { ProjectCreatedEvent, ProjectDeletedEvent } from '../../project/events';
+
+@EventsHandler(ProjectDeletedEvent)
+export class DetachProjectRootDirectoryHandler
+  implements IEventHandler<ProjectCreatedEvent> {
+  async handle(_event: ProjectDeletedEvent) {
+    // TODO Update DB is some fashion
+  }
+}

--- a/src/components/file/handlers/index.ts
+++ b/src/components/file/handlers/index.ts
@@ -1,0 +1,2 @@
+export * from './attach-project-root-directory.handler';
+export * from './detach-project-root-directory.handler';

--- a/src/components/partnership/events/index.ts
+++ b/src/components/partnership/events/index.ts
@@ -1,0 +1,3 @@
+export * from './partnership-created.event';
+export * from './partnership-updated.event';
+export * from './partnership-deleted.event';

--- a/src/components/partnership/events/partnership-created.event.ts
+++ b/src/components/partnership/events/partnership-created.event.ts
@@ -1,0 +1,6 @@
+import { ISession } from '../../../common';
+import { Partnership } from '../dto';
+
+export class PartnershipCreatedEvent {
+  constructor(readonly partnership: Partnership, readonly session: ISession) {}
+}

--- a/src/components/partnership/events/partnership-deleted.event.ts
+++ b/src/components/partnership/events/partnership-deleted.event.ts
@@ -1,0 +1,6 @@
+import { ISession } from '../../../common';
+import { Partnership } from '../dto';
+
+export class PartnershipDeletedEvent {
+  constructor(readonly partnership: Partnership, readonly session: ISession) {}
+}

--- a/src/components/partnership/events/partnership-updated.event.ts
+++ b/src/components/partnership/events/partnership-updated.event.ts
@@ -1,0 +1,10 @@
+import { ISession } from '../../../common';
+import { Partnership, UpdatePartnership } from '../dto';
+
+export class PartnershipUpdatedEvent {
+  constructor(
+    readonly partnership: Partnership,
+    readonly updates: UpdatePartnership,
+    readonly session: ISession
+  ) {}
+}

--- a/src/components/project/events/index.ts
+++ b/src/components/project/events/index.ts
@@ -1,0 +1,3 @@
+export * from './project-created.event';
+export * from './project-updated.event';
+export * from './project-deleted.event';

--- a/src/components/project/events/project-created.event.ts
+++ b/src/components/project/events/project-created.event.ts
@@ -1,0 +1,6 @@
+import { ISession } from '../../../common';
+import { Project } from '../dto';
+
+export class ProjectCreatedEvent {
+  constructor(readonly project: Project, readonly session: ISession) {}
+}

--- a/src/components/project/events/project-deleted.event.ts
+++ b/src/components/project/events/project-deleted.event.ts
@@ -1,0 +1,6 @@
+import { ISession } from '../../../common';
+import { Project } from '../dto';
+
+export class ProjectDeletedEvent {
+  constructor(readonly project: Project, readonly session: ISession) {}
+}

--- a/src/components/project/events/project-updated.event.ts
+++ b/src/components/project/events/project-updated.event.ts
@@ -1,0 +1,10 @@
+import { ISession } from '../../../common';
+import { Project, UpdateProject } from '../dto';
+
+export class ProjectUpdatedEvent {
+  constructor(
+    readonly project: Project,
+    readonly updates: UpdateProject,
+    readonly session: ISession
+  ) {}
+}

--- a/src/components/project/project.resolver.ts
+++ b/src/components/project/project.resolver.ts
@@ -1,6 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { IdArg, ISession, Session } from '../../common';
-import { CreateBudgetInput, CreateBudgetOutput } from '../budget';
 import {
   CreateProjectInput,
   CreateProjectOutput,
@@ -74,18 +73,6 @@ export class ProjectResolver {
   ): Promise<boolean> {
     await this.projectService.delete(id, session);
     return true;
-  }
-
-  @Mutation(() => CreateBudgetOutput, {
-    description: 'Create an budget entry',
-  })
-  async createBudget(
-    @Session() session: ISession,
-    @Args('input') { budget: input }: CreateBudgetInput
-  ): Promise<CreateBudgetOutput> {
-    const project = await this.projectService.readOne(input.projectId, session);
-    const budget = await this.projectService.createBudget(project, session);
-    return { budget };
   }
 
   @Query(() => Boolean, {

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -727,27 +727,6 @@ export class ProjectService {
           throw new ServerException('Could not find location');
         }
       }
-      // Create root directory
-      const rootDir = await this.fileService.createDirectory(
-        undefined,
-        `${id} root directory`,
-        session
-      );
-      await this.db
-        .query()
-        .match([
-          [node('project', 'Project', { id, active: true })],
-          [node('dir', 'Directory', { id: rootDir.id, active: true })],
-        ])
-        .create([
-          node('project'),
-          relation('out', '', 'rootDirectory', {
-            active: true,
-            createdAt: DateTime.local(),
-          }),
-          node('dir'),
-        ])
-        .run();
 
       const qry = `
         MATCH

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -6,6 +6,7 @@ import { ConfigModule } from './config/config.module';
 import { CoreController } from './core.controller';
 import { DatabaseModule } from './database/database.module';
 import { EmailModule } from './email';
+import { EventsModule } from './events';
 import { ExceptionFilter } from './exception.filter';
 import { GraphQLConfig } from './graphql.config';
 import { ValidationPipe } from './validation.pipe';
@@ -17,6 +18,7 @@ import { ValidationPipe } from './validation.pipe';
     DatabaseModule,
     EmailModule,
     GraphQLModule.forRootAsync({ useClass: GraphQLConfig }),
+    EventsModule,
   ],
   providers: [
     AwsS3Factory,
@@ -24,6 +26,12 @@ import { ValidationPipe } from './validation.pipe';
     { provide: APP_PIPE, useClass: ValidationPipe },
   ],
   controllers: [CoreController],
-  exports: [AwsS3Factory, ConfigModule, DatabaseModule, EmailModule],
+  exports: [
+    AwsS3Factory,
+    ConfigModule,
+    DatabaseModule,
+    EmailModule,
+    EventsModule,
+  ],
 })
 export class CoreModule {}

--- a/src/core/events/event-bus.service.ts
+++ b/src/core/events/event-bus.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, Type } from '@nestjs/common';
+// eslint-disable-next-line no-restricted-imports
+import { EventBus, IEvent } from '@nestjs/cqrs';
+import { AnyFn } from '../../common';
+import { IEventHandler } from './event-handler.decorator';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface IEventBus<EventBase extends IEvent = IEvent> {
+  publish: <T extends EventBase>(event: T) => Promise<void>;
+  publishAll: (events: EventBase[]) => Promise<void>;
+}
+
+// eslint-disable-next-line no-restricted-imports
+export { EventBus } from '@nestjs/cqrs';
+
+/**
+ * An EventBus where you can wait for event handling to finish.
+ */
+@Injectable()
+export class SyncEventBus extends EventBus implements IEventBus {
+  private readonly listenerMap = new Map<string, Set<AnyFn>>();
+
+  async publish<T extends IEvent>(event: T): Promise<void> {
+    const name = this.getEventName(event);
+    for (const handler of this.listeners(name)) {
+      await handler(event);
+    }
+  }
+
+  async publishAll<T extends IEvent>(events: T[]): Promise<void> {
+    await Promise.all(events.map((e) => this.publish(e)));
+  }
+
+  bind(handler: IEventHandler<IEvent>, name: string) {
+    this.listeners(name).add((event) => handler.handle(event));
+  }
+
+  registerSagas(types: Array<Type<unknown>>) {
+    if (types.length > 0) {
+      throw new Error('Sagas are not supported with this EventBus');
+    }
+  }
+
+  private listeners(name: string) {
+    return mapGetOrCreate(this.listenerMap, name, () => new Set());
+  }
+}
+
+const mapGetOrCreate = <K, V>(map: Map<K, V>, key: K, creator: () => V) => {
+  if (map.has(key)) {
+    return map.get(key)!;
+  }
+  const out = creator();
+  map.set(key, out);
+  return out;
+};

--- a/src/core/events/event-handler.decorator.ts
+++ b/src/core/events/event-handler.decorator.ts
@@ -1,0 +1,9 @@
+/* eslint-disable no-restricted-imports */
+import { IEvent } from '@nestjs/cqrs';
+
+export { EventsHandler } from '@nestjs/cqrs';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface IEventHandler<T extends IEvent = any> {
+  handle: (event: T) => Promise<void>;
+}

--- a/src/core/events/events.module.ts
+++ b/src/core/events/events.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+// eslint-disable-next-line no-restricted-imports
+import { CqrsModule, EventBus } from '@nestjs/cqrs';
+import { SyncEventBus } from './event-bus.service';
+
+@Module({
+  imports: [CqrsModule],
+  providers: [SyncEventBus, { provide: EventBus, useExisting: SyncEventBus }],
+  exports: [CqrsModule],
+})
+export class EventsModule {}

--- a/src/core/events/index.ts
+++ b/src/core/events/index.ts
@@ -1,0 +1,3 @@
+export * from './event-bus.service';
+export * from './event-handler.decorator';
+export * from './events.module';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,3 +5,4 @@ export * from './deprecated-database.service';
 export * from './database';
 export * from './database/indexer';
 export * from './email';
+export * from './events';

--- a/yarn.lock
+++ b/yarn.lock
@@ -702,6 +702,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nestjs/cqrs@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@nestjs/cqrs@npm:7.0.0"
+  peerDependencies:
+    "@nestjs/common": ^6.0.0 || ^7.0.0
+    "@nestjs/core": ^6.0.0 || ^7.0.0
+    reflect-metadata: 0.1.13
+    rxjs: ^6.4.0
+  checksum: 2/c20f1d31a9970cdfc53f88825dcf816867f9f18394a53c2d554159bf09f4c3c4373b21b0362e7f24c6712053164d64c268428d4a8d619c83e66d896e8b757c9f
+  languageName: node
+  linkType: hard
+
 "@nestjs/graphql@npm:^7.3.7":
   version: 7.3.7
   resolution: "@nestjs/graphql@npm:7.3.7"
@@ -4261,6 +4273,7 @@ __metadata:
     "@nestjs/cli": ^7.1.5
     "@nestjs/common": ^7.0.9
     "@nestjs/core": ^7.0.9
+    "@nestjs/cqrs": ^7.0.0
     "@nestjs/graphql": ^7.3.7
     "@nestjs/platform-express": ^7.0.9
     "@nestjs/schematics": ^7.0.0


### PR DESCRIPTION
Services can dispatch events that other services can listen/subscribe to in a decoupled way. This allows parts of the application to respond to _indirect_ mutations.

I've implemented some of our first ones as examples:
- [On project creation](https://github.com/SeedCompany/cord-api-v3/blob/7dc7cb2a0fccf2bfe5a7d5aceb8f2445f45dfeb1/src/components/project/project.service.ts#L757)
  - [create root directory](https://github.com/SeedCompany/cord-api-v3/blob/3b51dacde61d6593aa7bc601024c5664df4b3f17/src/components/file/handlers/attach-project-root-directory.handler.ts)
- On partnership mutation (created/updated/deleted)
  - [sync budget records](https://github.com/SeedCompany/cord-api-v3/blob/bfa19efa3c75e741ee402d29dc20ce184522d5a1/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts) (stubbed)