### PR TITLE
Remove list securedProperties usage in lists

### DIFF
--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -24,7 +24,6 @@ import {
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchMemberRoles,
   matchPropList,
   permissionsOfNode,
@@ -58,18 +57,6 @@ import { DbBudgetRecord } from './model/budget-record.model.db';
 
 @Injectable()
 export class BudgetService {
-  private readonly securedBudgetProperties = {
-    status: true,
-    records: true,
-    universalTemplateFile: true,
-  };
-
-  private readonly securedBudgetRecordProperties = {
-    organization: true,
-    fiscalYear: true,
-    amount: true,
-  };
-
   constructor(
     private readonly db: DatabaseService,
     private readonly config: ConfigService,
@@ -610,12 +597,7 @@ export class BudgetService {
             ]
           : []),
       ])
-      .call(
-        calculateTotalAndPaginateList,
-        listInput,
-        this.securedBudgetProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(Budget, listInput));
 
     return await runListQuery(query, listInput, (id) =>
       this.readOne(id, session)
@@ -642,12 +624,7 @@ export class BudgetService {
             ]
           : []),
       ])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedBudgetRecordProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(BudgetRecord, input));
 
     return await runListQuery(query, input, (id) =>
       this.readOneRecord(id, session)

--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -21,7 +21,6 @@ import {
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchMemberRoles,
   matchPropList,
   permissionsOfNode,
@@ -46,13 +45,6 @@ import {
 
 @Injectable()
 export class CeremonyService {
-  private readonly securedProperties = {
-    type: true,
-    planned: true,
-    estimatedDate: true,
-    actualDate: true,
-  };
-
   constructor(
     private readonly db: DatabaseService,
     private readonly config: ConfigService,
@@ -233,12 +225,7 @@ export class CeremonyService {
             ]
           : []),
       ])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(Ceremony, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -26,7 +26,6 @@ import {
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchMemberRoles,
   matchPropList,
   permissionsOfNode,
@@ -57,6 +56,7 @@ import {
   EngagementListInput,
   EngagementListOutput,
   EngagementStatus,
+  IEngagement,
   InternshipEngagement,
   LanguageEngagement,
   PnpData,
@@ -75,40 +75,6 @@ import { PnpExtractor } from './pnp-extractor.service';
 
 @Injectable()
 export class EngagementService {
-  private readonly securedProperties = {
-    status: true,
-    statusModifiedAt: true,
-    completeDate: true,
-    disbursementCompleteDate: true,
-    communicationsCompleteDate: true,
-    initialEndDate: true,
-    startDate: true,
-    endDate: true,
-    startDateOverride: true,
-    endDateOverride: true,
-    modifiedAt: true,
-    lastSuspendedAt: true,
-    lastReactivatedAt: true,
-    ceremony: true,
-
-    //Language Specific
-    firstScripture: true,
-    lukePartnership: true,
-    sentPrintingDate: true,
-    paratextRegistryId: true,
-    pnp: true,
-    language: true,
-    historicGoal: true,
-
-    //Internship Specific
-    position: true,
-    growthPlan: true,
-    methodologies: true,
-    intern: true,
-    mentor: true,
-    countryOfOrigin: true,
-  };
-
   constructor(
     private readonly db: DatabaseService,
     private readonly repo: EngagementRepository,
@@ -1079,12 +1045,7 @@ export class EngagementService {
             ]
           : []),
       ])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(IEngagement, input));
 
     const engagements = await runListQuery(query, input, (id) =>
       this.readOne(id, session)

--- a/src/components/field-region/field-region.service.ts
+++ b/src/components/field-region/field-region.service.ts
@@ -21,7 +21,6 @@ import {
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchPropList,
   permissionsOfNode,
   requestingUser,
@@ -44,12 +43,6 @@ import { DbFieldRegion } from './model';
 
 @Injectable()
 export class FieldRegionService {
-  private readonly securedProperties = {
-    name: true,
-    director: true,
-    fieldZone: true,
-  };
-
   constructor(
     @Logger('field-region:service') private readonly logger: ILogger,
     private readonly config: ConfigService,
@@ -270,12 +263,7 @@ export class FieldRegionService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode(label)])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(FieldRegion, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/field-zone/field-zone.service.ts
+++ b/src/components/field-zone/field-zone.service.ts
@@ -21,7 +21,6 @@ import {
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchPropList,
   permissionsOfNode,
   requestingUser,
@@ -44,11 +43,6 @@ import { DbFieldZone } from './model';
 
 @Injectable()
 export class FieldZoneService {
-  private readonly securedProperties = {
-    name: true,
-    director: true,
-  };
-
   constructor(
     @Logger('field-zone:service') private readonly logger: ILogger,
     private readonly config: ConfigService,
@@ -271,12 +265,7 @@ export class FieldZoneService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode(label)])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(FieldZone, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/film/film.service.ts
+++ b/src/components/film/film.service.ts
@@ -20,7 +20,6 @@ import {
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchPropList,
   permissionsOfNode,
   requestingUser,
@@ -44,11 +43,6 @@ import { DbFilm } from './model';
 
 @Injectable()
 export class FilmService {
-  private readonly securedProperties = {
-    name: true,
-    scriptureReferences: true,
-  };
-
   constructor(
     @Logger('film:service') private readonly logger: ILogger,
     private readonly db: DatabaseService,
@@ -232,12 +226,7 @@ export class FilmService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode('Film')])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(Film, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -20,7 +20,6 @@ import {
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchPropList,
   permissionsOfNode,
   requestingUser,
@@ -43,11 +42,6 @@ import { DbFundingAccount } from './model';
 
 @Injectable()
 export class FundingAccountService {
-  private readonly securedProperties = {
-    name: true,
-    accountNumber: true,
-  };
-
   constructor(
     @Logger('funding-account:service') private readonly logger: ILogger,
     private readonly db: DatabaseService,
@@ -234,12 +228,7 @@ export class FundingAccountService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode(label)])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(FundingAccount, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -67,22 +67,6 @@ import { languageListFilter } from './query.helpers';
 
 @Injectable()
 export class LanguageService {
-  private readonly securedProperties = {
-    name: true,
-    displayName: true,
-    isDialect: true,
-    populationOverride: true,
-    registryOfDialectsCode: true,
-    leastOfThese: true,
-    leastOfTheseReason: true,
-    displayNamePronunciation: true,
-    isSignLanguage: true,
-    signLanguageCode: true,
-    sponsorEstimatedEndDate: true,
-    hasExternalFirstScripture: true,
-    tags: true,
-  };
-
   constructor(
     private readonly db: DatabaseService,
     private readonly config: ConfigService,
@@ -437,23 +421,21 @@ export class LanguageService {
       .match([requestingUser(session), ...permissionsOfNode('Language')])
       .call(languageListFilter, filter)
       .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        (q, sort, order) =>
-          ['id', 'createdAt'].includes(sort)
-            ? q.with('*').orderBy(`node.${sort}`, order)
+        calculateTotalAndPaginateList(Language, input, (q) =>
+          ['id', 'createdAt'].includes(input.sort)
+            ? q.with('*').orderBy(`node.${input.sort}`, input.order)
             : q
                 .match([
                   node('node'),
-                  relation('out', '', sort, { active: true }),
+                  relation('out', '', input.sort, { active: true }),
                   node('prop', 'Property'),
                 ])
                 .with([
                   '*',
                   ...(input.sort === 'sensitivity' ? [sensitivityCase] : []),
                 ])
-                .orderBy(sortBy, order)
+                .orderBy(sortBy, input.order)
+        )
       );
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));

--- a/src/components/literacy-material/literacy-material.service.ts
+++ b/src/components/literacy-material/literacy-material.service.ts
@@ -21,7 +21,6 @@ import {
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchPropList,
   permissionsOfNode,
   requestingUser,
@@ -45,11 +44,6 @@ import { DbLiteracyMaterial } from './model';
 
 @Injectable()
 export class LiteracyMaterialService {
-  private readonly securedProperties = {
-    name: true,
-    scriptureReferences: true,
-  };
-
   constructor(
     @Logger('literacyMaterial:service') private readonly logger: ILogger,
     private readonly db: DatabaseService,
@@ -261,12 +255,7 @@ export class LiteracyMaterialService {
         requestingUser(session),
         ...permissionsOfNode('LiteracyMaterial'),
       ])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(LiteracyMaterial, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -21,7 +21,6 @@ import {
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchPropList,
   permissionsOfNode,
   requestingUser,
@@ -45,14 +44,6 @@ import { DbLocation } from './model';
 
 @Injectable()
 export class LocationService {
-  readonly securedProperties = {
-    name: true,
-    fundingAccount: true,
-    defaultFieldRegion: true,
-    isoAlpha3: true,
-    type: true,
-  };
-
   constructor(
     @Logger('location:service') private readonly logger: ILogger,
     private readonly config: ConfigService,
@@ -365,12 +356,7 @@ export class LocationService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode(label)])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(Location, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }
@@ -438,12 +424,7 @@ export class LocationService {
         relation('in', '', rel, { active: true }),
         node(`${label.toLowerCase()}`, label, { id }),
       ])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(Location, input));
 
     return {
       ...(await runListQuery(query, input, (id) => this.readOne(id, session))),

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -24,7 +24,6 @@ import {
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchPropList,
   permissionsOfNode,
   requestingUser,
@@ -53,11 +52,6 @@ import { DbOrganization } from './model';
 
 @Injectable()
 export class OrganizationService {
-  private readonly securedProperties = {
-    name: true,
-    address: true,
-  };
-
   constructor(
     @Logger('org:service') private readonly logger: ILogger,
     private readonly config: ConfigService,
@@ -268,10 +262,6 @@ export class OrganizationService {
     { filter, ...input }: OrganizationListInput,
     session: Session
   ): Promise<OrganizationListOutput> {
-    const orgSortMap: Partial<Record<typeof input.sort, string>> = {
-      name: 'toLower(prop.value)',
-    };
-    const sortBy = orgSortMap[input.sort] ?? 'prop.value';
     const query = this.db
       .query()
       .match([
@@ -284,13 +274,7 @@ export class OrganizationService {
             ]
           : []),
       ])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter,
-        sortBy
-      );
+      .call(calculateTotalAndPaginateList(Organization, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -24,7 +24,6 @@ import {
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchMemberRoles,
   matchPropList,
   permissionsOfNode,
@@ -59,21 +58,6 @@ import { DbPartnership } from './model';
 
 @Injectable()
 export class PartnershipService {
-  private readonly securedProperties = {
-    agreementStatus: true,
-    mouStatus: true,
-    mouStart: true,
-    mouEnd: true,
-    mouStartOverride: true,
-    mouEndOverride: true,
-    types: true,
-    financialReportingType: true,
-    mou: true,
-    agreement: true,
-    partner: true,
-    primary: true,
-  };
-
   constructor(
     private readonly files: FileService,
     private readonly db: DatabaseService,
@@ -500,12 +484,7 @@ export class PartnershipService {
             ]
           : []),
       ])
-      .call(
-        calculateTotalAndPaginateList,
-        listInput,
-        this.securedProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(Partnership, listInput));
 
     return await runListQuery(query, listInput, (id) =>
       this.readOne(id, session)

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -25,7 +25,6 @@ import {
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchMemberRoles,
   matchPropList,
   permissionsOfNode,
@@ -68,15 +67,6 @@ import { DbProduct } from './model';
 
 @Injectable()
 export class ProductService {
-  private readonly securedProperties = {
-    mediums: true,
-    purposes: true,
-    methodology: true,
-    scriptureReferences: true,
-    scriptureReferencesOverride: true,
-    produces: true,
-  };
-
   constructor(
     private readonly db: DatabaseService,
     private readonly config: ConfigService,
@@ -600,12 +590,7 @@ export class ProductService {
             ]
           : []),
       ])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(Product, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -26,7 +26,6 @@ import {
 } from '../../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchMemberRoles,
   matchPropList,
   permissionsOfNode,
@@ -54,11 +53,6 @@ import { DbProjectMember } from './model';
 
 @Injectable()
 export class ProjectMemberService {
-  private readonly securedProperties = {
-    user: true,
-    roles: true,
-  };
-
   constructor(
     private readonly db: DatabaseService,
     private readonly config: ConfigService,
@@ -348,12 +342,7 @@ export class ProjectMemberService {
             ]
           : []),
       ])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(ProjectMember, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/song/song.service.ts
+++ b/src/components/song/song.service.ts
@@ -20,7 +20,6 @@ import {
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchPropList,
   permissionsOfNode,
   requestingUser,
@@ -44,11 +43,6 @@ import { DbSong } from './model';
 
 @Injectable()
 export class SongService {
-  private readonly securedProperties = {
-    name: true,
-    scriptureReferences: true,
-  };
-
   constructor(
     @Logger('song:service') private readonly logger: ILogger,
     private readonly db: DatabaseService,
@@ -228,12 +222,7 @@ export class SongService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode('Song')])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(Song, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/story/story.service.ts
+++ b/src/components/story/story.service.ts
@@ -20,7 +20,6 @@ import {
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchPropList,
   permissionsOfNode,
   requestingUser,
@@ -44,11 +43,6 @@ import { DbStory } from './model';
 
 @Injectable()
 export class StoryService {
-  private readonly securedProperties = {
-    name: true,
-    scriptureReferences: true,
-  };
-
   constructor(
     @Logger('story:service') private readonly logger: ILogger,
     private readonly db: DatabaseService,
@@ -232,12 +226,7 @@ export class StoryService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode('Story')])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(Story, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -19,7 +19,6 @@ import {
 } from '../../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchPropList,
   permissionsOfNode,
   requestingUser,
@@ -42,12 +41,6 @@ import {
 
 @Injectable()
 export class EducationService {
-  private readonly securedProperties = {
-    degree: true,
-    institution: true,
-    major: true,
-  };
-
   constructor(
     @Logger('education:service') private readonly logger: ILogger,
     private readonly config: ConfigService,
@@ -208,12 +201,7 @@ export class EducationService {
             ]
           : []),
       ])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter
-      );
+      .call(calculateTotalAndPaginateList(Education, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -29,7 +29,6 @@ import {
 } from '../../core';
 import {
   calculateTotalAndPaginateList,
-  defaultSorter,
   matchPropList,
   permissionsOfNode,
   requestingUser,
@@ -114,20 +113,6 @@ export const fullName = (
 
 @Injectable()
 export class UserService {
-  private readonly securedProperties = {
-    email: true,
-    realFirstName: true,
-    realLastName: true,
-    displayFirstName: true,
-    displayLastName: true,
-    phone: true,
-    timezone: true,
-    about: true,
-    status: true,
-    title: true,
-    roles: true,
-  };
-
   constructor(
     private readonly educations: EducationService,
     private readonly organizations: OrganizationService,
@@ -468,23 +453,10 @@ export class UserService {
   }
 
   async list(input: UserListInput, session: Session): Promise<UserListOutput> {
-    const nameSortMap: Partial<Record<typeof input.sort, string>> = {
-      displayFirstName: 'toLower(prop.value)',
-      displayLastName: 'toLower(prop.value)',
-    };
-
-    const sortBy = nameSortMap[input.sort] ?? 'prop.value';
-
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode('User')])
-      .call(
-        calculateTotalAndPaginateList,
-        input,
-        this.securedProperties,
-        defaultSorter,
-        sortBy
-      );
+      .call(calculateTotalAndPaginateList(User, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }


### PR DESCRIPTION
Refactor `calculateTotalAndPaginateList` to use the resource classes instead of `securedProperties` for determining sorting.

This is just a stepping stone to remove the need for `securedProperties` everywhere.
We still need to refactor lists to not use _SecurityGroups_ in DB.
I'd like to separate sorting from pagination from hydration as well.