### PR TITLE
Update product scripture references

### DIFF
--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -212,12 +212,17 @@ export class ProductService {
     }
 
     if (input.produces) {
-      const produce = await this.db
+      const producible = await this.db
         .query()
-        .match([node('pr', 'Producible', { id: input.produces, active: true })])
-        .return('pr')
+        .match([
+          node('producible', 'Producible', {
+            id: input.produces,
+            active: true,
+          }),
+        ])
+        .return('producible')
         .first();
-      if (!produce) {
+      if (!producible) {
         this.logger.warning(`Could not find producible node`, {
           id: input.produces,
         });
@@ -227,7 +232,7 @@ export class ProductService {
         );
       }
       query.match([
-        node('pr', 'Producible', { id: input.produces, active: true }),
+        node('producible', 'Producible', { id: input.produces, active: true }),
       ]);
       if (input.scriptureReferencesOverride) {
         secureProps[3].value = true;
@@ -264,7 +269,7 @@ export class ProductService {
     if (input.produces) {
       query.create([
         [
-          node('pr'),
+          node('producible'),
           relation('in', '', 'produces', {
             active: true,
             createdAt,
@@ -360,24 +365,24 @@ export class ProductService {
       isOverriding: true,
     });
 
-    const pr = await this.db
+    const connectedProducible = await this.db
       .query()
       .match([
         node('product', 'Product', { id, active: true }),
         relation('out', 'produces', { active: true }),
-        node('p', 'Producible', { active: true }),
+        node('producible', 'Producible', { active: true }),
       ])
-      .return('p')
-      .asResult<{ p: Node<BaseNode> }>()
+      .return('producible')
+      .asResult<{ producible: Node<BaseNode> }>()
       .first();
 
     const scriptureReferencesValue = await this.scriptureRefService.list(
       id,
       session,
-      { isOverriding: pr ? true : false }
+      { isOverriding: connectedProducible ? true : false }
     );
 
-    if (!pr) {
+    if (!connectedProducible) {
       return {
         ...parseBaseNodeProperties(result.node),
         ...rest,
@@ -396,13 +401,13 @@ export class ProductService {
       };
     }
 
-    const typeName = (difference(pr.p.labels, [
+    const typeName = (difference(connectedProducible.producible.labels, [
       'Producible',
       'BaseNode',
     ]) as ProducibleType[])[0];
 
     const producible = await this.getProducibleByType(
-      pr.p.properties.id,
+      connectedProducible.producible.properties.id,
       typeName,
       session
     );
@@ -440,20 +445,27 @@ export class ProductService {
 
   async update(input: UpdateProduct, session: ISession): Promise<AnyProduct> {
     const {
-      produces,
+      produces: inputProducesId,
       scriptureReferences,
       scriptureReferencesOverride,
       ...rest
     } = input;
 
-    if (produces) {
-      const produce = await this.db
+    if (inputProducesId) {
+      const producible = await this.db
         .query()
-        .match([node('pr', 'Producible', { id: produces, active: true })])
-        .return('pr')
+        .match([
+          node('producible', 'Producible', {
+            id: inputProducesId,
+            active: true,
+          }),
+        ])
+        .return('producible')
         .first();
-      if (!produce) {
-        this.logger.warning(`Could not find producible node`, { id: produces });
+      if (!producible) {
+        this.logger.warning(`Could not find producible node`, {
+          id: inputProducesId,
+        });
         throw new NotFoundException(
           'Could not find producible node',
           'product.produces'
@@ -464,7 +476,7 @@ export class ProductService {
         .match([
           node('product', 'Product', { id: input.id, active: true }),
           relation('out', 'rel', 'produces', { active: true }),
-          node('p', 'Producible', { active: true }),
+          node('', 'Producible', { active: true }),
         ])
         .setValues({
           'rel.active': false,
@@ -475,14 +487,19 @@ export class ProductService {
       await this.db
         .query()
         .match([node('product', 'Product', { id: input.id, active: true })])
-        .match([node('pr', 'Producible', { id: produces, active: true })])
+        .match([
+          node('producible', 'Producible', {
+            id: inputProducesId,
+            active: true,
+          }),
+        ])
         .create([
           node('product'),
           relation('out', 'rel', 'produces', {
             active: true,
             createdAt: DateTime.local(),
           }),
-          node('pr'),
+          node('producible'),
         ])
         .return('rel')
         .first();
@@ -502,10 +519,10 @@ export class ProductService {
         .match([
           node('product', 'Product', { id: input.id, active: true }),
           relation('out', 'rel', 'isOverriding', { active: true }),
-          node('p', 'Property', { active: true }),
+          node('propertyNode', 'Property', { active: true }),
         ])
         .setValues({
-          'p.value': scriptureReferencesOverride !== null,
+          'propertyNode.value': scriptureReferencesOverride !== null,
         })
         .run();
     }

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -458,20 +458,23 @@ export class ProductService {
     //If current product is a Direct Scripture Product, cannot update scriptureReferencesOverride or produces
     if (isDirectScriptureProduct && scriptureReferencesOverride) {
       throw new InputException(
-        'Cannot update Scripture References Override on a Direct Scripture Product'
+        'Cannot update Scripture References Override on a Direct Scripture Product',
+        'product.scriptureReferencesOverride'
       );
     }
 
     if (isDirectScriptureProduct && inputProducesId) {
       throw new InputException(
-        'Cannot update produces on a Direct Scripture Product'
+        'Cannot update produces on a Direct Scripture Product',
+        'product.produces'
       );
     }
 
     //If current product is a Derivative Scripture Product, cannot update scriptureReferencesOverride
     if (!isDirectScriptureProduct && scriptureReferences) {
       throw new InputException(
-        'Cannot update Scripture References on a Derivative Scripture Product'
+        'Cannot update Scripture References on a Derivative Scripture Product',
+        'product.scriptureReferences'
       );
     }
 

--- a/src/components/scripture/scripture-reference.service.ts
+++ b/src/components/scripture/scripture-reference.service.ts
@@ -49,13 +49,27 @@ export class ScriptureReferenceService {
     scriptureRefs: ScriptureRangeInput[] | undefined,
     options: { isOverriding?: boolean } = {}
   ): Promise<void> {
-    if (!scriptureRefs) {
+    if (scriptureRefs === undefined) {
       return;
     }
 
     const rel = options.isOverriding
       ? 'scriptureReferencesOverride'
       : 'scriptureReferences';
+
+    if (options.isOverriding) {
+      await this.db
+        .query()
+        .match([
+          node('product', 'Product', { id: producibleId, active: true }),
+          relation('out', 'rel', 'isOverriding', { active: true }),
+          node('propertyNode', 'Property', { active: true }),
+        ])
+        .setValues({
+          'propertyNode.value': scriptureRefs !== null,
+        })
+        .run();
+    }
 
     await this.db
       .query()

--- a/test/product.e2e-spec.ts
+++ b/test/product.e2e-spec.ts
@@ -304,6 +304,95 @@ describe('Product e2e', () => {
     );
   });
 
+  it('update DirectScriptureProduct with scriptureReferencesOverride errors', async () => {
+    const product = await createProduct(app, {
+      engagementId: engagement.id,
+    });
+
+    await expect(
+      app.graphql.query(
+        gql`
+          mutation updateProduct($input: UpdateProductInput!) {
+            updateProduct(input: $input) {
+              product {
+                ...product
+              }
+            }
+          }
+          ${fragments.product}
+        `,
+        {
+          input: {
+            product: {
+              id: product.id,
+              scriptureReferencesOverride: ScriptureRange.randomList(),
+            },
+          },
+        }
+      )
+    ).rejects.toThrowError();
+  });
+
+  it('update produces on DirectScriptureProduct errors', async () => {
+    const product = await createProduct(app, {
+      engagementId: engagement.id,
+    });
+
+    await expect(
+      app.graphql.query(
+        gql`
+          mutation updateProduct($input: UpdateProductInput!) {
+            updateProduct(input: $input) {
+              product {
+                ...product
+              }
+            }
+          }
+          ${fragments.product}
+        `,
+        {
+          input: {
+            product: {
+              id: product.id,
+              scriptureReferencesOverride: ScriptureRange.randomList(),
+              produces: film.id,
+            },
+          },
+        }
+      )
+    ).rejects.toThrowError();
+  });
+
+  it('update DerivativeScriptureProduct with scriptureReferences errors', async () => {
+    const product = await createProduct(app, {
+      engagementId: engagement.id,
+      produces: film.id,
+    });
+
+    await expect(
+      app.graphql.query(
+        gql`
+          mutation updateProduct($input: UpdateProductInput!) {
+            updateProduct(input: $input) {
+              product {
+                ...product
+              }
+            }
+          }
+          ${fragments.product}
+        `,
+        {
+          input: {
+            product: {
+              id: product.id,
+              scriptureReferences: ScriptureRange.randomList(),
+            },
+          },
+        }
+      )
+    ).rejects.toThrowError();
+  });
+
   it('update DerivativeScriptureProduct', async () => {
     const product = await createProduct(app, {
       engagementId: engagement.id,

--- a/test/product.e2e-spec.ts
+++ b/test/product.e2e-spec.ts
@@ -330,7 +330,9 @@ describe('Product e2e', () => {
           },
         }
       )
-    ).rejects.toThrowError();
+    ).rejects.toThrowError(
+      'Cannot update Scripture References Override on a Direct Scripture Product'
+    );
   });
 
   it('update produces on DirectScriptureProduct errors', async () => {
@@ -354,13 +356,14 @@ describe('Product e2e', () => {
           input: {
             product: {
               id: product.id,
-              scriptureReferencesOverride: ScriptureRange.randomList(),
               produces: film.id,
             },
           },
         }
       )
-    ).rejects.toThrowError();
+    ).rejects.toThrowError(
+      'Cannot update produces on a Direct Scripture Product'
+    );
   });
 
   it('update DerivativeScriptureProduct with scriptureReferences errors', async () => {
@@ -390,7 +393,9 @@ describe('Product e2e', () => {
           },
         }
       )
-    ).rejects.toThrowError();
+    ).rejects.toThrowError(
+      'Cannot update Scripture References on a Derivative Scripture Product'
+    );
   });
 
   it('update DerivativeScriptureProduct', async () => {


### PR DESCRIPTION
Have input checks for updating product scripture references (override) based on product type.

Have `scriptureRefService.update` take care of accepting `null` override values and setting the isOverride tag to false