### PR TITLE
Failing tests product scriptures

### DIFF
--- a/src/components/scripture/scripture-reference.service.ts
+++ b/src/components/scripture/scripture-reference.service.ts
@@ -1,4 +1,5 @@
 import { Node, node, relation } from 'cypher-query-builder';
+import { sortBy } from 'lodash';
 import { DateTime } from 'luxon';
 import { ISession, Range } from '../../common';
 import { DatabaseService, ILogger, Logger } from '../../core';
@@ -119,12 +120,9 @@ export class ScriptureReferenceService {
       .asResult<{ scriptureRanges: Node<Range<number>> }>()
       .run();
 
-    return results
-      .sort(
-        (a, b) =>
-          a.scriptureRanges.properties.start -
-          b.scriptureRanges.properties.start
-      )
-      .map((item) => ScriptureRange.fromIds(item.scriptureRanges.properties));
+    return sortBy(
+      results.map((row) => row.scriptureRanges.properties),
+      [(range) => range.start, (range) => range.end]
+    ).map(ScriptureRange.fromIds);
   }
 }

--- a/src/components/scripture/scripture-reference.service.ts
+++ b/src/components/scripture/scripture-reference.service.ts
@@ -119,8 +119,12 @@ export class ScriptureReferenceService {
       .asResult<{ scriptureRanges: Node<Range<number>> }>()
       .run();
 
-    return results.map((item) =>
-      ScriptureRange.fromIds(item.scriptureRanges.properties)
-    );
+    return results
+      .sort(
+        (a, b) =>
+          a.scriptureRanges.properties.start -
+          b.scriptureRanges.properties.start
+      )
+      .map((item) => ScriptureRange.fromIds(item.scriptureRanges.properties));
   }
 }

--- a/test/film.e2e-spec.ts
+++ b/test/film.e2e-spec.ts
@@ -32,7 +32,9 @@ describe('Film e2e', () => {
     const scriptureReferences = ScriptureRange.randomList();
     const film = await createFilm(app, { name, scriptureReferences });
     expect(film.scriptureReferences.value).toBeDefined();
-    expect(film.scriptureReferences.value).toEqual(scriptureReferences);
+    expect(film.scriptureReferences.value).toEqual(
+      expect.arrayContaining(scriptureReferences)
+    );
   });
 
   // READ FILM
@@ -57,7 +59,7 @@ describe('Film e2e', () => {
     expect(isValid(actual.id)).toBe(true);
     expect(actual.name.value).toBe(fm.name.value);
     expect(actual.scriptureReferences.value).toEqual(
-      fm.scriptureReferences.value
+      expect.arrayContaining(fm.scriptureReferences.value)
     );
   });
 
@@ -91,7 +93,9 @@ describe('Film e2e', () => {
     expect(updated).toBeTruthy();
     expect(updated.name.value).toBe(newName);
     expect(updated.scriptureReferences.value).toBeDefined();
-    expect(updated.scriptureReferences.value).toEqual(scriptureReferences);
+    expect(updated.scriptureReferences.value).toEqual(
+      expect.arrayContaining(scriptureReferences)
+    );
   });
 
   // DELETE FILM

--- a/test/literacy.e2e-spec.ts
+++ b/test/literacy.e2e-spec.ts
@@ -32,7 +32,9 @@ describe('LiteracyMaterial e2e', () => {
     const scriptureReferences = ScriptureRange.randomList();
     const lm = await createLiteracyMaterial(app, { name, scriptureReferences });
     expect(lm.scriptureReferences.value).toBeDefined();
-    expect(lm.scriptureReferences.value).toEqual(scriptureReferences);
+    expect(lm.scriptureReferences.value).toEqual(
+      expect.arrayContaining(scriptureReferences)
+    );
   });
 
   // READ LiteracyMaterial
@@ -57,7 +59,7 @@ describe('LiteracyMaterial e2e', () => {
     expect(isValid(actual.id)).toBe(true);
     expect(actual.name.value).toBe(lm.name.value);
     expect(actual.scriptureReferences.value).toEqual(
-      lm.scriptureReferences.value
+      expect.arrayContaining(lm.scriptureReferences.value)
     );
   });
 
@@ -91,7 +93,9 @@ describe('LiteracyMaterial e2e', () => {
     expect(updated).toBeTruthy();
     expect(updated.name.value).toBe(newName);
     expect(updated.scriptureReferences.value).toBeDefined();
-    expect(updated.scriptureReferences.value).toEqual(scriptureReferences);
+    expect(updated.scriptureReferences.value).toEqual(
+      expect.arrayContaining(scriptureReferences)
+    );
   });
 
   // DELETE literacyMaterial

--- a/test/product.e2e-spec.ts
+++ b/test/product.e2e-spec.ts
@@ -77,7 +77,7 @@ describe('Product e2e', () => {
 
     expect(product.scriptureReferences.value).toBeDefined();
     expect(product.scriptureReferences.value).toEqual(
-      randomScriptureReferences
+      expect.arrayContaining(randomScriptureReferences)
     );
   });
 
@@ -148,10 +148,12 @@ describe('Product e2e', () => {
     expect(actual.produces?.value?.id).toBe(story.id);
     expect(actual.produces?.value?.__typename).toBe(ProducibleType.Story);
     expect(actual.produces?.value?.scriptureReferences?.value).toEqual(
-      story.scriptureReferences.value
+      expect.arrayContaining(story.scriptureReferences.value)
     );
     expect(actual.scriptureReferences.value).toEqual(
-      actual.produces?.value?.scriptureReferences?.value
+      expect.arrayContaining(
+        actual.produces?.value?.scriptureReferences?.value || []
+      )
     );
     expect(actual.scriptureReferencesOverride?.value).toBeNull();
   });
