### PR TITLE
Refactor & Fix Budget Record Sync

### DIFF
--- a/src/components/budget/budget.module.ts
+++ b/src/components/budget/budget.module.ts
@@ -4,6 +4,7 @@ import { FileModule } from '../file/file.module';
 import { LocationModule } from '../location/location.module';
 import { OrganizationModule } from '../organization/organization.module';
 import { PartnershipModule } from '../partnership/partnership.module';
+import { ProjectModule } from '../project/project.module';
 import { EducationModule } from '../user/education/education.module';
 import { UnavailabilityModule } from '../user/unavailability/unavailability.module';
 import { UserModule } from '../user/user.module';
@@ -20,6 +21,7 @@ import * as handlers from './handlers';
     LocationModule,
     forwardRef(() => PartnershipModule),
     forwardRef(() => OrganizationModule),
+    ProjectModule,
     UnavailabilityModule,
     UserModule,
   ],

--- a/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
+++ b/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
@@ -202,7 +202,7 @@ export class SyncBudgetRecordsToFundingPartners
     try {
       if (event instanceof PartnershipUpdatedEvent) {
         await this.synchronizePartnershipBudgetRecords(
-          event.partnership,
+          event.updated,
           event.session
         );
       }

--- a/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
+++ b/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
@@ -40,159 +40,6 @@ export class SyncBudgetRecordsToFundingPartners
     @Logger('budget:sync-partnerships') private readonly logger: ILogger
   ) {}
 
