### PR TITLE
Cluster/Cohort projects return only with 2 or more engagements

### DIFF
--- a/src/components/project/dto/list-projects.dto.ts
+++ b/src/components/project/dto/list-projects.dto.ts
@@ -64,10 +64,9 @@ export abstract class ProjectFilters {
 
   @Field({
     nullable: true,
-    description:
-      'When a project works on more than one language it is a "cluster" project. It has more than one engagement',
+    description: 'Filter for projects with two or more engagements.',
   })
-  readonly clusters?: boolean;
+  readonly onlyMultipleEngagements?: boolean;
 }
 
 const defaultFilters = {};

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -555,6 +555,7 @@ export class ProjectService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode(label)])
+      .with('distinct(node) as node')
       .call(projectListFilter, filter)
       .call(calculateTotalAndPaginateList, input, (q, sort, order) =>
         q

--- a/src/components/project/query.helpers.ts
+++ b/src/components/project/query.helpers.ts
@@ -1,4 +1,10 @@
-import { inArray, node, Query, relation } from 'cypher-query-builder';
+import {
+  greaterThan,
+  inArray,
+  node,
+  Query,
+  relation,
+} from 'cypher-query-builder';
 import { ProjectFilters } from './dto';
 
 export function projectListFilter(query: Query, filter: ProjectFilters) {
@@ -17,13 +23,14 @@ export function projectListFilter(query: Query, filter: ProjectFilters) {
     );
 
   if (filter.clusters) {
-    query.match([
-      node('node'),
-      relation('out', '', 'engagement'),
-      node('engagement'),
-      relation('out', '', 'language'),
-      node('language'),
-    ]);
+    query
+      .match([
+        node('node'),
+        relation('out', '', 'engagement', { active: true }),
+        node('engagement', 'Engagement'),
+      ])
+      .with('node, count(engagement) as engagementCount')
+      .where({ engagementCount: greaterThan(1) });
   }
 
   if (filter.mine) {

--- a/src/components/project/query.helpers.ts
+++ b/src/components/project/query.helpers.ts
@@ -22,7 +22,7 @@ export function projectListFilter(query: Query, filter: ProjectFilters) {
         : q
     );
 
-  if (filter.clusters) {
+  if (filter.onlyMultipleEngagements) {
     query
       .match([
         node('node'),


### PR DESCRIPTION
Rename the project filter to `clustersOrCohort` and have it filter on both types of engagements.

**This is a breaking change**, will need to update the Client side code.