### PR TITLE
Initial `budgetRecord.amount` set to `null` instead of `0`

### DIFF
--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -278,7 +278,7 @@ export class BudgetService {
       },
       {
         key: 'amount',
-        value: '0',
+        value: null,
         addToAdminSg: true,
         addToWriterSg: false,
         addToReaderSg: true,


### PR DESCRIPTION
Closes #1108 

Setting the initial `amount` property of a `budgetRecord` to `null` will indicate that it has not yet been set by the user.