### PR TITLE
DateInterval

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@types/express": "^4.17.11",
     "@types/express-serve-static-core": "^4.17.19",
     "@types/faker": "^5.5.0",
-    "@types/graphql": "^14.5.0",
     "@types/jest": "^26.0.22",
     "@types/js-yaml": "^4.0.0",
     "@types/jsonwebtoken": "^8.5.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@types/js-yaml": "^4.0.0",
     "@types/jsonwebtoken": "^8.5.1",
     "@types/lodash": "^4.14.168",
-    "@types/luxon": "^1.26.3",
+    "@types/luxon": "^1.26.4",
     "@types/mjml-react": "^1.0.6",
     "@types/node": "^14.14.37",
     "@types/react": "^16.14.2",

--- a/src/common/date-filter.input.ts
+++ b/src/common/date-filter.input.ts
@@ -1,7 +1,7 @@
 import { InputType } from '@nestjs/graphql';
 import { DateTime } from 'luxon';
-import { CalendarDate } from './calendar-date';
 import { DateField, DateTimeField } from './luxon.graphql';
+import { CalendarDate } from './temporal';
 
 @InputType({
   description: 'A filter range designed for date fields',

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,5 +1,5 @@
+export * from './temporal';
 export * from './context.type';
-export * from './calendar-date';
 export * from './date-filter.input';
 export * from './db-label.decorator';
 export * from './exceptions';

--- a/src/common/luxon.graphql.ts
+++ b/src/common/luxon.graphql.ts
@@ -3,11 +3,10 @@ import { CustomScalar, Field, FieldOptions, Scalar } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { Kind, ValueNode } from 'graphql';
 import { DateTime, Settings } from 'luxon';
-import { CalendarDate } from './calendar-date';
 import { InputException } from './exceptions';
+import { CalendarDate } from './temporal';
 import { Transform } from './transform.decorator';
 import { ValidateBy } from './validators/validateBy';
-import './luxon.neo4j'; // ensure our luxon methods are added
 
 Settings.throwOnInvalid = true;
 

--- a/src/common/retry.ts
+++ b/src/common/retry.ts
@@ -1,6 +1,6 @@
+import { Duration, DurationInput } from 'luxon';
 import * as pRetry from 'p-retry';
 import { Merge } from 'type-fest';
-import { MsDurationInput, parseMilliseconds } from './util';
 
 export { AbortError } from 'p-retry';
 
@@ -11,17 +11,17 @@ export type RetryOptions = Merge<
      * The maximum time (in milliseconds) that the retried operation is allowed to run.
      * @default Infinity
      */
-    maxRetryTime?: MsDurationInput;
+    maxRetryTime?: DurationInput;
     /**
      * The duration before starting the first retry.
      * @default 1 second
      */
-    minTimeout?: MsDurationInput;
+    minTimeout?: DurationInput;
     /**
      * The maximum duration between two retries.
      * @default Infinity
      */
-    maxTimeout?: MsDurationInput;
+    maxTimeout?: DurationInput;
   }
 >;
 
@@ -32,12 +32,12 @@ export const retry = <T>(
   pRetry(input, {
     ...options,
     maxRetryTime: options?.maxRetryTime
-      ? parseMilliseconds(options.maxRetryTime)
+      ? Duration.from(options.maxRetryTime).toMillis()
       : undefined,
     minTimeout: options?.minTimeout
-      ? parseMilliseconds(options.minTimeout)
+      ? Duration.from(options.minTimeout).toMillis()
       : undefined,
     maxTimeout: options?.maxTimeout
-      ? parseMilliseconds(options.maxTimeout)
+      ? Duration.from(options.maxTimeout).toMillis()
       : undefined,
   });

--- a/src/common/temporal/calendar-date.ts
+++ b/src/common/temporal/calendar-date.ts
@@ -147,11 +147,9 @@ export class CalendarDate extends DateTime {
   toUTC(): CalendarDate {
     return this; // noop
   }
-}
 
-(CalendarDate.prototype as any)[inspect.custom] = function (
-  this: CalendarDate
-) {
-  const str = this.toLocaleString(DateTime.DATE_SHORT);
-  return `[Date] ${str}`;
-};
+  [inspect.custom]() {
+    const str = this.toLocaleString(DateTime.DATE_SHORT);
+    return `[Date] ${str}`;
+  }
+}

--- a/src/common/temporal/calendar-date.ts
+++ b/src/common/temporal/calendar-date.ts
@@ -13,6 +13,7 @@ import {
   ZoneOptions,
 } from 'luxon';
 import { inspect } from 'util';
+import { DateInterval } from './date-interval';
 
 /**
  * Calendar Dates have no times or timezones.
@@ -106,6 +107,10 @@ export class CalendarDate extends DateTime {
 
   static utc(year?: number, month?: number, day?: number): CalendarDate {
     return CalendarDate.fromDateTime(super.utc(year, month, day));
+  }
+
+  until(other: CalendarDate): DateInterval {
+    return DateInterval.fromDateTimes(this, other);
   }
 
   endOf(unit: DurationUnit): CalendarDate {

--- a/src/common/temporal/date-interval.spec.ts
+++ b/src/common/temporal/date-interval.spec.ts
@@ -1,0 +1,325 @@
+import { differenceWith } from 'lodash';
+import { DateTime, Interval } from 'luxon';
+import { CalendarDate } from './calendar-date';
+import { DateInterval } from './date-interval';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace -- it's fine for module augmentation
+  namespace jest {
+    // eslint-disable-next-line @seedcompany/no-unused-vars,@typescript-eslint/ban-types
+    interface Matchers<R, T = {}> {
+      toBeDateInterval: (expected: DateInterval) => R;
+      toBeDateIntervals: (expected: DateInterval[]) => R;
+    }
+  }
+}
+
+expect.extend({
+  toBeDateInterval(received: DateInterval, expected: DateInterval) {
+    const pass = received.equals(expected);
+    const message = () =>
+      `${this.utils.matcherHint('toBeDateInterval', undefined, undefined, {
+        isNot: this.isNot,
+        promise: this.promise,
+      })}\n\nExpected:${this.isNot ? ' not' : ''} ${this.utils.EXPECTED_COLOR(
+        expected.toString()
+      )}\nReceived:${this.isNot ? '    ' : ''} ${this.utils.RECEIVED_COLOR(
+        received.toString()
+      )}`;
+    return { pass, message };
+  },
+  toBeDateIntervals(received: DateInterval[], expected: DateInterval[]) {
+    const diEqual = (a: DateInterval, b: DateInterval) => a.equals(b);
+    const pass =
+      received.length === expected.length &&
+      differenceWith(received, expected, diEqual).length === 0 &&
+      differenceWith(expected, received, diEqual).length === 0;
+    const matcherName = 'toBeDateIntervals';
+    const expectedStrs = expected.map((e) => e.toString());
+    const receivedStrs = received.map((e) => e.toString());
+    const message = () =>
+      `${this.utils.matcherHint(matcherName, undefined, undefined, {
+        isNot: this.isNot,
+        promise: this.promise,
+      })}\n\n${this.utils
+        .printDiffOrStringify(
+          expectedStrs,
+          receivedStrs,
+          'Expected',
+          'Received',
+          this.expand ?? true
+        )
+        .replace(/"/g, '')}`;
+    return {
+      pass,
+      message,
+      actual: receivedStrs,
+      expected: expectedStrs,
+      name: matcherName,
+    };
+  },
+});
+
+const expectInstances = (int: DateInterval) => {
+  expect(int).toBeInstanceOf(DateInterval);
+  expect(int.start).toBeInstanceOf(CalendarDate);
+  expect(int.end).toBeInstanceOf(CalendarDate);
+};
+
+const day = (day: number) => CalendarDate.local(2020, 5, day);
+const days = (start: number, end: number) => day(start).until(day(end));
+
+describe('DateInterval', () => {
+  it('fromISO -> toISO', () => {
+    const iso = '2020-03-04/2021-05-22';
+    const interval = DateInterval.fromISO(iso);
+    expectInstances(interval);
+    expect(interval.toISO()).toBe(iso);
+    expect(interval.toISODate()).toBe(iso);
+    expect(() => interval.toISOTime()).toThrowError();
+  });
+  it('toString', () => {
+    const interval = DateInterval.fromISO('2020-03-04/2021-05-22');
+    expect(interval.toString()).toBe('[2020-03-04 – 2021-05-22]');
+  });
+  it('length', () => {
+    const interval = DateInterval.fromISO('2020-03-04/2021-05-22');
+    expect(interval.length()).toBe(445);
+    expect(interval.length('year')).toBeCloseTo(1.216);
+    expect(interval.length('months')).toBeCloseTo(14.612);
+  });
+  it('toDuration', () => {
+    const interval = DateInterval.fromISO('2020-03-04/2021-05-22');
+    expect(interval.toDuration().toObject()).toEqual({ days: 445 });
+    expect(
+      interval.toDuration(['years', 'months', 'days']).toObject()
+    ).toEqual({ years: 1, months: 2, days: 19 });
+  });
+  it('fromInterval', () => {
+    const dtInterval = Interval.fromISO('2020-03-04T04/2021-05-22T05');
+    const interval = DateInterval.fromInterval(dtInterval);
+    expectInstances(interval);
+    expect(interval.toISO()).toBe('2020-03-04/2021-05-22');
+  });
+  it('after', () => {
+    const start = DateTime.fromISO('2020-03-01');
+    const interval = DateInterval.after(start, { days: 14 });
+    expectInstances(interval);
+    expect(interval.end.toISO()).toBe('2020-03-14');
+  });
+  it('before', () => {
+    const end = DateTime.fromISO('2020-03-14');
+    const interval = DateInterval.before(end, { days: 14 });
+    expectInstances(interval);
+    expect(interval.start.toISO()).toBe('2020-03-01');
+  });
+  it('fromDateTimes', () => {
+    const start = DateTime.local(2020, 4, 2, 13, 3, 1);
+    const end = DateTime.local(2020, 4, 23, 10);
+    const interval = DateInterval.fromDateTimes(start, end);
+    expectInstances(interval);
+    expect(interval.toISO()).toBe('2020-04-02/2020-04-23');
+  });
+  it('count', () => {
+    expect(days(5, 8).count()).toBe(4);
+    expect(days(5, 5).count('days')).toBe(1);
+    expect(days(5, 5).count('months')).toBe(1);
+    expect(days(5, 5).count('years')).toBe(1);
+  });
+  it('contains', () => {
+    expect(days(5, 8).contains(day(6))).toBeTruthy();
+    expect(days(5, 8).contains(day(5))).toBeTruthy();
+    expect(days(5, 8).contains(day(8))).toBeTruthy();
+    expect(days(5, 8).contains(day(9))).toBeFalsy();
+    expect(days(5, 8).contains(day(4))).toBeFalsy();
+  });
+  it('isBefore', () => {
+    expect(days(5, 8).isBefore(day(9))).toBeTruthy();
+    expect(days(5, 8).isBefore(day(6))).toBeFalsy();
+    expect(days(5, 8).isBefore(day(3))).toBeFalsy();
+    expect(days(5, 8).isBefore(day(8))).toBeFalsy();
+  });
+  it('isAfter', () => {
+    expect(days(5, 8).isAfter(day(4))).toBeTruthy();
+    expect(days(5, 8).isAfter(day(5))).toBeFalsy();
+    expect(days(5, 8).isAfter(day(10))).toBeFalsy();
+    expect(days(5, 8).isAfter(day(8))).toBeFalsy();
+  });
+  it('union', () => {
+    expect(days(5, 8).union(days(10, 11))).toBeDateInterval(days(5, 11));
+    expect(days(5, 8).union(days(2, 4))).toBeDateInterval(days(2, 8));
+    expect(days(5, 8).union(days(7, 10))).toBeDateInterval(days(5, 10));
+    expect(days(5, 8).union(days(4, 6))).toBeDateInterval(days(4, 8));
+    expect(days(5, 8).union(days(6, 7))).toBeDateInterval(days(5, 8));
+    expect(days(5, 8).union(days(4, 10))).toBeDateInterval(days(4, 10));
+    expect(days(5, 8).union(days(9, 10))).toBeDateInterval(days(5, 10));
+  });
+  describe('intersection', () => {
+    it('no intersection is null', () => {
+      expect(days(5, 8).intersection(days(2, 3))).toBeNull();
+    });
+    it('partial overlap', () => {
+      expect(days(5, 8).intersection(days(3, 7))).toBeDateInterval(days(5, 7));
+      expect(days(5, 8).intersection(days(7, 10))).toBeDateInterval(days(7, 8));
+    });
+    it('overlap', () => {
+      expect(days(5, 8).intersection(days(3, 10))).toBeDateInterval(days(5, 8));
+      expect(days(3, 10).intersection(days(5, 8))).toBeDateInterval(days(5, 8));
+    });
+    it('null for adjacent', () => {
+      expect(days(5, 8).intersection(days(9, 10))).toBeNull();
+      expect(days(5, 8).intersection(days(2, 4))).toBeNull();
+    });
+  });
+  it('merge', () => {
+    const merged = DateInterval.merge([
+      days(5, 19),
+      days(1, 4),
+      days(20, 22),
+      days(24, 27),
+      days(26, 29),
+    ]);
+    expect(merged).toBeDateIntervals([days(1, 22), days(24, 29)]);
+  });
+  describe('xor', () => {
+    it('non-overlapping', () => {
+      const nonOverlapping = [days(5, 6), days(8, 9)];
+      expect(DateInterval.xor(nonOverlapping)).toBeDateIntervals(
+        nonOverlapping
+      );
+    });
+
+    it('empty for fully overlapping', () => {
+      expect(DateInterval.xor([days(5, 8), days(5, 8)])).toBeDateIntervals([]);
+      expect(
+        DateInterval.xor([days(5, 8), days(5, 6), days(6, 8)])
+      ).toBeDateIntervals([]);
+    });
+
+    it('non-overlapping parts', () => {
+      // overlapping
+      expect(DateInterval.xor([days(5, 8), days(7, 11)])).toBeDateIntervals([
+        days(5, 6),
+        days(9, 11),
+      ]);
+
+      // engulfing
+      expect(DateInterval.xor([days(5, 12), days(9, 10)])).toBeDateIntervals([
+        days(5, 8),
+        days(11, 12),
+      ]);
+
+      // adjacent
+      expect(DateInterval.xor([days(5, 6), days(7, 8)])).toBeDateIntervals([
+        days(5, 8),
+      ]);
+
+      // three intervals
+      expect(
+        DateInterval.xor([days(10, 13), days(8, 10), days(12, 14)])
+      ).toBeDateIntervals([days(8, 9), days(11, 11), days(14, 14)]);
+    });
+  });
+  describe('difference', () => {
+    it('non-overlapping', () => {
+      expect(days(7, 8).difference(days(10, 11))).toBeDateIntervals([
+        days(7, 8),
+      ]);
+      expect(days(7, 8).difference(days(5, 6))).toBeDateIntervals([days(7, 8)]);
+    });
+    it('non-overlapping parts', () => {
+      expect(days(8, 10).difference(days(10, 11))).toBeDateIntervals([
+        days(8, 9),
+      ]);
+      expect(days(9, 11).difference(days(8, 9))).toBeDateIntervals([
+        days(10, 11),
+      ]);
+      expect(
+        days(8, 11).difference(days(7, 8), days(11, 12))
+      ).toBeDateIntervals([days(9, 10)]);
+      expect(
+        days(9, 11).difference(days(8, 9), days(11, 11))
+      ).toBeDateIntervals([days(10, 10)]);
+    });
+    it('empty for fully subtracted', () => {
+      expect(days(8, 10).difference(days(7, 11))).toBeDateIntervals([]);
+      expect(
+        days(8, 11).difference(days(8, 9), days(10, 11))
+      ).toBeDateIntervals([]);
+      expect(
+        days(6, 12).difference(days(6, 9), days(8, 11), days(10, 13))
+      ).toBeDateIntervals([]);
+    });
+    it('returns outside parts when engulfing another interval', () => {
+      expect(days(8, 13).difference(days(10, 11))).toBeDateIntervals([
+        days(8, 9),
+        days(12, 13),
+      ]);
+      expect(
+        days(8, 14).difference(days(10, 11), days(11, 12))
+      ).toBeDateIntervals([days(8, 9), days(13, 14)]);
+    });
+    it('allows holes', () => {
+      expect(
+        days(8, 14).difference(days(10, 10), days(12, 12))
+      ).toBeDateIntervals([days(8, 9), days(11, 11), days(13, 14)]);
+    });
+  });
+  it('overlaps', () => {
+    expect(days(5, 8).overlaps(days(4, 4))).toBeFalsy();
+    expect(days(5, 8).overlaps(days(4, 5))).toBeTruthy();
+    expect(days(5, 8).overlaps(days(5, 6))).toBeTruthy();
+    expect(days(5, 8).overlaps(days(8, 9))).toBeTruthy();
+    expect(days(5, 8).overlaps(days(9, 10))).toBeFalsy();
+  });
+  it('engulfs', () => {
+    const int = days(9, 12);
+    expect(int.engulfs(days(13, 15))).toBeFalsy(); // wholly later
+    expect(int.engulfs(days(11, 15))).toBeFalsy(); // partially later
+    expect(int.engulfs(days(6, 8))).toBeFalsy(); // wholly earlier
+    expect(int.engulfs(days(6, 10))).toBeFalsy(); // partially earlier
+    expect(int.engulfs(days(8, 13))).toBeFalsy(); // engulfed
+    expect(int.engulfs(days(10, 11))).toBeTruthy(); // engulfing
+    expect(int.engulfs(days(9, 12))).toBeTruthy(); // equal
+  });
+  it('abutsStart', () => {
+    expect(days(9, 10).abutsStart(days(11, 12))).toBeTruthy();
+    expect(days(9, 10).abutsStart(days(12, 13))).toBeFalsy();
+    expect(days(9, 10).abutsStart(days(8, 11))).toBeFalsy();
+    expect(days(9, 10).abutsStart(days(9, 10))).toBeFalsy();
+  });
+  it('abutsEnd', () => {
+    expect(days(9, 11).abutsEnd(days(7, 8))).toBeTruthy();
+    expect(days(9, 11).abutsEnd(days(7, 9))).toBeFalsy();
+    expect(days(9, 11).abutsEnd(days(7, 7))).toBeFalsy();
+    expect(days(9, 11).abutsEnd(days(9, 11))).toBeFalsy();
+  });
+  describe('splitAt', () => {
+    it('breaks up the interval', () => {
+      const split = days(5, 13).splitAt(day(7), day(10));
+      expect(split).toBeDateIntervals([days(5, 6), days(7, 9), days(10, 13)]);
+    });
+    it('ignores dates outside the interval', () => {
+      const allBefore = days(8, 13).splitAt(day(7));
+      expect(allBefore).toBeDateIntervals([days(8, 13)]);
+
+      const allAfter = days(8, 13).splitAt(day(14));
+      expect(allAfter).toBeDateIntervals([days(8, 13)]);
+
+      const oneBeforeOneDuring = days(8, 13).splitAt(day(7), day(10));
+      expect(oneBeforeOneDuring).toBeDateIntervals([days(8, 9), days(10, 13)]);
+
+      const oneAfterOneDuring = days(8, 13).splitAt(day(10), day(15));
+      expect(oneAfterOneDuring).toBeDateIntervals([days(8, 9), days(10, 13)]);
+    });
+  });
+  it('splitBy', () => {
+    expect(days(5, 13).splitBy({ days: 2 })).toBeDateIntervals([
+      days(5, 6),
+      days(7, 8),
+      days(9, 10),
+      days(11, 12),
+      days(13, 13),
+    ]);
+  });
+});

--- a/src/common/temporal/date-interval.ts
+++ b/src/common/temporal/date-interval.ts
@@ -69,6 +69,18 @@ export class DateInterval extends Interval {
     return super.xor(intervals.map(toSuper)).map(fromSuper);
   }
 
+  static tryFrom(start: CalendarDate, end: CalendarDate): DateInterval;
+  static tryFrom(
+    start: CalendarDate | null | undefined,
+    end: CalendarDate | null | undefined
+  ): DateInterval | null;
+  static tryFrom(
+    start: CalendarDate | null | undefined,
+    end: CalendarDate | null | undefined
+  ): DateInterval | null {
+    return start && end ? DateInterval.fromDateTimes(start, end) : null;
+  }
+
   abutsStart(other: DateInterval): boolean {
     return toSuper(this).abutsStart(toSuper(other));
   }

--- a/src/common/temporal/date-interval.ts
+++ b/src/common/temporal/date-interval.ts
@@ -1,0 +1,154 @@
+import {
+  DateInput,
+  DateTimeOptions,
+  Duration,
+  DurationInput,
+  DurationUnit,
+  DurationUnits,
+  Interval,
+  IntervalObject,
+} from 'luxon';
+import { inspect } from 'util';
+import { CalendarDate } from './calendar-date';
+import './duration';
+
+const toSuper = (int: DateInterval): Interval =>
+  Interval.fromDateTimes(int.start, int.end.plus({ day: 1 }));
+
+const fromSuper = (int: Interval): DateInterval =>
+  DateInterval.fromDateTimes(int.start, int.end.minus({ day: 1 }));
+
+/**
+ * An Interval for dates.
+ * Unlike the Luxon counterpart, this is a closed interval,
+ * meaning its inclusive of both it's starting & ending date.
+ * Luxon's Interval is half-open with it's end point not inclusive.
+ */
+export class DateInterval extends Interval {
+  end: CalendarDate;
+  start: CalendarDate;
+
+  protected constructor(config: Required<IntervalObject>) {
+    config.start =
+      config.start instanceof CalendarDate
+        ? config.start
+        : CalendarDate.fromDateTime(config.start);
+    config.end =
+      config.end instanceof CalendarDate
+        ? config.end
+        : CalendarDate.fromDateTime(config.end);
+    // @ts-expect-error constructor not typed because it's private
+    super(config);
+  }
+
+  static fromInterval(dateTime: Interval) {
+    return new DateInterval({
+      start: dateTime.start,
+      end: dateTime.end,
+    });
+  }
+  static after(start: DateInput, duration: DurationInput) {
+    const dur = Duration.from(duration).minus({ day: 1 });
+    return DateInterval.fromInterval(super.after(start, dur));
+  }
+  static before(end: DateInput, duration: DurationInput) {
+    const dur = Duration.from(duration).minus({ day: 1 });
+    return DateInterval.fromInterval(super.before(end, dur));
+  }
+  static fromDateTimes(start: DateInput, end: DateInput) {
+    const range = Interval.fromDateTimes(start, end);
+    return new DateInterval({ start: range.start, end: range.end });
+  }
+  static fromISO(string: string, options?: DateTimeOptions) {
+    return DateInterval.fromInterval(super.fromISO(string, options));
+  }
+  static merge(intervals: DateInterval[]) {
+    return super.merge(intervals.map(toSuper)).map(fromSuper);
+  }
+  static xor(intervals: DateInterval[]) {
+    return super.xor(intervals.map(toSuper)).map(fromSuper);
+  }
+
+  abutsStart(other: DateInterval): boolean {
+    return toSuper(this).abutsStart(toSuper(other));
+  }
+  abutsEnd(other: DateInterval): boolean {
+    return toSuper(this).abutsEnd(toSuper(other));
+  }
+  isEmpty(): boolean {
+    // Start & end points are inclusive, so this can never be empty.
+    // Even if they are the same "value" (day), that's a full day.
+    return false;
+  }
+  contains(date: CalendarDate): boolean {
+    return toSuper(this).contains(date);
+  }
+  count(unit: DurationUnit = 'days'): number {
+    return super.count(unit);
+  }
+  isAfter(date: CalendarDate): boolean {
+    return toSuper(this).isAfter(date);
+  }
+  isBefore(date: CalendarDate): boolean {
+    return toSuper(this).isBefore(date);
+  }
+  overlaps(other: DateInterval): boolean {
+    return toSuper(this).overlaps(toSuper(other));
+  }
+  equals(other: DateInterval): boolean {
+    return super.equals(other);
+  }
+  engulfs(other: DateInterval): boolean {
+    return super.engulfs(other);
+  }
+  difference(...intervals: DateInterval[]): DateInterval[] {
+    return DateInterval.xor([this, ...intervals])
+      .map((i) => this.intersection(i))
+      .filter((i): i is DateInterval => i != null);
+  }
+  divideEqually(_numberOfParts: number): DateInterval[] {
+    throw new Error('Dates cannot be divide equally');
+  }
+  intersection(other: DateInterval) {
+    const int = toSuper(this).intersection(toSuper(other));
+    return int && int.end > int.start ? fromSuper(int) : null;
+  }
+  set(values: Partial<Record<'start' | 'end', CalendarDate>>) {
+    return DateInterval.fromDateTimes(
+      values.start ?? this.start,
+      values.end ?? this.end
+    );
+  }
+  splitAt(...dates: CalendarDate[]) {
+    return toSuper(this)
+      .splitAt(...dates)
+      .map(fromSuper);
+  }
+  splitBy(duration: DurationInput) {
+    return toSuper(this).splitBy(duration).map(fromSuper);
+  }
+  union(other: DateInterval) {
+    return fromSuper(toSuper(this).union(toSuper(other)));
+  }
+  mapEndpoints(mapFn: (d: CalendarDate) => CalendarDate) {
+    return DateInterval.fromDateTimes(mapFn(this.start), mapFn(this.end));
+  }
+  length(unit: DurationUnit = 'days'): number {
+    return toSuper(this).length(unit);
+  }
+  toDuration(unit?: DurationUnits): Duration {
+    return toSuper(this).toDuration(unit ?? ['days']);
+  }
+  toISO() {
+    return super.toISODate();
+  }
+  toISOTime(): string {
+    throw new Error('Nope');
+  }
+  toString(): string {
+    return `[${this.start.toISO()} – ${this.end.toISO()}]`;
+  }
+  [inspect.custom]() {
+    return `[Dates ${this.start.toISO()} – ${this.end.toISO()}]`;
+  }
+}

--- a/src/common/temporal/date-interval.ts
+++ b/src/common/temporal/date-interval.ts
@@ -151,4 +151,10 @@ export class DateInterval extends Interval {
   [inspect.custom]() {
     return `[Dates ${this.start.toISO()} – ${this.end.toISO()}]`;
   }
+  expandToFull(unit: DurationUnit): DateInterval {
+    return DateInterval.fromDateTimes(
+      this.start.startOf(unit),
+      this.end.endOf(unit)
+    );
+  }
 }

--- a/src/common/temporal/date-time.ts
+++ b/src/common/temporal/date-time.ts
@@ -2,19 +2,20 @@ import { DateTime } from 'luxon';
 import * as Neo from 'neo4j-driver';
 import { inspect } from 'util';
 
-declare module 'luxon' {
+/* eslint-disable @typescript-eslint/method-signature-style */
+declare module 'luxon/src/datetime' {
   interface DateTime {
-    toNeo4JDate: (this: DateTime) => Neo.Date<number>;
-    toNeo4JDateTime: (this: DateTime) => Neo.DateTime<number>;
+    toNeo4JDate(this: DateTime): Neo.Date<number>;
+    toNeo4JDateTime(this: DateTime): Neo.DateTime<number>;
+    [inspect.custom](): string;
   }
 }
+/* eslint-enable @typescript-eslint/method-signature-style */
 
-// eslint-disable-next-line @typescript-eslint/unbound-method
 DateTime.prototype.toNeo4JDate = function (this: DateTime) {
   return new Neo.types.Date(this.year, this.month, this.day);
 };
 
-// eslint-disable-next-line @typescript-eslint/unbound-method
 DateTime.prototype.toNeo4JDateTime = function (this: DateTime) {
   return new Neo.types.DateTime(
     this.year,
@@ -29,7 +30,7 @@ DateTime.prototype.toNeo4JDateTime = function (this: DateTime) {
   );
 };
 
-(DateTime.prototype as any)[inspect.custom] = function (this: DateTime) {
+DateTime.prototype[inspect.custom] = function (this: DateTime) {
   const str = this.toLocaleString(DateTime.DATETIME_SHORT_WITH_SECONDS);
   return `[DateTime] ${str}`;
 };

--- a/src/common/temporal/duration.ts
+++ b/src/common/temporal/duration.ts
@@ -1,0 +1,24 @@
+import { isNumber } from 'lodash';
+import { Duration, DurationInput } from 'luxon';
+import { Mutable } from 'type-fest';
+
+declare module 'luxon/src/duration' {
+  // eslint-disable-next-line @typescript-eslint/no-namespace -- augmenting static class method
+  namespace Duration {
+    export const from: (durationish: DurationInput) => Duration;
+  }
+}
+(Duration as Mutable<typeof Duration>).from = function (
+  durationish: DurationInput
+) {
+  if (isNumber(durationish)) {
+    return Duration.fromMillis(durationish);
+  } else if (Duration.isDuration(durationish)) {
+    return durationish;
+  } else if (typeof durationish === 'object') {
+    return Duration.fromObject(durationish);
+  } else {
+    const _: never = durationish;
+    throw new Error();
+  }
+};

--- a/src/common/temporal/index.ts
+++ b/src/common/temporal/index.ts
@@ -1,2 +1,3 @@
+export * from './duration';
 export * from './date-time';
 export * from './calendar-date';

--- a/src/common/temporal/index.ts
+++ b/src/common/temporal/index.ts
@@ -1,0 +1,2 @@
+export * from './date-time';
+export * from './calendar-date';

--- a/src/common/temporal/index.ts
+++ b/src/common/temporal/index.ts
@@ -2,3 +2,4 @@ export * from './duration';
 export * from './date-time';
 export * from './interval';
 export * from './calendar-date';
+export * from './date-interval';

--- a/src/common/temporal/index.ts
+++ b/src/common/temporal/index.ts
@@ -1,3 +1,4 @@
 export * from './duration';
 export * from './date-time';
+export * from './interval';
 export * from './calendar-date';

--- a/src/common/temporal/interval.ts
+++ b/src/common/temporal/interval.ts
@@ -1,4 +1,5 @@
 import { DateTime, DurationUnit, Interval } from 'luxon';
+import { Mutable } from 'type-fest';
 import { inspect } from 'util';
 
 /* eslint-disable @typescript-eslint/method-signature-style */
@@ -10,6 +11,13 @@ declare module 'luxon/src/interval' {
      * Expand this interval to the full duration unit given
      */
     expandToFull(unit: DurationUnit): Interval;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Interval {
+    export const compare: (
+      previous: Interval | null,
+      updated: Interval | null
+    ) => Record<'additions' | 'removals', Interval[]>;
   }
 }
 /* eslint-enable @typescript-eslint/method-signature-style */
@@ -25,4 +33,13 @@ Interval.prototype.expandToFull = function (
   unit: DurationUnit
 ) {
   return Interval.fromDateTimes(this.start.startOf(unit), this.end.endOf(unit));
+};
+
+(Interval as Mutable<typeof Interval>).compare = (
+  prev: Interval | null,
+  now: Interval | null
+) => {
+  const removals = !prev ? [] : !now ? [prev] : prev.difference(now);
+  const additions = !now ? [] : !prev ? [now] : now.difference(prev);
+  return { removals, additions };
 };

--- a/src/common/temporal/interval.ts
+++ b/src/common/temporal/interval.ts
@@ -1,15 +1,28 @@
-import { DateTime, Interval } from 'luxon';
+import { DateTime, DurationUnit, Interval } from 'luxon';
 import { inspect } from 'util';
 
+/* eslint-disable @typescript-eslint/method-signature-style */
 declare module 'luxon/src/interval' {
   interface Interval {
-    // eslint-disable-next-line @typescript-eslint/method-signature-style
     [inspect.custom](): string;
+
+    /**
+     * Expand this interval to the full duration unit given
+     */
+    expandToFull(unit: DurationUnit): Interval;
   }
 }
+/* eslint-enable @typescript-eslint/method-signature-style */
 
 Interval.prototype[inspect.custom] = function (this: Interval) {
   const format = (dt: DateTime) =>
     dt.toLocaleString(DateTime.DATETIME_SHORT_WITH_SECONDS);
   return `[Interval ${format(this.start)} – ${format(this.end)})`;
+};
+
+Interval.prototype.expandToFull = function (
+  this: Interval,
+  unit: DurationUnit
+) {
+  return Interval.fromDateTimes(this.start.startOf(unit), this.end.endOf(unit));
 };

--- a/src/common/temporal/interval.ts
+++ b/src/common/temporal/interval.ts
@@ -18,6 +18,12 @@ declare module 'luxon/src/interval' {
       previous: Interval | null,
       updated: Interval | null
     ) => Record<'additions' | 'removals', Interval[]>;
+
+    export function tryFrom(start: DateTime, end: DateTime): Interval;
+    export function tryFrom(
+      start: DateTime | null | undefined,
+      end: DateTime | null | undefined
+    ): Interval | null;
   }
 }
 /* eslint-enable @typescript-eslint/method-signature-style */
@@ -35,11 +41,23 @@ Interval.prototype.expandToFull = function (
   return Interval.fromDateTimes(this.start.startOf(unit), this.end.endOf(unit));
 };
 
-(Interval as Mutable<typeof Interval>).compare = (
-  prev: Interval | null,
-  now: Interval | null
-) => {
+const IntervalStatic = Interval as Mutable<typeof Interval>;
+
+IntervalStatic.compare = (prev: Interval | null, now: Interval | null) => {
   const removals = !prev ? [] : !now ? [prev] : prev.difference(now);
   const additions = !now ? [] : !prev ? [now] : now.difference(prev);
   return { removals, additions };
 };
+
+function tryFrom(start: DateTime, end: DateTime): Interval;
+function tryFrom(
+  start: DateTime | null | undefined,
+  end: DateTime | null | undefined
+): Interval | null;
+function tryFrom(
+  start: DateTime | null | undefined,
+  end: DateTime | null | undefined
+): Interval | null {
+  return start && end ? Interval.fromDateTimes(start, end) : null;
+}
+IntervalStatic.tryFrom = tryFrom;

--- a/src/common/temporal/interval.ts
+++ b/src/common/temporal/interval.ts
@@ -1,0 +1,15 @@
+import { DateTime, Interval } from 'luxon';
+import { inspect } from 'util';
+
+declare module 'luxon/src/interval' {
+  interface Interval {
+    // eslint-disable-next-line @typescript-eslint/method-signature-style
+    [inspect.custom](): string;
+  }
+}
+
+Interval.prototype[inspect.custom] = function (this: Interval) {
+  const format = (dt: DateTime) =>
+    dt.toLocaleString(DateTime.DATETIME_SHORT_WITH_SECONDS);
+  return `[Interval ${format(this.start)} – ${format(this.end)})`;
+};

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -1,5 +1,4 @@
-import { isNumber } from 'lodash';
-import { Duration, DurationObject } from 'luxon';
+import { Duration, DurationInput } from 'luxon';
 
 export type Many<T> = T | readonly T[];
 export const many = <T>(item: Many<T>): readonly T[] =>
@@ -9,20 +8,9 @@ export const maybeMany = <T>(
   item: Many<T> | null | undefined
 ): readonly T[] | undefined => (item != null ? many(item) : undefined);
 
-export type MsDurationInput = number | Duration | DurationObject;
-export const parseMilliseconds = (durationOrMs: MsDurationInput) => {
-  const duration =
-    durationOrMs instanceof Duration
-      ? durationOrMs
-      : Duration.fromObject(
-          isNumber(durationOrMs) ? { milliseconds: durationOrMs } : durationOrMs
-        );
-  return duration.as('milliseconds');
-};
-
-export const sleep = (durationOrMs: MsDurationInput) =>
+export const sleep = (duration: DurationInput) =>
   new Promise((resolve) =>
-    setTimeout(resolve, parseMilliseconds(durationOrMs))
+    setTimeout(resolve, Duration.from(duration).toMillis())
   );
 
 export const simpleSwitch = <T>(

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -6,11 +6,11 @@ import {
 } from '@seedcompany/nestjs-email';
 import { CookieOptions } from 'express';
 import { LazyGetter as Lazy } from 'lazy-get-decorator';
-import { Duration } from 'luxon';
+import { Duration, DurationInput } from 'luxon';
 import { Config as Neo4JDriverConfig } from 'neo4j-driver';
 import { join } from 'path';
 import { Merge } from 'type-fest';
-import { ID, MsDurationInput, ServerException } from '../../common';
+import { ID, ServerException } from '../../common';
 import { FrontendUrlWrapper } from '../email/templates/frontend-url';
 import { LogLevel } from '../logger';
 import { EnvironmentService } from './environment.service';
@@ -177,7 +177,7 @@ export class ConfigService implements EmailOptionsFactory {
 
   @Lazy() get sessionCookie(): Merge<
     CookieOptions,
-    { name: string; expires?: MsDurationInput }
+    { name: string; expires?: DurationInput }
   > {
     const name = this.env.string('SESSION_COOKIE_NAME').optional('cordsession');
 

--- a/src/core/database/transaction.ts
+++ b/src/core/database/transaction.ts
@@ -1,10 +1,7 @@
 import { Connection } from 'cypher-query-builder';
+import { Duration, DurationInput } from 'luxon';
 import { Transaction } from 'neo4j-driver';
-import {
-  MsDurationInput,
-  parseMilliseconds,
-  ServerException,
-} from '../../common';
+import { ServerException } from '../../common';
 import { PatchedConnection } from './cypher.factory';
 
 /**
@@ -33,7 +30,7 @@ export interface TransactionOptions {
    * Specified timeout overrides the default timeout configured in configured
    * in the database using `dbms.transaction.timeout` setting.
    */
-  timeout?: MsDurationInput;
+  timeout?: DurationInput;
 
   /**
    * The transaction's metadata.
@@ -107,7 +104,7 @@ Connection.prototype.runInTransaction = async function withTransaction<R>(
       (tx) => this.transactionStorage.run(tx, inner),
       {
         timeout: options?.timeout
-          ? parseMilliseconds(options.timeout)
+          ? Duration.from(options.timeout).toMillis()
           : undefined,
         metadata: options?.metadata,
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1491,15 +1491,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/graphql@npm:^14.5.0":
-  version: 14.5.0
-  resolution: "@types/graphql@npm:14.5.0"
-  dependencies:
-    graphql: "*"
-  checksum: 93ecac6502808bb6b043d7a651b895dbbf1017cfd412b8ea7a923325ad9ddfee1b7cf3ae6997f15eccf44a53bf045cd85c28d594966559dd8b261826a7434288
-  languageName: node
-  linkType: hard
-
 "@types/http-assert@npm:*":
   version: 1.5.1
   resolution: "@types/http-assert@npm:1.5.1"
@@ -3969,7 +3960,6 @@ __metadata:
     "@types/express": ^4.17.11
     "@types/express-serve-static-core": ^4.17.19
     "@types/faker": ^5.5.0
-    "@types/graphql": ^14.5.0
     "@types/jest": ^26.0.22
     "@types/js-yaml": ^4.0.0
     "@types/jsonwebtoken": ^8.5.1
@@ -6226,7 +6216,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:*, graphql@npm:^15.5.0":
+"graphql@npm:^15.5.0":
   version: 15.5.0
   resolution: "graphql@npm:15.5.0"
   checksum: 789cdcb069a3e00592e779002217a6bc5fd09efad63ee8c4190c4b3ea96c89010e74f085fb1cba876a0bb0e324e01df2eddb84d79dca90a28e582bc425fef9ef

--- a/yarn.lock
+++ b/yarn.lock
@@ -1632,10 +1632,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/luxon@npm:^1.26.3":
-  version: 1.26.3
-  resolution: "@types/luxon@npm:1.26.3"
-  checksum: d34b3ceaeed2fadd008b5b41357fce7e3a2d6e0a7feb7e6f39dab1d93d77cd30afae3bc1dfb09d9a4dae812a3f80da3ffcaf9b315422e6ae6c2362f6ae8d885d
+"@types/luxon@npm:^1.26.4":
+  version: 1.26.4
+  resolution: "@types/luxon@npm:1.26.4"
+  checksum: 4ddb55f1c73b1efe0dae407d79f10aba0e3f87945c6386a0c09742b66b39a4b1a81673bc5ddb2483b107684d052fbd953af1aaacdf43bd9bd882742a936791ec
   languageName: node
   linkType: hard
 
@@ -3974,7 +3974,7 @@ __metadata:
     "@types/js-yaml": ^4.0.0
     "@types/jsonwebtoken": ^8.5.1
     "@types/lodash": ^4.14.168
-    "@types/luxon": ^1.26.3
+    "@types/luxon": ^1.26.4
     "@types/mjml-react": ^1.0.6
     "@types/node": ^14.14.37
     "@types/react": ^16.14.2


### PR DESCRIPTION
Most of this PR is `DateInterval` which is a range for `CalendarDates`

## What `DateInterval` solves
Our end dates are inclusive. This is different from Luxon's `Interval` where the end point is _not_ inclusive. This is a problem when trying to do date math because we consider a `CalendarDate` to just be midnight of that day.

So when we say March 1st to March 3rd, we _mean_ the interval is 3 days and ends at the end of the day of the 3rd, but Luxon's `Interval` interprets it as 2 days long.
To have Luxon's math work correctly, which works with date times, the end date time needs to be midnight of the 4th. However since we omit the time the fact that this is range is inclusive of 3rd at 23:59:59 but not 4th at midnight is lost.

So `DateInterval` hides all this. You give it the start and end date (1st - 3rd) and all math works like you'd expect. It does so by adding & subtracting 1 day from the end day when calling Luxon's math.

## Neo4J transformation

`DateInterval` also allows us to convert the start & end properties to `CalendarDate` objects. This means that the interval's properties can be passed right to neo4j query parameters and they'll get converted correctly. (`Date`s instead of `ZonedDateTime`)

# Helpers

I also added these helpers

## `Duration.from`
```ts
Duration.from(40);
Duration.from({ hours: 3 }).toMillis();
```

## `Interval.expandToFull`
```ts
DateInterval.fromISO('2020-01-15/2020-01-30').expandToFull('month')
//=> 2020-01-01/2020-01-31
```

## `Interval.compare`
Shortcut to call `difference` on two intervals both ways. Nulls will add/remove the entire range. This is useful when seeing what needs to be changed in the DB based on a date range change.
```ts
DateInterval.compare(
  DateInterval.fromISO('2020-01-15/2020-01-30')
  DateInterval.fromISO('2020-01-20/2020-02-30')
)
//=> {
  removals: [
    2020-01-15/2020-01-19
  ]
  additions: [
    2020-02-01/2020-02-30
  ]
}
```

## `Interval.tryFrom`
```ts
DateInterval.tryFrom(obj.startDate, obj.endDate); // => DateInterval
DateInterval.tryFrom(obj.startDate, null); // => null
```
Basically the same as `fromDateTimes` but if either are null then null is returned.