### PR TITLE
Cannot add mentor to internship engagement

### DIFF
--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -873,10 +873,19 @@ export class EngagementService {
             node('internshipEngagement', 'InternshipEngagement', {
               id: input.id,
             }),
+          ])
+          .optionalMatch([
+            node('internshipEngagement'),
             relation('out', 'rel', 'mentor', { active: true }),
             node('oldMentorUser', 'User'),
           ])
-          .delete('rel')
+          .set({
+            values: {
+              rel: {
+                active: false,
+              },
+            },
+          })
           .create([
             node('internshipEngagement'),
             relation('out', '', 'mentor', {

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -910,10 +910,19 @@ export class EngagementService {
             node('internshipEngagement', 'InternshipEngagement', {
               id: input.id,
             }),
+          ])
+          .optionalMatch([
+            node('internshipEngagement'),
             relation('out', 'rel', 'countryOfOrigin', { active: true }),
             node('oldCountry', 'Location'),
           ])
-          .delete('rel')
+          .set({
+            values: {
+              rel: {
+                active: false,
+              },
+            },
+          })
           .create([
             node('internshipEngagement'),
             relation('out', '', 'countryOfOrigin', {

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -18,6 +18,7 @@ import { Project, ProjectType } from '../src/components/project';
 import { User } from '../src/components/user';
 import {
   createInternshipEngagement,
+  createInternshipEngagementWithMinimumValues,
   createLanguage,
   createLanguageEngagement,
   createLocation,
@@ -361,10 +362,14 @@ describe('Engagement e2e', () => {
     internshipProject = await createProject(app, {
       type: ProjectType.Internship,
     });
-    const internshipEngagement = await createInternshipEngagement(app, {
-      projectId: internshipProject.id,
-      internId: intern.id,
-    });
+    const mentor = await createUser(app);
+    const internshipEngagement = await createInternshipEngagementWithMinimumValues(
+      app,
+      {
+        projectId: internshipProject.id,
+        internId: intern.id,
+      }
+    );
     const updatePosition = InternPosition.LanguageProgramManager;
     const updateMethodologies = [
       ProductMethodology.Paratext,
@@ -389,7 +394,7 @@ describe('Engagement e2e', () => {
         input: {
           engagement: {
             id: internshipEngagement.id,
-            // mentorId: mentor.id,
+            mentorId: mentor.id,
             countryOfOriginId: location.id,
             position: updatePosition,
             methodologies: updateMethodologies,
@@ -399,10 +404,9 @@ describe('Engagement e2e', () => {
     );
 
     const updated = result.updateInternshipEngagement.engagement;
-    // console.log('updated.mentor ', JSON.stringify(updated, null, 2));
     expect(updated).toBeTruthy();
     expect(updated.id).toBe(internshipEngagement.id);
-    // expect(updated.mentor.value.id).toBe(mentor.id);
+    expect(updated.mentor.value.id).toBe(mentor.id);
     expect(updated.countryOfOrigin.value.id).toBe(location.id);
     expect(updated.position.value).toBe(updatePosition);
     expect(updated.methodologies.value).toEqual(

--- a/test/utility/create-engagement.ts
+++ b/test/utility/create-engagement.ts
@@ -115,3 +115,42 @@ export async function createInternshipEngagement(
 
   return actual;
 }
+
+export async function createInternshipEngagementWithMinimumValues(
+  app: TestApp,
+  input: Partial<CreateInternshipEngagement> = {}
+) {
+  const currentUserId = (await getUserFromSession(app)).id;
+  const internshipEngagement: CreateInternshipEngagement = {
+    projectId: input.projectId || (await createProject(app)).id,
+    internId: input.internId || currentUserId || (await createPerson(app)).id,
+  };
+
+  const result = await app.graphql.mutate(
+    gql`
+      mutation createInternshipEngagement(
+        $input: CreateInternshipEngagementInput!
+      ) {
+        createInternshipEngagement(input: $input) {
+          engagement {
+            ...internshipEngagement
+          }
+        }
+      }
+      ${fragments.internshipEngagement}
+    `,
+    {
+      input: {
+        engagement: internshipEngagement,
+      },
+    }
+  );
+
+  const actual: RawInternshipEngagement =
+    result.createInternshipEngagement.engagement;
+
+  expect(actual).toBeTruthy();
+  expect(isValid(actual.id)).toBe(true);
+
+  return actual;
+}


### PR DESCRIPTION
The old update mentor only worked a mentor already existed because it used a hard match.  Now using optional match to set the old to inactive.

Same pattern for location