### PR TITLE
Cannot create person

### DIFF
--- a/src/components/user/dto/create-person.dto.ts
+++ b/src/components/user/dto/create-person.dto.ts
@@ -38,7 +38,7 @@ export abstract class CreatePerson {
   readonly status?: UserStatus;
 
   @Field(() => [Role], { nullable: true })
-  readonly roles?: Role[];
+  readonly roles?: Role[] = [Role.ProjectManager];
 
   @Field({ nullable: true })
   readonly title?: string;

--- a/src/components/user/dto/create-person.dto.ts
+++ b/src/components/user/dto/create-person.dto.ts
@@ -38,6 +38,7 @@ export abstract class CreatePerson {
   readonly status?: UserStatus;
 
   @Field(() => [Role], { nullable: true })
+  //TODO: default ProjectManager is a placeholder until the main Role based access control features are done
   readonly roles?: Role[] = [Role.ProjectManager];
 
   @Field({ nullable: true })


### PR DESCRIPTION
Added default **ProjectMember** role on create person.  This will give new non-root users ability to create project.  Will be removed once the roles features are implemented.