### PR TITLE
Query base node labels on delete

### DIFF
--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -509,12 +509,9 @@ export class BudgetService {
       budget.records.map((br) => this.deleteRecord(br.id, session))
     );
 
-    const baseNodeLabels = ['BaseNode', 'Budget'];
-
     try {
       await this.db.deleteNodeNew({
         object: budget,
-        baseNodeLabels,
       });
     } catch (e) {
       this.logger.warning('Failed to delete budget', {
@@ -538,12 +535,9 @@ export class BudgetService {
         'You do not have the permission to delete this Budget Record'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Budget'];
-
     try {
       await this.db.deleteNodeNew({
         object: br,
-        baseNodeLabels,
       });
     } catch (e) {
       this.logger.warning('Failed to delete Budget Record', {

--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -200,12 +200,9 @@ export class CeremonyService {
         'You do not have the permission to delete this Ceremony'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Ceremony'];
-
     try {
       await this.db.deleteNodeNew({
         object,
-        baseNodeLabels,
       });
     } catch (exception) {
       this.logger.warning('Failed to delete Ceremony', {

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -1058,12 +1058,9 @@ export class EngagementService {
       await this.verifyProjectStatus(result.projectId, session);
     }
 
-    const baseNodeLabels = ['BaseNode', 'Engagement', object.__typename];
-
     try {
       await this.db.deleteNodeNew({
         object,
-        baseNodeLabels,
       });
     } catch (e) {
       this.logger.warning('Failed to delete Engagement', {

--- a/src/components/field-region/field-region.service.ts
+++ b/src/components/field-region/field-region.service.ts
@@ -249,8 +249,6 @@ export class FieldRegionService {
         'You do not have the permission to delete this Field Region'
       );
 
-    const baseNodeLabels = ['BaseNode', 'FieldRegion'];
-
     const uniqueProperties: UniqueProperties<FieldRegion> = {
       name: ['Property', 'FieldRegionName'],
     };
@@ -258,7 +256,6 @@ export class FieldRegionService {
     try {
       await this.db.deleteNodeNew<FieldRegion>({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/field-zone/field-zone.service.ts
+++ b/src/components/field-zone/field-zone.service.ts
@@ -257,8 +257,6 @@ export class FieldZoneService {
         'You do not have the permission to delete this Field Zone'
       );
 
-    const baseNodeLabels = ['BaseNode', 'FieldZone'];
-
     const uniqueProperties: UniqueProperties<FieldZone> = {
       name: ['Property', 'FieldZoneName'],
     };
@@ -266,7 +264,6 @@ export class FieldZoneService {
     try {
       await this.db.deleteNodeNew({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -470,12 +470,9 @@ export class FileRepository {
         'You do not have the permission to delete this File item'
       );
 
-    const baseNodeLabels = ['BaseNode', fileNode.type];
-
     try {
       await this.db.deleteNodeNew({
         object: fileNode,
-        baseNodeLabels,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id: fileNode.id, exception });

--- a/src/components/film/film.service.ts
+++ b/src/components/film/film.service.ts
@@ -210,8 +210,6 @@ export class FilmService {
         'You do not have the permission to delete this Film'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Producible', 'Film'];
-
     const uniqueProperties: UniqueProperties<Film> = {
       name: ['Property', 'FilmName'],
     };
@@ -219,7 +217,6 @@ export class FilmService {
     try {
       await this.db.deleteNodeNew({
         object: film,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -208,8 +208,6 @@ export class FundingAccountService {
         'You do not have the permission to delete this Funding Account'
       );
 
-    const baseNodeLabels = ['BaseNode', 'FundingAccount'];
-
     const uniqueProperties: UniqueProperties<FundingAccount> = {
       name: ['Property', 'FundingAccountName'],
       accountNumber: ['Property', 'FundingAccountNumber'],
@@ -218,7 +216,6 @@ export class FundingAccountService {
     try {
       await this.db.deleteNodeNew({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -454,8 +454,6 @@ export class LanguageService {
         'You do not have the permission to delete this Language'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Language'];
-
     const uniqueProperties: UniqueProperties<Language> = {
       name: ['Property', 'LanguageName'],
       displayName: ['Property', 'LanguageDisplayName'],
@@ -465,7 +463,6 @@ export class LanguageService {
     try {
       await this.db.deleteNodeNew<Language>({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/literacy-material/literacy-material.service.ts
+++ b/src/components/literacy-material/literacy-material.service.ts
@@ -228,8 +228,6 @@ export class LiteracyMaterialService {
         'You do not have the permission to delete this Literacy Material'
       );
 
-    const baseNodeLabels = ['BaseNode', 'LiteracyMaterial', 'Producible'];
-
     const uniqueProperties: UniqueProperties<LiteracyMaterial> = {
       name: ['Property', 'LiteracyName'],
     };
@@ -237,7 +235,6 @@ export class LiteracyMaterialService {
     try {
       await this.db.deleteNodeNew<LiteracyMaterial>({
         object: literacyMaterial,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -337,8 +337,6 @@ export class LocationService {
         'You do not have the permission to delete this Location'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Location'];
-
     const uniqueProperties: UniqueProperties<Location> = {
       name: ['Property', 'LocationName'],
     };
@@ -346,7 +344,6 @@ export class LocationService {
     try {
       await this.db.deleteNodeNew<Location>({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -248,8 +248,6 @@ export class OrganizationService {
         'You do not have the permission to delete this Organization'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Organization'];
-
     const uniqueProperties: UniqueProperties<Organization> = {
       name: ['Property', 'OrgName'],
     };
@@ -257,7 +255,6 @@ export class OrganizationService {
     try {
       await this.db.deleteNodeNew<Organization>({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -398,12 +398,9 @@ export class PartnerService {
         'You do not have the permission to delete this Partner'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Partner'];
-
     try {
       await this.db.deleteNodeNew<Partner>({
         object,
-        baseNodeLabels,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -428,12 +428,9 @@ export class PartnershipService {
       new PartnershipWillDeleteEvent(object, session)
     );
 
-    const baseNodeLabels = ['BaseNode', 'Partnership'];
-
     try {
       await this.db.deleteNodeNew({
         object,
-        baseNodeLabels,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -511,18 +511,9 @@ export class ProductService {
         'You do not have the permission to delete this Product'
       );
 
-    const baseNodeLabels = [
-      'BaseNode',
-      'Product',
-      object.produces?.value
-        ? 'DerivativeScriptureProduct'
-        : 'DirectScriptureProduct',
-    ];
-
     try {
       await this.db.deleteNodeNew({
         object,
-        baseNodeLabels,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -709,8 +709,6 @@ export class ProjectService {
         'You do not have the permission to delete this Project'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Project', `${object.type}Project`];
-
     const uniqueProperties: UniqueProperties<Project> = {
       name: ['Property', 'ProjectName'],
     };
@@ -718,7 +716,6 @@ export class ProjectService {
     try {
       await this.db.deleteNodeNew({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (e) {

--- a/src/components/song/song.service.ts
+++ b/src/components/song/song.service.ts
@@ -207,8 +207,6 @@ export class SongService {
         'You do not have the permission to delete this Song'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Song', 'Producible'];
-
     const uniqueProperties: UniqueProperties<Song> = {
       name: ['Property', 'SongName'],
     };
@@ -216,7 +214,6 @@ export class SongService {
     try {
       await this.db.deleteNodeNew<Song>({
         object: song,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/story/story.service.ts
+++ b/src/components/story/story.service.ts
@@ -210,8 +210,6 @@ export class StoryService {
         'You do not have the permission to delete this Story'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Story', 'Producible'];
-
     const uniqueProperties: UniqueProperties<Story> = {
       name: ['Property', 'StoryName'],
     };
@@ -219,7 +217,6 @@ export class StoryService {
     try {
       await this.db.deleteNodeNew<Story>({
         object: story,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -451,8 +451,6 @@ export class UserService {
         'You do not have the permission to delete this User'
       );
 
-    const baseNodeLabels = ['BaseNode', 'User'];
-
     const uniqueProperties: UniqueProperties<User> = {
       email: ['Property', 'EmailAddress'],
     };
@@ -460,7 +458,6 @@ export class UserService {
     try {
       await this.db.deleteNodeNew<User>({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {


### PR DESCRIPTION
1. I believe the reason for errors regarding the uploading of files https://github.com/SeedCompany/cord-field/issues/748 has to do with the previous deletion of files with the same name in the same directory. 

2. Along with this change we need to also run a few queries in the db to change any `FileNode` labels to `Deleted_FileNode` labels. This can be accomplished by querying for `Deleted_File`, `Deleted_Directory` and `Deleted_File_Version` nodes. 

Because the label FileNode wasn't being passed in for node labels to be marked as `Deleted`, the query here matched a deleted FileNode and then returned an error of `Not Found` to the front end: 

https://github.com/SeedCompany/cord-api-v3/blob/2ed15ae2d88f007303f5f8323593244db9ef1929/src/components/file/file.repository.ts#L61-L75

This query also matched because this function isn't deactivating the deleted file's relationships here: 

https://github.com/SeedCompany/cord-api-v3/blob/2ed15ae2d88f007303f5f8323593244db9ef1929/src/core/database/database.service.ts#L558-L588

Note the relationship on 573 is only pointing at `BaseNodes` going **into** the file node to be deleted, not **out**, which is what we need for the pertinent relationship (on 69 of `file.repository`) to be deactivated in this case: 
`(fn:FileNode)-[p:parent]->(d:Directory)`

 My first solution was to make that relation have a direction of `either`, but I didn't know what ramifications that would have since this function is used for all deletes.
 
 I wonder if we have a need for new labels with a `Delete_` prefix or if we can just deactivate all relationships and replace the `id` property with `deleted_id` on the deleted node. Michael's comment here on deletion protocol didn't mention `Delete_` prefixed node labels: https://github.com/SeedCompany/cord-api-v3/pull/1705#issuecomment-790685440. There's work to be done here still, but I think this one liner will fix the bug for users pending running the queries above in the prod db. 
 

See https://github.com/SeedCompany/cord-api-v3/issues/1717 to perhaps prevent future bugs of this sort. 