### PR TITLE
Improve root user experience

### DIFF
--- a/src/components/admin/admin.service.ts
+++ b/src/components/admin/admin.service.ts
@@ -1,15 +1,16 @@
-/* eslint-disable prettier/prettier */
 import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
-import * as argon2 from 'argon2';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
+import { generateId, ServerException } from '../../common';
 import {
-  generateId,
-  ServerException,
-  UnauthenticatedException,
-} from '../../common';
-import { ConfigService, DatabaseService, ILogger, Logger, Transactional } from '../../core';
+  ConfigService,
+  DatabaseService,
+  ILogger,
+  Logger,
+  Transactional,
+} from '../../core';
 import { AuthenticationService } from '../authentication';
+import { CryptoService } from '../authentication/crypto.service';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { Powers } from '../authorization/dto/powers';
 import { Role } from '../project';
@@ -20,6 +21,7 @@ export class AdminService implements OnApplicationBootstrap {
     private readonly db: DatabaseService,
     private readonly config: ConfigService,
     private readonly authentication: AuthenticationService,
+    private readonly crypto: CryptoService,
     private readonly authorizationService: AuthorizationService,
     @Logger('admin:service') private readonly logger: ILogger
   ) {}
@@ -129,35 +131,25 @@ export class AdminService implements OnApplicationBootstrap {
   }
 
   @Transactional()
