### PR TITLE
Fix our EventBus not applying

### DIFF
--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -1,5 +1,4 @@
 import {
-  Inject,
   Injectable,
   NotFoundException,
   InternalServerErrorException as ServerException,
@@ -13,7 +12,6 @@ import { fiscalYears, ISession } from '../../common';
 import {
   ConfigService,
   DatabaseService,
-  EventBus,
   IEventBus,
   ILogger,
   Logger,
@@ -46,7 +44,7 @@ export class PartnershipService {
     private readonly budgetService: BudgetService,
     private readonly orgService: OrganizationService,
     private readonly projectService: ProjectService,
-    @Inject(EventBus) private readonly eventBus: IEventBus,
+    private readonly eventBus: IEventBus,
     @Logger('partnership:service') private readonly logger: ILogger
   ) {}
 

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -14,7 +14,6 @@ import {
   addBaseNodeMetaPropsWithClause,
   ConfigService,
   DatabaseService,
-  EventBus,
   IEventBus,
   ILogger,
   listWithSecureObject,
@@ -81,7 +80,7 @@ export class ProjectService {
     private readonly fileService: FileService,
     private readonly engagementService: EngagementService,
     private readonly config: ConfigService,
-    @Inject(EventBus) private readonly eventBus: IEventBus,
+    private readonly eventBus: IEventBus,
     @Logger('project:service') private readonly logger: ILogger
   ) {}
 

--- a/src/core/events/event-bus.service.ts
+++ b/src/core/events/event-bus.service.ts
@@ -5,13 +5,10 @@ import { AnyFn } from '../../common';
 import { IEventHandler } from './event-handler.decorator';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export interface IEventBus<EventBase extends IEvent = IEvent> {
+export abstract class IEventBus<EventBase extends IEvent = IEvent> {
   publish: <T extends EventBase>(event: T) => Promise<void>;
   publishAll: (events: EventBase[]) => Promise<void>;
 }
-
-// eslint-disable-next-line no-restricted-imports
-export { EventBus } from '@nestjs/cqrs';
 
 /**
  * An EventBus where you can wait for event handling to finish.

--- a/src/core/events/events.module.ts
+++ b/src/core/events/events.module.ts
@@ -2,7 +2,7 @@ import { Module, OnApplicationBootstrap } from '@nestjs/common';
 // eslint-disable-next-line no-restricted-imports
 import { CommandBus, EventBus } from '@nestjs/cqrs';
 import { ExplorerService } from '@nestjs/cqrs/dist/services/explorer.service';
-import { SyncEventBus } from './event-bus.service';
+import { IEventBus, SyncEventBus } from './event-bus.service';
 
 @Module({
   providers: [
@@ -10,8 +10,9 @@ import { SyncEventBus } from './event-bus.service';
     CommandBus,
     { provide: EventBus, useExisting: SyncEventBus },
     SyncEventBus,
+    { provide: IEventBus, useExisting: SyncEventBus },
   ],
-  exports: [EventBus],
+  exports: [EventBus, IEventBus],
 })
 export class EventsModule implements OnApplicationBootstrap {
   constructor(

--- a/src/core/events/events.module.ts
+++ b/src/core/events/events.module.ts
@@ -1,11 +1,26 @@
-import { Module } from '@nestjs/common';
+import { Module, OnApplicationBootstrap } from '@nestjs/common';
 // eslint-disable-next-line no-restricted-imports
-import { CqrsModule, EventBus } from '@nestjs/cqrs';
+import { CommandBus, EventBus } from '@nestjs/cqrs';
+import { ExplorerService } from '@nestjs/cqrs/dist/services/explorer.service';
 import { SyncEventBus } from './event-bus.service';
 
 @Module({
-  imports: [CqrsModule],
-  providers: [SyncEventBus, { provide: EventBus, useExisting: SyncEventBus }],
-  exports: [CqrsModule],
+  providers: [
+    ExplorerService,
+    CommandBus,
+    { provide: EventBus, useExisting: SyncEventBus },
+    SyncEventBus,
+  ],
+  exports: [EventBus],
 })
-export class EventsModule {}
+export class EventsModule implements OnApplicationBootstrap {
+  constructor(
+    private readonly explorer: ExplorerService,
+    private readonly eventBus: SyncEventBus
+  ) {}
+
+  onApplicationBootstrap() {
+    const { events } = this.explorer.explore();
+    this.eventBus.register(events);
+  }
+}


### PR DESCRIPTION
Fixes #703 

Turns out you cannot _replace_ a provider. NestJS just ignores these attempts which is annoying.
So instead of importing `CqrsModule` we are declaring its services ourselves to get around this.
This isn't that much more work, and it does give us more control.

I also changed `IEventBus` to a class so it can be injected without the `@Inject` decorator.
