### PR TITLE
Fix compatibility with Neo4j <4.1.5 (indexing transactions)

### DIFF
--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -80,6 +80,12 @@ export const matchSession = (
   }),
 ];
 
+export interface ServerInfo {
+  name: string;
+  version: string;
+  edition: string;
+}
+
 @Injectable()
 export class DatabaseService {
   constructor(
@@ -133,7 +139,7 @@ export class DatabaseService {
          unwind versions as version
          return name, version, edition`
       )
-      .asResult<{ name: string; version: string; edition: string }>()
+      .asResult<ServerInfo>()
       .first();
     if (!info) {
       throw new ServerException('Unable to determine server info');


### PR DESCRIPTION
Move reading server info outside of transaction that's modifying schema.

This makes it compatible with neo4j <4.1.5
https://neo4j.com/release-notes/neo4j-4-1-4/