### PR TITLE
On create user add the user to the existing SGs

### DIFF
--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -294,6 +294,8 @@ export class UserService {
         //
       }
     }
+    input.roles &&
+      (await this.authorizationService.roleAddedToUser(id, input.roles));
 
     return result.id;
   }

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -755,8 +755,8 @@ describe('Project e2e', () => {
     );
 
     // Remember the project Owner is also a team member so that should be +1
-    expect(queryProject.project.team.items.length).toBe(numProjectMembers);
-    expect(queryProject.project.team.total).toBe(numProjectMembers);
+    expect(queryProject.project.team.items.length).toBe(numProjectMembers + 1);
+    expect(queryProject.project.team.total).toBe(numProjectMembers + 1);
   });
 
   it('List view of partnerships by projectId', async () => {


### PR DESCRIPTION
When user creates a new `baseNode`, the auth service runs`mergeSecurityGroupForRole` then `addAllUsersToSgByTheUsersGlobalRole` , which gives the project the security groups then adds the users with matching roles to these security groups.  However, any new user created after that doesn't get added to those existing SGs.  Running `authorizationService.roleAddedToUser` at the end of `user.create` adds the new user to the existing SGs and seems to fix it.  `roleAddedToUser` is currently part of user.update