### PR TITLE
Update IdArg decorator to validate value is a short id

### DIFF
--- a/src/common/id.arg.ts
+++ b/src/common/id.arg.ts
@@ -1,7 +1,29 @@
-import { PipeTransform, Type } from '@nestjs/common';
+import { ArgumentMetadata, PipeTransform, Type } from '@nestjs/common';
 import { Args, ArgsOptions, ID } from '@nestjs/graphql';
+import { ValidationPipe } from '../core/validation.pipe';
+import { IsShortId } from './validators';
+
+// just an object with the validator metadata
+class IdHolder {
+  @IsShortId()
+  id: string;
+}
+
+class ValidateIdPipe implements PipeTransform {
+  async transform(id: any, _metadata: ArgumentMetadata) {
+    await new ValidationPipe().transform(
+      { id },
+      {
+        metatype: IdHolder,
+        type: 'body',
+        data: 'id',
+      }
+    );
+    return id;
+  }
+}
 
 export const IdArg = (
   opts: Partial<ArgsOptions> = {},
   ...pipes: Array<Type<PipeTransform> | PipeTransform>
-) => Args({ name: 'id', type: () => ID, ...opts }, ...pipes);
+) => Args({ name: 'id', type: () => ID, ...opts }, ValidateIdPipe, ...pipes);


### PR DESCRIPTION
Fixes #777
Supersedes #779 

Applies the `@IsShortId` validation decorator to the id values specified by `@IdArg` decorator.