### PR TITLE
Cannot create project

### DIFF
--- a/src/components/admin/admin.service.ts
+++ b/src/components/admin/admin.service.ts
@@ -6,6 +6,7 @@ import { generate } from 'shortid';
 import { ServerException, UnauthenticatedException } from '../../common';
 import { ConfigService, DatabaseService } from '../../core';
 import { AuthenticationService } from '../authentication';
+import { Role } from '../project';
 import { RootSecurityGroup } from './root-security-group';
 
 @Injectable()
@@ -162,6 +163,7 @@ export class AdminService implements OnApplicationBootstrap {
         phone: 'root',
         timezone: 'root',
         bio: 'root',
+        roles: Object.values(Role),
       });
 
       if (!adminUser) {


### PR DESCRIPTION
Cannot create project for admin because on create we automatically assign the creator **ProjectManager** on that project, but the root user doesn't have that role available (created without roles).  We recently added the role validation on adding a team member. Now on creating the admin user we give all roles