### PR TITLE
Fix engagement finalizing completion transition

### DIFF
--- a/src/components/engagement/engagement.rules.ts
+++ b/src/components/engagement/engagement.rules.ts
@@ -110,7 +110,10 @@ export class EngagementRules {
               to: EngagementStatus.FinalizingCompletion,
               type: EngagementTransitionType.Approve,
               label: 'Finalize Completion',
-              projectStepRequirements: [ProjectStep.Active],
+              projectStepRequirements: [
+                ProjectStep.Active,
+                ProjectStep.FinalizingCompletion,
+              ],
             },
           ],
         };
@@ -152,7 +155,10 @@ export class EngagementRules {
               to: EngagementStatus.FinalizingCompletion,
               type: EngagementTransitionType.Approve,
               label: 'Finalize Completion',
-              projectStepRequirements: [ProjectStep.Active],
+              projectStepRequirements: [
+                ProjectStep.Active,
+                ProjectStep.FinalizingCompletion,
+              ],
             },
           ],
         };


### PR DESCRIPTION
Allow engagement to transition to finalizing completion when the project is finalizing completion

When the project changes to finalizing completion, our event handler tries to move the engagements
to this as well, but was blocked here.

#1823 