### PR TITLE
Remove ID filters from API

### DIFF
--- a/src/components/budget/dto/list-budget.dto.ts
+++ b/src/components/budget/dto/list-budget.dto.ts
@@ -1,8 +1,7 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import {
-  IdField,
   PaginatedList,
   SecuredList,
   SortablePaginationInput,
@@ -12,10 +11,6 @@ import { Budget } from './budget.dto';
 
 @InputType()
 export abstract class BudgetFilters {
-  @IdField({
-    description: 'Only budgets matching this projectId',
-    nullable: true,
-  })
   readonly projectId?: string;
 }
 
@@ -27,7 +22,6 @@ export class BudgetListInput extends SortablePaginationInput<keyof Budget>({
 }) {
   static defaultVal = new BudgetListInput();
 
-  @Field({ nullable: true })
   @Type(() => BudgetFilters)
   @ValidateNested()
   readonly filter: BudgetFilters = defaultFilters;
@@ -43,10 +37,6 @@ export abstract class SecuredBudgetList extends SecuredList(Budget) {}
 
 @InputType()
 export abstract class BudgetRecordFilters {
-  @IdField({
-    description: 'Only budget records matching this budgetId',
-    nullable: true,
-  })
   readonly budgetId?: string;
 }
 
@@ -58,7 +48,6 @@ export class BudgetRecordListInput extends SortablePaginationInput<
 }) {
   static defaultVal = new BudgetListInput();
 
-  @Field({ nullable: true })
   @Type(() => BudgetRecordFilters)
   @ValidateNested()
   readonly filter: BudgetRecordFilters = defaultFilters;

--- a/src/components/engagement/dto/list-engagements.dto.ts
+++ b/src/components/engagement/dto/list-engagements.dto.ts
@@ -2,7 +2,6 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import {
-  IdField,
   PaginatedList,
   SecuredList,
   SortablePaginationInput,
@@ -17,10 +16,6 @@ export abstract class EngagementFilters {
   })
   readonly type?: 'language' | 'internship';
 
-  @IdField({
-    description: 'Only engagements matching this projectId',
-    nullable: true,
-  })
   readonly projectId?: string;
 }
 

--- a/src/components/organization/dto/list-organization.dto.ts
+++ b/src/components/organization/dto/list-organization.dto.ts
@@ -2,7 +2,6 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import {
-  IdField,
   PaginatedList,
   SecuredList,
   SortablePaginationInput,
@@ -17,10 +16,6 @@ export abstract class OrganizationFilters {
   })
   readonly name?: string;
 
-  @IdField({
-    description: 'User IDs ANY of which must belong to the organizations',
-    nullable: true,
-  })
   readonly userId?: string;
 }
 

--- a/src/components/partnership/dto/list-partnership.dto.ts
+++ b/src/components/partnership/dto/list-partnership.dto.ts
@@ -1,8 +1,7 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import {
-  IdField,
   PaginatedList,
   SecuredList,
   SortablePaginationInput,
@@ -11,10 +10,6 @@ import { Partnership } from './partnership.dto';
 
 @InputType()
 export abstract class PartnershipFilters {
-  @IdField({
-    description: 'Find all partnerships in a project',
-    nullable: true,
-  })
   readonly projectId?: string;
 }
 
@@ -28,7 +23,6 @@ export class PartnershipListInput extends SortablePaginationInput<
 }) {
   static defaultVal = new PartnershipListInput();
 
-  @Field({ nullable: true })
   @Type(() => PartnershipFilters)
   @ValidateNested()
   readonly filter: PartnershipFilters = defaultFilters;

--- a/src/components/product/dto/list-product.dto.ts
+++ b/src/components/product/dto/list-product.dto.ts
@@ -24,7 +24,7 @@ export abstract class ProductFilters {
   })
   readonly methodology?: ProductMethodology;
 
-  readonly engagementId?: string; // TODO
+  readonly engagementId?: string;
 }
 
 const defaultFilters = {};

--- a/src/components/project/dto/list-projects.dto.ts
+++ b/src/components/project/dto/list-projects.dto.ts
@@ -1,4 +1,4 @@
-import { Field, ID, InputType, ObjectType } from '@nestjs/graphql';
+import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import {
@@ -45,10 +45,6 @@ export abstract class ProjectFilters {
   })
   readonly step?: ProjectStep[];
 
