### PR TITLE
Authentication reset password test case

### DIFF
--- a/test/authentication.e2e-spec.ts
+++ b/test/authentication.e2e-spec.ts
@@ -62,6 +62,7 @@ describe('Authentication e2e', () => {
       .first();
 
     const token = tokenRes ? tokenRes.token : '';
+    const newPassword = faker.internet.password();
     const resetRes = await app.graphql.mutate(
       gql`
         mutation resetPassword($input: ResetPasswordInput!) {
@@ -71,14 +72,20 @@ describe('Authentication e2e', () => {
       {
         input: {
           token: token,
-          password: faker.internet.password(),
+          password: newPassword,
         },
       }
     );
 
+    const { login: newLogin } = await login(app, {
+      email: email,
+      password: newPassword,
+    });
+
     expect(checkRes.forgotPassword).toBe(true);
     expect(resetRes.resetPassword).toBe(true);
     expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(newLogin.user.id).toBeDefined();
   });
 
   it('login user', async () => {


### PR DESCRIPTION
Fixes: https://github.com/SeedCompany/cord-api-v3/issues/1213

@CarsonF Cannot reproduce the issue on backend. As you can see in this case, it passes all the reset password workflow (https://github.com/SeedCompany/cord-api-v3/blob/363826e9c396eab800a46afb5c590f25c76e046c/test/authentication.e2e-spec.ts#L29~L89)