### PR TITLE
DTOs canDelete

### DIFF
--- a/src/common/secured-list.ts
+++ b/src/common/secured-list.ts
@@ -23,6 +23,11 @@ export function SecuredList<Type, ListItem = Type>(
       description: `Whether the current user can add items to this list via the appropriate mutation`,
     })
     readonly canCreate: boolean;
+
+    @Field({
+      description: `Whether the current user can remove items from this list via the appropriate mutation`,
+    })
+    readonly canDelete: boolean;
   }
 
   return SecuredListClass;

--- a/src/common/secured-property.ts
+++ b/src/common/secured-property.ts
@@ -19,6 +19,7 @@ export interface Secured<T> {
   readonly value?: T;
   readonly canRead: boolean;
   readonly canEdit: boolean;
+  readonly canDelete: boolean;
 }
 
 export type SecuredKeys<Dto extends Record<string, any>> = ConditionalKeys<
@@ -106,6 +107,8 @@ function InnerSecuredProperty<
     readonly canRead: boolean;
     @Field()
     readonly canEdit: boolean;
+    @Field()
+    readonly canDelete: boolean;
   }
 
   return SecuredPropertyClass;
@@ -163,6 +166,8 @@ function SecuredList<GQL, TS, Nullable extends boolean | undefined = false>(
     readonly canRead: boolean;
     @Field()
     readonly canEdit: boolean;
+    @Field()
+    readonly canDelete: boolean;
   }
 
   return SecuredPropertyListClass;
@@ -242,6 +247,9 @@ export abstract class SecuredDateTime
 
   @Field()
   readonly canEdit: boolean;
+
+  @Field()
+  readonly canDelete: boolean;
 }
 
 @ObjectType({ implements: [Readable, Editable] })
@@ -255,6 +263,9 @@ export abstract class SecuredDateTimeNullable
 
   @Field()
   readonly canEdit: boolean;
+
+  @Field()
+  readonly canDelete: boolean;
 }
 
 @ObjectType({ implements: [Readable, Editable] })
@@ -268,6 +279,9 @@ export abstract class SecuredDate
 
   @Field()
   readonly canEdit: boolean;
+
+  @Field()
+  readonly canDelete: boolean;
 }
 
 @ObjectType({ implements: [Readable, Editable] })
@@ -281,4 +295,7 @@ export abstract class SecuredDateNullable
 
   @Field()
   readonly canEdit: boolean;
+
+  @Field()
+  readonly canDelete: boolean;
 }

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -693,11 +693,13 @@ export class EngagementService {
         value: startDate,
         canRead: canReadStartDate,
         canEdit: false,
+        canDelete: true,
       },
       endDate: {
         value: endDate,
         canRead: canReadEndDate,
         canEdit: false,
+        canDelete: true,
       },
       methodologies: {
         ...securedProperties.methodologies,
@@ -1076,6 +1078,8 @@ export class EngagementService {
       ...result,
       canRead: !!permission?.canRead,
       canCreate: !!permission?.canEdit,
+      // TODO update query to actually return this value and remove `?? true`
+      canDelete: !!permission?.canDelete ?? true,
     };
   }
 

--- a/src/components/language/language.resolver.ts
+++ b/src/components/language/language.resolver.ts
@@ -63,6 +63,7 @@ export class LanguageResolver {
     const { canRead, value } = language.populationOverride;
     return {
       canEdit: false, // this is a computed field
+      canDelete: true,
       canRead,
       value: canRead
         ? value ?? language.ethnologue.population.value

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -543,6 +543,7 @@ export class LanguageService {
       hasMore: false,
       canCreate: !!permission?.canReadLocationCreate,
       canRead: !!permission?.canReadLocationRead,
+      canDelete: true,
     };
   }
 
@@ -596,6 +597,7 @@ export class LanguageService {
       //TODO: use the upcoming Roles service to determine permissions.
       canCreate: true,
       canRead: true,
+      canDelete: true,
     };
   }
 
