### PR TITLE
Implement sub queries in query builder

### DIFF
--- a/src/core/database/query.overrides.ts
+++ b/src/core/database/query.overrides.ts
@@ -1,6 +1,7 @@
 import { Query } from 'cypher-query-builder';
 import { Except } from 'type-fest';
 import { LogLevel } from '../logger';
+import './subquery.override';
 
 /* eslint-disable @typescript-eslint/method-signature-style -- this is enforced
    to treat functions arguments as contravariant instead of bivariant. this

--- a/src/core/database/subquery.override.ts
+++ b/src/core/database/subquery.override.ts
@@ -1,0 +1,60 @@
+import { ClauseCollection, Query } from 'cypher-query-builder';
+import { repeat } from 'lodash';
+
+/* eslint-disable @typescript-eslint/method-signature-style -- this is enforced
+   to treat functions arguments as contravariant instead of bivariant. this
+   doesn't matter here as this class won't be overridden. Declaring them as
+   methods keeps their color the same as the rest of the query methods. */
+
+declare module 'cypher-query-builder/dist/typings/query' {
+  interface Query {
+    /**
+     * Creates a sub-query clause (`CALL { ... }`) and calls the given function
+     * to define it.
+     *
+     * @example
+     * .unwind([0, 1, 2], 'x')
+     * .subQuery((sub) => sub
+     *   .with('x')
+     *   .return('x * 10 as y')
+     * )
+     * .return(['x', 'y'])
+     */
+    subQuery(sub: (query: this) => void): this;
+  }
+}
+
+Query.prototype.subQuery = function subQuery(sub: (query: Query) => void) {
+  type Q = Query & {
+    indentationLevel?: number;
+  };
+  const self = this as Q;
+  const subQ = new Query() as Q;
+  subQ.indentationLevel = (self.indentationLevel || 0) + 1;
+  const subClause = new SubQueryClause(self.indentationLevel);
+  // @ts-expect-error yeah it's private, but it'll be ok.
+  // SubQueryClause is also a ClauseCollection so it's all good.
+  subQ.clauses = subClause;
+  sub(subQ);
+
+  this.addClause(subClause);
+
+  return this;
+};
+
+class SubQueryClause extends ClauseCollection {
+  constructor(private readonly indentationLevel = 0) {
+    super();
+  }
+
+  build(): string {
+    return [
+      `CALL {`,
+      ...this.clauses.map(
+        (clause) =>
+          `${repeat('  ', this.indentationLevel + 1)}${clause.build()}`
+      ),
+      `${repeat('  ', this.indentationLevel)}}`,
+    ].join('\n');
+  }
+}


### PR DESCRIPTION
Add support for subqueries. These include support for parameters and can be nested.

```ts
.unwind([0, 1, 2], 'x')
.subQuery((sub) => sub
  .with('x')
  .return('x * 10 as y')
)
.return(['x', 'y'])
```
Compiles to
```cql
UNWIND [0, 1, 2] AS x
CALL {
  WITH x
  RETURN x * 10 AS y
}
RETURN x, y
```

I'd prefer to have named the method `call` but we've already used that. This is the motivation behind #1843.
Possibly in the future we'll rename. It would need to have an overload for sub queries and for calling procedures.