### PR TITLE
Logging for deployed application (CloudWatch)

### DIFF
--- a/logging.example.yml
+++ b/logging.example.yml
@@ -5,8 +5,6 @@
 
 levels:
   # Only show errors for nest related loggers
-  # Note that we hook into the logger after bootstrap so this won't
-  # suppress those bootstrapping log messages
   nest, nest:*: errors
   # Show info logs up for config logger, but not for the environment service keep that at warning.
   config, -config:environment: info

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "dotenv-expand": "^5.1.0",
     "execa": "^4.0.3",
     "faker": "^4.1.0",
+    "fast-safe-stringify": "^2.0.7",
     "got": "^11.5.0",
     "graphql": "^15.3.0",
     "html-to-text": "^5.1.1",

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -172,7 +172,7 @@ export class ConfigService {
   /** Should logger output as JSON? Defaults to true if running in ECS */
   readonly jsonLogs = this.env
     .boolean('JSON_LOGS')
-    .optional(this.ecsMetadataUri);
+    .optional(!!this.ecsMetadataUri);
 
   /**
    * Default configuration for logging.

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -170,7 +170,8 @@ export class ConfigService {
   static logging = {
     defaultLevel: LogLevel.INFO,
     levels: {
-      'nest,nest:*': LogLevel.DEBUG,
+      'nest,nest:*,-nest:loader': LogLevel.DEBUG,
+      'nest:loader': LogLevel.WARNING,
       'config:environment': LogLevel.INFO,
       version: LogLevel.DEBUG,
     },

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -171,7 +171,7 @@ export class ConfigService {
     defaultLevel: LogLevel.INFO,
     levels: {
       'nest,nest:*,-nest:loader': LogLevel.DEBUG,
-      'nest:loader': LogLevel.WARNING,
+      'nest:loader,nest:router': LogLevel.WARNING,
       'config:environment': LogLevel.INFO,
       version: LogLevel.DEBUG,
     },

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -163,6 +163,18 @@ export class ConfigService {
   }
 
   /**
+   * @see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html
+   */
+  readonly ecsMetadataUri =
+    this.env.string('ECS_CONTAINER_METADATA_URI_V4').optional() ||
+    this.env.string('ECS_CONTAINER_METADATA_URI').optional();
+
+  /** Should logger output as JSON? Defaults to true if running in ECS */
+  readonly jsonLogs = this.env
+    .boolean('JSON_LOGS')
+    .optional(this.ecsMetadataUri);
+
+  /**
    * Default configuration for logging.
    * These can be overridden with logging.yml file at project root
    * This needs to be static to prevent circular dependency.

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -1,5 +1,5 @@
 import { Global, Module } from '@nestjs/common';
-import { APP_FILTER, APP_PIPE } from '@nestjs/core';
+import { APP_FILTER, APP_PIPE, BaseExceptionFilter } from '@nestjs/core';
 import { GraphQLModule } from '@nestjs/graphql';
 import { AwsS3Factory } from './aws-s3.factory';
 import { ConfigModule } from './config/config.module';
@@ -24,6 +24,7 @@ import { ValidationPipe } from './validation.pipe';
   providers: [
     AwsS3Factory,
     GraphqlLoggingPlugin,
+    BaseExceptionFilter,
     { provide: APP_FILTER, useClass: ExceptionFilter },
     { provide: APP_PIPE, useClass: ValidationPipe },
   ],

--- a/src/core/exception.filter.test.ts
+++ b/src/core/exception.filter.test.ts
@@ -5,13 +5,14 @@ import {
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
+import { BaseExceptionFilter } from '@nestjs/core';
 /* eslint-enable no-restricted-imports */
 import { InputException, ServerException } from '../common/exceptions';
 import { ConstraintError } from './database';
 import { ExceptionFilter } from './exception.filter';
 
 describe('ExceptionFilter', () => {
-  const filter = new ExceptionFilter();
+  const filter = new ExceptionFilter(new BaseExceptionFilter());
 
   describe('HttpException', () => {
     it('simple', () => {

--- a/src/core/logger/buffer-logger.service.ts
+++ b/src/core/logger/buffer-logger.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { AbstractLogger } from './abstract-logger';
+import { ILogger, LogEntry } from './logger.interface';
+
+/**
+ * Implementation of our Logger that stores log messages in array.
+ */
+@Injectable()
+export class BufferLoggerService extends AbstractLogger {
+  private entries: LogEntry[] = [];
+
+  logEntry(entry: LogEntry): void {
+    this.entries.push(entry);
+  }
+
+  flushTo(logger: ILogger): void {
+    const entries = this.entries.slice(0);
+    this.entries = [];
+    for (const entry of entries) {
+      logger.log(entry);
+    }
+  }
+}

--- a/src/core/logger/exception-logger.ts
+++ b/src/core/logger/exception-logger.ts
@@ -1,0 +1,29 @@
+import { ExceptionHandler as NestExceptionHandler } from '@nestjs/core/errors/exception-handler';
+import { ExceptionsZone } from '@nestjs/core/errors/exceptions-zone';
+import { ILogger } from './logger.interface';
+
+/**
+ * Replace the Nest exception handler with the ability to swap the logger
+ */
+class ExceptionLoggerClass implements NestExceptionHandler {
+  getLogger?: () => Pick<ILogger, 'error'>;
+
+  handle(exception: Error): void {
+    try {
+      if (this.getLogger) {
+        this.getLogger().error(exception.message, { exception });
+      } else {
+        // eslint-disable-next-line no-console
+        console.error(exception);
+      }
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(exception);
+    }
+  }
+}
+
+export const ExceptionHandler = new ExceptionLoggerClass();
+
+// @ts-expect-error I know it's private. hack hack.
+ExceptionsZone.exceptionHandler = ExceptionHandler;

--- a/src/core/logger/formatters.ts
+++ b/src/core/logger/formatters.ts
@@ -73,7 +73,7 @@ export const exceptionInfo = () =>
     info.exceptions = flatten(info.exception).map(
       (ex): ParsedError => {
         const stack = ex.stack!;
-        const type = stack.slice(0, stack.indexOf(':'));
+        const type = ex.constructor.name || stack.slice(0, stack.indexOf(':'));
         const trace = parseTrace({ stack } as any);
 
         return {
@@ -130,7 +130,7 @@ export const formatException = () =>
     }
     const exs: ParsedError[] = info.exceptions;
 
-    const bad = config.syslog.levels[info.level] > config.syslog.levels.warning;
+    const bad = config.syslog.levels[info.level] < config.syslog.levels.warning;
 
     info[MESSAGE] = exs
       .map((ex, index) => {

--- a/src/core/logger/formatters.ts
+++ b/src/core/logger/formatters.ts
@@ -87,6 +87,7 @@ export const exceptionInfo = () =>
         };
       }
     );
+    delete info.exception;
 
     return info;
   })();

--- a/src/core/logger/formatters.ts
+++ b/src/core/logger/formatters.ts
@@ -1,11 +1,12 @@
 import { ppRaw as prettyPrint } from '@patarapolw/prettyprint';
 import { enabled as colorsEnabled, red, yellow } from 'colors/safe';
+import stringify from 'fast-safe-stringify';
 import { identity, mapValues } from 'lodash';
 import { DateTime } from 'luxon';
 import { relative } from 'path';
 import { parse as parseTrace, StackFrame } from 'stack-trace';
 import { MESSAGE } from 'triple-beam';
-import { config, format } from 'winston';
+import { config, format, LogEntry } from 'winston';
 import { Exception } from '../../common/exceptions';
 import { getNameFromEntry } from './logger.interface';
 
@@ -174,4 +175,22 @@ export const printForCli = () =>
           })}`
         : '';
     return msg;
+  });
+
+export const printForJson = () =>
+  format.printf((info: LogEntry & { exceptions?: ParsedError[] }) => {
+    const { level, message, exceptions, metadata } = info;
+
+    const obj = {
+      '@name': getNameFromEntry(info),
+      level,
+      message,
+      exceptions: exceptions?.map(({ message, type, stack }) => ({
+        type,
+        message,
+        stack,
+      })),
+      ...metadata,
+    };
+    return stringify(obj);
   });

--- a/src/core/logger/index.ts
+++ b/src/core/logger/index.ts
@@ -1,3 +1,3 @@
 export * from './logger.interface';
-export * from './logger.decorator';
+export { Logger, LoggerToken } from './logger.decorator';
 export * from './logger.module';

--- a/src/core/logger/level-matcher.ts
+++ b/src/core/logger/level-matcher.ts
@@ -53,13 +53,15 @@ interface MatcherConfig {
  * logging.yml file in the project root. See the example file as a starting point.
  */
 export class LevelMatcher {
+  private readonly defaultLevel: LogLevel;
   private readonly matchers: MatcherConfig[] = [];
   private cached: Record<string, LogLevel> = {};
 
   constructor(
     levelMap: Record<string, string | undefined>,
-    private readonly defaultLevel: LogLevel
+    defaultLevel: LogLevel | string
   ) {
+    this.defaultLevel = parseLevel(defaultLevel) ?? LogLevel.INFO;
     this.matchers = Object.entries(levelMap).flatMap(
       ([namespaces, rawLevel]) => {
         const level = parseLevel(rawLevel);

--- a/src/core/logger/logger.decorator.ts
+++ b/src/core/logger/logger.decorator.ts
@@ -1,5 +1,4 @@
 import { Inject } from '@nestjs/common';
-import { LoggerToken } from './logger.module';
 
 /**
  * Injects a `ILogger`
@@ -8,3 +7,17 @@ import { LoggerToken } from './logger.module';
  *             Ex: `foo:bar:service`
  */
 export const Logger = (name: string) => Inject(LoggerToken(name));
+
+/**
+ * Internal to logging setup, don't reference directly.
+ */
+export const loggerNames = new Set<string>();
+
+/**
+ * Creates the token for a named logger
+ * @param name The name of the logger
+ */
+export const LoggerToken = (name: string) => {
+  loggerNames.add(name);
+  return `Logger(${name})`;
+};

--- a/src/core/logger/logger.module.ts
+++ b/src/core/logger/logger.module.ts
@@ -6,6 +6,7 @@ import {
   Provider,
 } from '@nestjs/common';
 import { format, transports } from 'winston';
+import { BufferLoggerService } from './buffer-logger.service';
 import {
   colorize,
   exceptionInfo,
@@ -22,21 +23,29 @@ import { ILogger } from './logger.interface';
 import { NamedLoggerService } from './named-logger.service';
 import { NestLoggerAdapterService } from './nest-logger-adapter.service';
 import { NullLoggerService } from './null-logger.service';
+import { ProxyLoggerService } from './proxy-logger.service';
 import { LoggerOptions, WinstonLoggerService } from './winston-logger.service';
 
 @Global()
 @Module({
   providers: [
     LevelMatcherProvider,
+    NamedLoggerService,
+    BufferLoggerService,
+    ProxyLoggerService,
+    WinstonLoggerService,
     {
       provide: ILogger,
-      useClass: WinstonLoggerService,
+      useFactory: (proxy: ProxyLoggerService, buffer: BufferLoggerService) => {
+        proxy.setLogger(buffer);
+        return proxy;
+      },
+      inject: [ProxyLoggerService, BufferLoggerService],
     },
     {
       provide: NestLogger,
       useClass: NestLoggerAdapterService,
     },
-    NamedLoggerService,
   ],
 })
 export class LoggerModule {
@@ -80,6 +89,15 @@ export class LoggerModule {
       ],
       exports: namedLoggerProviders,
     };
+  }
+
+  constructor(
+    proxy: ProxyLoggerService,
+    winston: WinstonLoggerService,
+    buffer: BufferLoggerService
+  ) {
+    proxy.setLogger(winston);
+    buffer.flushTo(winston);
   }
 }
 

--- a/src/core/logger/logger.module.ts
+++ b/src/core/logger/logger.module.ts
@@ -17,6 +17,7 @@ import {
   timestamp,
 } from './formatters';
 import { LevelMatcherProvider } from './level-matcher.provider';
+import { loggerNames, LoggerToken } from './logger.decorator';
 import { ILogger } from './logger.interface';
 import { NamedLoggerService } from './named-logger.service';
 import { NestLoggerAdapterService } from './nest-logger-adapter.service';
@@ -39,8 +40,6 @@ import { LoggerOptions, WinstonLoggerService } from './winston-logger.service';
   ],
 })
 export class LoggerModule {
-  static loggerNames: string[] = new Array<string>();
-
   static forTest(): DynamicModule {
     const module = LoggerModule.forRoot();
     module.providers?.push({
@@ -67,7 +66,9 @@ export class LoggerModule {
       ),
     };
 
-    const namedLoggerProviders = this.loggerNames.map(namedLoggerProvider);
+    const namedLoggerProviders = Array.from(loggerNames).map(
+      namedLoggerProvider
+    );
     return {
       module: LoggerModule,
       providers: [
@@ -81,17 +82,6 @@ export class LoggerModule {
     };
   }
 }
-
-/**
- * Creates the token for a named logger
- * @param name The name of the logger
- */
-export const LoggerToken = (name: string) => {
-  if (!LoggerModule.loggerNames.includes(name)) {
-    LoggerModule.loggerNames.push(name);
-  }
-  return `Logger(${name})`;
-};
 
 const namedLoggerProvider = (name: string): Provider<ILogger> => ({
   provide: LoggerToken(name),

--- a/src/core/logger/logger.module.ts
+++ b/src/core/logger/logger.module.ts
@@ -26,21 +26,22 @@ import { NullLoggerService } from './null-logger.service';
 import { ProxyLoggerService } from './proxy-logger.service';
 import { LoggerOptions, WinstonLoggerService } from './winston-logger.service';
 
+const buffer = new BufferLoggerService();
+const proxy = new ProxyLoggerService();
+proxy.setLogger(buffer);
+export const bootstrapLogger = new NestLoggerAdapterService(proxy);
+
 @Global()
 @Module({
   providers: [
     LevelMatcherProvider,
     NamedLoggerService,
-    BufferLoggerService,
-    ProxyLoggerService,
+    { provide: BufferLoggerService, useValue: buffer },
+    { provide: ProxyLoggerService, useValue: proxy },
     WinstonLoggerService,
     {
       provide: ILogger,
-      useFactory: (proxy: ProxyLoggerService, buffer: BufferLoggerService) => {
-        proxy.setLogger(buffer);
-        return proxy;
-      },
-      inject: [ProxyLoggerService, BufferLoggerService],
+      useExisting: ProxyLoggerService,
     },
     {
       provide: NestLogger,

--- a/src/core/logger/nest-logger-adapter.service.ts
+++ b/src/core/logger/nest-logger-adapter.service.ts
@@ -17,6 +17,8 @@ export class NestLoggerAdapterService implements INestLogger, OnModuleInit {
     InstanceLoader: 'nest:loader',
     ExceptionsHandler: 'nest:exception',
     NestApplication: 'nest:application',
+    RouterExplorer: 'nest:router:explorer',
+    RoutesResolver: 'nest:router:resolver',
   };
 
   constructor(private readonly logger: ILogger) {}

--- a/src/core/logger/nest-logger-adapter.service.ts
+++ b/src/core/logger/nest-logger-adapter.service.ts
@@ -40,7 +40,7 @@ export class NestLoggerAdapterService implements INestLogger, OnModuleInit {
 
   log(message: any, context?: string) {
     const name = this.mapName(context);
-    this.logger.debug(message, name);
+    this.logger.info(message, name);
   }
 
   verbose(message: any, context?: string) {

--- a/src/core/logger/proxy-logger.service.ts
+++ b/src/core/logger/proxy-logger.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { AbstractLogger } from './abstract-logger';
+import { ILogger, LogEntry } from './logger.interface';
+
+/**
+ * Implementation of our Logger that forwards to another logger.
+ */
+@Injectable()
+export class ProxyLoggerService extends AbstractLogger {
+  private logger?: ILogger;
+
+  logEntry(entry: LogEntry): void {
+    if (this.logger) {
+      this.logger.log(entry);
+    }
+  }
+
+  setLogger(logger: ILogger) {
+    const prev = this.logger;
+    this.logger = logger;
+    return prev;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,13 @@ import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import * as cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
-import { ConfigService } from './core';
+import { bootstrapLogger, ConfigService } from './core';
 import 'source-map-support/register';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, {
+    logger: bootstrapLogger,
+  });
   const config = app.get(ConfigService);
 
   app.enableCors(config.cors);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,16 +2157,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^7.1.1":
-  version: 7.4.0
-  resolution: "acorn@npm:7.4.0"
-  bin:
-    acorn: bin/acorn
-  checksum: a25b12d9e803df49593e983f05abd8084be883df23f78a3ceb49bfb9c453fdc43d51b3ce268b6acd7694c34d9cde1707acb1cdcbc5303bde47bee43ffc131491
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^7.4.0":
+"acorn@npm:^7.1.1, acorn@npm:^7.4.0":
   version: 7.4.1
   resolution: "acorn@npm:7.4.1"
   bin:
@@ -2223,7 +2214,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:6.12.0, ajv@npm:^6.1.0, ajv@npm:^6.10.0, ajv@npm:^6.10.2, ajv@npm:^6.5.5":
+"ajv@npm:6.12.0":
   version: 6.12.0
   resolution: "ajv@npm:6.12.0"
   dependencies:
@@ -2235,7 +2226,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.12.4":
+"ajv@npm:^6.1.0, ajv@npm:^6.10.0, ajv@npm:^6.10.2, ajv@npm:^6.12.4, ajv@npm:^6.5.5":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
@@ -4125,6 +4116,7 @@ __metadata:
     eslint-plugin-typescript-sort-keys: ^1.5.0
     execa: ^4.0.3
     faker: ^4.1.0
+    fast-safe-stringify: ^2.0.7
     got: ^11.5.0
     graphql: ^15.3.0
     html-to-text: ^5.1.1
@@ -5426,17 +5418,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^5.0.0":
-  version: 5.1.0
-  resolution: "eslint-scope@npm:5.1.0"
-  dependencies:
-    esrecurse: ^4.1.0
-    estraverse: ^4.1.1
-  checksum: 4a0e97979a855d09c4bb3a3f4f945cefaf8f6638a6a8f49472cefb0cf64982ab7ed1683a1e63d20ce1bcb01f94c133dc7a5bdf03b28eb945999f50f08878a2b4
-  languageName: node
-  linkType: hard
-
-"eslint-scope@npm:^5.1.1":
+"eslint-scope@npm:^5.0.0, eslint-scope@npm:^5.1.1":
   version: 5.1.1
   resolution: "eslint-scope@npm:5.1.1"
   dependencies:
@@ -5546,16 +5528,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esrecurse@npm:^4.1.0":
-  version: 4.2.1
-  resolution: "esrecurse@npm:4.2.1"
-  dependencies:
-    estraverse: ^4.1.0
-  checksum: 9acfa287729037ccb63ee725df2214b313fe1296a91f58fe42b151e1af0d51558ac18486e53f5717477ad9306f7a79d4e20fc7f8bac486d3175f86ab2dc67f73
-  languageName: node
-  linkType: hard
-
-"esrecurse@npm:^4.3.0":
+"esrecurse@npm:^4.1.0, esrecurse@npm:^4.3.0":
   version: 4.3.0
   resolution: "esrecurse@npm:4.3.0"
   dependencies:
@@ -5564,7 +5537,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estraverse@npm:^4.1.0, estraverse@npm:^4.1.1, estraverse@npm:^4.2.0":
+"estraverse@npm:^4.1.1, estraverse@npm:^4.2.0":
   version: 4.3.0
   resolution: "estraverse@npm:4.3.0"
   checksum: 1e4c627da9e9af07bf7b2817320f606841808fb2ec0cbd81097b30d5f90d8613288b3e523153babe04615d59b54ef876d98f0ca27488b6c0934dacd725a8d338
@@ -5872,7 +5845,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-safe-stringify@npm:2.0.7, fast-safe-stringify@npm:^2.0.4":
+"fast-safe-stringify@npm:2.0.7, fast-safe-stringify@npm:^2.0.4, fast-safe-stringify@npm:^2.0.7":
   version: 2.0.7
   resolution: "fast-safe-stringify@npm:2.0.7"
   checksum: 7bd22543263b707870d70c6f2336b6e8563e34d6807dc388cc0566895e31e0a8273af017a7eb1c9538d0ef54288284e1c0585b557bd856491295a847159fd929
@@ -6272,44 +6245,40 @@ __metadata:
   linkType: hard
 
 fsevents@^1.2.7:
-  version: 1.2.11
-  resolution: "fsevents@npm:1.2.11"
+  version: 1.2.13
+  resolution: "fsevents@npm:1.2.13"
   dependencies:
     bindings: ^1.5.0
     nan: ^2.12.1
-    node-gyp: latest
-    node-pre-gyp: "*"
-  checksum: aed1040495a4751298fa2df107fe387efd71d4b4dbc31e3044e86192318cccbca38481a9ad8a069aa24f42fdc6d793a04dc93bab4227178e58f9c9f76e3824ed
+  checksum: e70509558b5f49ce9dfacb8f9e2848c6e6751a61966027789561145a9c4ae9ba4c6b28b531bc8b4ae52fdd2d4c90a3bf314e6794717e51838b27910bb41ce588
   languageName: node
   linkType: hard
 
 "fsevents@^2.1.2, fsevents@~2.1.2":
-  version: 2.1.2
-  resolution: "fsevents@npm:2.1.2"
+  version: 2.1.3
+  resolution: "fsevents@npm:2.1.3"
   dependencies:
     node-gyp: latest
-  checksum: 8f61ef784058aa410def121afcf20014fbb845c678c04e43fe1fd1edec6c469c5452343b4a49960d89e8a207955c8e9b37a229af7a8fc5b28658c9e0faabe086
+  checksum: 8977781884d06c5bcb97b5f909efdce9683c925f2a0ce7e098d2cdffe2e0a0a50b1868547bb94dca75428c06535a4a70517a7bb3bb5a974d93bf9ffc067291eb
   languageName: node
   linkType: hard
 
 "fsevents@patch:fsevents@^1.2.7#builtin<compat/fsevents>":
-  version: 1.2.11
-  resolution: "fsevents@patch:fsevents@npm%3A1.2.11#builtin<compat/fsevents>::version=1.2.11&hash=87eb42"
+  version: 1.2.13
+  resolution: "fsevents@patch:fsevents@npm%3A1.2.13#builtin<compat/fsevents>::version=1.2.13&hash=87eb42"
   dependencies:
     bindings: ^1.5.0
     nan: ^2.12.1
-    node-gyp: latest
-    node-pre-gyp: "*"
-  checksum: 9cc9568c88c0a898c2c92234f3a573caadfca348881f89879b707e7552e7e0ef65f29cd1d01d1cbbf5c00b07636779804a22773c18f3357e9cad37724d57abdc
+  checksum: 31c62373556f061f4b4c52ff61c91bc9080243ea074a38a81cf12c1f2c9098da731ea3d39705c805b738427e4284af6b8151efe65ce9ca6b11378d43f36db2c4
   languageName: node
   linkType: hard
 
 "fsevents@patch:fsevents@^2.1.2#builtin<compat/fsevents>, fsevents@patch:fsevents@~2.1.2#builtin<compat/fsevents>":
-  version: 2.1.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.1.2#builtin<compat/fsevents>::version=2.1.2&hash=87eb42"
+  version: 2.1.3
+  resolution: "fsevents@patch:fsevents@npm%3A2.1.3#builtin<compat/fsevents>::version=2.1.3&hash=87eb42"
   dependencies:
     node-gyp: latest
-  checksum: 28fbb58d43f2949e9f7097b460bf594efc6cba5b4d4326158de82a116b01a1c059efee445b1c60b85acba408087e22d1e23a0595358d5d538ceb6a35bf5ae16a
+  checksum: d8ae862048fc127cdbd00d02b2feb7c25946c3ce4cbc44e958134be87e239577a16dafafa1c270d010b8624e1b1e0372e23f7865c55c6f83e83fc9f68b0a30d2
   languageName: node
   linkType: hard
 
@@ -7233,6 +7202,15 @@ fsevents@^1.2.7:
   bin:
     is-ci: bin.js
   checksum: 09083018edafd63221ff0506356f13c0aaf4b75a6435ea648bc67d07ddab199b2d5b9297de43d0821df1a14c18cd9f1edd1775a0166abfe37390843e79137213
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "is-core-module@npm:2.0.0"
+  dependencies:
+    has: ^1.0.3
+  checksum: de99dfbdf14d254f6d078aa37113512295acef3cfff5fb39fdf8020b04788535eae6da39e02b0c4ad07f7bc79594de8d5aeb4fce66f97feb9c597d7d6d6d43d4
   languageName: node
   linkType: hard
 
@@ -10170,7 +10148,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-pre-gyp@npm:*, node-pre-gyp@npm:^0.14.0":
+"node-pre-gyp@npm:^0.14.0":
   version: 0.14.0
   resolution: "node-pre-gyp@npm:0.14.0"
   dependencies:
@@ -11744,39 +11722,23 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.1, resolve@^1.13.1, resolve@^1.3.2":
-  version: 1.15.1
-  resolution: "resolve@npm:1.15.1"
+"resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.1, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2":
+  version: 1.18.1
+  resolution: "resolve@npm:1.18.1"
   dependencies:
+    is-core-module: ^2.0.0
     path-parse: ^1.0.6
-  checksum: 34f77287b44a7eb4588d9d631165c763099a82aca3132920e0fdcde428a51f2cf69190c19e2309e35288a0702f57fefeb951da6138677036a16636b2f0e7b8dd
+  checksum: deb5ba746e1c038ba8fb7ca5c35ee3fe88665e2f79be3e9a706e5254eeea55eb12b6f1830dd60a11bbafa327bcd868284fbf5caf428cf5761b3f094abdffee77
   languageName: node
   linkType: hard
 
-resolve@^1.17.0:
-  version: 1.17.0
-  resolution: "resolve@npm:1.17.0"
+"resolve@patch:resolve@^1.1.6#builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#builtin<compat/resolve>, resolve@patch:resolve@^1.11.1#builtin<compat/resolve>, resolve@patch:resolve@^1.13.1#builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#builtin<compat/resolve>":
+  version: 1.18.1
+  resolution: "resolve@patch:resolve@npm%3A1.18.1#builtin<compat/resolve>::version=1.18.1&hash=3388aa"
   dependencies:
+    is-core-module: ^2.0.0
     path-parse: ^1.0.6
-  checksum: 5e3cdb8cf68c20b0c5edeb6505e7fab20c6776af0cae4b978836e557420aef7bb50acd25339bbb143b7f80533aa1988c7e827a0061aee9c237926a7d2c41f8d0
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@^1.1.6#builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#builtin<compat/resolve>, resolve@patch:resolve@^1.11.1#builtin<compat/resolve>, resolve@patch:resolve@^1.13.1#builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#builtin<compat/resolve>":
-  version: 1.15.1
-  resolution: "resolve@patch:resolve@npm%3A1.15.1#builtin<compat/resolve>::version=1.15.1&hash=3388aa"
-  dependencies:
-    path-parse: ^1.0.6
-  checksum: 6588c8a8735d8b2a00cfee2a325538f325ae5e48653490882d3e8afe6124f25c25d60ec09864f30a03c4471a3201c9cfba0e14ca0f74f626ac4b5c8d2e42c2c2
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@^1.17.0#builtin<compat/resolve>":
-  version: 1.17.0
-  resolution: "resolve@patch:resolve@npm%3A1.17.0#builtin<compat/resolve>::version=1.17.0&hash=3388aa"
-  dependencies:
-    path-parse: ^1.0.6
-  checksum: 4bcfb568860d0c361fd16c26b6fce429711138ff0de7dd353bdd73fcb5c7eede2f4602d40ccfa08ff45ec7ef9830845eab2021a46036af0a6e5b58bab1ff6399
+  checksum: 9e62d2803ad1ec21b13780cc6a45b72bb7b6525eb5b44f0ede7cde37c00a8eb310c06ebfcc7de7dc10c2234d7d271bc4f1eed9783fb87acac141597cd4efaeec
   languageName: node
   linkType: hard
 
@@ -13311,10 +13273,17 @@ resolve@^1.17.0:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.0.0, tslib@npm:>=1.9.0, tslib@npm:~2.0.0":
+"tslib@npm:2.0.0":
   version: 2.0.0
   resolution: "tslib@npm:2.0.0"
   checksum: a7369a224f12e223fb42f2a720389601a24a1e1c96c55bf0d8d4b60c131e574c175ae23578b8d1bd3f4ec790c7e0a82b43733f022f866d48a23aeadd3910755d
+  languageName: node
+  linkType: hard
+
+"tslib@npm:>=1.9.0, tslib@npm:~2.0.0":
+  version: 2.0.3
+  resolution: "tslib@npm:2.0.3"
+  checksum: 447bfca5deaa157806c3f77eaba74d05dd0b38b014e47ce79d98b5c77ce7d91b00a687ba13ca1b5a74d35ca1098ac7a072c0a97fad06f0266612f2a03a6c8e8f
   languageName: node
   linkType: hard
 
@@ -13459,27 +13428,27 @@ resolve@^1.17.0:
   languageName: node
   linkType: hard
 
-"typescript@^3.0.3, typescript@^3.6.4, typescript@^3.7.5, typescript@^3.8.3, typescript@~3.8.2":
-  version: 3.8.3
-  resolution: "typescript@npm:3.8.3"
+"typescript@^3.0.3, typescript@^3.6.4, typescript@^3.7.5, typescript@^3.8.3, typescript@^3.9.5, typescript@^3.9.6":
+  version: 3.9.7
+  resolution: "typescript@npm:3.9.7"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 519b11576247fe3570d89a2aa757d8f666aafc0cb9465a6cdd4df09c1dc6bf7285f0c6008d2ac7a55ea26457e767aaab819f58439d80af2cce1d9805b2be1034
+  checksum: 10848a9c35fd8c70a8792b8bd9485317534bcd58768793d3b7d9c7486e9fd30cf345f83fa2a324e0bf6088bc8a4d8d061d58fda38b18c2ff187cf01fbbff6267
   languageName: node
   linkType: hard
 
-"typescript@^3.9.5, typescript@^3.9.6":
-  version: 3.9.6
-  resolution: "typescript@npm:3.9.6"
+"typescript@patch:typescript@^3.0.3#builtin<compat/typescript>, typescript@patch:typescript@^3.6.4#builtin<compat/typescript>, typescript@patch:typescript@^3.7.5#builtin<compat/typescript>, typescript@patch:typescript@^3.8.3#builtin<compat/typescript>, typescript@patch:typescript@^3.9.5#builtin<compat/typescript>, typescript@patch:typescript@^3.9.6#builtin<compat/typescript>":
+  version: 3.9.7
+  resolution: "typescript@patch:typescript@npm%3A3.9.7#builtin<compat/typescript>::version=3.9.7&hash=5b02a2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 75d8e3610ca435b0feaa3eb714ef3aa9060ec72621da3c62c45ceee1d8d0ddcbd8ff2a816de2d24ab28dcd2249953edb640d34595d59e491656156da4c2903fc
+  checksum: f0d3d9c987860c7c458229ab6dd7e3d322405db36b70abccba610b5efd9f9451e4e67a3fc7983c0d3741033c1f1a8d7aa859a1510caa8f20fad762fc39648bfa
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^3.0.3#builtin<compat/typescript>, typescript@patch:typescript@^3.6.4#builtin<compat/typescript>, typescript@patch:typescript@^3.7.5#builtin<compat/typescript>, typescript@patch:typescript@^3.8.3#builtin<compat/typescript>, typescript@patch:typescript@~3.8.2#builtin<compat/typescript>":
+"typescript@patch:typescript@~3.8.2#builtin<compat/typescript>":
   version: 3.8.3
   resolution: "typescript@patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=5b02a2"
   bin:
@@ -13489,13 +13458,13 @@ resolve@^1.17.0:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^3.9.5#builtin<compat/typescript>, typescript@patch:typescript@^3.9.6#builtin<compat/typescript>":
-  version: 3.9.6
-  resolution: "typescript@patch:typescript@npm%3A3.9.6#builtin<compat/typescript>::version=3.9.6&hash=5b02a2"
+typescript@~3.8.2:
+  version: 3.8.3
+  resolution: "typescript@npm:3.8.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: de0b64b2df571ddb6a87e058605b011b1d7e2ed5e1bb27ba658251a380041abbbdf5bdf8da25d5605ac84e7fb3882a816b9a283ffaddedebfde1a57db4c18c30
+  checksum: 519b11576247fe3570d89a2aa757d8f666aafc0cb9465a6cdd4df09c1dc6bf7285f0c6008d2ac7a55ea26457e767aaab819f58439d80af2cce1d9805b2be1034
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The main goal of this PR is to handle logging nicer for our deployed environments.


## Emit logs as json instead of cli-colored-pretty-print ones via env boolean

I spent a lot of time connecting up a direct connection to AWS cloudwatch via a winston transport, so we could send json instead of strings. It turns out the AWS API only accepts strings, _but_ it automatically parsing json strings.

This led to the discovery of that (json parsing) also working for stdout which ECS automatically forwards to cloudwatch.
This saves effort, complexity, and performance so I'm glad I found it - just wish I didn't take the hard route lol.

Previously the logs looked like this
![Screen Shot 2020-11-09 at 11 07 30 AM](https://user-images.githubusercontent.com/932566/98573275-4abb2580-227c-11eb-8574-697440e96c4f.png)

Now they look like this
![Screen Shot 2020-11-09 at 11 08 13 AM](https://user-images.githubusercontent.com/932566/98573312-5575ba80-227c-11eb-9f11-0937d0f8ca7c.png)

And more importantly they can be queried in CloudWatch Insights
![Screen Shot 2020-11-09 at 11 10 58 AM](https://user-images.githubusercontent.com/932566/98573363-68888a80-227c-11eb-9b1b-84eca26fa78a.png)


## Connect our logger while app is bootstrapping

I believe that the logger should be injected via DI to allow for flexibility & customization, however this creates a gap between when code execution starts and DI logger creation. This is what we've been experiencing so far where we see NestJS messages about module initialization and such, printed in a different format.

Now we inject a temporary "bootstrap logger" while creating the app ([here](https://github.com/SeedCompany/cord-api-v3/blob/baeb37253b65653cd17759229806f207d5b7ff0d/src/main.ts#L10) & [here](https://github.com/SeedCompany/cord-api-v3/blob/5c178906403de49cfd1be8ccaa724409687fcc97/src/core/logger/logger.module.ts#L33-L36)). This logger collects log statements and then prints them once the "real" logger is [ready](https://github.com/SeedCompany/cord-api-v3/blob/5c178906403de49cfd1be8ccaa724409687fcc97/src/core/logger/logger.module.ts#L116-L118). This allows us to control formatting from the start.

However, this still leaves a smaller edge case where the real logger is never created because of an error preventing NestJS from starting, like dependency failure. With the bootstrap logger collecting all the messages (including errors), the error is never printed.

This is now mitigated with our own [`ExceptionHandler`](https://github.com/SeedCompany/cord-api-v3/blob/5c178906403de49cfd1be8ccaa724409687fcc97/src/core/logger/exception-logger.ts) to replace Nest's. Its only purpose is to log the errors. All ours does is allow a logger to be injected/set at all point. While bootstrapping this handler uses a [winston logger](https://github.com/SeedCompany/cord-api-v3/blob/5c178906403de49cfd1be8ccaa724409687fcc97/src/core/logger/logger.module.ts#L39-L44) to log errors in the same format that our real logger does. Unfortunately, that configuration is duplicated as it has to happen outside of DI. 

I set the `nest:loader` logs to warning by default, as we really don't care about them unless there's an error.

Startup now looks like this:
![Screen Shot 2020-11-09 at 10 47 00 AM](https://user-images.githubusercontent.com/932566/98570304-eb0f4b00-2278-11eb-9d73-ea953be03883.png)
Short & sweet ❤️ 

App creation exceptions now look like this
![Screen Shot 2020-11-09 at 11 00 22 AM](https://user-images.githubusercontent.com/932566/98572302-15fa9e80-227b-11eb-9d41-7812d59f29a2.png)

Instead of this
![Screen Shot 2020-11-09 at 11 01 56 AM](https://user-images.githubusercontent.com/932566/98572312-1abf5280-227b-11eb-8414-04d1de3e66bf.png)
Most notably the duplicate message and useless stacktrace are hidden now.

## Log levels can be controlled via env now

This is mostly for deployments where our main/only configuration point is via environment.
It's the same idea as format in `logging.yml` it's just joined to a string via `=` & `;`

For example, given this logging.yml configuration
```yml
levels:
  config, config:*: info
  email: debug
defaultLevel: notice
```
it would look like this in env
```env
LOG_LEVELS=config,config:*=info;email=debug
LOG_LEVEL_DEFAULT=notice
```

I know it's not the prettiest, but that's the constraint of key/value pairs. We shouldn't need to tweak it much anyways.


## Other things

- Exceptions for non-GraphQL requests were thrown (and not caught) leaving the http request without a response. Fixed with df44506b423adbabd5c2c523cf1703e8310a03e9.
  The most evident point of this was our cloudwatch log being cluttered these node errors from spam/hack-attempt requests.
  ![Screen Shot 2020-11-09 at 10 57 44 AM](https://user-images.githubusercontent.com/932566/98571818-88b74a00-227a-11eb-8eda-fdfa2fecd5fe.png)
- Enumerable properties from exceptions are now logged. This allows props like [InputException.field](https://github.com/SeedCompany/cord-api-v3/blob/262d725d7b9045661c212f488a3dbe3786c81e4a/src/common/exceptions/input.exception.ts#L16) to be queried.
- Various fixes/tweaks to log formatting
