### PR TITLE
Fix input exception

### DIFF
--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -585,7 +585,7 @@ export class PartnershipService {
     if (!availableTypes?.includes(type)) {
       throw new InputException(
         `FinancialReportingType ${type} cannot be assigned to this partnership`,
-        'input.financialReportingType'
+        'partnership.financialReportingType'
       );
     }
   }


### PR DESCRIPTION
The input exception was throwing the wrong input field.  Now a proper message is passed to the client 
<img width="533" alt="Screen Shot 2020-10-21 at 3 08 59 PM" src="https://user-images.githubusercontent.com/43487134/96792499-5e771880-13af-11eb-82cb-c2899bdd43d7.png">

However, @CarsonF this does bring up a different issue.  On the form if a user selects a partner ( that has no financial reporting types), selects managing, selects a fin reporting type, gets the error, then switches the radio to the other fin type and gets the same error again.  There's no way "out" of this except to select a different type, partner, or close the dialog. 

Maybe we change the field from radio to the enumfield so the can toggle on an off the selection, or if we're really clever we read what financial reporting types are available and only show that option (then it'll have to be a enum button because a radio doesn't make sense for single options).