### PR TITLE
Remove old update property methods with acl

### DIFF
--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -390,7 +390,7 @@ export class FileRepository {
     session: ISession
   ): Promise<void> {
     try {
-      await this.db.updateProperty({
+      await this.db.sgUpdateProperty({
         session,
         object: fileNode,
         key: 'name',

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -512,7 +512,7 @@ export class ProductService {
 
     const object = await this.readOne(input.id, session);
 
-    return await this.db.updateProperties({
+    return await this.db.sgUpdateProperties({
       session,
       object,
       props: ['mediums', 'purposes', 'methodology'],

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -80,9 +80,15 @@ export class UnavailabilityService {
           [],
           session.userId === this.config.rootAdmin.id
         )
-        .return('node.id as id');
+        .return('node.id as id')
+        .asResult<{ id: string }>();
 
-      const unavailabilityId = await createUnavailability.first();
+      const createUnavailabilityResult = await createUnavailability.first();
+
+      this.logger.debug(`Created user unavailability`, {
+        id: createUnavailabilityResult!.id,
+        userId,
+      });
 
       // connect the Unavailability to the User.
 
@@ -96,14 +102,11 @@ export class UnavailabilityService {
         .query()
         .raw(query, {
           userId,
-          id: unavailabilityId?.id,
+          id: createUnavailabilityResult!.id,
         })
         .run();
-      this.logger.debug(`Created user unavailability`, {
-        id: unavailabilityId?.id,
-        userId,
-      });
-      return await this.readOne(unavailabilityId?.id, session);
+
+      return await this.readOne(createUnavailabilityResult!.id, session);
     } catch {
       this.logger.error(`Could not create unavailability`, {
         userId,

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -85,8 +85,15 @@ export class UnavailabilityService {
 
       const createUnavailabilityResult = await createUnavailability.first();
 
+      if (!createUnavailabilityResult) {
+        this.logger.error(`Could not create unavailability`, {
+          userId,
+        });
+        throw new ServerException('Could not create unavailability');
+      }
+
       this.logger.debug(`Created user unavailability`, {
-        id: createUnavailabilityResult!.id,
+        id: createUnavailabilityResult.id,
         userId,
       });
 
@@ -102,11 +109,11 @@ export class UnavailabilityService {
         .query()
         .raw(query, {
           userId,
-          id: createUnavailabilityResult!.id,
+          id: createUnavailabilityResult.id,
         })
         .run();
 
-      return await this.readOne(createUnavailabilityResult!.id, session);
+      return await this.readOne(createUnavailabilityResult.id, session);
     } catch {
       this.logger.error(`Could not create unavailability`, {
         userId,


### PR DESCRIPTION
Removed the old update property methods that searched by ACL connections.  Also refactored create unavailability because that was using the old create service with ACL connections.

Next will remove the old create service, will do that on a separate PR that includes refactoring file nodes create and file nodes read 