@@ -638,6 +640,7 @@ export class LanguageService {
       return {
         canRead,
         canEdit: false,
+        canDelete: true,
         value,
       };
     } catch {
@@ -645,6 +648,7 @@ export class LanguageService {
       return {
         canRead: false,
         canEdit: false,
+        canDelete: false,
         value: undefined,
       };
     }

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -346,6 +346,7 @@ export class OrganizationService {
         value: result?.name,
         canRead: false,
         canEdit: false,
+        canDelete: true,
       },
     });
 

--- a/src/components/partnership/partnership.service.spec.ts
+++ b/src/components/partnership/partnership.service.spec.ts
@@ -27,26 +27,31 @@ const createTestPartnership: Partial<Partnership> = {
     value: PartnershipAgreementStatus.Signed,
     canRead: true,
     canEdit: true,
+    canDelete: true,
   },
   mouStatus: {
     value: PartnershipAgreementStatus.Signed,
     canRead: true,
     canEdit: true,
+    canDelete: true,
   },
   mouStart: {
     value: DateTime.local(),
     canRead: true,
     canEdit: true,
+    canDelete: true,
   },
   mouEnd: {
     value: DateTime.local(),
     canRead: true,
     canEdit: true,
+    canDelete: true,
   },
   types: {
     value: [PartnerType.Technical],
     canRead: true,
     canEdit: true,
+    canDelete: true,
   },
 };
 

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -326,11 +326,13 @@ export class PartnershipService {
         value: mouStart,
         canRead: canReadMouStart,
         canEdit: false, // edit the project mou or edit the partnerhsip mou override
+        canDelete: true,
       },
       mouEnd: {
         value: mouEnd,
         canRead: canReadMouEnd,
         canEdit: false, // edit the project mou or edit the partnerhsip mou override
+        canDelete: true,
       },
       types: {
         ...securedProps.types,

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -530,7 +530,7 @@ export class ProjectService {
       sensitivity: 'sensitivityValue',
     };
 
-    const sensitivityCase = `case prop.value 
+    const sensitivityCase = `case prop.value
     when 'High' then 3
     when 'Medium' then 2
     when 'Low' then 1
@@ -630,6 +630,7 @@ export class ProjectService {
       ...result,
       canRead: !!permission?.canReadEngagementRead,
       canCreate: !!permission?.canReadEngagementCreate,
+      canDelete: true,
     };
   }
 
@@ -698,6 +699,7 @@ export class ProjectService {
       ...result,
       canRead: !!permission?.canReadTeamMemberRead,
       canCreate: !!permission?.canReadTeamMemberCreate,
+      canDelete: true,
     };
   }
 
@@ -766,6 +768,7 @@ export class ProjectService {
       ...result,
       canRead: !!permission?.canReadPartnershipRead,
       canCreate: !!permission?.canReadPartnershipCreate,
+      canDelete: true,
     };
   }
 
@@ -805,6 +808,7 @@ export class ProjectService {
       value: current ? current : pendingBudget,
       canEdit: true,
       canRead: true,
+      canDelete: true,
     };
   }
 
@@ -831,6 +835,7 @@ export class ProjectService {
       return {
         canEdit: false,
         canRead: false,
+        canDelete: true,
         value: undefined,
       };
     }
@@ -844,6 +849,7 @@ export class ProjectService {
     return {
       canEdit: false,
       canRead: true,
+      canDelete: true,
       value: await this.fileService.getDirectory(rootRef.id, session),
     };
   }

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -440,6 +440,7 @@ export class UserService {
       ...result,
       canRead: user.canRead,
       canCreate: user.canEdit,
+      canDelete: user.canDelete,
     };
   }
 
@@ -501,6 +502,7 @@ export class UserService {
       ...result,
       canRead: user.canRead,
       canCreate: user.canEdit,
+      canDelete: user.canDelete,
     };
   }
 
