### PR TITLE
Fix initial end handling

### DIFF
--- a/src/components/engagement/dto/update-engagement.dto.ts
+++ b/src/components/engagement/dto/update-engagement.dto.ts
@@ -30,7 +30,7 @@ export abstract class UpdateEngagement {
   @DateField({ nullable: true })
   readonly endDateOverride?: CalendarDate;
 
-  readonly initialEndDate?: CalendarDate;
+  readonly initialEndDate?: CalendarDate | null;
 
   @Field(() => EngagementStatus, { nullable: true })
   readonly status?: EngagementStatus;

--- a/src/components/engagement/handlers/set-initial-end-date.handler.ts
+++ b/src/components/engagement/handlers/set-initial-end-date.handler.ts
@@ -1,4 +1,9 @@
-import { CalendarDate, ServerException, Session } from '../../../common';
+import {
+  CalendarDate,
+  ServerException,
+  Session,
+  UnauthorizedException,
+} from '../../../common';
 import {
   DatabaseService,
   EventsHandler,
@@ -29,16 +34,28 @@ export class SetInitialEndDate implements IEventHandler<SubscribedEvent> {
 
     const engagement = 'engagement' in event ? event.engagement : event.updated;
 
-    const shouldUpdateInitialEndDate =
-      engagement.status.value === EngagementStatus.Active &&
-      engagement.initialEndDate.value == null &&
-      engagement.endDate.value != null;
-    if (!shouldUpdateInitialEndDate) {
+    if (engagement.status.value !== EngagementStatus.InDevelopment) {
+      return;
+    }
+    if (!engagement.endDate.canRead) {
+      throw new UnauthorizedException(
+        `Current user cannot read Engagement's end date thus initial end date cannot be set`
+      );
+    }
+    if (!engagement.initialEndDate.canRead) {
+      throw new UnauthorizedException(
+        `Current user cannot read Engagement's initial end date thus initial end date cannot be set`
+      );
+    }
+    if (
+      engagement.initialEndDate.value?.toMillis() ===
+      engagement.endDate.value?.toMillis()
+    ) {
       return;
     }
 
     try {
-      const initialEndDate = engagement.endDate.value!;
+      const initialEndDate = engagement.endDate.value;
 
       const updatedEngagement = await this.updateEngagementInitialEndDate(
         engagement,
@@ -65,12 +82,12 @@ export class SetInitialEndDate implements IEventHandler<SubscribedEvent> {
 
   private async updateEngagementInitialEndDate(
     engagement: Engagement,
-    initialEndDate: CalendarDate,
+    initialEndDate: CalendarDate | null | undefined,
     session: Session
   ) {
     const updateInput = {
       id: engagement.id,
-      initialEndDate: initialEndDate,
+      initialEndDate: initialEndDate || null,
     };
     // TODO: Refactor to call repository directly instead of engagementService methods
     if (engagement.__typename === this.languageEngagementTypeName) {

--- a/src/components/engagement/handlers/set-initial-end-date.handler.ts
+++ b/src/components/engagement/handlers/set-initial-end-date.handler.ts
@@ -34,7 +34,10 @@ export class SetInitialEndDate implements IEventHandler<SubscribedEvent> {
 
     const engagement = 'engagement' in event ? event.engagement : event.updated;
 
-    if (engagement.status.value !== EngagementStatus.InDevelopment) {
+    if (
+      event instanceof EngagementUpdatedEvent && // allow setting initial if creating with non-in-dev status
+      engagement.status.value !== EngagementStatus.InDevelopment
+    ) {
       return;
     }
     if (!engagement.endDate.canRead) {

--- a/src/components/project/dto/update-project.dto.ts
+++ b/src/components/project/dto/update-project.dto.ts
@@ -46,7 +46,7 @@ export abstract class UpdateProject {
   @DateField({ nullable: true })
   readonly mouEnd?: CalendarDate;
 
-  readonly initialMouEnd?: CalendarDate;
+  readonly initialMouEnd?: CalendarDate | null;
 
   @DateField({ nullable: true })
   readonly estimatedSubmission?: CalendarDate;

--- a/src/components/project/handlers/set-initial-mou-end.handler.ts
+++ b/src/components/project/handlers/set-initial-mou-end.handler.ts
@@ -8,7 +8,6 @@ import {
 } from '../../../core';
 import { ProjectStatus } from '../dto';
 import { ProjectCreatedEvent, ProjectUpdatedEvent } from '../events';
-import { ProjectService } from '../project.service';
 
 type SubscribedEvent = ProjectCreatedEvent | ProjectUpdatedEvent;
 
@@ -16,7 +15,6 @@ type SubscribedEvent = ProjectCreatedEvent | ProjectUpdatedEvent;
 export class SetInitialMouEnd implements IEventHandler<SubscribedEvent> {
   constructor(
     private readonly db: DatabaseService,
-    private readonly projectService: ProjectService,
     @Logger('project:set-initial-mou-end') private readonly logger: ILogger
   ) {}
 
@@ -52,15 +50,13 @@ export class SetInitialMouEnd implements IEventHandler<SubscribedEvent> {
     }
 
     try {
-      const initialMouEnd = project.mouEnd.value;
-      const updateInput = {
-        id: project.id,
-        initialMouEnd: initialMouEnd || null,
-      };
-      const updatedProject = await this.projectService.update(
-        updateInput,
-        event.session
-      );
+      const updatedProject = await this.db.sgUpdateProperty({
+        object: project,
+        nodevar: 'project',
+        key: 'initialMouEnd',
+        value: project.mouEnd.value || null,
+        session: event.session,
+      });
 
       if (event instanceof ProjectUpdatedEvent) {
         event.updated = updatedProject;

--- a/src/components/project/handlers/set-initial-mou-end.handler.ts
+++ b/src/components/project/handlers/set-initial-mou-end.handler.ts
@@ -28,7 +28,10 @@ export class SetInitialMouEnd implements IEventHandler<SubscribedEvent> {
 
     const project = 'project' in event ? event.project : event.updated;
 
-    if (project.status !== ProjectStatus.InDevelopment) {
+    if (
+      event instanceof ProjectUpdatedEvent && // allow setting initial if creating with non-in-dev status
+      project.status !== ProjectStatus.InDevelopment
+    ) {
       return;
     }
     if (!project.mouEnd.canRead) {

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -151,7 +151,7 @@ describe('Engagement e2e', () => {
     expect(actual.completeDate.value).toBeNull();
     expect(actual.disbursementCompleteDate.value).toBeNull();
     expect(actual.communicationsCompleteDate.value).toBeNull();
-    expect(actual.startDate.value).toBe(project.mouStart.value);
+    expect(actual.startDate.value).toBe(project.mouStart.value); // bump
     expect(actual.endDate.value).toBe(project.mouEnd.value);
     expect(actual.lastSuspendedAt.value).toBeNull();
     expect(actual.lastReactivatedAt.value).toBeNull();

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -155,7 +155,7 @@ describe('Engagement e2e', () => {
     expect(actual.endDate.value).toBe(project.mouEnd.value);
     expect(actual.lastSuspendedAt.value).toBeNull();
     expect(actual.lastReactivatedAt.value).toBeNull();
-    expect(actual.paraTextRegistryId.value).toBeNull();
+    expect(actual.paratextRegistryId.value).toBeNull();
   });
 
   it('creates a internship engagement', async () => {

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -153,11 +153,9 @@ describe('Engagement e2e', () => {
     expect(actual.communicationsCompleteDate.value).toBeNull();
     expect(actual.startDate.value).toBe(project.mouStart.value);
     expect(actual.endDate.value).toBe(project.mouEnd.value);
-    expect(actual.initialEndDate.value).toBeNull();
     expect(actual.lastSuspendedAt.value).toBeNull();
     expect(actual.lastReactivatedAt.value).toBeNull();
-    expect(actual.statusModifiedAt.value).toBeNull();
-    expect(actual.paratextRegistryId.value).toBeNull();
+    expect(actual.paraTextRegistryId.value).toBeNull();
   });
 
   it('creates a internship engagement', async () => {
@@ -222,10 +220,8 @@ describe('Engagement e2e', () => {
     expect(actual.communicationsCompleteDate.value).toBeNull();
     expect(actual.startDate.value).toBe(internshipProject.mouStart.value);
     expect(actual.endDate.value).toBe(internshipProject.mouEnd.value);
-    expect(actual.initialEndDate.value).toBeNull();
     expect(actual.lastSuspendedAt.value).toBeNull();
     expect(actual.lastReactivatedAt.value).toBeNull();
-    expect(actual.statusModifiedAt.value).toBeNull();
   });
 
   it('reads a an language engagement by id', async () => {


### PR DESCRIPTION
- Set initial end date if the project/engagement is in-dev (instead of active)
- Set initial end date regardless of whether it was previously set or not
- Set initial end date to null if end date is null (if in-dev)
- Ensure logic is using real by checking `canRead` & throwing
- Ignore status on creation (helps migration logic)