### PR TITLE
IdField decorator

### DIFF
--- a/src/common/id-field.ts
+++ b/src/common/id-field.ts
@@ -1,0 +1,13 @@
+import { applyDecorators } from '@nestjs/common';
+import { Field, FieldOptions, ID } from '@nestjs/graphql';
+import { ValidationOptions } from 'class-validator';
+import { IsShortId } from './validators';
+
+export const IdField = ({
+  validation,
+  ...options
+}: FieldOptions & { validation?: ValidationOptions } = {}) =>
+  applyDecorators(
+    Field(() => ID, options),
+    IsShortId(validation)
+  );

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -20,3 +20,4 @@ export { ISession, Session } from './session';
 export * from './types';
 export * from './validators';
 export * from './name-field';
+export * from './id-field';

--- a/src/common/validators/index.ts
+++ b/src/common/validators/index.ts
@@ -1,2 +1,3 @@
 export * from './email.validator';
 export * from './iana-timezone.validator';
+export * from './short-id.validator';

--- a/src/common/validators/short-id.validator.ts
+++ b/src/common/validators/short-id.validator.ts
@@ -1,0 +1,18 @@
+import { ValidationOptions } from 'class-validator';
+import { isValid } from 'shortid';
+import { ValidateBy } from './validateBy';
+
+export const IsShortId = (validationOptions?: ValidationOptions) =>
+  ValidateBy(
+    {
+      name: 'IsShortId',
+      validator: {
+        validate: isValid,
+        defaultMessage: () =>
+          validationOptions?.each
+            ? 'Each value in $property must be a valid ID'
+            : 'Invalid ID',
+      },
+    },
+    validationOptions
+  );


### PR DESCRIPTION
- Adds validator for _shortid_
- Adds `IdField` decorator as a shortcut for GQL ID Field with _shortid_ validation.

Next step is to apply below everywhere:
```diff
- @Field(() => ID, { ... })
+ @IdField({ ... })
```