### PR TITLE
Partner search

### DIFF
--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -115,17 +115,6 @@ export class PartnerService {
     return await this.readOne(result.id, session);
   }
 
-  async readOnePartnerByPartnerIdOrOrgId(
-    id: string,
-    session: ISession
-  ): Promise<Partner> {
-    try {
-      return await this.readOne(id, session);
-    } catch {
-      return await this.readOnePartnerByOrgId(id, session);
-    }
-  }
-
   async readOnePartnerByOrgId(id: string, session: ISession): Promise<Partner> {
     this.logger.debug(`Read Partner by Org Id`, {
       id: id,

--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -115,8 +115,46 @@ export class PartnerService {
     return await this.readOne(result.id, session);
   }
 
+  async readOnePartnerByPartnerIdOrOrgId(
+    id: string,
+    session: ISession
+  ): Promise<Partner> {
+    try {
+      return await this.readOne(id, session);
+    } catch {
+      return await this.readOnePartnerByOrgId(id, session);
+    }
+  }
+
+  async readOnePartnerByOrgId(id: string, session: ISession): Promise<Partner> {
+    this.logger.debug(`Read Partner by Org Id`, {
+      id: id,
+      userId: session.userId,
+    });
+    const query = this.db
+
+      .query()
+      .match([node('node', 'Organization', { id: id })])
+      .match([
+        node('node'),
+        relation('in', '', 'organization', { active: true }),
+        node('partner', 'Partner'),
+      ])
+      .return({
+        partner: [{ id: 'partnerId' }],
+      })
+      .asResult<{
+        partnerId: string;
+      }>();
+    const result = await query.first();
+    if (!result)
+      throw new NotFoundException('No Partner Exists for this Org Id');
+
+    return await this.readOne(result.partnerId, session);
+  }
+
   async readOne(id: string, session: ISession): Promise<Partner> {
-    this.logger.debug(`Read Partner`, {
+    this.logger.debug(`Read Partner by Partner Id`, {
       id: id,
       userId: session.userId,
     });

--- a/src/components/search/dto/search-results.dto.ts
+++ b/src/components/search/dto/search-results.dto.ts
@@ -1,5 +1,5 @@
 import { createUnionType, registerEnumType } from '@nestjs/graphql';
-import { mapValues } from 'lodash';
+import { mapValues, uniq } from 'lodash';
 import { keys, simpleSwitch } from '../../../common';
 import { Film } from '../../film/dto';
 import { Language } from '../../language/dto';
@@ -31,6 +31,7 @@ const searchable = {
   Story,
   LiteracyMaterial,
   Song,
+  PartnerByOrg: Partner,
 } as const;
 
 // Expand this to add more search types, but not result types.
@@ -62,7 +63,8 @@ export type SearchResult = SearchResultMap[keyof SearchableMap];
 
 export const SearchResult = createUnionType({
   name: 'SearchResult',
-  types: () => Object.values(searchable) as any, // ignore errors for abstract classes
+  //@ts-expect-error ignore errors for abstract classes
+  types: () => uniq(Object.values(searchable)),
   resolveType: (value: SearchResult) =>
     simpleSwitch(value.__typename, searchable),
 });

--- a/src/components/search/dto/search-results.dto.ts
+++ b/src/components/search/dto/search-results.dto.ts
@@ -1,6 +1,6 @@
 import { createUnionType, registerEnumType } from '@nestjs/graphql';
 import { mapValues } from 'lodash';
-import { simpleSwitch } from '../../../common';
+import { keys, simpleSwitch } from '../../../common';
 import { Film } from '../../film/dto';
 import { Language } from '../../language/dto';
 import { LiteracyMaterial } from '../../literacy-material/dto';
@@ -46,7 +46,7 @@ export type SearchableMap = {
   [K in keyof typeof searchable]: typeof searchable[K]['prototype'];
 };
 
-export const SearchResultTypes = Object.keys(searchable);
+export const SearchResultTypes = keys(searchable);
 
 // __typename is a GQL thing to identify type at runtime
 // It makes since to match this to not conflict with actual properties and

--- a/src/components/search/dto/search-results.dto.ts
+++ b/src/components/search/dto/search-results.dto.ts
@@ -6,6 +6,7 @@ import { Language } from '../../language/dto';
 import { LiteracyMaterial } from '../../literacy-material/dto';
 import { Country, Location, Region, Zone } from '../../location/dto';
 import { Organization } from '../../organization/dto';
+import { Partner } from '../../partner/dto';
 import {
   InternshipProject,
   IProject as Project,
@@ -18,6 +19,7 @@ import { User } from '../../user/dto';
 // Expand this to add to searchable types / results
 const searchable = {
   Organization,
+  Partner,
   Country,
   Region,
   Zone,

--- a/src/components/search/search.module.ts
+++ b/src/components/search/search.module.ts
@@ -4,6 +4,7 @@ import { LanguageModule } from '../language/language.module';
 import { LiteracyMaterialModule } from '../literacy-material/literacy-material.module';
 import { LocationModule } from '../location/location.module';
 import { OrganizationModule } from '../organization/organization.module';
+import { PartnerModule } from '../partner/partner.module';
 import { ProjectModule } from '../project/project.module';
 import { SongModule } from '../song/song.module';
 import { StoryModule } from '../story/story.module';
@@ -14,6 +15,7 @@ import { SearchService } from './search.service';
 @Module({
   imports: [
     OrganizationModule,
+    PartnerModule,
     UserModule,
     LocationModule,
     LanguageModule,

--- a/src/components/search/search.service.ts
+++ b/src/components/search/search.service.ts
@@ -1,7 +1,8 @@
+/* eslint-disable no-console */
 import { Injectable } from '@nestjs/common';
 import { node, regexp, relation } from 'cypher-query-builder';
 import { compact } from 'lodash';
-import { ISession } from '../../common';
+import { ISession, NotFoundException, ServerException } from '../../common';
 import {
   DatabaseService,
   matchRequestingUser,
@@ -106,6 +107,7 @@ export class SearchService {
       .asResult<{ id: string; type: keyof SearchResultMap }>();
 
     const results = await query.run();
+    console.log('results: ', JSON.stringify(results));
 
     // Individually convert each result (id & type) to its search result
     // based on this.hydrators
@@ -154,8 +156,9 @@ export class SearchService {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           __typename: type,
         };
-      } catch {
-        return null;
+      } catch (err) {
+        if (err instanceof NotFoundException) return null;
+        else throw new ServerException(`Error searching on ${type}`, err);
       }
     };
   }

--- a/src/components/search/search.service.ts
+++ b/src/components/search/search.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { Injectable } from '@nestjs/common';
 import { node, regexp, relation } from 'cypher-query-builder';
 import { compact } from 'lodash';
@@ -43,8 +42,8 @@ export class SearchService {
   private readonly hydrators: HydratorMap = {
     Organization: (...args) => this.orgs.readOne(...args),
     User: (...args) => this.users.readOne(...args),
-    Partner: (...args) =>
-      this.partners.readOnePartnerByPartnerIdOrOrgId(...args),
+    Partner: (...args) => this.partners.readOne(...args),
+    PartnerByOrg: (...args) => this.partners.readOnePartnerByOrgId(...args),
     Country: (...args) => this.location.readOneCountry(...args),
     Region: (...args) => this.location.readOneRegion(...args),
     Zone: (...args) => this.location.readOneZone(...args),
@@ -107,7 +106,6 @@ export class SearchService {
       .asResult<{ id: string; type: keyof SearchResultMap }>();
 
     const results = await query.run();
-    console.log('results: ', JSON.stringify(results));
 
     // Individually convert each result (id & type) to its search result
     // based on this.hydrators
@@ -121,7 +119,7 @@ export class SearchService {
                 ...(inputTypes.includes('Organization') ? [result] : []),
                 ...(inputTypes.includes('Partner')
                   ? // partner hydrator will need to handle id of org and partner
-                    [{ id: result.id, type: 'Partner' as const }]
+                    [{ id: result.id, type: 'PartnerByOrg' as const }]
                   : []),
               ]
         )

--- a/src/components/search/search.service.ts
+++ b/src/components/search/search.service.ts
@@ -12,6 +12,7 @@ import { LanguageService } from '../language';
 import { LiteracyMaterialService } from '../literacy-material';
 import { LocationService } from '../location';
 import { OrganizationService } from '../organization';
+import { PartnerService } from '../partner';
 import { ProjectService } from '../project';
 import { SongService } from '../song';
 import { StoryService } from '../story';
@@ -41,6 +42,7 @@ export class SearchService {
   private readonly hydrators: HydratorMap = {
     Organization: (...args) => this.orgs.readOne(...args),
     User: (...args) => this.users.readOne(...args),
+    Partner: (...args) => this.partners.readOne(...args),
     Country: (...args) => this.location.readOneCountry(...args),
     Region: (...args) => this.location.readOneRegion(...args),
     Zone: (...args) => this.location.readOneZone(...args),
@@ -58,6 +60,7 @@ export class SearchService {
     private readonly db: DatabaseService,
     private readonly users: UserService,
     private readonly orgs: OrganizationService,
+    private readonly partners: PartnerService,
     private readonly location: LocationService,
     private readonly language: LanguageService,
     private readonly projects: ProjectService,

--- a/src/components/search/search.service.ts
+++ b/src/components/search/search.service.ts
@@ -42,7 +42,8 @@ export class SearchService {
   private readonly hydrators: HydratorMap = {
     Organization: (...args) => this.orgs.readOne(...args),
     User: (...args) => this.users.readOne(...args),
-    Partner: (...args) => this.partners.readOne(...args),
+    Partner: (...args) =>
+      this.partners.readOnePartnerByPartnerIdOrOrgId(...args),
     Country: (...args) => this.location.readOneCountry(...args),
     Region: (...args) => this.location.readOneRegion(...args),
     Zone: (...args) => this.location.readOneZone(...args),
@@ -78,7 +79,7 @@ export class SearchService {
       ...inputTypes,
       // Add Organization label when searching for Partners we can search for
       // Partner by organization name
-      inputTypes.includes('Partner') ? ['Organization'] : [],
+      ...(inputTypes.includes('Partner') ? ['Organization'] : []),
     ];
 
     // Search for nodes based on input, only returning their id and "type"
@@ -146,12 +147,16 @@ export class SearchService {
       if (!hydrator) {
         return null;
       }
-      const obj = await hydrator(...args);
-      return {
-        ...obj,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        __typename: type,
-      };
+      try {
+        const obj = await hydrator(...args);
+        return {
+          ...obj,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          __typename: type,
+        };
+      } catch {
+        return null;
+      }
     };
   }
 }


### PR DESCRIPTION
created `readOnePartnerByOrgId` that finds the partner connected to this org id.  The the hydrator calls `readOnePartnerByPartnerIdOrOrgId`, calls both `partner.readOnePartnerByOrgId` and `partner.readOne`.  This pattern allows us to keep `partner.readOne` unchanged and consistent with the other service readOnes.