### PR TITLE
Make SES region configurable

### DIFF
--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -32,6 +32,7 @@ export class ConfigService {
       replyTo: this.env.string('EMAIL_REPLY_TO').optional() || undefined, // falsy -> undefined
       send,
       open: this.env.boolean('EMAIL_OPEN').optional(!send),
+      sesRegion: this.env.string('SES_REGION').optional(),
     };
   }
 

--- a/src/core/email/aws-ses.factory.ts
+++ b/src/core/email/aws-ses.factory.ts
@@ -1,11 +1,14 @@
 import { FactoryProvider } from '@nestjs/common/interfaces';
 import { SES } from 'aws-sdk';
+import { ConfigService } from '..';
 
 export const AwsSESFactory: FactoryProvider<SES> = {
   provide: SES,
-  useFactory: () => {
+  useFactory: (config: ConfigService) => {
     return new SES({
       correctClockSkew: true,
+      region: config.email.sesRegion,
     });
   },
+  inject: [ConfigService],
 };


### PR DESCRIPTION
We can't assume it will be setup with the same region as code is being ran in.

Part of fix for https://github.com/SeedCompany/cord-field/issues/448