### PR TITLE
Fix corrupted files in filesystem bucket

### DIFF
--- a/src/components/file/bucket/filesystem-bucket.ts
+++ b/src/components/file/bucket/filesystem-bucket.ts
@@ -45,7 +45,7 @@ export class FilesystemBucket extends LocalBucket {
       throw new NotFoundException();
     }
     const raw = await this.readFile(key + '.info');
-    const info = JSON.parse(raw);
+    const info = JSON.parse(raw.toString());
     info.LastModified = new Date(info.LastModified);
 
     return info;
@@ -65,9 +65,7 @@ export class FilesystemBucket extends LocalBucket {
   }
 
   private async readFile(key: string) {
-    return fs.readFile(this.getPath(key), {
-      encoding: 'utf8',
-    });
+    return fs.readFile(this.getPath(key));
   }
 
   private async writeFile(key: string, data: any) {
@@ -75,9 +73,7 @@ export class FilesystemBucket extends LocalBucket {
     await fs.mkdir(dirname(path), {
       recursive: true,
     });
-    await fs.writeFile(this.getPath(key), data, {
-      encoding: 'utf8',
-    });
+    await fs.writeFile(this.getPath(key), data);
   }
 
   private getPath(key: string) {

--- a/src/components/file/bucket/local-bucket.ts
+++ b/src/components/file/bucket/local-bucket.ts
@@ -9,7 +9,7 @@ export interface LocalBucketOptions extends BucketOptions {
 }
 
 export type FakeAwsFile = Required<Pick<GetObjectOutput, 'ContentType'>> &
-  Pick<GetObjectOutput, 'ContentLength' | 'LastModified'> & { Body: string };
+  Pick<GetObjectOutput, 'ContentLength' | 'LastModified'> & { Body: Buffer };
 
 /**
  * Common functionality for "local" (non-s3) buckets

--- a/src/components/file/bucket/local-bucket.ts
+++ b/src/components/file/bucket/local-bucket.ts
@@ -30,7 +30,7 @@ export abstract class LocalBucket extends FileBucket {
   async upload(signed: string, file: FakeAwsFile) {
     const key = this.validateSignedUrl('putObject', signed);
     await this.saveFile(key, {
-      ContentLength: file.Body.length,
+      ContentLength: file.Body.byteLength,
       LastModified: new Date(),
       ...file,
     });

--- a/src/components/file/local-bucket.controller.ts
+++ b/src/components/file/local-bucket.controller.ts
@@ -36,7 +36,7 @@ export class LocalBucketController {
     }
     // Chokes on json files because they are parsed with body-parser.
     // Need to disable it for this path or create a workaround.
-    const contents = (await rawBody(req)).toString('utf8').trim();
+    const contents = await rawBody(req);
     if (!contents) {
       throw new BadRequestException();
     }

--- a/test/utility/create-file.ts
+++ b/test/utility/create-file.ts
@@ -15,7 +15,7 @@ import * as fragments from './fragments';
 
 export const generateFakeFile = () => ({
   name: faker.system.fileName(),
-  content: faker.lorem.paragraph(),
+  content: Buffer.from(faker.image.dataUri(200, 200).split(',')[1], 'base64'),
   size: faker.random.number(1_000_000),
   mimeType: faker.random.arrayElement(mimeTypes).name,
 });


### PR DESCRIPTION
Fixes an issue where files uploaded to the "filesystem bucket" (for dev purposes) could not be opened directly or after download. This turned out to be due to us converting the incoming `Buffer` to a `string` and writing/reading it as such.

- Update `upload()` method of `local-bucket` controller to leave request body as `Buffer` instead of converting to a `string`
- Update `readFile()` and `writeFile()` methods of `filesystem-bucket` to read/write file as `Buffer`
- Update `FakeAwsFile` type to set `Body` property type to `Buffer`
- Update `generateFakeFile()` method in `test/utility/create-file` to generate `Buffer` for the `content` property instead of a `string`