-  // TODO: refactor into budget service or partnership service
-  private async getBudgetIdForPartnership(partnership: Partnership) {
-    const budgets = await this.db
-      .query()
-      .raw(
-        'MATCH (:Partnership { id: $partnershipId })-[:partnership]-(el)-[:budget]-(budget:Budget)',
-        { partnershipId: partnership.id }
-      )
-      .return('budget.id')
-      .run();
-
-    // TODO: determine if the business logic should allow for more then one budget per partnership
-    return budgets[0]['budget.id'];
-  }
-
-  // TODO: refactor into projectsService
-  private async getPartnershipsForProject(project: Project, session: ISession) {
-    const partnershipIds = await this.db
-      .query()
-      .raw(
-        'MATCH (:Project { id: $projectId })-[:partnership]-(partnership:Partnership)',
-        { projectId: project.id }
-      )
-      .return('partnership.id')
-      .run();
-
-    const partnerships = await Promise.all(
-      partnershipIds.map((partnershipId) =>
-        this.partnershipService.readOne(
-          partnershipId['partnership.id'],
-          session
-        )
-      )
-    );
-    return partnerships;
-  }
-
-  // TODO: refactor into partnershipsService
-  private async getExistingBudgetRecordYearsForPartnership(
-    partnership: Partnership,
-    session: ISession
-  ) {
-    const budgetId = await this.getBudgetIdForPartnership(partnership);
-    const budget = await this.budgets.readOne(budgetId, session);
-
-    return budget.records;
-  }
-
-  private calculateExpectedBudgetRecordYears(partnership: Partnership) {
-    let expectedBudgetRecordYears: number[];
-    if (
-      !partnership.mouStart?.value ||
-      !partnership.mouEnd?.value ||
-      // TODO: decide whether to move the following funding and type checks to an earlier step.
-      !partnership.types.value.includes(PartnerType.Funding) || // Partnership is not funding, so do nothing
-      !partnership.types?.value // Partnership Type is not provided, so do nothing.
-    ) {
-      expectedBudgetRecordYears = [];
-    } else {
-      const mouStart = partnership.mouStart.value;
-      const mouEnd = partnership.mouEnd.value;
-
-      expectedBudgetRecordYears = fiscalYears(mouStart, mouEnd);
-    }
-    return expectedBudgetRecordYears;
-  }
-
-  // TODO: refactor into partnershipsService
-  private async getOrganizationIdByPartnership(partnership: Partnership) {
-    // TODO: refactor so that partnership.organization.id returns a value instead of undefined.
-    // this is currently a workaround because of the partnership.organization.id returning undefined.
-    const organization = await this.db
-      .query()
-      .raw(
-        'MATCH (:Partnership { id: $partnershipId })-[:partner]->(partner:Partner)-[:organization]->(organization:Organization)',
-        { partnershipId: partnership.id }
-      )
-      .return('organization.id')
-      .run();
-
-    // TODO: determine if the business logic should allow for more then one budget per partnership
-    return organization[0]['organization.id'];
-  }
-
-  private async createMissingBudgetRecords(
-    partnership: Partnership,
-    session: ISession,
-    existing: readonly BudgetRecord[],
-    expected: number[]
-  ) {
-    const existingYears = existing.map(
-      (budgetRecord) => budgetRecord.fiscalYear.value
-    );
-    const budgetRecordsToBeCreated = expected.filter(
-      (year) => !existingYears.includes(year)
-    );
-    const budgetId = await this.getBudgetIdForPartnership(partnership);
-    const organizationId = await this.getOrganizationIdByPartnership(
-      partnership
-    );
-
-    const budgetRecords = budgetRecordsToBeCreated.map((year) => ({
-      budgetId: budgetId,
-      organizationId: organizationId,
-      fiscalYear: year,
-    }));
-    await Promise.all(
-      budgetRecords.map((record) => this.budgets.createRecord(record, session))
-    );
-  }
-
-  private async deactivateOldBudgetRecords(
-    session: ISession,
-    existing: readonly BudgetRecord[],
-    expected: number[]
-  ) {
-    // TODO: validate that record.fiscalYear.value cannot be undefined
-    const budgetRecoredsToBeDeactivated = existing.filter(
-      (record) => !expected.includes(record.fiscalYear.value!)
-    );
-
-    await Promise.all(
-      budgetRecoredsToBeDeactivated.map((record) =>
-        this.budgets.deleteRecord(record.id, session)
-      )
-    );
-  }
-
-  private async synchronizePartnershipBudgetRecords(
-    partnership: Partnership,
-    session: ISession
-  ) {
-    const expectedBudgetRecordYears = this.calculateExpectedBudgetRecordYears(
-      partnership
-    );
-    // in cases where the expected budget years array is empty you could optimize by skipping some queries
-    const existingBudgetRecordYears = await this.getExistingBudgetRecordYearsForPartnership(
-      partnership,
-      session
-    );
-    await this.createMissingBudgetRecords(
-      partnership,
-      session,
-      existingBudgetRecordYears,
-      expectedBudgetRecordYears
-    );
-    await this.deactivateOldBudgetRecords(
-      session,
-      existingBudgetRecordYears,
-      expectedBudgetRecordYears
-    );
-  }
-
   async handle(event: SubscribedEvent) {
     this.logger.debug('Partnership/Project mutation, syncing budget records', {
       ...event,
@@ -252,5 +99,158 @@ export class SyncBudgetRecordsToFundingPartners
 
     // TODO: only continue if budget is pending
     // TODO: Fiscal years may need to be determined from project. See #596 for details
+  }
+
+  private async synchronizePartnershipBudgetRecords(
+    partnership: Partnership,
+    session: ISession
+  ) {
+    const expectedBudgetRecordYears = this.calculateExpectedBudgetRecordYears(
+      partnership
+    );
+    // in cases where the expected budget years array is empty you could optimize by skipping some queries
+    const existingBudgetRecordYears = await this.getExistingBudgetRecordYearsForPartnership(
+      partnership,
+      session
+    );
+    await this.createMissingBudgetRecords(
+      partnership,
+      session,
+      existingBudgetRecordYears,
+      expectedBudgetRecordYears
+    );
+    await this.deactivateOldBudgetRecords(
+      session,
+      existingBudgetRecordYears,
+      expectedBudgetRecordYears
+    );
+  }
+
+  private calculateExpectedBudgetRecordYears(partnership: Partnership) {
+    let expectedBudgetRecordYears: number[];
+    if (
+      !partnership.mouStart?.value ||
+      !partnership.mouEnd?.value ||
+      // TODO: decide whether to move the following funding and type checks to an earlier step.
+      !partnership.types.value.includes(PartnerType.Funding) || // Partnership is not funding, so do nothing
+      !partnership.types?.value // Partnership Type is not provided, so do nothing.
+    ) {
+      expectedBudgetRecordYears = [];
+    } else {
+      const mouStart = partnership.mouStart.value;
+      const mouEnd = partnership.mouEnd.value;
+
+      expectedBudgetRecordYears = fiscalYears(mouStart, mouEnd);
+    }
+    return expectedBudgetRecordYears;
+  }
+
+  // TODO: refactor into partnershipsService
+  private async getExistingBudgetRecordYearsForPartnership(
+    partnership: Partnership,
+    session: ISession
+  ) {
+    const budgetId = await this.getBudgetIdForPartnership(partnership);
+    const budget = await this.budgets.readOne(budgetId, session);
+
+    return budget.records;
+  }
+
+  private async createMissingBudgetRecords(
+    partnership: Partnership,
+    session: ISession,
+    existing: readonly BudgetRecord[],
+    expected: number[]
+  ) {
+    const existingYears = existing.map(
+      (budgetRecord) => budgetRecord.fiscalYear.value
+    );
+    const budgetRecordsToBeCreated = expected.filter(
+      (year) => !existingYears.includes(year)
+    );
+    const budgetId = await this.getBudgetIdForPartnership(partnership);
+    const organizationId = await this.getOrganizationIdByPartnership(
+      partnership
+    );
+
+    const budgetRecords = budgetRecordsToBeCreated.map((year) => ({
+      budgetId: budgetId,
+      organizationId: organizationId,
+      fiscalYear: year,
+    }));
+    await Promise.all(
+      budgetRecords.map((record) => this.budgets.createRecord(record, session))
+    );
+  }
+
+  private async deactivateOldBudgetRecords(
+    session: ISession,
+    existing: readonly BudgetRecord[],
+    expected: number[]
+  ) {
+    // TODO: validate that record.fiscalYear.value cannot be undefined
+    const budgetRecoredsToBeDeactivated = existing.filter(
+      (record) => !expected.includes(record.fiscalYear.value!)
+    );
+
+    await Promise.all(
+      budgetRecoredsToBeDeactivated.map((record) =>
+        this.budgets.deleteRecord(record.id, session)
+      )
+    );
+  }
+
+  // TODO: refactor into partnershipsService
+  private async getOrganizationIdByPartnership(partnership: Partnership) {
+    // TODO: refactor so that partnership.organization.id returns a value instead of undefined.
+    // this is currently a workaround because of the partnership.organization.id returning undefined.
+    const organization = await this.db
+      .query()
+      .raw(
+        'MATCH (:Partnership { id: $partnershipId })-[:partner]->(partner:Partner)-[:organization]->(organization:Organization)',
+        { partnershipId: partnership.id }
+      )
+      .return('organization.id')
+      .run();
+
+    // TODO: determine if the business logic should allow for more then one budget per partnership
+    return organization[0]['organization.id'];
+  }
+
+  // TODO: refactor into budget service or partnership service
+  private async getBudgetIdForPartnership(partnership: Partnership) {
+    const budgets = await this.db
+      .query()
+      .raw(
+        'MATCH (:Partnership { id: $partnershipId })-[:partnership]-(el)-[:budget]-(budget:Budget)',
+        { partnershipId: partnership.id }
+      )
+      .return('budget.id')
+      .run();
+
+    // TODO: determine if the business logic should allow for more then one budget per partnership
+    return budgets[0]['budget.id'];
+  }
+
+  // TODO: refactor into projectsService
+  private async getPartnershipsForProject(project: Project, session: ISession) {
+    const partnershipIds = await this.db
+      .query()
+      .raw(
+        'MATCH (:Project { id: $projectId })-[:partnership]-(partnership:Partnership)',
+        { projectId: project.id }
+      )
+      .return('partnership.id')
+      .run();
+
+    const partnerships = await Promise.all(
+      partnershipIds.map((partnershipId) =>
+        this.partnershipService.readOne(
+          partnershipId['partnership.id'],
+          session
+        )
+      )
+    );
+    return partnerships;
   }
 }

--- a/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
+++ b/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
@@ -1,4 +1,12 @@
-import { fiscalYears, ISession, ServerException } from '../../../common';
+import { node, relation } from 'cypher-query-builder';
+import { difference } from 'lodash';
+import {
+  fiscalYears,
+  ISession,
+  NotFoundException,
+  Secured,
+  UnauthorizedException,
+} from '../../../common';
 import {
   DatabaseService,
   EventsHandler,
@@ -14,10 +22,10 @@ import {
   PartnershipUpdatedEvent,
   PartnershipWillDeleteEvent,
 } from '../../partnership/events';
-import { Project } from '../../project/dto';
+import { ProjectService } from '../../project';
 import { ProjectUpdatedEvent } from '../../project/events';
 import { BudgetService } from '../budget.service';
-import { BudgetRecord } from '../dto';
+import { Budget, BudgetRecord, BudgetStatus } from '../dto';
 
 type SubscribedEvent =
   | ProjectUpdatedEvent
@@ -37,6 +45,7 @@ export class SyncBudgetRecordsToFundingPartners
     private readonly db: DatabaseService,
     private readonly budgets: BudgetService,
     private readonly partnershipService: PartnershipService,
+    private readonly projects: ProjectService,
     @Logger('budget:sync-partnerships') private readonly logger: ILogger
   ) {}
 
@@ -46,211 +55,208 @@ export class SyncBudgetRecordsToFundingPartners
       event: event.constructor.name,
     });
 