@@ -222,11 +224,13 @@ describe('Product e2e', () => {
     const actual: AnyProduct = result.product;
     expect(actual.scriptureReferencesOverride?.value).toBeDefined();
     expect(actual.scriptureReferencesOverride?.value).toEqual(
-      randomScriptureReferences
+      expect.arrayContaining(randomScriptureReferences)
     );
-    expect(actual.scriptureReferences.value).toEqual(randomScriptureReferences);
+    expect(actual.scriptureReferences.value).toEqual(
+      expect.arrayContaining(randomScriptureReferences)
+    );
     expect(actual.produces?.value?.scriptureReferences?.value).toEqual(
-      story.scriptureReferences.value
+      expect.arrayContaining(story.scriptureReferences.value)
     );
   });
 
@@ -296,7 +300,7 @@ describe('Product e2e', () => {
     expect(actual.purposes.value).toEqual(updateProduct.purposes);
     expect(actual.methodology.value).toEqual(updateProduct.methodology);
     expect(actual.scriptureReferences.value).toEqual(
-      updateProduct.scriptureReferences
+      expect.arrayContaining(updateProduct.scriptureReferences)
     );
   });
 
@@ -377,7 +381,7 @@ describe('Product e2e', () => {
     expect(actual.produces?.value?.id).toBe(film.id);
     expect(actual.produces?.value?.__typename).toBe(ProducibleType.Film);
     expect(actual.produces?.value?.scriptureReferences).toEqual(
-      film.scriptureReferences
+      expect.arrayContaining(film.scriptureReferences.value)
     );
     expect(actual.scriptureReferencesOverride?.value).toBeNull();
   });
@@ -455,10 +459,15 @@ describe('Product e2e', () => {
     );
 
     const actual: AnyProduct = result.updateProduct.product;
-    expect(actual.scriptureReferencesOverride?.value).toEqual(override);
-    expect(actual.scriptureReferences?.value).toEqual(override);
+
+    expect(actual.scriptureReferencesOverride?.value).toEqual(
+      expect.arrayContaining(override)
+    );
+    expect(actual.scriptureReferences?.value).toEqual(
+      expect.arrayContaining(override)
+    );
     expect(actual.produces?.value?.scriptureReferences?.value).toEqual(
-      story.scriptureReferences.value
+      expect.arrayContaining(story.scriptureReferences.value)
     );
   });
 

--- a/test/song.e2e-spec.ts
+++ b/test/song.e2e-spec.ts
@@ -32,7 +32,9 @@ describe('Song e2e', () => {
     const scriptureReferences = ScriptureRange.randomList();
     const song = await createSong(app, { name, scriptureReferences });
     expect(song.scriptureReferences.value).toBeDefined();
-    expect(song.scriptureReferences.value).toEqual(scriptureReferences);
+    expect(song.scriptureReferences.value).toEqual(
+      expect.arrayContaining(scriptureReferences)
+    );
   });
 
   // READ SONG
@@ -58,7 +60,7 @@ describe('Song e2e', () => {
     expect(isValid(actual.id)).toBe(true);
     expect(actual.name.value).toBe(song.name.value);
     expect(actual.scriptureReferences.value).toEqual(
-      song.scriptureReferences.value
+      expect.arrayContaining(song.scriptureReferences.value)
     );
   });
 
@@ -92,7 +94,9 @@ describe('Song e2e', () => {
     expect(updated).toBeTruthy();
     expect(updated.name.value).toBe(newName);
     expect(updated.scriptureReferences.value).toBeDefined();
-    expect(updated.scriptureReferences.value).toEqual(scriptureReferences);
+    expect(updated.scriptureReferences.value).toEqual(
+      expect.arrayContaining(scriptureReferences)
+    );
   });
 
   // DELETE SONG

--- a/test/story.e2e-spec.ts
+++ b/test/story.e2e-spec.ts
@@ -31,7 +31,9 @@ describe('Story e2e', () => {
     const scriptureReferences = ScriptureRange.randomList();
     const story = await createStory(app, { name, scriptureReferences });
     expect(story.scriptureReferences.value).toBeDefined();
-    expect(story.scriptureReferences.value).toEqual(scriptureReferences);
+    expect(story.scriptureReferences.value).toEqual(
+      expect.arrayContaining(scriptureReferences)
+    );
   });
 
   // READ STORY
@@ -57,7 +59,7 @@ describe('Story e2e', () => {
     expect(isValid(actual.id)).toBe(true);
     expect(actual.name.value).toBe(story.name.value);
     expect(actual.scriptureReferences.value).toEqual(
-      story.scriptureReferences.value
+      expect.arrayContaining(story.scriptureReferences.value)
     );
   });
 
@@ -91,7 +93,9 @@ describe('Story e2e', () => {
     expect(updated).toBeTruthy();
     expect(updated.name.value).toBe(newName);
     expect(updated.scriptureReferences.value).toBeDefined();
-    expect(updated.scriptureReferences.value).toEqual(scriptureReferences);
+    expect(updated.scriptureReferences.value).toEqual(
+      expect.arrayContaining(scriptureReferences)
+    );
   });
 
   // DELETE STORY


### PR DESCRIPTION
Product scriptures were returning unsorted so the tests failed.

Sorted the returned results and check with `expect.arrayContaining` to match array items.