### PR TITLE
Fix user role update deadlock

### DIFF
--- a/src/components/authorization/authorization.service.ts
+++ b/src/components/authorization/authorization.service.ts
@@ -50,26 +50,33 @@ export class AuthorizationService {
     baseNodeId: string,
     creatorUserId: string
   ) {
-    const label = baseNodeObj.__className.substring(2);
+    await this.afterTransaction(async () => {
+      await this.db
+        .query()
+        .raw(
+          `CALL cord.processNewBaseNode($baseNodeId, $label, $creatorUserId)`,
+          {
+            baseNodeId,
+            label: baseNodeObj.__className.substring(2),
+            creatorUserId,
+          }
+        )
+        .run();
+    });
+  }
+
+  /**
+   * Run code after current transaction finishes, if there is one.
+   * This is a hack to allow our procedure and apoc.periodic.iterate to work
+   * without dead-locking. They use separate transactions so they need the
+   * resource being modified to be unlocked (which happens after the
+   * transaction commits/finishes).
+   */
+  private async afterTransaction(fn: () => Promise<void>) {
     const process = async () => {
-      await retry(
-        async () => {
-          await this.db
-            .query()
-            .raw(
-              `CALL cord.processNewBaseNode($baseNodeId, $label, $creatorUserId)`,
-              {
-                baseNodeId,
-                label,
-                creatorUserId,
-              }
-            )
-            .run();
-        },
-        {
-          retries: 3,
-        }
-      );
+      await retry(fn, {
+        retries: 3,
+      });
     };
 
     const tx = this.dbConn.currentTransaction;

--- a/src/components/authorization/authorization.service.ts
+++ b/src/components/authorization/authorization.service.ts
@@ -194,6 +194,10 @@ export class AuthorizationService {
   }
 
   async roleAddedToUser(id: string, roles: Role[]) {
+    await this.afterTransaction(() => this.doRoleAddedToUser(id, roles));
+  }
+
+  private async doRoleAddedToUser(id: string, roles: Role[]) {
     // todo: this only applies to global roles, the only kind we have until next week
     // iterate through all roles and assign to all SGs with that role
 

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -100,10 +100,7 @@ describe('User e2e', () => {
 
   it('update user', async () => {
     // create user first
-    const newUser = await generateRegisterInput();
-    await createSession(app);
-    const user = await registerUser(app, newUser);
-    await login(app, { email: newUser.email, password: newUser.password });
+    const user = await registerUser(app);
 
     const fakeUser: UpdateUser = {
       id: user.id,
@@ -118,8 +115,7 @@ describe('User e2e', () => {
       status: UserStatus.Disabled,
     };
 
-    // update
-    await app.graphql.mutate(
+    const result = await app.graphql.mutate(
       gql`
         mutation updateUser($input: UpdateUserInput!) {
           updateUser(input: $input) {
@@ -138,21 +134,7 @@ describe('User e2e', () => {
         },
       }
     );
-    // get the user from the ID
-    const result = await app.graphql.query(
-      gql`
-        query user($id: ID!) {
-          user(id: $id) {
-            ...user
-          }
-        }
-        ${fragments.user}
-      `,
-      {
-        id: user.id,
-      }
-    );
-    const actual: User = result.user;
+    const actual: User = result.updateUser.user;
 
     expect(actual).toBeTruthy();
 


### PR DESCRIPTION
We were getting a deadlock in production trying to update user roles, because the code to modify the user runs in a transaction and its uncommitted when we ask the db to update security groups for that user. The transaction in progress locks the user node and then the security group query, which uses apoc.periodic.iterate (which uses separate transactions), waits for that lock to be released.

Unfortunately I was unable to reproduce this deadlock locally.

This is the cause of #1729 