### PR TITLE
Remove active true on property node match

### DIFF
--- a/src/components/project/query.helpers.ts
+++ b/src/components/project/query.helpers.ts
@@ -49,7 +49,7 @@ function propMatch(property: string) {
     [
       node('node'),
       relation('out', '', property, { active: true }),
-      node(property, 'Property', { active: true }),
+      node(property, 'Property'),
     ],
   ];
 }


### PR DESCRIPTION
Don't have the active property on the Node itself, only on the relation