### PR TITLE
Check is not null on sort value

### DIFF
--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -313,7 +313,7 @@ export class BudgetService {
 
     const records = await this.listRecords(
       {
-        sort: 'fiscalYear',
+        sort: 'createdAt',
         order: Order.ASC,
         page: 1,
         count: 25,

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -673,11 +673,12 @@ export class ProjectService {
               relation('out', '', sort, { active: true }),
               node('prop', 'Property'),
             ])
-            .where({ [sortBy]: not(isNull()) })
             .with([
               '*',
               ...(input.sort === 'sensitivity' ? [sensitivityCase] : []),
             ])
+            .where({ [sortBy]: not(isNull()) })
+            .with('*')
             .orderBy(sortBy, order)
       );
 

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -1,5 +1,5 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
-import { node, relation } from 'cypher-query-builder';
+import { isNull, node, not, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import {
   DuplicateException,
@@ -673,6 +673,7 @@ export class ProjectService {
               relation('out', '', sort, { active: true }),
               node('prop', 'Property'),
             ])
+            .where({ [sortBy]: not(isNull()) })
             .with([
               '*',
               ...(input.sort === 'sensitivity' ? [sensitivityCase] : []),

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -428,6 +428,13 @@ export class UserService {
   }
 
   async list(input: UserListInput, session: ISession): Promise<UserListOutput> {
+    const nameSortMap: Partial<Record<typeof input.sort, string>> = {
+      displayFirstName: 'toLower(prop.value)',
+      displayLastName: 'toLower(prop.value)',
+    };
+
+    const sortBy = nameSortMap[input.sort] ?? 'prop.value';
+
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode('User')])
@@ -435,7 +442,8 @@ export class UserService {
         calculateTotalAndPaginateList,
         input,
         this.securedProperties,
-        defaultSorter
+        defaultSorter,
+        sortBy
       );
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));

--- a/src/core/database/query/lists.ts
+++ b/src/core/database/query/lists.ts
@@ -1,4 +1,4 @@
-import { node, Query, relation } from 'cypher-query-builder';
+import { isNull, node, not, Query, relation } from 'cypher-query-builder';
 import { Order, SortablePaginationInput } from '../../../common';
 
 type SecuredProperties = Record<string, boolean>;
@@ -60,7 +60,12 @@ export const defaultSorter: Sorter = (
           relation('out', '', sortInput, { active: true }),
           node('prop', 'Property'),
         ])
+        .where({ [sortValSecuredProp]: not(isNull()) })
         .with('*')
         .orderBy(sortValSecuredProp, order)
-    : q.with('*').orderBy(sortValBaseNodeProp, order);
+    : q
+        .with('*')
+        .where({ [sortValBaseNodeProp]: not(isNull()) })
+        .with('*')
+        .orderBy(sortValBaseNodeProp, order);
 };


### PR DESCRIPTION
remove null sort values when specified.  This will fix sorting by a optional value like project estimated submission date, so projects without that date will be removed from the list.  Otherwise cypher will make those projects will appear at the beginning or the end depending on the sort order.

The issue with this approach is it really breaks the Partner sort.  While it's currently not working, aka the partners are always returned in random order, this will not return any partner because a Partner doesn't have a name (it's the org's name).  We can either write a custom sort query for Partner in this case, or actually store a name field on create partner