### PR TITLE
Sort project sensitivity including translation project

### DIFF
--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -711,11 +711,32 @@ export class ProjectService {
       sensitivity: 'sensitivityValue',
     };
 
-    const sensitivityCase = `case prop.value
-    when 'High' then 3
-    when 'Medium' then 2
-    when 'Low' then 1
-    end as sensitivityValue`;
+    // Subquery to get the sensitivity value for a Translation Project.
+    // Get the highest sensitivity of the connected Language Engagement's Language
+    // If an Engagement doesn't exist, then default to 3 (high)
+    const sensitivitySubquery = `call { 
+      with node
+      optional match (node)-[:engagement { active: true }]->(:LanguageEngagement)-[:language { active: true }]->  
+      (:Language)-[:sensitivity { active: true }]->(sensitivityProp:Property)
+      WITH *, case sensitivityProp.value
+        when null then 3
+        when 'High' then 3
+        when 'Medium' then 2
+        when 'Low' then 1
+        end as langSensitivityVal
+      ORDER BY langSensitivityVal desc
+      limit 1
+      return langSensitivityVal
+      }`;
+
+    // In the first case, if the node is a translation project, use the langSensitivityVal from above.
+    // Else use the sensitivity prop value
+    const sensitivityCase = `case
+      when 'TranslationProject' in labels(node) then langSensitivityVal
+      when prop.value = 'High' then 3
+      when prop.value = 'Medium' then 2
+      when prop.value = 'Low' then 1
+      end as sensitivityValue`;
 
     const sortBy = projectSortMap[input.sort] ?? 'prop.value';
     const query = this.db
@@ -729,6 +750,7 @@ export class ProjectService {
         this.securedProperties,
         (q, sort, order) =>
           q
+            .raw(input.sort === 'sensitivity' ? sensitivitySubquery : '')
             .match([
               node('node'),
               relation('out', '', sort, { active: true }),


### PR DESCRIPTION
Use a subquery to get the translation project sensitivity value, and use that value in the sorting.

Full query: 
```
MATCH (requestingUser:User { id: 'h6iPkJ7AfXz' })<-[:member]-(:SecurityGroup)-[:permission]->(perms:Permission)-[:baseNode]->(node:Project)
WITH distinct(node) as node, requestingUser
MATCH (node)
MATCH (node)
MATCH (requestingUser)<-[:user]-(projectMember)<-[:member]-(node)
WITH collect(distinct node) as nodes, count(distinct node) as total
unwind nodes as node
call {
      with node
      optional match (node)-[:engagement { active: true }]->(:LanguageEngagement)-[:language { active: true }]->
      (:Language)-[:sensitivity { active: true }]->(sensitivityProp:Property)
      WITH *, case sensitivityProp.value
        when null then 3
        when 'High' then 3
        when 'Medium' then 2
        when 'Low' then 1
        end as langSensitivityVal
      ORDER BY langSensitivityVal desc
      limit 1
      return langSensitivityVal
      }
MATCH (node)-[:sensitivity { active: true }]->(prop:Property)
WITH *, case
      when 'TranslationProject' in labels(node) then langSensitivityVal
      when prop.value = 'High' then 3
      when prop.value = 'Medium' then 2
      when prop.value = 'Low' then 1
      end as sensitivityValue
ORDER BY sensitivityValue DESC
WITH collect(distinct node.id)[0..25] as items, total
RETURN items, total;
```