### PR TITLE
Refactor delete

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -23,7 +23,7 @@ rules:
       filter: __typename
       format: ~
     - selector: property
-      format: [camelCase, PascalCase]
+      format: [camelCase, PascalCase, snake_case]
       leadingUnderscore: forbid
     - selector: enumMember
       format: [PascalCase, UPPER_CASE]

--- a/src/components/authorization/dto/powers.ts
+++ b/src/components/authorization/dto/powers.ts
@@ -32,6 +32,7 @@ export enum Powers {
   CreateUnavailability = 'CreateUnavailability',
   CreateUser = 'CreateUser',
   CreateZone = 'CreateZone',
+  DeleteLanguage = 'DeleteLanguage',
   GrantAdministratorRole = 'GrantAdministratorRole',
   GrantConsultuntManagerRole = 'GrantConsultuntManagerRole',
   GrantControllerRole = 'GrantControllerRole',

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -452,11 +452,12 @@ export class LanguageService {
       throw new NotFoundException('Could not find language', 'language.id');
     }
 
+    const baseNodeLabels = ['BaseNode', 'Language'];
+
     try {
-      await this.db.deleteNode({
-        session,
+      await this.db.deleteNodeNew<Language>({
         object,
-        aclEditProp: 'canDeleteOwnUser',
+        baseNodeLabels,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -447,6 +447,11 @@ export class LanguageService {
   }
 
   async delete(id: string, session: ISession): Promise<void> {
+    await this.authorizationService.checkPower(
+      Powers.DeleteLanguage,
+      session.userId
+    );
+
     const object = await this.readOne(id, session);
 
     if (!object) {

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -22,6 +22,7 @@ import {
   matchSession,
   OnIndex,
   UniquenessError,
+  UniqueProperties,
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
@@ -454,10 +455,17 @@ export class LanguageService {
 
     const baseNodeLabels = ['BaseNode', 'Language'];
 
+    const uniqueProperties: UniqueProperties<Language> = {
+      name: ['Property', 'LanguageName'],
+      displayName: ['Property', 'LanguageDisplayName'],
+      registryOfDialectsCode: ['Property'],
+    };
+
     try {
       await this.db.deleteNodeNew<Language>({
         object,
         baseNodeLabels,
+        uniqueProperties,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -194,6 +194,7 @@ export class UserService {
       Powers.CreateStory,
       Powers.CreateTranslationEngagement,
       Powers.CreateUnavailability,
+      Powers.DeleteLanguage,
     ];
     for (const power of grants) {
       await this.authorizationService.grantPower(power, id);

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -674,6 +674,30 @@ export class DatabaseService {
     };
   }
 
+  async deleteNodeNew<TObject extends Resource>({
+    object,
+  }: {
+    object: TObject;
+  }) {
+    const query = this.db
+
+      .query()
+      .match(node('node', { id: object.id }))
+      //Mark any parent base node relationships (pointing to the base node) as active = false.
+      .optionalMatch([
+        node('node'),
+        relation('in', 'rel'),
+        node('', 'BaseNode'),
+      ])
+      .set({
+        values: {
+          'rel.active': false,
+        },
+      })
+      .with('*');
+    await query.run();
+  }
+
   async deleteNode<TObject extends Resource>({
     session,
     object,

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -29,7 +29,7 @@ import { ILogger, Logger } from '..';
 import { ConfigService } from '../config/config.service';
 import {
   hasMore,
-  setBaseNodeLabelsDeleted,
+  setBaseNodeLabelsAndIdDeleted,
   setPropLabelsAndValuesDeleted,
   UniqueProperties,
 } from './query.helpers';
@@ -703,8 +703,9 @@ export class DatabaseService {
         },
       })
       .with('distinct(node) as node')
-      //Mark labels Deleted
-      .call(setBaseNodeLabelsDeleted, baseNodeLabels)
+      //Mark baseNode labels and id deleted
+      .call(setBaseNodeLabelsAndIdDeleted, baseNodeLabels)
+      //Mark unique property labels and values deleted
       .call(setPropLabelsAndValuesDeleted, uniqueProperties)
       .return('*');
     await query.run();

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -27,7 +27,7 @@ import {
 } from '../../common';
 import { ILogger, Logger } from '..';
 import { ConfigService } from '../config/config.service';
-import { hasMore } from './query.helpers';
+import { hasMore, setBaseNodeLabelsDeleted } from './query.helpers';
 
 interface ReadPropertyResult {
   value: any;
@@ -676,8 +676,10 @@ export class DatabaseService {
 
   async deleteNodeNew<TObject extends Resource>({
     object,
+    baseNodeLabels,
   }: {
     object: TObject;
+    baseNodeLabels: string[];
   }) {
     const query = this.db
 
@@ -694,7 +696,11 @@ export class DatabaseService {
           'rel.active': false,
         },
       })
-      .with('*');
+      .with('*')
+      //Mark labels Deleted
+      .call(setBaseNodeLabelsDeleted, baseNodeLabels)
+      .return('*');
+
     await query.run();
   }
 

--- a/src/core/database/query.helpers.ts
+++ b/src/core/database/query.helpers.ts
@@ -897,6 +897,7 @@ export const setBaseNodeLabelsDeleted = (
   query: Query,
   baseNodeLabels: string[]
 ) => {
+  //set labels as Deleted
   baseNodeLabels.forEach((label) => {
     query
       .set({
@@ -909,6 +910,20 @@ export const setBaseNodeLabelsDeleted = (
       })
       .with('distinct(node) as node');
   });
+
+  //set id as deleted_id
+
+  query
+    .with('*, node.id as nodeId')
+    .set({
+      variables: {
+        'node.deleted_id': 'nodeId',
+      },
+    })
+    .removeProperties({
+      node: 'id',
+    })
+    .with('distinct(node) as node');
 };
 
 export type UniqueProperties<BaseNode extends Resource> = Partial<

--- a/src/core/database/query.helpers.ts
+++ b/src/core/database/query.helpers.ts
@@ -885,3 +885,23 @@ export const getPermList = matchPermList;
 
 /** @deprecated */
 export const getPropList = matchPropList;
+
+//DELETE service
+export const setBaseNodeLabelsDeleted = (
+  query: Query,
+  baseNodeLabels: string[]
+) => {
+  baseNodeLabels.forEach((label) => {
+    query
+      .match(node('node'))
+      .set({
+        labels: {
+          node: `Deleted_${label}`,
+        },
+      })
+      .removeLabels({
+        node: label,
+      })
+      .with('*');
+  });
+};

--- a/test/language.e2e-spec.ts
+++ b/test/language.e2e-spec.ts
@@ -137,7 +137,7 @@ describe('Language e2e', () => {
   });
 
   // DELETE LANGUAGE
-  it.skip('delete language', async () => {
+  it('delete language', async () => {
     const language = await createLanguage(app);
 
     const result = await app.graphql.mutate(


### PR DESCRIPTION
Following the steps defined in the ticket description.  To use `deleteNodeNew` will need to pass in all the baseNode labels, and a dictionary of all of its unique property relations and those property node labels.