-  @Field(() => [ID], {
-    description: 'Only projects in ANY of these locations',
-    nullable: true,
-  })
   readonly locationIds?: string[];
 
   @Field({

--- a/src/components/project/project-member/dto/list-project-members.dto.ts
+++ b/src/components/project/project-member/dto/list-project-members.dto.ts
@@ -2,7 +2,6 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import {
-  IdField,
   PaginatedList,
   SecuredList,
   SortablePaginationInput,
@@ -18,10 +17,6 @@ export abstract class ProjectMemberFilters {
   })
   readonly roles?: Role[];
 
-  @IdField({
-    description: 'Only members of this project',
-    nullable: true,
-  })
   readonly projectId?: string;
 }
 

--- a/src/components/user/education/dto/list-education.dto.ts
+++ b/src/components/user/education/dto/list-education.dto.ts
@@ -1,8 +1,7 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import {
-  IdField,
   PaginatedList,
   SecuredList,
   SortablePaginationInput,
@@ -11,10 +10,6 @@ import { Education } from './education.dto';
 
 @InputType()
 export abstract class EducationFilters {
-  @IdField({
-    description: 'Educations for UserId',
-    nullable: true,
-  })
   readonly userId?: string;
 }
 
@@ -28,7 +23,6 @@ export class EducationListInput extends SortablePaginationInput<
 }) {
   static defaultVal = new EducationListInput();
 
-  @Field({ nullable: true })
   @Type(() => EducationFilters)
   @ValidateNested()
   readonly filter: EducationFilters = defaultFilters;

--- a/src/components/user/unavailability/dto/list-unavailabilities.dto.ts
+++ b/src/components/user/unavailability/dto/list-unavailabilities.dto.ts
@@ -1,8 +1,7 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import {
-  IdField,
   Order,
   PaginatedList,
   SecuredList,
@@ -12,10 +11,6 @@ import { Unavailability } from './unavailability.dto';
 
 @InputType()
 export abstract class UnavailabilityFilters {
-  @IdField({
-    description: 'Unavailabilities for UserId',
-    nullable: true,
-  })
   readonly userId?: string;
 }
 
@@ -30,7 +25,6 @@ export class UnavailabilityListInput extends SortablePaginationInput<
 }) {
   static defaultVal = new UnavailabilityListInput();
 
-  @Field({ nullable: true })
   @Type(() => UnavailabilityFilters)
   @ValidateNested()
   readonly filter: UnavailabilityFilters = defaultFilters;

--- a/test/budget.e2e-spec.ts
+++ b/test/budget.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { gql } from 'apollo-server-core';
-import { times } from 'lodash';
 import { isValid } from 'shortid';
 import { CalendarDate, fiscalYears, Secured } from '../src/common';
 import { Budget } from '../src/components/budget';
@@ -143,34 +142,6 @@ describe('Budget e2e', () => {
         }
       )
     ).rejects.toThrowError();
-  });
-
-  it('lists budget for a projectId', async () => {
-    // create budget first
-    // create 2 budget first
-    const numBudget = 2;
-    await Promise.all(
-      times(numBudget).map(() => createBudget(app, { projectId: project.id }))
-    );
-
-    const { budgets } = await app.graphql.query(
-      gql`
-        query budgets($id: ID!) {
-          budgets(input: { filter: { projectId: $id } }) {
-            items {
-              ...budget
-            }
-            hasMore
-            total
-          }
-        }
-        ${fragments.budget}
-      `,
-      {
-        id: project.id,
-      }
-    );
-    expect(budgets.items.length).toBeGreaterThanOrEqual(numBudget);
   });
 
   it.skip('Check consistency across budget nodes', async () => {

--- a/test/education.e2e-spec.ts
+++ b/test/education.e2e-spec.ts
@@ -111,18 +111,25 @@ describe('Education e2e', () => {
       times(numEducations).map(() => createEducation(app, { userId: user.id }))
     );
 
-    const { educations } = await app.graphql.query(gql`
-      query {
-        educations (input: { filter: { userId : "${user.id}" }}) {
-          items {
-            ...education
+    const { educations } = await app.graphql.query(
+      gql`
+        query UserEducation($id: ID!) {
+          user(id: $id) {
+            education {
+              items {
+                ...education
+              }
+              hasMore
+              total
+            }
           }
-          hasMore
-          total
         }
+        ${fragments.education}
+      `,
+      {
+        id: user.id,
       }
-      ${fragments.education}
-    `);
+    );
 
     expect(educations.items.length).toBeGreaterThanOrEqual(numEducations);
   });

--- a/test/education.e2e-spec.ts
+++ b/test/education.e2e-spec.ts
@@ -104,14 +104,14 @@ describe('Education e2e', () => {
   });
 
   // LIST Educations