-    try {
-      if (event instanceof PartnershipUpdatedEvent) {
-        await this.synchronizePartnershipBudgetRecords(
-          event.updated,
-          event.session
-        );
-      }
-
-      if (event instanceof PartnershipCreatedEvent) {
-        await this.synchronizePartnershipBudgetRecords(
-          event.partnership,
-          event.session
-        );
-      }
-
-      if (event instanceof PartnershipWillDeleteEvent) {
-        const expectedBudgetRecordYears: number[] = [];
-        const existingBudgetRecordYears = await this.getExistingBudgetRecordYearsForPartnership(
-          event.partnership,
-          event.session
-        );
-        await this.deactivateOldBudgetRecords(
-          event.session,
-          existingBudgetRecordYears,
-          expectedBudgetRecordYears
-        );
-      }
-
-      if (event instanceof ProjectUpdatedEvent) {
-        const partnerships = await this.getPartnershipsForProject(
-          event.updated,
-          event.session
-        );
-
-        await Promise.all(
-          partnerships.map((partnership) =>
-            this.synchronizePartnershipBudgetRecords(partnership, event.session)
-          )
-        );
-      }
-    } catch (exception) {
-      this.logger.error(`Could not synchronize budget records`, {
-        userId: event.session.userId,
-        exception,
-      });
-      throw new ServerException(
-        'Could not synchronize budget records',
-        exception
-      );
-    }
-
-    // TODO: only continue if budget is pending
-    // TODO: Fiscal years may need to be determined from project. See #596 for details
-  }
-
-  private async synchronizePartnershipBudgetRecords(
-    partnership: Partnership,
-    session: ISession
-  ) {
-    const expectedBudgetRecordYears = this.calculateExpectedBudgetRecordYears(
-      partnership
-    );
-    // in cases where the expected budget years array is empty you could optimize by skipping some queries
-    const existingBudgetRecordYears = await this.getExistingBudgetRecordYearsForPartnership(
-      partnership,
-      session
-    );
-    await this.createMissingBudgetRecords(
-      partnership,
-      session,
-      existingBudgetRecordYears,
-      expectedBudgetRecordYears
-    );
-    await this.deactivateOldBudgetRecords(
-      session,
-      existingBudgetRecordYears,
-      expectedBudgetRecordYears
-    );
-  }
-
-  private calculateExpectedBudgetRecordYears(partnership: Partnership) {
-    let expectedBudgetRecordYears: number[];
+    // Get some easy conditions out of the way that don't require DB queries
     if (
-      !partnership.mouStart?.value ||
-      !partnership.mouEnd?.value ||
-      // TODO: decide whether to move the following funding and type checks to an earlier step.
-      !partnership.types.value.includes(PartnerType.Funding) || // Partnership is not funding, so do nothing
-      !partnership.types?.value // Partnership Type is not provided, so do nothing.
+      event instanceof PartnershipCreatedEvent &&
+      !isFunding(event.partnership)
     ) {
-      expectedBudgetRecordYears = [];
-    } else {
-      const mouStart = partnership.mouStart.value;
-      const mouEnd = partnership.mouEnd.value;
-
-      expectedBudgetRecordYears = fiscalYears(mouStart, mouEnd);
+      // Partnership is not and never was funding, so do nothing.
+      return;
     }
-    return expectedBudgetRecordYears;
+    if (
+      event instanceof PartnershipWillDeleteEvent &&
+      !isFunding(event.partnership)
+    ) {
+      // Partnership was not funding, so do nothing.
+      return;
+    }
+
+    const projectId = await this.determineProjectId(event);
+
+    // Fetch budget & only continue if it is pending
+    const projectsCurrentBudget = await this.projects.currentBudget(
+      { id: projectId },
+      event.session
+    );
+    const budget = readSecured(projectsCurrentBudget, 'budget');
+
+    if (budget.status !== BudgetStatus.Pending) {
+      this.logger.debug('Budget is not pending, skipping sync', budget);
+      return;
+    }
+
+    const partnerships = await this.determinePartnerships(event);
+
+    for (const partnership of partnerships) {
+      await this.syncRecords(budget, partnership, event.session);
+    }
   }
 
