### PR TITLE
ISO 3166-1 validation & lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "got": "^11.5.0",
     "graphql": "^15.3.0",
     "html-to-text": "^5.1.1",
+    "iso-3166-1": "^2.0.1",
     "js-yaml": "^3.14.0",
     "jsonwebtoken": "^8.5.1",
     "lazy-get-decorator": "^2.2.0",

--- a/src/common/validators/index.ts
+++ b/src/common/validators/index.ts
@@ -1,3 +1,4 @@
 export * from './email.validator';
 export * from './iana-timezone.validator';
+export * from './iso-3166-1-alpha-3.validator';
 export * from './short-id.validator';

--- a/src/common/validators/iso-3166-1-alpha-3.validator.ts
+++ b/src/common/validators/iso-3166-1-alpha-3.validator.ts
@@ -1,0 +1,16 @@
+import { ValidationOptions } from 'class-validator';
+import { whereAlpha3 } from 'iso-3166-1';
+import { ValidateBy } from './validateBy';
+
+export const ISO31661Alpha3 = (validationOptions?: ValidationOptions) =>
+  ValidateBy(
+    {
+      name: 'ISO-3166-1-Alpha-3',
+      validator: {
+        validate: (input) =>
+          input != null ? Boolean(whereAlpha3(input)) : true,
+        defaultMessage: () => 'Invalid ISO-3166-1 alpha-3 country code',
+      },
+    },
+    validationOptions
+  );

--- a/src/components/location/dto/create-location.dto.ts
+++ b/src/components/location/dto/create-location.dto.ts
@@ -1,8 +1,12 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
-import { IsAlpha, Length, ValidateNested } from 'class-validator';
-import { toUpper } from 'lodash';
-import { IdField, NameField, Sensitivity } from '../../../common';
+import { ValidateNested } from 'class-validator';
+import {
+  IdField,
+  ISO31661Alpha3,
+  NameField,
+  Sensitivity,
+} from '../../../common';
 import { Transform } from '../../../common/transform.decorator';
 import { LocationType } from './location-type.enum';
 import { Location } from './location.dto';
