### PR TITLE
Query.call -> apply

### DIFF
--- a/src/components/authentication/authentication.service.ts
+++ b/src/components/authentication/authentication.service.ts
@@ -271,7 +271,7 @@ export class AuthenticationService {
 
     const result = await this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([
         node('requestingUser'),
         relation('out', '', 'password', { active: true }),
@@ -288,7 +288,7 @@ export class AuthenticationService {
     const newPasswordHash = await this.crypto.hash(newPassword);
     await this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([
         node('requestingUser'),
         relation('out', '', 'password', { active: true }),
@@ -303,7 +303,7 @@ export class AuthenticationService {
     // inactivate all the relationships between the current user and all of their tokens except current one
     await this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([
         node('requestingUser'),
         relation('out', 'oldRel', 'token', { active: true }),

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -120,8 +120,8 @@ export class BudgetService {
     try {
       const createBudget = this.db
         .query()
-        .call(matchRequestingUser, session)
-        .call(createBaseNode, budgetId, 'Budget', secureProps)
+        .apply(matchRequestingUser(session))
+        .apply(createBaseNode(budgetId, 'Budget', secureProps))
         .return('node.id as id');
 
       const result = await createBudget.first();
@@ -219,14 +219,9 @@ export class BudgetService {
     try {
       const createBudgetRecord = this.db
         .query()
-        .call(matchRequestingUser, session);
-      createBudgetRecord.call(
-        createBaseNode,
-        await generateId(),
-        'BudgetRecord',
-        secureProps
-      );
-      createBudgetRecord.return('node.id as id');
+        .apply(matchRequestingUser(session))
+        .apply(createBaseNode(await generateId(), 'BudgetRecord', secureProps))
+        .return('node.id as id');
 
       const result = await createBudgetRecord.first();
 
@@ -321,7 +316,7 @@ export class BudgetService {
 
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'Budget', { id })])
       .apply(matchPropList)
       .optionalMatch([
@@ -330,7 +325,7 @@ export class BudgetService {
         node('node', 'Budget', { id }),
       ])
       .with(['project', 'node', 'propList'])
-      .call(matchMemberRoles, session.userId)
+      .apply(matchMemberRoles(session.userId))
       .return(['propList', 'node', 'memberRoles'])
       .asResult<
         StandardReadResult<DbPropsOfDto<Budget>> & {
@@ -379,7 +374,7 @@ export class BudgetService {
 
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'BudgetRecord', { id })])
       .apply(matchPropList)
       .match([
@@ -390,7 +385,7 @@ export class BudgetService {
         node('node', 'BudgetRecord', { id }),
       ])
       .with(['project', 'node', 'propList'])
-      .call(matchMemberRoles, session.userId)
+      .apply(matchMemberRoles(session.userId))
       .match([
         node('node'),
         relation('out', '', 'organization', { active: true }),

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -323,7 +323,7 @@ export class BudgetService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'Budget', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .optionalMatch([
         node('project', 'Project'),
         relation('out', '', 'budget', { active: true }),
@@ -381,7 +381,7 @@ export class BudgetService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'BudgetRecord', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .match([
         node('project', 'Project'),
         relation('out', '', 'budget', { active: true }),
@@ -593,7 +593,7 @@ export class BudgetService {
             ]
           : []),
       ])
-      .call(calculateTotalAndPaginateList(Budget, listInput));
+      .apply(calculateTotalAndPaginateList(Budget, listInput));
 
     return await runListQuery(query, listInput, (id) =>
       this.readOne(id, session)
@@ -620,7 +620,7 @@ export class BudgetService {
             ]
           : []),
       ])
-      .call(calculateTotalAndPaginateList(BudgetRecord, input));
+      .apply(calculateTotalAndPaginateList(BudgetRecord, input));
 
     return await runListQuery(query, input, (id) =>
       this.readOneRecord(id, session)

--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -128,7 +128,7 @@ export class CeremonyService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'Ceremony', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .optionalMatch([
         node('project', 'Project'),
         relation('out', '', 'engagement', { active: true }),
@@ -223,7 +223,7 @@ export class CeremonyService {
             ]
           : []),
       ])
-      .call(calculateTotalAndPaginateList(Ceremony, input));
+      .apply(calculateTotalAndPaginateList(Ceremony, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -90,8 +90,8 @@ export class CeremonyService {
     try {
       const query = this.db
         .query()
-        .call(matchRequestingUser, session)
-        .call(createBaseNode, await generateId(), 'Ceremony', secureProps)
+        .apply(matchRequestingUser(session))
+        .apply(createBaseNode(await generateId(), 'Ceremony', secureProps))
         .return('node.id as id');
 
       const result = await query.first();
@@ -126,7 +126,7 @@ export class CeremonyService {
     }
     const readCeremony = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'Ceremony', { id })])
       .apply(matchPropList)
       .optionalMatch([
@@ -137,7 +137,7 @@ export class CeremonyService {
         node('node', 'Ceremony', { id }),
       ])
       .with(['node', 'propList', 'project'])
-      .call(matchMemberRoles, session.userId)
+      .apply(matchMemberRoles(session.userId))
       .return(['node', 'propList', 'memberRoles'])
       .asResult<
         StandardReadResult<DbPropsOfDto<Ceremony>> & {

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -569,7 +569,7 @@ export class EngagementService {
 
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'Engagement', { id })])
       .apply(matchPropList)
       .optionalMatch([
@@ -577,7 +577,7 @@ export class EngagementService {
         relation('out', '', 'engagement', { active: true }),
         node('node'),
       ])
-      .call(matchMemberRoles, session.userId)
+      .apply(matchMemberRoles(session.userId))
       .with([
         'propList',
         'node',

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -571,7 +571,7 @@ export class EngagementService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'Engagement', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .optionalMatch([
         node('project'),
         relation('out', '', 'engagement', { active: true }),
@@ -1043,7 +1043,7 @@ export class EngagementService {
             ]
           : []),
       ])
-      .call(calculateTotalAndPaginateList(IEngagement, input));
+      .apply(calculateTotalAndPaginateList(IEngagement, input));
 
     const engagements = await runListQuery(query, input, (id) =>
       this.readOne(id, session)
@@ -1287,7 +1287,7 @@ export class EngagementService {
     languageId,
   }: MergeExclusive<{ engagementId: ID }, { languageId: ID }>) {
     const startQuery = () =>
-      this.db.query().call((query) =>
+      this.db.query().apply((query) =>
         engagementId
           ? query.match([
               node('languageEngagement', 'LanguageEngagement', {

--- a/src/components/field-region/field-region.service.ts
+++ b/src/components/field-region/field-region.service.ts
@@ -107,7 +107,7 @@ export class FieldRegionService {
     // create field region
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([
         node('director', 'User', {
           id: directorId,
@@ -118,7 +118,7 @@ export class FieldRegionService {
           id: fieldZoneId,
         }),
       ])
-      .call(createBaseNode, await generateId(), 'FieldRegion', secureProps)
+      .apply(createBaseNode(await generateId(), 'FieldRegion', secureProps))
       .create([
         node('node'),
         relation('out', '', 'director', { active: true, createdAt }),
@@ -156,7 +156,7 @@ export class FieldRegionService {
 
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'FieldRegion', { id: id })])
       .apply(matchPropList)
       .optionalMatch([

--- a/src/components/field-region/field-region.service.ts
+++ b/src/components/field-region/field-region.service.ts
@@ -158,7 +158,7 @@ export class FieldRegionService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'FieldRegion', { id: id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .optionalMatch([
         node('node'),
         relation('out', '', 'director', { active: true }),
@@ -261,7 +261,7 @@ export class FieldRegionService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode(label)])
-      .call(calculateTotalAndPaginateList(FieldRegion, input));
+      .apply(calculateTotalAndPaginateList(FieldRegion, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/field-zone/field-zone.service.ts
+++ b/src/components/field-zone/field-zone.service.ts
@@ -106,13 +106,13 @@ export class FieldZoneService {
     // create field zone
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([
         node('director', 'User', {
           id: directorId,
         }),
       ])
-      .call(createBaseNode, await generateId(), 'FieldZone', secureProps)
+      .apply(createBaseNode(await generateId(), 'FieldZone', secureProps))
       .create([
         node('node'),
         relation('out', '', 'director', { active: true, createdAt }),
@@ -145,7 +145,7 @@ export class FieldZoneService {
 
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'FieldZone', { id: id })])
       .apply(matchPropList)
       .optionalMatch([

--- a/src/components/field-zone/field-zone.service.ts
+++ b/src/components/field-zone/field-zone.service.ts
@@ -147,7 +147,7 @@ export class FieldZoneService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'FieldZone', { id: id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .optionalMatch([
         node('node'),
         relation('out', '', 'director', { active: true }),
@@ -263,7 +263,7 @@ export class FieldZoneService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode(label)])
-      .call(calculateTotalAndPaginateList(FieldZone, input));
+      .apply(calculateTotalAndPaginateList(FieldZone, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -106,7 +106,7 @@ export class FileRepository {
         matchCreatedBy(),
         matchName(),
       ])
-      .call((q) => {
+      .apply((q) => {
         const conditions: AnyConditions = {};
         if (options?.filter?.name) {
           conditions['name.value'] = contains(options.filter.name);
@@ -202,7 +202,7 @@ export class FileRepository {
     const query = this.db
       .query()
       .match(node('node', 'FileVersion', { id }))
-      .call(matchPropList)
+      .apply(matchPropList)
       .match([
         node('node'),
         relation('out', '', 'createdBy', { active: true }),

--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -252,12 +252,9 @@ export class FileRepository {
 
     const createFile = this.db
       .query()
-      .call(matchRequestingUser, session)
-      .call(
-        createBaseNode,
-        await generateId(),
-        ['Directory', 'FileNode'],
-        props
+      .apply(matchRequestingUser(session))
+      .apply(
+        createBaseNode(await generateId(), ['Directory', 'FileNode'], props)
       )
       .return('node.id as id')
       .asResult<{ id: ID }>();
@@ -295,8 +292,8 @@ export class FileRepository {
 
     const createFile = this.db
       .query()
-      .call(matchRequestingUser, session)
-      .call(createBaseNode, fileId, ['File', 'FileNode'], props)
+      .apply(matchRequestingUser(session))
+      .apply(createBaseNode(fileId, ['File', 'FileNode'], props))
       .return('node.id as id')
       .asResult<{ id: ID }>();
 
@@ -349,8 +346,8 @@ export class FileRepository {
 
     const createFile = this.db
       .query()
-      .call(matchRequestingUser, session)
-      .call(createBaseNode, input.id, ['FileVersion', 'FileNode'], props)
+      .apply(matchRequestingUser(session))
+      .apply(createBaseNode(input.id, ['FileVersion', 'FileNode'], props))
       .return('node.id as id')
       .asResult<{ id: ID }>();
 

--- a/src/components/film/film.service.ts
+++ b/src/components/film/film.service.ts
@@ -146,7 +146,7 @@ export class FilmService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'Film', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .return('node, propList')
       .asResult<StandardReadResult<DbPropsOfDto<Film>>>();
 
@@ -224,7 +224,7 @@ export class FilmService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode('Film')])
-      .call(calculateTotalAndPaginateList(Film, input));
+      .apply(calculateTotalAndPaginateList(Film, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/film/film.service.ts
+++ b/src/components/film/film.service.ts
@@ -98,12 +98,13 @@ export class FilmService {
     try {
       const result = await this.db
         .query()
-        .call(matchRequestingUser, session)
-        .call(
-          createBaseNode,
-          await generateId(),
-          ['Film', 'Producible'],
-          secureProps
+        .apply(matchRequestingUser(session))
+        .apply(
+          createBaseNode(
+            await generateId(),
+            ['Film', 'Producible'],
+            secureProps
+          )
         )
         .return('node.id as id')
         .first();
@@ -144,7 +145,7 @@ export class FilmService {
 
     const readFilm = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'Film', { id })])
       .apply(matchPropList)
       .return('node, propList')

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -112,8 +112,10 @@ export class FundingAccountService {
     try {
       const query = this.db
         .query()
-        .call(matchRequestingUser, session)
-        .call(createBaseNode, await generateId(), 'FundingAccount', secureProps)
+        .apply(matchRequestingUser(session))
+        .apply(
+          createBaseNode(await generateId(), 'FundingAccount', secureProps)
+        )
         .return('node.id as id');
 
       const result = await query.first();
@@ -149,7 +151,7 @@ export class FundingAccountService {
 
     const readFundingAccount = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'FundingAccount', { id })])
       .apply(matchPropList)
       .return('propList, node')

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -151,7 +151,7 @@ export class FundingAccountService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'FundingAccount', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .return('propList, node')
       .asResult<StandardReadResult<DbPropsOfDto<FundingAccount>>>();
 
@@ -226,7 +226,7 @@ export class FundingAccountService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode(label)])
-      .call(calculateTotalAndPaginateList(FundingAccount, input));
+      .apply(calculateTotalAndPaginateList(FundingAccount, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/language/ethnologue-language/ethnologue-language.service.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.service.ts
@@ -110,7 +110,7 @@ export class EthnologueLanguageService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'EthnologueLanguage', { id: id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .return('propList, node')
       .asResult<StandardReadResult<EthLangDbProps>>();
 

--- a/src/components/language/ethnologue-language/ethnologue-language.service.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.service.ts
@@ -77,12 +77,9 @@ export class EthnologueLanguageService {
 
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
-      .call(
-        createBaseNode,
-        await generateId(),
-        'EthnologueLanguage',
-        secureProps
+      .apply(matchRequestingUser(session))
+      .apply(
+        createBaseNode(await generateId(), 'EthnologueLanguage', secureProps)
       )
       .return('node.id as id');
 
@@ -108,7 +105,7 @@ export class EthnologueLanguageService {
   async readOne(id: ID, session: Session): Promise<EthnologueLanguage> {
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'EthnologueLanguage', { id: id })])
       .apply(matchPropList)
       .return('propList, node')

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -300,7 +300,7 @@ export class LanguageService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'Language', { id: langId })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .match([
         node('node'),
         relation('out', '', 'ethnologue'),
@@ -418,7 +418,7 @@ export class LanguageService {
       .query()
       .match([requestingUser(session), ...permissionsOfNode('Language')])
       .call(languageListFilter, filter)
-      .call(
+      .apply(
         calculateTotalAndPaginateList(Language, input, (q) =>
           ['id', 'createdAt'].includes(input.sort)
             ? q.with('*').orderBy(`node.${input.sort}`, input.order)

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -237,8 +237,8 @@ export class LanguageService {
 
       const createLanguage = this.db
         .query()
-        .call(matchRequestingUser, session)
-        .call(createBaseNode, await generateId(), 'Language', secureProps)
+        .apply(matchRequestingUser(session))
+        .apply(createBaseNode(await generateId(), 'Language', secureProps))
         .return('node.id as id');
 
       const resultLanguage = await createLanguage.first();
@@ -298,7 +298,7 @@ export class LanguageService {
   async readOne(langId: ID, session: Session): Promise<Language> {
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'Language', { id: langId })])
       .apply(matchPropList)
       .match([
@@ -417,7 +417,7 @@ export class LanguageService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode('Language')])
-      .call(languageListFilter, filter)
+      .apply(languageListFilter(filter))
       .apply(
         calculateTotalAndPaginateList(Language, input, (q) =>
           ['id', 'createdAt'].includes(input.sort)

--- a/src/components/language/query.helpers.ts
+++ b/src/components/language/query.helpers.ts
@@ -2,31 +2,24 @@ import { inArray, node, Query } from 'cypher-query-builder';
 import { propMatch } from '../project';
 import { LanguageFilters } from './dto';
 
-export function languageListFilter(query: Query, filter: LanguageFilters) {
-  query.call((q) =>
-    filter.sensitivity ||
-    filter.leastOfThese ||
-    filter.isSignLanguage ||
-    filter.isDialect
-      ? q
-          .match(filter.sensitivity ? propMatch('sensitivity') : [node('node')])
-          .match(
-            filter.leastOfThese ? propMatch('leastOfThese') : [node('node')]
-          )
-          .match(
-            filter.isSignLanguage ? propMatch('isSignLanguage') : [node('node')]
-          )
-          .match(filter.isDialect ? propMatch('isDialect') : [node('node')])
-          .where({
-            ...(filter.sensitivity
-              ? { sensitivity: { value: inArray(filter.sensitivity) } }
-              : {}),
-            ...(filter.leastOfThese ? { leastOfThese: { value: true } } : {}),
-            ...(filter.isSignLanguage
-              ? { isSignLanguage: { value: true } }
-              : {}),
-            ...(filter.isDialect ? { isDialect: { value: true } } : {}),
-          })
-      : q
-  );
-}
+export const languageListFilter = (filter: LanguageFilters) => (query: Query) =>
+  filter.sensitivity ||
+  filter.leastOfThese ||
+  filter.isSignLanguage ||
+  filter.isDialect
+    ? query
+        .match(filter.sensitivity ? propMatch('sensitivity') : [node('node')])
+        .match(filter.leastOfThese ? propMatch('leastOfThese') : [node('node')])
+        .match(
+          filter.isSignLanguage ? propMatch('isSignLanguage') : [node('node')]
+        )
+        .match(filter.isDialect ? propMatch('isDialect') : [node('node')])
+        .where({
+          ...(filter.sensitivity
+            ? { sensitivity: { value: inArray(filter.sensitivity) } }
+            : {}),
+          ...(filter.leastOfThese ? { leastOfThese: { value: true } } : {}),
+          ...(filter.isSignLanguage ? { isSignLanguage: { value: true } } : {}),
+          ...(filter.isDialect ? { isDialect: { value: true } } : {}),
+        })
+    : query;

--- a/src/components/literacy-material/literacy-material.service.ts
+++ b/src/components/literacy-material/literacy-material.service.ts
@@ -156,7 +156,7 @@ export class LiteracyMaterialService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'LiteracyMaterial', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .return('node, propList')
       .asResult<StandardReadResult<DbPropsOfDto<LiteracyMaterial>>>();
 
@@ -253,7 +253,7 @@ export class LiteracyMaterialService {
         requestingUser(session),
         ...permissionsOfNode('LiteracyMaterial'),
       ])
-      .call(calculateTotalAndPaginateList(LiteracyMaterial, input));
+      .apply(calculateTotalAndPaginateList(LiteracyMaterial, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/literacy-material/literacy-material.service.ts
+++ b/src/components/literacy-material/literacy-material.service.ts
@@ -105,12 +105,13 @@ export class LiteracyMaterialService {
     try {
       const result = await this.db
         .query()
-        .call(matchRequestingUser, session)
-        .call(
-          createBaseNode,
-          await generateId(),
-          ['LiteracyMaterial', 'Producible'],
-          secureProps
+        .apply(matchRequestingUser(session))
+        .apply(
+          createBaseNode(
+            await generateId(),
+            ['LiteracyMaterial', 'Producible'],
+            secureProps
+          )
         )
         .return('node.id as id')
         .first();
@@ -154,7 +155,7 @@ export class LiteracyMaterialService {
 
     const readLiteracyMaterial = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'LiteracyMaterial', { id })])
       .apply(matchPropList)
       .return('node, propList')

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -187,7 +187,7 @@ export class LocationService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'Location', { id: id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .optionalMatch([
         node('node'),
         relation('out', '', 'fundingAccount', { active: true }),
@@ -354,7 +354,7 @@ export class LocationService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode(label)])
-      .call(calculateTotalAndPaginateList(Location, input));
+      .apply(calculateTotalAndPaginateList(Location, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }
@@ -422,7 +422,7 @@ export class LocationService {
         relation('in', '', rel, { active: true }),
         node(`${label.toLowerCase()}`, label, { id }),
       ])
-      .call(calculateTotalAndPaginateList(Location, input));
+      .apply(calculateTotalAndPaginateList(Location, input));
 
     return {
       ...(await runListQuery(query, input, (id) => this.readOne(id, session))),

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -117,8 +117,8 @@ export class LocationService {
     // create location
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
-      .call(createBaseNode, await generateId(), 'Location', secureProps)
+      .apply(matchRequestingUser(session))
+      .apply(createBaseNode(await generateId(), 'Location', secureProps))
       .return('node.id as id');
 
     const result = await query.first();
@@ -185,7 +185,7 @@ export class LocationService {
 
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'Location', { id: id })])
       .apply(matchPropList)
       .optionalMatch([
@@ -261,7 +261,7 @@ export class LocationService {
       const createdAt = DateTime.local();
       await this.db
         .query()
-        .call(matchRequestingUser, session)
+        .apply(matchRequestingUser(session))
         .matchNode('location', 'Location', { id: input.id })
         .matchNode('newFundingAccount', 'FundingAccount', {
           id: fundingAccountId,
@@ -293,7 +293,7 @@ export class LocationService {
       const createdAt = DateTime.local();
       await this.db
         .query()
-        .call(matchRequestingUser, session)
+        .apply(matchRequestingUser(session))
         .matchNode('location', 'Location', { id: input.id })
         .matchNode('newDefaultFieldRegion', 'FieldRegion', {
           id: defaultFieldRegionId,

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -78,11 +78,10 @@ export class OrganizationService {
 
   // assumes 'root' cypher variable is declared in query
   private readonly createSG = (
-    query: Query,
     cypherIdentifier: string,
     id: ID,
     label?: string
-  ) => {
+  ) => (query: Query) => {
     const labels = ['SecurityGroup'];
     if (label) {
       labels.push(label);
@@ -150,14 +149,11 @@ export class OrganizationService {
           id: this.config.publicSecurityGroup.id,
         }),
       ])
-      .call(matchRequestingUser, session)
-      .call(
-        this.createSG,
-        'orgSG',
-        await generateId(),
-        'OrgPublicSecurityGroup'
+      .apply(matchRequestingUser(session))
+      .apply(
+        this.createSG('orgSG', await generateId(), 'OrgPublicSecurityGroup')
       )
-      .call(createBaseNode, await generateId(), 'Organization', secureProps)
+      .apply(createBaseNode(await generateId(), 'Organization', secureProps))
       .return('node.id as id');
 
     const result = await query.first();
@@ -188,7 +184,7 @@ export class OrganizationService {
 
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'Organization', { id: orgId })])
       .apply(matchPropList)
       .return('propList, node')

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -190,7 +190,7 @@ export class OrganizationService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'Organization', { id: orgId })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .return('propList, node')
       .asResult<StandardReadResult<DbPropsOfDto<Organization>>>();
     const result = await query.first();
@@ -272,7 +272,7 @@ export class OrganizationService {
             ]
           : []),
       ])
-      .call(calculateTotalAndPaginateList(Organization, input));
+      .apply(calculateTotalAndPaginateList(Organization, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -235,7 +235,7 @@ export class PartnerService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'Partner', { id: id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .optionalMatch([
         node('node'),
         relation('out', '', 'organization', { active: true }),
@@ -406,7 +406,7 @@ export class PartnerService {
             ]
           : []),
       ])
-      .call(
+      .apply(
         calculateTotalAndPaginateList(
           Partner,
           input,

--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -147,13 +147,13 @@ export class PartnerService {
     // create partner
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([
         node('organization', 'Organization', {
           id: input.organizationId,
         }),
       ])
-      .call(createBaseNode, await generateId(), 'Partner', secureProps)
+      .apply(createBaseNode(await generateId(), 'Partner', secureProps))
       .create([
         node('node'),
         relation('out', '', 'organization', { active: true, createdAt }),
@@ -233,7 +233,7 @@ export class PartnerService {
 
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'Partner', { id: id })])
       .apply(matchPropList)
       .optionalMatch([
@@ -334,7 +334,7 @@ export class PartnerService {
       const createdAt = DateTime.local();
       await this.db
         .query()
-        .call(matchRequestingUser, session)
+        .apply(matchRequestingUser(session))
         .matchNode('partner', 'Partner', { id: input.id })
         .matchNode('newPointOfContact', 'User', {
           id: input.pointOfContactId,

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -253,7 +253,7 @@ export class PartnershipService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'Partnership', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .match([
         node('project', 'Project'),
         relation('out', '', 'partnership', { active: true }),
@@ -482,7 +482,7 @@ export class PartnershipService {
             ]
           : []),
       ])
-      .call(calculateTotalAndPaginateList(Partnership, listInput));
+      .apply(calculateTotalAndPaginateList(Partnership, listInput));
 
     return await runListQuery(query, listInput, (id) =>
       this.readOne(id, session)

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -159,8 +159,8 @@ export class PartnershipService {
     try {
       const createPartnership = this.db
         .query()
-        .call(matchRequestingUser, session)
-        .call(createBaseNode, partnershipId, 'Partnership', secureProps)
+        .apply(matchRequestingUser(session))
+        .apply(createBaseNode(partnershipId, 'Partnership', secureProps))
         .return('node.id as id');
 
       try {
@@ -251,7 +251,7 @@ export class PartnershipService {
 
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'Partnership', { id })])
       .apply(matchPropList)
       .match([
@@ -260,7 +260,7 @@ export class PartnershipService {
         node('', 'Partnership', { id: id }),
       ])
       .with(['project', 'node', 'propList'])
-      .call(matchMemberRoles, session.userId)
+      .apply(matchMemberRoles(session.userId))
       .match([
         node('node'),
         relation('in', '', 'partnership'),

--- a/src/components/pin/pin.repository.ts
+++ b/src/components/pin/pin.repository.ts
@@ -11,7 +11,7 @@ export class PinRepository {
   async isPinned(id: ID, session: Session): Promise<boolean> {
     const result = await this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([
         node('requestingUser'),
         relation('out', '', 'pinned'),
@@ -26,7 +26,7 @@ export class PinRepository {
     const createdAt = DateTime.local();
     await this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'BaseNode', { id })])
       .merge([
         node('requestingUser'),
@@ -42,7 +42,7 @@ export class PinRepository {
   async remove(id: ID, session: Session): Promise<void> {
     await this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .optionalMatch([
         node('requestingUser'),
         relation('out', 'rel', 'pinned'),

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -256,7 +256,7 @@ export class ProductService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'Product', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .match([
         node('project', 'Project'),
         relation('out', '', 'engagement', { active: true }),
@@ -588,7 +588,7 @@ export class ProductService {
             ]
           : []),
       ])
-      .call(calculateTotalAndPaginateList(Product, input));
+      .apply(calculateTotalAndPaginateList(Product, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -168,17 +168,18 @@ export class ProductService {
     }
 
     query
-      .call(matchRequestingUser, session)
-      .call(
-        createBaseNode,
-        await generateId(),
-        [
-          'Product',
-          input.produces
-            ? 'DerivativeScriptureProduct'
-            : 'DirectScriptureProduct',
-        ],
-        secureProps
+      .apply(matchRequestingUser(session))
+      .apply(
+        createBaseNode(
+          await generateId(),
+          [
+            'Product',
+            input.produces
+              ? 'DerivativeScriptureProduct'
+              : 'DirectScriptureProduct',
+          ],
+          secureProps
+        )
       );
 
     if (engagementId) {
@@ -254,7 +255,7 @@ export class ProductService {
   async readOne(id: ID, session: Session): Promise<AnyProduct> {
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'Product', { id })])
       .apply(matchPropList)
       .match([
@@ -265,7 +266,7 @@ export class ProductService {
         node('', 'Product', { id }),
       ])
       .with(['project', 'node', 'propList'])
-      .call(matchMemberRoles, session.userId)
+      .apply(matchMemberRoles(session.userId))
       .return(['propList, node, memberRoles'])
       .asResult<
         StandardReadResult<

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -197,7 +197,7 @@ export class ProjectMemberService {
 
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'ProjectMember', { id })])
       .apply(matchPropList)
       .match([
@@ -206,7 +206,7 @@ export class ProjectMemberService {
         node('', 'ProjectMember', { id }),
       ])
       .with(['project', 'node', 'propList'])
-      .call(matchMemberRoles, session.userId)
+      .apply(matchMemberRoles(session.userId))
       .match([node('node'), relation('out', '', 'user'), node('user', 'User')])
       .return('node, propList, user.id as userId, memberRoles')
       .asResult<

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -199,7 +199,7 @@ export class ProjectMemberService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'ProjectMember', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .match([
         node('project', 'Project'),
         relation('out', '', 'member', { active: true }),
@@ -338,7 +338,7 @@ export class ProjectMemberService {
             ]
           : []),
       ])
-      .call(calculateTotalAndPaginateList(ProjectMember, input));
+      .apply(calculateTotalAndPaginateList(ProjectMember, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -250,7 +250,7 @@ export class ProjectService {
       },
     ];
     try {
-      const createProject = this.db.query().call(matchRequestingUser, session);
+      const createProject = this.db.query().apply(matchRequestingUser(session));
 
       if (fieldRegionId) {
         await this.validateOtherResourceId(
@@ -300,14 +300,15 @@ export class ProjectService {
         node('organization', 'Organization', { id: this.config.defaultOrg.id }),
       ]);
 
-      createProject.call(
-        createBaseNode,
-        await generateId(),
-        `Project:${input.type}Project`,
-        secureProps,
-        {
-          type: createInput.type,
-        }
+      createProject.apply(
+        createBaseNode(
+          await generateId(),
+          `Project:${input.type}Project`,
+          secureProps,
+          {
+            type: createInput.type,
+          }
+        )
       );
 
       if (fieldRegionId) {
@@ -790,7 +791,7 @@ export class ProjectService {
       .query()
       .match([requestingUser(session), ...permissionsOfNode(label)])
       .with('distinct(node) as node, requestingUser')
-      .call(projectListFilter, filter)
+      .apply(projectListFilter(filter))
       .apply(
         calculateTotalAndPaginateList(IProject, input, (q) =>
           ['id', 'createdAt'].includes(input.sort)

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -455,7 +455,7 @@ export class ProjectService {
     const query = this.db
       .query()
       .match([node('node', 'Project', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .with(['node', 'propList'])
       .optionalMatch([
         [node('user', 'User', { id: userId })],
@@ -791,7 +791,7 @@ export class ProjectService {
       .match([requestingUser(session), ...permissionsOfNode(label)])
       .with('distinct(node) as node, requestingUser')
       .call(projectListFilter, filter)
-      .call(
+      .apply(
         calculateTotalAndPaginateList(IProject, input, (q) =>
           ['id', 'createdAt'].includes(input.sort)
             ? q.with('*').orderBy(`node.${input.sort}`, input.order)

--- a/src/components/project/query.helpers.ts
+++ b/src/components/project/query.helpers.ts
@@ -7,23 +7,17 @@ import {
 } from 'cypher-query-builder';
 import { ProjectFilters } from './dto';
 
-export function projectListFilter(query: Query, filter: ProjectFilters) {
-  query
-    .call((q) =>
-      filter.status
-        ? q
-            .match(propMatch('status'))
-            .where({ status: { value: inArray(filter.status) } })
-        : q
-    )
-    .call((q) =>
-      filter.sensitivity
-        ? q
-            .match(propMatch('sensitivity'))
-            .where({ sensitivity: { value: inArray(filter.sensitivity) } })
-        : q
-    );
-
+export const projectListFilter = (filter: ProjectFilters) => (query: Query) => {
+  if (filter.status) {
+    query
+      .match(propMatch('status'))
+      .where({ status: { value: inArray(filter.status) } });
+  }
+  if (filter.sensitivity) {
+    query
+      .match(propMatch('sensitivity'))
+      .where({ sensitivity: { value: inArray(filter.sensitivity) } });
+  }
   if (filter.onlyMultipleEngagements) {
     query
       .match([
@@ -56,7 +50,7 @@ export function projectListFilter(query: Query, filter: ProjectFilters) {
       query.raw('where not (requestingUser)-[:pinned]->(node)');
     }
   }
-}
+};
 
 export const propMatch = (property: string) => [
   node('node'),

--- a/src/components/search/search.service.ts
+++ b/src/components/search/search.service.ts
@@ -94,7 +94,7 @@ export class SearchService {
     const query = this.db
       .query()
       .call(matchRequestingUser, session)
-      .call(matchUserPermissions)
+      .apply(matchUserPermissions)
       .match([
         node('node'),
         relation('out', 'r', { active: true }),

--- a/src/components/search/search.service.ts
+++ b/src/components/search/search.service.ts
@@ -93,7 +93,7 @@ export class SearchService {
     // which is based on their first valid search label.
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .apply(matchUserPermissions)
       .match([
         node('node'),

--- a/src/components/song/song.service.ts
+++ b/src/components/song/song.service.ts
@@ -100,12 +100,13 @@ export class SongService {
     try {
       const result = await this.db
         .query()
-        .call(matchRequestingUser, session)
-        .call(
-          createBaseNode,
-          await generateId(),
-          ['Song', 'Producible'],
-          secureProps
+        .apply(matchRequestingUser(session))
+        .apply(
+          createBaseNode(
+            await generateId(),
+            ['Song', 'Producible'],
+            secureProps
+          )
         )
         .return('node.id as id')
         .first();
@@ -141,7 +142,7 @@ export class SongService {
   async readOne(id: ID, session: Session): Promise<Song> {
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'Song', { id })])
       .apply(matchPropList)
       .return('propList, node')

--- a/src/components/song/song.service.ts
+++ b/src/components/song/song.service.ts
@@ -143,7 +143,7 @@ export class SongService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'Song', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .return('propList, node')
       .asResult<StandardReadResult<DbPropsOfDto<Song>>>();
 
@@ -220,7 +220,7 @@ export class SongService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode('Song')])
-      .call(calculateTotalAndPaginateList(Song, input));
+      .apply(calculateTotalAndPaginateList(Song, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/story/story.service.ts
+++ b/src/components/story/story.service.ts
@@ -147,7 +147,7 @@ export class StoryService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'Story', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .return('node, propList')
       .asResult<StandardReadResult<DbPropsOfDto<Story>>>();
 
@@ -224,7 +224,7 @@ export class StoryService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode('Story')])
-      .call(calculateTotalAndPaginateList(Story, input));
+      .apply(calculateTotalAndPaginateList(Story, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/story/story.service.ts
+++ b/src/components/story/story.service.ts
@@ -99,12 +99,13 @@ export class StoryService {
     try {
       const result = await this.db
         .query()
-        .call(matchRequestingUser, session)
-        .call(
-          createBaseNode,
-          await generateId(),
-          ['Story', 'Producible'],
-          secureProps
+        .apply(matchRequestingUser(session))
+        .apply(
+          createBaseNode(
+            await generateId(),
+            ['Story', 'Producible'],
+            secureProps
+          )
         )
         .return('node.id as id')
         .first();
@@ -145,7 +146,7 @@ export class StoryService {
 
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'Story', { id })])
       .apply(matchPropList)
       .return('node, propList')

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -119,7 +119,7 @@ export class EducationService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'Education', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .return('propList, node')
       .asResult<StandardReadResult<DbPropsOfDto<Education>>>();
 
@@ -201,7 +201,7 @@ export class EducationService {
             ]
           : []),
       ])
-      .call(calculateTotalAndPaginateList(Education, input));
+      .apply(calculateTotalAndPaginateList(Education, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -79,13 +79,13 @@ export class EducationService {
     // create education
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([
         node('user', 'User', {
           id: userId,
         }),
       ])
-      .call(createBaseNode, await generateId(), 'Education', secureProps)
+      .apply(createBaseNode(await generateId(), 'Education', secureProps))
       .create([
         node('user'),
         relation('out', '', 'education', { active: true, createdAt }),
@@ -117,7 +117,7 @@ export class EducationService {
 
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'Education', { id })])
       .apply(matchPropList)
       .return('propList, node')
@@ -146,7 +146,7 @@ export class EducationService {
     const ed = await this.readOne(input.id, session);
     const result = await this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([
         node('user', 'User'),
         relation('out', '', 'education', { active: true }),

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -132,7 +132,7 @@ export class UnavailabilityService {
       .query()
       .call(matchRequestingUser, session)
       .match([node('node', 'Unavailability', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .return('propList, node')
       .asResult<StandardReadResult<DbPropsOfDto<Unavailability>>>();
 

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -70,13 +70,9 @@ export class UnavailabilityService {
     try {
       const createUnavailability = this.db
         .query()
-        .call(matchRequestingUser, session)
-        .call(
-          createBaseNode,
-          await generateId(),
-          'Unavailability',
-          secureProps,
-          {}
+        .apply(matchRequestingUser(session))
+        .apply(
+          createBaseNode(await generateId(), 'Unavailability', secureProps)
         )
         .return('node.id as id')
         .asResult<{ id: ID }>();
@@ -130,7 +126,7 @@ export class UnavailabilityService {
   async readOne(id: ID, session: Session): Promise<Unavailability> {
     const query = this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([node('node', 'Unavailability', { id })])
       .apply(matchPropList)
       .return('propList, node')
@@ -162,7 +158,7 @@ export class UnavailabilityService {
 
     const result = await this.db
       .query()
-      .call(matchRequestingUser, session)
+      .apply(matchRequestingUser(session))
       .match([
         node('user', 'User'),
         relation('out', '', 'unavailability', { active: true }),

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -273,7 +273,7 @@ export class UserService {
     const query = this.db
       .query()
       .match([node('node', 'User', { id })])
-      .call(matchPropList)
+      .apply(matchPropList)
       .return('propList, node')
       .asResult<StandardReadResult<DbPropsOfDto<User>>>();
 
@@ -350,7 +350,7 @@ export class UserService {
       await this.db
         .query()
         .match([node('node', ['User', 'BaseNode'], { id: user.id })])
-        .call(deleteProperties(User, 'email'))
+        .apply(deleteProperties(User, 'email'))
         .return('*')
         .run();
 
@@ -454,7 +454,7 @@ export class UserService {
     const query = this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode('User')])
-      .call(calculateTotalAndPaginateList(User, input));
+      .apply(calculateTotalAndPaginateList(User, input));
 
     return await runListQuery(query, input, (id) => this.readOne(id, session));
   }

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -559,7 +559,7 @@ export class DatabaseService {
     const query = this.db
       .query()
       .matchNode('baseNode', { id })
-      .call(deleteBaseNode)
+      .apply(deleteBaseNode)
       .return('*');
     await query.run();
   }

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -537,7 +537,7 @@ export class DatabaseService {
     return true;
     // const query = this.db
     //   .query()
-    //   .call(matchRequestingUser, session)
+    //   .apply(matchRequestingUser(session))
     //   .match(node('node', { id }))
     //   .match([
     //     node('requestingUser'),

--- a/src/core/database/query.helpers.ts
+++ b/src/core/database/query.helpers.ts
@@ -25,13 +25,12 @@ export const determineSortValue = (value: unknown) =>
 
 // assumes 'requestingUser', and 'publicSG' cypher identifiers have been matched
 // add baseNodeProps and editableProps
-export function createBaseNode(
-  query: Query,
+export const createBaseNode = (
   id: ID,
   label: string | string[],
   props: Property[],
   baseNodeProps?: { owningOrgId?: string | undefined; type?: string }
-) {
+) => (query: Query) => {
   const createdAt = DateTime.local();
 
   if (typeof label === 'string') {
@@ -69,7 +68,7 @@ export function createBaseNode(
       node('', labels, nodeProps),
     ]);
   }
-}
+};
 
 export function matchUserPermissions(
   query: Query,
@@ -92,16 +91,14 @@ export function matchUserPermissions(
   query.with(`collect(perms) as permList, node, requestingUser`);
 }
 
-export function matchRequestingUser(
-  query: Query,
-  { userId }: Pick<Session, 'userId'>
-) {
+export const matchRequestingUser = ({ userId }: Pick<Session, 'userId'>) => (
+  query: Query
+) =>
   query.match([
     node('requestingUser', 'User', {
       id: userId,
     }),
   ]);
-}
 
 /**
  * This will set all relationships given to active false

--- a/src/core/database/query.overrides.ts
+++ b/src/core/database/query.overrides.ts
@@ -2,6 +2,11 @@ import { Query } from 'cypher-query-builder';
 import { Except } from 'type-fest';
 import { LogLevel } from '../logger';
 
+/* eslint-disable @typescript-eslint/method-signature-style -- this is enforced
+   to treat functions arguments as contravariant instead of bivariant. this
+   doesn't matter here as this class won't be overridden. Declaring them as
+   methods keeps their color the same as the rest of the query methods. */
+
 // Work around `Dictionary` return type
 export type QueryWithResult<R> = Except<Query, 'run' | 'first'> & {
   run: () => Promise<R[]>;
@@ -26,23 +31,22 @@ declare module 'cypher-query-builder/dist/typings/query' {
      *   .first();
      * ```
      */
-    call: <A extends any[], R extends this | QueryWithResult<any> | void>(
+    call<A extends any[], R extends this | QueryWithResult<any> | void>(
       fn: (query: this, ...args: A) => R,
       ...args: A
-    ) => R extends void ? this : R;
+    ): R extends void ? this : R;
 
     /**
      * Defines the result type of the query.
      * Only useful for TypeScript.
      * Must be called directly before run()/first().
      */
-    asResult: <R>() => QueryWithResult<R>;
+    asResult<R>(): QueryWithResult<R>;
 
-    logIt: (level?: LogLevel) => this;
+    logIt(level?: LogLevel): this;
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/unbound-method
 Query.prototype.call = function call<
   A extends any[],
   R extends Query | QueryWithResult<any> | void

--- a/src/core/database/query.overrides.ts
+++ b/src/core/database/query.overrides.ts
@@ -18,22 +18,43 @@ declare module 'cypher-query-builder/dist/typings/query' {
     /**
      * Apply custom query modifications while maintaining the fluent chain.
      *
-     * ```
+     * @deprecated Use {@link apply}() instead.
+     *
+     * In the future this could be changed to utilize native neo4j call logic.
+     */
+    call<A extends any[], R extends this | QueryWithResult<any> | void>(
+      fn: (query: this, ...args: A) => R,
+      ...args: A
+    ): R extends void ? this : R;
+
+    /**
+     * Apply custom query modifications while maintaining the fluent chain.
+     *
+     * Note: Unlike call() this does not have varargs that forward to the given
+     * function. This not necessary as helpers can just be written as higher-order
+     * functions, see second example. It also made generics on the function
+     * impossible to be applied.
+     *
+     * @example Using an if condition
      * await this.db.query()
      *   .raw(`
      *     ...
      *   `)
-     *   .call(q => {
+     *   .apply(q => {
      *     if (addTheThing) {
      *       q.raw('...');
      *     }
      *   })
      *   .first();
-     * ```
+     *
+     * @example Abstracting a query fragment with args
+     * const matchFoo = (label: string) => (query: Query) =>
+     *   query.matchNode('', label, ...)...
+     *
+     * db.query().apply(matchFoo('Movie'));
      */
-    call<A extends any[], R extends this | QueryWithResult<any> | void>(
-      fn: (query: this, ...args: A) => R,
-      ...args: A
+    apply<R extends this | QueryWithResult<any> | void>(
+      fn: (query: this) => R
     ): R extends void ? this : R;
 
     /**
@@ -56,6 +77,12 @@ Query.prototype.call = function call<
   ...args: A
 ): R extends void ? Query : R {
   return (fn(this, ...args) || this) as Exclude<R, void>;
+};
+
+Query.prototype.apply = function apply<
+  R extends Query | QueryWithResult<any> | void
+>(fn: (q: Query) => R): R extends void ? Query : R {
+  return (fn(this) || this) as Exclude<R, void>;
 };
 
 Query.prototype.asResult = function asResult<R>(this: Query) {

--- a/src/core/database/query/lists.ts
+++ b/src/core/database/query/lists.ts
@@ -17,7 +17,7 @@ export const calculateTotalAndPaginateList = <
     .with(['collect(distinct node) as nodes', 'count(distinct node) as total'])
     .raw(`unwind nodes as node`)
     // .with(['node', 'total']) TODO needed?
-    .call(sorter ?? defaultSorter(resource, sort, order))
+    .apply(sorter ?? defaultSorter(resource, sort, order))
     .with([
       `collect(distinct node.id)[${(page - 1) * count}..${
         page * count

--- a/src/core/database/query/matching.ts
+++ b/src/core/database/query/matching.ts
@@ -36,7 +36,7 @@ export const matchPropList = (query: Query, nodeName = 'node') =>
     ]);
 
 // Have to match project before using this
-export const matchMemberRoles = (query: Query, userId: ID) =>
+export const matchMemberRoles = (userId: ID) => (query: Query) =>
   query
     .with(['project', 'node', 'propList'])
     .optionalMatch([


### PR DESCRIPTION
Neo4j has a CALL clause so this query method could be confused with that. In the future, we could defined a call that is for call clauses instead of what it currently is.

I also took the opportunity to remove forwarding varargs. There wasn't a need for this complexity and doing so prevented generics from being used. In turn, we already started defining query fragments this way (`calculateTotalAndPaginateList`), so this unifies the way they are defined.