### PR TITLE
Lint exception imports

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -35,29 +35,28 @@ rules:
     - paths:
         - name: '@nestjs/cqrs'
           message: Import from our core module instead
-# TODO Enable and fix errors
-#        - name: '@nestjs/common'
-#          importNames:
-#            - BadRequestException
-#            - HttpException
-#            - UnauthorizedException
-#            - MethodNotAllowedException
-#            - NotFoundException
-#            - ForbiddenException
-#            - NotAcceptableException
-#            - RequestTimeoutException
-#            - ConflictException
-#            - GoneException
-#            - PayloadTooLargeException
-#            - UnsupportedMediaTypeException
-#            - UnprocessableEntityException
-#            - InternalServerErrorException
-#            - NotImplementedException
-#            - HttpVersionNotSupportedException
-#            - BadGatewayException
-#            - ServiceUnavailableException
-#            - GatewayTimeoutException
-#          message: Use our exceptions in common folder instead
+        - name: '@nestjs/common'
+          importNames:
+            - BadRequestException
+            - HttpException
+            - UnauthorizedException
+            - MethodNotAllowedException
+            - NotFoundException
+            - ForbiddenException
+            - NotAcceptableException
+            - RequestTimeoutException
+            - ConflictException
+            - GoneException
+            - PayloadTooLargeException
+            - UnsupportedMediaTypeException
+            - UnprocessableEntityException
+            - InternalServerErrorException
+            - NotImplementedException
+            - HttpVersionNotSupportedException
+            - BadGatewayException
+            - ServiceUnavailableException
+            - GatewayTimeoutException
+          message: Use our exceptions in common folder instead
 
   # TODO Enable this and fix errors (both types & logic changes will be needed)
   '@typescript-eslint/no-unnecessary-condition': off

--- a/src/common/luxon.graphql.ts
+++ b/src/common/luxon.graphql.ts
@@ -1,9 +1,10 @@
-import { applyDecorators, BadRequestException } from '@nestjs/common';
+import { applyDecorators } from '@nestjs/common';
 import { CustomScalar, Field, FieldOptions, Scalar } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { Kind, ValueNode } from 'graphql';
 import { DateTime, Settings } from 'luxon';
 import { CalendarDate } from './calendar-date';
+import { InputException } from './exceptions';
 import { Transform } from './transform.decorator';
 import { ValidateBy } from './validators/validateBy';
 import './luxon.neo4j'; // ensure our luxon methods are added
@@ -71,7 +72,7 @@ export class DateTimeScalar
       return value.toISO();
     }
     if (!value) {
-      throw new BadRequestException('No DateTime to serialize');
+      throw new InputException('No DateTime to serialize');
     }
     return value;
   }

--- a/src/components/admin/admin.service.ts
+++ b/src/components/admin/admin.service.ts
@@ -1,13 +1,9 @@
-import {
-  Injectable,
-  OnApplicationBootstrap,
-  InternalServerErrorException as ServerException,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
 import * as argon2 from 'argon2';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { generate } from 'shortid';
+import { ServerException, UnauthorizedException } from '../../common';
 import { ConfigService, DatabaseService } from '../../core';
 import { AuthenticationService } from '../authentication';
 import { RootSecurityGroup } from './root-security-group';

--- a/src/components/admin/admin.service.ts
+++ b/src/components/admin/admin.service.ts
@@ -3,7 +3,7 @@ import * as argon2 from 'argon2';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { generate } from 'shortid';
-import { ServerException, UnauthorizedException } from '../../common';
+import { ServerException, UnauthenticatedException } from '../../common';
 import { ConfigService, DatabaseService } from '../../core';
 import { AuthenticationService } from '../authentication';
 import { RootSecurityGroup } from './root-security-group';
@@ -183,7 +183,9 @@ export class AdminService implements OnApplicationBootstrap {
     } else {
       // password did not match
 
-      throw new UnauthorizedException('Root Email or Password are incorrect');
+      throw new UnauthenticatedException(
+        'Root Email or Password are incorrect'
+      );
     }
   }
 

--- a/src/components/authentication/authentication.resolver.ts
+++ b/src/components/authentication/authentication.resolver.ts
@@ -49,13 +49,13 @@ export class AuthenticationResolver {
     let session;
     try {
       session = await this.authService.createSession(token);
-    } catch (e) {
+    } catch (exception) {
       // if (!(e instanceof UnauthenticatedException)) {
       //   throw e;
       // }
       this.logger.info(
         'Failed to use existing session token, creating new one.',
-        { exception: e }
+        { exception }
       );
       token = await this.authService.createToken();
       session = await this.authService.createSession(token);

--- a/src/components/authentication/authentication.service.ts
+++ b/src/components/authentication/authentication.service.ts
@@ -396,11 +396,11 @@ export class AuthenticationService {
 
     try {
       return verify(token, this.config.jwtKey) as JwtPayload;
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to validate JWT', {
-        exception: e,
+        exception,
       });
-      throw new UnauthenticatedException();
+      throw new UnauthenticatedException(exception);
     }
   }
 }

--- a/src/components/authentication/no-session.exception.ts
+++ b/src/components/authentication/no-session.exception.ts
@@ -1,0 +1,14 @@
+import { UnauthenticatedException } from '../../common';
+
+/**
+ * No session established for the user
+ */
+
+export class NoSessionException extends UnauthenticatedException {
+  description: string | undefined;
+
+  constructor(message?: string, description?: string, previous?: Error) {
+    super(message ?? `No session`, previous);
+    this.description = description;
+  }
+}

--- a/src/components/authentication/session.pipe.ts
+++ b/src/components/authentication/session.pipe.ts
@@ -1,7 +1,7 @@
 import { Injectable, PipeTransform } from '@nestjs/common';
 import { Request } from 'express';
 import type * as core from 'express-serve-static-core';
-import { ISession, UnauthorizedException } from '../../common';
+import { ISession, UnauthenticatedException } from '../../common';
 import { ConfigService } from '../../core';
 import { AuthenticationService } from './authentication.service';
 
@@ -30,7 +30,7 @@ export class SessionPipe implements PipeTransform<Request, Promise<ISession>> {
 
     const session = await this.createSessionFromRequest(request);
     if (!session) {
-      throw new UnauthorizedException();
+      throw new UnauthenticatedException();
     }
     request.session = session;
 

--- a/src/components/authentication/session.pipe.ts
+++ b/src/components/authentication/session.pipe.ts
@@ -1,11 +1,7 @@
-import {
-  Injectable,
-  PipeTransform,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Injectable, PipeTransform } from '@nestjs/common';
 import { Request } from 'express';
 import type * as core from 'express-serve-static-core';
-import { ISession } from '../../common';
+import { ISession, UnauthorizedException } from '../../common';
 import { ConfigService } from '../../core';
 import { AuthenticationService } from './authentication.service';
 

--- a/src/components/authorization/authorization.service.ts
+++ b/src/components/authorization/authorization.service.ts
@@ -1,11 +1,7 @@
-import {
-  Injectable,
-  NotFoundException,
-  InternalServerErrorException as ServerException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { generate } from 'shortid';
-import { ISession } from '../../common';
+import { ISession, NotFoundException, ServerException } from '../../common';
 import {
   DatabaseService,
   ILogger,

--- a/src/components/authorization/authorization.service.ts
+++ b/src/components/authorization/authorization.service.ts
@@ -608,11 +608,11 @@ export class AuthorizationService {
         ])
         .detachDelete('sg')
         .run();
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to delete security group', {
-        exception: e,
+        exception,
       });
-      throw new ServerException('Failed to delete security group');
+      throw new ServerException('Failed to delete security group', exception);
     }
   }
 

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -1,13 +1,14 @@
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-  InternalServerErrorException as ServerException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
 import { upperFirst } from 'lodash';
 import { DateTime } from 'luxon';
-import { ISession, Order } from '../../common';
+import {
+  InputException,
+  ISession,
+  NotFoundException,
+  Order,
+  ServerException,
+} from '../../common';
 import {
   ConfigService,
   createBaseNode,
@@ -247,7 +248,7 @@ export class BudgetService {
     session: ISession
   ): Promise<BudgetRecord> {
     if (!input.fiscalYear || !organizationId) {
-      throw new BadRequestException();
+      throw new InputException();
     }
 
     this.logger.info('Creating BudgetRecord', input);
@@ -505,7 +506,7 @@ export class BudgetService {
 
     const readBudget = await budgetStatusQuery.first();
     if (!readBudget?.status.includes(BudgetStatus.Pending)) {
-      throw new BadRequestException('budget records can not be modified');
+      throw new InputException('budget records can not be modified');
     }
 
     const br = await this.readOneRecord(id, session);

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -176,7 +176,7 @@ export class BudgetService {
 
     const result = await readProject.first();
     if (!result) {
-      throw new NotFoundException('project does not exist');
+      throw new NotFoundException('project does not exist', 'budget.projectId');
     }
 
     const secureProps: Property[] = [
@@ -234,12 +234,12 @@ export class BudgetService {
       });
 
       return await this.readOne(result.id, session);
-    } catch (e) {
+    } catch (exception) {
       this.logger.error(`Could not create budget`, {
         userId: session.userId,
-        exception: e,
+        exception,
       });
-      throw new ServerException('Could not create budget');
+      throw new ServerException('Could not create budget', exception);
     }
   }
 
@@ -248,7 +248,9 @@ export class BudgetService {
     session: ISession
   ): Promise<BudgetRecord> {
     if (!input.fiscalYear || !organizationId) {
-      throw new InputException();
+      throw new InputException(
+        !input.fiscalYear ? 'budget.fiscalYear' : 'budget.organization'
+      );
     }
 
     this.logger.info('Creating BudgetRecord', input);
@@ -343,7 +345,7 @@ export class BudgetService {
         userId: session.userId,
         exception,
       });
-      throw new ServerException('Could not create Budget Record');
+      throw new ServerException('Could not create Budget Record', exception);
     }
   }
 
