### PR TITLE
Expose exception chain to API consumers

### DIFF
--- a/src/core/exception.filter.test.ts
+++ b/src/core/exception.filter.test.ts
@@ -5,24 +5,29 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { InputException, ServerException } from '../common/exceptions';
+import { ConstraintError } from './database';
 import { ExceptionFilter } from './exception.filter';
 
 describe('ExceptionFilter', () => {
+  const filter = new ExceptionFilter();
+
   describe('HttpException', () => {
     it('simple', () => {
       const ex = new NotFoundException();
-      const res = new ExceptionFilter().catchGql(ex);
+      const res = filter.catchGql(ex);
       expect(res.message).toEqual('Not Found');
       expect(res.extensions.status).toEqual(404);
       expect(res.extensions.code).toEqual('NotFound');
+      expect(res.extensions.codes).toEqual(['NotFound', 'Client']);
     });
 
     it('custom message', () => {
       const ex = new NotFoundException('Could not find resource');
-      const res = new ExceptionFilter().catchGql(ex);
+      const res = filter.catchGql(ex);
       expect(res.message).toEqual('Could not find resource');
       expect(res.extensions.status).toEqual(404);
       expect(res.extensions.code).toEqual('NotFound');
+      expect(res.extensions.codes).toEqual(['NotFound', 'Client']);
     });
 
     it('custom code', () => {
@@ -30,10 +35,15 @@ describe('ExceptionFilter', () => {
         'Could not find resource',
         'CustomNotFound'
       );
-      const res = new ExceptionFilter().catchGql(ex);
+      const res = filter.catchGql(ex);
       expect(res.message).toEqual('Could not find resource');
       expect(res.extensions.status).toEqual(404);
       expect(res.extensions.code).toEqual('CustomNotFound');
+      expect(res.extensions.codes).toEqual([
+        'CustomNotFound',
+        'NotFound',
+        'Client',
+      ]);
     });
 
     it('custom error object with message', () => {
@@ -41,10 +51,11 @@ describe('ExceptionFilter', () => {
         { message: 'Could not find resource', foo: 'bar' },
         'Ignored'
       );
-      const res = new ExceptionFilter().catchGql(ex);
+      const res = filter.catchGql(ex);
       expect(res.message).toEqual('Could not find resource');
       expect(res.extensions.status).toEqual(404);
       expect(res.extensions.code).toEqual('NotFound');
+      expect(res.extensions.codes).toEqual(['NotFound', 'Client']);
       expect(res.extensions.foo).toEqual('bar');
     });
 
@@ -57,10 +68,15 @@ describe('ExceptionFilter', () => {
         },
         'Ignored'
       );
-      const res = new ExceptionFilter().catchGql(ex);
+      const res = filter.catchGql(ex);
       expect(res.message).toEqual('Could not find resource');
       expect(res.extensions.status).toEqual(404);
       expect(res.extensions.code).toEqual('CustomNotFound');
+      expect(res.extensions.codes).toEqual([
+        'CustomNotFound',
+        'NotFound',
+        'Client',
+      ]);
       expect(res.extensions.foo).toEqual('bar');
     });
 
@@ -69,48 +85,72 @@ describe('ExceptionFilter', () => {
         { description: 'Could not find resource' },
         'Ignored'
       );
-      const res = new ExceptionFilter().catchGql(ex);
+      const res = filter.catchGql(ex);
       expect(res.message).toEqual('Not Found Exception');
       expect(res.extensions.status).toEqual(404);
       expect(res.extensions.code).toEqual('NotFound');
+      expect(res.extensions.codes).toEqual(['NotFound', 'Client']);
       expect(res.extensions.description).toEqual('Could not find resource');
     });
 
     it('BadRequestException', () => {
       const ex = new BadRequestException('what happened');
-      const res = new ExceptionFilter().catchGql(ex);
+      const res = filter.catchGql(ex);
       expect(res.message).toEqual('what happened');
       expect(res.extensions.status).toEqual(400);
       expect(res.extensions.code).toEqual('Input');
+      expect(res.extensions.codes).toEqual(['Input', 'Client']);
     });
 
     it('ForbiddenException', () => {
       const ex = new ForbiddenException();
-      const res = new ExceptionFilter().catchGql(ex);
+      const res = filter.catchGql(ex);
       expect(res.extensions.code).toEqual('Unauthorized');
+      expect(res.extensions.codes).toEqual(['Unauthorized', 'Client']);
     });
 
     it('UnauthorizedException', () => {
       const ex = new UnauthorizedException();
-      const res = new ExceptionFilter().catchGql(ex);
+      const res = filter.catchGql(ex);
       expect(res.extensions.code).toEqual('Unauthenticated');
+      expect(res.extensions.codes).toEqual(['Unauthenticated', 'Client']);
     });
   });
 
   it('ServerException', () => {
     const ex = new ServerException('what happened');
-    const res = new ExceptionFilter().catchGql(ex);
+    const res = filter.catchGql(ex);
     expect(res.message).toEqual('what happened');
     expect(res.extensions.status).toEqual(500);
     expect(res.extensions.code).toEqual('Server');
+    expect(res.extensions.codes).toEqual(['Server']);
   });
 
   it('InputException', () => {
     const ex = new InputException('what happened', 'field.name');
-    const res = new ExceptionFilter().catchGql(ex);
+    const res = filter.catchGql(ex);
     expect(res.message).toEqual('what happened');
     expect(res.extensions.status).toEqual(400);
     expect(res.extensions.code).toEqual('Input');
+    expect(res.extensions.codes).toEqual(['Input', 'Client']);
     expect(res.extensions.field).toEqual('field.name');
+  });
+
+  it('Generic Error', () => {
+    const ex = new Error('what happened');
+    const res = filter.catchGql(ex);
+    expect(res.message).toEqual('what happened');
+    expect(res.extensions.status).toEqual(500);
+    expect(res.extensions.code).toEqual('InternalServerError');
+    expect(res.extensions.codes).toEqual(['InternalServerError']);
+  });
+
+  it('Unknown Error', () => {
+    const ex = new ConstraintError('what happened');
+    const res = filter.catchGql(ex);
+    expect(res.message).toEqual('what happened');
+    expect(res.extensions.status).toEqual(500);
+    expect(res.extensions.code).toEqual('InternalServerError');
+    expect(res.extensions.codes).toEqual(['InternalServerError']);
   });
 });


### PR DESCRIPTION
Discovered in #701 

Problem is if errors change and become more specific they are suddenly not handled on the consumption side.
For example if we are handling creating a user with a duplicate email address as an `Input` error and then the API decides to create a `DuplicateException` extending `InputException then that comes back as `Duplicate` with no relation to `Input` even though they could at worst, be handled in the same way.

This changes `code` to `codes` that is a hierarchy of the exceptions classes (as codes).
So in the example above the error response would go from
```tsx
codes: ['Input']
```
to
```tsx
codes: ['Duplicate', 'Input']
```
So if API consumer was checking for `Input` in the array that will still work. They now have the option to handle `Duplicate`  in a more specific way.

In the future, we could have an even more specific exception like `DuplicateEmailException extends DuplicateException`.
This would be returned as
```tsx
codes: ['DuplicateEmail', 'Duplicate', 'Input']
```
Thus we've maintained compatibility with consumer's error handling. 


----

This also gives us the ability to add `Client` or `Server` to the `codes` array. This removes the need to have a separate `status` field for that purpose. I've added both of those to the codes array. So we'll give the frontend time to switch to the new `codes` pattern and then come back and remove `code` & `status`.