### PR TITLE
Add historicGoal to language engagement

### DIFF
--- a/src/components/authorization/roles/administrator.role.ts
+++ b/src/components/authorization/roles/administrator.role.ts
@@ -183,6 +183,7 @@ export const Administrator = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/consultant-manager.role.ts
+++ b/src/components/authorization/roles/consultant-manager.role.ts
@@ -196,6 +196,7 @@ export const ConsultantManager = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/consultant.role.ts
+++ b/src/components/authorization/roles/consultant.role.ts
@@ -195,6 +195,7 @@ export const Consultant = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/controller.role.ts
+++ b/src/components/authorization/roles/controller.role.ts
@@ -196,6 +196,7 @@ export const Controller = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/field-operations-director.role.ts
+++ b/src/components/authorization/roles/field-operations-director.role.ts
@@ -210,6 +210,7 @@ export const FieldOperationsDirector = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/financial-analyst.role.ts
+++ b/src/components/authorization/roles/financial-analyst.role.ts
@@ -196,6 +196,7 @@ export const FinancialAnalyst = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/fundraising.role.ts
+++ b/src/components/authorization/roles/fundraising.role.ts
@@ -187,6 +187,7 @@ export const Fundraising = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/intern.role.ts
+++ b/src/components/authorization/roles/intern.role.ts
@@ -190,6 +190,7 @@ export const Intern = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/leadership.role.ts
+++ b/src/components/authorization/roles/leadership.role.ts
@@ -187,6 +187,7 @@ export const Leadership = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/liason.role.ts
+++ b/src/components/authorization/roles/liason.role.ts
@@ -190,6 +190,7 @@ export const Liason = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/marketing.role.ts
+++ b/src/components/authorization/roles/marketing.role.ts
@@ -190,6 +190,7 @@ export const Marketing = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/mentor.role.ts
+++ b/src/components/authorization/roles/mentor.role.ts
@@ -190,6 +190,7 @@ export const Mentor = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/project-manager.role.ts
+++ b/src/components/authorization/roles/project-manager.role.ts
@@ -188,6 +188,7 @@ export const ProjectManager = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/regional-communications-coordinator.role.ts
+++ b/src/components/authorization/roles/regional-communications-coordinator.role.ts
@@ -190,6 +190,7 @@ export const RegionalCommunicationsCoordinator = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/regional-director.role.ts
+++ b/src/components/authorization/roles/regional-director.role.ts
@@ -210,6 +210,7 @@ export const RegionalDirector = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/staff-member.role.ts
+++ b/src/components/authorization/roles/staff-member.role.ts
@@ -187,6 +187,7 @@ export const StaffMember = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/authorization/roles/translator.role.ts
+++ b/src/components/authorization/roles/translator.role.ts
@@ -190,6 +190,7 @@ export const Translator = new DbRole({
         { propertyName: 'lukePartnership',            permission: { read, write, }, },
         { propertyName: 'paraTextRegistryId',         permission: { read, write, }, },
         { propertyName: 'pnp',                        permission: { read, write, }, },
+        { propertyName: 'historicGoal',               permission: { read, write, }, },
         { propertyName: 'sentPrintingDate',           permission: { read, write, }, },
         { propertyName: 'startDate',                  permission: { read, write, }, },
         { propertyName: 'startDateOverride',          permission: { read, write, }, },

--- a/src/components/engagement/dto/create-engagement.dto.ts
+++ b/src/components/engagement/dto/create-engagement.dto.ts
@@ -50,6 +50,9 @@ export abstract class CreateLanguageEngagement extends CreateEngagement {
 
   @Field({ nullable: true })
   readonly pnp?: CreateDefinedFileVersionInput;
+
+  @Field({ nullable: true })
+  readonly historicGoal?: string;
 }
 
 @InputType()

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -112,6 +112,9 @@ export class LanguageEngagement extends Engagement {
   readonly paraTextRegistryId: SecuredString;
 
   readonly pnp: DefinedFile;
+
+  @Field()
+  readonly historicGoal: SecuredString;
 }
 
 @ObjectType({

--- a/src/components/engagement/dto/update-engagement.dto.ts
+++ b/src/components/engagement/dto/update-engagement.dto.ts
@@ -49,6 +49,9 @@ export abstract class UpdateLanguageEngagement extends UpdateEngagement {
 
   @Field({ nullable: true })
   readonly pnp?: CreateDefinedFileVersionInput;
+
+  @Field({ nullable: true })
+  readonly historicGoal?: string;
 }
 
 @InputType()

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -88,6 +88,7 @@ export class EngagementService {
     paraTextRegistryId: true,
     pnp: true,
     language: true,
+    historicGoal: true,
 
     //Internship Specific
     position: true,
@@ -212,6 +213,11 @@ export class EngagementService {
         'languageEngagement'
       ),
       ...property('pnp', pnpId || undefined, 'languageEngagement'),
+      ...property(
+        'historicGoal',
+        input.historicGoal || undefined,
+        'languageEngagement'
+      ),
       ...property('statusModifiedAt', undefined, 'languageEngagement'),
       ...property('lastSuspendedAt', undefined, 'languageEngagement'),
       ...property('lastReactivatedAt', undefined, 'languageEngagement'),
@@ -777,6 +783,7 @@ export class EngagementService {
           'startDateOverride',
           'endDateOverride',
           'paraTextRegistryId',
+          'historicGoal',
           'modifiedAt',
           'status',
           'initialEndDate',

--- a/src/components/engagement/model/langauage-engagement.model.db.ts
+++ b/src/components/engagement/model/langauage-engagement.model.db.ts
@@ -11,4 +11,5 @@ export class DbLanguageEngagement extends DbEngagement {
   pnp: any = null;
   sentPrintingDate: any = null;
   product: any = null;
+  historicGoal: any = null;
 }


### PR DESCRIPTION
Fixes: https://github.com/SeedCompany/cord-api-v3/issues/1491
@michaelmarshall Please update the schema/cord-procedures with this new field.