@@ -18,11 +22,13 @@ export abstract class CreateLocation {
   @Field(() => Sensitivity)
   readonly sensitivity: Sensitivity;
 
-  @Field({ nullable: true, description: 'Must be 3 alpha characters' })
-  @IsAlpha()
-  @Length(3, 3)
-  @Transform(toUpper)
-  readonly isoAlpha3?: string;
+  @Field(() => String, {
+    nullable: true,
+    description: 'An ISO 3166-1 alpha-3 country code',
+  })
+  @ISO31661Alpha3()
+  @Transform((str) => (str ? str.toUpperCase() : null))
+  readonly isoAlpha3?: string | null;
 
   @IdField({ nullable: true })
   readonly fundingAccountId?: string;

--- a/src/components/location/dto/iso-country.dto.ts
+++ b/src/components/location/dto/iso-country.dto.ts
@@ -1,0 +1,27 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { Country } from 'iso-3166-1/dist/iso-3166';
+
+@ObjectType({
+  description: 'An entry of the ISO 3166-1 standard list for countries',
+})
+export abstract class IsoCountry implements Country {
+  @Field({
+    description: 'The name of the country in plain English',
+  })
+  country: string;
+
+  @Field({
+    description: 'The 2 letter code',
+  })
+  alpha2: string;
+
+  @Field({
+    description: 'The 3 letter code',
+  })
+  alpha3: string;
+
+  @Field({
+    description: 'The numeric code',
+  })
+  numeric: string;
+}

--- a/src/components/location/dto/location-type.enum.ts
+++ b/src/components/location/dto/location-type.enum.ts
@@ -1,10 +1,10 @@
 import { registerEnumType } from '@nestjs/graphql';
 
 export enum LocationType {
+  Country = 'Country',
   City = 'City',
   County = 'County',
   State = 'State',
-  Country = 'Country',
   CrossBorderArea = 'CrossBorderArea',
 }
 

--- a/src/components/location/dto/location.dto.ts
+++ b/src/components/location/dto/location.dto.ts
@@ -5,6 +5,7 @@ import {
   SecuredEnum,
   SecuredProperty,
   SecuredString,
+  SecuredStringNullable,
   Sensitivity,
 } from '../../../common';
 import { LocationType } from './location-type.enum';
@@ -28,7 +29,7 @@ export class Location extends Resource {
   readonly sensitivity: Sensitivity;
 
   @Field()
-  readonly isoAlpha3: SecuredString;
+  readonly isoAlpha3: SecuredStringNullable;
 
   readonly fundingAccount: Secured<string>;
 }

--- a/src/components/location/dto/update-location.dto.ts
+++ b/src/components/location/dto/update-location.dto.ts
@@ -1,8 +1,12 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
-import { IsAlpha, Length, ValidateNested } from 'class-validator';
-import { toUpper } from 'lodash';
-import { IdField, NameField, Sensitivity } from '../../../common';
+import { ValidateNested } from 'class-validator';
+import {
+  IdField,
+  ISO31661Alpha3,
+  NameField,
+  Sensitivity,
+} from '../../../common';
 import { Transform } from '../../../common/transform.decorator';
 import { LocationType } from './location-type.enum';
 import { Location } from './location.dto';
@@ -21,11 +25,13 @@ export abstract class UpdateLocation {
   @Field(() => Sensitivity, { nullable: true })
   readonly sensitivity?: Sensitivity;
 
-  @Field({ nullable: true, description: 'Must be 3 alpha characters' })
-  @IsAlpha()
-  @Length(3, 3)
-  @Transform(toUpper)
-  readonly isoAlpha3?: string;
+  @Field(() => String, {
+    nullable: true,
+    description: 'An ISO 3166-1 alpha-3 country code',
+  })
+  @ISO31661Alpha3()
+  @Transform((str) => (str ? str.toUpperCase() : null))
+  readonly isoAlpha3?: string | null;
 
   @IdField({ nullable: true })
   readonly fundingAccountId?: string;

--- a/src/components/location/location.resolver.ts
+++ b/src/components/location/location.resolver.ts
@@ -7,6 +7,7 @@ import {
   Resolver,
 } from '@nestjs/graphql';
 import { whereAlpha3 } from 'iso-3166-1';
+import countries from 'iso-3166-1/dist/iso-3166';
 import { IdArg, ISession, Session } from '../../common';
 import {
   FundingAccountService,
@@ -82,6 +83,13 @@ export class LocationResolver {
       return null;
     }
     return whereAlpha3(value) ?? null;
+  }
+
+  @Query(() => [IsoCountry], {
+    description: 'A list of ISO 3166-1 countries',
+  })
+  async isoCountries(): Promise<IsoCountry[]> {
+    return countries;
   }
 
   @Mutation(() => CreateLocationOutput, {

--- a/src/components/location/location.resolver.ts
+++ b/src/components/location/location.resolver.ts
@@ -6,6 +6,7 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
+import { whereAlpha3 } from 'iso-3166-1';
 import { IdArg, ISession, Session } from '../../common';
 import {
   FundingAccountService,
@@ -20,6 +21,7 @@ import {
   UpdateLocationInput,
   UpdateLocationOutput,
 } from './dto';
+import { IsoCountry } from './dto/iso-country.dto';
 import { LocationService } from './location.service';
 
 @Resolver(Location)
@@ -67,6 +69,19 @@ export class LocationResolver {
       value,
       ...rest,
     };
+  }
+
+  @ResolveField(() => IsoCountry, {
+    nullable: true,
+    description:
+      "An ISO 3166-1 country, looked up by the `Location`'s `isoAlpha3` code",
+  })
+  async isoCountry(@Parent() location: Location): Promise<IsoCountry | null> {
+    const { value, canRead } = location.isoAlpha3;
+    if (!value || !canRead) {
+      return null;
+    }
+    return whereAlpha3(value) ?? null;
   }
 
   @Mutation(() => CreateLocationOutput, {

--- a/test/utility/create-location.ts
+++ b/test/utility/create-location.ts
@@ -1,5 +1,6 @@
 import { gql } from 'apollo-server-core';
 import * as faker from 'faker';
+import countries from 'iso-3166-1/dist/iso-3166';
 import { isValidId, Sensitivity } from '../../src/common';
 import {
   CreateLocation,
@@ -17,7 +18,7 @@ export async function createLocation(
     name: faker.random.word() + ' ' + faker.random.uuid(),
     type: LocationType.County,
     sensitivity: Sensitivity.High,
-    isoAlpha3: faker.helpers.replaceSymbols('???'),
+    isoAlpha3: faker.random.arrayElement(countries).alpha3,
     ...input,
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4082,6 +4082,7 @@ __metadata:
     graphql: ^15.3.0
     html-to-text: ^5.1.1
     husky: ^4.2.5
+    iso-3166-1: ^2.0.1
     jest: ^26.1.0
     js-yaml: ^3.14.0
     jsonwebtoken: ^8.5.1
@@ -7469,6 +7470,13 @@ fsevents@^1.2.7:
   version: 2.0.0
   resolution: "isexe@npm:2.0.0"
   checksum: 7b437980bb77881a146fba85cfbdf01edc2b148673e9c2722a1e49661fea73adf524430a80fdbfb8ce9f60d43224e682c657c45030482bd39e0c488fc29b4afe
+  languageName: node
+  linkType: hard
+
+"iso-3166-1@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "iso-3166-1@npm:2.0.1"
+  checksum: 91324f4f4482d0f65f19a8d7f75ef009b79498ca8eb182e244a64a16dc44e31333aa696ac6ee7ade68d94ee6f89a3f3477a147608d03fb74f7ec6a9ed2f508bc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Alpha 3 codes are now confirmed against the actual list. Note that `abc` will no longer work.
- Alpha 3 field now allows null on update to remove previous value
- New (lazy) field `isoCountry` on `Location` looks up the alpha 3 code and provides the entry (name, 2-letter/3-letter/numeric code).
  ![Screen Shot 2020-10-20 at 3 43 07 PM](https://user-images.githubusercontent.com/932566/96641954-1262a000-12eb-11eb-9cc0-ea718bfd64a4.png)
- New `isoCountries` query provides list from our API
  ![Screen Shot 2020-10-20 at 3 43 46 PM](https://user-images.githubusercontent.com/932566/96641998-1ee6f880-12eb-11eb-9504-17cd5a528a92.png)
