### PR TITLE
Fix duplicate department IDs

### DIFF
--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -243,6 +243,7 @@ export class ProjectService {
         value: null,
         isPublic: false,
         isOrgPublic: false,
+        label: 'DepartmentId',
       },
       {
         key: 'tags',
@@ -759,6 +760,7 @@ export class ProjectService {
 
     const uniqueProperties: UniqueProperties<Project> = {
       name: ['Property', 'ProjectName'],
+      departmentId: ['Property', 'DepartmentId'],
     };
 
     try {


### PR DESCRIPTION
- Create new dept ids at xxx11 and up to avoid colliding with historic ids in intacct
- Select randomized new dept id from list of unused ids in the acceptable range –– this will prevent duplicate dept ids stemming from simultaneous requests in the vast majority of cases