### PR TITLE
Update SecuredProperty/Enum to handle nullable

### DIFF
--- a/src/common/secured-property.ts
+++ b/src/common/secured-property.ts
@@ -93,26 +93,20 @@ SecuredEnum.descriptionFor = SecuredProperty.descriptionFor = (
   These \`can*\` authorization properties are specific to the user making the request.
 `;
 
-export interface SecuredPropertyListOptions<
-  Override extends boolean | undefined = false
-> {
-  isOverride?: Override;
-}
-
-type SecuredList<
-  T,
-  Override extends boolean | undefined
-> = Override extends true ? T[] | null | undefined : T[];
+type SecuredList<T, Nullable extends boolean | undefined> = SecuredValue<
+  T[],
+  Nullable
+>;
 
 export function SecuredEnumList<
   T extends string,
   EnumValue extends string,
-  Override extends boolean | undefined = false
+  Nullable extends boolean | undefined = false
 >(
   valueClass: { [key in T]: EnumValue },
-  options: SecuredPropertyListOptions<Override> = {}
+  options: SecuredPropertyOptions<Nullable> = {}
 ) {
-  return SecuredList<EnumValue, EnumValue, Override>(
+  return SecuredList<EnumValue, EnumValue, Nullable>(
     valueClass as any,
     options
   );
@@ -120,25 +114,25 @@ export function SecuredEnumList<
 
 export function SecuredPropertyList<
   T,
-  Override extends boolean | undefined = false
+  Nullable extends boolean | undefined = false
 >(
   valueClass: Class<T> | AbstractClassType<T> | GraphQLScalarType,
-  options: SecuredPropertyListOptions<Override> = {}
+  options: SecuredPropertyOptions<Nullable> = {}
 ) {
-  return SecuredList<typeof valueClass, T, Override>(valueClass, options);
+  return SecuredList<typeof valueClass, T, Nullable>(valueClass, options);
 }
 
-function SecuredList<GQL, TS, Override extends boolean | undefined = false>(
+function SecuredList<GQL, TS, Nullable extends boolean | undefined = false>(
   valueClass: GQL,
-  options: SecuredPropertyListOptions<Override> = {}
+  options: SecuredPropertyOptions<Nullable> = {}
 ) {
   @ObjectType({ isAbstract: true, implements: [Readable, Editable] })
   abstract class SecuredPropertyListClass
-    implements Readable, Editable, Secured<SecuredList<TS, Override>> {
+    implements Readable, Editable, Secured<SecuredList<TS, Nullable>> {
     @Field(() => [valueClass], {
-      nullable: options.isOverride,
+      nullable: options.nullable,
     })
-    readonly value: SecuredList<TS, Override>;
+    readonly value: SecuredList<TS, Nullable>;
     @Field()
     readonly canRead: boolean;
     @Field()

--- a/src/common/secured-property.ts
+++ b/src/common/secured-property.ts
@@ -151,6 +151,17 @@ SecuredEnumList.descriptionFor = SecuredPropertyList.descriptionFor = (
 `;
 
 @ObjectType({
+  description: SecuredProperty.descriptionFor('a string or null'),
+})
+export abstract class SecuredStringNullable extends SecuredProperty<
+  string,
+  string,
+  true
+>(GraphQLString, {
+  nullable: true,
+}) {}
+
+@ObjectType({
   description: SecuredProperty.descriptionFor('a string'),
 })
 export abstract class SecuredString extends SecuredProperty<string>(
@@ -161,6 +172,17 @@ export abstract class SecuredString extends SecuredProperty<string>(
   description: SecuredProperty.descriptionFor('an integer'),
 })
 export abstract class SecuredInt extends SecuredProperty<number>(Int) {}
+
+@ObjectType({
+  description: SecuredProperty.descriptionFor('an integer or null'),
+})
+export abstract class SecuredIntNullable extends SecuredProperty<
+  number,
+  number,
+  true
+>(Int, {
+  nullable: true,
+}) {}
 
 @ObjectType({
   description: SecuredProperty.descriptionFor('a float'),
@@ -188,10 +210,36 @@ export abstract class SecuredDateTime
 }
 
 @ObjectType({ implements: [Readable, Editable] })
+export abstract class SecuredDateTimeNullable
+  implements Readable, Editable, Secured<DateTime | null> {
+  @DateTimeField({ nullable: true })
+  readonly value?: DateTime | null;
+
+  @Field()
+  readonly canRead: boolean;
+
+  @Field()
+  readonly canEdit: boolean;
+}
+
+@ObjectType({ implements: [Readable, Editable] })
 export abstract class SecuredDate
   implements Readable, Editable, Secured<CalendarDate> {
   @DateField({ nullable: true })
   readonly value?: CalendarDate;
+
+  @Field()
+  readonly canRead: boolean;
+
+  @Field()
+  readonly canEdit: boolean;
+}
+
+@ObjectType({ implements: [Readable, Editable] })
+export abstract class SecuredDateNullable
+  implements Readable, Editable, Secured<CalendarDate | null> {
+  @DateTimeField({ nullable: true })
+  readonly value?: CalendarDate | null;
 
   @Field()
   readonly canRead: boolean;

--- a/src/components/scripture/dto/scripture-range.dto.ts
+++ b/src/components/scripture/dto/scripture-range.dto.ts
@@ -51,5 +51,5 @@ export class SecuredScriptureRanges extends SecuredPropertyList(
 })
 export class SecuredScriptureRangesOverride extends SecuredPropertyList(
   ScriptureRange,
-  { isOverride: true }
+  { nullable: true }
 ) {}


### PR DESCRIPTION
We've been pretty lax about whether secured values can actually be null or not. Because if you can't read the value then we send back null, which means we can't represent in schema whether this is a null for security or null because it can be.

With this we are step closer to define that ambiguity. Now we have the option to add `nullable: true` when calling `SecuredProperty/Enum`, which will add `null` as a possible type to the value property in TS. I also added nullable variants to the common scalar secured objects - i.e. `SecuredStringNullable` (I'm not thrilled about the name)

I know in GQL schema both `SecuredString` & `SecuredStringNullable` will be identical. But we can still use this convention to know client-side when a null is intended or not and we can use null server side as well.

Example:
```tsx
class SecuredX extends SecuredProperty(X, {
  nullable: true
}) {}
```

Next we should add this nullable option to the types its intended on and swap the types on the properties for the nullable ones. 