### PR TITLE
Allow file mime type to be defined by API instead of uploaded file

### DIFF
--- a/src/components/file/dto/upload.dto.ts
+++ b/src/components/file/dto/upload.dto.ts
@@ -29,6 +29,13 @@ export abstract class CreateFileVersionInput {
     description: 'The file name',
   })
   readonly name: string;
+
+  @Field({
+    description:
+      'Override the mime type of the file. Default pulls mime typed defined on uploaded file',
+    nullable: true,
+  })
+  readonly mimeType?: string;
 }
 
 @InputType()

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -257,7 +257,12 @@ export class FileService {
    * the existing file with the same name or create a new file if not found.
    */
   async createFileVersion(
-    { parentId, uploadId, name }: CreateFileVersionInput,
+    {
+      parentId,
+      uploadId,
+      name,
+      mimeType: mimeTypeOverride,
+    }: CreateFileVersionInput,
     session: Session
   ): Promise<File> {
     const [tempUpload, existingUpload] = await Promise.allSettled([
@@ -325,7 +330,8 @@ export class FileService {
         ? existingUpload.value
         : undefined;
 
-    const mimeType = upload?.ContentType ?? 'application/octet-stream';
+    const mimeType =
+      mimeTypeOverride ?? upload?.ContentType ?? 'application/octet-stream';
     await this.repo.createFileVersion(
       fileId,
       {


### PR DESCRIPTION
This is a workaround for v2 migration.

The files for in the v2 bucket do not have their content-type set correctly for whatever reason. It's not a problem because the v2 API is told directly what the mime type is and it's saved in the database.
There's no way to retroactively update this metadata on the S3 objects. So we'll just continue this for the migrated files because it's the simplest path forward.