### PR TITLE
Use fiscalYears function for budget records

### DIFF
--- a/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
+++ b/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
@@ -1,4 +1,4 @@
-import { ISession, ServerException } from '../../../common';
+import { fiscalYears, ISession, ServerException } from '../../../common';
 import {
   DatabaseService,
   EventsHandler,
@@ -99,15 +99,10 @@ export class SyncBudgetRecordsToFundingPartners
     ) {
       expectedBudgetRecordYears = [];
     } else {
-      // TODO: mous starting at midnight on Jan 1st might cause issues with UTC vs local issues here.
-      // double check how year should be calculated
-      const mouStartYear = partnership.mouStart.value.year;
-      const mouEndYear = partnership.mouEnd.value.year;
+      const mouStart = partnership.mouStart.value;
+      const mouEnd = partnership.mouEnd.value;
 
-      expectedBudgetRecordYears = Array.from(
-        { length: mouEndYear - mouStartYear },
-        (_v, k) => k + mouStartYear
-      );
+      expectedBudgetRecordYears = fiscalYears(mouStart, mouEnd);
     }
     return expectedBudgetRecordYears;
   }

--- a/test/partnership.e2e-spec.ts
+++ b/test/partnership.e2e-spec.ts
@@ -393,6 +393,6 @@ describe('Partnership e2e', () => {
 
     const actual = result.project;
     expect(actual.id).toBe(project.id);
-    expect(actual.budget.value.records.length).toBe(2);
+    expect(actual.budget.value.records.length).toBe(3);
   });
 });

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -943,7 +943,7 @@ describe('Project e2e', () => {
 
     const actual = result.updateProject.project;
     expect(actual.id).toBe(proj.id);
-    expect(actual.budget.value.records.length).toBe(1);
+    expect(actual.budget.value.records.length).toBe(2);
   });
 
   /**


### PR DESCRIPTION
This fixes a bug where the fiscal year is calculated as being the same as the year of the date, which is not the case.