### PR TITLE
Refactor delete all services

### DIFF
--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -16,6 +16,7 @@ import {
   NotFoundException,
   ServerException,
   Session,
+  UnauthorizedException,
 } from '../../common';
 import {
   ConfigService,
@@ -259,6 +260,12 @@ export class FileRepository {
         isPublic: false,
         isOrgPublic: false,
       },
+      {
+        key: 'canDelete',
+        value: true,
+        isPublic: false,
+        isOrgPublic: false,
+      },
     ];
 
     const createFile = this.db
@@ -298,6 +305,12 @@ export class FileRepository {
       {
         key: 'name',
         value: name,
+        isPublic: false,
+        isOrgPublic: false,
+      },
+      {
+        key: 'canDelete',
+        value: true,
         isPublic: false,
         isOrgPublic: false,
       },
@@ -346,6 +359,12 @@ export class FileRepository {
       {
         key: 'size',
         value: input.size,
+        isPublic: false,
+        isOrgPublic: false,
+      },
+      {
+        key: 'canDelete',
+        value: true,
         isPublic: false,
         isOrgPublic: false,
       },
@@ -467,15 +486,23 @@ export class FileRepository {
   }
 
   async delete(fileNode: BaseNode, session: Session): Promise<void> {
+    const canDelete = await this.db.checkDeletePermission(fileNode.id, session);
+
+    if (!canDelete)
+      throw new UnauthorizedException(
+        'You do not have the permission to delete this File item'
+      );
+
+    const baseNodeLabels = ['BaseNode', fileNode.type];
+
     try {
-      await this.db.deleteNode({
-        session,
+      await this.db.deleteNodeNew({
         object: fileNode,
-        aclEditProp: 'canDeleteOwnUser',
+        baseNodeLabels,
       });
-    } catch (e) {
-      this.logger.error('Failed to delete', { id: fileNode.id, exception: e });
-      throw new ServerException('Failed to delete', e);
+    } catch (exception) {
+      this.logger.error('Failed to delete', { id: fileNode.id, exception });
+      throw new ServerException('Failed to delete', exception);
     }
   }
 

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -6,6 +6,7 @@ import {
   NotFoundException,
   ServerException,
   Session,
+  UnauthorizedException,
 } from '../../common';
 import {
   ConfigService,
@@ -15,6 +16,7 @@ import {
   Logger,
   matchRequestingUser,
   OnIndex,
+  UniqueProperties,
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
@@ -107,6 +109,12 @@ export class FundingAccountService {
         isOrgPublic: false,
         label: 'FundingAccountNumber',
       },
+      {
+        key: 'canDelete',
+        value: true,
+        isPublic: false,
+        isOrgPublic: false,
+      },
     ];
 
     try {
@@ -171,7 +179,7 @@ export class FundingAccountService {
     return {
       ...parseBaseNodeProperties(result.node),
       ...secured,
-      canDelete: true, // TODO
+      canDelete: await this.db.checkDeletePermission(id, session),
     };
   }
 
@@ -190,8 +198,37 @@ export class FundingAccountService {
     });
   }
 
-  async delete(_id: string, _session: Session): Promise<void> {
-    // Not implemented
+  async delete(id: string, session: Session): Promise<void> {
+    const object = await this.readOne(id, session);
+
+    if (!object) {
+      throw new NotFoundException('Could not find Funding Account');
+    }
+
+    const canDelete = await this.db.checkDeletePermission(id, session);
+
+    if (!canDelete)
+      throw new UnauthorizedException(
+        'You do not have the permission to delete this Funding Account'
+      );
+
+    const baseNodeLabels = ['BaseNode', 'FundingAccount'];
+
+    const uniqueProperties: UniqueProperties<FundingAccount> = {
+      name: ['Property', 'FundingAccountName'],
+      accountNumber: ['Property', 'FundingAccountNumber'],
+    };
+
+    try {
+      await this.db.deleteNodeNew({
+        object,
+        baseNodeLabels,
+        uniqueProperties,
+      });
+    } catch (exception) {
+      this.logger.error('Failed to delete', { id, exception });
+      throw new ServerException('Failed to delete', exception);
+    }
   }
 
   async list(

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -119,13 +119,13 @@ export class LanguageService {
       // DISPLAYNAME NODE
       'CREATE CONSTRAINT ON (n:LanguageDisplayName) ASSERT EXISTS(n.value)',
 
-      // RODNUMBER REL
-      'CREATE CONSTRAINT ON ()-[r:rodNumber]-() ASSERT EXISTS(r.active)',
-      'CREATE CONSTRAINT ON ()-[r:rodNumber]-() ASSERT EXISTS(r.createdAt)',
+      // REGISTRYOFDIALECTSCODE REL
+      'CREATE CONSTRAINT ON ()-[r:registryOfDialectsCode]-() ASSERT EXISTS(r.active)',
+      'CREATE CONSTRAINT ON ()-[r:registryOfDialectsCode]-() ASSERT EXISTS(r.createdAt)',
 
-      // RODNUMBER NODE
-      'CREATE CONSTRAINT ON (n:LanguageRodNumber) ASSERT EXISTS(n.value)',
-      'CREATE CONSTRAINT ON (n:LanguageRodNumber) ASSERT n.value IS UNIQUE',
+      // REGISTRYOFDIALECTSCODE NODE
+      'CREATE CONSTRAINT ON (n:RegistryOfDialectsCode) ASSERT EXISTS(n.value)',
+      'CREATE CONSTRAINT ON (n:RegistryOfDialectsCode) ASSERT n.value IS UNIQUE',
 
       // ETHNOLOGUELANGUAGE REL
       'CREATE CONSTRAINT ON ()-[r:ethnologue]-() ASSERT EXISTS(r.active)',
@@ -308,7 +308,7 @@ export class LanguageService {
           simpleSwitch(e.label, {
             LanguageName: 'name',
             LanguageDisplayName: 'displayName',
-            LanguageRodNumber: 'rodNumber',
+            RegistryOfDialectsCode: `registryOfDialectsCode`,
           }) ?? e.label;
         throw new DuplicateException(
           `language.${prop}`,
@@ -470,7 +470,7 @@ export class LanguageService {
     const uniqueProperties: UniqueProperties<Language> = {
       name: ['Property', 'LanguageName'],
       displayName: ['Property', 'LanguageDisplayName'],
-      registryOfDialectsCode: ['Property'],
+      registryOfDialectsCode: ['Property', 'RegistryOfDialectsCode'],
     };
 
     try {

--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -8,6 +8,7 @@ import {
   NotFoundException,
   ServerException,
   Session,
+  UnauthorizedException,
 } from '../../common';
 import {
   ConfigService,
@@ -145,6 +146,12 @@ export class PartnerService {
       {
         key: 'modifiedAt',
         value: createdAt,
+        isPublic: false,
+        isOrgPublic: false,
+      },
+      {
+        key: 'canDelete',
+        value: true,
         isPublic: false,
         isOrgPublic: false,
       },
@@ -297,7 +304,7 @@ export class PartnerService {
         ...secured.financialReportingTypes,
         value: secured.financialReportingTypes.value || [],
       },
-      canDelete: true, // TODO
+      canDelete: await this.db.checkDeletePermission(id, session),
     };
   }
 
@@ -382,16 +389,28 @@ export class PartnerService {
   }
 
   async delete(id: string, session: Session): Promise<void> {
-    const ed = await this.readOne(id, session);
+    const object = await this.readOne(id, session);
+    if (!object) {
+      throw new NotFoundException('Could not find Partner');
+    }
+
+    const canDelete = await this.db.checkDeletePermission(id, session);
+
+    if (!canDelete)
+      throw new UnauthorizedException(
+        'You do not have the permission to delete this Partner'
+      );
+
+    const baseNodeLabels = ['BaseNode', 'Partner'];
+
     try {
-      await this.db.deleteNode({
-        session,
-        object: ed,
-        aclEditProp: 'canDeleteOwnUser',
+      await this.db.deleteNodeNew<Partner>({
+        object,
+        baseNodeLabels,
       });
-    } catch (e) {
-      this.logger.error('Failed to delete', { id, exception: e });
-      throw new ServerException('Failed to delete');
+    } catch (exception) {
+      this.logger.error('Failed to delete', { id, exception });
+      throw new ServerException('Failed to delete', exception);
     }
 
     this.logger.debug(`deleted partner with id`, { id });

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -42,6 +42,7 @@ import {
   StandardReadResult,
 } from '../../core/database/results';
 import { AuthorizationService } from '../authorization/authorization.service';
+import { Powers } from '../authorization/dto/powers';
 import { BudgetService, BudgetStatus, SecuredBudget } from '../budget';
 import {
   EngagementListInput,

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -10,6 +10,7 @@ import {
   Sensitivity,
   ServerException,
   Session,
+  UnauthorizedException,
 } from '../../common';
 import {
   ConfigService,
@@ -41,7 +42,6 @@ import {
   StandardReadResult,
 } from '../../core/database/results';
 import { AuthorizationService } from '../authorization/authorization.service';
-import { Powers } from '../authorization/dto/powers';
 import { BudgetService, BudgetStatus, SecuredBudget } from '../budget';
 import {
   EngagementListInput,
@@ -251,6 +251,12 @@ export class ProjectService {
       {
         key: 'financialReportReceivedAt',
         value: createInput.financialReportReceivedAt,
+        isPublic: false,
+        isOrgPublic: false,
+      },
+      {
+        key: 'canDelete',
+        value: true,
         isPublic: false,
         isOrgPublic: false,
       },
@@ -529,7 +535,7 @@ export class ProjectService {
         ...securedProps.owningOrganization,
         value: result.owningOrganizationId,
       },
-      canDelete: true, // TODO
+      canDelete: await this.db.checkDeletePermission(id, { userId }),
     };
   }
 
@@ -673,12 +679,17 @@ export class ProjectService {
   }
 
   async delete(id: string, session: Session): Promise<void> {
-    await this.authorizationService.checkPower(Powers.DeleteProject, session);
-
     const object = await this.readOne(id, session);
     if (!object) {
       throw new NotFoundException('Could not find project');
     }
+
+    const canDelete = await this.db.checkDeletePermission(id, session);
+
+    if (!canDelete)
+      throw new UnauthorizedException(
+        'You do not have the permission to delete this Project'
+      );
 
     const baseNodeLabels = ['BaseNode', 'Project', `${object.type}Project`];
 

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -478,11 +478,11 @@ export class DatabaseService {
   async deleteNodeNew<TObject extends Resource>({
     object,
     baseNodeLabels,
-    uniqueProperties,
+    uniqueProperties = {},
   }: {
     object: TObject;
     baseNodeLabels: string[];
-    uniqueProperties: UniqueProperties<TObject>;
+    uniqueProperties?: UniqueProperties<TObject>;
   }) {
     const query = this.db
       .query()

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -455,7 +455,7 @@ export class DatabaseService {
     };
   }
 
-  async checkDeletePermission(id: string, session: Session) {
+  async checkDeletePermission(id: string, session: Partial<Session>) {
     const query = this.db
       .query()
       .call(matchRequestingUser, session)

--- a/test/zone.e2e-spec.ts
+++ b/test/zone.e2e-spec.ts
@@ -154,15 +154,15 @@ describe('Field Zone e2e', () => {
 
     const result = await app.graphql.mutate(
       gql`
-        mutation deleteFieldRegion($id: ID!) {
-          deleteFieldRegion(id: $id)
+        mutation deleteFieldZone($id: ID!) {
+          deleteFieldZone(id: $id)
         }
       `,
       {
         id: fieldZone.id,
       }
     );
-    const actual: FieldZone | undefined = result.deleteFieldRegion;
+    const actual: FieldZone | undefined = result.deleteFieldZone;
 
     expect(actual).toBeTruthy();
   });


### PR DESCRIPTION
It looks like the Engagement and User service's `Create` needs to be refactored, they are using a different create style ```...property('realFirstName', input.realFirstName, 'user'),``` vs `createBaseNode`

@michaelmarshall The workflow delete, and most of the entire service looks to be very old.  Does the delete need to be refactored similarly?