### PR TITLE
Consolidate query for determining project current step for engagement status rules

### DIFF
--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -779,21 +779,10 @@ export class EngagementService {
     }
 
     if (input.status) {
-      const projectRes = await this.db
-        .query()
-        .match([
-          node('engagement', 'Engagement', { id: input.id }),
-          relation('in', '', 'engagement'),
-          node('project', 'Project'),
-        ])
-        .return('project.id as projectId')
-        .asResult<{ projectId: string }>()
-        .first();
       await this.engagementRules.verifyStatusChange(
         input.id,
         session,
-        input.status,
-        projectRes?.projectId
+        input.status
       );
     }
 
@@ -877,21 +866,10 @@ export class EngagementService {
   ): Promise<InternshipEngagement> {
     const createdAt = DateTime.local();
     if (input.status) {
-      const projectRes = await this.db
-        .query()
-        .match([
-          node('engagement', 'Engagement', { id: input.id }),
-          relation('in', '', 'engagement'),
-          node('project', 'Project'),
-        ])
-        .return('project.id as projectId')
-        .asResult<{ projectId: string }>()
-        .first();
       await this.engagementRules.verifyStatusChange(
         input.id,
         session,
-        input.status,
-        projectRes?.projectId
+        input.status
       );
     }
 

--- a/src/components/project/project.rules.ts
+++ b/src/components/project/project.rules.ts
@@ -773,7 +773,7 @@ export class ProjectRules {
     }
   }
 
-  async getCurrentStep(id: string) {
+  private async getCurrentStep(id: string) {
     const currentStep = await this.db
       .query()
       .match([


### PR DESCRIPTION
There's no need to lookup the project id of the engagement just to then look up its current step later. It can be be looked up directly in one query.