-  // TODO: refactor into partnershipsService
-  private async getExistingBudgetRecordYearsForPartnership(
+  private async determineProjectId(event: SubscribedEvent) {
+    if (event instanceof ProjectUpdatedEvent) {
+      return event.updated.id;
+    }
+    if (event instanceof PartnershipUpdatedEvent) {
+      return await this.getProjectIdFromPartnership(event.updated);
+    }
+    return await this.getProjectIdFromPartnership(event.partnership);
+  }
+
+  private async determinePartnerships(event: SubscribedEvent) {
+    if (event instanceof PartnershipCreatedEvent) {
+      return [event.partnership];
+    }
+
+    if (event instanceof PartnershipUpdatedEvent) {
+      return [event.updated];
+    }
+
+    if (event instanceof PartnershipWillDeleteEvent) {
+      return [event.partnership];
+    }
+
+    // event instanceof ProjectUpdatedEvent
+    const list = await this.partnershipService.list(
+      { filter: { projectId: event.updated.id } },
+      event.session
+    );
+    return list.items.filter(isFunding);
+  }
+
+  private async syncRecords(
+    budget: Budget,
     partnership: Partnership,
     session: ISession
   ) {
-    const budgetId = await this.getBudgetIdForPartnership(partnership);
-    const budget = await this.budgets.readOne(budgetId, session);
-
-    return budget.records;
-  }
-
-  private async createMissingBudgetRecords(
-    partnership: Partnership,
-    session: ISession,
-    existing: readonly BudgetRecord[],
-    expected: number[]
-  ) {
-    const existingYears = existing.map(
-      (budgetRecord) => budgetRecord.fiscalYear.value
-    );
-    const budgetRecordsToBeCreated = expected.filter(
-      (year) => !existingYears.includes(year)
-    );
-    const budgetId = await this.getBudgetIdForPartnership(partnership);
     const organizationId = await this.getOrganizationIdByPartnership(
       partnership
     );
 
-    const budgetRecords = budgetRecordsToBeCreated.map((year) => ({
-      budgetId: budgetId,
-      organizationId: organizationId,
-      fiscalYear: year,
-    }));
+    const previous = budget.records
+      .filter((record) => recordOrganization(record) === organizationId)
+      .map(recordFiscalYear);
+    const updated = partnershipFiscalYears(partnership);
+
+    const removals = difference(previous, updated);
+    const additions = difference(updated, previous);
+
+    await this.removeRecords(budget, organizationId, removals, session);
+    await this.addRecords(budget, organizationId, additions, session);
+  }
+
+  private async addRecords(
+    budget: Budget,
+    organizationId: string,
+    additions: readonly FiscalYear[],
+    session: ISession
+  ) {
     await Promise.all(
-      budgetRecords.map((record) => this.budgets.createRecord(record, session))
+      additions.map((fiscalYear) =>
+        this.budgets.createRecord(
+          {
+            budgetId: budget.id,
+            fiscalYear,
+            organizationId,
+          },
+          session
+        )
+      )
     );
   }
 
-  private async deactivateOldBudgetRecords(
-    session: ISession,
-    existing: readonly BudgetRecord[],
-    expected: number[]
+  private async removeRecords(
+    budget: Budget,
+    organizationId: string,
+    removals: readonly FiscalYear[],
+    session: ISession
   ) {
-    // TODO: validate that record.fiscalYear.value cannot be undefined
-    const budgetRecoredsToBeDeactivated = existing.filter(
-      (record) => !expected.includes(record.fiscalYear.value!)
+    const recordsToDelete = budget.records.filter(
+      (record) =>
+        recordOrganization(record) === organizationId &&
+        removals.includes(recordFiscalYear(record))
     );
 
     await Promise.all(
-      budgetRecoredsToBeDeactivated.map((record) =>
+      recordsToDelete.map((record) =>
         this.budgets.deleteRecord(record.id, session)
       )
     );
   }
 
-  // TODO: refactor into partnershipsService
   private async getOrganizationIdByPartnership(partnership: Partnership) {
-    // TODO: refactor so that partnership.organization.id returns a value instead of undefined.
-    // this is currently a workaround because of the partnership.organization.id returning undefined.
-    const organization = await this.db
-      .query()
-      .raw(
-        'MATCH (:Partnership { id: $partnershipId })-[:partner]->(partner:Partner)-[:organization]->(organization:Organization)',
-        { partnershipId: partnership.id }
-      )
-      .return('organization.id')
-      .run();
+    const partnerId = readSecured(partnership.partner, `partnership's partner`);
 
-    // TODO: determine if the business logic should allow for more then one budget per partnership
-    return organization[0]['organization.id'];
+    const result = await this.db
+      .query()
+      .match([
+        node('partner', 'Partner', { id: partnerId }),
+        relation('out', '', 'organization', { active: true }),
+        node('organization', 'Organization'),
+      ])
+      .return('organization.id as id')
+      .asResult<{ id: string }>()
+      .first();
+    if (!result) {
+      throw new NotFoundException("Could not find partner's organization");
+    }
+
+    return result.id;
   }
 
-  // TODO: refactor into budget service or partnership service
-  private async getBudgetIdForPartnership(partnership: Partnership) {
-    const budgets = await this.db
+  private async getProjectIdFromPartnership({ id }: Partnership) {
+    const result = await this.db
       .query()
-      .raw(
-        'MATCH (:Partnership { id: $partnershipId })-[:partnership]-(el)-[:budget]-(budget:Budget)',
-        { partnershipId: partnership.id }
-      )
-      .return('budget.id')
-      .run();
-
-    // TODO: determine if the business logic should allow for more then one budget per partnership
-    return budgets[0]['budget.id'];
-  }
-
-  // TODO: refactor into projectsService
-  private async getPartnershipsForProject(project: Project, session: ISession) {
-    const partnershipIds = await this.db
-      .query()
-      .raw(
-        'MATCH (:Project { id: $projectId })-[:partnership]-(partnership:Partnership)',
-        { projectId: project.id }
-      )
-      .return('partnership.id')
-      .run();
-
-    const partnerships = await Promise.all(
-      partnershipIds.map((partnershipId) =>
-        this.partnershipService.readOne(
-          partnershipId['partnership.id'],
-          session
-        )
-      )
-    );
-    return partnerships;
+      .match([
+        node('', 'Partnership', { id }),
+        relation('either', '', 'partnership', { active: true }),
+        node('project', 'Project'),
+      ])
+      .return('project.id as id')
+      .asResult<{ id: string }>()
+      .first();
+    if (!result) {
+      throw new NotFoundException("Unable to find partnership's project");
+    }
+    return result.id;
   }
 }
+
+const isFunding = (partnership: Partnership) =>
+  readSecured(partnership.types, `partnership's types`).includes(
+    PartnerType.Funding
+  );
+
+type FiscalYear = number;
+
+const partnershipFiscalYears = (
+  partnership: Partnership
+): readonly FiscalYear[] => {
+  if (!isFunding(partnership)) {
+    return [];
+  }
+
+  const start = readSecured(
+    partnership.mouStart,
+    `partnership's mouStart date`
+  );
+  const end = readSecured(partnership.mouEnd, `partnership's mouEnd date`);
+  return start && end ? fiscalYears(start, end) : [];
+};
+
+const recordOrganization = (record: BudgetRecord) =>
+  readSecured(record.organization, `budget record's organization`);
+
+const recordFiscalYear = (record: BudgetRecord) =>
+  readSecured(record.fiscalYear, `budget record's fiscal year`);
+
+const readSecured = <T extends Secured<any>>(
+  field: T,
+  errorMessage: string
+): Exclude<T['value'], undefined> => {
+  if (!field.canRead) {
+    throw new UnauthorizedException(
+      `Current user cannot read ${errorMessage} thus record sync cannot continue`
+    );
+  }
+  return field.value;
+};

--- a/src/components/partnership/events/partnership-updated.event.ts
+++ b/src/components/partnership/events/partnership-updated.event.ts
@@ -3,7 +3,8 @@ import { Partnership, UpdatePartnership } from '../dto';
 
 export class PartnershipUpdatedEvent {
   constructor(
-    readonly partnership: Partnership,
+    public updated: Partnership,
+    readonly previous: Partnership,
     readonly updates: UpdatePartnership,
     readonly session: ISession
   ) {}

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -405,10 +405,14 @@ export class PartnershipService {
     );
 
     const partnership = await this.readOne(input.id, session);
-    await this.eventBus.publish(
-      new PartnershipUpdatedEvent(partnership, input, session)
+    const event = new PartnershipUpdatedEvent(
+      partnership,
+      object,
+      input,
+      session
     );
-    return partnership;
+    await this.eventBus.publish(event);
+    return event.updated;
   }
 
   async delete(id: string, session: ISession): Promise<void> {

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -801,7 +801,7 @@ export class ProjectService {
   }
 
   async currentBudget(
-    project: Project,
+    project: Project | { id: string },
     session: ISession
   ): Promise<SecuredBudget> {
     const budgets = await this.budgetService.list(


### PR DESCRIPTION
- CRITICAL: Fixed records being deleted for _ALL_ organizations for a fiscal year (instead of the one partnership changing)
- Only sync records if budget status is _pending_
- Determine budget based on project's _current_ budget (instead of first one found)
- Throw errors if any field cannot be read (instead of silently failing)
- Refactored code to be more linear, thus easier to follow

I reordered methods in handler before changing logic so check this [diff](https://github.com/SeedCompany/cord-api-v3/compare/4ffe4e1..72a12c8) for the actual logic changes