### PR TITLE
Ceremony readOne fix type property

### DIFF
--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -27,6 +27,7 @@ import {
 import {
   DbPropsOfDto,
   parseBaseNodeProperties,
+  parsePropList,
   parseSecuredProperties,
   runListQuery,
   StandardReadResult,
@@ -135,8 +136,9 @@ export class CeremonyService {
       throw new NotFoundException('Could not find ceremony', 'ceremony.id');
     }
 
+    const parsedProps = parsePropList(result.propList);
     const securedProps = parseSecuredProperties(
-      result.propList,
+      parsedProps,
       result.permList,
       this.securedProperties
     );
@@ -144,7 +146,7 @@ export class CeremonyService {
     return {
       ...parseBaseNodeProperties(result.node),
       ...securedProps,
-      type: securedProps.type.value!,
+      type: parsedProps.type,
     };
   }
 

--- a/src/components/ceremony/handlers/create-engagement-default-ceremony.handler.ts
+++ b/src/components/ceremony/handlers/create-engagement-default-ceremony.handler.ts
@@ -13,7 +13,8 @@ export class CreateEngagementDefaultCeremonyHandler
     private readonly db: DatabaseService
   ) {}
 
-  async handle({ engagement, session }: EngagementCreatedEvent) {
+  async handle(event: EngagementCreatedEvent) {
+    const { engagement, session } = event;
     const input = {
       type:
         engagement.__typename === 'LanguageEngagement'
@@ -38,5 +39,13 @@ export class CreateEngagementDefaultCeremonyHandler
         node('engagement'),
       ])
       .run();
+
+    event.engagement = {
+      ...engagement,
+      ceremony: {
+        ...engagement.ceremony, // permissions
+        value: ceremony.id,
+      },
+    };
   }
 }


### PR DESCRIPTION
The Role refactor exposed 2 existing issues

1. On create LanguageEngagement, the returned engagement doesn't include the ceremonyId that was created by the event handler.  This was never found because we never needed the ceremony after creating a langEngagement

2. On Ceremony readOne, the type value was returned from the parseSecuredProperties function.  But now with the new roles refactor the type property doesn't get a Permission node because according to the dto it's not a secured property, so now it's values are always undefined.  This wasn't found because we manually gave it a Permission Node in the old create process