### PR TITLE
[RFC] Error Handling Again

### DIFF
--- a/src/common/exceptions/duplicate.exception.ts
+++ b/src/common/exceptions/duplicate.exception.ts
@@ -1,0 +1,14 @@
+import { InputException } from './input.exception';
+
+/**
+ * A duplicate was found where uniqueness is required.
+ */
+export class DuplicateException extends InputException {
+  constructor(field: string, message?: string, previous?: Error) {
+    super(
+      message ?? `${field} already exists and needs to be unique`,
+      field,
+      previous
+    );
+  }
+}

--- a/src/common/exceptions/exception.ts
+++ b/src/common/exceptions/exception.ts
@@ -1,0 +1,24 @@
+/**
+ * The base of all of our exceptions.
+ * Don't throw this, but rather a sub-class instead.
+ */
+export abstract class Exception extends Error {
+  /**
+   * Basically just to group exceptions into client/server groups.
+   * This may be removed later.
+   */
+  abstract readonly status: number;
+
+  constructor(message: string, readonly previous?: Error) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+export class ServerException extends Exception {
+  readonly status: number = 500;
+}
+
+export abstract class ClientException extends Exception {
+  readonly status: number = 400;
+}

--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -1,5 +1,6 @@
 export * from './exception';
 export * from './input.exception';
 export * from './duplicate.exception';
+export * from './not-implemented.exception';
 export * from './unauthenticated.exception';
 export * from './unauthorized.exception';

--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -1,0 +1,5 @@
+export * from './exception';
+export * from './input.exception';
+export * from './duplicate.exception';
+export * from './unauthenticated.exception';
+export * from './unauthorized.exception';

--- a/src/common/exceptions/input.exception.ts
+++ b/src/common/exceptions/input.exception.ts
@@ -1,0 +1,22 @@
+import { ClientException } from './exception';
+
+/**
+ * Useful in services where complex logic is needed
+ * to confirm user input/request is valid.
+ */
+export class InputException extends ClientException {
+  /**
+   * @example
+   * throw new InputException(
+   *   `User's bio must be written in MLA format`,
+   *   'user.bio'
+   * );
+   *
+   * @param message A human (dev) readable message
+   * @param field The field name in a.b.c nested notation from the Input DTO.
+   * @param previous A previous error if any
+   */
+  constructor(message: string, readonly field?: string, previous?: Error) {
+    super(message, previous);
+  }
+}

--- a/src/common/exceptions/not-implemented.exception.ts
+++ b/src/common/exceptions/not-implemented.exception.ts
@@ -1,0 +1,7 @@
+import { ServerException } from './exception';
+
+export class NotImplementedException extends ServerException {
+  constructor(message?: string, previous?: Error) {
+    super(message ?? 'Not implemented', previous);
+  }
+}

--- a/src/common/exceptions/unauthenticated.exception.ts
+++ b/src/common/exceptions/unauthenticated.exception.ts
@@ -1,0 +1,13 @@
+import { HttpStatus } from '@nestjs/common';
+import { ClientException } from './exception';
+
+/**
+ * We cannot identify the requester.
+ */
+export class UnauthenticatedException extends ClientException {
+  readonly status = HttpStatus.UNAUTHORIZED;
+
+  constructor(message?: string, previous?: Error) {
+    super(message ?? `Not authenticated`, previous);
+  }
+}

--- a/src/common/exceptions/unauthorized.exception.ts
+++ b/src/common/exceptions/unauthorized.exception.ts
@@ -1,0 +1,13 @@
+import { HttpStatus } from '@nestjs/common';
+import { InputException } from './input.exception';
+
+/**
+ * The requester has insufficient permission to do this operation.
+ */
+export class UnauthorizedException extends InputException {
+  readonly status = HttpStatus.FORBIDDEN;
+
+  constructor(message?: string, field?: string, previous?: Error) {
+    super(message ?? `Insufficient permission`, field, previous);
+  }
+}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -2,6 +2,7 @@ export * from './context.type';
 export * from './calendar-date';
 export * from './date-filter.input';
 export * from './editable.interface';
+export * from './exceptions';
 export * from './firstLettersOfWords';
 export * from './fiscal-year';
 export * from './id.arg';

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -7,7 +7,6 @@ export * from './firstLettersOfWords';
 export * from './fiscal-year';
 export * from './id.arg';
 export { DateField, DateTimeField } from './luxon.graphql';
-export * from './not-implemented.error';
 export * from './order.enum';
 export * from './pagination.input';
 export * from './pagination-list';

--- a/src/common/not-implemented.error.ts
+++ b/src/common/not-implemented.error.ts
@@ -1,5 +1,0 @@
-export class NotImplementedError extends Error {
-  constructor() {
-    super('Not implemented');
-  }
-}

--- a/src/core/database/errors.ts
+++ b/src/core/database/errors.ts
@@ -28,6 +28,7 @@ export class UniquenessError extends ConstraintError {
   constructor(
     readonly node: number,
     readonly label: string,
+    readonly property: string,
     readonly value: string,
     message: string
   ) {
@@ -39,7 +40,13 @@ export class UniquenessError extends ConstraintError {
       return e;
     }
     const info = getUniqueFailureInfo(e);
-    const ex = new this(info.node, info.label, info.value, e.message);
+    const ex = new this(
+      info.node,
+      info.label,
+      info.property,
+      info.value,
+      e.message
+    );
     ex.stack = e.stack;
     return ex;
   }
@@ -48,6 +55,7 @@ export class UniquenessError extends ConstraintError {
     level: LogLevel.WARNING,
     message: 'Duplicate property',
     label: this.label,
+    property: this.property,
     value: this.value,
   };
 }
@@ -68,7 +76,7 @@ export const createBetterError = (e: Error) => {
   return e;
 };
 
-const uniqueMsgRegex = /^Node\((\d+)\) already exists with label `(\w+)` and property `value` = '(.+)'$/;
+const uniqueMsgRegex = /^Node\((\d+)\) already exists with label `(\w+)` and property `(.+)` = '(.+)'$/;
 const getUniqueFailureInfo = (e: Neo.Neo4jError) => {
   const matches = uniqueMsgRegex.exec(e.message);
   if (!matches) {
@@ -79,6 +87,7 @@ const getUniqueFailureInfo = (e: Neo.Neo4jError) => {
   return {
     node: Number(matches[1]),
     label: matches[2],
-    value: matches[3],
+    property: matches[3],
+    value: matches[4],
   };
 };

--- a/src/core/exception.filter.test.ts
+++ b/src/core/exception.filter.test.ts
@@ -1,4 +1,10 @@
-import { NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InputException, ServerException } from '../common/exceptions';
 import { ExceptionFilter } from './exception.filter';
 
 describe('ExceptionFilter', () => {
@@ -69,5 +75,42 @@ describe('ExceptionFilter', () => {
       expect(res.extensions.code).toEqual('NotFound');
       expect(res.extensions.description).toEqual('Could not find resource');
     });
+
+    it('BadRequestException', () => {
+      const ex = new BadRequestException('what happened');
+      const res = new ExceptionFilter().catchGql(ex);
+      expect(res.message).toEqual('what happened');
+      expect(res.extensions.status).toEqual(400);
+      expect(res.extensions.code).toEqual('Input');
+    });
+
+    it('ForbiddenException', () => {
+      const ex = new ForbiddenException();
+      const res = new ExceptionFilter().catchGql(ex);
+      expect(res.extensions.code).toEqual('Unauthorized');
+    });
+
+    it('UnauthorizedException', () => {
+      const ex = new UnauthorizedException();
+      const res = new ExceptionFilter().catchGql(ex);
+      expect(res.extensions.code).toEqual('Unauthenticated');
+    });
+  });
+
+  it('ServerException', () => {
+    const ex = new ServerException('what happened');
+    const res = new ExceptionFilter().catchGql(ex);
+    expect(res.message).toEqual('what happened');
+    expect(res.extensions.status).toEqual(500);
+    expect(res.extensions.code).toEqual('Server');
+  });
+
+  it('InputException', () => {
+    const ex = new InputException('what happened', 'field.name');
+    const res = new ExceptionFilter().catchGql(ex);
+    expect(res.message).toEqual('what happened');
+    expect(res.extensions.status).toEqual(400);
+    expect(res.extensions.code).toEqual('Input');
+    expect(res.extensions.field).toEqual('field.name');
   });
 });


### PR DESCRIPTION
This is an addendum to #414 

# Problem
The problem currently is there's not an easy way to give _custom_, _statically-typed_ info in exceptions (beyond a custom code).

It's true that NestJS' `HttpExceptions` accept really anything and we do send that back to the client. However, that flexibility is really the problem. They allow for anything so it's hard to be consistent on the error creation side (without subclass) and hard on the receiving side, whether that's formatting for client or catching the exception somewhere else in the codebase.
See [exception.filter.test.ts](https://github.com/SeedCompany/cord-api-v3/blob/d92f857ddccaa653547ac80dfbbbf0f839c3d413/src/core/exception.filter.test.ts) for all the different ways the exceptions can be created. 

Custom codes are _too_ easy to mess up. 
https://github.com/SeedCompany/cord-api-v3/blob/d92f857ddccaa653547ac80dfbbbf0f839c3d413/src/components/authentication/authentication.service.ts#L242-L245
This `NoSession` becomes the type that the frontend maps on, however it's essentially a magic string here. 
We want this to be harder to mess up, like a class name.

# Solution 🤞
So, in an effort to distance ourselves from that mess and to ease the creation of custom types of errors I've implemented a new exception hierarchy.

## Root Exception Class
We have a root `Exception` class that everything will extend from 
https://github.com/SeedCompany/cord-api-v3/blob/6b294cf6f8d05a3550dfa2f41dd7fef8871c4a07/src/common/exceptions/exception.ts#L1-L16

This gives us:
- optional `previous` error property (more later)
- a class to do `instanceof` checks from
- All properties of these errors are sent back to the consumer and declared here in a type safe way
- status property, but I'm not sure that's a good thing. We might remove later.


## InputException

This is useful in services where complex logic is needed to confirm user input/request is valid.
This adds an optional `field` property to tell the user which input field has this error.
https://github.com/SeedCompany/cord-api-v3/blob/6b294cf6f8d05a3550dfa2f41dd7fef8871c4a07/src/common/exceptions/input.exception.ts#L19

## DuplicateException

This is a subclass of `InputException` specifically for duplicates/uniqueness failures.
https://github.com/SeedCompany/cord-api-v3/blob/6b294cf6f8d05a3550dfa2f41dd7fef8871c4a07/src/common/exceptions/duplicate.exception.ts#L6-L14

This subclass was easy to create, it has a custom code (`Duplicate`), it made `field` required, and it defaulted the message to something appropriate for this type of error.
It's a simple one-liner to use this exception and there's no question about what kinda of info should be passed in.


## ValidationException

Previously validation errors had to be mapped in our ExceptionFilter and it had a special check for it. This violated the open/close principle.
Now `ValidationException` extends our base `Exception` and the `ExceptionFilter` just handles it. Now this logic lives in the validation file.
https://github.com/SeedCompany/cord-api-v3/blob/6b294cf6f8d05a3550dfa2f41dd7fef8871c4a07/src/core/validation.pipe.ts#L20-L22

## Previous/Original errors

Most other languages have the concept of previous errors. This allows errors to be wrapped and "handled" without loosing information.

Here's an example for us:
https://github.com/SeedCompany/cord-api-v3/blob/969fb6d15e225cd3240ac5644d3bfa9348ca965d/src/components/user/user.service.ts#L537-L544
We wrap the uniqueness database error in a `DuplicateException`. This allows the API consumer to handle it correctly, but we still pass the previous or "original" along with the new one.
Same with the `ServerException` below it. 

Now we can log the original message to see what the actual error was while still providing a nice error to the consumer.
Logging these is not done yet 😞 

# Pitfalls

## Exposed data

Currently all enumerable properties (besides name & previous) are exposed in client response. These have to be opt-ed out of by defining the property without enumerability
https://github.com/SeedCompany/cord-api-v3/blob/6b294cf6f8d05a3550dfa2f41dd7fef8871c4a07/src/core/validation.pipe.ts#L27 

It might be better to have this be opt-in functionality with like an `@Expose` decorator.

## Unconsumable Exception Code Hierarchy 

The API consumers don't have access to our exception hierarchy.
So for example, DuplicateException is a instanceof InputException, but to the API they are two completely different errors.
This also means we can't get more specific without a "breaking" change.

How could this be represented in a JSON structure?
Maybe `code` is an ordered list of `codes`?
```json
{
  "codes": ["Duplicate", "Input", "Client"]
}
```
This could allow for the consumer to handle with the first that matches. Thoughts?
