### PR TITLE
Finish deletes refactor

### DIFF
--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -548,9 +548,7 @@ export class BudgetService {
     );
 
     try {
-      await this.db.deleteNodeNew({
-        object: budget,
-      });
+      await this.db.deleteNode(budget);
     } catch (e) {
       this.logger.warning('Failed to delete budget', {
         exception: e,
@@ -574,9 +572,7 @@ export class BudgetService {
       );
 
     try {
-      await this.db.deleteNodeNew({
-        object: br,
-      });
+      await this.db.deleteNode(br);
     } catch (e) {
       this.logger.warning('Failed to delete Budget Record', {
         exception: e,

--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -205,9 +205,7 @@ export class CeremonyService {
       );
 
     try {
-      await this.db.deleteNodeNew({
-        object,
-      });
+      await this.db.deleteNode(object);
     } catch (exception) {
       this.logger.warning('Failed to delete Ceremony', {
         exception,

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -1039,9 +1039,7 @@ export class EngagementService {
     }
 
     try {
-      await this.db.deleteNodeNew({
-        object,
-      });
+      await this.db.deleteNode(object);
     } catch (e) {
       this.logger.warning('Failed to delete Engagement', {
         exception: e,

--- a/src/components/field-region/field-region.service.ts
+++ b/src/components/field-region/field-region.service.ts
@@ -253,9 +253,7 @@ export class FieldRegionService {
       );
 
     try {
-      await this.db.deleteNodeNew<FieldRegion>({
-        object,
-      });
+      await this.db.deleteNode(object);
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/components/field-zone/field-zone.service.ts
+++ b/src/components/field-zone/field-zone.service.ts
@@ -254,9 +254,7 @@ export class FieldZoneService {
       );
 
     try {
-      await this.db.deleteNodeNew({
-        object,
-      });
+      await this.db.deleteNode(object);
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -467,9 +467,7 @@ export class FileRepository {
       );
 
     try {
-      await this.db.deleteNodeNew({
-        object: fileNode,
-      });
+      await this.db.deleteNode(fileNode);
     } catch (exception) {
       this.logger.error('Failed to delete', { id: fileNode.id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/components/film/film.service.ts
+++ b/src/components/film/film.service.ts
@@ -214,9 +214,7 @@ export class FilmService {
       );
 
     try {
-      await this.db.deleteNodeNew({
-        object: film,
-      });
+      await this.db.deleteNode(film);
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -216,9 +216,7 @@ export class FundingAccountService {
       );
 
     try {
-      await this.db.deleteNodeNew({
-        object,
-      });
+      await this.db.deleteNode(object);
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -406,9 +406,7 @@ export class LanguageService {
       );
 
     try {
-      await this.db.deleteNodeNew<Language>({
-        object,
-      });
+      await this.db.deleteNode(object);
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/components/literacy-material/literacy-material.service.ts
+++ b/src/components/literacy-material/literacy-material.service.ts
@@ -240,9 +240,7 @@ export class LiteracyMaterialService {
       );
 
     try {
-      await this.db.deleteNodeNew<LiteracyMaterial>({
-        object: literacyMaterial,
-      });
+      await this.db.deleteNode(literacyMaterial);
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -348,9 +348,7 @@ export class LocationService {
       );
 
     try {
-      await this.db.deleteNodeNew<Location>({
-        object,
-      });
+      await this.db.deleteNode(object);
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -253,9 +253,7 @@ export class OrganizationService {
       );
 
     try {
-      await this.db.deleteNodeNew<Organization>({
-        object,
-      });
+      await this.db.deleteNode(object);
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -389,9 +389,7 @@ export class PartnerService {
       );
 
     try {
-      await this.db.deleteNodeNew<Partner>({
-        object,
-      });
+      await this.db.deleteNode(object);
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -466,9 +466,7 @@ export class PartnershipService {
     );
 
     try {
-      await this.db.deleteNodeNew({
-        object,
-      });
+      await this.db.deleteNode(object);
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -571,9 +571,7 @@ export class ProductService {
       );
 
     try {
-      await this.db.deleteNodeNew({
-        object,
-      });
+      await this.db.deleteNode(object);
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -314,11 +314,7 @@ export class ProjectMemberService {
     }
 
     try {
-      await this.db.deleteNode({
-        session,
-        object,
-        aclEditProp: 'canDeleteOwnUser',
-      });
+      await this.db.deleteNode(object);
     } catch (exception) {
       this.logger.warning('Failed to delete project member', {
         exception,

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -755,9 +755,7 @@ export class ProjectService {
       );
 
     try {
-      await this.db.deleteNodeNew({
-        object,
-      });
+      await this.db.deleteNode(object);
     } catch (e) {
       this.logger.warning('Failed to delete project', {
         exception: e,

--- a/src/components/song/song.service.ts
+++ b/src/components/song/song.service.ts
@@ -210,9 +210,7 @@ export class SongService {
       );
 
     try {
-      await this.db.deleteNodeNew<Song>({
-        object: song,
-      });
+      await this.db.deleteNode(song);
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/components/story/story.service.ts
+++ b/src/components/story/story.service.ts
@@ -214,9 +214,7 @@ export class StoryService {
       );
 
     try {
-      await this.db.deleteNodeNew<Story>({
-        object: story,
-      });
+      await this.db.deleteNode(story);
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -205,11 +205,7 @@ export class UnavailabilityService {
         'unavailability.id'
       );
     }
-    await this.db.deleteNode({
-      session,
-      object: ua,
-      aclEditProp: 'canDeleteOwnUser',
-    });
+    await this.db.deleteNode(ua);
   }
 
   async list(

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -458,9 +458,7 @@ export class UserService {
       );
 
     try {
-      await this.db.deleteNodeNew<User>({
-        object,
-      });
+      await this.db.deleteNode(object);
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -31,6 +31,7 @@ import { ILogger, Logger, ServiceUnavailableError, UniquenessError } from '..';
 import { AbortError, retry, RetryOptions } from '../../common/retry';
 import { ConfigService } from '../config/config.service';
 import { DbChanges, getChanges } from './changes';
+import { deleteBaseNode } from './query';
 import { determineSortValue } from './query.helpers';
 import { hasMore } from './results';
 import { Transactional } from './transactional.decorator';
@@ -557,56 +558,10 @@ export class DatabaseService {
   }: {
     object: TObject;
   }) {
-    const deletedAt = DateTime.local();
     const query = this.db
       .query()
-      .match([
-        node('baseNode', { id: object.id }),
-        /**
-         in this case we want to set Deleted_ labels for all properties
-         including active = false
-         deleteProperties does this, but deletes from before that was changed only prefixed
-         unique property labels
-        */
-        relation('out', ''),
-        node('propertyNode', 'Property'),
-      ])
-      // Mark any parent base node relationships (pointing to the base node) as active = false.
-      .optionalMatch([
-        node('baseNode'),
-        relation('in', 'baseNodeRel'),
-        node('', 'BaseNode'),
-      ])
-      .setValues({
-        'baseNode.deletedAt': deletedAt,
-        'baseNodeRel.active': false,
-      })
-      /**
-       if we set anything on property nodes or property relationships in the query above (as was done previously)
-       we need to distinct propertyNode to avoid collecting and labeling each propertyNode more than once
-      */
-      .with('[baseNode] + collect(propertyNode) as nodeList')
-      /**
-       check if labels already have the "Deleted_" prefix to avoid "Deleted_Deleted_"
-       yielding a node from the label procedures is necessary I believe
-       they're not used in rest of the query and are aliased to avoid colliding with the unwound "node" alias
-      */
-      .raw(
-        `
-        unwind nodeList as node
-        with node,
-        reduce(
-          deletedLabels = [], label in labels(node) |
-            case
-              when label starts with "Deleted_" then deletedLabels + label
-              else deletedLabels + ("Deleted_" + label)
-            end
-        ) as deletedLabels
-        call apoc.create.removeLabels(node, labels(node)) yield node as nodeRemoved
-        with node, deletedLabels
-        call apoc.create.addLabels(node, deletedLabels) yield node as nodeAdded
-      `
-      )
+      .matchNode('baseNode', { id: object.id })
+      .call(deleteBaseNode)
       .return('*');
     await query.run();
   }

--- a/src/core/database/query/deletes.ts
+++ b/src/core/database/query/deletes.ts
@@ -1,0 +1,52 @@
+import { node, Query, relation } from 'cypher-query-builder';
+import { DateTime } from 'luxon';
+
+export const deleteBaseNode = (query: Query) =>
+  query
+    .match([
+      node('baseNode'),
+      /**
+         in this case we want to set Deleted_ labels for all properties
+         including active = false
+         deleteProperties does this, but deletes from before that was changed only prefixed
+         unique property labels
+         */
+      relation('out', ''),
+      node('propertyNode', 'Property'),
+    ])
+    // Mark any parent base node relationships (pointing to the base node) as active = false.
+    .optionalMatch([
+      node('baseNode'),
+      relation('in', 'baseNodeRel'),
+      node('', 'BaseNode'),
+    ])
+    .setValues({
+      'baseNode.deletedAt': DateTime.local(),
+      'baseNodeRel.active': false,
+    })
+    /**
+       if we set anything on property nodes or property relationships in the query above (as was done previously)
+       we need to distinct propertyNode to avoid collecting and labeling each propertyNode more than once
+       */
+    .with('[baseNode] + collect(propertyNode) as nodeList')
+    /**
+       check if labels already have the "Deleted_" prefix to avoid "Deleted_Deleted_"
+       yielding a node from the label procedures is necessary I believe
+       they're not used in rest of the query and are aliased to avoid colliding with the unwound "node" alias
+       */
+    .raw(
+      `
+        unwind nodeList as node
+        with node,
+        reduce(
+          deletedLabels = [], label in labels(node) |
+            case
+              when label starts with "Deleted_" then deletedLabels + label
+              else deletedLabels + ("Deleted_" + label)
+            end
+        ) as deletedLabels
+        call apoc.create.removeLabels(node, labels(node)) yield node as nodeRemoved
+        with node, deletedLabels
+        call apoc.create.addLabels(node, deletedLabels) yield node as nodeAdded
+      `
+    );

--- a/src/core/database/query/index.ts
+++ b/src/core/database/query/index.ts
@@ -2,3 +2,4 @@ export * from './cypher-functions';
 export * from './lists';
 export * from './mapping';
 export * from './matching';
+export * from './deletes';


### PR DESCRIPTION
- Removed old `deleteNode` query
- Renamed `deleteNodeNew` to `deleteNode`. Change signature to just take the single argument.
- Split off delete query logic into separate function. I'd like to leverage this to be able to do multiple deletes at once. This could be useful in several places like syncing budget records or periodic reports where multiple deletes could happen at once. i.e. matching via custom logic and then forwarding to the delete query fragment.