-  async setupRootObjects(): Promise<void> {
+  private async setupRootObjects(): Promise<void> {
     this.logger.debug('Setting up root objects');
 
-    // merge root security group
     await this.mergeRootSecurityGroup();
 
-    // merge public security group
     await this.mergePublicSecurityGroup();
 
-    // merge anon user and connect to public sg
     await this.mergeAnonUser();
 
-    // Root Admin
-
-    if (!(await this.doesRootAdminUserAlreadyExist())) {
-      await this.createRootAdminUser();
-    }
-
-    // Connect Root Security Group and Root Admin
+    await this.mergeRootAdminUser();
 
     await this.mergeRootAdminUserToSecurityGroup();
 
     await this.mergePublicSecurityGroupWithRootSg();
 
-    // Default Organization
     await this.mergeDefaultOrg();
   }
 
-  async mergeRootSecurityGroup() {
+  private async mergeRootSecurityGroup() {
     // merge root security group
 
     const powers = Object.keys(Powers);
@@ -179,7 +171,7 @@ export class AdminService implements OnApplicationBootstrap {
       .run();
   }
 
-  async mergePublicSecurityGroup() {
+  private async mergePublicSecurityGroup() {
     await this.db
       .query()
       .merge([
@@ -194,7 +186,7 @@ export class AdminService implements OnApplicationBootstrap {
       .run();
   }
 
-  async mergeAnonUser() {
+  private async mergeAnonUser() {
     const createdAt = DateTime.local();
     await this.db
       .query()
@@ -218,54 +210,37 @@ export class AdminService implements OnApplicationBootstrap {
       .run();
   }
 
-  async doesRootAdminUserAlreadyExist(): Promise<boolean> {
-    const result = await this.db
-      .query()
-      .match([
-        [
-          node('user', 'User'),
-          relation('out', '', 'email', {
-            active: true,
-          }),
-          node('email', 'EmailAddress', {
-            value: this.config.rootAdmin.email,
-          }),
-        ],
-      ])
-      .raw('RETURN user.id as id')
-      .first();
-
-    if (result) {
-      // set id to root user id
-      this.config.setRootAdminId(result.id);
-      this.logger.notice(`root admin id`, { id: result.id });
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  async createRootAdminUser(): Promise<void> {
+  private async mergeRootAdminUser(): Promise<void> {
     const { email, password } = this.config.rootAdmin;
 
+    let id: string;
+
     // see if root already exists
-    const findRoot = await this.db
+    const existing = await this.db
       .query()
       .match([
         node('email', 'EmailAddress', { value: email }),
         relation('in', '', 'email', { active: true }),
-        node('root', ['User']),
+        node('root', 'User'),
         relation('out', '', 'password', { active: true }),
         node('pw', 'Propety'),
       ])
-      .return('pw.value as pash')
+      .return(['root.id as id', 'pw.value as hash'])
+      .asResult<{ id: string; hash: string }>()
       .first();
-
-    if (findRoot === undefined) {
-      // not found, create
-
-      const adminUser = await this.authentication.register({
-        email: email,
+    if (existing) {
+      if (!(await this.crypto.verify(existing.hash, password))) {
+        const msg = 'Root user password does not match configuration';
+        if (this.config.jest) {
+          throw new ServerException(msg);
+        } else {
+          this.logger.warning(msg);
+        }
+      }
+      id = existing.id;
+    } else {
+      id = await this.authentication.register({
+        email,
         password,
         displayFirstName: 'root',
         displayLastName: 'root',
@@ -276,37 +251,21 @@ export class AdminService implements OnApplicationBootstrap {
         roles: [Role.Administrator], // do not give root all the roles
       });
 
-      // update config with new root admin id
-      this.config.setRootAdminId(adminUser);
-      this.logger.notice('root user id: ' + adminUser);
-
-      if (!adminUser) {
-        throw new ServerException('Could not create root admin user');
-      } else {
-        // give all powers
-        const powers = Object.keys(Powers);
-        await this.db
-          .query()
-          .match([
-            node('user', 'User', {
-              id: adminUser,
-            }),
-          ])
-          .setValues({ user: { powers: powers } }, true)
-          .run();
-      }
-    } else if (await argon2.verify(findRoot.pash, password)) {
-      // password match - do nothing
-    } else {
-      // password did not match
-
-      throw new UnauthenticatedException(
-        'Root Email or Password are incorrect'
-      );
+      // give all powers
+      const powers = Object.keys(Powers);
+      await this.db
+        .query()
+        .matchNode('user', 'User', { id })
+        .setValues({ user: { powers } }, true)
+        .run();
     }
+
+    // TODO do this a different way. Using a global like this can cause race conditions.
+    this.config.setRootAdminId(id);
+    this.logger.notice('Setting actual root user id', { id });
   }
 
-  async mergeRootAdminUserToSecurityGroup(): Promise<void> {
+  private async mergeRootAdminUserToSecurityGroup(): Promise<void> {
     const makeAdmin = await this.db
       .query()
       .match([
@@ -343,7 +302,7 @@ export class AdminService implements OnApplicationBootstrap {
     }
   }
 
-  async mergePublicSecurityGroupWithRootSg(): Promise<void> {
+  private async mergePublicSecurityGroupWithRootSg(): Promise<void> {
     await this.db
       .query()
       .merge([
@@ -367,7 +326,7 @@ export class AdminService implements OnApplicationBootstrap {
       .run();
   }
 
-  async mergeDefaultOrg(): Promise<void> {
+  private async mergeDefaultOrg(): Promise<void> {
     // is there a default org
     const isDefaultOrgResult = await this.db
       .query()

--- a/src/components/admin/admin.service.ts
+++ b/src/components/admin/admin.service.ts
@@ -261,7 +261,7 @@ export class AdminService implements OnApplicationBootstrap {
     }
 
     // TODO do this a different way. Using a global like this can cause race conditions.
-    this.config.setRootAdminId(id);
+    this.config.rootAdmin.id = id;
     this.logger.notice('Setting actual root user id', { id });
   }
 

--- a/src/components/admin/admin.service.ts
+++ b/src/components/admin/admin.service.ts
@@ -289,13 +289,7 @@ export class AdminService implements OnApplicationBootstrap {
         ],
       ])
       .with('*')
-      .match([
-        [
-          node('newRootAdmin', 'User', {
-            id: this.config.rootAdmin.id,
-          }),
-        ],
-      ])
+      .match(node('newRootAdmin', 'RootUser'))
       .with('*')
       .merge([
         [
@@ -390,11 +384,7 @@ export class AdminService implements OnApplicationBootstrap {
               id: this.config.publicSecurityGroup.id,
             })
           )
-          .match(
-            node('rootuser', 'User', {
-              id: this.config.rootAdmin.id,
-            })
-          )
+          .match(node('rootuser', 'RootUser'))
           .create([
             node('orgSg', ['OrgPublicSecurityGroup', 'SecurityGroup'], {
               id: orgSgId,

--- a/src/components/admin/admin.service.ts
+++ b/src/components/admin/admin.service.ts
@@ -223,7 +223,7 @@ export class AdminService implements OnApplicationBootstrap {
         relation('in', '', 'email', { active: true }),
         node('root', 'User'),
         relation('out', '', 'password', { active: true }),
-        node('pw', 'Propety'),
+        node('pw', 'Property'),
       ])
       .return(['root.id as id', 'pw.value as hash'])
       .asResult<{ id: string; hash: string }>()

--- a/src/components/authentication/authentication.module.ts
+++ b/src/components/authentication/authentication.module.ts
@@ -4,6 +4,7 @@ import { AuthorizationModule } from '../authorization/authorization.module';
 import { UserModule } from '../user/user.module';
 import { AuthenticationResolver } from './authentication.resolver';
 import { AuthenticationService } from './authentication.service';
+import { CryptoService } from './crypto.service';
 import { SessionPipe } from './session.pipe';
 
 const ProvideSessionPipe: Provider = {
@@ -20,9 +21,15 @@ const ProvideSessionPipe: Provider = {
   providers: [
     AuthenticationResolver,
     AuthenticationService,
+    CryptoService,
     SessionPipe,
     ProvideSessionPipe,
   ],
-  exports: [AuthenticationService, SessionPipe, SESSION_PIPE_TOKEN],
+  exports: [
+    AuthenticationService,
+    CryptoService,
+    SessionPipe,
+    SESSION_PIPE_TOKEN,
+  ],
 })
 export class AuthenticationModule {}

--- a/src/components/authentication/authentication.service.ts
+++ b/src/components/authentication/authentication.service.ts
@@ -1,11 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { EmailService } from '@seedcompany/nestjs-email';
-import * as argon2 from 'argon2';
 import { node, relation } from 'cypher-query-builder';
 import { sign, verify } from 'jsonwebtoken';
-import { pickBy } from 'lodash';
 import { DateTime } from 'luxon';
-import { Except } from 'type-fest';
 import {
   DuplicateException,
   InputException,
@@ -24,6 +21,7 @@ import {
 import { ForgotPassword } from '../../core/email/templates';
 import { User, UserService } from '../user';
 import { LoginInput, ResetPasswordInput } from './authentication.dto';
+import { CryptoService } from './crypto.service';
 import { RegisterInput } from './dto';
 import { NoSessionException } from './no-session.exception';
 
@@ -36,6 +34,7 @@ export class AuthenticationService {
   constructor(
     private readonly db: DatabaseService,
     private readonly config: ConfigService,
+    private readonly crypto: CryptoService,
     private readonly email: EmailService,
     private readonly userService: UserService,
     @Logger('authentication:service') private readonly logger: ILogger
@@ -109,7 +108,7 @@ export class AuthenticationService {
       throw e;
     }
 
-    const passwordHash = await argon2.hash(input.password, this.argon2Options);
+    const passwordHash = await this.crypto.hash(input.password);
     await this.db
       .query()
       .match([
@@ -158,10 +157,7 @@ export class AuthenticationService {
       )
       .first();
 
-    if (
-      !result1 ||
-      !(await argon2.verify(result1.pash, input.password, this.argon2Options))
-    ) {
+    if (!(await this.crypto.verify(result1?.pash, input.password))) {
       throw new UnauthenticatedException('Invalid credentials');
     }
 
@@ -274,20 +270,14 @@ export class AuthenticationService {
         node('password', 'Property'),
       ])
       .return('password.value as passwordHash')
+      .asResult<{ passwordHash: string }>()
       .first();
 
-    if (
-      !result ||
-      !(await argon2.verify(
-        result.passwordHash,
-        oldPassword,
-        this.argon2Options
-      ))
-    ) {
+    if (!(await this.crypto.verify(result?.passwordHash, oldPassword))) {
       throw new UnauthenticatedException('Invalid credentials');
     }
 
-    const newPasswordHash = await argon2.hash(newPassword, this.argon2Options);
+    const newPasswordHash = await this.crypto.hash(newPassword);
     await this.db
       .query()
       .call(matchRequestingUser, session)
@@ -367,7 +357,7 @@ export class AuthenticationService {
       throw new InputException('Token has expired', 'TokenExpired');
     }
 
-    const pash = await argon2.hash(password, this.argon2Options);
+    const pash = await this.crypto.hash(password);
 
     await this.db
       .query()
@@ -416,15 +406,5 @@ export class AuthenticationService {
       });
       throw new UnauthenticatedException(exception);
     }
-  }
-
-  private get argon2Options() {
-    const options: Except<argon2.Options, 'raw'> = {
-      secret: this.config.passwordSecret
-        ? Buffer.from(this.config.passwordSecret, 'utf-8')
-        : undefined,
-    };
-    // argon doesn't like undefined values even though the types allow them
-    return pickBy(options, (v) => v !== undefined);
   }
 }

--- a/src/components/authentication/crypto.service.ts
+++ b/src/components/authentication/crypto.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import * as argon2 from 'argon2';
+import { pickBy } from 'lodash';
+import { Except } from 'type-fest';
+import { ConfigService } from '../../core';
+
+@Injectable()
+export class CryptoService {
+  constructor(private readonly config: ConfigService) {}
+
+  async hash(plain: string) {
+    return await argon2.hash(plain, this.argon2Options);
+  }
+
+  async verify(hash: string | null | undefined, plain: string) {
+    return !!hash && (await argon2.verify(hash, plain, this.argon2Options));
+  }
+
+  private get argon2Options() {
+    const options: Except<argon2.Options, 'raw'> = {
+      secret: this.config.passwordSecret
+        ? Buffer.from(this.config.passwordSecret, 'utf-8')
+        : undefined,
+    };
+    // argon doesn't like undefined values even though the types allow them
+    return pickBy(options, (v) => v !== undefined);
+  }
+}

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -125,11 +125,6 @@ export class BudgetService {
       const createBudget = this.db
         .query()
         .call(matchRequestingUser, session)
-        .match([
-          node('root', 'User', {
-            id: this.config.rootAdmin.id,
-          }),
-        ])
         .call(createBaseNode, budgetId, 'Budget', secureProps)
         .return('node.id as id');
 

--- a/src/components/language/ethnologue-language/ethnologue-language.service.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.service.ts
@@ -86,10 +86,7 @@ export class EthnologueLanguageService {
         createBaseNode,
         await generateId(),
         'EthnologueLanguage',
-        secureProps,
-        {},
-        [],
-        session.userId === this.config.rootAdmin.id
+        secureProps
       )
       .return('node.id as id');
 

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -256,15 +256,7 @@ export class LanguageService {
       const createLanguage = this.db
         .query()
         .call(matchRequestingUser, session)
-        .call(
-          createBaseNode,
-          await generateId(),
-          'Language',
-          secureProps,
-          {},
-          [],
-          session.userId === this.config.rootAdmin.id
-        )
+        .call(createBaseNode, await generateId(), 'Language', secureProps)
         .return('node.id as id');
 
       const resultLanguage = await createLanguage.first();

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -193,15 +193,7 @@ export class PartnershipService {
       const createPartnership = this.db
         .query()
         .call(matchRequestingUser, session)
-        .call(
-          createBaseNode,
-          partnershipId,
-          'Partnership',
-          secureProps,
-          {},
-          [],
-          session.userId === this.config.rootAdmin.id
-        )
+        .call(createBaseNode, partnershipId, 'Partnership', secureProps)
         .return('node.id as id');
 
       try {

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -125,9 +125,7 @@ export class ProductService {
       },
     ];
 
-    const query = this.db
-      .query()
-      .match([node('root', 'User', { id: this.config.rootAdmin.id })]);
+    const query = this.db.query();
 
     if (engagementId) {
       const engagement = await this.db
@@ -183,10 +181,7 @@ export class ProductService {
             ? 'DerivativeScriptureProduct'
             : 'DirectScriptureProduct',
         ],
-        secureProps,
-        {},
-        [],
-        session.userId === this.config.rootAdmin.id
+        secureProps
       );
 
     if (engagementId) {

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -67,7 +67,6 @@ import {
   Project,
   ProjectListInput,
   ProjectListOutput,
-  ProjectStatus,
   ProjectStep,
   ProjectType,
   stepToStatus,
@@ -171,7 +170,6 @@ export class ProjectService {
       status: stepToStatus(step),
       modifiedAt: DateTime.local(),
     };
-    const canEdit = createInput.status === ProjectStatus.InDevelopment;
     const secureProps: Property[] = [
       {
         key: 'name',
@@ -296,8 +294,7 @@ export class ProjectService {
         secureProps,
         {
           type: createInput.type,
-        },
-        canEdit ? ['name', 'mouStart', 'mouEnd'] : []
+        }
       );
 
       if (fieldRegionId) {

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -71,19 +71,12 @@ export class UnavailabilityService {
       const createUnavailability = this.db
         .query()
         .call(matchRequestingUser, session)
-        .match([
-          node('root', 'User', {
-            id: this.config.rootAdmin.id,
-          }),
-        ])
         .call(
           createBaseNode,
           await generateId(),
           'Unavailability',
           secureProps,
-          {},
-          [],
-          session.userId === this.config.rootAdmin.id
+          {}
         )
         .return('node.id as id')
         .asResult<{ id: string }>();

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -8,6 +8,7 @@ import { LazyGetter as Lazy } from 'lazy-get-decorator';
 import { Duration } from 'luxon';
 import { Config as Neo4JDriverConfig } from 'neo4j-driver';
 import { join } from 'path';
+import { ServerException } from '../../common';
 import { FrontendUrlWrapper } from '../email/templates/frontend-url';
 import { LogLevel } from '../logger';
 import { EnvironmentService } from './environment.service';
@@ -101,15 +102,22 @@ export class ConfigService implements EmailOptionsFactory {
   }
 
   @Lazy() get rootAdmin() {
+    let rootId: string;
     return {
-      id: 'rootadminid',
+      get id(): string {
+        if (!rootId) {
+          throw new ServerException(
+            'Cannot access root admin ID before it is initialized'
+          );
+        }
+        return rootId;
+      },
+      set id(newId: string) {
+        rootId = newId;
+      },
       email: 'devops@tsco.org',
       password: this.env.string('ROOT_ADMIN_PASSWORD').optional('admin'),
     };
-  }
-
-  setRootAdminId(id: string) {
-    this.rootAdmin.id = id;
   }
 
   passwordSecret = this.env.string('PASSWORD_SECRET').optional();

--- a/src/core/database/query.helpers.ts
+++ b/src/core/database/query.helpers.ts
@@ -121,7 +121,7 @@ export function matchUserPermissions(
 
 export function matchRequestingUser(
   query: Query,
-  { userId }: Partial<Session>
+  { userId }: Pick<Session, 'userId'>
 ) {
   query.match([
     node('requestingUser', 'User', {

--- a/src/core/database/query.helpers.ts
+++ b/src/core/database/query.helpers.ts
@@ -30,9 +30,7 @@ export function createBaseNode(
   id: string,
   label: string | string[],
   props: Property[],
-  baseNodeProps?: { owningOrgId?: string | undefined; type?: string },
-  _editableProps?: string[],
-  _isRootuser?: boolean
+  baseNodeProps?: { owningOrgId?: string | undefined; type?: string }
 ) {
   const createdAt = DateTime.local();
 


### PR DESCRIPTION
I was unable to reproduce the issue in #710. However, this PR should help with maybe the actual issue.

Now an existing root user's email/password in DB is updated to match the app's configuration on boot. This makes things simpler for users as their app config will always be right (previously it was wrong/ignored when the user was created by another app configuration). 
**Breaking change:** The root user is now identified by a `RootUser` label instead of the email address.

Another problem was a misspelling in the existing user query, however I think this was never previously encountered as there was a duplicate existing user check. I removed the duplicate check and fixed the misspelling.

I'm not a fan of setting the root user ID and then using it in other places in the app. It is a global and could cause race conditions. I added a check to ensure that it is not used before it is initialized.

I also cleaned up unused code related to admin user.