### PR TITLE
Refactor Session (no nulls)

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -17,7 +17,7 @@ export * from './secured-list';
 export * from './secured-property';
 export * from './sensitivity.enum';
 export * from './util';
-export { ISession, Session } from './session';
+export { Session, LoggedInSession, AnonSession } from './session';
 export * from './types';
 export * from './validators';
 export * from './name-field';

--- a/src/components/authentication/authentication.resolver.ts
+++ b/src/components/authentication/authentication.resolver.ts
@@ -2,7 +2,8 @@ import { forwardRef, Inject } from '@nestjs/common';
 import { Args, Context, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { Request, Response } from 'express';
 import { DateTime } from 'luxon';
-import { ISession, Session } from '../../common';
+import { AnonSession, LoggedInSession, Session } from '../../common';
+import { anonymousSession, loggedInSession } from '../../common/session';
 import { ConfigService, ILogger, Logger } from '../../core';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { UserService } from '../user';
@@ -50,9 +51,9 @@ export class AuthenticationResolver {
       this.sessionPipe.getTokenFromCookie(req);
 
     let token = existingToken || (await this.authService.createToken());
-    let session;
+    let rawSession;
     try {
-      session = await this.authService.createSession(token);
+      rawSession = await this.authService.createSession(token);
     } catch (exception) {
       // if (!(e instanceof UnauthenticatedException)) {
       //   throw e;
@@ -62,10 +63,13 @@ export class AuthenticationResolver {
         { exception }
       );
       token = await this.authService.createToken();
-      session = await this.authService.createSession(token);
+      rawSession = await this.authService.createSession(token);
     }
+    const session = anonymousSession(rawSession);
 
-    const userFromSession = await this.authService.userFromSession(session);
+    const userFromSession = session.anonymous
+      ? null
+      : await this.authService.userFromSession(session);
     const powers = await this.authorizationService.readPower(session);
 
     if (browser) {
@@ -90,13 +94,13 @@ export class AuthenticationResolver {
   })
   async login(
     @Args('input') input: LoginInput,
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Context('request') req: Request
   ): Promise<LoginOutput> {
     const userId = await this.authService.login(input, session);
-    const loggedInSession = await this.updateSession(req);
-    const user = await this.userService.readOne(userId, loggedInSession);
-    const powers = await this.authorizationService.readPower(loggedInSession);
+    const newSession = loggedInSession(await this.updateSession(req));
+    const user = await this.userService.readOne(userId, newSession);
+    const powers = await this.authorizationService.readPower(newSession);
     return { user, powers };
   }
 
@@ -104,7 +108,7 @@ export class AuthenticationResolver {
     description: 'Logout a user',
   })
   async logout(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Context('request') req: Request
   ): Promise<boolean> {
     await this.authService.logout(session.token);
@@ -117,14 +121,14 @@ export class AuthenticationResolver {
   })
   async register(
     @Args('input') input: RegisterInput,
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Context('request') req: Request
   ): Promise<RegisterOutput> {
     const userId = await this.authService.register(input, session);
     await this.authService.login(input, session);
-    const loggedInSession = await this.updateSession(req);
-    const user = await this.userService.readOne(userId, loggedInSession);
-    const powers = await this.authorizationService.readPower(loggedInSession);
+    const newSession = loggedInSession(await this.updateSession(req));
+    const user = await this.userService.readOne(userId, newSession);
+    const powers = await this.authorizationService.readPower(newSession);
     return { user, powers };
   }
 
@@ -139,7 +143,7 @@ export class AuthenticationResolver {
   })
   async changePassword(
     @Args() { oldPassword, newPassword }: ChangePasswordArgs,
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<boolean> {
     await this.authService.changePassword(oldPassword, newPassword, session);
     return true;

--- a/src/components/authentication/authentication.service.ts
+++ b/src/components/authentication/authentication.service.ts
@@ -8,10 +8,11 @@ import { Except } from 'type-fest';
 import {
   DuplicateException,
   InputException,
-  ISession,
   ServerException,
+  Session,
   UnauthenticatedException,
 } from '../../common';
+import { RawSession } from '../../common/session';
 import {
   ConfigService,
   DatabaseService,
@@ -68,7 +69,7 @@ export class AuthenticationService {
     return result.token;
   }
 
-  async userFromSession(session: ISession): Promise<User | null> {
+  async userFromSession(session: Session): Promise<User | null> {
     const userRes = await this.db
       .query()
       .match([
@@ -91,7 +92,7 @@ export class AuthenticationService {
     return await this.userService.readOne(userRes.id, session);
   }
 
-  async register(input: RegisterInput, session?: ISession): Promise<string> {
+  async register(input: RegisterInput, session?: Session): Promise<string> {
     // ensure no other tokens are associated with this user
     if (session) {
       await this.logout(session.token);
@@ -131,7 +132,7 @@ export class AuthenticationService {
     return userId;
   }
 
-  async login(input: LoginInput, session: ISession): Promise<string> {
+  async login(input: LoginInput, session: Session): Promise<string> {
     const result1 = await this.db
       .query()
       .raw(
@@ -217,7 +218,7 @@ export class AuthenticationService {
       .run();
   }
 
-  async createSession(token: string): Promise<ISession> {
+  async createSession(token: string): Promise<RawSession> {
     this.logger.debug('Decoding token', { token });
 
     const { iat } = this.decodeJWT(token);
@@ -259,7 +260,7 @@ export class AuthenticationService {
   async changePassword(
     oldPassword: string,
     newPassword: string,
-    session: ISession
+    session: Session
   ): Promise<void> {
     if (!oldPassword)
       throw new InputException('Old Password Required', 'oldPassword');

--- a/src/components/authentication/session.pipe.ts
+++ b/src/components/authentication/session.pipe.ts
@@ -1,7 +1,8 @@
 import { Injectable, PipeTransform } from '@nestjs/common';
 import { Request } from 'express';
 import type * as core from 'express-serve-static-core';
-import { ISession, UnauthenticatedException } from '../../common';
+import { UnauthenticatedException } from '../../common';
+import { RawSession } from '../../common/session';
 import { ConfigService } from '../../core';
 import { AuthenticationService } from './authentication.service';
 
@@ -12,18 +13,19 @@ declare module 'express' {
     ReqBody = any,
     ReqQuery = core.Query
   > extends core.Request<P, ResBody, ReqBody, ReqQuery> {
-    session?: ISession;
+    session?: RawSession;
   }
 }
 
 @Injectable()
-export class SessionPipe implements PipeTransform<Request, Promise<ISession>> {
+export class SessionPipe
+  implements PipeTransform<Request, Promise<RawSession>> {
   constructor(
     private readonly auth: AuthenticationService,
     private readonly config: ConfigService
   ) {}
 
-  async transform(request: Request): Promise<ISession> {
+  async transform(request: Request): Promise<RawSession> {
     if (request?.session) {
       return request.session;
     }
@@ -37,7 +39,9 @@ export class SessionPipe implements PipeTransform<Request, Promise<ISession>> {
     return session;
   }
 
-  async createSessionFromRequest(req: Request): Promise<ISession | undefined> {
+  async createSessionFromRequest(
+    req: Request
+  ): Promise<RawSession | undefined> {
     const token =
       this.getTokenFromAuthHeader(req) || this.getTokenFromCookie(req);
 

--- a/src/components/authorization/authorization.resolver.ts
+++ b/src/components/authorization/authorization.resolver.ts
@@ -6,7 +6,7 @@ import {
   Query,
   Resolver,
 } from '@nestjs/graphql';
-import { IdField, ISession, Session } from '../../common';
+import { AnonSession, IdField, LoggedInSession, Session } from '../../common';
 import { Powers } from '../authorization/dto/powers';
 import { AuthorizationService } from './authorization.service';
 
@@ -24,13 +24,13 @@ export class AuthorizationResolver {
   constructor(private readonly authorizationService: AuthorizationService) {}
 
   @Query(() => [Powers])
-  async powers(@Session() session: ISession): Promise<Powers[]> {
+  async powers(@AnonSession() session: Session): Promise<Powers[]> {
     return await this.authorizationService.readPower(session);
   }
 
   @Mutation(() => Boolean)
   async grantPower(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args() { userId, power }: ModifyPowerArgs
   ): Promise<boolean> {
     await this.authorizationService.createPower(userId, power, session);
@@ -39,7 +39,7 @@ export class AuthorizationResolver {
 
   @Mutation(() => Boolean)
   async deletePower(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args() { userId, power }: ModifyPowerArgs
   ): Promise<boolean> {
     await this.authorizationService.deletePower(userId, power, session);
@@ -47,7 +47,9 @@ export class AuthorizationResolver {
   }
 
   @Mutation(() => Boolean)
-  async authorizationSpecial1(@Session() session: ISession): Promise<boolean> {
+  async authorizationSpecial1(
+    @LoggedInSession() session: Session
+  ): Promise<boolean> {
     await this.authorizationService.createSGsForEveryRoleForAllBaseNodes(
       session
     );

--- a/src/components/budget/budget-record.resolver.ts
+++ b/src/components/budget/budget-record.resolver.ts
@@ -5,7 +5,7 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
-import { ISession, Session } from '../../common';
+import { AnonSession, LoggedInSession, Session } from '../../common';
 import { OrganizationService } from '../organization';
 import { SecuredOrganization } from '../organization/dto';
 import { BudgetService } from './budget.service';
@@ -24,7 +24,7 @@ export class BudgetRecordResolver {
 
   @ResolveField(() => SecuredOrganization)
   async organization(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() record: BudgetRecord
   ): Promise<SecuredOrganization> {
     const id = record.organization.value;
@@ -41,7 +41,7 @@ export class BudgetRecordResolver {
     description: 'Update a budgetRecord',
   })
   async updateBudgetRecord(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { budgetRecord: input }: UpdateBudgetRecordInput
   ): Promise<UpdateBudgetRecordOutput> {
     const budgetRecord = await this.service.updateRecord(input, session);

--- a/src/components/budget/budget.resolver.ts
+++ b/src/components/budget/budget.resolver.ts
@@ -8,7 +8,7 @@ import {
   Resolver,
 } from '@nestjs/graphql';
 import { sumBy } from 'lodash';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import { FileService, SecuredFile } from '../file';
 import { BudgetService } from './budget.service';
 import {
@@ -32,7 +32,7 @@ export class BudgetResolver {
     description: 'Look up a budget by its ID',
   })
   async budget(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<Budget> {
     return await this.service.readOne(id, session);
@@ -42,7 +42,7 @@ export class BudgetResolver {
     description: 'Look up budgets by projectId',
   })
   async budgets(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => BudgetListInput,
@@ -63,7 +63,7 @@ export class BudgetResolver {
   })
   async universalTemplateFile(
     @Parent() budget: Budget,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredFile> {
     return await this.files.resolveDefinedFile(
       budget.universalTemplateFile,
@@ -75,7 +75,7 @@ export class BudgetResolver {
     description: 'Create a budget',
   })
   async createBudget(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { budget: input }: CreateBudgetInput
   ): Promise<CreateBudgetOutput> {
     const budget = await this.service.create(input, session);
@@ -86,7 +86,7 @@ export class BudgetResolver {
     description: 'Update a budget',
   })
   async updateBudget(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { budget: input }: UpdateBudgetInput
   ): Promise<UpdateBudgetOutput> {
     const budget = await this.service.update(input, session);
@@ -97,7 +97,7 @@ export class BudgetResolver {
     description: 'Delete an budget',
   })
   async deleteBudget(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.service.delete(id, session);
@@ -107,7 +107,9 @@ export class BudgetResolver {
   @Query(() => Boolean, {
     description: 'Check Consistency in Budget Nodes',
   })
-  async checkBudgetConsistency(@Session() session: ISession): Promise<boolean> {
+  async checkBudgetConsistency(
+    @LoggedInSession() session: Session
+  ): Promise<boolean> {
     return await this.service.checkBudgetConsistency(session);
   }
 }

--- a/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
+++ b/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
@@ -2,9 +2,9 @@ import { node, relation } from 'cypher-query-builder';
 import { difference } from 'lodash';
 import {
   fiscalYears,
-  ISession,
   NotFoundException,
   Secured,
+  Session,
   UnauthorizedException,
 } from '../../../common';
 import {
@@ -151,7 +151,7 @@ export class SyncBudgetRecordsToFundingPartners
     budget: Budget,
     organizationId: string,
     additions: readonly FiscalYear[],
-    session: ISession
+    session: Session
   ) {
     await Promise.all(
       additions.map((fiscalYear) =>
@@ -171,7 +171,7 @@ export class SyncBudgetRecordsToFundingPartners
     budget: Budget,
     organizationId: string,
     removals: readonly FiscalYear[],
-    session: ISession
+    session: Session
   ) {
     const recordsToDelete = budget.records.filter(
       (record) =>

--- a/src/components/ceremony/ceremony.resolver.ts
+++ b/src/components/ceremony/ceremony.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import { CeremonyService } from './ceremony.service';
 import {
   Ceremony,
@@ -17,7 +17,7 @@ export class CeremonyResolver {
     description: 'Look up a ceremony by its ID',
   })
   async ceremony(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<Ceremony> {
     return await this.service.readOne(id, session);
@@ -27,7 +27,7 @@ export class CeremonyResolver {
     description: 'Look up ceremonies',
   })
   async ceremonies(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => CeremonyListInput,
@@ -42,7 +42,7 @@ export class CeremonyResolver {
     description: 'Update a ceremony',
   })
   async updateCeremony(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { ceremony: input }: UpdateCeremonyInput
   ): Promise<UpdateCeremonyOutput> {
     const ceremony = await this.service.update(input, session);
@@ -59,7 +59,7 @@ export class CeremonyResolver {
     description: 'Check Consistency in Ceremony Nodes',
   })
   async checkCeremonyConsistency(
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<boolean> {
     return await this.service.checkCeremonyConsistency(session);
   }

--- a/src/components/ceremony/handlers/create-engagement-default-ceremony.handler.ts
+++ b/src/components/ceremony/handlers/create-engagement-default-ceremony.handler.ts
@@ -47,7 +47,7 @@ export class CreateEngagementDefaultCeremonyHandler
     await this.authorizationService.processNewBaseNode(
       dbCeremony,
       ceremony.id,
-      session.userId as string
+      session.userId
     );
 
     event.engagement = {

--- a/src/components/engagement/engagement.resolver.ts
+++ b/src/components/engagement/engagement.resolver.ts
@@ -6,7 +6,7 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import { CeremonyService, SecuredCeremony } from '../ceremony';
 import {
   CreateInternshipEngagementInput,
@@ -37,7 +37,7 @@ export class EngagementResolver {
   })
   async engagement(
     @IdArg() id: string,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<Engagement> {
     return await this.service.readOne(id, session);
   }
@@ -53,7 +53,7 @@ export class EngagementResolver {
       defaultValue: EngagementListInput.defaultVal,
     })
     input: EngagementListInput,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<EngagementListOutput> {
     return this.service.list(input, session);
   }
@@ -61,7 +61,7 @@ export class EngagementResolver {
   @ResolveField(() => SecuredCeremony)
   async ceremony(
     @Parent() engagement: Engagement,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredCeremony> {
     const { value: id, ...rest } = engagement.ceremony;
     const value = id ? await this.ceremonies.readOne(id, session) : undefined;
@@ -76,7 +76,7 @@ export class EngagementResolver {
   })
   async createLanguageEngagement(
     @Args('input') { engagement: input }: CreateLanguageEngagementInput,
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<CreateLanguageEngagementOutput> {
     const engagement = await this.service.createLanguageEngagement(
       input,
@@ -90,7 +90,7 @@ export class EngagementResolver {
   })
   async createInternshipEngagement(
     @Args('input') { engagement: input }: CreateInternshipEngagementInput,
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<CreateInternshipEngagementOutput> {
     const engagement = await this.service.createInternshipEngagement(
       input,
@@ -104,7 +104,7 @@ export class EngagementResolver {
   })
   async updateLanguageEngagement(
     @Args('input') { engagement: input }: UpdateLanguageEngagementInput,
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<UpdateLanguageEngagementOutput> {
     const engagement = await this.service.updateLanguageEngagement(
       input,
@@ -118,7 +118,7 @@ export class EngagementResolver {
   })
   async updateInternshipEngagement(
     @Args('input') { engagement: input }: UpdateInternshipEngagementInput,
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<UpdateInternshipEngagementOutput> {
     const engagement = await this.service.updateInternshipEngagement(
       input,
@@ -132,7 +132,7 @@ export class EngagementResolver {
   })
   async deleteEngagement(
     @IdArg() id: string,
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<boolean> {
     await this.service.delete(id, session);
     return true;
@@ -143,7 +143,7 @@ export class EngagementResolver {
   })
   async checkEngagementConsistency(
     @Args('input') input: EngagementConsistencyInput,
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<boolean> {
     return await this.service.checkEngagementConsistency(
       input.baseNode,

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -6,10 +6,9 @@ import {
   DuplicateException,
   generateId,
   InputException,
-  ISession,
   NotFoundException,
   ServerException,
-  UnauthenticatedException,
+  Session,
 } from '../../common';
 import {
   ConfigService,
@@ -116,11 +115,8 @@ export class EngagementService {
 
   async createLanguageEngagement(
     { languageId, projectId, ...input }: CreateLanguageEngagement,
-    session: ISession
+    session: Session
   ): Promise<LanguageEngagement> {
-    if (!session.userId) {
-      throw new UnauthenticatedException('user not logged in');
-    }
     // LanguageEngagements can only be created on TranslationProjects
     const projectType = await this.getProjectTypeById(projectId);
 
@@ -320,11 +316,8 @@ export class EngagementService {
       countryOfOriginId,
       ...input
     }: CreateInternshipEngagement,
-    session: ISession
+    session: Session
   ): Promise<InternshipEngagement> {
-    if (!session.userId) {
-      throw new UnauthenticatedException('user not logged in');
-    }
     // InternshipEngagements can only be created on InternshipProjects
     const projectType = await this.getProjectTypeById(projectId);
 
@@ -576,17 +569,12 @@ export class EngagementService {
 
   async readOne(
     id: string,
-    session: ISession
+    session: Session
   ): Promise<LanguageEngagement | InternshipEngagement> {
     this.logger.debug('readOne', { id, userId: session.userId });
 
     if (!id) {
       throw new NotFoundException('no id given', 'engagement.id');
-    }
-
-    if (!session.userId) {
-      this.logger.debug('using anon user id');
-      session.userId = this.config.anonUser.id;
     }
 
     const query = this.db
@@ -750,7 +738,7 @@ export class EngagementService {
 
   async updateLanguageEngagement(
     input: UpdateLanguageEngagement,
-    session: ISession
+    session: Session
   ): Promise<LanguageEngagement> {
     if (input.firstScripture) {
       await this.verifyFirstScripture({ engagementId: input.id });
@@ -823,7 +811,7 @@ export class EngagementService {
       countryOfOriginId,
       ...input
     }: UpdateInternshipEngagement,
-    session: ISession
+    session: Session
   ): Promise<InternshipEngagement> {
     const createdAt = DateTime.local();
 
@@ -973,7 +961,7 @@ export class EngagementService {
 
   // DELETE /////////////////////////////////////////////////////////
 
-  async delete(id: string, session: ISession): Promise<void> {
+  async delete(id: string, session: Session): Promise<void> {
     const object = await this.readOne(id, session);
 
     if (!object) {
@@ -1000,7 +988,7 @@ export class EngagementService {
 
   async list(
     { filter, ...input }: EngagementListInput,
-    session: ISession
+    session: Session
   ): Promise<EngagementListOutput> {
     let label = 'Engagement';
     if (filter.type === 'language') {
@@ -1036,7 +1024,7 @@ export class EngagementService {
   async listProducts(
     engagement: LanguageEngagement,
     input: ProductListInput,
-    session: ISession
+    session: Session
   ): Promise<SecuredProductList> {
     const result = await this.products.list(
       {
@@ -1097,7 +1085,7 @@ export class EngagementService {
 
   async checkEngagementConsistency(
     baseNode: string,
-    session: ISession
+    session: Session
   ): Promise<boolean> {
     const nodes = await this.db
       .query()
@@ -1124,7 +1112,7 @@ export class EngagementService {
   async isLanguageEngagementConsistent(
     nodes: Record<string, any>,
     baseNode: string,
-    session: ISession
+    session: Session
   ): Promise<boolean> {
     const requiredProperties: never[] = []; // add more after discussing
     return (
@@ -1163,7 +1151,7 @@ export class EngagementService {
   async isInternshipEngagementConsistent(
     nodes: Record<string, any>,
     baseNode: string,
-    session: ISession
+    session: Session
   ): Promise<boolean> {
     // right now all properties are optional
     const requiredProperties: never[] = [];

--- a/src/components/engagement/events/engagement-created.event.ts
+++ b/src/components/engagement/events/engagement-created.event.ts
@@ -1,6 +1,6 @@
-import { ISession } from '../../../common';
+import { Session } from '../../../common';
 import { Engagement } from '../dto';
 
 export class EngagementCreatedEvent {
-  constructor(public engagement: Engagement, readonly session: ISession) {}
+  constructor(public engagement: Engagement, readonly session: Session) {}
 }

--- a/src/components/engagement/events/engagement-deleted.event.ts
+++ b/src/components/engagement/events/engagement-deleted.event.ts
@@ -1,6 +1,6 @@
-import { ISession } from '../../../common';
+import { Session } from '../../../common';
 import { Engagement } from '../dto';
 
 export class EngagementDeletedEvent {
-  constructor(readonly engagement: Engagement, readonly session: ISession) {}
+  constructor(readonly engagement: Engagement, readonly session: Session) {}
 }

--- a/src/components/engagement/events/engagement-updated.event.ts
+++ b/src/components/engagement/events/engagement-updated.event.ts
@@ -1,4 +1,4 @@
-import { ISession } from '../../../common';
+import { Session } from '../../../common';
 import { Engagement, UpdateEngagement } from '../dto';
 
 export class EngagementUpdatedEvent {
@@ -6,6 +6,6 @@ export class EngagementUpdatedEvent {
     public updated: Engagement,
     readonly previous: Engagement,
     readonly updates: UpdateEngagement,
-    readonly session: ISession
+    readonly session: Session
   ) {}
 }

--- a/src/components/engagement/handlers/set-initial-end-date.handler.ts
+++ b/src/components/engagement/handlers/set-initial-end-date.handler.ts
@@ -1,4 +1,4 @@
-import { CalendarDate, ISession, ServerException } from '../../../common';
+import { CalendarDate, ServerException, Session } from '../../../common';
 import {
   DatabaseService,
   EventsHandler,
@@ -66,7 +66,7 @@ export class SetInitialEndDate implements IEventHandler<SubscribedEvent> {
   private async updateEngagementInitialEndDate(
     engagement: Engagement,
     initialEndDate: CalendarDate,
-    session: ISession
+    session: Session
   ) {
     const updateInput = {
       id: engagement.id,

--- a/src/components/engagement/internship-engagement.resolver.ts
+++ b/src/components/engagement/internship-engagement.resolver.ts
@@ -1,5 +1,5 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { ISession, Session } from '../../common';
+import { AnonSession, Session } from '../../common';
 import { FileService, SecuredFile } from '../file';
 import { LocationService } from '../location';
 import { SecuredLocation } from '../location/dto';
@@ -17,7 +17,7 @@ export class InternshipEngagementResolver {
   @ResolveField(() => SecuredFile)
   async growthPlan(
     @Parent() engagement: InternshipEngagement,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredFile> {
     return await this.files.resolveDefinedFile(engagement.growthPlan, session);
   }
@@ -25,7 +25,7 @@ export class InternshipEngagementResolver {
   @ResolveField(() => SecuredUser)
   async intern(
     @Parent() engagement: InternshipEngagement,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredUser> {
     const { value: id, ...rest } = engagement.intern;
     const value = id ? await this.users.readOne(id, session) : undefined;
@@ -38,7 +38,7 @@ export class InternshipEngagementResolver {
   @ResolveField(() => SecuredUser)
   async mentor(
     @Parent() engagement: InternshipEngagement,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredUser> {
     const { value: id, ...rest } = engagement.mentor;
     const value = id ? await this.users.readOne(id, session) : undefined;
@@ -51,7 +51,7 @@ export class InternshipEngagementResolver {
   @ResolveField(() => SecuredLocation)
   async countryOfOrigin(
     @Parent() engagement: InternshipEngagement,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredLocation> {
     const { value: id, ...rest } = engagement.countryOfOrigin;
     const value = id ? await this.locations.readOne(id, session) : undefined;

--- a/src/components/engagement/language-engagement.resolver.ts
+++ b/src/components/engagement/language-engagement.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { ISession, Session } from '../../common';
+import { AnonSession, Session } from '../../common';
 import { FileService, SecuredFile } from '../file';
 import { LanguageService } from '../language';
 import { SecuredLanguage } from '../language/dto';
@@ -18,7 +18,7 @@ export class LanguageEngagementResolver {
   @ResolveField(() => SecuredLanguage)
   async language(
     @Parent() engagement: LanguageEngagement,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredLanguage> {
     const { value: id, ...rest } = engagement.language;
     const value = id ? await this.languages.readOne(id, session) : undefined;
@@ -31,7 +31,7 @@ export class LanguageEngagementResolver {
   @ResolveField(() => SecuredProductList)
   async products(
     @Parent() engagement: LanguageEngagement,
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => ProductListInput,
@@ -49,7 +49,7 @@ export class LanguageEngagementResolver {
   @ResolveField(() => SecuredFile)
   async pnp(
     @Parent() engagement: LanguageEngagement,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredFile> {
     return await this.files.resolveDefinedFile(engagement.pnp, session);
   }

--- a/src/components/field-region/field-region.resolver.ts
+++ b/src/components/field-region/field-region.resolver.ts
@@ -6,7 +6,7 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import { FieldZoneService, SecuredFieldZone } from '../field-zone';
 import { SecuredUser, UserService } from '../user';
 import {
@@ -32,7 +32,7 @@ export class FieldRegionResolver {
     description: 'Read one field region by id',
   })
   async fieldRegion(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<FieldRegion> {
     return await this.fieldRegionService.readOne(id, session);
@@ -42,7 +42,7 @@ export class FieldRegionResolver {
     description: 'Look up field regions',
   })
   async fieldRegions(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => FieldRegionListInput,
@@ -56,7 +56,7 @@ export class FieldRegionResolver {
   @ResolveField(() => SecuredUser)
   async director(
     @Parent() fieldRegion: FieldRegion,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredUser> {
     const { value: id, ...rest } = fieldRegion.director;
     const value = id ? await this.userService.readOne(id, session) : undefined;
@@ -69,7 +69,7 @@ export class FieldRegionResolver {
   @ResolveField(() => SecuredFieldZone)
   async fieldZone(
     @Parent() region: FieldRegion,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredFieldZone> {
     const { value: id, ...rest } = region.fieldZone;
     const value = id
@@ -85,7 +85,7 @@ export class FieldRegionResolver {
     description: 'Create a field region',
   })
   async createFieldRegion(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { fieldRegion: input }: CreateFieldRegionInput
   ): Promise<CreateFieldRegionOutput> {
     const fieldRegion = await this.fieldRegionService.create(input, session);
@@ -96,7 +96,7 @@ export class FieldRegionResolver {
     description: 'Update a field region',
   })
   async updateFieldRegion(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { fieldRegion: input }: UpdateFieldRegionInput
   ): Promise<UpdateFieldRegionOutput> {
     const fieldRegion = await this.fieldRegionService.update(input, session);
@@ -107,7 +107,7 @@ export class FieldRegionResolver {
     description: 'Delete a field region',
   })
   async deleteFieldRegion(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.fieldRegionService.delete(id, session);

--- a/src/components/field-region/field-region.service.ts
+++ b/src/components/field-region/field-region.service.ts
@@ -4,9 +4,9 @@ import { DateTime } from 'luxon';
 import {
   DuplicateException,
   generateId,
-  ISession,
   NotFoundException,
   ServerException,
+  Session,
 } from '../../common';
 import {
   ConfigService,
@@ -78,7 +78,7 @@ export class FieldRegionService {
 
   async create(
     { fieldZoneId, directorId, ...input }: CreateFieldRegion,
-    session: ISession
+    session: Session
   ): Promise<FieldRegion> {
     const checkName = await this.db
       .query()
@@ -142,22 +142,18 @@ export class FieldRegionService {
     await this.authorizationService.processNewBaseNode(
       dbFieldRegion,
       result.id,
-      session.userId as string
+      session.userId
     );
 
     this.logger.debug(`field region created`, { id: result.id });
     return await this.readOne(result.id, session);
   }
 
-  async readOne(id: string, session: ISession): Promise<FieldRegion> {
+  async readOne(id: string, session: Session): Promise<FieldRegion> {
     this.logger.debug(`Read Field Region`, {
       id: id,
       userId: session.userId,
     });
-
-    if (!session.userId) {
-      session.userId = this.config.anonUser.id;
-    }
 
     const query = this.db
       .query()
@@ -217,7 +213,7 @@ export class FieldRegionService {
 
   async update(
     input: UpdateFieldRegion,
-    session: ISession
+    session: Session
   ): Promise<FieldRegion> {
     const fieldRegion = await this.readOne(input.id, session);
 
@@ -234,13 +230,13 @@ export class FieldRegionService {
     return await this.readOne(input.id, session);
   }
 
-  async delete(_id: string, _session: ISession): Promise<void> {
+  async delete(_id: string, _session: Session): Promise<void> {
     // Not Implemented
   }
 
   async list(
     { filter, ...input }: FieldRegionListInput,
-    session: ISession
+    session: Session
   ): Promise<FieldRegionListOutput> {
     const label = 'FieldRegion';
     const query = this.db

--- a/src/components/field-zone/field-zone.resolver.ts
+++ b/src/components/field-zone/field-zone.resolver.ts
@@ -6,7 +6,7 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import { SecuredUser, UserService } from '../user';
 import {
   CreateFieldZoneInput,
@@ -30,7 +30,7 @@ export class FieldZoneResolver {
     description: 'Read one field zone by id',
   })
   async fieldZone(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<FieldZone> {
     return await this.fieldZoneService.readOne(id, session);
@@ -40,7 +40,7 @@ export class FieldZoneResolver {
     description: 'Look up field zones',
   })
   async fieldZones(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => FieldZoneListInput,
@@ -54,7 +54,7 @@ export class FieldZoneResolver {
   @ResolveField(() => SecuredUser)
   async director(
     @Parent() fieldZone: FieldZone,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredUser> {
     const { value: id, ...rest } = fieldZone.director;
     const value = id ? await this.userService.readOne(id, session) : undefined;
@@ -68,7 +68,7 @@ export class FieldZoneResolver {
     description: 'Create a field zone',
   })
   async createFieldZone(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { fieldZone: input }: CreateFieldZoneInput
   ): Promise<CreateFieldZoneOutput> {
     const fieldZone = await this.fieldZoneService.create(input, session);
@@ -79,7 +79,7 @@ export class FieldZoneResolver {
     description: 'Update a field zone',
   })
   async updateFieldZone(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { fieldZone: input }: UpdateFieldZoneInput
   ): Promise<UpdateFieldZoneOutput> {
     const fieldZone = await this.fieldZoneService.update(input, session);
@@ -90,7 +90,7 @@ export class FieldZoneResolver {
     description: 'Delete a field zone',
   })
   async deleteFieldZone(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.fieldZoneService.delete(id, session);

--- a/src/components/field-zone/field-zone.service.ts
+++ b/src/components/field-zone/field-zone.service.ts
@@ -4,9 +4,9 @@ import { DateTime } from 'luxon';
 import {
   DuplicateException,
   generateId,
-  ISession,
   NotFoundException,
   ServerException,
+  Session,
 } from '../../common';
 import {
   ConfigService,
@@ -76,7 +76,7 @@ export class FieldZoneService {
 
   async create(
     { directorId, ...input }: CreateFieldZone,
-    session: ISession
+    session: Session
   ): Promise<FieldZone> {
     const checkName = await this.db
       .query()
@@ -130,22 +130,18 @@ export class FieldZoneService {
     await this.authorizationService.processNewBaseNode(
       dbFieldZone,
       result.id,
-      session.userId as string
+      session.userId
     );
 
     this.logger.debug(`field zone created`, { id: result.id });
     return await this.readOne(result.id, session);
   }
 
-  async readOne(id: string, session: ISession): Promise<FieldZone> {
+  async readOne(id: string, session: Session): Promise<FieldZone> {
     this.logger.debug(`Read Field Zone`, {
       id: id,
       userId: session.userId,
     });
-
-    if (!session.userId) {
-      session.userId = this.config.anonUser.id;
-    }
 
     const query = this.db
       .query()
@@ -188,7 +184,7 @@ export class FieldZoneService {
     };
   }
 
-  async update(input: UpdateFieldZone, session: ISession): Promise<FieldZone> {
+  async update(input: UpdateFieldZone, session: Session): Promise<FieldZone> {
     const fieldZone = await this.readOne(input.id, session);
 
     // update director
@@ -204,13 +200,13 @@ export class FieldZoneService {
     return await this.readOne(input.id, session);
   }
 
-  async delete(_id: string, _session: ISession): Promise<void> {
+  async delete(_id: string, _session: Session): Promise<void> {
     // Not Implemented
   }
 
   async list(
     { filter, ...input }: FieldZoneListInput,
-    session: ISession
+    session: Session
   ): Promise<FieldZoneListOutput> {
     const label = 'FieldZone';
     const query = this.db

--- a/src/components/file/directory.resolver.ts
+++ b/src/components/file/directory.resolver.ts
@@ -6,7 +6,7 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import {
   CreateDirectoryInput,
   Directory,
@@ -22,7 +22,7 @@ export class DirectoryResolver {
   @Query(() => Directory)
   async directory(
     @IdArg() id: string,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<Directory> {
     return await this.service.getDirectory(id, session);
   }
@@ -31,7 +31,7 @@ export class DirectoryResolver {
     description: 'Return the file nodes of this directory',
   })
   async children(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() node: Directory,
     @Args({
       name: 'input',
@@ -45,7 +45,7 @@ export class DirectoryResolver {
 
   @Mutation(() => Directory)
   async createDirectory(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { parentId, name }: CreateDirectoryInput
   ): Promise<Directory> {
     return await this.service.createDirectory(parentId, name, session);

--- a/src/components/file/file-node.resolver.ts
+++ b/src/components/file/file-node.resolver.ts
@@ -1,6 +1,6 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
-import { ISession, Session } from '../../common';
+import { AnonSession, Session } from '../../common';
 import { User, UserService } from '../user';
 import { FileNode, IFileNode } from './dto';
 import { FileService } from './file.service';
@@ -20,7 +20,7 @@ export class FileNodeResolver {
   })
   async createdBy(
     @Parent() node: FileNode,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<User> {
     return await this.users.readOne(node.createdById, session);
   }
@@ -34,7 +34,7 @@ export class FileNodeResolver {
   })
   async parents(
     @Parent() node: FileNode,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<readonly FileNode[]> {
     return await this.service.getParents(node.id, session);
   }

--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -13,9 +13,9 @@ import { isEmpty } from 'lodash';
 import { DateTime } from 'luxon';
 import {
   generateId,
-  ISession,
   NotFoundException,
   ServerException,
+  Session,
 } from '../../common';
 import {
   ConfigService,
@@ -39,7 +39,7 @@ export class FileRepository {
     @Logger('file:repository') private readonly logger: ILogger
   ) {}
 
-  async getBaseNodeById(id: string, session: ISession): Promise<BaseNode> {
+  async getBaseNodeById(id: string, session: Session): Promise<BaseNode> {
     return await this.getBaseNodeBy(session, [
       [node('node', 'FileNode', { id })],
       matchName(),
@@ -49,7 +49,7 @@ export class FileRepository {
   async getBaseNodeByName(
     parentId: string,
     name: string,
-    session: ISession
+    session: Session
   ): Promise<BaseNode> {
     return await this.getBaseNodeBy(session, [
       [
@@ -62,7 +62,7 @@ export class FileRepository {
     ]);
   }
 
-  async getParentsById(id: string, session: ISession): Promise<BaseNode[]> {
+  async getParentsById(id: string, session: Session): Promise<BaseNode[]> {
     const query = this.getBaseNodeQuery(session, [
       [
         node('start', 'FileNode', { id }),
@@ -76,7 +76,7 @@ export class FileRepository {
   }
 
   async getChildrenById(
-    session: ISession,
+    session: Session,
     nodeId: string,
     options: FileListInput | undefined
   ) {
@@ -133,7 +133,7 @@ export class FileRepository {
   }
 
   private async getBaseNodeBy(
-    session: ISession,
+    session: Session,
     patterns: Pattern[][]
   ): Promise<BaseNode> {
     const nodes = await this.getBaseNodesBy(session, patterns);
@@ -141,7 +141,7 @@ export class FileRepository {
   }
 
   private async getBaseNodesBy(
-    session: ISession,
+    session: Session,
     patterns: Pattern[][]
   ): Promise<BaseNode[]> {
     const query = this.getBaseNodeQuery(session, patterns);
@@ -149,7 +149,7 @@ export class FileRepository {
     return results;
   }
 
-  private getBaseNodeQuery(session: ISession, patterns: Pattern[][]) {
+  private getBaseNodeQuery(session: Session, patterns: Pattern[][]) {
     this.db.assertPatternsIncludeIdentifier(patterns, 'node', 'name');
 
     const query = this.db
@@ -185,7 +185,7 @@ export class FileRepository {
     return latestVersionResult.fv.properties.id;
   }
 
-  async getVersionDetails(id: string, session: ISession): Promise<FileVersion> {
+  async getVersionDetails(id: string, session: Session): Promise<FileVersion> {
     const matchLatestVersionProp = (q: Query, prop: string, variable = prop) =>
       q
         .with('*')
@@ -250,7 +250,7 @@ export class FileRepository {
   async createDirectory(
     parentId: string | undefined,
     name: string,
-    session: ISession
+    session: Session
   ): Promise<string> {
     const props: Property[] = [
       {
@@ -291,7 +291,7 @@ export class FileRepository {
   async createFile(
     fileId: string,
     name: string,
-    session: ISession,
+    session: Session,
     parentId?: string
   ) {
     const props: Property[] = [
@@ -328,7 +328,7 @@ export class FileRepository {
   async createFileVersion(
     fileId: string,
     input: Pick<FileVersion, 'id' | 'name' | 'mimeType' | 'size'>,
-    session: ISession
+    session: Session
   ) {
     const props: Property[] = [
       {
@@ -370,7 +370,7 @@ export class FileRepository {
     return result;
   }
 
-  private async attachCreator(id: string, session: ISession) {
+  private async attachCreator(id: string, session: Session) {
     await this.db
       .query()
       .match([
@@ -421,7 +421,7 @@ export class FileRepository {
   async rename(
     fileNode: BaseNode,
     newName: string,
-    session: ISession
+    session: Session
   ): Promise<void> {
     try {
       await this.db.sgUpdateProperty({
@@ -437,11 +437,7 @@ export class FileRepository {
     }
   }
 
-  async move(
-    id: string,
-    newParentId: string,
-    session: ISession
-  ): Promise<void> {
+  async move(id: string, newParentId: string, session: Session): Promise<void> {
     try {
       await this.db
         .query()
@@ -470,7 +466,7 @@ export class FileRepository {
     }
   }
 
-  async delete(fileNode: BaseNode, session: ISession): Promise<void> {
+  async delete(fileNode: BaseNode, session: Session): Promise<void> {
     try {
       await this.db.deleteNode({
         session,
@@ -483,7 +479,7 @@ export class FileRepository {
     }
   }
 
-  async checkConsistency(type: FileNodeType, session: ISession): Promise<void> {
+  async checkConsistency(type: FileNodeType, session: Session): Promise<void> {
     const fileNodes = await this.db
       .query()
       .matchNode('fileNode', type)

--- a/src/components/file/file.resolver.ts
+++ b/src/components/file/file.resolver.ts
@@ -7,7 +7,7 @@ import {
   Resolver,
 } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import { User, UserService } from '../user';
 import {
   CreateFileVersionInput,
@@ -31,14 +31,17 @@ export class FileResolver {
   ) {}
 
   @Query(() => File)
-  async file(@IdArg() id: string, @Session() session: ISession): Promise<File> {
+  async file(
+    @IdArg() id: string,
+    @AnonSession() session: Session
+  ): Promise<File> {
     return await this.service.getFile(id, session);
   }
 
   @Query(() => IFileNode)
   async fileNode(
     @IdArg() id: string,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<FileNode> {
     return await this.service.getFileNode(id, session);
   }
@@ -48,7 +51,7 @@ export class FileResolver {
   })
   async modifiedBy(
     @Parent() node: File,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<User> {
     return await this.users.readOne(node.modifiedById, session);
   }
@@ -57,7 +60,7 @@ export class FileResolver {
     description: 'Return the versions of this file',
   })
   async children(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() node: File,
     @Args({
       name: 'input',
@@ -81,7 +84,7 @@ export class FileResolver {
   })
   async deleteFileNode(
     @IdArg() id: string,
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<boolean> {
     await this.service.delete(id, session);
     return true;
@@ -91,7 +94,7 @@ export class FileResolver {
     description: 'Start the file upload process by requesting an upload',
   })
   async requestFileUpload(
-    @Session() _session: ISession // require authorized
+    @LoggedInSession() _session: Session // require authorized
   ): Promise<RequestUploadOutput> {
     return await this.service.requestUpload();
   }
@@ -107,7 +110,7 @@ export class FileResolver {
   })
   createFileVersion(
     @Args('input') input: CreateFileVersionInput,
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<File> {
     return this.service.createFileVersion(input, session);
   }
@@ -117,7 +120,7 @@ export class FileResolver {
   })
   async renameFileNode(
     @Args('input') input: RenameFileInput,
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<FileNode> {
     await this.service.rename(input, session);
     return await this.service.getFileNode(input.id, session);
@@ -128,7 +131,7 @@ export class FileResolver {
   })
   moveFileNode(
     @Args('input') input: MoveFileInput,
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<FileNode> {
     return this.service.move(input, session);
   }
@@ -139,7 +142,7 @@ export class FileResolver {
   })
   async checkFileConsistency(
     @Args({ name: 'type', type: () => FileNodeType }) type: FileNodeType,
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<boolean> {
     try {
       await this.service.checkConsistency(type, session);

--- a/src/components/file/handlers/attach-project-root-directory.handler.ts
+++ b/src/components/file/handlers/attach-project-root-directory.handler.ts
@@ -44,7 +44,7 @@ export class AttachProjectRootDirectoryHandler
     await this.authorizationService.processNewBaseNode(
       dbDirectory,
       rootDir.id,
-      session.userId!
+      session.userId
     );
   }
 }

--- a/src/components/film/film.resolver.ts
+++ b/src/components/film/film.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import {
   CreateFilmInput,
   CreateFilmOutput,
@@ -18,7 +18,10 @@ export class FilmResolver {
   @Query(() => Film, {
     description: 'Look up a film by its ID',
   })
-  async film(@Session() session: ISession, @IdArg() id: string): Promise<Film> {
+  async film(
+    @AnonSession() session: Session,
+    @IdArg() id: string
+  ): Promise<Film> {
     return await this.filmService.readOne(id, session);
   }
 
@@ -26,7 +29,7 @@ export class FilmResolver {
     description: 'Look up films',
   })
   async films(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => FilmListInput,
@@ -41,7 +44,7 @@ export class FilmResolver {
     description: 'Create a film',
   })
   async createFilm(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { film: input }: CreateFilmInput
   ): Promise<CreateFilmOutput> {
     const film = await this.filmService.create(input, session);
@@ -52,7 +55,7 @@ export class FilmResolver {
     description: 'Update a film',
   })
   async updateFilm(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { film: input }: UpdateFilmInput
   ): Promise<UpdateFilmOutput> {
     const film = await this.filmService.update(input, session);
@@ -63,7 +66,7 @@ export class FilmResolver {
     description: 'Delete a film',
   })
   async deleteFilm(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.filmService.delete(id, session);

--- a/src/components/funding-account/funding-account.resolver.ts
+++ b/src/components/funding-account/funding-account.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import {
   CreateFundingAccountInput,
   CreateFundingAccountOutput,
@@ -19,7 +19,7 @@ export class FundingAccountResolver {
     description: 'Look up a funding account by its ID',
   })
   async fundingAccount(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<FundingAccount> {
     return await this.fundingAccountService.readOne(id, session);
@@ -29,7 +29,7 @@ export class FundingAccountResolver {
     description: 'Look up funding accounts',
   })
   async fundingAccounts(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => FundingAccountListInput,
@@ -44,7 +44,7 @@ export class FundingAccountResolver {
     description: 'Create a funding account',
   })
   async createFundingAccount(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { fundingAccount: input }: CreateFundingAccountInput
   ): Promise<CreateFundingAccountOutput> {
     const fundingAccount = await this.fundingAccountService.create(
@@ -58,7 +58,7 @@ export class FundingAccountResolver {
     description: 'Update a funding account',
   })
   async updateFundingAccount(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { fundingAccount: input }: UpdateFundingAccountInput
   ): Promise<UpdateFundingAccountOutput> {
     const fundingAccount = await this.fundingAccountService.update(
@@ -72,7 +72,7 @@ export class FundingAccountResolver {
     description: 'Delete a funding account',
   })
   async deleteFundingAccount(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.fundingAccountService.delete(id, session);

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -3,9 +3,9 @@ import { node } from 'cypher-query-builder';
 import {
   DuplicateException,
   generateId,
-  ISession,
   NotFoundException,
   ServerException,
+  Session,
 } from '../../common';
 import {
   ConfigService,
@@ -78,7 +78,7 @@ export class FundingAccountService {
 
   async create(
     input: CreateFundingAccount,
-    session: ISession
+    session: Session
   ): Promise<FundingAccount> {
     const checkFundingAccount = await this.db
       .query()
@@ -126,7 +126,7 @@ export class FundingAccountService {
       await this.authorizationService.processNewBaseNode(
         dbFundingAccount,
         result.id,
-        session.userId as string
+        session.userId
       );
 
       this.logger.info(`funding account created`, { id: result.id });
@@ -141,15 +141,11 @@ export class FundingAccountService {
     }
   }
 
-  async readOne(id: string, session: ISession): Promise<FundingAccount> {
+  async readOne(id: string, session: Session): Promise<FundingAccount> {
     this.logger.info('readOne', { id, userId: session.userId });
 
     if (!id) {
       throw new NotFoundException('Invalid: Blank ID');
-    }
-
-    if (!session.userId) {
-      session.userId = this.config.anonUser.id;
     }
 
     const readFundingAccount = this.db
@@ -182,7 +178,7 @@ export class FundingAccountService {
 
   async update(
     input: UpdateFundingAccount,
-    session: ISession
+    session: Session
   ): Promise<FundingAccount> {
     const fundingAccount = await this.readOne(input.id, session);
 
@@ -195,13 +191,13 @@ export class FundingAccountService {
     });
   }
 
-  async delete(_id: string, _session: ISession): Promise<void> {
+  async delete(_id: string, _session: Session): Promise<void> {
     // Not implemented
   }
 
   async list(
     input: FundingAccountListInput,
-    session: ISession
+    session: Session
   ): Promise<FundingAccountListOutput> {
     const label = 'FundingAccount';
 

--- a/src/components/language/ethnologue-language/ethnologue-language.service.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.service.ts
@@ -3,9 +3,9 @@ import { node, relation } from 'cypher-query-builder';
 import { pickBy } from 'lodash';
 import {
   generateId,
-  ISession,
   NotFoundException,
   ServerException,
+  Session,
 } from '../../../common';
 import {
   ConfigService,
@@ -43,7 +43,7 @@ export class EthnologueLanguageService {
 
   async create(
     input: CreateEthnologueLanguage,
-    session: ISession
+    session: Session
   ): Promise<string> {
     const secureProps: Property[] = [
       {
@@ -99,7 +99,7 @@ export class EthnologueLanguageService {
     await this.authorizationService.processNewBaseNode(
       dbEthnologueLanguage,
       result.id,
-      session.userId as string
+      session.userId
     );
 
     const id = result.id;
@@ -109,11 +109,7 @@ export class EthnologueLanguageService {
     return id;
   }
 
-  async readOne(id: string, session: ISession): Promise<EthnologueLanguage> {
-    if (!session.userId) {
-      session.userId = this.config.anonUser.id;
-    }
-
+  async readOne(id: string, session: Session): Promise<EthnologueLanguage> {
     const query = this.db
       .query()
       .call(matchRequestingUser, session)
@@ -157,7 +153,7 @@ export class EthnologueLanguageService {
     };
   }
 
-  async update(id: string, input: UpdateEthnologueLanguage, session: ISession) {
+  async update(id: string, input: UpdateEthnologueLanguage, session: Session) {
     if (!input) return;
 
     // Make a mapping of the fields that we want to set in the db to the inputs

--- a/src/components/language/language.resolver.ts
+++ b/src/components/language/language.resolver.ts
@@ -9,10 +9,11 @@ import {
 } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import {
+  AnonSession,
   firstLettersOfWords,
   IdArg,
   IdField,
-  ISession,
+  LoggedInSession,
   SecuredDate,
   SecuredInt,
   Session,
@@ -47,7 +48,7 @@ export class LanguageResolver {
     description: 'Look up a language by its ID',
   })
   async language(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<Language> {
     return await this.langService.readOne(id, session);
@@ -82,7 +83,7 @@ export class LanguageResolver {
 
   @ResolveField(() => SecuredLocationList)
   async locations(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() language: Language,
     @Args({
       name: 'input',
@@ -98,7 +99,7 @@ export class LanguageResolver {
     description: 'The earliest start date from its engagements.',
   })
   async sponsorStartDate(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() language: Language
   ): Promise<SecuredDate> {
     return await this.langService.sponsorStartDate(language, session);
@@ -108,7 +109,7 @@ export class LanguageResolver {
     description: 'The list of projects the language is engagement in.',
   })
   async projects(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() language: Language,
     @Args({
       name: 'input',
@@ -124,7 +125,7 @@ export class LanguageResolver {
     description: 'Look up languages',
   })
   async languages(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => LanguageListInput,
@@ -139,7 +140,7 @@ export class LanguageResolver {
     description: 'Create a language',
   })
   async createLanguage(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { language: input }: CreateLanguageInput
   ): Promise<CreateLanguageOutput> {
     const language = await this.langService.create(input, session);
@@ -150,7 +151,7 @@ export class LanguageResolver {
     description: 'Update a language',
   })
   async updateLanguage(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { language: input }: UpdateLanguageInput
   ): Promise<UpdateLanguageOutput> {
     const language = await this.langService.update(input, session);
@@ -161,7 +162,7 @@ export class LanguageResolver {
     description: 'Delete a language',
   })
   async deleteLanguage(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.langService.delete(id, session);
@@ -172,7 +173,7 @@ export class LanguageResolver {
     description: 'Add a location to a language',
   })
   async addLocationToLanguage(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args() { languageId, locationId }: ModifyLocationArgs
   ): Promise<Language> {
     await this.langService.addLocation(languageId, locationId, session);
@@ -183,7 +184,7 @@ export class LanguageResolver {
     description: 'Remove a location from a language',
   })
   async removeLocationFromLanguage(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args() { languageId, locationId }: ModifyLocationArgs
   ): Promise<Language> {
     await this.langService.removeLocation(languageId, locationId, session);
@@ -194,7 +195,7 @@ export class LanguageResolver {
     description: 'Check language node consistency',
   })
   async checkLanguageConsistency(
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<boolean> {
     return await this.langService.checkLanguageConsistency(session);
   }

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -7,10 +7,10 @@ import {
   DuplicateException,
   generateId,
   InputException,
-  ISession,
   NotFoundException,
   SecuredDate,
   ServerException,
+  Session,
   simpleSwitch,
 } from '../../common';
 import {
@@ -141,17 +141,14 @@ export class LanguageService {
     ];
   }
 
-  async create(input: CreateLanguage, session: ISession): Promise<Language> {
+  async create(input: CreateLanguage, session: Session): Promise<Language> {
     const createdAt = DateTime.local();
 
-    await this.authorizationService.checkPower(
-      Powers.CreateLanguage,
-      session.userId
-    );
+    await this.authorizationService.checkPower(Powers.CreateLanguage, session);
 
     await this.authorizationService.checkPower(
       Powers.CreateEthnologueLanguage,
-      session.userId
+      session
     );
 
     try {
@@ -292,7 +289,7 @@ export class LanguageService {
       await this.authorizationService.processNewBaseNode(
         dbLanguage,
         resultLanguage.id,
-        session.userId as string
+        session.userId
       );
 
       const result = await this.readOne(resultLanguage.id, session);
@@ -317,11 +314,7 @@ export class LanguageService {
     }
   }
 
-  async readOne(langId: string, session: ISession): Promise<Language> {
-    if (!session.userId) {
-      session.userId = this.config.anonUser.id;
-    }
-
+  async readOne(langId: string, session: Session): Promise<Language> {
     const query = this.db
       .query()
       .call(matchRequestingUser, session)
@@ -387,7 +380,7 @@ export class LanguageService {
 
   async update(
     { ethnologue: newEthnologue, ...input }: UpdateLanguage,
-    session: ISession
+    session: Session
   ): Promise<Language> {
     if (input.hasExternalFirstScripture) {
       await this.verifyExternalFirstScripture(input.id);
@@ -466,11 +459,8 @@ export class LanguageService {
     return await this.readOne(input.id, session);
   }
 
-  async delete(id: string, session: ISession): Promise<void> {
-    await this.authorizationService.checkPower(
-      Powers.DeleteLanguage,
-      session.userId
-    );
+  async delete(id: string, session: Session): Promise<void> {
+    await this.authorizationService.checkPower(Powers.DeleteLanguage, session);
 
     const object = await this.readOne(id, session);
 
@@ -500,7 +490,7 @@ export class LanguageService {
 
   async list(
     { filter, ...input }: LanguageListInput,
-    session: ISession
+    session: Session
   ): Promise<LanguageListOutput> {
     const query = this.db
       .query()
@@ -518,7 +508,7 @@ export class LanguageService {
   async listLocations(
     languageId: string,
     input: LocationListInput,
-    session: ISession
+    session: Session
   ): Promise<SecuredLocationList> {
     return await this.locationService.listLocationsFromNode(
       'Language',
@@ -532,7 +522,7 @@ export class LanguageService {
   async listProjects(
     language: Language,
     input: ProjectListInput,
-    session: ISession
+    session: Session
   ): Promise<SecuredProjectList> {
     const { page, count } = {
       ...ProjectListInput.defaultVal,
@@ -584,7 +574,7 @@ export class LanguageService {
 
   async sponsorStartDate(
     language: Language,
-    session: ISession
+    session: Session
   ): Promise<SecuredDate> {
     const result = await this.db
       .query()
@@ -636,7 +626,7 @@ export class LanguageService {
   async addLocation(
     languageId: string,
     locationId: string,
-    _session: ISession
+    _session: Session
   ): Promise<void> {
     try {
       await this.locationService.addLocationToNode(
@@ -653,7 +643,7 @@ export class LanguageService {
   async removeLocation(
     languageId: string,
     locationId: string,
-    _session: ISession
+    _session: Session
   ): Promise<void> {
     try {
       await this.locationService.removeLocationFromNode(
@@ -667,7 +657,7 @@ export class LanguageService {
     }
   }
 
-  async checkLanguageConsistency(session: ISession): Promise<boolean> {
+  async checkLanguageConsistency(session: Session): Promise<boolean> {
     const languages = await this.db
       .query()
       .match([matchSession(session), [node('lang', 'Language')]])

--- a/src/components/literacy-material/literacy-material.resolver.ts
+++ b/src/components/literacy-material/literacy-material.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import {
   CreateLiteracyMaterialInput,
   CreateLiteracyMaterialOutput,
@@ -21,7 +21,7 @@ export class LiteracyMaterialResolver {
     description: 'Look up a literacy material',
   })
   async literacyMaterial(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<LiteracyMaterial> {
     return await this.literacyMaterialService.readOne(id, session);
@@ -31,7 +31,7 @@ export class LiteracyMaterialResolver {
     description: 'Look up literacy materials',
   })
   async literacyMaterials(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => LiteracyMaterialListInput,
@@ -46,7 +46,7 @@ export class LiteracyMaterialResolver {
     description: 'Create a literacy material',
   })
   async createLiteracyMaterial(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { literacyMaterial: input }: CreateLiteracyMaterialInput
   ): Promise<CreateLiteracyMaterialOutput> {
     const literacyMaterial = await this.literacyMaterialService.create(
@@ -60,7 +60,7 @@ export class LiteracyMaterialResolver {
     description: 'Update a literacy material',
   })
   async updateLiteracyMaterial(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { literacyMaterial: input }: UpdateLiteracyMaterialInput
   ): Promise<UpdateLiteracyMaterialOutput> {
     const literacyMaterial = await this.literacyMaterialService.update(
@@ -74,7 +74,7 @@ export class LiteracyMaterialResolver {
     description: 'Delete a literacy material',
   })
   async deleteLiteracyMaterial(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.literacyMaterialService.delete(id, session);

--- a/src/components/literacy-material/literacy-material.service.ts
+++ b/src/components/literacy-material/literacy-material.service.ts
@@ -3,9 +3,9 @@ import { node } from 'cypher-query-builder';
 import {
   DuplicateException,
   generateId,
-  ISession,
   NotFoundException,
   ServerException,
+  Session,
 } from '../../common';
 import {
   ConfigService,
@@ -76,7 +76,7 @@ export class LiteracyMaterialService {
 
   async create(
     input: CreateLiteracyMaterial,
-    session: ISession
+    session: Session
   ): Promise<LiteracyMaterial> {
     const checkLiteracy = await this.db
       .query()
@@ -123,7 +123,7 @@ export class LiteracyMaterialService {
       await this.authorizationService.processNewBaseNode(
         dbLiteracyMaterial,
         result.id,
-        session.userId as string
+        session.userId
       );
 
       await this.scriptureRefService.create(
@@ -146,15 +146,11 @@ export class LiteracyMaterialService {
     }
   }
 
-  async readOne(id: string, session: ISession): Promise<LiteracyMaterial> {
+  async readOne(id: string, session: Session): Promise<LiteracyMaterial> {
     this.logger.debug(`Read literacyMaterial`, {
       id,
       userId: session.userId,
     });
-
-    if (!session.userId) {
-      session.userId = this.config.anonUser.id;
-    }
 
     const readLiteracyMaterial = this.db
       .query()
@@ -198,7 +194,7 @@ export class LiteracyMaterialService {
 
   async update(
     input: UpdateLiteracyMaterial,
-    session: ISession
+    session: Session
   ): Promise<LiteracyMaterial> {
     await this.scriptureRefService.update(input.id, input.scriptureReferences);
 
@@ -213,7 +209,7 @@ export class LiteracyMaterialService {
     });
   }
 
-  async delete(id: string, session: ISession): Promise<void> {
+  async delete(id: string, session: Session): Promise<void> {
     const literacyMaterial = await this.readOne(id, session);
     try {
       await this.db.deleteNode({
@@ -231,7 +227,7 @@ export class LiteracyMaterialService {
 
   async list(
     { filter, ...input }: LiteracyMaterialListInput,
-    session: ISession
+    session: Session
   ): Promise<LiteracyMaterialListOutput> {
     const query = this.db
       .query()

--- a/src/components/location/location.resolver.ts
+++ b/src/components/location/location.resolver.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/graphql';
 import { whereAlpha3 } from 'iso-3166-1';
 import countries from 'iso-3166-1/dist/iso-3166';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import {
   FundingAccountService,
   SecuredFundingAccount,
@@ -36,7 +36,7 @@ export class LocationResolver {
     description: 'Read one Location by id',
   })
   async location(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<Location> {
     return await this.locationService.readOne(id, session);
@@ -46,7 +46,7 @@ export class LocationResolver {
     description: 'Look up locations',
   })
   async locations(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => LocationListInput,
@@ -60,7 +60,7 @@ export class LocationResolver {
   @ResolveField(() => SecuredFundingAccount)
   async fundingAccount(
     @Parent() location: Location,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredFundingAccount> {
     const { value: id, ...rest } = location.fundingAccount;
     const value = id
@@ -96,7 +96,7 @@ export class LocationResolver {
     description: 'Create a location',
   })
   async createLocation(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { location: input }: CreateLocationInput
   ): Promise<CreateLocationOutput> {
     const location = await this.locationService.create(input, session);
@@ -107,7 +107,7 @@ export class LocationResolver {
     description: 'Update a location',
   })
   async updateLocation(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { location: input }: UpdateLocationInput
   ): Promise<UpdateLocationOutput> {
     const location = await this.locationService.update(input, session);
@@ -118,7 +118,7 @@ export class LocationResolver {
     description: 'Delete a location',
   })
   async deleteLocation(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.locationService.delete(id, session);

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -4,10 +4,10 @@ import { DateTime } from 'luxon';
 import {
   DuplicateException,
   generateId,
-  ISession,
   NotFoundException,
   Sensitivity,
   ServerException,
+  Session,
 } from '../../common';
 import {
   ConfigService,
@@ -78,7 +78,7 @@ export class LocationService {
     ];
   }
 
-  async create(input: CreateLocation, session: ISession): Promise<Location> {
+  async create(input: CreateLocation, session: Session): Promise<Location> {
     const checkName = await this.db
       .query()
       .match([node('name', 'LocationName', { value: input.name })])
@@ -160,22 +160,18 @@ export class LocationService {
     await this.authorizationService.processNewBaseNode(
       dbLocation,
       result.id,
-      session.userId as string
+      session.userId
     );
 
     this.logger.debug(`location created`, { id: result.id });
     return await this.readOne(result.id, session);
   }
 
-  async readOne(id: string, session: ISession): Promise<Location> {
+  async readOne(id: string, session: Session): Promise<Location> {
     this.logger.debug(`Read Location`, {
       id: id,
       userId: session.userId,
     });
-
-    if (!session.userId) {
-      session.userId = this.config.anonUser.id;
-    }
 
     const query = this.db
       .query()
@@ -219,7 +215,7 @@ export class LocationService {
     };
   }
 
-  async update(input: UpdateLocation, session: ISession): Promise<Location> {
+  async update(input: UpdateLocation, session: Session): Promise<Location> {
     const location = await this.readOne(input.id, session);
 
     await this.db.sgUpdateProperties({
@@ -266,13 +262,13 @@ export class LocationService {
     return await this.readOne(input.id, session);
   }
 
-  async delete(_id: string, _session: ISession): Promise<void> {
+  async delete(_id: string, _session: Session): Promise<void> {
     // Not Implemented
   }
 
   async list(
     { filter, ...input }: LocationListInput,
-    session: ISession
+    session: Session
   ): Promise<LocationListOutput> {
     const label = 'Location';
     const query = this.db
@@ -346,7 +342,7 @@ export class LocationService {
     id: string,
     rel: string,
     input: LocationListInput,
-    session: ISession
+    session: Session
   ): Promise<SecuredLocationList> {
     const query = this.db
       .query()

--- a/src/components/organization/organization.resolver.ts
+++ b/src/components/organization/organization.resolver.ts
@@ -8,10 +8,11 @@ import {
   Resolver,
 } from '@nestjs/graphql';
 import {
+  AnonSession,
   firstLettersOfWords,
   IdArg,
   IdField,
-  ISession,
+  LoggedInSession,
   Session,
 } from '../../common';
 import { LocationListInput, SecuredLocationList } from '../location';
@@ -43,7 +44,7 @@ export class OrganizationResolver {
     description: 'Create an organization',
   })
   async createOrganization(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { organization: input }: CreateOrganizationInput
   ): Promise<CreateOrganizationOutput> {
     const organization = await this.orgs.create(input, session);
@@ -54,7 +55,7 @@ export class OrganizationResolver {
     description: 'Look up an organization by its ID',
   })
   async organization(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<Organization> {
     return await this.orgs.readOne(id, session);
@@ -71,7 +72,7 @@ export class OrganizationResolver {
     description: 'Look up organizations',
   })
   async organizations(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => OrganizationListInput,
@@ -84,7 +85,7 @@ export class OrganizationResolver {
 
   @ResolveField(() => SecuredLocationList)
   async locations(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() organization: Organization,
     @Args({
       name: 'input',
@@ -100,7 +101,7 @@ export class OrganizationResolver {
     description: 'Update an organization',
   })
   async updateOrganization(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { organization: input }: UpdateOrganizationInput
   ): Promise<UpdateOrganizationOutput> {
     const organization = await this.orgs.update(input, session);
@@ -111,7 +112,7 @@ export class OrganizationResolver {
     description: 'Delete an organization',
   })
   async deleteOrganization(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.orgs.delete(id, session);
@@ -122,7 +123,7 @@ export class OrganizationResolver {
     description: 'Add a location to a organization',
   })
   async addLocationToOrganization(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args() { organizationId, locationId }: ModifyLocationArgs
   ): Promise<Organization> {
     await this.orgs.addLocation(organizationId, locationId, session);
@@ -133,7 +134,7 @@ export class OrganizationResolver {
     description: 'Remove a location from a organization',
   })
   async removeLocationFromOrganization(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args() { organizationId, locationId }: ModifyLocationArgs
   ): Promise<Organization> {
     await this.orgs.removeLocation(organizationId, locationId, session);
@@ -143,7 +144,7 @@ export class OrganizationResolver {
   @Query(() => Boolean, {
     description: 'Check all organization nodes for consistency',
   })
-  async checkOrganizations(@Session() session: ISession): Promise<boolean> {
+  async checkOrganizations(@AnonSession() session: Session): Promise<boolean> {
     return await this.orgs.checkAllOrgs(session);
   }
 
@@ -151,7 +152,7 @@ export class OrganizationResolver {
     description: 'Check Consistency in Organization Nodes',
   })
   async checkOrganizationConsistency(
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<boolean> {
     return await this.orgs.checkOrganizationConsistency(session);
   }

--- a/src/components/partner/partner.resolver.ts
+++ b/src/components/partner/partner.resolver.ts
@@ -6,7 +6,7 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import { OrganizationService, SecuredOrganization } from '../organization';
 import { SecuredUser, UserService } from '../user';
 import {
@@ -32,7 +32,7 @@ export class PartnerResolver {
     description: 'Look up a partner by its ID',
   })
   async partner(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<Partner> {
     return await this.partnerService.readOne(id, session);
@@ -42,7 +42,7 @@ export class PartnerResolver {
     description: 'Look up partners',
   })
   async partners(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => PartnerListInput,
@@ -56,7 +56,7 @@ export class PartnerResolver {
   @ResolveField(() => SecuredOrganization)
   async organization(
     @Parent() partner: Partner,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredOrganization> {
     const { value: id, ...rest } = partner.organization;
     const value = id ? await this.orgService.readOne(id, session) : undefined;
@@ -69,7 +69,7 @@ export class PartnerResolver {
   @ResolveField(() => SecuredUser)
   async pointOfContact(
     @Parent() partner: Partner,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredUser> {
     const { value: id, ...rest } = partner.pointOfContact;
     const value = id ? await this.userService.readOne(id, session) : undefined;
@@ -83,7 +83,7 @@ export class PartnerResolver {
     description: 'Create a partner',
   })
   async createPartner(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { partner: input }: CreatePartnerInput
   ): Promise<CreatePartnerOutput> {
     const partner = await this.partnerService.create(input, session);
@@ -94,7 +94,7 @@ export class PartnerResolver {
     description: 'Update a partner',
   })
   async updatePartner(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { partner: input }: UpdatePartnerInput
   ): Promise<UpdatePartnerOutput> {
     const partner = await this.partnerService.update(input, session);
@@ -105,7 +105,7 @@ export class PartnerResolver {
     description: 'Delete a partner',
   })
   async deletePartner(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.partnerService.delete(id, session);

--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -5,10 +5,9 @@ import {
   DuplicateException,
   generateId,
   InputException,
-  ISession,
   NotFoundException,
   ServerException,
-  UnauthenticatedException,
+  Session,
 } from '../../common';
 import {
   ConfigService,
@@ -78,7 +77,7 @@ export class PartnerService {
     ];
   }
 
-  async create(input: CreatePartner, session: ISession): Promise<Partner> {
+  async create(input: CreatePartner, session: Session): Promise<Partner> {
     this.verifyFinancialReportingType(
       input.financialReportingTypes,
       input.types
@@ -197,14 +196,14 @@ export class PartnerService {
     await this.authorizationService.processNewBaseNode(
       dbPartner,
       result.id,
-      session.userId as string
+      session.userId
     );
 
     this.logger.debug(`partner created`, { id: result.id });
     return await this.readOne(result.id, session);
   }
 
-  async readOnePartnerByOrgId(id: string, session: ISession): Promise<Partner> {
+  async readOnePartnerByOrgId(id: string, session: Session): Promise<Partner> {
     this.logger.debug(`Read Partner by Org Id`, {
       id: id,
       userId: session.userId,
@@ -231,15 +230,11 @@ export class PartnerService {
     return await this.readOne(result.partnerId, session);
   }
 
-  async readOne(id: string, session: ISession): Promise<Partner> {
+  async readOne(id: string, session: Session): Promise<Partner> {
     this.logger.debug(`Read Partner by Partner Id`, {
       id: id,
       userId: session.userId,
     });
-
-    if (!session.userId) {
-      session.userId = this.config.anonUser.id;
-    }
 
     const query = this.db
       .query()
@@ -306,7 +301,7 @@ export class PartnerService {
     };
   }
 
-  async update(input: UpdatePartner, session: ISession): Promise<Partner> {
+  async update(input: UpdatePartner, session: Session): Promise<Partner> {
     const object = await this.readOne(input.id, session);
     let changes = {
       ...input,
@@ -387,10 +382,7 @@ export class PartnerService {
     return await this.readOne(input.id, session);
   }
 
-  async delete(id: string, session: ISession): Promise<void> {
-    if (!session.userId) {
-      throw new UnauthenticatedException('user not logged in');
-    }
+  async delete(id: string, session: Session): Promise<void> {
     const ed = await this.readOne(id, session);
     try {
       await this.db.deleteNode({
@@ -408,7 +400,7 @@ export class PartnerService {
 
   async list(
     { filter, ...input }: PartnerListInput,
-    session: ISession
+    session: Session
   ): Promise<PartnerListOutput> {
     const label = 'Partner';
     const query = this.db

--- a/src/components/partnership/events/partnership-created.event.ts
+++ b/src/components/partnership/events/partnership-created.event.ts
@@ -1,6 +1,6 @@
-import { ISession } from '../../../common';
+import { Session } from '../../../common';
 import { Partnership } from '../dto';
 
 export class PartnershipCreatedEvent {
-  constructor(readonly partnership: Partnership, readonly session: ISession) {}
+  constructor(readonly partnership: Partnership, readonly session: Session) {}
 }

--- a/src/components/partnership/events/partnership-deleted.event.ts
+++ b/src/components/partnership/events/partnership-deleted.event.ts
@@ -1,6 +1,6 @@
-import { ISession } from '../../../common';
+import { Session } from '../../../common';
 import { Partnership } from '../dto';
 
 export class PartnershipWillDeleteEvent {
-  constructor(readonly partnership: Partnership, readonly session: ISession) {}
+  constructor(readonly partnership: Partnership, readonly session: Session) {}
 }

--- a/src/components/partnership/events/partnership-updated.event.ts
+++ b/src/components/partnership/events/partnership-updated.event.ts
@@ -1,4 +1,4 @@
-import { ISession } from '../../../common';
+import { Session } from '../../../common';
 import { Partnership, UpdatePartnership } from '../dto';
 
 export class PartnershipUpdatedEvent {
@@ -6,6 +6,6 @@ export class PartnershipUpdatedEvent {
     public updated: Partnership,
     readonly previous: Partnership,
     readonly updates: UpdatePartnership,
-    readonly session: ISession
+    readonly session: Session
   ) {}
 }

--- a/src/components/partnership/partnership.resolver.ts
+++ b/src/components/partnership/partnership.resolver.ts
@@ -6,7 +6,7 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import { FileService, SecuredFile } from '../file';
 import { SecuredPartner } from '../partner/dto';
 import { PartnerService } from '../partner/partner.service';
@@ -33,7 +33,7 @@ export class PartnershipResolver {
     description: 'Create a Partnership entry',
   })
   async createPartnership(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { partnership: input }: CreatePartnershipInput
   ): Promise<CreatePartnershipOutput> {
     const partnership = await this.service.create(input, session);
@@ -44,7 +44,7 @@ export class PartnershipResolver {
     description: 'Look up a partnership by ID',
   })
   async partnership(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<Partnership> {
     return await this.service.readOne(id, session);
@@ -55,7 +55,7 @@ export class PartnershipResolver {
   })
   async mou(
     @Parent() partnership: Partnership,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredFile> {
     return await this.files.resolveDefinedFile(partnership.mou, session);
   }
@@ -65,7 +65,7 @@ export class PartnershipResolver {
   })
   async agreement(
     @Parent() partnership: Partnership,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredFile> {
     return await this.files.resolveDefinedFile(partnership.agreement, session);
   }
@@ -74,7 +74,7 @@ export class PartnershipResolver {
   async partner(
     @Parent()
     partnership: Partnership,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredPartner> {
     const { value: id, ...rest } = partnership.partner;
     const value = id ? await this.partners.readOne(id, session) : undefined;
@@ -88,7 +88,7 @@ export class PartnershipResolver {
     description: 'Look up partnerships',
   })
   async partnerships(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => PartnershipListInput,
@@ -103,7 +103,7 @@ export class PartnershipResolver {
     description: 'Update a Partnership',
   })
   async updatePartnership(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { partnership: input }: UpdatePartnershipInput
   ): Promise<UpdatePartnershipOutput> {
     const partnership = await this.service.update(input, session);
@@ -114,7 +114,7 @@ export class PartnershipResolver {
     description: 'Delete a Partnership',
   })
   async deletePartnership(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.service.delete(id, session);
@@ -125,7 +125,7 @@ export class PartnershipResolver {
     description: 'Check partnership node consistency',
   })
   async checkPartnershipConsistency(
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<boolean> {
     return await this.service.checkPartnershipConsistency(session);
   }

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -6,9 +6,9 @@ import {
   DuplicateException,
   generateId,
   InputException,
-  ISession,
   NotFoundException,
   ServerException,
+  Session,
 } from '../../common';
 import {
   ConfigService,
@@ -86,7 +86,7 @@ export class PartnershipService {
 
   async create(
     { partnerId, projectId, ...input }: CreatePartnership,
-    session: ISession
+    session: Session
   ): Promise<Partnership> {
     const createdAt = DateTime.local();
 
@@ -257,7 +257,7 @@ export class PartnershipService {
       await this.authorizationService.processNewBaseNode(
         new DbPartnership(),
         result.id,
-        session.userId!
+        session.userId
       );
 
       const partnership = await this.readOne(result.id, session);
@@ -276,13 +276,8 @@ export class PartnershipService {
     }
   }
 
-  async readOne(id: string, session: ISession): Promise<Partnership> {
+  async readOne(id: string, session: Session): Promise<Partnership> {
     this.logger.debug('readOne', { id, userId: session.userId });
-
-    if (!session.userId) {
-      this.logger.debug('using anon user id');
-      session.userId = this.config.anonUser.id;
-    }
 
     const query = this.db
       .query()
@@ -366,7 +361,7 @@ export class PartnershipService {
     };
   }
 
-  async update(input: UpdatePartnership, session: ISession) {
+  async update(input: UpdatePartnership, session: Session) {
     // mou start and end are now computed fields and do not get updated directly
     const object = await this.readOne(input.id, session);
     let changes = input;
@@ -438,7 +433,7 @@ export class PartnershipService {
     return event.updated;
   }
 
-  async delete(id: string, session: ISession): Promise<void> {
+  async delete(id: string, session: Session): Promise<void> {
     const object = await this.readOne(id, session);
 
     if (!object) {
@@ -469,7 +464,7 @@ export class PartnershipService {
 
   async list(
     input: Partial<PartnershipListInput>,
-    session: ISession
+    session: Session
   ): Promise<PartnershipListOutput> {
     const { filter, ...listInput } = {
       ...PartnershipListInput.defaultVal,
@@ -504,7 +499,7 @@ export class PartnershipService {
     );
   }
 
-  async checkPartnershipConsistency(session: ISession): Promise<boolean> {
+  async checkPartnershipConsistency(session: Session): Promise<boolean> {
     const partnerships = await this.db
       .query()
       .match([matchSession(session), [node('partnership', 'Partnership')]])

--- a/src/components/product/product.resolver.ts
+++ b/src/components/product/product.resolver.ts
@@ -6,7 +6,7 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import {
   AnyProduct,
   CreateProductInput,
@@ -31,7 +31,7 @@ export class ProductResolver {
     description: 'Read a product by id',
   })
   async product(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<AnyProduct> {
     return await this.productService.readOne(id, session);
@@ -41,7 +41,7 @@ export class ProductResolver {
     description: 'Look up products',
   })
   async products(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => ProductListInput,
@@ -84,7 +84,7 @@ export class ProductResolver {
     description: 'Create a product entry',
   })
   async createProduct(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { product: input }: CreateProductInput
   ): Promise<CreateProductOutput> {
     return {
@@ -96,7 +96,7 @@ export class ProductResolver {
     description: 'Update a product entry',
   })
   async updateProduct(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { product: input }: UpdateProductInput
   ): Promise<UpdateProductOutput> {
     const product = await this.productService.update(input, session);
@@ -107,7 +107,7 @@ export class ProductResolver {
     description: 'Delete a product entry',
   })
   async deleteProduct(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.productService.delete(id, session);

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -7,9 +7,9 @@ import { DateTime } from 'luxon';
 import {
   generateId,
   InputException,
-  ISession,
   NotFoundException,
   ServerException,
+  Session,
 } from '../../common';
 import {
   ConfigService,
@@ -84,7 +84,7 @@ export class ProductService {
 
   async create(
     { engagementId, ...input }: CreateProduct,
-    session: ISession
+    session: Session
   ): Promise<AnyProduct> {
     const createdAt = DateTime.local();
     const secureProps: Property[] = [
@@ -245,14 +245,14 @@ export class ProductService {
     await this.authorizationService.processNewBaseNode(
       dbProduct,
       result.id,
-      session.userId as string
+      session.userId
     );
 
     this.logger.debug(`product created`, { id: result.id });
     return await this.readOne(result.id, session);
   }
 
-  async readOne(id: string, session: ISession): Promise<AnyProduct> {
+  async readOne(id: string, session: Session): Promise<AnyProduct> {
     const query = this.db
       .query()
       .call(matchRequestingUser, session)
@@ -372,7 +372,7 @@ export class ProductService {
     };
   }
 
-  async update(input: UpdateProduct, session: ISession): Promise<AnyProduct> {
+  async update(input: UpdateProduct, session: Session): Promise<AnyProduct> {
     const {
       produces: inputProducesId,
       scriptureReferences,
@@ -484,7 +484,7 @@ export class ProductService {
     });
   }
 
-  async delete(id: string, session: ISession): Promise<void> {
+  async delete(id: string, session: Session): Promise<void> {
     const object = await this.readOne(id, session);
 
     if (!object) {
@@ -507,7 +507,7 @@ export class ProductService {
 
   async list(
     { filter, ...input }: ProductListInput,
-    session: ISession
+    session: Session
   ): Promise<ProductListOutput> {
     const label = 'Product';
 
@@ -562,7 +562,7 @@ export class ProductService {
   protected async getProducibleByType(
     id: string,
     type: string,
-    session: ISession
+    session: Session
   ): Promise<Film | Story | Song | LiteracyMaterial> {
     if (type === 'Film') {
       return await this.film.readOne(id, session);

--- a/src/components/project/events/project-created.event.ts
+++ b/src/components/project/events/project-created.event.ts
@@ -1,6 +1,6 @@
-import { ISession } from '../../../common';
+import { Session } from '../../../common';
 import { Project } from '../dto';
 
 export class ProjectCreatedEvent {
-  constructor(public project: Project, readonly session: ISession) {}
+  constructor(public project: Project, readonly session: Session) {}
 }

--- a/src/components/project/events/project-deleted.event.ts
+++ b/src/components/project/events/project-deleted.event.ts
@@ -1,6 +1,6 @@
-import { ISession } from '../../../common';
+import { Session } from '../../../common';
 import { Project } from '../dto';
 
 export class ProjectDeletedEvent {
-  constructor(readonly project: Project, readonly session: ISession) {}
+  constructor(readonly project: Project, readonly session: Session) {}
 }

--- a/src/components/project/events/project-updated.event.ts
+++ b/src/components/project/events/project-updated.event.ts
@@ -1,4 +1,4 @@
-import { ISession } from '../../../common';
+import { Session } from '../../../common';
 import { Project, UpdateProject } from '../dto';
 
 export class ProjectUpdatedEvent {
@@ -6,6 +6,6 @@ export class ProjectUpdatedEvent {
     public updated: Project,
     readonly previous: Project,
     readonly updates: UpdateProject,
-    readonly session: ISession
+    readonly session: Session
   ) {}
 }

--- a/src/components/project/handlers/step-changed-notification.handler.ts
+++ b/src/components/project/handlers/step-changed-notification.handler.ts
@@ -26,7 +26,7 @@ export class ProjectStepChangedNotificationHandler
     const recipients = await this.projectRules.getNotifications(
       event.updated.id,
       event.updated.step.value!,
-      event.session.userId!,
+      event.session.userId,
       event.previous.step.value
     );
 

--- a/src/components/project/project-member/project-member.resolver.ts
+++ b/src/components/project/project-member/project-member.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../../common';
 import {
   CreateProjectMemberInput,
   CreateProjectMemberOutput,
@@ -19,7 +19,7 @@ export class ProjectMemberResolver {
     description: 'Create a project member',
   })
   async createProjectMember(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { projectMember: input }: CreateProjectMemberInput
   ): Promise<CreateProjectMemberOutput> {
     const projectMember = await this.service.create(input, session);
@@ -30,7 +30,7 @@ export class ProjectMemberResolver {
     description: 'Look up a project member by ID',
   })
   async projectMember(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<ProjectMember> {
     return await this.service.readOne(id, session);
@@ -40,7 +40,7 @@ export class ProjectMemberResolver {
     description: 'Look up project members',
   })
   async projectMembers(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => ProjectMemberListInput,
@@ -55,7 +55,7 @@ export class ProjectMemberResolver {
     description: 'Update a project member',
   })
   async updateProjectMember(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { projectMember: input }: UpdateProjectMemberInput
   ): Promise<UpdateProjectMemberOutput> {
     const projectMember = await this.service.update(input, session);
@@ -66,7 +66,7 @@ export class ProjectMemberResolver {
     description: 'Delete a project member',
   })
   async deleteProjectMember(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.service.delete(id, session);

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -7,9 +7,9 @@ import {
   DuplicateException,
   generateId,
   InputException,
-  ISession,
   NotFoundException,
   ServerException,
+  Session,
 } from '../../../common';
 import {
   ConfigService,
@@ -89,7 +89,7 @@ export class ProjectMemberService {
 
   async create(
     { userId, projectId, ...input }: CreateProjectMember,
-    session: ISession
+    session: Session
   ): Promise<ProjectMember> {
     const id = await generateId();
     const createdAt = DateTime.local();
@@ -151,7 +151,7 @@ export class ProjectMemberService {
       await this.authorizationService.processNewBaseNode(
         dbProjectMember,
         memberQuery?.id,
-        session.userId!
+        session.userId
       );
 
       // await this.addProjectAdminsToUserSg(projectId, userId);
@@ -166,7 +166,7 @@ export class ProjectMemberService {
     }
   }
 
-  async readOne(id: string, session: ISession): Promise<ProjectMember> {
+  async readOne(id: string, session: Session): Promise<ProjectMember> {
     this.logger.debug(`read one`, {
       id,
       userId: session.userId,
@@ -225,7 +225,7 @@ export class ProjectMemberService {
 
   async update(
     input: UpdateProjectMember,
-    session: ISession
+    session: Session
   ): Promise<ProjectMember> {
     const object = await this.readOne(input.id, session);
 
@@ -262,7 +262,7 @@ export class ProjectMemberService {
     }
   }
 
-  async delete(id: string, session: ISession): Promise<void> {
+  async delete(id: string, session: Session): Promise<void> {
     const object = await this.readOne(id, session);
 
     if (!object) {
@@ -289,7 +289,7 @@ export class ProjectMemberService {
 
   async list(
     { filter, ...input }: ProjectMemberListInput,
-    session: ISession
+    session: Session
   ): Promise<ProjectMemberListOutput> {
     const label = 'ProjectMember';
 

--- a/src/components/project/project-step.resolver.ts
+++ b/src/components/project/project-step.resolver.ts
@@ -1,5 +1,5 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { ISession, ServerException, Session } from '../../common';
+import { AnonSession, ServerException, Session } from '../../common';
 import { ProjectStepTransition, SecuredProjectStep } from './dto';
 import { ProjectRules } from './project.rules';
 
@@ -12,7 +12,7 @@ export class ProjectStepResolver {
   })
   async transitions(
     @Parent() step: SecuredProjectStep & { projectId?: string },
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<ProjectStepTransition[]> {
     if (!step.projectId) {
       throw new ServerException(
@@ -24,7 +24,7 @@ export class ProjectStepResolver {
     }
     return await this.projectRules.getAvailableTransitions(
       step.projectId,
-      session.userId
+      session
     );
   }
 }

--- a/src/components/project/project.resolver.ts
+++ b/src/components/project/project.resolver.ts
@@ -8,10 +8,11 @@ import {
   Resolver,
 } from '@nestjs/graphql';
 import {
+  AnonSession,
   firstLettersOfWords,
   IdArg,
   IdField,
-  ISession,
+  LoggedInSession,
   SecuredString,
   Session,
 } from '../../common';
@@ -66,7 +67,7 @@ export class ProjectResolver {
   })
   async project(
     @IdArg() id: string,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<Project> {
     const project = await this.projectService.readOne(id, session);
     // @ts-expect-error hack project id into step object so the lazy transitions
@@ -86,7 +87,7 @@ export class ProjectResolver {
       defaultValue: ProjectListInput.defaultVal,
     })
     input: ProjectListInput,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<ProjectListOutput> {
     const list = await this.projectService.list(input, session);
     for (const project of list.items) {
@@ -118,14 +119,14 @@ export class ProjectResolver {
   })
   async budget(
     @Parent() project: Project,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredBudget> {
     return await this.projectService.currentBudget(project, session);
   }
 
   @ResolveField(() => SecuredEngagementList)
   async engagements(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() project: Project,
     @Args({
       name: 'input',
@@ -142,7 +143,7 @@ export class ProjectResolver {
     description: 'The project members',
   })
   async team(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() { id }: Project,
     @Args({
       name: 'input',
@@ -156,7 +157,7 @@ export class ProjectResolver {
 
   @ResolveField(() => SecuredPartnershipList)
   async partnerships(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() { id }: Project,
     @Args({
       name: 'input',
@@ -172,7 +173,7 @@ export class ProjectResolver {
     description: 'The root filesystem directory of this project',
   })
   async rootDirectory(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() { id }: Project
   ): Promise<SecuredDirectory> {
     return await this.projectService.getRootDirectory(id, session);
@@ -181,7 +182,7 @@ export class ProjectResolver {
   @ResolveField(() => SecuredLocation)
   async primaryLocation(
     @Parent() project: Project,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredLocation> {
     const { value: id, ...rest } = project.primaryLocation;
     const value = id
@@ -192,7 +193,7 @@ export class ProjectResolver {
 
   @ResolveField(() => SecuredLocationList)
   async otherLocations(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() { id }: Project,
     @Args({
       name: 'input',
@@ -207,7 +208,7 @@ export class ProjectResolver {
   @ResolveField(() => SecuredLocation)
   async marketingLocation(
     @Parent() project: Project,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredLocation> {
     const { value: id, ...rest } = project.marketingLocation;
     const value = id
@@ -219,7 +220,7 @@ export class ProjectResolver {
   @ResolveField(() => SecuredFieldRegion)
   async fieldRegion(
     @Parent() project: Project,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredFieldRegion> {
     const { value: id, ...rest } = project.fieldRegion;
     const value = id
@@ -231,7 +232,7 @@ export class ProjectResolver {
   @ResolveField(() => SecuredOrganization)
   async owningOrganization(
     @Parent() project: Project,
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<SecuredOrganization> {
     const { value: id, ...rest } = project.owningOrganization;
     const value = id
@@ -245,7 +246,7 @@ export class ProjectResolver {
   })
   async createProject(
     @Args('input') { project: input }: CreateProjectInput,
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<CreateProjectOutput> {
     const project = await this.projectService.create(input, session);
     // @ts-expect-error hack project id into step object so the lazy transitions
@@ -259,7 +260,7 @@ export class ProjectResolver {
   })
   async updateProject(
     @Args('input') { project: input }: UpdateProjectInput,
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<UpdateProjectOutput> {
     const project = await this.projectService.update(input, session);
     // @ts-expect-error hack project id into step object so the lazy transitions
@@ -273,7 +274,7 @@ export class ProjectResolver {
   })
   async deleteProject(
     @IdArg() id: string,
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<boolean> {
     await this.projectService.delete(id, session);
     return true;
@@ -283,7 +284,7 @@ export class ProjectResolver {
     description: 'Add a location to a project',
   })
   async addOtherLocationToProject(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args() { projectId, locationId }: ModifyOtherLocationArgs
   ): Promise<Project> {
     await this.projectService.addOtherLocation(projectId, locationId, session);
@@ -294,7 +295,7 @@ export class ProjectResolver {
     description: 'Remove a location from a project',
   })
   async removeOtherLocationFromProject(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args() { projectId, locationId }: ModifyOtherLocationArgs
   ): Promise<Project> {
     await this.projectService.removeOtherLocation(
@@ -309,7 +310,7 @@ export class ProjectResolver {
     description: 'Check Consistency in Project Nodes',
   })
   async checkProjectConsistency(
-    @Session() session: ISession
+    @LoggedInSession() session: Session
   ): Promise<boolean> {
     return await this.projectService.consistencyChecker(session);
   }

--- a/src/components/scripture/scripture-reference.service.ts
+++ b/src/components/scripture/scripture-reference.service.ts
@@ -1,7 +1,7 @@
 import { Node, node, relation } from 'cypher-query-builder';
 import { sortBy } from 'lodash';
 import { DateTime } from 'luxon';
-import { ISession, Range } from '../../common';
+import { Range, Session } from '../../common';
 import { DatabaseService, ILogger, Logger } from '../../core';
 import { ScriptureRange, ScriptureRangeInput } from './dto';
 
@@ -15,7 +15,7 @@ export class ScriptureReferenceService {
     producibleId: string,
     scriptureRefs: ScriptureRangeInput[] | undefined,
     // eslint-disable-next-line @seedcompany/no-unused-vars
-    session: ISession
+    session: Session
   ): Promise<void> {
     if (!scriptureRefs) {
       return;
@@ -106,7 +106,7 @@ export class ScriptureReferenceService {
 
   async list(
     producibleId: string,
-    session: ISession,
+    session: Session,
     options: { isOverriding?: boolean } = {}
   ): Promise<ScriptureRange[]> {
     const results = await this.db

--- a/src/components/search/search.resolver.ts
+++ b/src/components/search/search.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Query, Resolver } from '@nestjs/graphql';
-import { ISession, Session } from '../../common';
+import { AnonSession, Session } from '../../common';
 import { SearchInput, SearchOutput } from './dto';
 import { SearchService } from './search.service';
 
@@ -11,7 +11,7 @@ export class SearchResolver {
     description: 'Perform a search across resources',
   })
   async search(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => SearchInput,

--- a/src/components/search/search.service.ts
+++ b/src/components/search/search.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { node, regexp, relation } from 'cypher-query-builder';
 import { compact } from 'lodash';
-import { ISession, NotFoundException, ServerException } from '../../common';
+import { NotFoundException, ServerException, Session } from '../../common';
 import {
   DatabaseService,
   matchRequestingUser,
@@ -32,7 +32,7 @@ import {
 type HydratorMap = {
   [K in keyof SearchableMap]?: Hydrator<SearchableMap[K]>;
 };
-type Hydrator<R> = (id: string, session: ISession) => Promise<R>;
+type Hydrator<R> = (id: string, session: Session) => Promise<R>;
 
 const labels = JSON.stringify(SearchResultTypes);
 const typeFromLabels = `[l in labels(node) where l in ${labels}][0] as type`;
@@ -78,7 +78,7 @@ export class SearchService {
     private readonly fundingAccount: FundingAccountService
   ) {}
 
-  async search(input: SearchInput, session: ISession): Promise<SearchOutput> {
+  async search(input: SearchInput, session: Session): Promise<SearchOutput> {
     // if type isn't specified default to all types
     const inputTypes = input.type || SearchResultTypes;
 

--- a/src/components/song/song.resolver.ts
+++ b/src/components/song/song.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import {
   CreateSongInput,
   CreateSongOutput,
@@ -18,7 +18,10 @@ export class SongResolver {
   @Query(() => Song, {
     description: 'Look up a song by its ID',
   })
-  async song(@Session() session: ISession, @IdArg() id: string): Promise<Song> {
+  async song(
+    @AnonSession() session: Session,
+    @IdArg() id: string
+  ): Promise<Song> {
     return await this.storyService.readOne(id, session);
   }
 
@@ -26,7 +29,7 @@ export class SongResolver {
     description: 'Look up stories',
   })
   async songs(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => SongListInput,
@@ -41,7 +44,7 @@ export class SongResolver {
     description: 'Create a song',
   })
   async createSong(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { song: input }: CreateSongInput
   ): Promise<CreateSongOutput> {
     const song = await this.storyService.create(input, session);
@@ -52,7 +55,7 @@ export class SongResolver {
     description: 'Update a song',
   })
   async updateSong(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { song: input }: UpdateSongInput
   ): Promise<UpdateSongOutput> {
     const song = await this.storyService.update(input, session);
@@ -63,7 +66,7 @@ export class SongResolver {
     description: 'Delete a song',
   })
   async deleteSong(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.storyService.delete(id, session);

--- a/src/components/story/story.resolver.ts
+++ b/src/components/story/story.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import {
   CreateStoryInput,
   CreateStoryOutput,
@@ -19,7 +19,7 @@ export class StoryResolver {
     description: 'Look up a story by its ID',
   })
   async story(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<Story> {
     return await this.storyService.readOne(id, session);
@@ -29,7 +29,7 @@ export class StoryResolver {
     description: 'Look up stories',
   })
   async stories(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => StoryListInput,
@@ -44,7 +44,7 @@ export class StoryResolver {
     description: 'Create a story',
   })
   async createStory(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { story: input }: CreateStoryInput
   ): Promise<CreateStoryOutput> {
     const story = await this.storyService.create(input, session);
@@ -55,7 +55,7 @@ export class StoryResolver {
     description: 'Update a story',
   })
   async updateStory(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { story: input }: UpdateStoryInput
   ): Promise<UpdateStoryOutput> {
     const story = await this.storyService.update(input, session);
@@ -66,7 +66,7 @@ export class StoryResolver {
     description: 'Delete a story',
   })
   async deleteStory(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.storyService.delete(id, session);

--- a/src/components/user/education/education.resolver.ts
+++ b/src/components/user/education/education.resolver.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Args, Mutation, Query } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../../common';
 import {
   CreateEducationInput,
   CreateEducationOutput,
@@ -20,7 +20,7 @@ export class EducationResolver {
     description: 'Create an education entry',
   })
   async createEducation(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { education: input }: CreateEducationInput
   ): Promise<CreateEducationOutput> {
     const education = await this.service.create(input, session);
@@ -31,7 +31,7 @@ export class EducationResolver {
     description: 'Look up an education by its ID',
   })
   async education(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<Education> {
     return await this.service.readOne(id, session);
@@ -41,7 +41,7 @@ export class EducationResolver {
     description: 'Look up educations by user id',
   })
   async educations(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => EducationListInput,
@@ -56,7 +56,7 @@ export class EducationResolver {
     description: 'Update an education',
   })
   async updateEducation(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { education: input }: UpdateEducationInput
   ): Promise<UpdateEducationOutput> {
     const education = await this.service.update(input, session);
@@ -67,7 +67,7 @@ export class EducationResolver {
     description: 'Delete an education',
   })
   async deleteEducation(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.service.delete(id, session);
@@ -78,7 +78,7 @@ export class EducationResolver {
     description: 'Check Consistency across Education Nodes',
   })
   async checkEducationConsistency(
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<boolean> {
     return await this.service.checkEducationConsistency(session);
   }

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -3,9 +3,9 @@ import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import {
   generateId,
-  ISession,
   NotFoundException,
   ServerException,
+  Session,
 } from '../../../common';
 import {
   ConfigService,
@@ -59,7 +59,7 @@ export class EducationService {
 
   async create(
     { userId, ...input }: CreateEducation,
-    session: ISession
+    session: Session
   ): Promise<Education> {
     const createdAt = DateTime.local();
 
@@ -117,15 +117,11 @@ export class EducationService {
     return await this.readOne(result.id, session);
   }
 
-  async readOne(id: string, session: ISession): Promise<Education> {
+  async readOne(id: string, session: Session): Promise<Education> {
     this.logger.debug(`Read Education`, {
       id: id,
       userId: session.userId,
     });
-
-    if (!session.userId) {
-      session.userId = this.config.anonUser.id;
-    }
 
     const query = this.db
       .query()
@@ -155,7 +151,7 @@ export class EducationService {
     };
   }
 
-  async update(input: UpdateEducation, session: ISession): Promise<Education> {
+  async update(input: UpdateEducation, session: Session): Promise<Education> {
     const ed = await this.readOne(input.id, session);
 
     return await this.db.sgUpdateProperties({
@@ -167,13 +163,13 @@ export class EducationService {
     });
   }
 
-  async delete(_id: string, _session: ISession): Promise<void> {
+  async delete(_id: string, _session: Session): Promise<void> {
     // Not Implemented
   }
 
   async list(
     { filter, ...input }: EducationListInput,
-    session: ISession
+    session: Session
   ): Promise<EducationListOutput> {
     const label = 'Education';
 
@@ -201,7 +197,7 @@ export class EducationService {
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }
 
-  async checkEducationConsistency(session: ISession): Promise<boolean> {
+  async checkEducationConsistency(session: Session): Promise<boolean> {
     const educations = await this.db
       .query()
       .match([matchSession(session), [node('education', 'Education')]])

--- a/src/components/user/unavailability/unavailability.resolver.ts
+++ b/src/components/user/unavailability/unavailability.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../../common';
 import {
   CreateUnavailabilityInput,
   CreateUnavailabilityOutput,
@@ -19,7 +19,7 @@ export class UnavailabilityResolver {
     description: 'Look up a unavailability by its ID',
   })
   async unavailability(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() id: string
   ): Promise<Unavailability> {
     return await this.service.readOne(id, session);
@@ -29,7 +29,7 @@ export class UnavailabilityResolver {
     description: 'Look up unavailabilities by user id',
   })
   async unavailabilities(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => UnavailabilityListInput,
@@ -44,7 +44,7 @@ export class UnavailabilityResolver {
     description: 'Create an unavailability',
   })
   async createUnavailability(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { unavailability: input }: CreateUnavailabilityInput
   ): Promise<CreateUnavailabilityOutput> {
     const unavailability = await this.service.create(input, session);
@@ -55,7 +55,7 @@ export class UnavailabilityResolver {
     description: 'Update an unavailability',
   })
   async updateUnavailability(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { unavailability: input }: UpdateUnavailabilityInput
   ): Promise<UpdateUnavailabilityOutput> {
     const unavailability = await this.service.update(input, session);
@@ -66,7 +66,7 @@ export class UnavailabilityResolver {
     description: 'Delete an unavailability',
   })
   async deleteUnavailability(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() id: string
   ): Promise<boolean> {
     await this.service.delete(id, session);
@@ -77,7 +77,7 @@ export class UnavailabilityResolver {
     description: 'Check Consistency across Unavailability Nodes',
   })
   async checkUnavailabilityConsistency(
-    @Session() session: ISession
+    @AnonSession() session: Session
   ): Promise<boolean> {
     return await this.service.checkUnavailabilityConsistency(session);
   }

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -2,9 +2,9 @@ import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { node } from 'cypher-query-builder';
 import {
   generateId,
-  ISession,
   NotFoundException,
   ServerException,
+  Session,
 } from '../../../common';
 import {
   ConfigService,
@@ -44,7 +44,7 @@ export class UnavailabilityService {
 
   async create(
     { userId, ...input }: CreateUnavailability,
-    session: ISession
+    session: Session
   ): Promise<Unavailability> {
     const secureProps = [
       {
@@ -134,10 +134,7 @@ export class UnavailabilityService {
     }
   }
 
-  async readOne(id: string, session: ISession): Promise<Unavailability> {
-    if (!session.userId) {
-      session.userId = this.config.anonUser.id;
-    }
+  async readOne(id: string, session: Session): Promise<Unavailability> {
     const query = this.db
       .query()
       .call(matchRequestingUser, session)
@@ -171,7 +168,7 @@ export class UnavailabilityService {
 
   async update(
     input: UpdateUnavailability,
-    session: ISession
+    session: Session
   ): Promise<Unavailability> {
     const unavailability = await this.readOne(input.id, session);
 
@@ -184,7 +181,7 @@ export class UnavailabilityService {
     });
   }
 
-  async delete(id: string, session: ISession): Promise<void> {
+  async delete(id: string, session: Session): Promise<void> {
     this.logger.debug(`mutation delete unavailability`);
     const ua = await this.readOne(id, session);
     if (!ua) {
@@ -202,7 +199,7 @@ export class UnavailabilityService {
 
   async list(
     { page, count, sort, order, filter }: UnavailabilityListInput,
-    session: ISession
+    session: Session
   ): Promise<UnavailabilityListOutput> {
     const result = await this.db.list<Unavailability>({
       session,
@@ -225,7 +222,7 @@ export class UnavailabilityService {
       total: result.total,
     };
   }
-  async checkUnavailabilityConsistency(session: ISession): Promise<boolean> {
+  async checkUnavailabilityConsistency(session: Session): Promise<boolean> {
     const unavailabilities = await this.db
       .query()
       .match([

--- a/src/components/user/user.resolver.ts
+++ b/src/components/user/user.resolver.ts
@@ -8,10 +8,11 @@ import {
   Resolver,
 } from '@nestjs/graphql';
 import {
+  AnonSession,
   firstLettersOfWords,
   IdArg,
   IdField,
-  ISession,
+  LoggedInSession,
   Session,
 } from '../../common';
 import { LocationListInput, SecuredLocationList } from '../location';
@@ -58,7 +59,10 @@ export class UserResolver {
   @Query(() => User, {
     description: 'Look up a user by its ID',
   })
-  async user(@Session() session: ISession, @IdArg() id: string): Promise<User> {
+  async user(
+    @AnonSession() session: Session,
+    @IdArg() id: string
+  ): Promise<User> {
     return await this.userService.readOne(id, session);
   }
 
@@ -92,7 +96,7 @@ export class UserResolver {
     description: 'Look up users',
   })
   async users(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Args({
       name: 'input',
       type: () => UserListInput,
@@ -112,7 +116,7 @@ export class UserResolver {
 
   @ResolveField(() => SecuredUnavailabilityList)
   async unavailabilities(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() { id }: User,
     @Args({
       name: 'input',
@@ -126,7 +130,7 @@ export class UserResolver {
 
   @ResolveField(() => SecuredOrganizationList)
   async organizations(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() { id }: User,
     @Args({
       name: 'input',
@@ -140,7 +144,7 @@ export class UserResolver {
 
   @ResolveField(() => SecuredEducationList)
   async education(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() { id }: User,
     @Args({
       name: 'input',
@@ -154,7 +158,7 @@ export class UserResolver {
 
   @ResolveField(() => SecuredLocationList)
   async locations(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @Parent() user: User,
     @Args({
       name: 'input',
@@ -170,7 +174,7 @@ export class UserResolver {
     description: 'Create a person',
   })
   async createPerson(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { person: input }: CreatePersonInput
   ): Promise<CreatePersonOutput> {
     const userId = await this.userService.create(input, session);
@@ -182,7 +186,7 @@ export class UserResolver {
     description: 'Update a user',
   })
   async updateUser(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { user: input }: UpdateUserInput
   ): Promise<UpdateUserOutput> {
     const user = await this.userService.update(input, session);
@@ -192,7 +196,7 @@ export class UserResolver {
   @Mutation(() => Boolean, {
     description: 'Delete a user',
   })
-  async deleteUser(@Session() session: ISession, @IdArg() id: string) {
+  async deleteUser(@LoggedInSession() session: Session, @IdArg() id: string) {
     await this.userService.delete(id, session);
     return true;
   }
@@ -201,7 +205,7 @@ export class UserResolver {
     description: 'Add a location to a user',
   })
   async addLocationToUser(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args() { userId, locationId }: ModifyLocationArgs
   ): Promise<User> {
     await this.userService.addLocation(userId, locationId, session);
@@ -212,7 +216,7 @@ export class UserResolver {
     description: 'Remove a location from a user',
   })
   async removeLocationFromUser(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args() { userId, locationId }: ModifyLocationArgs
   ): Promise<User> {
     await this.userService.removeLocation(userId, locationId, session);
@@ -222,7 +226,9 @@ export class UserResolver {
   @Query(() => Boolean, {
     description: 'Check Consistency across User Nodes',
   })
-  async checkUserConsistency(@Session() session: ISession): Promise<boolean> {
+  async checkUserConsistency(
+    @AnonSession() session: Session
+  ): Promise<boolean> {
     return await this.userService.checkUserConsistency(session);
   }
 
@@ -230,7 +236,7 @@ export class UserResolver {
     description: 'Assign organization OR primaryOrganization to user',
   })
   async assignOrganizationToUser(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') input: AssignOrganizationToUserInput
   ): Promise<boolean> {
     await this.userService.assignOrganizationToUser(input.request, session);
@@ -241,7 +247,7 @@ export class UserResolver {
     description: 'Remove organization OR primaryOrganization from user',
   })
   async removeOrganizationFromUser(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') input: RemoveOrganizationFromUserInput
   ): Promise<boolean> {
     await this.userService.removeOrganizationFromUser(input.request, session);

--- a/src/components/workflow/workflow.resolver.ts
+++ b/src/components/workflow/workflow.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { IdArg, ISession, Session } from '../../common';
+import { AnonSession, IdArg, LoggedInSession, Session } from '../../common';
 import {
   AddStateInput,
   AddStateOutput,
@@ -23,7 +23,7 @@ export class WorkflowResolver {
     description: 'Create an Workflow',
   })
   async createWorkflow(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { workflow: input }: CreateWorkflowInput
   ): Promise<CreateWorkflowOutput> {
     const workflow = await this.service.createWorkflow(session, input);
@@ -34,7 +34,7 @@ export class WorkflowResolver {
     description: 'Delete an Workflow',
   })
   async deleteWorkflow(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() workflowId: string
   ): Promise<boolean> {
     await this.service.deleteWorkflow(session, workflowId);
@@ -45,7 +45,7 @@ export class WorkflowResolver {
     description: 'Add a State to a Workflow',
   })
   async addState(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { state: input }: AddStateInput
   ): Promise<AddStateOutput> {
     const state = await this.service.addState(session, input);
@@ -56,7 +56,7 @@ export class WorkflowResolver {
     description: 'Update a State',
   })
   async updateState(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { state: input }: UpdateStateInput
   ): Promise<AddStateOutput> {
     const state = await this.service.updateState(session, input);
@@ -67,7 +67,7 @@ export class WorkflowResolver {
     description: 'Delete an State from Workflow',
   })
   async deleteState(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @IdArg() stateId: string
   ): Promise<boolean> {
     await this.service.deleteState(session, stateId);
@@ -78,7 +78,7 @@ export class WorkflowResolver {
     description: 'Look up all states on workflow',
   })
   async states(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() baseNodeId: string
   ): Promise<StateListOutput> {
     return await this.service.listStates(session, baseNodeId);
@@ -88,7 +88,7 @@ export class WorkflowResolver {
     description: 'Look up all next possible states on workflow',
   })
   async nextStates(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() stateId: string
   ): Promise<StateListOutput> {
     return await this.service.listNextStates(session, stateId);
@@ -98,7 +98,7 @@ export class WorkflowResolver {
     description: 'Attach securitygroup to state',
   })
   async attachSecurityGroup(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { groupState: input }: GroupStateInput
   ): Promise<boolean> {
     await this.service.attachSecurityGroup(session, input);
@@ -109,7 +109,7 @@ export class WorkflowResolver {
     description: 'Remove security group from state',
   })
   async removeSecurityGroup(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { groupState: input }: GroupStateInput
   ): Promise<boolean> {
     await this.service.removeSecurityGroup(session, input);
@@ -120,7 +120,7 @@ export class WorkflowResolver {
     description: 'Attach notification group to state',
   })
   async attachNotificationGroup(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { groupState: input }: GroupStateInput
   ): Promise<boolean> {
     await this.service.attachNotificationGroup(session, input);
@@ -131,7 +131,7 @@ export class WorkflowResolver {
     description: 'Remove notification group to state',
   })
   async removeNotificationGroup(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { groupState: input }: GroupStateInput
   ): Promise<boolean> {
     await this.service.removeNotificationGroup(session, input);
@@ -142,7 +142,7 @@ export class WorkflowResolver {
     description: 'Change current statee in workflow',
   })
   async changeCurrentState(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { state: input }: ChangeCurrentStateInput
   ): Promise<boolean> {
     await this.service.changeCurrentState(session, input);
@@ -153,7 +153,7 @@ export class WorkflowResolver {
     description: 'Add possible state to a state',
   })
   async addPossibleState(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { state: input }: PossibleStateInput
   ): Promise<boolean> {
     await this.service.addPossibleState(session, input);
@@ -164,7 +164,7 @@ export class WorkflowResolver {
     description: 'Remove possible state to a state',
   })
   async removePossibleState(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { state: input }: PossibleStateInput
   ): Promise<boolean> {
     await this.service.removePossibleState(session, input);
@@ -175,7 +175,7 @@ export class WorkflowResolver {
     description: 'Add a required field to a state',
   })
   async addRequiredField(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { field: input }: RequiredFieldInput
   ): Promise<boolean> {
     await this.service.addRequiredField(session, input);
@@ -186,7 +186,7 @@ export class WorkflowResolver {
     description: 'List required fields in state',
   })
   async listRequiredFields(
-    @Session() session: ISession,
+    @AnonSession() session: Session,
     @IdArg() stateId: string
   ): Promise<RequiredFieldListOutput> {
     const fields = await this.service.listRequiredFields(session, stateId);
@@ -197,7 +197,7 @@ export class WorkflowResolver {
     description: 'Remove a required field from state',
   })
   async removeRequiredField(
-    @Session() session: ISession,
+    @LoggedInSession() session: Session,
     @Args('input') { field: input }: RequiredFieldInput
   ): Promise<boolean> {
     await this.service.removeRequiredField(session, input);

--- a/src/components/workflow/workflow.service.ts
+++ b/src/components/workflow/workflow.service.ts
@@ -2,9 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import {
   generateId,
-  ISession,
   NotFoundException,
   ServerException,
+  Session,
   UnauthorizedException,
 } from '../../common';
 import { DatabaseService, ILogger, Logger, matchSession } from '../../core';
@@ -32,7 +32,7 @@ export class WorkflowService {
 
   // multiple workflows will be able to be created per one base node.
   async createWorkflow(
-    session: ISession,
+    session: Session,
     input: CreateWorkflow
   ): Promise<Workflow> {
     try {
@@ -121,7 +121,7 @@ export class WorkflowService {
     }
   }
 
-  async deleteWorkflow(session: ISession, workflowId: string): Promise<void> {
+  async deleteWorkflow(session: Session, workflowId: string): Promise<void> {
     try {
       await this.db
         .query()
@@ -159,7 +159,7 @@ export class WorkflowService {
   }
 
   // the stateName is stored in the (:State)'s 'value' property (consistent with (:Property)s on (:BaseNode)s )  // addStateToWorkflow
-  async addState(session: ISession, input: AddState): Promise<State> {
+  async addState(session: Session, input: AddState): Promise<State> {
     try {
       const stateId = await generateId();
       const result = await this.db
@@ -224,7 +224,7 @@ export class WorkflowService {
   }
 
   // updateStateName
-  async updateState(session: ISession, input: UpdateState): Promise<State> {
+  async updateState(session: Session, input: UpdateState): Promise<State> {
     try {
       // get current state and workflow
       const workflow = await this.db
@@ -351,7 +351,7 @@ export class WorkflowService {
   }
 
   // deleteStateFromWorkflow
-  async deleteState(session: ISession, stateId: string): Promise<void> {
+  async deleteState(session: Session, stateId: string): Promise<void> {
     try {
       await this.db
         .query()
@@ -394,7 +394,7 @@ export class WorkflowService {
 
   // we don't need to have a list workflow function when we have a list state function that takes the baseNodeId // listAllStatesOnWorkflow
   async listStates(
-    session: ISession,
+    session: Session,
     baseNodeId: string
   ): Promise<StateListOutput> {
     try {
@@ -443,7 +443,7 @@ export class WorkflowService {
 
   // this will be used to get the next possible states of any state, including the current state  // listNextPossibleStates
   async listNextStates(
-    session: ISession,
+    session: Session,
     stateId: string
   ): Promise<StateListOutput> {
     try {
@@ -490,7 +490,7 @@ export class WorkflowService {
 
   // attachSecurityGroupToState
   async attachSecurityGroup(
-    session: ISession,
+    session: Session,
     input: GroupState
   ): Promise<void> {
     try {
@@ -544,7 +544,7 @@ export class WorkflowService {
 
   // removeSecurityGroupFromState
   async removeSecurityGroup(
-    session: ISession,
+    session: Session,
     input: GroupState
   ): Promise<void> {
     try {
@@ -593,7 +593,7 @@ export class WorkflowService {
   // we are using security groups as notification groups for now
   // attachNotificationGroupToState
   async attachNotificationGroup(
-    session: ISession,
+    session: Session,
     input: GroupState
   ): Promise<void> {
     try {
@@ -646,7 +646,7 @@ export class WorkflowService {
 
   // removeNotificationGroupFromState
   async removeNotificationGroup(
-    session: ISession,
+    session: Session,
     input: GroupState
   ): Promise<void> {
     try {
@@ -692,7 +692,7 @@ export class WorkflowService {
 
   // changeCurrentStateInWorkflow
   async changeCurrentState(
-    session: ISession,
+    session: Session,
     input: ChangeCurrentState
   ): Promise<void> {
     try {
@@ -831,7 +831,7 @@ export class WorkflowService {
   // later we can create an abstracted function that creates and attaches a state to another state
   // addPossibleStateToState
   async addPossibleState(
-    session: ISession,
+    session: Session,
     input: PossibleState
   ): Promise<void> {
     try {
@@ -893,7 +893,7 @@ export class WorkflowService {
 
   // removePossibleStateFromState
   async removePossibleState(
-    session: ISession,
+    session: Session,
     input: PossibleState
   ): Promise<void> {
     try {
@@ -938,7 +938,7 @@ export class WorkflowService {
   // this is so each required field can be queried without inspecting the property name in app code.
   // addRequiredFieldToState
   async addRequiredField(
-    session: ISession,
+    session: Session,
     input: RequiredField
   ): Promise<void> {
     try {
@@ -1015,7 +1015,7 @@ export class WorkflowService {
 
   // listAllRequiredFieldsInAState
   async listRequiredFields(
-    session: ISession,
+    session: Session,
     stateId: string
   ): Promise<RequiredFieldListOutput> {
     try {
@@ -1059,7 +1059,7 @@ export class WorkflowService {
 
   // removeRequiredFieldFromState
   async removeRequiredField(
-    session: ISession,
+    session: Session,
     input: RequiredField
   ): Promise<void> {
     try {

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -12,12 +12,12 @@ import { cloneDeep, Many, upperFirst } from 'lodash';
 import { DateTime } from 'luxon';
 import { assert } from 'ts-essentials';
 import {
-  ISession,
   isSecured,
   many,
   Order,
   Resource,
   ServerException,
+  Session,
   UnauthorizedException,
   UnwrapSecured,
   unwrapSecured,
@@ -51,7 +51,7 @@ export const property = (
 ];
 
 export const matchSession = (
-  session: ISession,
+  session: Session,
   {
     // eslint-disable-next-line @seedcompany/no-unused-vars
     withAclEdit,
@@ -113,7 +113,7 @@ export class DatabaseService {
     changes,
     nodevar,
   }: {
-    session: ISession;
+    session: Session;
     object: TObject;
     props: ReadonlyArray<keyof TObject & string>;
     changes: { [Key in keyof TObject]?: UnwrapSecured<TObject[Key]> };
@@ -148,7 +148,7 @@ export class DatabaseService {
     value,
     nodevar,
   }: {
-    session: ISession;
+    session: Session;
     object: TObject;
     key: Key;
     value?: UnwrapSecured<TObject[Key]>;
@@ -239,7 +239,7 @@ export class DatabaseService {
     aclEditProp,
     input,
   }: {
-    session: ISession;
+    session: Session;
     props: ReadonlyArray<
       keyof TObject | { secure: boolean; name: keyof TObject; list?: boolean }
     >;
@@ -457,7 +457,7 @@ export class DatabaseService {
     // eslint-disable-next-line @seedcompany/no-unused-vars
     aclEditProp, // example canCreateLangs
   }: {
-    session: ISession;
+    session: Session;
     object: TObject;
     aclEditProp: string;
   }) {
@@ -498,7 +498,7 @@ export class DatabaseService {
     nodevar,
   }: {
     id: string;
-    session: ISession;
+    session: Session;
     props: string[];
     nodevar: string;
   }): Promise<boolean> {
@@ -522,7 +522,7 @@ export class DatabaseService {
     nodevar,
   }: {
     id: string;
-    session: ISession;
+    session: Session;
     prop: string;
     nodevar: string;
   }): Promise<boolean> {
@@ -553,7 +553,7 @@ export class DatabaseService {
     relName,
     srcNodeLabel,
   }: {
-    session: ISession;
+    session: Session;
     id: string;
     relName: string;
     srcNodeLabel: string;
@@ -587,7 +587,7 @@ export class DatabaseService {
     nodevar,
   }: {
     id: string;
-    session: ISession;
+    session: Session;
     props: string[];
     nodevar: string;
   }): Promise<boolean> {
@@ -611,7 +611,7 @@ export class DatabaseService {
     nodevar,
   }: {
     id: string;
-    session: ISession;
+    session: Session;
     prop: string;
     nodevar: string;
   }): Promise<boolean> {

--- a/src/core/database/query.helpers.ts
+++ b/src/core/database/query.helpers.ts
@@ -1,6 +1,6 @@
 import { node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
-import { entries, ISession, Resource } from '../../common';
+import { entries, Resource, Session } from '../../common';
 
 // CREATE clauses //////////////////////////////////////////////////////
 
@@ -106,7 +106,7 @@ export function matchUserPermissions(
 
 export function matchRequestingUser(
   query: Query,
-  { userId }: Partial<ISession>
+  { userId }: Partial<Session>
 ) {
   query.match([
     node('requestingUser', 'User', {

--- a/src/core/database/query/matching.ts
+++ b/src/core/database/query/matching.ts
@@ -1,10 +1,10 @@
 import { node, Query, relation } from 'cypher-query-builder';
 import { Term } from 'cypher-query-builder/dist/typings/clauses/term-list-clause';
-import { ISession } from '../../../common';
+import { Session } from '../../../common';
 import { collect } from './cypher-functions';
 import { mapping } from './mapping';
 
-export const requestingUser = (session: ISession) =>
+export const requestingUser = (session: Session) =>
   node('requestingUser', 'User', {
     id: session.userId,
   });

--- a/test/file.e2e-spec.ts
+++ b/test/file.e2e-spec.ts
@@ -2,6 +2,7 @@ import { gql } from 'apollo-server-core';
 import * as faker from 'faker';
 import { startCase, times } from 'lodash';
 import { DateTime, Duration, DurationObject, Settings } from 'luxon';
+import { anonymousSession } from '../src/common/session';
 import { AuthenticationService } from '../src/components/authentication';
 import {
   Directory,
@@ -472,9 +473,11 @@ describe('File e2e', () => {
 
   describe.skip('check consistency', () => {
     const expectConsistency = async (type: FileNodeType, expected = true) => {
-      const session = await app
-        .get(AuthenticationService)
-        .createSession(app.graphql.authToken);
+      const session = anonymousSession(
+        await app
+          .get(AuthenticationService)
+          .createSession(app.graphql.authToken)
+      );
 
       const expecting = expect(
         app.get(FileRepository).checkConsistency(type, session)

--- a/test/utility/create-directory.ts
+++ b/test/utility/create-directory.ts
@@ -1,6 +1,7 @@
 import { gql } from 'apollo-server-core';
 import * as faker from 'faker';
 import { startCase } from 'lodash';
+import { loggedInSession } from '../../src/common/session';
 import { AuthenticationService } from '../../src/components/authentication';
 import { FileService } from '../../src/components/file';
 import { TestApp } from './create-app';
@@ -8,9 +9,10 @@ import { fileNode, RawDirectory } from './fragments';
 
 export async function createRootDirectory(app: TestApp, name?: string) {
   name = name ?? startCase(faker.lorem.words());
-  const session = await app
+  const rawSession = await app
     .get(AuthenticationService)
     .createSession(app.graphql.authToken);
+  const session = loggedInSession(rawSession);
   const actual = await app
     .get(FileService)
     .createDirectory(undefined, name, session);


### PR DESCRIPTION
- Resolvers now specify if they want an anonymous session or a logged-in one.
  Anonymous will default the `userId` to the anonymous one and logged-in will throw an error if the user isn't logged in.
- It's now read-only. Modifying it like it previous was could have unintended side-effects.
- Renamed `ISession` -> `Session` since that doesn't conflict with the decorator now.

Related to #1126 