### PR TITLE
Database Transactions v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">=12"
+    "node": ">=12.17 || >=14"
   },
   "scripts": {
     "prebuild": "rimraf dist",

--- a/src/components/admin/admin.service.ts
+++ b/src/components/admin/admin.service.ts
@@ -8,7 +8,7 @@ import {
   ServerException,
   UnauthenticatedException,
 } from '../../common';
-import { ConfigService, DatabaseService, ILogger, Logger } from '../../core';
+import { ConfigService, DatabaseService, ILogger, Logger, Transactional } from '../../core';
 import { AuthenticationService } from '../authentication';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { Powers } from '../authorization/dto/powers';
@@ -128,7 +128,10 @@ export class AdminService implements OnApplicationBootstrap {
     }
   }
 
+  @Transactional()
   async setupRootObjects(): Promise<void> {
+    this.logger.debug('Setting up root objects');
+
     // merge root security group
     await this.mergeRootSecurityGroup();
 

--- a/src/core/database/cypher.factory.ts
+++ b/src/core/database/cypher.factory.ts
@@ -1,7 +1,10 @@
 import { FactoryProvider } from '@nestjs/common/interfaces';
+import { AsyncLocalStorage } from 'async_hooks';
 import { stripIndent } from 'common-tags';
 import { Connection } from 'cypher-query-builder';
-import { Session } from 'neo4j-driver';
+import { Session, Transaction } from 'neo4j-driver';
+import QueryRunner from 'neo4j-driver/types/query-runner';
+import { Merge } from 'type-fest';
 import { ConfigService } from '..';
 import { jestSkipFileInExceptionSource } from '../jest-skip-source-file';
 import { ILogger, LoggerToken, LogLevel } from '../logger';
@@ -10,6 +13,15 @@ import { ParameterTransformer } from './parameter-transformer.service';
 import { MyTransformer } from './transformer';
 import './transaction'; // import our transaction augmentation
 import './query.overrides'; // import our query augmentation
+
+export type PatchedConnection = Merge<
+  Connection,
+  {
+    transactionStorage: AsyncLocalStorage<Transaction>;
+    logger: ILogger;
+    transformer: MyTransformer;
+  }
+>;
 
 export const CypherFactory: FactoryProvider<Connection> = {
   provide: Connection,
@@ -20,7 +32,8 @@ export const CypherFactory: FactoryProvider<Connection> = {
     driverLogger: ILogger
   ) => {
     const { url, username, password, driverConfig } = config.neo4j;
-    const conn = new Connection(
+    // @ts-expect-error yes we are patching the connection object
+    const conn: PatchedConnection = new Connection(
       url,
       { username, password },
       {
@@ -38,60 +51,56 @@ export const CypherFactory: FactoryProvider<Connection> = {
       }
     );
 
-    // wrap session.run calls to add logging
-    /* eslint-disable @typescript-eslint/unbound-method */
-    const origSession = conn.session;
-    conn.session = function (this: never) {
-      const session: Session | null = origSession.call(conn);
-      if (session) {
-        const origRun = session.run;
-        session.run = function (this: never, origStatement, parameters, conf) {
-          const statement = stripIndent(origStatement.slice(0, -1)) + ';';
-          logger.log(
-            (parameters?.logIt as LogLevel | undefined) ?? LogLevel.DEBUG,
-            'Executing query',
-            {
-              statement,
-              ...parameters,
-            }
-          );
+    // Holder for the current transaction using native async storage context.
+    conn.transactionStorage = new AsyncLocalStorage();
 
-          const params = parameters
-            ? parameterTransformer.transform(parameters)
-            : undefined;
-          const result = origRun.call(session, statement, params, conf);
-
-          const origSubscribe = result.subscribe;
-          result.subscribe = function (this: never, observer) {
-            if (observer.onError) {
-              const onError = observer.onError;
-              observer.onError = (e) => {
-                const patched = jestSkipFileInExceptionSource(e, __filename);
-                const mapped = createBetterError(patched);
-                if (isNeo4jError(mapped) && mapped.logProps) {
-                  logger.log(mapped.logProps);
-                }
-                onError(mapped);
-              };
-            }
-            origSubscribe.call(result, observer);
-          };
-
-          return result;
+    // Wrap session call to apply:
+    // - transparent transaction handling
+    // - query logging
+    // - parameter transformation
+    // - error transformation
+    const origSession = conn.session.bind(conn);
+    conn.session = function (this: PatchedConnection) {
+      const currentTransaction = this.transactionStorage.getStore();
+      if (currentTransaction) {
+        // Fake a "session", which is really only used as a QueryRunner,
+        // in order to forward methods to the current transaction.
+        // @ts-expect-error yes we are only supporting these two methods
+        const txSession: Session = {
+          run: wrapQueryRun(currentTransaction, logger, parameterTransformer),
+          close: async () => {
+            // No need to close anything when finishing the query inside of the
+            // transaction. The close will happen when the transaction work finishes.
+          },
         };
+        return txSession;
       }
-      /* eslint-enable @typescript-eslint/unbound-method */
+
+      const session: Session | null = origSession();
+      if (!session) {
+        return null;
+      }
+
+      session.run = wrapQueryRun(session, logger, parameterTransformer);
 
       return session;
     };
 
+    // Also tear down transaction storage on close.
+    const origClose = conn.close.bind(conn);
+    conn.close = async () => {
+      await origClose();
+      conn.transactionStorage.disable();
+    };
+
     // inject logger so transactions can use it
-    (conn as any).logger = logger;
+    conn.logger = logger;
 
     // Replace transformer with our own
-    (conn as any).transformer = new MyTransformer();
+    conn.transformer = new MyTransformer();
 
-    return conn;
+    // @ts-expect-error yes we are patching it back
+    return conn as Connection;
   },
   inject: [
     ConfigService,
@@ -99,4 +108,44 @@ export const CypherFactory: FactoryProvider<Connection> = {
     LoggerToken('database:query'),
     LoggerToken('database:driver'),
   ],
+};
+
+const wrapQueryRun = (
+  runner: QueryRunner,
+  logger: ILogger,
+  parameterTransformer: ParameterTransformer
+): QueryRunner['run'] => {
+  const origRun = runner.run.bind(runner);
+  return (origStatement, parameters) => {
+    const statement = stripIndent(origStatement.slice(0, -1)) + ';';
+    logger.log(
+      (parameters?.logIt as LogLevel | undefined) ?? LogLevel.DEBUG,
+      'Executing query',
+      {
+        statement,
+        ...parameters,
+      }
+    );
+
+    const params = parameters
+      ? parameterTransformer.transform(parameters)
+      : undefined;
+    const result = origRun(statement, params);
+
+    const origSubscribe = result.subscribe.bind(result);
+    result.subscribe = function (this: never, observer) {
+      const onError = observer.onError?.bind(observer);
+      observer.onError = (e) => {
+        const patched = jestSkipFileInExceptionSource(e, __filename);
+        const mapped = createBetterError(patched);
+        if (isNeo4jError(mapped) && mapped.logProps) {
+          logger.log(mapped.logProps);
+        }
+        onError?.(mapped);
+      };
+      origSubscribe(observer);
+    };
+
+    return result;
+  };
 };

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -32,6 +32,7 @@ import {
   UniqueProperties,
 } from './query.helpers';
 import { hasMore } from './results';
+import { Transactional } from './transactional.decorator';
 
 export const property = (
   prop: string,
@@ -122,6 +123,7 @@ export class DatabaseService {
     return this.db.query();
   }
 
+  @Transactional()
   async getServerInfo() {
     const info = await this.db
       .query()

--- a/src/core/database/index.ts
+++ b/src/core/database/index.ts
@@ -1,3 +1,4 @@
+export * from './transactional.decorator';
 export * from './database.service';
 export * from './errors';
 export * from './query.helpers';

--- a/src/core/database/index.ts
+++ b/src/core/database/index.ts
@@ -2,3 +2,4 @@ export * from './transactional.decorator';
 export * from './database.service';
 export * from './errors';
 export * from './query.helpers';
+export * from './transaction';

--- a/src/core/database/indexer/indexer.module.ts
+++ b/src/core/database/indexer/indexer.module.ts
@@ -9,6 +9,7 @@ import { ConfigService } from '../..';
 import { many } from '../../../common';
 import { ILogger, Logger } from '../../logger';
 import { DatabaseService } from '../database.service';
+import { Transactional } from '../transactional.decorator';
 import { DB_INDEX_KEY } from './indexer.constants';
 
 @Module({
@@ -48,6 +49,7 @@ export class IndexerModule implements OnModuleInit {
     }
   }
 
+  @Transactional()
   async doIndexing(discovered: Array<DiscoveredMethodWithMeta<unknown>>) {
     const serverInfo = await this.db.getServerInfo();
     const isV4 = serverInfo.version.startsWith('4');

--- a/src/core/database/transaction.ts
+++ b/src/core/database/transaction.ts
@@ -6,13 +6,21 @@ import {
 } from '../../common';
 import { PatchedConnection } from './cypher.factory';
 
+/**
+ * A neo4j transaction mode
+ */
+export const enum TxMode {
+  Read = 'read',
+  Write = 'write',
+}
+
 export interface TransactionOptions {
   /**
    * Should this method start a read or write transaction?
    * `write` is default.
    * Note that a write transaction cannot be called from within a read transaction.
    */
-  mode?: 'read' | 'write';
+  mode?: TxMode;
 
   /**
    * The transaction's timeout.

--- a/src/core/database/transaction.ts
+++ b/src/core/database/transaction.ts
@@ -1,9 +1,10 @@
 import { Connection } from 'cypher-query-builder';
-import { TransactionConfig } from 'neo4j-driver/types/session';
+import { MsDurationInput, parseMilliseconds } from '../../common';
 import { PatchedConnection } from './cypher.factory';
 
-export interface TransactionOptions extends TransactionConfig {
+export interface TransactionOptions {
   mode?: 'read' | 'write';
+  timeout?: MsDurationInput;
 }
 
 declare module 'cypher-query-builder/dist/typings/connection' {
@@ -46,7 +47,11 @@ Connection.prototype.runInTransaction = async function withTransaction<R>(
   try {
     return await runTransaction(
       (tx) => this.transactionStorage.run(tx, inner),
-      options
+      {
+        timeout: options?.timeout
+          ? parseMilliseconds(options.timeout)
+          : undefined,
+      }
     );
   } finally {
     await session.close();

--- a/src/core/database/transaction.ts
+++ b/src/core/database/transaction.ts
@@ -1,145 +1,54 @@
-/* eslint-disable @typescript-eslint/unbound-method */
+import { Connection } from 'cypher-query-builder';
+import { TransactionConfig } from 'neo4j-driver/types/session';
+import { PatchedConnection } from './cypher.factory';
 
-import { stripIndent } from 'common-tags';
-import { Connection, Query, Transformer } from 'cypher-query-builder';
-import { Dictionary } from 'lodash';
-import { Transaction as NeoTransaction, Session } from 'neo4j-driver';
-import { Observable } from 'rxjs';
-import { ILogger } from '../logger';
+export interface TransactionOptions extends TransactionConfig {
+  mode?: 'read' | 'write';
+}
 
 declare module 'cypher-query-builder/dist/typings/connection' {
   interface Connection {
-    /**
-     * Returns a new transaction.
-     */
-    transaction: () => Transaction;
-
     /**
      * This will create a transaction and call the given function with it.
      * The result of the function is returned.
      * Afterwards it will commit the transaction.
      * On any error the transaction will be rolled back.
+     *
+     * Normal db query methods inside of this function call will be applied
+     * to the transaction.
      */
-    withTransaction: <R>(inTx: (tx: Transaction) => Promise<R>) => Promise<R>;
+    runInTransaction: <R>(
+      inTx: (this: void) => Promise<R>,
+      options?: TransactionOptions
+    ) => Promise<R>;
   }
 }
 
-Connection.prototype.withTransaction = async function withTransaction<R>(
-  this: Connection,
-  inner: (tx: Transaction) => Promise<R>
+Connection.prototype.runInTransaction = async function withTransaction<R>(
+  this: PatchedConnection,
+  inner: (this: void) => Promise<R>,
+  options?: TransactionOptions
 ): Promise<R> {
-  const tx = this.transaction();
-  let res: R;
+  const outer = this.transactionStorage.getStore();
+  if (outer) {
+    return await inner();
+  }
+  const session = this.session();
+  if (!session) {
+    throw new Error('Cannot run query because connection is not open.');
+  }
+
+  const runTransaction =
+    options?.mode === 'read'
+      ? session.readTransaction.bind(session)
+      : session.writeTransaction.bind(session);
+
   try {
-    res = await inner(tx);
-  } catch (e) {
-    await tx.rollback();
-    throw e;
+    return await runTransaction(
+      (tx) => this.transactionStorage.run(tx, inner),
+      options
+    );
+  } finally {
+    await session.close();
   }
-  await tx.commit();
-  return res;
 };
-
-Connection.prototype.transaction = function transaction(this: Connection) {
-  return new Transaction(this, this.transformer, (this as any).logger);
-};
-
-/** A type matching what Query actually uses from its connection parameter */
-type QueryConnection = Pick<Connection, 'run' | 'stream'>;
-
-export class Transaction implements QueryConnection {
-  private session: Session | null;
-  private wrapped: NeoTransaction;
-
-  constructor(
-    private readonly connection: Connection,
-    private readonly transformer: Transformer,
-    private readonly logger: ILogger
-  ) {}
-
-  query(): Query {
-    // Query only calls `run` and `stream` from connection
-    return new Query((this as any) as Connection);
-  }
-
-  /** Commit the transaction */
-  async commit(): Promise<void> {
-    if (!this.wrapped) {
-      return;
-    }
-    try {
-      await this.wrapped.commit();
-    } finally {
-      await this.close();
-    }
-  }
-
-  /** Rollback the transaction */
-  async rollback(): Promise<void> {
-    if (!this.wrapped) {
-      return;
-    }
-    try {
-      await this.wrapped.rollback();
-    } finally {
-      await this.close();
-    }
-  }
-
-  /**
-   * Close this transaction's session.
-   * This will be automatically called on commit/rollback.
-   */
-  async close() {
-    if (this.session) {
-      await this.session?.close();
-      this.session = null;
-    }
-  }
-
-  private begin(): void {
-    if (this.wrapped) {
-      // Keep previous transaction
-      // trying to run a query on a finalized transaction should throw an error.
-      return;
-    }
-    const session = this.connection.session();
-    if (!session) {
-      throw new Error('Could not open session: connection is not open.');
-    }
-    this.session = session;
-    this.wrapped = this.session.beginTransaction();
-  }
-
-  /**
-   * Runs the provided query on this transaction, regardless of which connection
-   * the query was created from (if any).
-   *
-   * @see {Connection.run} for more details
-   */
-  async run<R = any>(query: Query): Promise<Array<Dictionary<R>>> {
-    if (query.getClauses().length === 0) {
-      throw new Error('Cannot run query: no clauses attached to the query.');
-    }
-
-    this.begin();
-
-    const { query: q, params } = query.buildQueryObject();
-    const statement = stripIndent(q);
-    this.logger.debug('\n' + statement, params);
-
-    const result = await this.wrapped.run(statement, params);
-
-    return this.transformer.transformRecords(result.records);
-  }
-
-  /**
-   * Streaming is not supported on transactions
-   * This observable will immediately emit an error.
-   */
-  stream<R = any>(_query: Query): Observable<Dictionary<R>> {
-    return new Observable((subscriber: { error: (e: Error) => void }) => {
-      subscriber.error(new Error('Transactions cannot be streamed.'));
-    });
-  }
-}

--- a/src/core/database/transaction.ts
+++ b/src/core/database/transaction.ts
@@ -25,6 +25,15 @@ export interface TransactionOptions {
    * in the database using `dbms.transaction.timeout` setting.
    */
   timeout?: MsDurationInput;
+
+  /**
+   * The transaction's metadata.
+   *
+   * Specified metadata will be attached to the executing transaction and visible
+   * in the output of `dbms.listQueries` and `dbms.listTransactions` procedures.
+   * It will also get logged to the `query.log`.
+   */
+  metadata?: Record<string, unknown>;
 }
 
 declare module 'cypher-query-builder/dist/typings/connection' {
@@ -79,6 +88,7 @@ Connection.prototype.runInTransaction = async function withTransaction<R>(
         timeout: options?.timeout
           ? parseMilliseconds(options.timeout)
           : undefined,
+        metadata: options?.metadata,
       }
     );
   } finally {

--- a/src/core/database/transaction.ts
+++ b/src/core/database/transaction.ts
@@ -7,7 +7,23 @@ import {
 import { PatchedConnection } from './cypher.factory';
 
 export interface TransactionOptions {
+  /**
+   * Should this method start a read or write transaction?
+   * `write` is default.
+   * Note that a write transaction cannot be called from within a read transaction.
+   */
   mode?: 'read' | 'write';
+
+  /**
+   * The transaction's timeout.
+   *
+   * Transactions that execute longer than the configured timeout will be
+   * terminated by the database. This functionality allows to limit
+   * query/transaction execution time.
+   *
+   * Specified timeout overrides the default timeout configured in configured
+   * in the database using `dbms.transaction.timeout` setting.
+   */
   timeout?: MsDurationInput;
 }
 

--- a/src/core/database/transactional.decorator.ts
+++ b/src/core/database/transactional.decorator.ts
@@ -1,0 +1,43 @@
+import { Inject } from '@nestjs/common';
+import { Connection } from 'cypher-query-builder';
+import { TransactionOptions } from './transaction';
+
+type AsyncFn = (...args: any[]) => Promise<any>;
+
+const ConnKey = Symbol('DbConnectionForTransactions');
+
+/**
+ * Ensure the method is ran in a transaction.
+ * If a transaction has already been established, then this will continue
+ * inside of that one.
+ * Note that code can be executed multiple times when retrying transient errors.
+ * The code executed should be idempotent.
+ *
+ * This is just a shortcut for calling `Connection.runInTransaction()`.
+ */
+export function Transactional(options?: TransactionOptions) {
+  return ((
+    target: any,
+    methodName: string | symbol,
+    descriptor: TypedPropertyDescriptor<AsyncFn>
+  ) => {
+    // Use property-based injection to get access to the db connection object
+    // at a known location.
+    if (target[ConnKey] === undefined) {
+      Inject(Connection)(target, ConnKey);
+      // ensure prop injection is only done once.
+      target[ConnKey] = null;
+    }
+
+    // Wrap the method in a runInTransaction call
+    const origMethod = descriptor.value!;
+    descriptor.value = async function (...args: any[]) {
+      // @ts-expect-error this works but TS still has problems with indexing on symbols
+      const connection: Connection = this[ConnKey];
+      return await connection.runInTransaction(
+        () => origMethod.apply(this, args),
+        options
+      );
+    };
+  }) as MethodDecorator;
+}


### PR DESCRIPTION
At a high level, this adds a `@Transactional()` decorator to run method inside of transactions.

## Picture(ish) speaks a thousand words.
```tsx
@Injectable()
class Foo {
  @Transactional()
  async doThing() {
    await this.db.query().matchNode('n').return('n').run();
    await this.doOtherThing();
  }

  @Transactional()
  doOtherThing() {
    try {
      await this.db.query().matchNode('n').return('n').run();
    } catch (e) {
      throw new ServerException('Failed to do other thing', e);
    }
  }
}
```
### What's happening here?
- Database calls work exactly the same way.
- `doOtherThing` when called from `doThing` uses the existing transaction from the `doThing` call instead of creating a new one. If `doOtherThing` is called directly it will create it's own transaction (assuming there isn't one already up the call stack).
- Transaction is rolled-back when an exception is thrown. This doesn't have to be a DB exception.
- Methods are retried automatically when a retry-able error is encountered.
  - This does mean that the logic needs to be idempotent.
  - Neo4j connection failure, Neo4j session expired, and Neo4j transient errors are all considered retry-able.
  - Retry logic also checks the exceptions previous list when looking for neo4j transient errors.
    This means that the `ServerException` thrown in `doOtherThing` does not circumvent the retry logic.
    This is important because it's a common practice we have to wrap errors and give them a more descriptive human/dev error message.

## Options
```tsx
@Transactional({
  mode: TxMode.Read,
  timeout: { minutes: 2 },
})
```
By default the transaction is a _write_ transaction. By specifying the mode it can be started as a read transaction. Note that we block methods declaring a write transaction called from a read transaction.

Timeout can be specified as well which limits the execution time to this. The default is configured in database server under the `dbms.transaction.timeout` config setting.

## Other

I've added this decorator to admin setup and indexer. This should fix the startup errors described in #1496.

See implementation notes [here](https://github.com/SeedCompany/cord-api-v3/pull/1596/commits/2db580b0230ae453f408d63809ea125677ea6e47).

## What's next?

Apply this decorator to all db query entry points & ensure they are idempotent. 