### PR TITLE
Bugfix: add project member after delete

### DIFF
--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -167,7 +167,7 @@ export class ProjectMemberService {
       .match([
         node('project'),
         relation('out', '', 'member'),
-        node('projectMember'),
+        node('projectMember', 'ProjectMember', { active: true }),
         relation('out', '', 'user'),
         node('user'),
       ])

--- a/test/project-member.e2e-spec.ts
+++ b/test/project-member.e2e-spec.ts
@@ -161,6 +161,34 @@ describe('ProjectMember e2e', () => {
     ).rejects.toThrowError();
   });
 
+  it('Can create the same projectMember after deletion', async () => {
+    await login(app, { email: user.email.value, password });
+    const project = await createProject(app);
+    const member = await createUser(app, { password });
+    const projectMember = await createProjectMember(app, {
+      userId: member.id,
+      projectId: project.id,
+    });
+
+    await app.graphql.mutate(
+      gql`
+        mutation deleteProjectMember($id: ID!) {
+          deleteProjectMember(id: $id)
+        }
+      `,
+      {
+        id: projectMember.id,
+      }
+    );
+
+    const newProjectMember = await createProjectMember(app, {
+      userId: member.id,
+      projectId: project.id,
+    });
+
+    expect(newProjectMember.id).toBeTruthy();
+  });
+
   it('update projectMember', async () => {
     await login(app, { email: user.email.value, password });
     const project = await createProject(app);


### PR DESCRIPTION
Couldn't add the same user as project member after deleting it because wasn't looking for the `active` tag on existing project members