### PR TITLE
Issue: 733 - Fix user readOne returns null values

### DIFF
--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -3,7 +3,7 @@ import {
   NotFoundException,
   UnauthorizedException as UnauthenticatedException,
 } from '@nestjs/common';
-import { node, relation } from 'cypher-query-builder';
+import { node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { generate } from 'shortid';
 import { DuplicateException, ISession, ServerException } from '../../common';
@@ -13,7 +13,6 @@ import {
   DatabaseService,
   ILogger,
   Logger,
-  matchProperties,
   matchSession,
   OnIndex,
   UniquenessError,
@@ -642,6 +641,43 @@ export class UserService {
     return result.id;
   }
 
+  propMatch = (query: Query, property: string, baseNode: string) => {
+    const readPerm = property + 'ReadPerm';
+    const editPerm = property + 'EditPerm';
+    query.optionalMatch([
+      [
+        node(baseNode),
+        relation('in', '', 'member', { active: true }),
+        node('sg', 'SecurityGroup', { active: true }),
+        relation('out', '', 'permission', { active: true }),
+        node(editPerm, 'Permission', {
+          property,
+          active: true,
+          edit: true,
+        }),
+        relation('out', '', 'baseNode', { active: true }),
+        node(baseNode),
+      ],
+    ]);
+    query.optionalMatch([
+      [
+        node(baseNode),
+        relation('in', '', 'member', { active: true }),
+        node('sg', 'SecurityGroup', { active: true }),
+        relation('out', '', 'permission', { active: true }),
+        node(readPerm, 'Permission', {
+          property,
+          active: true,
+          read: true,
+        }),
+        relation('out', '', 'baseNode', { active: true }),
+        node(baseNode),
+        relation('out', '', property, { active: true }),
+        node(property, 'Property', { active: true }),
+      ],
+    ]);
+  };
+
   async readOne(id: string, session: ISession): Promise<User> {
     const props = [
       'email',
@@ -656,14 +692,14 @@ export class UserService {
     ];
     const query = this.db
       .query()
-      .match([
-        node('requestingUser', 'User', {
-          active: true,
-          id: session.userId,
-        }),
-      ])
-      .match([node('user', 'User', { active: true, id })])
-      .call(matchProperties, 'user', ...props)
+      .match(matchSession(session, { withAclRead: 'canReadUsers' }))
+      .match([node('user', 'User', { active: true, id })]);
+
+    for (const prop of props) {
+      this.propMatch(query, prop, 'user');
+    }
+
+    query
       .with([
         ...props.map(addPropertyCoalesceWithClause),
         'coalesce(user.id) as id',

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -692,7 +692,13 @@ export class UserService {
     ];
     const query = this.db
       .query()
-      .match(matchSession(session, { withAclRead: 'canReadUsers' }))
+      .match([
+        node('requestingUser', 'User', {
+          active: true,
+          id: session.userId,
+          canReadUsers: true,
+        }),
+      ])
       .match([node('user', 'User', { active: true, id })]);
 
     for (const prop of props) {


### PR DESCRIPTION
Fixes: https://github.com/SeedCompany/cord-api-v3/issues/733

Fix user.service `readOne` returns null values even if requesting user has canReadUsers permission.