### PR TITLE
Project Transition Notifiers

### DIFF
--- a/src/components/project/handlers/step-changed-notification.handler.ts
+++ b/src/components/project/handlers/step-changed-notification.handler.ts
@@ -32,7 +32,7 @@ export class ProjectStepChangedNotificationHandler
       event.updated.id,
       event.updated.step.value!,
       event.session.userId,
-      event.previous.step.value
+      event.previous.step.value!
     );
 
     this.logger.info('Notifying', {

--- a/src/components/project/project.rules.ts
+++ b/src/components/project/project.rules.ts
@@ -949,8 +949,8 @@ export class ProjectRules {
         node('email', 'EmailAddress'),
         relation('in', '', 'email', { active: true }),
         node('user', 'User'),
-        relation('out', '', 'roles', { active: true, role }),
-        node('role', 'Property'),
+        relation('out', '', 'roles', { active: true }),
+        node('role', 'Property', { value: role }),
       ])
       .raw('return collect(email.value) as emails')
       .first();

--- a/src/components/project/project.rules.ts
+++ b/src/components/project/project.rules.ts
@@ -313,7 +313,11 @@ export class ProjectRules {
               to: ProjectStep.Active,
               type: TransitionType.Approve,
               label: 'Confirm Project 🎉',
-              notifiers: 'projects@tsco.org',
+              notifiers: async () => [
+                ...(await this.getRoleEmails(Role.Controller)),
+                'project_approval@tsco.org',
+                'projects@tsco.org',
+              ],
             },
             {
               to: ProjectStep.OnHoldFinanceConfirmation,
@@ -344,6 +348,11 @@ export class ProjectRules {
               to: ProjectStep.Active,
               type: TransitionType.Approve,
               label: 'Confirm Project 🎉',
+              notifiers: async () => [
+                ...(await this.getRoleEmails(Role.Controller)),
+                'project_approval@tsco.org',
+                'projects@tsco.org',
+              ],
             },
             {
               to: ProjectStep.FinalizingProposal,
@@ -386,11 +395,7 @@ export class ProjectRules {
               label: 'Finalize Completion',
             },
           ],
-          getNotifiers: async () => [
-            ...(await this.getProjectTeamUserIds(id)),
-            ...(await this.getRoleEmails(Role.Controller)),
-            'project_approval@tsco.org',
-          ],
+          getNotifiers: () => this.getProjectTeamUserIds(id),
         };
       case ProjectStep.ActiveChangedPlan:
         return {
@@ -419,6 +424,7 @@ export class ProjectRules {
           ],
           getNotifiers: async () => [
             ...(await this.getProjectTeamUserIds(id)),
+            ...(await this.getRoleEmails(Role.Controller)),
             'project_extension@tsco.org',
             'project_revision@tsco.org',
           ],
@@ -515,6 +521,7 @@ export class ProjectRules {
           ],
           getNotifiers: async () => [
             ...(await this.getProjectTeamUserIds(id)),
+            ...(await this.getRoleEmails(Role.Controller)),
             'project_extension@tsco.org',
             'project_revision@tsco.org',
           ],

--- a/src/components/project/project.rules.ts
+++ b/src/components/project/project.rules.ts
@@ -32,7 +32,7 @@ interface StepRule {
   approvers: Role[];
   transitions: Transition[];
   // Users/emails to notify when the project arrives at this step
-  getNotifiers: () => MaybeAsync<ReadonlyArray<EmailAddress | string>>;
+  getNotifiers?: () => MaybeAsync<ReadonlyArray<EmailAddress | string>>;
 }
 
 export interface EmailNotification {
@@ -778,7 +778,6 @@ export class ProjectRules {
         return {
           approvers: [Role.Administrator],
           transitions: [],
-          getNotifiers: () => [],
         };
     }
   }
@@ -897,7 +896,7 @@ export class ProjectRules {
     ).transitions.find((t) => t.to === step)?.notifiers;
 
     const userIdsAndEmailAddresses = uniq([
-      ...(await arrivalNotifiers()),
+      ...((await arrivalNotifiers?.()) ?? []),
       ...(maybeMany(
         typeof transitionNotifiers === 'function'
           ? await transitionNotifiers()

--- a/src/components/project/project.rules.ts
+++ b/src/components/project/project.rules.ts
@@ -389,7 +389,7 @@ export class ProjectRules {
           getNotifiers: async () => [
             ...(await this.getProjectTeamUserIds(id)),
             ...(await this.getRoleEmails(Role.Controller)),
-            'project_approve@tsco.org',
+            'project_approval@tsco.org',
           ],
         };
       case ProjectStep.ActiveChangedPlan:

--- a/src/components/project/project.rules.ts
+++ b/src/components/project/project.rules.ts
@@ -313,6 +313,7 @@ export class ProjectRules {
               to: ProjectStep.Active,
               type: TransitionType.Approve,
               label: 'Confirm Project 🎉',
+              notifiers: 'projects@tsco.org',
             },
             {
               to: ProjectStep.OnHoldFinanceConfirmation,


### PR DESCRIPTION
Fixes #1746 

- Add optional notifiers to individual project transitions so we can say notify these additional people when going "from step to this step"
- Notify `projects@tsco.org` when going from _PendingFinanceConfirmation_ to _Active_