### PR TITLE
Fix location name duplication

### DIFF
--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -99,7 +99,7 @@ export class LocationService {
         value: input.name,
         isPublic: false,
         isOrgPublic: false,
-        label: 'FieldRegionName',
+        label: 'LocationName',
       },
       {
         key: 'iso31663',


### PR DESCRIPTION
Replace `FieldRegionName` with `LocationName` while creating location