### PR TITLE
Require email when creating person and allow updating

### DIFF
--- a/src/components/user/dto/create-person.dto.ts
+++ b/src/components/user/dto/create-person.dto.ts
@@ -7,9 +7,9 @@ import { User } from './user.dto';
 
 @InputType()
 export abstract class CreatePerson {
-  @Field({ nullable: true })
+  @Field()
   @IsEmail()
-  readonly email?: string;
+  readonly email: string;
 
   @NameField()
   readonly realFirstName: string;

--- a/src/components/user/dto/update-user.dto.ts
+++ b/src/components/user/dto/update-user.dto.ts
@@ -10,7 +10,8 @@ export abstract class UpdateUser {
   @IdField()
   readonly id: string;
 
-  // TODO Allow email to be changed? Implications?
+  @Field({ nullable: true })
+  readonly email?: string;
 
   @NameField({ nullable: true })
   readonly realFirstName?: string;


### PR DESCRIPTION
@sethmcknight Says that having email optional for people isn't necessary.
We have no reason not to allow changing email currently.

Open to comments about why we shouldn't do this.