### PR TITLE
Allow session cookie in 3rd party

### DIFF
--- a/src/components/authentication/authentication.resolver.ts
+++ b/src/components/authentication/authentication.resolver.ts
@@ -78,14 +78,12 @@ export class AuthenticationResolver {
     const powers = await this.authorizationService.readPower(session);
 
     if (browser) {
-      // http cookies must have an expiration in order to persist, so we're setting it to 10 years in the future
-      const expires = DateTime.local().plus({ years: 10 }).toJSDate();
-
-      res.cookie(this.config.session.cookieName, token, {
-        expires,
-        httpOnly: true,
-        path: '/',
-        domain: this.config.session.cookieDomain,
+      const { name, expires, ...options } = this.config.sessionCookie;
+      res.cookie(name, token, {
+        ...options,
+        expires: expires
+          ? DateTime.local().plus(expires).toJSDate()
+          : undefined,
       });
 
       return { user: userFromSession, powers };

--- a/src/components/authentication/session.pipe.ts
+++ b/src/components/authentication/session.pipe.ts
@@ -66,6 +66,6 @@ export class SessionPipe
   }
 
   getTokenFromCookie(req: Request): string | null {
-    return req?.cookies?.[this.config.session.cookieName] || null;
+    return req?.cookies?.[this.config.sessionCookie.name] || null;
   }
 }

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -196,6 +196,10 @@ export class ConfigService implements EmailOptionsFactory {
       httpOnly: true,
       // All paths, not just the current one
       path: '/',
+      // Require HTTPS (required for SameSite)
+      secure: true,
+      // Allow 3rd party (other domains)
+      sameSite: 'none',
     };
   }
 

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -4,11 +4,13 @@ import {
   EmailModuleOptions,
   EmailOptionsFactory,
 } from '@seedcompany/nestjs-email';
+import { CookieOptions } from 'express';
 import { LazyGetter as Lazy } from 'lazy-get-decorator';
 import { Duration } from 'luxon';
 import { Config as Neo4JDriverConfig } from 'neo4j-driver';
 import { join } from 'path';
-import { ServerException } from '../../common';
+import { Merge } from 'type-fest';
+import { MsDurationInput, ServerException } from '../../common';
 import { FrontendUrlWrapper } from '../email/templates/frontend-url';
 import { LogLevel } from '../logger';
 import { EnvironmentService } from './environment.service';
@@ -172,24 +174,28 @@ export class ConfigService implements EmailOptionsFactory {
     };
   }
 
-  @Lazy() get session(): {
-    cookieName: string;
-    cookieDomain: string | undefined;
-  } {
-    const cookieName = this.env
-      .string('SESSION_COOKIE_NAME')
-      .optional('cordsession');
+  @Lazy() get sessionCookie(): Merge<
+    CookieOptions,
+    { name: string; expires?: MsDurationInput }
+  > {
+    const name = this.env.string('SESSION_COOKIE_NAME').optional('cordsession');
 
-    let cookieDomain = this.env.string('SESSION_COOKIE_DOMAIN').optional();
+    let domain = this.env.string('SESSION_COOKIE_DOMAIN').optional();
 
-    // prepend a leading "." to the domain if one doesn't exist, to ensure cookies are cross-domain-enabled
-    if (cookieDomain && !cookieDomain.startsWith('.')) {
-      cookieDomain = '.' + cookieDomain;
+    // Ensure sub-domains are allowed
+    if (domain && !domain.startsWith('.')) {
+      domain = '.' + domain;
     }
 
     return {
-      cookieName,
-      cookieDomain,
+      name,
+      domain,
+      // Persist past current browser session
+      expires: { years: 10 },
+      // Cannot be retrieved by JS
+      httpOnly: true,
+      // All paths, not just the current one
+      path: '/',
     };
   }
 


### PR DESCRIPTION
`SameSite=none` means it works in 3rd party.
This was the default but needs to be explicit now.
Browser have changed the default to be 1st party.

Specifying `SameSite` requires `Secure=true` (HTTPS).

This is needed for Apollo Studio.