-  it.skip('List view of educations', async () => {
+  it('List view of educations', async () => {
     // create 2 educations
     const numEducations = 2;
     await Promise.all(
       times(numEducations).map(() => createEducation(app, { userId: user.id }))
     );
 
-    const { educations } = await app.graphql.query(
+    const result = await app.graphql.query(
       gql`
         query UserEducation($id: ID!) {
           user(id: $id) {
@@ -131,7 +131,9 @@ describe('Education e2e', () => {
       }
     );
 
-    expect(educations.items.length).toBeGreaterThanOrEqual(numEducations);
+    expect(result.user.education.items.length).toBeGreaterThanOrEqual(
+      numEducations
+    );
   });
 
   it('Check consistency across education nodes', async () => {

--- a/test/education.e2e-spec.ts
+++ b/test/education.e2e-spec.ts
@@ -104,7 +104,7 @@ describe('Education e2e', () => {
   });
 
   // LIST Educations
-  it('List view of educations', async () => {
+  it.skip('List view of educations', async () => {
     // create 2 educations
     const numEducations = 2;
     await Promise.all(

--- a/test/partnership.e2e-spec.ts
+++ b/test/partnership.e2e-spec.ts
@@ -210,7 +210,7 @@ describe('Partnership e2e', () => {
     const { partnerships } = await app.graphql.query(
       gql`
         query {
-          partnerships(input: { filter: {} }) {
+          partnerships {
             items {
               id
               agreementStatus {
@@ -239,18 +239,20 @@ describe('Partnership e2e', () => {
       )
     );
 
-    const { partnerships } = await app.graphql.query(
+    const result = await app.graphql.query(
       gql`
         query partnerships($projectId: ID!) {
-          partnerships(input: { filter: { projectId: $projectId } }) {
-            items {
-              id
-              agreementStatus {
-                value
+          project(id: $projectId) {
+            partnerships {
+              items {
+                id
+                agreementStatus {
+                  value
+                }
               }
+              hasMore
+              total
             }
-            hasMore
-            total
           }
         }
       `,
@@ -259,7 +261,9 @@ describe('Partnership e2e', () => {
       }
     );
 
-    expect(partnerships.items.length).toBeGreaterThanOrEqual(numPartnerships);
+    expect(result.project.partnerships.items.length).toBeGreaterThanOrEqual(
+      numPartnerships
+    );
   });
 
   // skipping until we refactor consistency checks

--- a/test/unavailability.e2e-spec.ts
+++ b/test/unavailability.e2e-spec.ts
@@ -112,18 +112,25 @@ describe('Unavailability e2e', () => {
       )
     );
 
-    const { unavailabilities } = await app.graphql.query(gql`
-      query {
-        unavailabilities (input: { filter: { userId : "${user.id}" }}) {
-          items {
-            ...unavailability
+    const { unavailabilities } = await app.graphql.query(
+      gql`
+        query UsersUnavailabilities($id: ID!) {
+          user(id: $id) {
+            unavailabilities {
+              items {
+                ...unavailability
+              }
+              hasMore
+              total
+            }
           }
-          hasMore
-          total
         }
+        ${fragments.unavailability}
+      `,
+      {
+        id: user.id,
       }
-      ${fragments.unavailability}
-    `);
+    );
 
     expect(unavailabilities.items.length).toBeGreaterThanOrEqual(numUnavail);
   });

--- a/test/unavailability.e2e-spec.ts
+++ b/test/unavailability.e2e-spec.ts
@@ -103,7 +103,7 @@ describe('Unavailability e2e', () => {
     expect(actual).toBeTruthy();
   });
 
-  it('List view of unavailabilities', async () => {
+  it.skip('List view of unavailabilities', async () => {
     // create 2 unavailabilities
     const numUnavail = 2;
     await Promise.all(

--- a/test/unavailability.e2e-spec.ts
+++ b/test/unavailability.e2e-spec.ts
@@ -103,7 +103,7 @@ describe('Unavailability e2e', () => {
     expect(actual).toBeTruthy();
   });
 
-  it.skip('List view of unavailabilities', async () => {
+  it('List view of unavailabilities', async () => {
     // create 2 unavailabilities
     const numUnavail = 2;
     await Promise.all(
@@ -112,7 +112,7 @@ describe('Unavailability e2e', () => {
       )
     );
 
-    const { unavailabilities } = await app.graphql.query(
+    const result = await app.graphql.query(
       gql`
         query UsersUnavailabilities($id: ID!) {
           user(id: $id) {
@@ -132,7 +132,9 @@ describe('Unavailability e2e', () => {
       }
     );
 
-    expect(unavailabilities.items.length).toBeGreaterThanOrEqual(numUnavail);
+    expect(result.user.unavailabilities.items.length).toBeGreaterThanOrEqual(
+      numUnavail
+    );
   });
 
   it('Check consistency across unavailability nodes', async () => {


### PR DESCRIPTION
Those lists can be determined by relationships on the owning objects
`budgets.filters.projectId` -> `project.budgets`