### PR TITLE
Language sponsor start date and projects permissions

### DIFF
--- a/src/components/language/dto/language.dto.ts
+++ b/src/components/language/dto/language.dto.ts
@@ -95,12 +95,6 @@ export class Language extends Resource {
   readonly sponsorEstimatedEndDate: SecuredDate;
 
   // Calculated. Not settable.
-  @Field({
-    description: 'The earliest start date from its engagements',
-  })
-  readonly sponsorStartDate: SecuredDate;
-
-  // Calculated. Not settable.
   @Field(() => Sensitivity, {
     description: stripIndent`
       The language's sensitivity.

--- a/src/components/language/language.module.ts
+++ b/src/components/language/language.module.ts
@@ -1,4 +1,5 @@
 import { forwardRef, Module } from '@nestjs/common';
+import { EngagementModule } from '../engagement/engagement.module';
 import { LocationModule } from '../location/location.module';
 import { ProjectModule } from '../project/project.module';
 import { EthnologueLanguageService } from './ethnologue-language';
@@ -6,7 +7,11 @@ import { LanguageResolver } from './language.resolver';
 import { LanguageService } from './language.service';
 
 @Module({
-  imports: [LocationModule, forwardRef(() => ProjectModule)],
+  imports: [
+    LocationModule,
+    forwardRef(() => ProjectModule),
+    forwardRef(() => EngagementModule),
+  ],
   providers: [LanguageResolver, LanguageService, EthnologueLanguageService],
   exports: [LanguageService],
 })

--- a/src/components/language/language.resolver.ts
+++ b/src/components/language/language.resolver.ts
@@ -12,6 +12,7 @@ import {
   firstLettersOfWords,
   IdArg,
   ISession,
+  SecuredDate,
   SecuredInt,
   Session,
 } from '../../common';
@@ -81,6 +82,16 @@ export class LanguageResolver {
     input: LocationListInput
   ): Promise<SecuredLocationList> {
     return this.langService.listLocations(language, input, session);
+  }
+
+  @ResolveField(() => SecuredDate, {
+    description: 'The earliest start date from its engagements.',
+  })
+  async sponsorStartDate(
+    @Session() session: ISession,
+    @Parent() language: Language
+  ): Promise<SecuredDate> {
+    return await this.langService.sponsorStartDate(language, session);
   }
 
   @ResolveField(() => SecuredProjectList, {

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -579,24 +579,15 @@ export class LanguageService {
 
     const queryProject = this.db
       .query()
-      .match(matchSession(session, { withAclRead: 'canReadProjects' }))
       .match([node('language', 'Language', { id: language.id })])
       .match([
         node('language'),
         relation('in', '', 'language', { active: true }),
-        node('langEngagement', 'LanguageEngagement'),
+        node('', 'LanguageEngagement'),
         relation('in', '', 'engagement', { active: true }),
         node('project', 'Project'),
-      ]);
-    queryProject.return({
-      project: [{ id: 'id', createdAt: 'createdAt' }],
-      requestingUser: [
-        {
-          canReadProjects: 'canReadProjects',
-          canCreateProject: 'canCreateProject',
-        },
-      ],
-    });
+      ])
+      .return({ project: [{ id: 'id', createdAt: 'createdAt' }] });
 
     let readProject = await queryProject.run();
     this.logger.debug(`list projects results`, { total: readProject.length });
@@ -617,8 +608,9 @@ export class LanguageService {
       items: result.items,
       hasMore: result.hasMore,
       total: result.total,
-      canCreate: !!readProject[0]?.canCreateProject,
-      canRead: !!readProject[0]?.canReadProjects,
+      //TODO: use the upcoming Roles service to determine permissions.
+      canCreate: true,
+      canRead: true,
     };
   }
 

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
-import { first, intersection } from 'lodash';
+import { compact, first, intersection } from 'lodash';
 import { DateTime } from 'luxon';
 import {
   CalendarDate,
@@ -638,9 +638,10 @@ export class LanguageService {
         this.engagementService.readOne(engagementId, session)
       )
     );
-    const dates = engagments
-      .map((engagement) => engagement.startDate.value)
-      .filter((date) => date) as CalendarDate[];
+
+    const dates = compact(
+      engagments.map((engagement) => engagement.startDate.value)
+    );
 
     if (!dates.length) {
       return {


### PR DESCRIPTION
Pull language sponsorStartDate field in its own resolver.

Also moved acl permissions out of language.projects list read, hardcoded to `true` until Roles services are done