### PR TITLE
Refactor SecuredEnumList out of SecuredPropertyList to fix types

### DIFF
--- a/src/components/partnership/dto/partnership.dto.ts
+++ b/src/components/partnership/dto/partnership.dto.ts
@@ -2,8 +2,8 @@ import { Field, ObjectType } from '@nestjs/graphql';
 import {
   Resource,
   SecuredDate,
+  SecuredEnumList,
   SecuredProperty,
-  SecuredPropertyList,
 } from '../../../common';
 import { DefinedFile } from '../../file/dto';
 import { Organization } from '../../organization';
@@ -18,9 +18,9 @@ export abstract class SecuredPartnershipAgreementStatus extends SecuredProperty(
 ) {}
 
 @ObjectType({
-  description: SecuredPropertyList.descriptionFor('partnership types'),
+  description: SecuredEnumList.descriptionFor('partnership types'),
 })
-export abstract class SecuredPartnershipTypes extends SecuredPropertyList(
+export abstract class SecuredPartnershipTypes extends SecuredEnumList(
   PartnershipType
 ) {}
 

--- a/src/components/product/dto/product-medium.ts
+++ b/src/components/product/dto/product-medium.ts
@@ -1,5 +1,5 @@
 import { ObjectType, registerEnumType } from '@nestjs/graphql';
-import { SecuredPropertyList } from '../../../common';
+import { SecuredEnumList } from '../../../common';
 
 /**
  * How the product is delivered.
@@ -23,6 +23,6 @@ registerEnumType(ProductMedium, {
 });
 
 @ObjectType({
-  description: SecuredPropertyList.descriptionFor('product mediums'),
+  description: SecuredEnumList.descriptionFor('product mediums'),
 })
-export class SecuredProductMediums extends SecuredPropertyList(ProductMedium) {}
+export class SecuredProductMediums extends SecuredEnumList(ProductMedium) {}

--- a/src/components/product/dto/product-methodology.ts
+++ b/src/components/product/dto/product-methodology.ts
@@ -1,5 +1,5 @@
 import { ObjectType, registerEnumType } from '@nestjs/graphql';
-import { SecuredProperty, SecuredPropertyList } from '../../../common';
+import { SecuredEnumList, SecuredProperty } from '../../../common';
 import { ProductApproach } from './product-approach';
 
 /**
@@ -64,8 +64,6 @@ export class SecuredMethodology extends SecuredProperty<
 >(ProductMethodology) {}
 
 @ObjectType({
-  description: SecuredPropertyList.descriptionFor('methodologies'),
+  description: SecuredEnumList.descriptionFor('methodologies'),
 })
-export class SecuredMethodologies extends SecuredPropertyList(
-  ProductMethodology
-) {}
+export class SecuredMethodologies extends SecuredEnumList(ProductMethodology) {}

--- a/src/components/product/dto/product-purpose.ts
+++ b/src/components/product/dto/product-purpose.ts
@@ -1,5 +1,5 @@
 import { ObjectType, registerEnumType } from '@nestjs/graphql';
-import { SecuredPropertyList } from '../../../common';
+import { SecuredEnumList } from '../../../common';
 
 /**
  * Why is this translation happening?
@@ -17,8 +17,6 @@ registerEnumType(ProductPurpose, {
 });
 
 @ObjectType({
-  description: SecuredPropertyList.descriptionFor('product purposes'),
+  description: SecuredEnumList.descriptionFor('product purposes'),
 })
-export class SecuredProductPurposes extends SecuredPropertyList(
-  ProductPurpose
-) {}
+export class SecuredProductPurposes extends SecuredEnumList(ProductPurpose) {}

--- a/src/components/project/project-member/dto/role.dto.ts
+++ b/src/components/project/project-member/dto/role.dto.ts
@@ -1,5 +1,5 @@
 import { ObjectType, registerEnumType } from '@nestjs/graphql';
-import { SecuredPropertyList } from '../../../../common';
+import { SecuredEnumList } from '../../../../common';
 
 export enum Role {
   BibleTranslationLiaison = 'BibleTranslationLiaison',
@@ -28,6 +28,6 @@ export enum Role {
 registerEnumType(Role, { name: 'Role' });
 
 @ObjectType({
-  description: SecuredPropertyList.descriptionFor('roles'),
+  description: SecuredEnumList.descriptionFor('roles'),
 })
-export abstract class SecuredRoles extends SecuredPropertyList(Role) {}
+export abstract class SecuredRoles extends SecuredEnumList(Role) {}

--- a/src/components/scripture/dto/scripture-range.dto.ts
+++ b/src/components/scripture/dto/scripture-range.dto.ts
@@ -49,7 +49,7 @@ export class SecuredScriptureRanges extends SecuredPropertyList(
 @ObjectType({
   description: SecuredPropertyList.descriptionFor('scripture ranges override'),
 })
-export class SecuredScriptureRangesOverride extends SecuredPropertyList<
+export class SecuredScriptureRangesOverride extends SecuredPropertyList(
   ScriptureRange,
-  true
->(ScriptureRange, { isOverride: true }) {}
+  { isOverride: true }
+) {}

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -488,7 +488,7 @@ export class UserService {
 
     // Update roles
     if (input.roles) {
-      const newRoles = difference(input.roles, user.roles.value) as Role[];
+      const newRoles = difference(input.roles, user.roles.value);
       await this.db
         .query()
         .match([


### PR DESCRIPTION
TS enums are weird because they are objects but also only certain strings.
Due to this we need to handle them separately from other object types so that types can be inferred correctly.
The good news is the types can be inferred so the new code is still easy to use. 