@@ -558,6 +560,7 @@ export class UserService {
       ...result,
       canRead: user.canRead,
       canCreate: user.canEdit,
+      canDelete: user.canDelete,
     };
   }
 

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -33,6 +33,7 @@ interface ReadPropertyResult {
   value: any;
   canEdit: boolean;
   canRead: boolean;
+  canDelete: boolean;
 }
 
 export type ACLs = Record<string, boolean>;
@@ -269,17 +270,19 @@ export class DatabaseService {
     }
 
     return {
-      id: { value: id, canRead: true, canEdit: true },
+      id: { value: id, canRead: true, canEdit: true, canDelete: true },
       createdAt: {
         value: result.n.properties.createdat,
         canRead: true,
         canEdit: true,
+        canDelete: true,
       },
       ...mapFromList(nonMetaProps, (property) => {
         const val = {
           value: result[property].properties.value,
           canRead: result['perm' + property].properties.read,
           canEdit: result['perm' + property].properties.edit,
+          canDelete: true, // TODO: actually retrieve from properties list
         };
         return [property, val];
       }),
@@ -457,7 +460,7 @@ export class DatabaseService {
       .first()) as ReadPropertyResult;
 
     if (!result) {
-      return { value: null, canRead: false, canEdit: false };
+      return { value: null, canRead: false, canEdit: false, canDelete: false };
     }
 
     return result;
@@ -1215,6 +1218,7 @@ export class DatabaseService {
             value: rootResult![prop],
             canRead: true,
             canEdit: true,
+            canDelete: true,
           };
           return [prop, val];
         }),

--- a/src/core/database/query.helpers.ts
+++ b/src/core/database/query.helpers.ts
@@ -777,6 +777,7 @@ export const securedProperty = (property: string) => ({
   value: coalesce(`${property}.value`),
   canRead: coalesce(`${property}ReadPerm.read`, false),
   canEdit: coalesce(`${property}EditPerm.edit`, false),
+  canDelete: coalesce(`${property}EditPerm.delete`, false),
 });
 
 export function returnWithSecurePropertyClauseForList(property: string) {
@@ -784,7 +785,8 @@ export function returnWithSecurePropertyClauseForList(property: string) {
     ${property}: {
       value: coalesce(${property}.value, null),
       canRead: coalesce(${property}ReadPerm.read, false),
-      canEdit: coalesce(${property}EditPerm.edit, false)
+      canEdit: coalesce(${property}EditPerm.edit, false),
+      canDelete: coalesce(${property}EditPerm.delete, false)
     }
   `;
 }

--- a/src/core/database/results/parse-permissions.ts
+++ b/src/core/database/results/parse-permissions.ts
@@ -10,11 +10,13 @@ export interface PermissionNode<Key extends string = string> {
   admin: boolean;
   edit: boolean;
   read: boolean;
+  delete: boolean;
 }
 
 export const permissionDefaults = {
   canRead: false,
   canEdit: false,
+  canDelete: false,
 };
 export type Permission = typeof permissionDefaults;
 
@@ -28,7 +30,7 @@ export type PermListDbResult<DbProps extends Record<string, any>> = Array<
 /**
  * Parse a list of permission nodes (from DB) to an object.
  * The object's keys are the unique property names.
- * The object's values are an object of canRead/canEdit which take the most
+ * The object's values are an object of canRead/canEdit/canDelete which take the most
  * permissive (true) values of the matching permission nodes.
  */
 export function parsePermissions<DbProps extends Record<string, any>>(
@@ -48,6 +50,7 @@ export function parsePermissions<DbProps extends Record<string, any>>(
         pickBy({
           canRead: node.read || null,
           canEdit: node.edit || null,
+          canDelete: node.delete || null,
         })
       );
       // Merge the all the true permissions together, otherwise default to false


### PR DESCRIPTION
Closes #1274 

Update all definitions and logic for secured properties to use a `canDelete` property, set for moment to always be `true`