### PR TITLE
Query.logIt

### DIFF
--- a/src/core/database/cypher.factory.ts
+++ b/src/core/database/cypher.factory.ts
@@ -47,10 +47,14 @@ export const CypherFactory: FactoryProvider<Connection> = {
         const origRun = session.run;
         session.run = function (this: never, origStatement, parameters, conf) {
           const statement = stripIndent(origStatement.slice(0, -1)) + ';';
-          logger.debug('Executing query', {
-            statement,
-            ...parameters,
-          });
+          logger.log(
+            (parameters?.logIt as LogLevel | undefined) ?? LogLevel.DEBUG,
+            'Executing query',
+            {
+              statement,
+              ...parameters,
+            }
+          );
 
           const params = parameters
             ? parameterTransformer.transform(parameters)


### PR DESCRIPTION
Added `Query.logIt` to log the query.

All of our queries are already logged on the `database:query` channel at a _debug_ level. This level is ignored by default to not spam the log.

This method works by changing the log level of that query. By default it bumps the level from _debug_ to _notice_.
So you need to make sure if you've changed your `logging.yml` file to allow that channel to at least the _notice_ level for it work properly.

Example:
```tsx
const createFile = this.db
  .query()
  .call(matchRequestingUser, session)
  .call(createBaseNode, input.id, ['FileVersion', 'FileNode'], props)
  .return('node.id as id')

  .logIt()

  .asResult<{ id: string }>();
const result = await createFile.first();
```
![Screen Shot 2020-10-21 at 2 22 13 PM](https://user-images.githubusercontent.com/932566/96772516-da219700-13a8-11eb-9dd0-64cab80d59ef.png)

@michaelmarshall @SeedCompany/external Let me know if you think this is helpful.