### PR TITLE
Create multiple scripture references verride bug

### DIFF
--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -286,7 +286,7 @@ export class ProductService {
           relation('out', '', 'scriptureReferencesOverride', {
             active: true,
           }),
-          node('sr', ['ScriptureRange', 'BaseNode'], {
+          node('', ['ScriptureRange', 'BaseNode'], {
             start: verseRange.start,
             end: verseRange.end,
             active: true,

--- a/src/components/scripture/reference.ts
+++ b/src/components/scripture/reference.ts
@@ -150,25 +150,28 @@ export const validateVerse = (
 };
 
 // return random scriptureRefenence as an array
-export const createRandomScriptureReferences = (): ScriptureRangeInput[] => {
+export const createRandomScriptureReferences = (): ScriptureRangeInput[] => [
+  createRandomScriptureRange(),
+  createRandomScriptureRange(),
+];
+
+const createRandomScriptureRange = (): ScriptureRangeInput => {
   const book = books[random(books.length - 1)];
   const endChapter = random(book.chapters.length - 1);
   const endVerse = random(book.chapters[endChapter] - 1);
   const startChapter = random(endChapter);
   const startVerse = random(endVerse);
 
-  return [
-    {
-      start: {
-        book: book.names[0],
-        chapter: startChapter + 1,
-        verse: startVerse + 1,
-      },
-      end: {
-        book: book.names[0],
-        chapter: endChapter + 1,
-        verse: endVerse + 1,
-      },
+  return {
+    start: {
+      book: book.names[0],
+      chapter: startChapter + 1,
+      verse: startVerse + 1,
     },
-  ];
+    end: {
+      book: book.names[0],
+      chapter: endChapter + 1,
+      verse: endVerse + 1,
+    },
+  };
 };

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -132,7 +132,7 @@ export class DatabaseService {
     props: ReadonlyArray<keyof TObject>;
     changes: { [Key in keyof TObject]?: UnwrapSecured<TObject[Key]> };
     nodevar: string;
-  }) {
+  }): Promise<TObject> {
     let updated = object;
     for (const prop of props) {
       if (


### PR DESCRIPTION
The unused `sr` node alias was causing a duplicate variable error when multiple scripture references were made 