### PR TITLE
convert post shareable boolean to shareability enum

### DIFF
--- a/src/components/post/dto/create-post.dto.ts
+++ b/src/components/post/dto/create-post.dto.ts
@@ -3,6 +3,7 @@ import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { IdField } from '../../../common';
 import { Post } from './post.dto';
+import { PostShareability } from './shareability.dto';
 import { PostType } from './type.enum';
 
 @InputType()
@@ -13,8 +14,8 @@ export class CreatePost {
   @Field(() => PostType)
   readonly type: PostType;
 
-  @Field(() => Boolean)
-  readonly shareable: boolean;
+  @Field(() => PostShareability)
+  readonly shareability: PostShareability;
 
   @Field({
     description: 'the post body',

--- a/src/components/post/dto/post.dto.ts
+++ b/src/components/post/dto/post.dto.ts
@@ -8,6 +8,7 @@ import {
   SecuredProps,
   SecuredString,
 } from '../../../common';
+import { PostShareability } from './shareability.dto';
 import { PostType } from './type.enum';
 
 @ObjectType({
@@ -22,8 +23,8 @@ export class Post extends Resource {
   @Field(() => PostType)
   readonly type: PostType;
 
-  @Field(() => Boolean)
-  readonly shareable: boolean;
+  @Field(() => PostShareability)
+  readonly shareability: PostShareability;
 
   @Field()
   readonly body: SecuredString;

--- a/src/components/post/dto/shareability.dto.ts
+++ b/src/components/post/dto/shareability.dto.ts
@@ -1,0 +1,12 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum PostShareability {
+  ProjectTeam = 'ProjectTeam',
+  Internal = 'Internal',
+  AskToSharePublicly = 'AskToSharePublicly',
+  Public = 'Public',
+}
+
+registerEnumType(PostShareability, {
+  name: 'PostShareability',
+});

--- a/src/components/post/dto/update-post.dto.ts
+++ b/src/components/post/dto/update-post.dto.ts
@@ -3,6 +3,7 @@ import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { ID, IdField } from '../../../common';
 import { Post } from './post.dto';
+import { PostShareability } from './shareability.dto';
 import { PostType } from './type.enum';
 
 @InputType()
@@ -13,8 +14,8 @@ export abstract class UpdatePost {
   @Field(() => PostType)
   readonly type: PostType;
 
-  @Field(() => Boolean)
-  readonly shareable: boolean;
+  @Field(() => PostShareability)
+  readonly shareability: PostShareability;
 
   @Field({
     description: 'the post body',

--- a/src/components/post/post.service.ts
+++ b/src/components/post/post.service.ts
@@ -72,8 +72,8 @@ export class PostService {
         isOrgPublic: false,
       },
       {
-        key: 'shareable',
-        value: input.shareable,
+        key: 'shareability',
+        value: input.shareability,
         isPublic: false,
         isOrgPublic: false,
       },
@@ -180,7 +180,7 @@ export class PostService {
       ...parseBaseNodeProperties(result.node),
       ...securedProps,
       type: props.type,
-      shareable: props.shareable,
+      shareability: props.shareability,
       body: {
         value: props.body,
         canRead: true,


### PR DESCRIPTION
Fixes #1852

## Important Notes
* Must be merged along with its frontend counterpart (https://github.com/SeedCompany/cord-field/pull/829), as this is a breaking change to the frontend
* The existing `Post` nodes in the DB _shouldn't have to be cleared_ as a result of this update. But worth keeping an eye out for any odd behavior relating to this.
