### PR TITLE
Fix uniqueness check not accounting for deleted nodes

### DIFF
--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -1329,9 +1329,9 @@ export class EngagementService {
       .query()
       .match([
         node('project', 'Project', { id: projectId }),
-        relation('out', '', 'engagement'),
+        relation('out', '', 'engagement', { active: true }),
         node('engagement'),
-        relation('out', '', property),
+        relation('out', '', property, { active: true }),
         node('other', type === 'language' ? 'Language' : 'User', {
           id: otherId,
         }),

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -585,9 +585,9 @@ export class PartnershipService {
       .match([node('project', 'Project', { id: projectId })])
       .match([
         node('project'),
-        relation('out', '', 'partnership'),
+        relation('out', '', 'partnership', { active: true }),
         node('partnership'),
-        relation('out', '', 'partner'),
+        relation('out', '', 'partner', { active: true }),
         node('partner'),
       ])
       .return('partnership.id as id')

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -85,9 +85,9 @@ export class ProjectMemberService {
       .match([node('project', 'Project', { id: projectId })])
       .match([
         node('project'),
-        relation('out', '', 'member'),
+        relation('out', '', 'member', { active: true }),
         node('projectMember', 'ProjectMember'),
-        relation('out', '', 'user'),
+        relation('out', '', 'user', { active: true }),
         node('user'),
       ])
       .return('projectMember.id as id')

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -881,7 +881,7 @@ describe('Engagement e2e', () => {
         internId: intern.id,
         mentorId: mentor.id,
       })
-    ).rejects.toThrow('projectId is invalid');
+    ).rejects.toThrow('Could not find project');
     await expect(
       createInternshipEngagement(app, {
         projectId: internshipProject.id,
@@ -902,7 +902,7 @@ describe('Engagement e2e', () => {
         internId: invalidId,
         mentorId: mentor.id,
       })
-    ).rejects.toThrow('internId is invalid');
+    ).rejects.toThrow('Could not find person');
 
     internshipProject = await createProject(app, {
       type: ProjectType.Internship,
@@ -918,20 +918,20 @@ describe('Engagement e2e', () => {
     ).rejects.toThrow('mentorId is invalid');
   });
 
-  it('translation engagement creation fails and lets you know why if your ids are bad', async () => {
+  it('language engagement creation fails and lets you know why if your ids are bad', async () => {
     const invalidId = await generateId();
     await expect(
       createLanguageEngagement(app, {
         projectId: invalidId,
         languageId: language.id,
       })
-    ).rejects.toThrow('projectId is invalid');
+    ).rejects.toThrow('Could not find project');
     await expect(
       createLanguageEngagement(app, {
         projectId: project.id,
         languageId: invalidId,
       })
-    ).rejects.toThrow('languageId is invalid');
+    ).rejects.toThrow('Could not find language');
   });
 
   it('should return empty methodologies array even if it is null', async () => {
@@ -972,7 +972,7 @@ describe('Engagement e2e', () => {
       })
     ).rejects.toThrowError(
       new InputException(
-        'That Project type is not Internship',
+        'Only Internship Engagements can be created on Internship Projects',
         'engagement.projectId'
       )
     );

--- a/test/partnership.e2e-spec.ts
+++ b/test/partnership.e2e-spec.ts
@@ -5,7 +5,6 @@ import { CalendarDate, NotFoundException } from '../src/common';
 import { Powers } from '../src/components/authorization/dto/powers';
 import { PartnerType } from '../src/components/partner';
 import {
-  CreatePartnership,
   FinancialReportingType,
   Partnership,
   PartnershipAgreementStatus,
@@ -302,36 +301,20 @@ describe('Partnership e2e', () => {
   });
 
   it('create partnership does not create if organizationId is invalid', async () => {
-    // create bad partnership with fake project id and org id
-    const badPartnership: CreatePartnership = {
-      projectId: 'fakeProj',
-      agreementStatus: PartnershipAgreementStatus.AwaitingSignature,
-      mouStatus: PartnershipAgreementStatus.AwaitingSignature,
-      types: [PartnerType.Managing],
-      partnerId: 'fakePartner',
-      mouStartOverride: CalendarDate.local(),
-      mouEndOverride: CalendarDate.local(),
-    };
-
     await expect(
-      app.graphql.mutate(
-        gql`
-          mutation createPartnership($input: CreatePartnershipInput!) {
-            createPartnership(input: $input) {
-              partnership {
-                ...partnership
-              }
-            }
-          }
-          ${fragments.partnership}
-        `,
-        {
-          input: {
-            partnership: badPartnership,
-          },
-        }
-      )
+      createPartnership(app, {
+        projectId: project.id,
+        partnerId: 'fakePartner',
+      })
     ).rejects.toThrowError(new NotFoundException('Could not find partner'));
+  });
+
+  it('create partnership does not create if projectId is invalid', async () => {
+    await expect(
+      createPartnership(app, {
+        projectId: 'fakeProject',
+      })
+    ).rejects.toThrowError(new NotFoundException('Could not find project'));
   });
 
   it('should create partnership without mou dates but returns project mou dates if exists', async () => {


### PR DESCRIPTION
- Fix engagement, partnership, project member uniqueness checks not accounting for deleted nodes
- Merge node existence & relationship uniqueness to same query and return better error messages to consumer

Related to #1646 