### PR TITLE
Error Logging

### DIFF
--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -8,6 +8,7 @@ import { DatabaseModule } from './database/database.module';
 import { EmailModule } from './email';
 import { EventsModule } from './events';
 import { ExceptionFilter } from './exception.filter';
+import { GraphqlLoggingPlugin } from './graphql-logging.plugin';
 import { GraphQLConfig } from './graphql.config';
 import { ValidationPipe } from './validation.pipe';
 
@@ -22,6 +23,7 @@ import { ValidationPipe } from './validation.pipe';
   ],
   providers: [
     AwsS3Factory,
+    GraphqlLoggingPlugin,
     { provide: APP_FILTER, useClass: ExceptionFilter },
     { provide: APP_PIPE, useClass: ValidationPipe },
   ],

--- a/src/core/graphql-logging.plugin.ts
+++ b/src/core/graphql-logging.plugin.ts
@@ -1,0 +1,55 @@
+import { Plugin } from '@nestjs/graphql';
+import { GraphQLRequestContext } from 'apollo-server-core';
+import {
+  ApolloServerPlugin,
+  GraphQLRequestListener,
+} from 'apollo-server-plugin-base';
+import { GraphQLError } from 'graphql';
+import { ILogger, Logger } from './logger';
+
+/**
+ * Logging for GraphQL errors that are not handled anywhere else
+ * Note: Lot's of assumptions here.
+ */
+@Plugin()
+export class GraphqlLoggingPlugin implements ApolloServerPlugin {
+  constructor(@Logger('graphql') private readonly logger: ILogger) {}
+
+  requestDidStart(
+    _context: GraphQLRequestContext
+  ): GraphQLRequestListener | void {
+    return {
+      didEncounterErrors: ({ errors }) => {
+        for (const error of errors) {
+          this.onError(error);
+        }
+      },
+    };
+  }
+
+  private onError(error: GraphQLError) {
+    // Assume errors with extensions have already been logged by our ExceptionFilter
+    // This means that these are native GraphQL errors
+    if (error.extensions) {
+      return;
+    }
+
+    const path = error.path?.join('.');
+    const pathInfo = path ? { path } : {};
+
+    if (!error.originalError) {
+      // Assume client schema error.
+      this.logger.warning('Invalid query', {
+        error: error.message,
+        ...pathInfo,
+      });
+      return;
+    }
+
+    // Assume server schema error.
+    this.logger.error('Invalid response for GraphQL schema', {
+      error: error.message,
+      ...pathInfo,
+    });
+  }
+}

--- a/src/core/logger/formatters.ts
+++ b/src/core/logger/formatters.ts
@@ -80,13 +80,17 @@ export const formatException = () =>
         const subject = t.getFunctionName();
 
         const absolute: string | null = t.getFileName();
-        const file = absolute
-          ? relative(`${__dirname}/../../..`, absolute)
-          : '';
-        const location =
-          !file || file.startsWith('internal')
-            ? ''
-            : `${file}:${t.getLineNumber()}:${t.getColumnNumber()}`;
+        if (
+          !absolute ||
+          absolute.includes('node_modules') ||
+          absolute.startsWith('internal/') ||
+          absolute.includes('<anonymous>')
+        ) {
+          return null;
+        }
+
+        const file = relative(`${__dirname}/../../..`, absolute);
+        const location = `${file}:${t.getLineNumber()}:${t.getColumnNumber()}`;
 
         return (
           red(`    at`) +
@@ -94,6 +98,7 @@ export const formatException = () =>
           (subject && location ? red(` (${location})`) : red(` ${location}`))
         );
       })
+      .filter(identity)
       .join('\n');
 
     const bad = config.syslog.levels[info.level] > config.syslog.levels.warning;


### PR DESCRIPTION
- Exceptions from requests (90%) now logged
- Stacktraces for both GQL responses and console logs have:
  - No worthless traces like for schema & validation errors
  - Frames are limited to and relative to our src files
Examples shown below

## Previous Exceptions 
Previous exceptions are logged to console. This can help identify what actually went wrong while still giving the requestor a sane default/unknown error message. (This should also reduce the need to both log the exception in addition to re-throwing a different one)

Here's what a "server" error looks like:
<img width="841" alt="Screen Shot 2020-08-08 at 2 52 05 PM" src="https://user-images.githubusercontent.com/932566/89718736-f0fa4500-d986-11ea-8f29-e4da22bb6e85.png">

We can see from this message that we need to handle this error as a `DuplicateException`.
We actually already do handle this in _master_ I just commented it out for screenshot.
Here's that logic: https://github.com/SeedCompany/cord-api-v3/blob/3a407850163a84baca052a7079b9a69297b9638d/src/components/user/user.service.ts#L317-L323

With that logic in place the error outputs like this:
<img width="840" alt="Screen Shot 2020-08-08 at 2 22 22 PM" src="https://user-images.githubusercontent.com/932566/89718229-f6559080-d982-11ea-8c71-f8150087e2a8.png">

`DuplicateException` is a client error, and client errors log at a warning level. They aren't our fault, but they still could be help to note even though they don't require any code changes.


---

These previous errors, unfortunately, don't get captured automatically. They do require that we pass them through with our own Exception classes. This needs to happen across the codebase.