@@ -384,7 +386,7 @@ export class BudgetService {
 
     const result = await query.first();
     if (!result) {
-      throw new NotFoundException('Could not find budget');
+      throw new NotFoundException('Could not find budget', 'budget.id');
     }
 
     const records = await this.listRecords(
@@ -449,7 +451,10 @@ export class BudgetService {
     const result = await query.first();
 
     if (!result) {
-      throw new NotFoundException('Could not find BudgetRecord');
+      throw new NotFoundException(
+        'Could not find BudgetRecord',
+        'budgetRecord.id'
+      );
     }
 
     const props = parsePropList(result.propList);
@@ -506,7 +511,10 @@ export class BudgetService {
 
     const readBudget = await budgetStatusQuery.first();
     if (!readBudget?.status.includes(BudgetStatus.Pending)) {
-      throw new InputException('budget records can not be modified');
+      throw new InputException(
+        'budget records can not be modified',
+        'budget.id'
+      );
     }
 
     const br = await this.readOneRecord(id, session);

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -249,7 +249,7 @@ export class BudgetService {
   ): Promise<BudgetRecord> {
     if (!input.fiscalYear || !organizationId) {
       throw new InputException(
-        !input.fiscalYear ? 'budget.fiscalYear' : 'budget.organization'
+        !input.fiscalYear ? 'budget.fiscalYear' : 'budget.organizationId'
       );
     }
 
@@ -453,7 +453,7 @@ export class BudgetService {
     if (!result) {
       throw new NotFoundException(
         'Could not find BudgetRecord',
-        'budgetRecord.id'
+        'budgetRecord.budgetId'
       );
     }
 
@@ -513,7 +513,7 @@ export class BudgetService {
     if (!readBudget?.status.includes(BudgetStatus.Pending)) {
       throw new InputException(
         'budget records can not be modified',
-        'budget.id'
+        'budgetRecord.id'
       );
     }
 

--- a/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
+++ b/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
@@ -248,7 +248,10 @@ export class SyncBudgetRecordsToFundingPartners
         userId: event.session.userId,
         exception,
       });
-      throw new ServerException('Could not synchronize budget records');
+      throw new ServerException(
+        'Could not synchronize budget records',
+        exception
+      );
     }
 
     // TODO: only continue if budget is pending

--- a/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
+++ b/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
@@ -1,5 +1,4 @@
-import { InternalServerErrorException as ServerException } from '@nestjs/common';
-import { ISession } from '../../../common';
+import { ISession, ServerException } from '../../../common';
 import {
   DatabaseService,
   EventsHandler,

--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -1,13 +1,13 @@
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-  InternalServerErrorException as ServerException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { upperFirst } from 'lodash';
 import { DateTime } from 'luxon';
-import { ISession } from '../../common';
+import {
+  InputException,
+  ISession,
+  NotFoundException,
+  ServerException,
+} from '../../common';
 import {
   ConfigService,
   createBaseNode,
@@ -204,7 +204,7 @@ export class CeremonyService {
   async readOne(id: string, session: ISession): Promise<Ceremony> {
     this.logger.info(`Query readOne Ceremony`, { id, userId: session.userId });
     if (!id) {
-      throw new BadRequestException('No ceremony id to search for');
+      throw new InputException('No ceremony id to search for');
     }
     const readCeremony = this.db
       .query()

--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -192,19 +192,19 @@ export class CeremonyService {
       }
 
       return await this.readOne(result.id, session);
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to create ceremony', {
-        exception: e,
+        exception,
       });
 
-      throw e;
+      throw exception;
     }
   }
 
   async readOne(id: string, session: ISession): Promise<Ceremony> {
     this.logger.info(`Query readOne Ceremony`, { id, userId: session.userId });
     if (!id) {
-      throw new InputException('No ceremony id to search for');
+      throw new InputException('No ceremony id to search for', 'ceremony.id');
     }
     const readCeremony = this.db
       .query()
@@ -218,7 +218,7 @@ export class CeremonyService {
     const result = await readCeremony.first();
 
     if (!result) {
-      throw new NotFoundException('Could not find ceremony');
+      throw new NotFoundException('Could not find ceremony', 'ceremony.id');
     }
 
     const securedProps = parseSecuredProperties(
@@ -255,7 +255,7 @@ export class CeremonyService {
     const object = await this.readOne(id, session);
 
     if (!object) {
-      throw new NotFoundException('Could not find ceremony');
+      throw new NotFoundException('Could not find ceremony', 'ceremony.id');
     }
 
     try {
@@ -264,11 +264,11 @@ export class CeremonyService {
         object,
         aclEditProp: 'canDeleteOwnUser',
       });
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to delete ceremony', {
-        exception: e,
+        exception,
       });
-      throw e;
+      throw exception;
     }
   }
 

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -1,17 +1,16 @@
-import {
-  BadRequestException,
-  forwardRef,
-  Inject,
-  Injectable,
-  NotFoundException,
-  InternalServerErrorException as ServerException,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
 import { upperFirst } from 'lodash';
 import { DateTime } from 'luxon';
 import { generate } from 'shortid';
-import { DuplicateException, ISession } from '../../common';
+import {
+  DuplicateException,
+  InputException,
+  ISession,
+  NotFoundException,
+  ServerException,
+  UnauthorizedException,
+} from '../../common';
 import {
   ConfigService,
   DatabaseService,
@@ -243,7 +242,7 @@ export class EngagementService {
     const projectType = await this.getProjectTypeById(projectId);
 
     if (projectType && projectType !== ProjectType.Translation) {
-      throw new BadRequestException('That Project type is not Translation');
+      throw new InputException('That Project type is not Translation');
     }
 
     if (await this.getLEByProjectAndLanguage(projectId, languageId)) {
@@ -447,7 +446,7 @@ export class EngagementService {
           .return('project.id')
           .first())
       ) {
-        throw new BadRequestException('projectId is invalid');
+        throw new InputException('projectId is invalid');
       }
       if (
         languageId &&
@@ -459,7 +458,7 @@ export class EngagementService {
           .return('language.id')
           .first())
       ) {
-        throw new BadRequestException('languageId is invalid');
+        throw new InputException('languageId is invalid');
       }
       throw new ServerException('Could not create Language Engagement');
     }
@@ -484,7 +483,7 @@ export class EngagementService {
     const projectType = await this.getProjectTypeById(projectId);
 
     if (projectType && projectType !== ProjectType.Internship) {
-      throw new BadRequestException('That Project type is not Intership');
+      throw new InputException('That Project type is not Intership');
     }
 
     if (await this.getIEByProjectAndIntern(projectId, internId)) {
@@ -724,7 +723,7 @@ export class EngagementService {
           .return('intern.id')
           .first())
       ) {
-        throw new BadRequestException('internId is invalid');
+        throw new InputException('internId is invalid');
       }
       if (
         mentorId &&
@@ -734,7 +733,7 @@ export class EngagementService {
           .return('mentor.id')
           .first())
       ) {
-        throw new BadRequestException('mentorId is invalid');
+        throw new InputException('mentorId is invalid');
       }
       if (
         projectId &&
@@ -744,7 +743,7 @@ export class EngagementService {
           .return('project.id')
           .first())
       ) {
-        throw new BadRequestException('projectId is invalid');
+        throw new InputException('projectId is invalid');
       }
       if (
         countryOfOriginId &&
@@ -759,7 +758,7 @@ export class EngagementService {
           .return('country.id')
           .first())
       ) {
-        throw new BadRequestException('countryOfOriginId is invalid');
+        throw new InputException('countryOfOriginId is invalid');
       }
       throw new ServerException('Could not create Internship Engagement');
     }

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -436,9 +436,12 @@ export class EngagementService {
     let le;
     try {
       le = await createLE.first();
-    } catch (e) {
-      this.logger.error('could not create Language Engagement ', e);
-      throw new ServerException('Could not create Langauge Engagement', e);
+    } catch (exception) {
+      this.logger.error('could not create Language Engagement ', { exception });
+      throw new ServerException(
+        'Could not create Langauge Engagement',
+        exception
+      );
     }
     if (!le) {
       if (
@@ -719,12 +722,17 @@ export class EngagementService {
     let IE;
     try {
       IE = await createIE.first();
-    } catch (e) {
+    } catch (exception) {
       // secondary queries to see what ID is bad
       // check internId
 
-      this.logger.error('could not create Internship Engagement ', e);
-      throw new ServerException('Could not create Internship Engagement', e);
+      this.logger.error('could not create Internship Engagement ', {
+        exception,
+      });
+      throw new ServerException(
+        'Could not create Internship Engagement',
+        exception
+      );
     }
     if (!IE) {
       if (

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -9,7 +9,7 @@ import {
   ISession,
   NotFoundException,
   ServerException,
-  UnauthorizedException,
+  UnauthenticatedException,
 } from '../../common';
 import {
   ConfigService,
@@ -236,7 +236,7 @@ export class EngagementService {
     session: ISession
   ): Promise<LanguageEngagement> {
     if (!session.userId) {
-      throw new UnauthorizedException('user not logged in');
+      throw new UnauthenticatedException('user not logged in');
     }
     // LanguageEngagements can only be created on TranslationProjects
     const projectType = await this.getProjectTypeById(projectId);
@@ -477,7 +477,7 @@ export class EngagementService {
     session: ISession
   ): Promise<InternshipEngagement> {
     if (!session.userId) {
-      throw new UnauthorizedException('user not logged in');
+      throw new UnauthenticatedException('user not logged in');
     }
     // InternshipEngagements can only be created on InternshipProjects
     const projectType = await this.getProjectTypeById(projectId);

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -242,7 +242,10 @@ export class EngagementService {
     const projectType = await this.getProjectTypeById(projectId);
 
     if (projectType && projectType !== ProjectType.Translation) {
-      throw new InputException('That Project type is not Translation');
+      throw new InputException(
+        'That Project type is not Translation',
+        'engagement.projectId'
+      );
     }
 
     if (await this.getLEByProjectAndLanguage(projectId, languageId)) {
@@ -435,7 +438,7 @@ export class EngagementService {
       le = await createLE.first();
     } catch (e) {
       this.logger.error('could not create Language Engagement ', e);
-      throw new ServerException('Could not create Langauge Engagement');
+      throw new ServerException('Could not create Langauge Engagement', e);
     }
     if (!le) {
       if (
@@ -446,7 +449,10 @@ export class EngagementService {
           .return('project.id')
           .first())
       ) {
-        throw new InputException('projectId is invalid');
+        throw new InputException(
+          'projectId is invalid',
+          'engagement.projectId'
+        );
       }
       if (
         languageId &&
@@ -458,7 +464,10 @@ export class EngagementService {
           .return('language.id')
           .first())
       ) {
-        throw new InputException('languageId is invalid');
+        throw new InputException(
+          'languageId is invalid',
+          'engagement.languageId'
+        );
       }
       throw new ServerException('Could not create Language Engagement');
     }
@@ -483,7 +492,10 @@ export class EngagementService {
     const projectType = await this.getProjectTypeById(projectId);
 
     if (projectType && projectType !== ProjectType.Internship) {
-      throw new InputException('That Project type is not Intership');
+      throw new InputException(
+        'That Project type is not Intership',
+        'engagement.projectId'
+      );
     }
 
     if (await this.getIEByProjectAndIntern(projectId, internId)) {
@@ -712,7 +724,7 @@ export class EngagementService {
       // check internId
 
       this.logger.error('could not create Internship Engagement ', e);
-      throw new ServerException('Could not create Internship Engagement');
+      throw new ServerException('Could not create Internship Engagement', e);
     }
     if (!IE) {
       if (
@@ -723,7 +735,7 @@ export class EngagementService {
           .return('intern.id')
           .first())
       ) {
-        throw new InputException('internId is invalid');
+        throw new InputException('internId is invalid', 'engagement.internId');
       }
       if (
         mentorId &&
@@ -733,7 +745,7 @@ export class EngagementService {
           .return('mentor.id')
           .first())
       ) {
-        throw new InputException('mentorId is invalid');
+        throw new InputException('mentorId is invalid', 'engagement.mentorId');
       }
       if (
         projectId &&
@@ -743,7 +755,10 @@ export class EngagementService {
           .return('project.id')
           .first())
       ) {
-        throw new InputException('projectId is invalid');
+        throw new InputException(
+          'projectId is invalid',
+          'engagement.projectId'
+        );
       }
       if (
         countryOfOriginId &&
@@ -758,7 +773,10 @@ export class EngagementService {
           .return('country.id')
           .first())
       ) {
-        throw new InputException('countryOfOriginId is invalid');
+        throw new InputException(
+          'countryOfOriginId is invalid',
+          'engagement.countryOfOriginId'
+        );
       }
       throw new ServerException('Could not create Internship Engagement');
     }
@@ -767,7 +785,7 @@ export class EngagementService {
     } catch (e) {
       this.logger.error(e);
 
-      throw new ServerException(`Could not create InternshipEngagement`);
+      throw new ServerException(`Could not create InternshipEngagement`, e);
     }
   }
 
@@ -780,7 +798,7 @@ export class EngagementService {
     this.logger.info('readOne', { id, userId: session.userId });
 
     if (!id) {
-      throw new NotFoundException('no id given');
+      throw new NotFoundException('no id given', 'engagement.id');
     }
 
     if (!session.userId) {
@@ -875,7 +893,7 @@ export class EngagementService {
     const result = await query.first();
 
     if (!result) {
-      throw new NotFoundException('could not find Engagement');
+      throw new NotFoundException('could not find Engagement', 'engagement.id');
     }
 
     const props = parsePropList(result.propList);
@@ -1012,9 +1030,12 @@ export class EngagementService {
         changes,
         nodevar: 'LanguageEngagement',
       });
-    } catch (e) {
-      this.logger.error('Error updating language engagement', { exception: e });
-      throw new ServerException('Could not update LanguageEngagement');
+    } catch (exception) {
+      this.logger.error('Error updating language engagement', { exception });
+      throw new ServerException(
+        'Could not update LanguageEngagement',
+        exception
+      );
     }
 
     return (await this.readOne(input.id, session)) as LanguageEngagement;
@@ -1135,11 +1156,14 @@ export class EngagementService {
           ]);
         }
       });
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to update InternshipEngagement', {
-        exception: e,
+        exception,
       });
-      throw new ServerException('Could not find update InternshipEngagement');
+      throw new ServerException(
+        'Could not find update InternshipEngagement',
+        exception
+      );
     }
 
     return (await this.readOne(input.id, session)) as InternshipEngagement;
@@ -1151,7 +1175,7 @@ export class EngagementService {
     const object = await this.readOne(id, session);
 
     if (!object) {
-      throw new NotFoundException('Could not find engagement');
+      throw new NotFoundException('Could not find engagement', 'engagement.id');
     }
 
     try {
@@ -1160,12 +1184,12 @@ export class EngagementService {
         object,
         aclEditProp: 'canDeleteOwnUser',
       });
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to delete partnership', {
-        exception: e,
+        exception,
       });
 
-      throw new ServerException('Failed to delete partnership');
+      throw new ServerException('Failed to delete partnership', exception);
     }
   }
 

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -493,7 +493,7 @@ export class EngagementService {
 
     if (projectType && projectType !== ProjectType.Internship) {
       throw new InputException(
-        'That Project type is not Intership',
+        'That Project type is not Internship',
         'engagement.projectId'
       );
     }
@@ -528,7 +528,7 @@ export class EngagementService {
         session
       );
     } catch (e) {
-      throw new Error('could not create ceremony');
+      throw new ServerException('could not create ceremony', e);
     }
 
     const createIE = this.db

--- a/src/components/favorites/favorite.service.ts
+++ b/src/components/favorites/favorite.service.ts
@@ -57,9 +57,11 @@ export class FavoriteService {
       .return('rel');
     try {
       await query.first();
-    } catch (e) {
-      this.logger.error(`Could not add favorite for user ${session.userId}`);
-      throw new ServerException('Could not add favorite', e);
+    } catch (exception) {
+      this.logger.error(`Could not add favorite for user ${session.userId}`, {
+        exception,
+      });
+      throw new ServerException('Could not add favorite', exception);
     }
     return input.baseNodeId;
   }

--- a/src/components/favorites/favorite.service.ts
+++ b/src/components/favorites/favorite.service.ts
@@ -1,7 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
-import { ISession, ServerException, UnauthorizedException } from '../../common';
+import {
+  ISession,
+  ServerException,
+  UnauthenticatedException,
+} from '../../common';
 import {
   DatabaseService,
   ILogger,
@@ -36,7 +40,7 @@ export class FavoriteService {
 
   async add(input: AddFavorite, session: ISession): Promise<string> {
     if (!session.userId) {
-      throw new UnauthorizedException('user not logged in');
+      throw new UnauthenticatedException('user not logged in');
     }
     const createdAt = DateTime.local();
     const query = this.db
@@ -62,7 +66,7 @@ export class FavoriteService {
 
   async remove(baseNodeId: string, session: ISession): Promise<void> {
     if (!session.userId) {
-      throw new UnauthorizedException('user not logged in');
+      throw new UnauthenticatedException('user not logged in');
     }
     const del = this.db
       .query()
@@ -92,7 +96,7 @@ export class FavoriteService {
     session: ISession
   ): Promise<FavoriteListOutput> {
     if (!session.userId) {
-      throw new UnauthorizedException('user not logged in');
+      throw new UnauthenticatedException('user not logged in');
     }
     const baseNode = input.filter.baseNode
       ? input.filter.baseNode + ':BaseNode'

--- a/src/components/favorites/favorite.service.ts
+++ b/src/components/favorites/favorite.service.ts
@@ -1,11 +1,7 @@
-import {
-  Injectable,
-  InternalServerErrorException as ServerException,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
-import { ISession } from '../../common';
+import { ISession, ServerException, UnauthorizedException } from '../../common';
 import {
   DatabaseService,
   ILogger,

--- a/src/components/favorites/favorite.service.ts
+++ b/src/components/favorites/favorite.service.ts
@@ -57,9 +57,9 @@ export class FavoriteService {
       .return('rel');
     try {
       await query.first();
-    } catch (err) {
+    } catch (e) {
       this.logger.error(`Could not add favorite for user ${session.userId}`);
-      throw new ServerException('Could not add favorite');
+      throw new ServerException('Could not add favorite', e);
     }
     return input.baseNodeId;
   }
@@ -87,7 +87,7 @@ export class FavoriteService {
       await del.first();
     } catch (e) {
       this.logger.error(e);
-      throw new ServerException('favorite not removed');
+      throw new ServerException('favorite not removed', e);
     }
   }
 
@@ -130,7 +130,7 @@ export class FavoriteService {
       countResult = await countQuery.run();
     } catch (e) {
       this.logger.error(e);
-      throw new ServerException('favorite not found');
+      throw new ServerException('favorite not found', e);
     }
     if (!result) {
       return { items: [], total: 0, hasMore: false };

--- a/src/components/file/bucket/filesystem-bucket.ts
+++ b/src/components/file/bucket/filesystem-bucket.ts
@@ -1,7 +1,7 @@
-import { NotFoundException } from '@nestjs/common';
 import { GetObjectOutput, HeadObjectOutput } from 'aws-sdk/clients/s3';
 import { promises as fs } from 'fs';
 import { dirname, join, resolve } from 'path';
+import { NotFoundException } from '../../../common';
 import { FakeAwsFile, LocalBucket, LocalBucketOptions } from './local-bucket';
 
 export interface FilesystemBucketOptions extends LocalBucketOptions {

--- a/src/components/file/bucket/filesystem-bucket.ts
+++ b/src/components/file/bucket/filesystem-bucket.ts
@@ -42,7 +42,7 @@ export class FilesystemBucket extends LocalBucket {
     try {
       await fs.stat(path);
     } catch (e) {
-      throw new NotFoundException();
+      throw new NotFoundException(e);
     }
     const raw = await this.readFile(key + '.info');
     const info = JSON.parse(raw.toString());

--- a/src/components/file/bucket/local-bucket.ts
+++ b/src/components/file/bucket/local-bucket.ts
@@ -1,7 +1,7 @@
-import { BadRequestException } from '@nestjs/common';
 import { GetObjectOutput } from 'aws-sdk/clients/s3';
 import { DateTime } from 'luxon';
 import { assert } from 'ts-essentials';
+import { InputException } from '../../../common';
 import { BucketOptions, FileBucket } from './file-bucket';
 
 export interface LocalBucketOptions extends BucketOptions {
@@ -69,10 +69,10 @@ export abstract class LocalBucket extends FileBucket {
       assert(typeof parsed.key === 'string');
       assert(typeof parsed.expires === 'number');
     } catch (e) {
-      throw new BadRequestException();
+      throw new InputException();
     }
     if (DateTime.local() > DateTime.fromMillis(parsed.expires)) {
-      throw new BadRequestException('url expired');
+      throw new InputException('url expired');
     }
     return parsed.key as string;
   }

--- a/src/components/file/bucket/local-bucket.ts
+++ b/src/components/file/bucket/local-bucket.ts
@@ -69,7 +69,7 @@ export abstract class LocalBucket extends FileBucket {
       assert(typeof parsed.key === 'string');
       assert(typeof parsed.expires === 'number');
     } catch (e) {
-      throw new InputException();
+      throw new InputException(e);
     }
     if (DateTime.local() > DateTime.fromMillis(parsed.expires)) {
       throw new InputException('url expired');

--- a/src/components/file/bucket/memory-bucket.ts
+++ b/src/components/file/bucket/memory-bucket.ts
@@ -1,5 +1,5 @@
-import { NotFoundException } from '@nestjs/common';
 import { HeadObjectOutput } from 'aws-sdk/clients/s3';
+import { NotFoundException } from '../../../common';
 import { FakeAwsFile, LocalBucket } from './local-bucket';
 
 /**

--- a/src/components/file/local-bucket.controller.ts
+++ b/src/components/file/local-bucket.controller.ts
@@ -1,10 +1,8 @@
 import {
-  BadRequestException,
   Controller,
   Get,
   Headers,
   Inject,
-  InternalServerErrorException,
   Put,
   Query,
   Request,
@@ -14,6 +12,7 @@ import {
 import { BaseExceptionFilter } from '@nestjs/core';
 import { Request as IRequest, Response as IResponse } from 'express';
 import * as rawBody from 'raw-body';
+import { InputException, ServerException } from '../../common';
 import { FileBucket, LocalBucket } from './bucket';
 import { FilesBucketToken } from './files-bucket.factory';
 
@@ -32,13 +31,13 @@ export class LocalBucketController {
     @Request() req: IRequest
   ) {
     if (!this.bucket) {
-      throw new InternalServerErrorException('Cannot upload file here');
+      throw new ServerException('Cannot upload file here');
     }
     // Chokes on json files because they are parsed with body-parser.
     // Need to disable it for this path or create a workaround.
     const contents = await rawBody(req);
     if (!contents) {
-      throw new BadRequestException();
+      throw new InputException();
     }
 
     await this.bucket.upload(signed, {
@@ -51,7 +50,7 @@ export class LocalBucketController {
   @Get()
   async download(@Query('signed') signed: string, @Response() res: IResponse) {
     if (!this.bucket) {
-      throw new InternalServerErrorException('Cannot download file here');
+      throw new ServerException('Cannot download file here');
     }
 
     const out = await this.bucket.download(signed);

--- a/src/components/film/film.service.ts
+++ b/src/components/film/film.service.ts
@@ -1,7 +1,12 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
-import { DuplicateException, ISession, ServerException } from '../../common';
+import {
+  DuplicateException,
+  ISession,
+  NotFoundException,
+  ServerException,
+} from '../../common';
 import {
   addAllMetaPropertiesOfChildBaseNodes,
   addAllSecureProperties,

--- a/src/components/film/film.service.ts
+++ b/src/components/film/film.service.ts
@@ -209,12 +209,12 @@ export class FilmService {
 
       this.logger.info(`flim created`, { id: result.id });
       return await this.readOne(result.id, session);
-    } catch (err) {
+    } catch (exception) {
       this.logger.error(`Could not create film`, {
-        exception: err,
+        exception,
         userId: session.userId,
       });
-      throw new ServerException('Could not create film', err);
+      throw new ServerException('Could not create film', exception);
     }
   }
 
@@ -358,9 +358,9 @@ export class FilmService {
         object: film,
         aclEditProp: 'canDeleteOwnUser',
       });
-    } catch (e) {
-      this.logger.error('Failed to delete', { id, exception: e });
-      throw new ServerException('Failed to delete');
+    } catch (exception) {
+      this.logger.error('Failed to delete', { id, exception });
+      throw new ServerException('Failed to delete', exception);
     }
 
     this.logger.info(`deleted film with id`, { id });

--- a/src/components/language/ethnologue-language/ethnologue-language.service.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.service.ts
@@ -1,11 +1,8 @@
-import {
-  Injectable,
-  InternalServerErrorException as ServerException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { upperFirst } from 'lodash';
 import { DateTime } from 'luxon';
-import { ISession, NotFoundException } from '../../../common';
+import { ISession, NotFoundException, ServerException } from '../../../common';
 import {
   ConfigService,
   createBaseNode,

--- a/src/components/language/ethnologue-language/ethnologue-language.service.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.service.ts
@@ -245,7 +245,10 @@ export class EthnologueLanguageService {
 
     const result = await query.first();
     if (!result) {
-      throw new NotFoundException('Could not find ethnologue language');
+      throw new NotFoundException(
+        'Could not find ethnologue language',
+        'ethnologue.id'
+      );
     }
 
     const ethnologue = parseSecuredProperties(
@@ -383,9 +386,12 @@ export class EthnologueLanguageService {
           'population.value': input.population,
         });
       await query.run();
-    } catch (e) {
-      this.logger.error('update failed', { exception: e });
-      throw new ServerException('Failed to update ethnologue language');
+    } catch (exception) {
+      this.logger.error('update failed', { exception });
+      throw new ServerException(
+        'Failed to update ethnologue language',
+        exception
+      );
     }
   }
 }

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -714,7 +714,7 @@ export class LanguageService {
     const locationLabel = await this.getLocationLabelById(locationId);
 
     if (!locationLabel) {
-      throw new InputException('Cannot find location', 'language.locationId');
+      throw new InputException('Cannot find location', 'locationId');
     }
 
     await this.removeLocation(languageId, locationId, session);
@@ -744,7 +744,7 @@ export class LanguageService {
     const locationLabel = await this.getLocationLabelById(locationId);
 
     if (!locationLabel) {
-      throw new InputException('Cannot find location', 'language.locationId');
+      throw new InputException('Cannot find location', 'locationId');
     }
 
     await this.db

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -1,9 +1,10 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Node, node, relation } from 'cypher-query-builder';
 import { first, intersection, upperFirst } from 'lodash';
 import { DateTime } from 'luxon';
 import {
   DuplicateException,
+  InputException,
   ISession,
   NotFoundException,
   Sensitivity,
@@ -710,7 +711,7 @@ export class LanguageService {
     const locationLabel = await this.getLocationLabelById(locationId);
 
     if (!locationLabel) {
-      throw new BadRequestException('Cannot find location');
+      throw new InputException('Cannot find location');
     }
 
     await this.removeLocation(languageId, locationId, session);
@@ -740,7 +741,7 @@ export class LanguageService {
     const locationLabel = await this.getLocationLabelById(locationId);
 
     if (!locationLabel) {
-      throw new BadRequestException('Cannot find location');
+      throw new InputException('Cannot find location');
     }
 
     await this.db

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -497,7 +497,10 @@ export class LanguageService {
         this.logger.warning(`Could not find ethnologue language`, {
           id: input.id,
         });
-        throw new NotFoundException('Could not find ethnologue language');
+        throw new NotFoundException(
+          'Could not find ethnologue language',
+          'language.id'
+        );
       }
 
       await this.ethnologueLanguageService.update(
@@ -514,7 +517,7 @@ export class LanguageService {
     const object = await this.readOne(id, session);
 
     if (!object) {
-      throw new NotFoundException('Could not find language');
+      throw new NotFoundException('Could not find language', 'language.id');
     }
 
     try {
@@ -523,9 +526,9 @@ export class LanguageService {
         object,
         aclEditProp: 'canDeleteOwnUser',
       });
-    } catch (e) {
-      this.logger.error('Failed to delete', { id, exception: e });
-      throw new ServerException('Failed to delete');
+    } catch (exception) {
+      this.logger.error('Failed to delete', { id, exception });
+      throw new ServerException('Failed to delete', exception);
     }
   }
 
@@ -711,7 +714,7 @@ export class LanguageService {
     const locationLabel = await this.getLocationLabelById(locationId);
 
     if (!locationLabel) {
-      throw new InputException('Cannot find location');
+      throw new InputException('Cannot find location', 'language.locationId');
     }
 
     await this.removeLocation(languageId, locationId, session);
@@ -741,7 +744,7 @@ export class LanguageService {
     const locationLabel = await this.getLocationLabelById(locationId);
 
     if (!locationLabel) {
-      throw new InputException('Cannot find location');
+      throw new InputException('Cannot find location', 'language.locationId');
     }
 
     await this.db

--- a/src/components/literacy-material/literacy-material.service.ts
+++ b/src/components/literacy-material/literacy-material.service.ts
@@ -209,12 +209,15 @@ export class LiteracyMaterialService {
 
       this.logger.info(`literacy material created`, { id: result.id });
       return await this.readOne(result.id, session);
-    } catch (err) {
+    } catch (exception) {
       this.logger.error(`Could not create literacy material`, {
-        exception: err,
+        exception,
         userId: session.userId,
       });
-      throw new ServerException('Could not create literacy material', err);
+      throw new ServerException(
+        'Could not create literacy material',
+        exception
+      );
     }
   }
 
@@ -370,9 +373,9 @@ export class LiteracyMaterialService {
         object: literacyMaterial,
         aclEditProp: 'canDeleteOwnUser',
       });
-    } catch (e) {
-      this.logger.error('Failed to delete', { id, exception: e });
-      throw new ServerException('Failed to delete');
+    } catch (exception) {
+      this.logger.error('Failed to delete', { id, exception });
+      throw new ServerException('Failed to delete', exception);
     }
 
     this.logger.info(`deleted literacyMaterial with id`, { id });

--- a/src/components/literacy-material/literacy-material.service.ts
+++ b/src/components/literacy-material/literacy-material.service.ts
@@ -1,7 +1,12 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
-import { DuplicateException, ISession, ServerException } from '../../common';
+import {
+  DuplicateException,
+  ISession,
+  NotFoundException,
+  ServerException,
+} from '../../common';
 import {
   addAllMetaPropertiesOfChildBaseNodes,
   addAllSecureProperties,

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -283,7 +283,7 @@ export class LocationService {
     try {
       return await this.readOneZone(id, session);
     } catch (e) {
-      throw new ServerException('Could not create zone');
+      throw new ServerException('Could not create zone', e);
     }
   }
 
@@ -391,7 +391,7 @@ export class LocationService {
           })
           .first();
       }
-    } catch (e) {
+    } catch (exception) {
       // creating this region may have failed because the name already exists.  Looking up the Region
       const lookup = this.db
         .query()
@@ -406,15 +406,15 @@ export class LocationService {
         id = region.regionId;
       } else {
         this.logger.warning(`Could not create region`, {
-          exception: e,
+          exception,
         });
-        throw new ServerException('Could not create region');
+        throw new ServerException('Could not create region', exception);
       }
     }
     try {
       return await this.readOneRegion(id, session);
     } catch (e) {
-      throw new ServerException('Could not create region');
+      throw new ServerException('Could not create region', e);
     }
   }
 
@@ -500,7 +500,7 @@ export class LocationService {
           })
           .first();
       }
-    } catch (e) {
+    } catch (exception) {
       // creating this region may have failed because the name already exists.  Looking up the Region
       const lookup = this.db
         .query()
@@ -515,15 +515,15 @@ export class LocationService {
         id = country.countryId;
       } else {
         this.logger.warning(`Could not create country`, {
-          exception: e,
+          exception,
         });
-        throw new ServerException('Could not create country');
+        throw new ServerException('Could not create country', exception);
       }
     }
     try {
       return await this.readOneCountry(id, session);
     } catch (e) {
-      throw new ServerException('Could not create country');
+      throw new ServerException('Could not create country', e);
     }
   }
 
@@ -553,7 +553,7 @@ export class LocationService {
         return await this.readOneCountry(id, session);
       }
       default: {
-        throw new InputException('Not a location');
+        throw new InputException('Not a location', 'location.id');
       }
     }
   }
@@ -562,7 +562,7 @@ export class LocationService {
     this.logger.info(`Read Zone`, { id, userId: session.userId });
 
     if (!id) {
-      throw new NotFoundException('no id given');
+      throw new NotFoundException('no id given', 'zone.id');
     }
 
     if (!session.userId) {
@@ -625,7 +625,7 @@ export class LocationService {
     this.logger.info(`Read Region`, { id, userId: session.userId });
 
     if (!id) {
-      throw new NotFoundException('no id given');
+      throw new NotFoundException('no id given', 'region.id');
     }
 
     if (!session.userId) {
@@ -705,7 +705,7 @@ export class LocationService {
     this.logger.info(`Query readOne Country`, { id, userId: session.userId });
 
     if (!id) {
-      throw new InputException('No country id to search for');
+      throw new InputException('No country id to search for', 'country.id');
     }
 
     const props = ['name'];
@@ -747,7 +747,7 @@ export class LocationService {
     const result = await query.first();
     if (!result) {
       this.logger.error(`Could not find country`);
-      throw new NotFoundException('Could not find country');
+      throw new NotFoundException('Could not find country', 'country.id');
     }
 
     const response: any = {
@@ -977,9 +977,9 @@ export class LocationService {
       // if (!object) {
       //   throw new NotFoundException('Location not found');
       // }
-    } catch (e) {
-      this.logger.error('Could not delete location', { exception: e });
-      throw new ServerException('Could not delete location');
+    } catch (exception) {
+      this.logger.error('Could not delete location', { exception });
+      throw new ServerException('Could not delete location', exception);
     }
   }
 

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -1,14 +1,14 @@
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-  InternalServerErrorException as ServerException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { inArray, node, regexp, relation } from 'cypher-query-builder';
 import { first, intersection } from 'lodash';
 import { DateTime } from 'luxon';
 import { generate } from 'shortid';
-import { ISession } from '../../common';
+import {
+  InputException,
+  ISession,
+  NotFoundException,
+  ServerException,
+} from '../../common';
 import {
   addAllMetaPropertiesOfChildBaseNodes,
   addAllSecureProperties,
@@ -553,7 +553,7 @@ export class LocationService {
         return await this.readOneCountry(id, session);
       }
       default: {
-        throw new BadRequestException('Not a location');
+        throw new InputException('Not a location');
       }
     }
   }
@@ -705,7 +705,7 @@ export class LocationService {
     this.logger.info(`Query readOne Country`, { id, userId: session.userId });
 
     if (!id) {
-      throw new BadRequestException('No country id to search for');
+      throw new InputException('No country id to search for');
     }
 
     const props = ['name'];
@@ -1022,7 +1022,7 @@ export class LocationService {
 
     const result = await runListQuery(query, input, false);
     if (!result) {
-      throw new BadRequestException('No location');
+      throw new InputException('No location');
     }
     const items = await Promise.all(
       result.items.map((row: any) => this.readOne(row.id, session))

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -334,12 +334,12 @@ export class PartnershipService {
       );
 
       return partnership;
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to create partnership', {
-        exception: e,
+        exception,
       });
 
-      throw new ServerException('Failed to create partnership');
+      throw new ServerException('Failed to create partnership', exception);
     }
   }
 
@@ -380,7 +380,10 @@ export class PartnershipService {
     const result = await query.first();
 
     if (!result) {
-      throw new NotFoundException('could not find Partnership');
+      throw new NotFoundException(
+        'could not find Partnership',
+        'partnership.id'
+      );
     }
 
     const readProject = await this.projectService.readOne(
@@ -495,7 +498,10 @@ export class PartnershipService {
     const object = await this.readOne(id, session);
 
     if (!object) {
-      throw new NotFoundException('Could not find partnership');
+      throw new NotFoundException(
+        'Could not find partnership',
+        'partnership.id'
+      );
     }
 
     try {
@@ -504,12 +510,12 @@ export class PartnershipService {
         object,
         aclEditProp: 'canDeleteOwnUser',
       });
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to delete partnership', {
-        exception: e,
+        exception,
       });
 
-      throw new ServerException('Failed to delete partnership');
+      throw new ServerException('Failed to delete partnership', exception);
     }
 
     await this.eventBus.publish(new PartnershipDeletedEvent(object, session));

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -1,14 +1,14 @@
-import {
-  forwardRef,
-  Inject,
-  Injectable,
-  InternalServerErrorException as ServerException,
-} from '@nestjs/common';
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
 import { RelationDirection } from 'cypher-query-builder/dist/typings/clauses/relation-pattern';
 import { upperFirst } from 'lodash';
 import { DateTime } from 'luxon';
-import { InputException, ISession, NotFoundException } from '../../common';
+import {
+  InputException,
+  ISession,
+  NotFoundException,
+  ServerException,
+} from '../../common';
 import {
   addAllMetaPropertiesOfChildBaseNodes,
   addAllSecureProperties,

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -594,11 +594,11 @@ export class ProductService {
         object,
         aclEditProp: 'canDeleteOwnUser',
       });
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to delete product', {
-        exception: e,
+        exception,
       });
-      throw new ServerException('Failed to delete product');
+      throw new ServerException('Failed to delete product', exception);
     }
   }
 

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -1,12 +1,14 @@
-import {
-  Injectable,
-  InternalServerErrorException as ServerException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
 import { RelationDirection } from 'cypher-query-builder/dist/typings/clauses/relation-pattern';
 import { difference } from 'lodash';
 import { DateTime } from 'luxon';
-import { DuplicateException, ISession, NotFoundException } from '../../common';
+import {
+  DuplicateException,
+  ISession,
+  NotFoundException,
+  ServerException,
+} from '../../common';
 import {
   addAllMetaPropertiesOfChildBaseNodes,
   ChildBaseNodeMetaProperty,

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -1,15 +1,15 @@
-import {
-  Injectable,
-  InternalServerErrorException,
-  NotFoundException,
-  InternalServerErrorException as ServerException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
 import { RelationDirection } from 'cypher-query-builder/dist/typings/clauses/relation-pattern';
 import { upperFirst } from 'lodash';
 import { DateTime } from 'luxon';
 import { generate } from 'shortid';
-import { DuplicateException, ISession } from '../../../common';
+import {
+  DuplicateException,
+  ISession,
+  NotFoundException,
+  ServerException,
+} from '../../../common';
 import {
   addAllMetaPropertiesOfChildBaseNodes,
   addAllSecureProperties,
@@ -274,7 +274,7 @@ export class ProjectMemberService {
         exception: e,
       });
 
-      throw new InternalServerErrorException('Could not create project member');
+      throw new ServerException('Could not create project member');
     }
   }
 

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -269,12 +269,12 @@ export class ProjectMemberService {
         .first();
 
       return await this.readOne(id, session);
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to create project member', {
-        exception: e,
+        exception,
       });
 
-      throw new ServerException('Could not create project member');
+      throw new ServerException('Could not create project member', exception);
     }
   }
 
@@ -318,7 +318,10 @@ export class ProjectMemberService {
 
     const result = await query.first();
     if (!result) {
-      throw new NotFoundException('Could not find project memeber');
+      throw new NotFoundException(
+        'Could not find project member',
+        'projectMember.id'
+      );
     }
 
     const response: any = {
@@ -363,7 +366,10 @@ export class ProjectMemberService {
     const object = await this.readOne(id, session);
 
     if (!object) {
-      throw new NotFoundException('Could not find project member');
+      throw new NotFoundException(
+        'Could not find project member',
+        'projectMember.id'
+      );
     }
 
     try {
@@ -372,12 +378,12 @@ export class ProjectMemberService {
         object,
         aclEditProp: 'canDeleteOwnUser',
       });
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to delete project member', {
-        exception: e,
+        exception,
       });
 
-      throw new ServerException('Failed to delete project member');
+      throw new ServerException('Failed to delete project member', exception);
     }
   }
 

--- a/src/components/song/song.service.ts
+++ b/src/components/song/song.service.ts
@@ -1,7 +1,12 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
-import { DuplicateException, ISession, ServerException } from '../../common';
+import {
+  DuplicateException,
+  ISession,
+  NotFoundException,
+  ServerException,
+} from '../../common';
 import {
   addUserToSG,
   ConfigService,

--- a/src/components/song/song.service.ts
+++ b/src/components/song/song.service.ts
@@ -188,12 +188,12 @@ export class SongService {
       this.logger.info(`song created`, { id: result.id });
 
       return await this.readOne(result.id, session);
-    } catch (err) {
+    } catch (exception) {
       this.logger.error(`Could not create song`, {
-        exception: err,
+        exception,
         userId: session.userId,
       });
-      throw new ServerException('Could not create song', err);
+      throw new ServerException('Could not create song', exception);
     }
   }
 
@@ -234,7 +234,7 @@ export class SongService {
     const result = await query.first();
 
     if (!result) {
-      throw new NotFoundException('Could not find song');
+      throw new NotFoundException('Could not find song', 'song.id');
     }
 
     const props = parsePropList(result.propList);
@@ -275,9 +275,9 @@ export class SongService {
         object: song,
         aclEditProp: 'canDeleteOwnUser',
       });
-    } catch (e) {
-      this.logger.error('Failed to delete', { id, exception: e });
-      throw new ServerException('Failed to delete');
+    } catch (exception) {
+      this.logger.error('Failed to delete', { id, exception });
+      throw new ServerException('Failed to delete', exception);
     }
 
     this.logger.info(`deleted song with id`, { id });

--- a/src/components/story/story.service.ts
+++ b/src/components/story/story.service.ts
@@ -1,7 +1,12 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
-import { DuplicateException, ISession, ServerException } from '../../common';
+import {
+  DuplicateException,
+  ISession,
+  NotFoundException,
+  ServerException,
+} from '../../common';
 import {
   addAllSecureProperties,
   addBaseNodeMetaPropsWithClauseAsObject,

--- a/src/components/story/story.service.ts
+++ b/src/components/story/story.service.ts
@@ -204,12 +204,12 @@ export class StoryService {
 
       this.logger.info(`story created`, { id: result.id });
       return await this.readOne(result.id, session);
-    } catch (err) {
+    } catch (exception) {
       this.logger.error(`Could not create story`, {
-        exception: err,
+        exception,
         userId: session.userId,
       });
-      throw new ServerException('Could not create story', err);
+      throw new ServerException('Could not create story', exception);
     }
   }
 
@@ -236,7 +236,7 @@ export class StoryService {
     const result = await query.first();
 
     if (!result) {
-      throw new NotFoundException('Could not find story');
+      throw new NotFoundException('Could not find story', 'story.id');
     }
 
     const scriptureReferences = await this.listScriptureReferences(
@@ -316,9 +316,9 @@ export class StoryService {
         object: story,
         aclEditProp: 'canDeleteOwnUser',
       });
-    } catch (e) {
-      this.logger.error('Failed to delete', { id, exception: e });
-      throw new ServerException('Failed to delete');
+    } catch (exception) {
+      this.logger.error('Failed to delete', { id, exception });
+      throw new ServerException('Failed to delete', exception);
     }
 
     this.logger.info(`deleted story with id`, { id });

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -233,7 +233,7 @@ export class EducationService {
         id,
         userId,
       });
-      throw new ServerException('Could not create education');
+      throw new ServerException('Could not create education', e);
     }
   }
 
@@ -272,7 +272,7 @@ export class EducationService {
       this.logger.error('e :>> ', e);
     }
     if (!result) {
-      throw new NotFoundException('Could not find education');
+      throw new NotFoundException('Could not find education', 'education.id');
     }
 
     return {
@@ -322,9 +322,9 @@ export class EducationService {
         object: ed,
         aclEditProp: 'canDeleteOwnUser',
       });
-    } catch (e) {
-      this.logger.error('Failed to delete', { id, exception: e });
-      throw new ServerException('Failed to delete');
+    } catch (exception) {
+      this.logger.error('Failed to delete', { id, exception });
+      throw new ServerException('Failed to delete', exception);
     }
   }
 

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -1,14 +1,9 @@
-import {
-  Injectable,
-  InternalServerErrorException,
-  NotFoundException,
-  InternalServerErrorException as ServerException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { upperFirst } from 'lodash';
 import { DateTime } from 'luxon';
 import { generate } from 'shortid';
-import { ISession } from '../../../common';
+import { ISession, NotFoundException, ServerException } from '../../../common';
 import {
   ConfigService,
   DatabaseService,
@@ -238,7 +233,7 @@ export class EducationService {
         id,
         userId,
       });
-      throw new InternalServerErrorException('Could not create education');
+      throw new ServerException('Could not create education');
     }
   }
 

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -1,11 +1,7 @@
-import {
-  Injectable,
-  InternalServerErrorException,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { node } from 'cypher-query-builder';
 import { generate } from 'shortid';
-import { ISession } from '../../../common';
+import { ISession, NotFoundException, ServerException } from '../../../common';
 import { DatabaseService, ILogger, Logger, matchSession } from '../../../core';
 import {
   CreateUnavailability,
@@ -47,7 +43,7 @@ export class UnavailabilityService {
         id,
         userId,
       });
-      throw new InternalServerErrorException('Could not create unavailability');
+      throw new ServerException('Could not create unavailability');
     }
 
     this.logger.info(`Created user unavailability`, {

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -115,7 +115,10 @@ export class UnavailabilityService {
       )
       .first();
     if (!result) {
-      throw new NotFoundException('Could not find unavailability');
+      throw new NotFoundException(
+        'Could not find unavailability',
+        'unavailability.id'
+      );
     }
 
     return {
@@ -164,7 +167,10 @@ export class UnavailabilityService {
     this.logger.info(`mutation delete unavailability`);
     const ua = await this.readOne(id, session);
     if (!ua) {
-      throw new NotFoundException('Unavailability not found');
+      throw new NotFoundException(
+        'Unavailability not found',
+        'unavailability.id'
+      );
     }
     await this.db.deleteNode({
       session,

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -449,7 +449,7 @@ export class UserService {
 
     const result = await query.first();
     if (!result) {
-      throw new NotFoundException('Could not find User');
+      throw new NotFoundException('Could not find user', 'user.id');
     }
 
     const rolesValue = result.propList
@@ -543,9 +543,9 @@ export class UserService {
         object: user,
         aclEditProp: 'canDeleteOwnUser',
       });
-    } catch (e) {
-      this.logger.error('Could not delete user', { exception: e });
-      throw new ServerException('Could not delete user');
+    } catch (exception) {
+      this.logger.error('Could not delete user', { exception });
+      throw new ServerException('Could not delete user', exception);
     }
   }
 
@@ -639,15 +639,15 @@ export class UserService {
     let user;
     try {
       user = await query.first();
-    } catch (e) {
+    } catch (exception) {
       this.logger.error(`Could not find education`, {
-        exception: e,
+        exception,
         userId: session.userId,
       });
-      throw new ServerException('Could not find education', e);
+      throw new ServerException('Could not find education', exception);
     }
     if (!user) {
-      throw new NotFoundException('Could not find user');
+      throw new NotFoundException('Could not find user', 'user.id');
     }
     if (!user.canRead) {
       throw new UnauthenticatedException('cannot read education list');
@@ -698,15 +698,15 @@ export class UserService {
     let user;
     try {
       user = await query.first();
-    } catch (e) {
+    } catch (exception) {
       this.logger.error(`Could not find organizations`, {
-        exception: e,
+        exception,
         userId: session.userId,
       });
-      throw new ServerException('Could not find organization', e);
+      throw new ServerException('Could not find organization', exception);
     }
     if (!user) {
-      throw new NotFoundException('Could not find user');
+      throw new NotFoundException('Could not find user', 'user.id');
     }
     if (!user.canRead) {
       this.logger.warning('Cannot read organization list', {
@@ -761,15 +761,15 @@ export class UserService {
     let user;
     try {
       user = await query.first();
-    } catch (e) {
+    } catch (exception) {
       this.logger.error(`Could not find unavailability`, {
-        exception: e,
+        exception,
         userId: session.userId,
       });
-      throw new ServerException('Could not find unavailability', e);
+      throw new ServerException('Could not find unavailability', exception);
     }
     if (!user) {
-      throw new NotFoundException('Could not find user');
+      throw new NotFoundException('Could not find user', 'user.id');
     }
     if (!user.canRead) {
       throw new UnauthenticatedException('cannot read unavailability list');

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -1,13 +1,15 @@
-import {
-  Injectable,
-  NotFoundException,
-  UnauthorizedException as UnauthenticatedException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { difference } from 'lodash';
 import { DateTime } from 'luxon';
 import { generate } from 'shortid';
-import { DuplicateException, ISession, ServerException } from '../../common';
+import {
+  DuplicateException,
+  ISession,
+  NotFoundException,
+  ServerException,
+  UnauthenticatedException,
+} from '../../common';
 import {
   addAllSecureProperties,
   addBaseNodeMetaPropsWithClause,

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -647,7 +647,7 @@ export class UserService {
       throw new ServerException('Could not find education', exception);
     }
     if (!user) {
-      throw new NotFoundException('Could not find user', 'user.id');
+      throw new NotFoundException('Could not find user', 'userId');
     }
     if (!user.canRead) {
       throw new UnauthenticatedException('cannot read education list');
@@ -706,7 +706,7 @@ export class UserService {
       throw new ServerException('Could not find organization', exception);
     }
     if (!user) {
-      throw new NotFoundException('Could not find user', 'user.id');
+      throw new NotFoundException('Could not find user', 'userId');
     }
     if (!user.canRead) {
       this.logger.warning('Cannot read organization list', {
@@ -769,7 +769,7 @@ export class UserService {
       throw new ServerException('Could not find unavailability', exception);
     }
     if (!user) {
-      throw new NotFoundException('Could not find user', 'user.id');
+      throw new NotFoundException('Could not find user', 'userId');
     }
     if (!user.canRead) {
       throw new UnauthenticatedException('cannot read unavailability list');

--- a/src/components/workflow/workflow.service.ts
+++ b/src/components/workflow/workflow.service.ts
@@ -257,7 +257,10 @@ export class WorkflowService {
         .first();
 
       if (!workflow) {
-        throw new NotFoundException('could not find workflow', 'workflow.id');
+        throw new NotFoundException(
+          'could not find workflow',
+          'state.workflowId'
+        );
       }
 
       // validate the new state is a legal nextPossibleState on the current state
@@ -333,7 +336,7 @@ export class WorkflowService {
         .first();
 
       if (!result) {
-        throw new NotFoundException('Could not update state', 'state.id');
+        throw new NotFoundException('Could not update state', 'state.stateId');
       }
 
       return {
@@ -723,7 +726,10 @@ export class WorkflowService {
         .first();
 
       if (!workflow) {
-        throw new NotFoundException('could not find workflow', 'workflow.id');
+        throw new NotFoundException(
+          'could not find workflow',
+          'state.workflowId'
+        );
       }
 
       // validate the new state is a legal nextPossibleState on the current state
@@ -967,7 +973,7 @@ export class WorkflowService {
       if (!field) {
         throw new NotFoundException(
           'could not find such field existing.',
-          'addRequiredField.field'
+          'field.propertyName'
         );
       }
 

--- a/src/components/workflow/workflow.service.ts
+++ b/src/components/workflow/workflow.service.ts
@@ -113,12 +113,12 @@ export class WorkflowService {
           value: result.startingStateValue,
         },
       };
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to create workflow', {
-        exception: e,
+        exception,
       });
 
-      throw new ServerException('Could not create workflow');
+      throw new ServerException('Could not create workflow', exception);
     }
   }
 
@@ -150,12 +150,12 @@ export class WorkflowService {
         ])
         .detachDelete('workflow')
         .run();
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to delete workflow', {
-        exception: e,
+        exception,
       });
 
-      throw new ServerException('Failed to delete workflow');
+      throw new ServerException('Failed to delete workflow', exception);
     }
   }
 
@@ -213,11 +213,14 @@ export class WorkflowService {
         id: result.id,
         value: result.value,
       };
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('could not add new state to a workflow', {
-        exception: e,
+        exception,
       });
-      throw new ServerException('could not add new state to a workflow');
+      throw new ServerException(
+        'could not add new state to a workflow',
+        exception
+      );
     }
   }
 
@@ -254,7 +257,7 @@ export class WorkflowService {
         .first();
 
       if (!workflow) {
-        throw new NotFoundException('could not find workflow');
+        throw new NotFoundException('could not find workflow', 'workflow.id');
       }
 
       // validate the new state is a legal nextPossibleState on the current state
@@ -306,7 +309,7 @@ export class WorkflowService {
 
       if (!possibleState) {
         throw new NotFoundException(
-          'new state provided is not a nextpossiblstate of current state'
+          'new state provided is not a nextpossiblestate of current state'
         );
       }
 
@@ -330,18 +333,18 @@ export class WorkflowService {
         .first();
 
       if (!result) {
-        throw new NotFoundException('Could not update state');
+        throw new NotFoundException('Could not update state', 'state.id');
       }
 
       return {
         id: result.id,
         value: result.value,
       };
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('could not update state', {
-        exception: e,
+        exception,
       });
-      throw new ServerException('could not update state');
+      throw new ServerException('could not update state', exception);
     }
   }
 
@@ -378,12 +381,12 @@ export class WorkflowService {
         ])
         .detachDelete('state')
         .first();
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to delete state', {
-        exception: e,
+        exception,
       });
 
-      throw new ServerException('Failed to delete state');
+      throw new ServerException('Failed to delete state', exception);
     }
   }
 
@@ -427,12 +430,12 @@ export class WorkflowService {
         .run()) as State[];
 
       return { items: result.filter((item) => item.id && item.value) };
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to delete state', {
-        exception: e,
+        exception,
       });
 
-      throw new ServerException('Failed to delete state');
+      throw new ServerException('Failed to delete state', exception);
     }
   }
 
@@ -474,12 +477,12 @@ export class WorkflowService {
         .run()) as State[];
 
       return { items: result.filter((item) => item.id && item.value) };
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('Failed to delete state', {
-        exception: e,
+        exception,
       });
 
-      throw new ServerException('Failed to delete state');
+      throw new ServerException('Failed to delete state', exception);
     }
   }
 
@@ -526,11 +529,14 @@ export class WorkflowService {
           ],
         ])
         .first();
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('could not attach security group to state', {
-        exception: e,
+        exception,
       });
-      throw new ServerException('could not attach security group to state');
+      throw new ServerException(
+        'could not attach security group to state',
+        exception
+      );
     }
   }
 
@@ -571,11 +577,14 @@ export class WorkflowService {
         ])
         .detachDelete('rel')
         .first();
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('could not remove security group from state', {
-        exception: e,
+        exception,
       });
-      throw new ServerException('could not remove security group from state');
+      throw new ServerException(
+        'could not remove security group from state',
+        exception
+      );
     }
   }
 
@@ -622,11 +631,14 @@ export class WorkflowService {
           ],
         ])
         .first();
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('could not attach security group to state', {
-        exception: e,
+        exception,
       });
-      throw new ServerException('could not attach security group to state');
+      throw new ServerException(
+        'could not attach security group to state',
+        exception
+      );
     }
   }
 
@@ -665,11 +677,14 @@ export class WorkflowService {
         ])
         .detachDelete('rel')
         .first();
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('could not remove security group from state', {
-        exception: e,
+        exception,
       });
-      throw new ServerException('could not remove security group from state');
+      throw new ServerException(
+        'could not remove security group from state',
+        exception
+      );
     }
   }
 
@@ -708,7 +723,7 @@ export class WorkflowService {
         .first();
 
       if (!workflow) {
-        throw new NotFoundException('could not find workflow');
+        throw new NotFoundException('could not find workflow', 'workflow.id');
       }
 
       // validate the new state is a legal nextPossibleState on the current state
@@ -758,7 +773,7 @@ export class WorkflowService {
 
       if (!possibleState) {
         throw new NotFoundException(
-          'new state provided is not a nextpossiblstate of current state'
+          'new state provided is not a nextpossiblestate of current state'
         );
       }
 
@@ -801,11 +816,11 @@ export class WorkflowService {
           ],
         ])
         .run();
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('could not change current state', {
-        exception: e,
+        exception,
       });
-      throw new ServerException('could not change current state');
+      throw new ServerException('could not change current state', exception);
     }
   }
 
@@ -862,11 +877,14 @@ export class WorkflowService {
       if (!result) {
         throw new NotFoundException('could not make correct query result');
       }
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('failed to add possible state to state', {
-        exception: e,
+        exception,
       });
-      throw new ServerException('failed to add possible state to state');
+      throw new ServerException(
+        'failed to add possible state to state',
+        exception
+      );
     }
   }
 
@@ -905,11 +923,11 @@ export class WorkflowService {
         ])
         .detachDelete('rel')
         .run();
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('failed to remove possible state', {
-        exception: e,
+        exception,
       });
-      throw new ServerException('failed to remove possible state');
+      throw new ServerException('failed to remove possible state', exception);
     }
   }
 
@@ -947,7 +965,10 @@ export class WorkflowService {
         .first();
 
       if (!field) {
-        throw new NotFoundException('could not find such field existing.');
+        throw new NotFoundException(
+          'could not find such field existing.',
+          'addRequiredField.field'
+        );
       }
 
       await this.db
@@ -981,11 +1002,11 @@ export class WorkflowService {
           node('state'),
         ])
         .first();
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('could not add field to state', {
-        exception: e,
+        exception,
       });
-      throw new ServerException('could not add field to state');
+      throw new ServerException('could not add field to state', exception);
     }
   }
 
@@ -1025,11 +1046,11 @@ export class WorkflowService {
       return {
         items: result.filter((item) => item.value),
       };
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('could not list fields', {
-        exception: e,
+        exception,
       });
-      throw new ServerException('could not list fields');
+      throw new ServerException('could not list fields', exception);
     }
   }
 
@@ -1065,11 +1086,11 @@ export class WorkflowService {
         ])
         .detachDelete('rel')
         .run();
-    } catch (e) {
+    } catch (exception) {
       this.logger.warning('could not remove field from state', {
-        exception: e,
+        exception,
       });
-      throw new ServerException('could not remove field from state');
+      throw new ServerException('could not remove field from state', exception);
     }
   }
 }

--- a/src/components/workflow/workflow.service.ts
+++ b/src/components/workflow/workflow.service.ts
@@ -1,13 +1,12 @@
-import {
-  Injectable,
-  InternalServerErrorException,
-  NotFoundException,
-  InternalServerErrorException as ServerException,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { generate } from 'shortid';
-import { ISession } from '../../common';
+import {
+  ISession,
+  NotFoundException,
+  ServerException,
+  UnauthorizedException,
+} from '../../common';
 import { DatabaseService, ILogger, Logger, matchSession } from '../../core';
 import {
   AddState,
@@ -119,7 +118,7 @@ export class WorkflowService {
         exception: e,
       });
 
-      throw new InternalServerErrorException('Could not create workflow');
+      throw new ServerException('Could not create workflow');
     }
   }
 

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -1023,7 +1023,7 @@ export class DatabaseService {
           ],
         ])
         .run();
-    } catch (e) {
+    } catch (exception) {
       // If there is no aclEditProp, then this is not an access-related issue
       // and we can move forward with throwing
       if (!aclEdit) {
@@ -1045,10 +1045,10 @@ export class DatabaseService {
       }
 
       this.logger.error(`createNode error`, {
-        exception: e,
+        exception,
       });
 
-      throw new ServerException('createNode error');
+      throw new ServerException('createNode error', exception);
     }
   }
 
@@ -1384,12 +1384,12 @@ export class DatabaseService {
         throw new ServerException('failed to create node');
       }
       return result.id;
-    } catch (err) {
+    } catch (exception) {
       this.logger.error(`Could not create node`, {
-        exception: err,
+        exception,
         userId: session.userId,
       });
-      throw new ServerException('Could not create node');
+      throw new ServerException('Could not create node', exception);
     }
   }
 
@@ -1599,12 +1599,12 @@ export class DatabaseService {
     let result: any;
     try {
       result = await query.first();
-    } catch (e) {
+    } catch (exception) {
       this.logger.error(`Could not find node`, {
-        exception: e,
+        exception,
         userId: session.userId,
       });
-      throw new ServerException('Could not find node');
+      throw new ServerException('Could not find node', exception);
     }
 
     if (!result) {

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -1,9 +1,4 @@
-import {
-  ForbiddenException,
-  Injectable,
-  NotFoundException,
-  InternalServerErrorException as ServerException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import {
   Connection,
   equals,
@@ -19,12 +14,15 @@ import { generate } from 'shortid';
 import { assert } from 'ts-essentials';
 import {
   AbstractClassType,
+  InputException,
   ISession,
   isSecured,
   many,
   mapFromList,
   Order,
   Resource,
+  ServerException,
+  UnauthorizedException,
   UnwrapSecured,
   unwrapSecured,
 } from '../../common';
@@ -217,7 +215,7 @@ export class DatabaseService {
     const result = await update.first();
 
     if (!result) {
-      throw new NotFoundException('Could not find object');
+      throw new InputException('Could not find object');
     }
 
     return {
@@ -526,7 +524,7 @@ export class DatabaseService {
     }
 
     if (!result) {
-      throw new NotFoundException('Could not find object');
+      throw new InputException('Could not find object');
     }
 
     return {
@@ -934,7 +932,7 @@ export class DatabaseService {
       .first();
 
     if (!result) {
-      throw new NotFoundException('Could not find object');
+      throw new InputException('Could not find object');
     }
   }
 
@@ -1043,7 +1041,7 @@ export class DatabaseService {
 
       // If the user doesn't have permission to perform the create action...
       if (!aclResult || !aclResult.editProp) {
-        throw new ForbiddenException(`Cannot create ${type.name}`);
+        throw new UnauthorizedException(`Cannot create ${type.name}`);
       }
 
       this.logger.error(`createNode error`, {
@@ -1610,10 +1608,10 @@ export class DatabaseService {
     }
 
     if (!result) {
-      throw new NotFoundException('Could not find node');
+      throw new InputException('Could not find node');
     }
     if (!result[aclCreatePropName]) {
-      throw new ForbiddenException(
+      throw new UnauthorizedException(
         'User does not have permission to create an node'
       );
     }

--- a/src/core/exception.filter.test.ts
+++ b/src/core/exception.filter.test.ts
@@ -1,9 +1,11 @@
+/* eslint-disable no-restricted-imports */
 import {
   BadRequestException,
   ForbiddenException,
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
+/* eslint-enable no-restricted-imports */
 import { InputException, ServerException } from '../common/exceptions';
 import { ConstraintError } from './database';
 import { ExceptionFilter } from './exception.filter';

--- a/src/core/exception.filter.ts
+++ b/src/core/exception.filter.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 import {
   ArgumentsHost,
   BadRequestException,
@@ -8,6 +9,7 @@ import {
   InternalServerErrorException,
   UnauthorizedException,
 } from '@nestjs/common';
+/* eslint-enable no-restricted-imports */
 import { GqlArgumentsHost, GqlExceptionFilter } from '@nestjs/graphql';
 import { compact, mapValues, uniq } from 'lodash';
 import { Exception, simpleSwitch } from '../common';


### PR DESCRIPTION
- Un-comment rule in `.eslintrc.yml` that prohibits import of `@nestjs/common`
  Exception classes
- Replace all instances of NestJS Exceptions with our own, EXCEPT
- In `src/core/exception.filter` and `src/core/exception.filter.test`, add
  `eslint-disable` wrapper around imports of NestJS Exceptions. These are
  needed in order to replace the default Exceptions with our own
- Create `NoSessionException` class in `authentication` module to handle specific use case for session handling in Apollo client
- Add `field` and `previous` params to exceptions where appropriate

Also, we have quite a few instances of this kind of thing:

```
} catch (e) {
  this.logger.info(
    'Failed to use existing session token, creating new one.',
    { exception: e }
  );
  throw new ServerException('Could not delete user', exception);
}
```

Sometimes we were naming this error `e`, as above, but sometimes `exception`, so we could use property value shorthand. While I was updating the `ServerException`s, I changed every instance I encountered to `exception`, for consistency.