### PR TITLE
Revert adding all of the project's creator's roles to their new membership

### DIFF
--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -355,22 +355,9 @@ export class ProjectService {
 
       createProject.return('node.id as id').asResult<{ id: string }>();
       const result = await createProject.first();
-
       if (!result) {
         throw new ServerException('failed to create a project');
       }
-
-      // get the creating user's roles. Assign them on this project.
-      // I'm going direct for performance reasons
-      const roles = await this.db
-        .query()
-        .match([
-          node('user', 'User', { id: session.userId }),
-          relation('out', '', 'roles', { active: true }),
-          node('roles', 'Property'),
-        ])
-        .raw('RETURN roles.value as roles')
-        .first();
 
       if (!this.config.migration) {
         // Add creator to the project team if not in migration
@@ -378,7 +365,7 @@ export class ProjectService {
           {
             userId: session.userId,
             projectId: result.id,
-            roles: [roles?.roles],
+            roles: [],
           },
           session
         );


### PR DESCRIPTION
Reverts 6c1feaf

This was done to make some permissions happy or something. But this is incorrect business logic.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3655585350) by [Unito](https://www.unito.io)
