### PR TITLE
Fix "name" in log entry overriding the logger name

### DIFF
--- a/src/core/logger/formatters.ts
+++ b/src/core/logger/formatters.ts
@@ -7,6 +7,7 @@ import { parse as parseTrace, StackFrame } from 'stack-trace';
 import { MESSAGE } from 'triple-beam';
 import { config, format } from 'winston';
 import { Exception } from '../../common/exceptions';
+import { getNameFromEntry } from './logger.interface';
 
 type Color = (str: string) => string;
 
@@ -19,7 +20,7 @@ interface ParsedError {
 
 export const metadata = () =>
   format.metadata({
-    fillExcept: ['level', 'message', 'name', 'exceptions'],
+    fillExcept: ['level', 'message', 'exceptions'],
   });
 
 export const maskSecrets = () =>
@@ -157,10 +158,12 @@ export const printForCli = () =>
       return info[MESSAGE];
     }
 
+    const name = getNameFromEntry(info);
+
     let msg = '';
     // msg += green(`[Nest] ${info.pid}   - `);
     // msg += `${info.timestamp}   `;
-    msg += typeof info.name === 'string' ? yellow(`[${info.name}] `) : '';
+    msg += typeof name === 'string' ? yellow(`[${name}] `) : '';
     msg += info.message;
     msg += ` ${yellow(info.ms)}`;
     msg +=

--- a/src/core/logger/logger.interface.ts
+++ b/src/core/logger/logger.interface.ts
@@ -9,6 +9,16 @@ export enum LogLevel {
   DEBUG = 'debug',
 }
 
+export const LoggerName = Symbol('LoggerName');
+
+export const getNameFromEntry = (
+  entry: Record<string, any>
+): string | undefined => {
+  // @ts-expect-error TS can't index on symbols??
+  // https://github.com/Microsoft/TypeScript/issues/24587
+  return entry[LoggerName];
+};
+
 export type LogEntry = { level: LogLevel; message: string } & LogEntryContext;
 
 export type LogEntryContext = Record<string, any>;

--- a/src/core/logger/named-logger.service.ts
+++ b/src/core/logger/named-logger.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Scope } from '@nestjs/common';
 import { AbstractLogger } from './abstract-logger';
-import { ILogger, LogEntry } from './logger.interface';
+import { ILogger, LogEntry, LoggerName } from './logger.interface';
 
 /**
  * This is the logger that will be injected everywhere in app code.
@@ -26,7 +26,7 @@ export class NamedLoggerService extends AbstractLogger {
 
   logEntry(entry: LogEntry): void {
     this.realLogger.log({
-      ...(this.name ? { name: this.name } : {}),
+      ...(this.name ? { [LoggerName]: this.name } : {}),
       ...entry,
     });
   }

--- a/src/core/logger/nest-logger-adapter.service.ts
+++ b/src/core/logger/nest-logger-adapter.service.ts
@@ -4,7 +4,7 @@ import {
   Logger as NestLogger,
   OnModuleInit,
 } from '@nestjs/common';
-import { ILogger } from './logger.interface';
+import { ILogger, LoggerName } from './logger.interface';
 
 /**
  * Adapts/wraps our Logger into a Nest Logger interface.
@@ -27,35 +27,36 @@ export class NestLoggerAdapterService implements INestLogger, OnModuleInit {
 
   debug(message: any, context?: string) {
     const name = this.mapName(context);
-    this.logger.debug(message, { name });
+    this.logger.debug(message, name);
   }
 
   error(message: any, trace?: string, context?: string) {
     const name = this.mapName(context);
     this.logger.error(message, {
-      name,
+      ...name,
       ...(trace ? { stack: trace, exception: true } : {}),
     });
   }
 
   log(message: any, context?: string) {
     const name = this.mapName(context);
-    this.logger.info(message, { name });
+    this.logger.info(message, name);
   }
 
   verbose(message: any, context?: string) {
     const name = this.mapName(context);
-    this.logger.debug(message, { name });
+    this.logger.debug(message, name);
   }
 
   warn(message: any, context?: string) {
     const name = this.mapName(context);
-    this.logger.warning(message, { name });
+    this.logger.warning(message, name);
   }
 
   private mapName(context?: string) {
-    return context
+    const name = context
       ? NestLoggerAdapterService.nameMap[context] || context
       : 'nest';
+    return { [LoggerName]: name };
   }
 }

--- a/src/core/logger/winston-logger.service.ts
+++ b/src/core/logger/winston-logger.service.ts
@@ -4,7 +4,7 @@ import { config, createLogger, Logger as WinstonLogger } from 'winston';
 import * as Transport from 'winston-transport';
 import { AbstractLogger } from './abstract-logger';
 import { LevelMatcher } from './level-matcher';
-import { LogEntry, LogLevel } from './logger.interface';
+import { getNameFromEntry, LogEntry, LogLevel } from './logger.interface';
 
 export class LoggerOptions {
   format: Format;
@@ -32,10 +32,12 @@ export class WinstonLoggerService extends AbstractLogger
     });
   }
 
-  logEntry({ level, message, name = 'unknown', ...context }: LogEntry): void {
+  logEntry({ level, message, ...context }: LogEntry): void {
     if (this.closing) {
       return;
     }
+
+    const name = getNameFromEntry(context) ?? 'unknown';
 
     // Skip logging exceptions as Jest will display them properly.
     if (name === 'nest:exception' && (global as any).jasmine) {
@@ -45,7 +47,7 @@ export class WinstonLoggerService extends AbstractLogger
     if (!this.matcher.isEnabled(name, level)) {
       return;
     }
-    this.logger.log(level, message, { name, ...context });
+    this.logger.log(level, message, context);
   }
 
   async onModuleDestroy() {


### PR DESCRIPTION
## Problem
```tsx
export class UserService {
  constructor(@Logger('user:service') private readonly logger: ILogger) {
    this.logger.info('User changed their name', { name: 'Carson' });
  }
}
```
This log statement would have a logger name of `Carson` instead of `user:service`.
This causes the logger to match the level incorrectly & remove the `name: Carson` from the logged statement.

## Solution

Changed internal logger logic to use a symbol for the logger name so it doesn't interfere with the given context.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3655157331) by [Unito](https://www.unito.io)
