### PR TITLE
Fix budgetRecord.organization

### DIFF
--- a/src/components/budget/budget-record.resolver.ts
+++ b/src/components/budget/budget-record.resolver.ts
@@ -27,12 +27,12 @@ export class BudgetRecordResolver {
     @Session() session: ISession,
     @Parent() record: BudgetRecord
   ): Promise<SecuredOrganization> {
-    const id = record.organizationId.value;
+    const id = record.organization.value;
     const value = id
       ? await this.organizations.readOne(id, session)
       : undefined;
     return {
-      ...record.organizationId,
+      ...record.organization,
       value,
     };
   }

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -450,10 +450,11 @@ export class BudgetService {
         relation('out', '', 'organization', { active: true }),
         node('organization', 'Organization', { active: true }),
       ])
-      .with('propList, permList, node, organization.id as organizationId')
-      .return(
-        'propList + [{value: organizationId, property: "organization"}] as propList, permList, node'
-      )
+      .return([
+        'propList + [{value: organization.id, property: "organization"}] as propList',
+        'permList',
+        'node',
+      ])
       .asResult<StandardReadResult<DbPropsOfDto<BudgetRecord>>>();
 
     const result = await query.first();

--- a/src/components/budget/dto/budget-record.dto.ts
+++ b/src/components/budget/dto/budget-record.dto.ts
@@ -10,7 +10,7 @@ import {
   implements: [Resource],
 })
 export class BudgetRecord extends Resource {
-  readonly organizationId: SecuredString;
+  readonly organization: SecuredString;
 
   @Field()
   readonly fiscalYear: SecuredInt;


### PR DESCRIPTION
Added missing organization secured property to budget service method readOneRecord. 
'organizationId' was being set incorrectly which was resulting in null responses to API queries.

Updated budget record DTO and resolver to call organization id string 'organization' instead of 'organizationId'.
This matches the naming convention in the partnership DTO and resolver.

Closes #1082 