### PR TITLE
Query unique property node labels on delete

### DIFF
--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -509,12 +509,9 @@ export class BudgetService {
       budget.records.map((br) => this.deleteRecord(br.id, session))
     );
 
-    const baseNodeLabels = ['BaseNode', 'Budget'];
-
     try {
       await this.db.deleteNodeNew({
         object: budget,
-        baseNodeLabels,
       });
     } catch (e) {
       this.logger.warning('Failed to delete budget', {
@@ -538,12 +535,9 @@ export class BudgetService {
         'You do not have the permission to delete this Budget Record'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Budget'];
-
     try {
       await this.db.deleteNodeNew({
         object: br,
-        baseNodeLabels,
       });
     } catch (e) {
       this.logger.warning('Failed to delete Budget Record', {

--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -200,12 +200,9 @@ export class CeremonyService {
         'You do not have the permission to delete this Ceremony'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Ceremony'];
-
     try {
       await this.db.deleteNodeNew({
         object,
-        baseNodeLabels,
       });
     } catch (exception) {
       this.logger.warning('Failed to delete Ceremony', {

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -1058,12 +1058,9 @@ export class EngagementService {
       await this.verifyProjectStatus(result.projectId, session);
     }
 
-    const baseNodeLabels = ['BaseNode', 'Engagement', object.__typename];
-
     try {
       await this.db.deleteNodeNew({
         object,
-        baseNodeLabels,
       });
     } catch (e) {
       this.logger.warning('Failed to delete Engagement', {

--- a/src/components/field-region/field-region.service.ts
+++ b/src/components/field-region/field-region.service.ts
@@ -17,7 +17,6 @@ import {
   Logger,
   matchRequestingUser,
   OnIndex,
-  UniqueProperties,
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
@@ -249,14 +248,9 @@ export class FieldRegionService {
         'You do not have the permission to delete this Field Region'
       );
 
-    const uniqueProperties: UniqueProperties<FieldRegion> = {
-      name: ['Property', 'FieldRegionName'],
-    };
-
     try {
       await this.db.deleteNodeNew<FieldRegion>({
         object,
-        uniqueProperties,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/field-region/field-region.service.ts
+++ b/src/components/field-region/field-region.service.ts
@@ -249,8 +249,6 @@ export class FieldRegionService {
         'You do not have the permission to delete this Field Region'
       );
 
-    const baseNodeLabels = ['BaseNode', 'FieldRegion'];
-
     const uniqueProperties: UniqueProperties<FieldRegion> = {
       name: ['Property', 'FieldRegionName'],
     };
@@ -258,7 +256,6 @@ export class FieldRegionService {
     try {
       await this.db.deleteNodeNew<FieldRegion>({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/field-zone/field-zone.service.ts
+++ b/src/components/field-zone/field-zone.service.ts
@@ -17,7 +17,6 @@ import {
   Logger,
   matchRequestingUser,
   OnIndex,
-  UniqueProperties,
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
@@ -257,14 +256,9 @@ export class FieldZoneService {
         'You do not have the permission to delete this Field Zone'
       );
 
-    const uniqueProperties: UniqueProperties<FieldZone> = {
-      name: ['Property', 'FieldZoneName'],
-    };
-
     try {
       await this.db.deleteNodeNew({
         object,
-        uniqueProperties,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/field-zone/field-zone.service.ts
+++ b/src/components/field-zone/field-zone.service.ts
@@ -257,8 +257,6 @@ export class FieldZoneService {
         'You do not have the permission to delete this Field Zone'
       );
 
-    const baseNodeLabels = ['BaseNode', 'FieldZone'];
-
     const uniqueProperties: UniqueProperties<FieldZone> = {
       name: ['Property', 'FieldZoneName'],
     };
@@ -266,7 +264,6 @@ export class FieldZoneService {
     try {
       await this.db.deleteNodeNew({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -470,12 +470,9 @@ export class FileRepository {
         'You do not have the permission to delete this File item'
       );
 
-    const baseNodeLabels = ['BaseNode', fileNode.type];
-
     try {
       await this.db.deleteNodeNew({
         object: fileNode,
-        baseNodeLabels,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id: fileNode.id, exception });

--- a/src/components/film/film.service.ts
+++ b/src/components/film/film.service.ts
@@ -210,8 +210,6 @@ export class FilmService {
         'You do not have the permission to delete this Film'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Producible', 'Film'];
-
     const uniqueProperties: UniqueProperties<Film> = {
       name: ['Property', 'FilmName'],
     };
@@ -219,7 +217,6 @@ export class FilmService {
     try {
       await this.db.deleteNodeNew({
         object: film,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/film/film.service.ts
+++ b/src/components/film/film.service.ts
@@ -16,7 +16,6 @@ import {
   Logger,
   matchRequestingUser,
   OnIndex,
-  UniqueProperties,
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
@@ -210,14 +209,9 @@ export class FilmService {
         'You do not have the permission to delete this Film'
       );
 
-    const uniqueProperties: UniqueProperties<Film> = {
-      name: ['Property', 'FilmName'],
-    };
-
     try {
       await this.db.deleteNodeNew({
         object: film,
-        uniqueProperties,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -208,8 +208,6 @@ export class FundingAccountService {
         'You do not have the permission to delete this Funding Account'
       );
 
-    const baseNodeLabels = ['BaseNode', 'FundingAccount'];
-
     const uniqueProperties: UniqueProperties<FundingAccount> = {
       name: ['Property', 'FundingAccountName'],
       accountNumber: ['Property', 'FundingAccountNumber'],
@@ -218,7 +216,6 @@ export class FundingAccountService {
     try {
       await this.db.deleteNodeNew({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -16,7 +16,6 @@ import {
   Logger,
   matchRequestingUser,
   OnIndex,
-  UniqueProperties,
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
@@ -208,15 +207,9 @@ export class FundingAccountService {
         'You do not have the permission to delete this Funding Account'
       );
 
-    const uniqueProperties: UniqueProperties<FundingAccount> = {
-      name: ['Property', 'FundingAccountName'],
-      accountNumber: ['Property', 'FundingAccountNumber'],
-    };
-
     try {
       await this.db.deleteNodeNew({
         object,
-        uniqueProperties,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -454,8 +454,6 @@ export class LanguageService {
         'You do not have the permission to delete this Language'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Language'];
-
     const uniqueProperties: UniqueProperties<Language> = {
       name: ['Property', 'LanguageName'],
       displayName: ['Property', 'LanguageDisplayName'],
@@ -465,7 +463,6 @@ export class LanguageService {
     try {
       await this.db.deleteNodeNew<Language>({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -24,7 +24,6 @@ import {
   matchSession,
   OnIndex,
   UniquenessError,
-  UniqueProperties,
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
@@ -454,16 +453,9 @@ export class LanguageService {
         'You do not have the permission to delete this Language'
       );
 
-    const uniqueProperties: UniqueProperties<Language> = {
-      name: ['Property', 'LanguageName'],
-      displayName: ['Property', 'LanguageDisplayName'],
-      registryOfDialectsCode: ['Property', 'RegistryOfDialectsCode'],
-    };
-
     try {
       await this.db.deleteNodeNew<Language>({
         object,
-        uniqueProperties,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/literacy-material/literacy-material.service.ts
+++ b/src/components/literacy-material/literacy-material.service.ts
@@ -17,7 +17,6 @@ import {
   matchRequestingUser,
   OnIndex,
   Property,
-  UniqueProperties,
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
@@ -228,14 +227,9 @@ export class LiteracyMaterialService {
         'You do not have the permission to delete this Literacy Material'
       );
 
-    const uniqueProperties: UniqueProperties<LiteracyMaterial> = {
-      name: ['Property', 'LiteracyName'],
-    };
-
     try {
       await this.db.deleteNodeNew<LiteracyMaterial>({
         object: literacyMaterial,
-        uniqueProperties,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/literacy-material/literacy-material.service.ts
+++ b/src/components/literacy-material/literacy-material.service.ts
@@ -228,8 +228,6 @@ export class LiteracyMaterialService {
         'You do not have the permission to delete this Literacy Material'
       );
 
-    const baseNodeLabels = ['BaseNode', 'LiteracyMaterial', 'Producible'];
-
     const uniqueProperties: UniqueProperties<LiteracyMaterial> = {
       name: ['Property', 'LiteracyName'],
     };
@@ -237,7 +235,6 @@ export class LiteracyMaterialService {
     try {
       await this.db.deleteNodeNew<LiteracyMaterial>({
         object: literacyMaterial,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -337,8 +337,6 @@ export class LocationService {
         'You do not have the permission to delete this Location'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Location'];
-
     const uniqueProperties: UniqueProperties<Location> = {
       name: ['Property', 'LocationName'],
     };
@@ -346,7 +344,6 @@ export class LocationService {
     try {
       await this.db.deleteNodeNew<Location>({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -17,7 +17,6 @@ import {
   Logger,
   matchRequestingUser,
   OnIndex,
-  UniqueProperties,
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
@@ -337,14 +336,9 @@ export class LocationService {
         'You do not have the permission to delete this Location'
       );
 
-    const uniqueProperties: UniqueProperties<Location> = {
-      name: ['Property', 'LocationName'],
-    };
-
     try {
       await this.db.deleteNodeNew<Location>({
         object,
-        uniqueProperties,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -248,8 +248,6 @@ export class OrganizationService {
         'You do not have the permission to delete this Organization'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Organization'];
-
     const uniqueProperties: UniqueProperties<Organization> = {
       name: ['Property', 'OrgName'],
     };
@@ -257,7 +255,6 @@ export class OrganizationService {
     try {
       await this.db.deleteNodeNew<Organization>({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -20,7 +20,6 @@ import {
   matchSession,
   OnIndex,
   Property,
-  UniqueProperties,
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
@@ -248,14 +247,9 @@ export class OrganizationService {
         'You do not have the permission to delete this Organization'
       );
 
-    const uniqueProperties: UniqueProperties<Organization> = {
-      name: ['Property', 'OrgName'],
-    };
-
     try {
       await this.db.deleteNodeNew<Organization>({
         object,
-        uniqueProperties,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -398,12 +398,9 @@ export class PartnerService {
         'You do not have the permission to delete this Partner'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Partner'];
-
     try {
       await this.db.deleteNodeNew<Partner>({
         object,
-        baseNodeLabels,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -428,12 +428,9 @@ export class PartnershipService {
       new PartnershipWillDeleteEvent(object, session)
     );
 
-    const baseNodeLabels = ['BaseNode', 'Partnership'];
-
     try {
       await this.db.deleteNodeNew({
         object,
-        baseNodeLabels,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -511,18 +511,9 @@ export class ProductService {
         'You do not have the permission to delete this Product'
       );
 
-    const baseNodeLabels = [
-      'BaseNode',
-      'Product',
-      object.produces?.value
-        ? 'DerivativeScriptureProduct'
-        : 'DirectScriptureProduct',
-    ];
-
     try {
       await this.db.deleteNodeNew({
         object,
-        baseNodeLabels,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -24,7 +24,6 @@ import {
   OnIndex,
   Property,
   UniquenessError,
-  UniqueProperties,
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
@@ -709,14 +708,9 @@ export class ProjectService {
         'You do not have the permission to delete this Project'
       );
 
-    const uniqueProperties: UniqueProperties<Project> = {
-      name: ['Property', 'ProjectName'],
-    };
-
     try {
       await this.db.deleteNodeNew({
         object,
-        uniqueProperties,
       });
     } catch (e) {
       this.logger.warning('Failed to delete project', {

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -709,8 +709,6 @@ export class ProjectService {
         'You do not have the permission to delete this Project'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Project', `${object.type}Project`];
-
     const uniqueProperties: UniqueProperties<Project> = {
       name: ['Property', 'ProjectName'],
     };
@@ -718,7 +716,6 @@ export class ProjectService {
     try {
       await this.db.deleteNodeNew({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (e) {

--- a/src/components/song/song.service.ts
+++ b/src/components/song/song.service.ts
@@ -16,7 +16,6 @@ import {
   Logger,
   matchRequestingUser,
   OnIndex,
-  UniqueProperties,
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
@@ -207,14 +206,9 @@ export class SongService {
         'You do not have the permission to delete this Song'
       );
 
-    const uniqueProperties: UniqueProperties<Song> = {
-      name: ['Property', 'SongName'],
-    };
-
     try {
       await this.db.deleteNodeNew<Song>({
         object: song,
-        uniqueProperties,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/song/song.service.ts
+++ b/src/components/song/song.service.ts
@@ -207,8 +207,6 @@ export class SongService {
         'You do not have the permission to delete this Song'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Song', 'Producible'];
-
     const uniqueProperties: UniqueProperties<Song> = {
       name: ['Property', 'SongName'],
     };
@@ -216,7 +214,6 @@ export class SongService {
     try {
       await this.db.deleteNodeNew<Song>({
         object: song,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/story/story.service.ts
+++ b/src/components/story/story.service.ts
@@ -210,8 +210,6 @@ export class StoryService {
         'You do not have the permission to delete this Story'
       );
 
-    const baseNodeLabels = ['BaseNode', 'Story', 'Producible'];
-
     const uniqueProperties: UniqueProperties<Story> = {
       name: ['Property', 'StoryName'],
     };
@@ -219,7 +217,6 @@ export class StoryService {
     try {
       await this.db.deleteNodeNew<Story>({
         object: story,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/story/story.service.ts
+++ b/src/components/story/story.service.ts
@@ -16,7 +16,6 @@ import {
   Logger,
   matchRequestingUser,
   OnIndex,
-  UniqueProperties,
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
@@ -210,14 +209,9 @@ export class StoryService {
         'You do not have the permission to delete this Story'
       );
 
-    const uniqueProperties: UniqueProperties<Story> = {
-      name: ['Property', 'StoryName'],
-    };
-
     try {
       await this.db.deleteNodeNew<Story>({
         object: story,
-        uniqueProperties,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -451,8 +451,6 @@ export class UserService {
         'You do not have the permission to delete this User'
       );
 
-    const baseNodeLabels = ['BaseNode', 'User'];
-
     const uniqueProperties: UniqueProperties<User> = {
       email: ['Property', 'EmailAddress'],
     };
@@ -460,7 +458,6 @@ export class UserService {
     try {
       await this.db.deleteNodeNew<User>({
         object,
-        baseNodeLabels,
         uniqueProperties,
       });
     } catch (exception) {

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -362,14 +362,15 @@ export class UserService {
 
     // Update email
     if (input.email) {
-      // Remove old emails and relations
       const uniqueProperties: UniqueProperties<User> = {
-        email: ['Property', 'EmailAddress'],
+        email: ['EmailAddress'],
       };
+
+      // Remove old emails and relations
       await this.db
         .query()
         .match([node('node', ['User', 'BaseNode'], { id: user.id })])
-        .call(setPropLabelsAndValuesDeleted, uniqueProperties)
+        .call(setPropLabelsAndValuesDeleted, uniqueProperties.email!)
         .return('*')
         .run();
 
@@ -451,14 +452,9 @@ export class UserService {
         'You do not have the permission to delete this User'
       );
 
-    const uniqueProperties: UniqueProperties<User> = {
-      email: ['Property', 'EmailAddress'],
-    };
-
     try {
       await this.db.deleteNodeNew<User>({
         object,
-        uniqueProperties,
       });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });


### PR DESCRIPTION
Depends on https://github.com/SeedCompany/cord-api-v3/pull/1713. 

This eliminates the need to enumerate  property labels when deleting nodes and reduces the chance for bugs there.