### PR TITLE
Common/DTO Repositories

### DIFF
--- a/src/components/budget/budget-record.repository.ts
+++ b/src/components/budget/budget-record.repository.ts
@@ -1,0 +1,195 @@
+import { Injectable } from '@nestjs/common';
+import { node, Query, relation } from 'cypher-query-builder';
+import { Dictionary } from 'lodash';
+import { DateTime } from 'luxon';
+import { generateId, ID, Order, Resource, Session } from '../../common';
+import {
+  createBaseNode,
+  DatabaseService,
+  matchRequestingUser,
+  Property,
+} from '../../core';
+import {
+  calculateTotalAndPaginateList,
+  matchPropsAndProjectSensAndScopedRoles,
+  permissionsOfNode,
+  requestingUser,
+} from '../../core/database/query';
+import { QueryWithResult } from '../../core/database/query.overrides';
+import { DbPropsOfDto } from '../../core/database/results';
+import { ScopedRole } from '../authorization';
+import { BudgetRecord, BudgetRecordFilters, CreateBudgetRecord } from './dto';
+
+@Injectable()
+export class BudgetRecordRepository {
+  constructor(private readonly db: DatabaseService) {}
+
+  async create(session: Session, secureProps: Property[]): Promise<Query> {
+    const createBudgetRecord = this.db
+      .query()
+      .apply(matchRequestingUser(session))
+      .apply(createBaseNode(await generateId(), 'BudgetRecord', secureProps))
+      .return('node.id as id');
+    return createBudgetRecord;
+  }
+
+  async connectToBudget(
+    budgetId: ID,
+    organizationId: ID,
+    result: Dictionary<any> | undefined,
+    createdAt: DateTime
+  ): Promise<Query> {
+    // connect to budget
+    const query = this.db
+      .query()
+      .match([node('budget', 'Budget', { id: budgetId })])
+      .match([node('br', 'BudgetRecord', { id: result?.id })])
+      .create([
+        node('budget'),
+        relation('out', '', 'record', { active: true, createdAt }),
+        node('br'),
+      ])
+      .return('br');
+    await query.first();
+
+    // connect budget record to org
+    const orgQuery = this.db
+      .query()
+      .match([
+        node('organization', 'Organization', {
+          id: organizationId,
+        }),
+      ])
+      .match([node('br', 'BudgetRecord', { id: result?.id })])
+      .create([
+        node('br'),
+        relation('out', '', 'organization', { active: true, createdAt }),
+        node('organization'),
+      ])
+      .return('br');
+
+    return orgQuery;
+  }
+
+  async verifyUniqueness(
+    input: CreateBudgetRecord
+  ): Promise<Dictionary<any> | undefined> {
+    const existingRecord = await this.db
+      .query()
+      .match([
+        node('budget', 'Budget', { id: input.budgetId }),
+        relation('out', '', 'record', { active: true }),
+        node('br', 'BudgetRecord'),
+        relation('out', '', 'organization', { active: true }),
+        node('', 'Organization', { id: input.organizationId }),
+      ])
+      .match([
+        node('br'),
+        relation('out', '', 'fiscalYear', { active: true }),
+        node('', 'Property', { value: input.fiscalYear }),
+      ])
+      .return('br')
+      .first();
+    return existingRecord;
+  }
+
+  readOne(id: ID, session: Session) {
+    const query = this.db
+      .query()
+      .match([
+        node('project', 'Project'),
+        relation('out', '', 'budget', { active: true }),
+        node('', 'Budget'),
+        relation('out', '', 'record', { active: true }),
+        node('node', 'BudgetRecord', { id }),
+        relation('out', '', 'organization', { active: true }),
+        node('organization', 'Organization'),
+      ])
+      .apply(matchPropsAndProjectSensAndScopedRoles(session))
+      .return([
+        'apoc.map.merge(props, { organization: organization.id }) as props',
+        'scopedRoles',
+      ])
+      .asResult<{
+        props: DbPropsOfDto<BudgetRecord, true>;
+        scopedRoles: ScopedRole[];
+      }>();
+
+    return query;
+  }
+
+  getActualChanges(
+    br: BudgetRecord,
+    input: {
+      amount: number | null;
+    }
+  ): Partial<
+    Omit<
+      {
+        amount: number | null;
+      },
+      keyof Resource
+    >
+  > {
+    return this.db.getActualChanges(BudgetRecord, br, input);
+  }
+
+  async updateProperties(
+    br: BudgetRecord,
+    changes: Partial<
+      Omit<
+        {
+          amount: number | null;
+        },
+        keyof Resource
+      >
+    >
+  ): Promise<BudgetRecord> {
+    return await this.db.updateProperties({
+      type: BudgetRecord,
+      object: br,
+      changes: changes,
+    });
+  }
+
+  async checkDeletePermission(id: ID, session: Session): Promise<boolean> {
+    return await this.db.checkDeletePermission(id, session);
+  }
+
+  async deleteNode(node: BudgetRecord) {
+    await this.db.deleteNode(node);
+  }
+
+  list(
+    filter: BudgetRecordFilters,
+    input: {
+      sort: keyof BudgetRecord;
+      order: Order;
+      count: number;
+      page: number;
+    },
+    session: Session
+  ): QueryWithResult<{
+    items: ID[];
+    total: number;
+  }> {
+    const label = 'BudgetRecord';
+
+    const query = this.db
+      .query()
+      .match([
+        requestingUser(session),
+        ...permissionsOfNode(label),
+        ...(filter.budgetId
+          ? [
+              relation('in', '', 'record', { active: true }),
+              node('budget', 'Budget', {
+                id: filter.budgetId,
+              }),
+            ]
+          : []),
+      ])
+      .apply(calculateTotalAndPaginateList(BudgetRecord, input));
+    return query;
+  }
+}

--- a/src/components/budget/budget-record.repository.ts
+++ b/src/components/budget/budget-record.repository.ts
@@ -2,10 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
 import { Dictionary } from 'lodash';
 import { DateTime } from 'luxon';
-import { generateId, ID, Order, Resource, Session } from '../../common';
+import { generateId, ID, Order, Session } from '../../common';
 import {
   createBaseNode,
-  DatabaseService,
+  DtoRepository,
   matchRequestingUser,
   Property,
 } from '../../core';
@@ -21,9 +21,7 @@ import { ScopedRole } from '../authorization';
 import { BudgetRecord, BudgetRecordFilters, CreateBudgetRecord } from './dto';
 
 @Injectable()
-export class BudgetRecordRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class BudgetRecordRepository extends DtoRepository(BudgetRecord) {
   async create(session: Session, secureProps: Property[]): Promise<Query> {
     const createBudgetRecord = this.db
       .query()
@@ -116,48 +114,6 @@ export class BudgetRecordRepository {
       }>();
 
     return query;
-  }
-
-  getActualChanges(
-    br: BudgetRecord,
-    input: {
-      amount: number | null;
-    }
-  ): Partial<
-    Omit<
-      {
-        amount: number | null;
-      },
-      keyof Resource
-    >
-  > {
-    return this.db.getActualChanges(BudgetRecord, br, input);
-  }
-
-  async updateProperties(
-    br: BudgetRecord,
-    changes: Partial<
-      Omit<
-        {
-          amount: number | null;
-        },
-        keyof Resource
-      >
-    >
-  ): Promise<BudgetRecord> {
-    return await this.db.updateProperties({
-      type: BudgetRecord,
-      object: br,
-      changes: changes,
-    });
-  }
-
-  async checkDeletePermission(id: ID, session: Session): Promise<boolean> {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  async deleteNode(node: BudgetRecord) {
-    await this.db.deleteNode(node);
   }
 
   list(

--- a/src/components/budget/budget.module.ts
+++ b/src/components/budget/budget.module.ts
@@ -8,6 +8,7 @@ import { ProjectModule } from '../project/project.module';
 import { EducationModule } from '../user/education/education.module';
 import { UnavailabilityModule } from '../user/unavailability/unavailability.module';
 import { UserModule } from '../user/user.module';
+import { BudgetRecordRepository } from './budget-record.repository';
 import { BudgetRecordResolver } from './budget-record.resolver';
 import { BudgetRepository } from './budget.repository';
 import { BudgetResolver } from './budget.resolver';
@@ -31,6 +32,7 @@ import * as handlers from './handlers';
     BudgetRecordResolver,
     BudgetService,
     BudgetRepository,
+    BudgetRecordRepository,
     ...Object.values(handlers),
   ],
   exports: [BudgetService, BudgetRepository],

--- a/src/components/budget/budget.repository.ts
+++ b/src/components/budget/budget.repository.ts
@@ -2,14 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
 import { Dictionary } from 'lodash';
 import { DateTime } from 'luxon';
-import {
-  generateId,
-  ID,
-  Order,
-  Resource,
-  ServerException,
-  Session,
-} from '../../common';
+import { generateId, ID, Order, ServerException, Session } from '../../common';
 import {
   createBaseNode,
   DatabaseService,
@@ -26,15 +19,7 @@ import {
 import { QueryWithResult } from '../../core/database/query.overrides';
 import { DbPropsOfDto } from '../../core/database/results';
 import { ScopedRole } from '../authorization';
-import {
-  Budget,
-  BudgetFilters,
-  BudgetRecord,
-  BudgetRecordFilters,
-  BudgetStatus,
-  CreateBudgetRecord,
-  UpdateBudget,
-} from './dto';
+import { Budget, BudgetFilters, BudgetStatus, UpdateBudget } from './dto';
 
 @Injectable()
 export class BudgetRepository {
@@ -101,88 +86,6 @@ export class BudgetRepository {
     return createBudgetRecord;
   }
 
-  async connectBudget(
-    budgetId: ID,
-    organizationId: ID,
-    result: Dictionary<any> | undefined,
-    createdAt: DateTime
-  ): Promise<Query> {
-    // connect to budget
-    const query = this.db
-      .query()
-      .match([node('budget', 'Budget', { id: budgetId })])
-      .match([node('br', 'BudgetRecord', { id: result?.id })])
-      .create([
-        node('budget'),
-        relation('out', '', 'record', { active: true, createdAt }),
-        node('br'),
-      ])
-      .return('br');
-    await query.first();
-
-    // connect budget record to org
-    const orgQuery = this.db
-      .query()
-      .match([
-        node('organization', 'Organization', {
-          id: organizationId,
-        }),
-      ])
-      .match([node('br', 'BudgetRecord', { id: result?.id })])
-      .create([
-        node('br'),
-        relation('out', '', 'organization', { active: true, createdAt }),
-        node('organization'),
-      ])
-      .return('br');
-
-    return orgQuery;
-  }
-
-  async existingRecord(
-    input: CreateBudgetRecord
-  ): Promise<Dictionary<any> | undefined> {
-    const existingRecord = await this.db
-      .query()
-      .match([
-        node('budget', 'Budget', { id: input.budgetId }),
-        relation('out', '', 'record', { active: true }),
-        node('br', 'BudgetRecord'),
-        relation('out', '', 'organization', { active: true }),
-        node('', 'Organization', { id: input.organizationId }),
-      ])
-      .match([
-        node('br'),
-        relation('out', '', 'fiscalYear', { active: true }),
-        node('', 'Property', { value: input.fiscalYear }),
-      ])
-      .return('br')
-      .first();
-    return existingRecord;
-  }
-
-  async verifyRecordUniqueness(
-    input: CreateBudgetRecord
-  ): Promise<Dictionary<any> | undefined> {
-    const existingRecord = await this.db
-      .query()
-      .match([
-        node('budget', 'Budget', { id: input.budgetId }),
-        relation('out', '', 'record', { active: true }),
-        node('br', 'BudgetRecord'),
-        relation('out', '', 'organization', { active: true }),
-        node('', 'Organization', { id: input.organizationId }),
-      ])
-      .match([
-        node('br'),
-        relation('out', '', 'fiscalYear', { active: true }),
-        node('', 'Property', { value: input.fiscalYear }),
-      ])
-      .return('br')
-      .first();
-    return existingRecord;
-  }
-
   readOne(id: ID, session: Session) {
     const query = this.db
       .query()
@@ -195,31 +98,6 @@ export class BudgetRepository {
       .return(['props', 'scopedRoles'])
       .asResult<{
         props: DbPropsOfDto<Budget, true>;
-        scopedRoles: ScopedRole[];
-      }>();
-
-    return query;
-  }
-
-  readOneRecord(id: ID, session: Session) {
-    const query = this.db
-      .query()
-      .match([
-        node('project', 'Project'),
-        relation('out', '', 'budget', { active: true }),
-        node('', 'Budget'),
-        relation('out', '', 'record', { active: true }),
-        node('node', 'BudgetRecord', { id }),
-        relation('out', '', 'organization', { active: true }),
-        node('organization', 'Organization'),
-      ])
-      .apply(matchPropsAndProjectSensAndScopedRoles(session))
-      .return([
-        'apoc.map.merge(props, { organization: organization.id }) as props',
-        'scopedRoles',
-      ])
-      .asResult<{
-        props: DbPropsOfDto<BudgetRecord, true>;
         scopedRoles: ScopedRole[];
       }>();
 
@@ -240,40 +118,6 @@ export class BudgetRepository {
       type: Budget,
       object: budget,
       changes: simpleChanges,
-    });
-  }
-
-  getActualRecordChanges(
-    br: BudgetRecord,
-    input: {
-      amount: number | null;
-    }
-  ): Partial<
-    Omit<
-      {
-        amount: number | null;
-      },
-      keyof Resource
-    >
-  > {
-    return this.db.getActualChanges(BudgetRecord, br, input);
-  }
-
-  async updateRecordProperties(
-    br: BudgetRecord,
-    changes: Partial<
-      Omit<
-        {
-          amount: number | null;
-        },
-        keyof Resource
-      >
-    >
-  ): Promise<BudgetRecord> {
-    return await this.db.updateProperties({
-      type: BudgetRecord,
-      object: br,
-      changes: changes,
     });
   }
 
@@ -301,7 +145,7 @@ export class BudgetRepository {
     return await this.db.checkDeletePermission(id, session);
   }
 
-  async deleteNode(node: Budget | BudgetRecord) {
+  async deleteNode(node: Budget) {
     await this.db.deleteNode(node);
   }
 
@@ -335,38 +179,6 @@ export class BudgetRepository {
           : []),
       ])
       .apply(calculateTotalAndPaginateList(Budget, listInput));
-    return query;
-  }
-  listRecords(
-    filter: BudgetRecordFilters,
-    input: {
-      sort: keyof BudgetRecord;
-      order: Order;
-      count: number;
-      page: number;
-    },
-    session: Session
-  ): QueryWithResult<{
-    items: ID[];
-    total: number;
-  }> {
-    const label = 'BudgetRecord';
-
-    const query = this.db
-      .query()
-      .match([
-        requestingUser(session),
-        ...permissionsOfNode(label),
-        ...(filter.budgetId
-          ? [
-              relation('in', '', 'record', { active: true }),
-              node('budget', 'Budget', {
-                id: filter.budgetId,
-              }),
-            ]
-          : []),
-      ])
-      .apply(calculateTotalAndPaginateList(BudgetRecord, input));
     return query;
   }
 }

--- a/src/components/budget/budget.repository.ts
+++ b/src/components/budget/budget.repository.ts
@@ -5,7 +5,7 @@ import { DateTime } from 'luxon';
 import { generateId, ID, Order, ServerException, Session } from '../../common';
 import {
   createBaseNode,
-  DatabaseService,
+  DtoRepository,
   matchRequestingUser,
   matchSession,
   Property,
@@ -19,12 +19,10 @@ import {
 import { QueryWithResult } from '../../core/database/query.overrides';
 import { DbPropsOfDto } from '../../core/database/results';
 import { ScopedRole } from '../authorization';
-import { Budget, BudgetFilters, BudgetStatus, UpdateBudget } from './dto';
+import { Budget, BudgetFilters, BudgetStatus } from './dto';
 
 @Injectable()
-export class BudgetRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class BudgetRepository extends DtoRepository(Budget) {
   readProject(projectId: ID, session: Session): Query {
     const readProject = this.db
       .query()
@@ -104,23 +102,6 @@ export class BudgetRepository {
     return query;
   }
 
-  getActualChanges(budget: Budget, input: UpdateBudget) {
-    return this.db.getActualChanges(Budget, budget, input);
-  }
-
-  async updateProperties(
-    budget: Budget,
-    simpleChanges: {
-      status?: BudgetStatus | undefined;
-    }
-  ): Promise<Budget> {
-    return await this.db.updateProperties({
-      type: Budget,
-      object: budget,
-      changes: simpleChanges,
-    });
-  }
-
   async verifyCanEdit(id: ID): Promise<
     | {
         status: BudgetStatus;
@@ -139,14 +120,6 @@ export class BudgetRepository {
       .return('status.value as status')
       .asResult<{ status: BudgetStatus }>()
       .first();
-  }
-
-  async checkDeletePermission(id: ID, session: Session): Promise<boolean> {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  async deleteNode(node: Budget) {
-    await this.db.deleteNode(node);
   }
 
   list(

--- a/src/components/ceremony/ceremony.repository.ts
+++ b/src/components/ceremony/ceremony.repository.ts
@@ -3,11 +3,10 @@ import { node, relation } from 'cypher-query-builder';
 import { generateId, ID, Session } from '../../common';
 import {
   createBaseNode,
-  DatabaseService,
+  DtoRepository,
   matchRequestingUser,
   Property,
 } from '../../core';
-import { DbChanges } from '../../core/database/changes';
 import {
   calculateTotalAndPaginateList,
   matchPropsAndProjectSensAndScopedRoles,
@@ -16,12 +15,10 @@ import {
 } from '../../core/database/query';
 import { DbPropsOfDto } from '../../core/database/results';
 import { ScopedRole } from '../authorization';
-import { Ceremony, CeremonyListInput, UpdateCeremony } from './dto';
+import { Ceremony, CeremonyListInput } from './dto';
 
 @Injectable()
-export class CeremonyRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class CeremonyRepository extends DtoRepository(Ceremony) {
   async create(session: Session, secureProps: Property[]) {
     return this.db
       .query()
@@ -48,26 +45,6 @@ export class CeremonyRepository {
       }>();
 
     return await readCeremony.first();
-  }
-
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  getActualChanges(object: Ceremony, input: UpdateCeremony) {
-    return this.db.getActualChanges(Ceremony, object, input);
-  }
-
-  async updateProperties(object: Ceremony, changes: DbChanges<Ceremony>) {
-    return await this.db.updateProperties({
-      type: Ceremony,
-      object,
-      changes,
-    });
-  }
-
-  async deleteNode(node: Ceremony) {
-    await this.db.deleteNode(node);
   }
 
   list({ filter, ...input }: CeremonyListInput, session: Session) {

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -3,8 +3,8 @@ import { inArray, node, Node, Query, relation } from 'cypher-query-builder';
 import { Dictionary } from 'lodash';
 import { DateTime } from 'luxon';
 import { CalendarDate, ID, Session } from '../../common';
-import { DatabaseService, matchSession } from '../../core';
-import { DbChanges } from '../../core/database/changes';
+import { CommonRepository, matchSession } from '../../core';
+import { DbChanges, getChanges } from '../../core/database/changes';
 import {
   calculateTotalAndPaginateList,
   matchPropsAndProjectSensAndScopedRoles,
@@ -22,13 +22,10 @@ import {
   OngoingEngagementStatuses,
   PnpData,
   UpdateInternshipEngagement,
-  UpdateLanguageEngagement,
 } from './dto';
 
 @Injectable()
-export class EngagementRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class EngagementRepository extends CommonRepository {
   // CREATE ///////////////////////////////////////////////////////////
   query(): Query {
     return this.db.query();
@@ -161,29 +158,9 @@ export class EngagementRepository {
       }>();
   }
 
-  // getActualChanges(
-  //   type: string,
-  //   object: LanguageEngagement | InternshipEngagement,
-  //   input: UpdateLanguageEngagement | UpdateInternshipEngagement
-  // ): ChangesOf<LanguageEngagement> | ChangesOf<InternshipEngagement> {
-  //   if (type === 'language') {
-  //     return this.db.getActualChanges(LanguageEngagement, object, input);
-  //   }
-  //   // else if (type === 'internship')
-  //   else {
-  //     return this.db.getActualChanges(InternshipEngagement, object, input);
-  //   }
-  //   // return undefined;
-  // }
-
   // UPDATE ///////////////////////////////////////////////////////////
 
-  getActualLanguageChanges(
-    object: LanguageEngagement,
-    input: UpdateLanguageEngagement
-  ) {
-    return this.db.getActualChanges(LanguageEngagement, object, input);
-  }
+  getActualLanguageChanges = getChanges(LanguageEngagement);
 
   async updateLanguageProperties(
     object: LanguageEngagement,
@@ -196,12 +173,7 @@ export class EngagementRepository {
     });
   }
 
-  getActualInternshipChanges(
-    object: InternshipEngagement,
-    input: UpdateInternshipEngagement
-  ) {
-    return this.db.getActualChanges(InternshipEngagement, object, input);
-  }
+  getActualInternshipChanges = getChanges(InternshipEngagement);
 
   mentorQ(
     mentorId: ID,
@@ -310,10 +282,6 @@ export class EngagementRepository {
 
   // DELETE /////////////////////////////////////////////////////////
 
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
   async findNodeToDelete(id: ID) {
     return await this.db
       .query()
@@ -326,12 +294,6 @@ export class EngagementRepository {
       .asResult<{ projectId: ID }>()
       .first();
     // return result;
-  }
-
-  async deleteNode(
-    object: LanguageEngagement | InternshipEngagement
-  ): Promise<void> {
-    await this.db.deleteNode(object);
   }
 
   // LIST ///////////////////////////////////////////////////////////

--- a/src/components/field-region/field-region.repository.ts
+++ b/src/components/field-region/field-region.repository.ts
@@ -2,12 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { generateId, ID, Session } from '../../common';
-import {
-  createBaseNode,
-  DatabaseService,
-  matchRequestingUser,
-} from '../../core';
-import { DbChanges } from '../../core/database/changes';
+import { createBaseNode, DtoRepository, matchRequestingUser } from '../../core';
 import {
   calculateTotalAndPaginateList,
   matchPropList,
@@ -15,12 +10,10 @@ import {
   requestingUser,
 } from '../../core/database/query';
 import { DbPropsOfDto, StandardReadResult } from '../../core/database/results';
-import { FieldRegion, FieldRegionListInput, UpdateFieldRegion } from './dto';
+import { FieldRegion, FieldRegionListInput } from './dto';
 
 @Injectable()
-export class FieldRegionRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class FieldRegionRepository extends DtoRepository(FieldRegion) {
   async checkName(name: string) {
     return await this.db
       .query()
@@ -110,29 +103,6 @@ export class FieldRegionRepository {
       >();
 
     return await query.first();
-  }
-
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  getActualChanges(fieldRegion: FieldRegion, input: UpdateFieldRegion) {
-    return this.db.getActualChanges(FieldRegion, fieldRegion, input);
-  }
-
-  async updateProperties(
-    fieldRegion: FieldRegion,
-    changes: DbChanges<FieldRegion>
-  ) {
-    await this.db.updateProperties({
-      type: FieldRegion,
-      object: fieldRegion,
-      changes: changes,
-    });
-  }
-
-  async deleteNode(node: FieldRegion) {
-    await this.db.deleteNode(node);
   }
 
   list({ filter, ...input }: FieldRegionListInput, session: Session) {

--- a/src/components/field-zone/field-zone.repository.ts
+++ b/src/components/field-zone/field-zone.repository.ts
@@ -2,12 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { generateId, ID, Session } from '../../common';
-import {
-  createBaseNode,
-  DatabaseService,
-  matchRequestingUser,
-} from '../../core';
-import { DbChanges } from '../../core/database/changes';
+import { createBaseNode, DtoRepository, matchRequestingUser } from '../../core';
 import {
   calculateTotalAndPaginateList,
   matchPropList,
@@ -15,12 +10,10 @@ import {
   requestingUser,
 } from '../../core/database/query';
 import { DbPropsOfDto, StandardReadResult } from '../../core/database/results';
-import { FieldZone, FieldZoneListInput, UpdateFieldZone } from './dto';
+import { FieldZone, FieldZoneListInput } from './dto';
 
 @Injectable()
-export class FieldZoneRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class FieldZoneRepository extends DtoRepository(FieldZone) {
   async checkName(name: string) {
     return await this.db
       .query()
@@ -96,14 +89,6 @@ export class FieldZoneRepository {
     return await query.first();
   }
 
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  getActualChanges(fieldZone: FieldZone, input: UpdateFieldZone) {
-    return this.db.getActualChanges(FieldZone, fieldZone, input);
-  }
-
   async updateDirector(directorId: ID, id: ID) {
     const createdAt = DateTime.local();
     const query = this.db
@@ -130,18 +115,6 @@ export class FieldZoneRepository {
       ]);
 
     await query.run();
-  }
-
-  async updateProperties(fieldZone: FieldZone, changes: DbChanges<FieldZone>) {
-    await this.db.updateProperties({
-      type: FieldZone,
-      object: fieldZone,
-      changes: changes,
-    });
-  }
-
-  async deleteNode(node: FieldZone) {
-    await this.db.deleteNode(node);
   }
 
   list({ filter, ...input }: FieldZoneListInput, session: Session) {

--- a/src/components/film/film.repository.ts
+++ b/src/components/film/film.repository.ts
@@ -1,11 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { node } from 'cypher-query-builder';
 import { generateId, ID, Session } from '../../common';
-import {
-  createBaseNode,
-  DatabaseService,
-  matchRequestingUser,
-} from '../../core';
+import { createBaseNode, DtoRepository, matchRequestingUser } from '../../core';
 import {
   calculateTotalAndPaginateList,
   matchPropList,
@@ -13,12 +9,10 @@ import {
   requestingUser,
 } from '../../core/database/query';
 import { DbPropsOfDto, StandardReadResult } from '../../core/database/results';
-import { Film, FilmListInput, UpdateFilm } from './dto';
+import { Film, FilmListInput } from './dto';
 
 @Injectable()
-export class FilmRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class FilmRepository extends DtoRepository(Film) {
   async checkFilm(name: string) {
     return await this.db
       .query()
@@ -63,30 +57,6 @@ export class FilmRepository {
       .asResult<StandardReadResult<DbPropsOfDto<Film>>>();
 
     return await readFilm.first();
-  }
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  getActualChanges(film: Film, input: UpdateFilm) {
-    return this.db.getActualChanges(Film, film, input);
-  }
-
-  async updateProperties(
-    object: Film,
-    changes: {
-      name?: string | undefined;
-    }
-  ) {
-    await this.db.updateProperties({
-      type: Film,
-      object,
-      changes,
-    });
-  }
-
-  async deleteNode(node: Film) {
-    return void (await this.db.deleteNode(node));
   }
 
   list({ filter, ...input }: FilmListInput, session: Session) {

--- a/src/components/funding-account/funding-account.repository.ts
+++ b/src/components/funding-account/funding-account.repository.ts
@@ -1,12 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { node } from 'cypher-query-builder';
 import { generateId, ID, Session } from '../../common';
-import {
-  createBaseNode,
-  DatabaseService,
-  matchRequestingUser,
-} from '../../core';
-import { DbChanges } from '../../core/database/changes';
+import { createBaseNode, DtoRepository, matchRequestingUser } from '../../core';
 import {
   calculateTotalAndPaginateList,
   matchPropList,
@@ -18,13 +13,10 @@ import {
   CreateFundingAccount,
   FundingAccount,
   FundingAccountListInput,
-  UpdateFundingAccount,
 } from './dto';
 
 @Injectable()
-export class FundingAccountRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class FundingAccountRepository extends DtoRepository(FundingAccount) {
   async checkFundingAccount(name: string) {
     return await this.db
       .query()
@@ -75,32 +67,6 @@ export class FundingAccountRepository {
       .asResult<StandardReadResult<DbPropsOfDto<FundingAccount>>>();
 
     return await readFundingAccount.first();
-  }
-
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  getActualChanges(
-    fundingAccount: FundingAccount,
-    input: UpdateFundingAccount
-  ) {
-    return this.db.getActualChanges(FundingAccount, fundingAccount, input);
-  }
-
-  async updateProperties(
-    object: FundingAccount,
-    changes: DbChanges<FundingAccount>
-  ) {
-    return await this.db.updateProperties({
-      type: FundingAccount,
-      object,
-      changes,
-    });
-  }
-
-  async deleteNode(node: FundingAccount) {
-    return void (await this.db.deleteNode(node));
   }
 
   list(input: FundingAccountListInput, session: Session) {

--- a/src/components/language/ethnologue-language/ethnologue-language.repository.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.repository.ts
@@ -3,7 +3,7 @@ import { node } from 'cypher-query-builder';
 import { generateId, ID, Session } from '../../../common';
 import {
   createBaseNode,
-  DatabaseService,
+  DtoRepository,
   matchRequestingUser,
   Property,
 } from '../../../core';
@@ -12,14 +12,14 @@ import {
   DbPropsOfDto,
   StandardReadResult,
 } from '../../../core/database/results';
-import { EthnologueLanguage, UpdateEthnologueLanguage } from '../dto';
+import { EthnologueLanguage } from '../dto';
 
 type EthLangDbProps = DbPropsOfDto<EthnologueLanguage> & { id: ID };
 
 @Injectable()
-export class EthnologueLanguageRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class EthnologueLanguageRepository extends DtoRepository(
+  EthnologueLanguage
+) {
   async create(secureProps: Property[], session: Session) {
     const query = this.db
       .query()
@@ -42,31 +42,5 @@ export class EthnologueLanguageRepository {
       .asResult<StandardReadResult<EthLangDbProps>>();
 
     return await query.first();
-  }
-
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  getActualChanges(
-    ethnologueLanguage: EthnologueLanguage,
-    input: UpdateEthnologueLanguage
-  ) {
-    return this.db.getActualChanges(
-      EthnologueLanguage,
-      ethnologueLanguage,
-      input
-    );
-  }
-
-  async updateProperties(
-    object: EthnologueLanguage,
-    changes: UpdateEthnologueLanguage
-  ) {
-    return await this.db.updateProperties({
-      type: EthnologueLanguage,
-      object: object,
-      changes,
-    });
   }
 }

--- a/src/components/language/ethnologue-language/ethnologue-language.repository.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.repository.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { node, relation } from 'cypher-query-builder';
-import { Dictionary } from 'lodash';
+import { node } from 'cypher-query-builder';
 import { generateId, ID, Session } from '../../../common';
 import {
   createBaseNode,
@@ -61,39 +60,13 @@ export class EthnologueLanguageRepository {
   }
 
   async updateProperties(
-    id: ID,
-    valueSet: Dictionary<string | number | undefined>
+    object: EthnologueLanguage,
+    changes: UpdateEthnologueLanguage
   ) {
-    const query = this.db
-      .query()
-      .match([
-        node('ethnologueLanguage', 'EthnologueLanguage', {
-          id: id,
-        }),
-      ])
-      .match([
-        [
-          node('ethnologueLanguage'),
-          relation('out', '', 'code', { active: true }),
-          node('code', 'Property'),
-        ],
-        [
-          node('ethnologueLanguage'),
-          relation('out', '', 'provisionalCode', { active: true }),
-          node('provisionalCode', 'Property'),
-        ],
-        [
-          node('ethnologueLanguage'),
-          relation('out', '', 'name', { active: true }),
-          node('name', 'Property'),
-        ],
-        [
-          node('ethnologueLanguage'),
-          relation('out', '', 'population', { active: true }),
-          node('population', 'Property'),
-        ],
-      ])
-      .setValues(valueSet);
-    await query.run();
+    return await this.db.updateProperties({
+      type: EthnologueLanguage,
+      object: object,
+      changes,
+    });
   }
 }

--- a/src/components/language/ethnologue-language/ethnologue-language.service.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { pickBy } from 'lodash';
 import {
   ID,
   NotFoundException,
@@ -119,23 +118,8 @@ export class EthnologueLanguageService {
       changes
     );
 
-    if (Object.keys(changes).length === 0) {
-      return;
-    }
-
-    // Make a mapping of the fields that we want to set in the db to the inputs
-    const valueSet = pickBy(
-      {
-        'code.value': changes.code,
-        'provisionalCode.value': changes.provisionalCode,
-        'name.value': changes.name,
-        'population.value': changes.population,
-      },
-      (v) => v !== undefined
-    );
-
     try {
-      await this.repo.updateProperties(id, valueSet);
+      await this.repo.updateProperties(ethnologueLanguage, changes);
     } catch (exception) {
       this.logger.error('update failed', { exception });
       throw new ServerException(

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -2,12 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { generateId, ID, Session } from '../../common';
-import {
-  createBaseNode,
-  DatabaseService,
-  matchRequestingUser,
-} from '../../core';
-import { DbChanges } from '../../core/database/changes';
+import { createBaseNode, DtoRepository, matchRequestingUser } from '../../core';
 import {
   calculateTotalAndPaginateList,
   collect,
@@ -16,18 +11,11 @@ import {
   requestingUser,
 } from '../../core/database/query';
 import { DbPropsOfDto, StandardReadResult } from '../../core/database/results';
-import {
-  CreateLanguage,
-  Language,
-  LanguageListInput,
-  UpdateLanguage,
-} from './dto';
+import { CreateLanguage, Language, LanguageListInput } from './dto';
 import { languageListFilter } from './query.helpers';
 
 @Injectable()
-export class LanguageRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class LanguageRepository extends DtoRepository(Language) {
   async create(input: CreateLanguage, session: Session) {
     const secureProps = [
       {
@@ -171,25 +159,6 @@ export class LanguageRepository {
         }
       >();
     return await query.first();
-  }
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  getActualChanges(object: Language, input: UpdateLanguage) {
-    return this.db.getActualChanges(Language, object, input);
-  }
-
-  async updateProperties(object: Language, changes: DbChanges<Language>) {
-    await this.db.updateProperties({
-      type: Language,
-      object,
-      changes,
-    });
-  }
-
-  async deleteNode(node: Language) {
-    await this.db.deleteNode(node);
   }
 
   list({ filter, ...input }: LanguageListInput, session: Session) {

--- a/src/components/literacy-material/literacy-material.repository.ts
+++ b/src/components/literacy-material/literacy-material.repository.ts
@@ -3,11 +3,10 @@ import { node } from 'cypher-query-builder';
 import { generateId, ID, Session } from '../../common';
 import {
   createBaseNode,
-  DatabaseService,
+  DtoRepository,
   matchRequestingUser,
   Property,
 } from '../../core';
-import { DbChanges } from '../../core/database/changes';
 import {
   calculateTotalAndPaginateList,
   matchPropList,
@@ -15,16 +14,12 @@ import {
   requestingUser,
 } from '../../core/database/query';
 import { DbPropsOfDto, StandardReadResult } from '../../core/database/results';
-import {
-  LiteracyMaterial,
-  LiteracyMaterialListInput,
-  UpdateLiteracyMaterial,
-} from './dto';
+import { LiteracyMaterial, LiteracyMaterialListInput } from './dto';
 
 @Injectable()
-export class LiteracyMaterialRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class LiteracyMaterialRepository extends DtoRepository(
+  LiteracyMaterial
+) {
   async checkLiteracy(name: string) {
     return await this.db
       .query()
@@ -75,31 +70,6 @@ export class LiteracyMaterialRepository {
     return await readLiteracyMaterial.first();
   }
 
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  getActualChanges(
-    literacyMaterial: LiteracyMaterial,
-    input: UpdateLiteracyMaterial
-  ) {
-    return this.db.getActualChanges(LiteracyMaterial, literacyMaterial, input);
-  }
-
-  async updateProperties(
-    object: LiteracyMaterial,
-    changes: DbChanges<LiteracyMaterial>
-  ) {
-    await this.db.updateProperties({
-      type: LiteracyMaterial,
-      object,
-      changes,
-    });
-  }
-
-  async deleteNode(node: LiteracyMaterial) {
-    await this.db.deleteNode(node);
-  }
   list({ filter, ...input }: LiteracyMaterialListInput, session: Session) {
     return this.db
       .query()

--- a/src/components/location/location.repository.ts
+++ b/src/components/location/location.repository.ts
@@ -3,12 +3,7 @@ import { node, relation } from 'cypher-query-builder';
 import { Dictionary } from 'lodash';
 import { DateTime } from 'luxon';
 import { generateId, ID, Session } from '../../common';
-import {
-  createBaseNode,
-  DatabaseService,
-  matchRequestingUser,
-} from '../../core';
-import { DbChanges } from '../../core/database/changes';
+import { createBaseNode, DtoRepository, matchRequestingUser } from '../../core';
 import {
   calculateTotalAndPaginateList,
   matchPropList,
@@ -16,17 +11,10 @@ import {
   requestingUser,
 } from '../../core/database/query';
 import { DbPropsOfDto, StandardReadResult } from '../../core/database/results';
-import {
-  CreateLocation,
-  Location,
-  LocationListInput,
-  UpdateLocation,
-} from './dto';
+import { CreateLocation, Location, LocationListInput } from './dto';
 
 @Injectable()
-export class LocationRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class LocationRepository extends DtoRepository(Location) {
   async checkName(name: string) {
     return await this.db
       .query()
@@ -149,22 +137,6 @@ export class LocationRepository {
     // return await query.first();
   }
 
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  getActualChanges(location: Location, input: UpdateLocation) {
-    return this.db.getActualChanges(Location, location, input);
-  }
-
-  async updateProperties(object: Location, changes: DbChanges<Location>) {
-    await this.db.updateProperties({
-      type: Location,
-      object,
-      changes,
-    });
-  }
-
   async updateLocationProperties(
     type: 'fundingAccount' | 'defaultFieldRegion',
     session: Session,
@@ -232,10 +204,6 @@ export class LocationRepository {
         })
         .run();
     }
-  }
-
-  async deleteNode(node: Location) {
-    await this.db.deleteNode(node);
   }
 
   list({ filter, ...input }: LocationListInput, session: Session) {

--- a/src/components/organization/organization.repository.ts
+++ b/src/components/organization/organization.repository.ts
@@ -4,11 +4,10 @@ import { DateTime } from 'luxon';
 import { generateId, ID, Session } from '../../common';
 import {
   createBaseNode,
-  DatabaseService,
+  DtoRepository,
   matchRequestingUser,
   Property,
 } from '../../core';
-import { DbChanges } from '../../core/database/changes';
 import {
   calculateTotalAndPaginateList,
   matchPropList,
@@ -16,16 +15,10 @@ import {
   requestingUser,
 } from '../../core/database/query';
 import { DbPropsOfDto, StandardReadResult } from '../../core/database/results';
-import {
-  CreateOrganization,
-  Organization,
-  OrganizationListInput,
-  UpdateOrganization,
-} from './dto';
+import { CreateOrganization, Organization, OrganizationListInput } from './dto';
 
 @Injectable()
-export class OrganizationRepository {
-  constructor(private readonly db: DatabaseService) {}
+export class OrganizationRepository extends DtoRepository(Organization) {
   // assumes 'root' cypher variable is declared in query
   private readonly createSG =
     (cypherIdentifier: string, id: ID, label?: string) => (query: Query) => {
@@ -101,29 +94,6 @@ export class OrganizationRepository {
       .return('propList, node')
       .asResult<StandardReadResult<DbPropsOfDto<Organization>>>();
     return await query.first();
-  }
-
-  async checkDeletePermission(orgId: ID, session: Session) {
-    return await this.db.checkDeletePermission(orgId, session);
-  }
-
-  getActualChanges(organization: Organization, input: UpdateOrganization) {
-    return this.db.getActualChanges(Organization, organization, input);
-  }
-
-  async updateProperties(
-    object: Organization,
-    changes: DbChanges<Organization>
-  ) {
-    return await this.db.updateProperties({
-      type: Organization,
-      object,
-      changes,
-    });
-  }
-
-  async deleteNode(node: Organization) {
-    await this.db.deleteNode(node);
   }
 
   list({ filter, ...input }: OrganizationListInput, session: Session) {

--- a/src/components/partner/partner.repository.ts
+++ b/src/components/partner/partner.repository.ts
@@ -3,12 +3,7 @@ import { node, Query, relation } from 'cypher-query-builder';
 import { Dictionary } from 'lodash';
 import { DateTime } from 'luxon';
 import { generateId, ID, Order, Session } from '../../common';
-import {
-  createBaseNode,
-  DatabaseService,
-  matchRequestingUser,
-} from '../../core';
-import { DbChanges } from '../../core/database/changes';
+import { createBaseNode, DtoRepository, matchRequestingUser } from '../../core';
 import {
   calculateTotalAndPaginateList,
   matchPropList,
@@ -19,8 +14,7 @@ import { DbPropsOfDto, StandardReadResult } from '../../core/database/results';
 import { CreatePartner, Partner, PartnerListInput, UpdatePartner } from './dto';
 
 @Injectable()
-export class PartnerRepository {
-  constructor(private readonly db: DatabaseService) {}
+export class PartnerRepository extends DtoRepository(Partner) {
   private readonly orgNameSorter =
     (sortInput: string, order: Order) => (q: Query) => {
       // If the user inputs orgName as the sort value, then match the organization node for the sortValue match
@@ -229,22 +223,6 @@ export class PartnerRepository {
     return await query.first();
   }
 
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  getActualChanges(object: Partner, input: UpdatePartner) {
-    return this.db.getActualChanges(Partner, object, input);
-  }
-
-  async updateProperties(object: Partner, changes: DbChanges<Partner>) {
-    await this.db.updateProperties({
-      type: Partner,
-      object,
-      changes,
-    });
-  }
-
   async updatePartnerProperties(input: UpdatePartner, session: Session) {
     const createdAt = DateTime.local();
     await this.db
@@ -274,10 +252,6 @@ export class PartnerRepository {
         node('newPointOfContact'),
       ])
       .run();
-  }
-
-  async deleteNode(node: Partner) {
-    await this.db.deleteNode(node);
   }
 
   list({ filter, ...input }: PartnerListInput, session: Session) {

--- a/src/components/partnership/partnership.repository.ts
+++ b/src/components/partnership/partnership.repository.ts
@@ -5,11 +5,10 @@ import { DateTime } from 'luxon';
 import { ID, Order, Session } from '../../common';
 import {
   createBaseNode,
-  DatabaseService,
+  DtoRepository,
   matchRequestingUser,
   Property,
 } from '../../core';
-import { DbChanges } from '../../core/database/changes';
 import {
   calculateTotalAndPaginateList,
   matchPropsAndProjectSensAndScopedRoles,
@@ -18,12 +17,10 @@ import {
 } from '../../core/database/query';
 import { DbPropsOfDto } from '../../core/database/results';
 import { ScopedRole } from '../authorization';
-import { Partnership, PartnershipFilters, UpdatePartnership } from './dto';
+import { Partnership, PartnershipFilters } from './dto';
 
 @Injectable()
-export class PartnershipRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class PartnershipRepository extends DtoRepository(Partnership) {
   create(partnershipId: ID, session: Session, secureProps: Property[]) {
     return this.db
       .query()
@@ -91,26 +88,6 @@ export class PartnershipRepository {
       }>();
 
     return await query.first();
-  }
-
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  getActualChanges(object: Partnership, input: UpdatePartnership) {
-    return this.db.getActualChanges(Partnership, object, input);
-  }
-
-  async updateProperties(object: Partnership, changes: DbChanges<Partnership>) {
-    await this.db.updateProperties({
-      type: Partnership,
-      object,
-      changes,
-    });
-  }
-
-  async deleteNode(node: Partnership) {
-    await this.db.deleteNode(node);
   }
 
   list(

--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -103,7 +103,7 @@ export class PeriodicReportRepository extends DtoRepository(IPeriodicReport) {
         relation('out', '', 'report', { active: true }),
         node('node', ['PeriodicReport', `${reportType}Report`]),
       ])
-      .call(
+      .apply(
         calculateTotalAndPaginateList(
           reportType === 'Financial' ? FinancialReport : NarrativeReport,
           input
@@ -123,7 +123,7 @@ export class PeriodicReportRepository extends DtoRepository(IPeriodicReport) {
         relation('out', '', 'report', { active: true }),
         node('node', `PeriodicReport:${reportType}Report`),
       ])
-      .call(calculateTotalAndPaginateList(ProgressReport, input));
+      .apply(calculateTotalAndPaginateList(ProgressReport, input));
   }
 
   async delete(baseNodeId: ID, type: ReportType, intervals: Interval[]) {

--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -4,7 +4,7 @@ import { node, relation } from 'cypher-query-builder';
 import { Dictionary } from 'lodash';
 import { DateTime, Interval } from 'luxon';
 import { ID, Session } from '../../common';
-import { DatabaseService, matchRequestingUser, property } from '../../core';
+import { DtoRepository, matchRequestingUser, property } from '../../core';
 import {
   calculateTotalAndPaginateList,
   deleteBaseNode,
@@ -14,6 +14,7 @@ import { DbPropsOfDto, StandardReadResult } from '../../core/database/results';
 import {
   CreatePeriodicReport,
   FinancialReport,
+  IPeriodicReport,
   NarrativeReport,
   PeriodicReport,
   PeriodicReportListInput,
@@ -22,9 +23,7 @@ import {
 } from './dto';
 
 @Injectable()
-export class PeriodicReportRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class PeriodicReportRepository extends DtoRepository(IPeriodicReport) {
   async create(
     input: CreatePeriodicReport,
     createdAt: DateTime,
@@ -90,10 +89,6 @@ export class PeriodicReportRepository {
       .asResult<StandardReadResult<DbPropsOfDto<PeriodicReport>>>();
 
     return await query.first();
-  }
-
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
   }
 
   listProjectReports(

--- a/src/components/post/post.repository.ts
+++ b/src/components/post/post.repository.ts
@@ -96,6 +96,6 @@ export class PostRepository extends DtoRepository(Post) {
             ]
           : []),
       ])
-      .call(calculateTotalAndPaginateList(Post, input));
+      .apply(calculateTotalAndPaginateList(Post, input));
   }
 }

--- a/src/components/post/post.repository.ts
+++ b/src/components/post/post.repository.ts
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon';
 import { ID, Session } from '../../common';
 import {
   createBaseNode,
-  DatabaseService,
+  DtoRepository,
   matchRequestingUser,
   Property,
 } from '../../core';
@@ -13,13 +13,11 @@ import {
   matchPropList,
 } from '../../core/database/query';
 import { DbPropsOfDto, StandardReadResult } from '../../core/database/results';
-import { Post, UpdatePost } from './dto';
+import { Post } from './dto';
 import { PostListInput } from './dto/list-posts.dto';
 
 @Injectable()
-export class PostRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class PostRepository extends DtoRepository(Post) {
   async create(
     parentId: string,
     postId: ID,
@@ -74,24 +72,6 @@ export class PostRepository {
       .asResult<StandardReadResult<DbPropsOfDto<Post>>>();
 
     return await query.first();
-  }
-
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  async updateProperties(input: UpdatePost, object: Post) {
-    await this.db.updateProperties({
-      type: Post,
-      object,
-      changes: {
-        body: input.body,
-      },
-    });
-  }
-
-  async deleteNode(node: Post) {
-    await this.db.deleteNode(node);
   }
 
   securedList({ filter, ...input }: PostListInput) {

--- a/src/components/post/post.service.ts
+++ b/src/components/post/post.service.ts
@@ -146,7 +146,8 @@ export class PostService {
   async update(input: UpdatePost, session: Session): Promise<Post> {
     const object = await this.readOne(input.id, session);
 
-    await this.repo.updateProperties(input, object);
+    const changes = this.repo.getActualChanges(object, input);
+    await this.repo.updateProperties(object, changes);
 
     return await this.readOne(input.id, session);
   }

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -374,12 +374,6 @@ export class ProductService {
       session
     );
 
-    // return await this.db.updateProperties({
-    //   type: DirectScriptureProduct,
-    //   object: productUpdatedScriptureReferences,
-    //   changes: simpleChanges,
-    // });
-
     return await this.repo.updateProperties(
       productUpdatedScriptureReferences,
       simpleChanges

--- a/src/components/project/project-member/project-member.repository.ts
+++ b/src/components/project/project-member/project-member.repository.ts
@@ -6,11 +6,9 @@ import {
   ProjectMember,
   ProjectMemberListInput,
   ScopedRole,
-  UpdateProjectMember,
 } from '.';
 import { ID, Session } from '../../../common';
-import { DatabaseService, property } from '../../../core';
-import { DbChanges } from '../../../core/database/changes';
+import { DtoRepository, property } from '../../../core';
 import {
   calculateTotalAndPaginateList,
   matchPropsAndProjectSensAndScopedRoles,
@@ -20,9 +18,7 @@ import {
 import { DbPropsOfDto } from '../../../core/database/results';
 
 @Injectable()
-export class ProjectMemberRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class ProjectMemberRepository extends DtoRepository(ProjectMember) {
   async verifyRelationshipEligibility(projectId: ID, userId: ID) {
     return await this.db
       .query()
@@ -105,29 +101,6 @@ export class ProjectMemberRepository {
         scopedRoles: ScopedRole[];
       }>();
     return await query.first();
-  }
-
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  getActualChanges(object: ProjectMember, input: UpdateProjectMember) {
-    return this.db.getActualChanges(ProjectMember, object, input);
-  }
-
-  async updateProperties(
-    object: ProjectMember,
-    changes: DbChanges<ProjectMember>
-  ) {
-    await this.db.updateProperties({
-      type: ProjectMember,
-      object,
-      changes,
-    });
-  }
-
-  async deleteNode(node: ProjectMember) {
-    await this.db.deleteNode(node);
   }
 
   list({ filter, ...input }: ProjectMemberListInput, session: Session) {

--- a/src/components/song/song.repository.ts
+++ b/src/components/song/song.repository.ts
@@ -3,11 +3,10 @@ import { node } from 'cypher-query-builder';
 import { generateId, ID, Session } from '../../common';
 import {
   createBaseNode,
-  DatabaseService,
+  DtoRepository,
   matchRequestingUser,
   Property,
 } from '../../core';
-import { DbChanges } from '../../core/database/changes';
 import {
   calculateTotalAndPaginateList,
   matchPropList,
@@ -15,12 +14,10 @@ import {
   requestingUser,
 } from '../../core/database/query';
 import { DbPropsOfDto, StandardReadResult } from '../../core/database/results';
-import { CreateSong, Song, SongListInput, UpdateSong } from './dto';
+import { CreateSong, Song, SongListInput } from './dto';
 
 @Injectable()
-export class SongRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class SongRepository extends DtoRepository(Song) {
   async checkSong(input: CreateSong) {
     return await this.db
       .query()
@@ -50,26 +47,6 @@ export class SongRepository {
       .asResult<StandardReadResult<DbPropsOfDto<Song>>>();
 
     return await query.first();
-  }
-
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  getActualChanges(song: Song, input: UpdateSong) {
-    return this.db.getActualChanges(Song, song, input);
-  }
-
-  async updateProperties(song: Song, simpleChanges: DbChanges<Song>) {
-    await this.db.updateProperties({
-      type: Song,
-      object: song,
-      changes: simpleChanges,
-    });
-  }
-
-  async deleteNode(node: Song) {
-    return void (await this.db.deleteNode(node));
   }
 
   list({ filter, ...input }: SongListInput, session: Session) {

--- a/src/components/story/story.repository.ts
+++ b/src/components/story/story.repository.ts
@@ -3,11 +3,10 @@ import { node } from 'cypher-query-builder';
 import { generateId, ID, Session } from '../../common';
 import {
   createBaseNode,
-  DatabaseService,
+  DtoRepository,
   matchRequestingUser,
   Property,
 } from '../../core';
-import { DbChanges } from '../../core/database/changes';
 import {
   calculateTotalAndPaginateList,
   matchPropList,
@@ -15,12 +14,10 @@ import {
   requestingUser,
 } from '../../core/database/query';
 import { DbPropsOfDto, StandardReadResult } from '../../core/database/results';
-import { Story, StoryListInput, UpdateStory } from './dto';
+import { Story, StoryListInput } from './dto';
 
 @Injectable()
-export class StoryRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class StoryRepository extends DtoRepository(Story) {
   async checkStory(name: string) {
     return await this.db
       .query()
@@ -50,26 +47,6 @@ export class StoryRepository {
       .asResult<StandardReadResult<DbPropsOfDto<Story>>>();
 
     return await query.first();
-  }
-
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
-  getActualChanges(story: Story, input: UpdateStory) {
-    return this.db.getActualChanges(Story, story, input);
-  }
-
-  async updateProperties(story: Story, simpleChanges: DbChanges<Story>) {
-    await this.db.updateProperties({
-      type: Story,
-      object: story,
-      changes: simpleChanges,
-    });
-  }
-
-  async deleteNode(node: Story) {
-    return void (await this.db.deleteNode(node));
   }
 
   list({ filter, ...input }: StoryListInput, session: Session) {

--- a/src/components/user/education/education.repository.ts
+++ b/src/components/user/education/education.repository.ts
@@ -4,11 +4,10 @@ import { DateTime } from 'luxon';
 import { generateId, ID, Session } from '../../../common';
 import {
   createBaseNode,
-  DatabaseService,
+  DtoRepository,
   matchRequestingUser,
   Property,
 } from '../../../core';
-import { DbChanges } from '../../../core/database/changes';
 import {
   calculateTotalAndPaginateList,
   matchPropList,
@@ -19,12 +18,10 @@ import {
   DbPropsOfDto,
   StandardReadResult,
 } from '../../../core/database/results';
-import { Education, EducationListInput, UpdateEducation } from './dto';
+import { Education, EducationListInput } from './dto';
 
 @Injectable()
-export class EducationRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class EducationRepository extends DtoRepository(Education) {
   async create(
     userId: ID,
     secureProps: Property[],
@@ -62,10 +59,6 @@ export class EducationRepository {
     return await query.first();
   }
 
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
   async getUserEducation(session: Session, id: ID) {
     return await this.db
       .query()
@@ -77,18 +70,6 @@ export class EducationRepository {
       ])
       .return('user')
       .first();
-  }
-
-  getActualChanges(ed: Education, input: UpdateEducation) {
-    return this.db.getActualChanges(Education, ed, input);
-  }
-
-  async updateProperties(ed: Education, changes: DbChanges<Education>) {
-    await this.db.updateProperties({
-      type: Education,
-      object: ed,
-      changes,
-    });
   }
 
   list({ filter, ...input }: EducationListInput, session: Session) {

--- a/src/components/user/unavailability/unavailability.repository.ts
+++ b/src/components/user/unavailability/unavailability.repository.ts
@@ -3,11 +3,10 @@ import { node, relation } from 'cypher-query-builder';
 import { generateId, ID, Session } from '../../../common';
 import {
   createBaseNode,
-  DatabaseService,
+  DtoRepository,
   matchRequestingUser,
   Property,
 } from '../../../core';
-import { DbChanges } from '../../../core/database/changes';
 import { matchPropList } from '../../../core/database/query';
 import {
   DbPropsOfDto,
@@ -20,9 +19,7 @@ import {
 } from './dto';
 
 @Injectable()
-export class UnavailabilityRepository {
-  constructor(private readonly db: DatabaseService) {}
-
+export class UnavailabilityRepository extends DtoRepository(Unavailability) {
   async create(session: Session, secureProps: Property[]) {
     const createUnavailability = this.db
       .query()
@@ -62,10 +59,6 @@ export class UnavailabilityRepository {
     return await query.first();
   }
 
-  async checkDeletePermission(id: ID, session: Session) {
-    return await this.db.checkDeletePermission(id, session);
-  }
-
   async getUnavailability(session: Session, input: UpdateUnavailability) {
     return await this.db
       .query()
@@ -77,28 +70,6 @@ export class UnavailabilityRepository {
       ])
       .return('user')
       .first();
-  }
-
-  getActualChanges(
-    unavailability: Unavailability,
-    input: UpdateUnavailability
-  ) {
-    return this.db.getActualChanges(Unavailability, unavailability, input);
-  }
-
-  async updateProperties(
-    unavailability: Unavailability,
-    changes: DbChanges<Unavailability>
-  ) {
-    return await this.db.updateProperties({
-      type: Unavailability,
-      object: unavailability,
-      changes,
-    });
-  }
-
-  async deleteNode(node: Unavailability) {
-    await this.db.deleteNode(node);
   }
 
   async list(

--- a/src/components/user/user.repository.ts
+++ b/src/components/user/user.repository.ts
@@ -6,7 +6,6 @@ import {
   DuplicateException,
   ID,
   NotFoundException,
-  Resource,
   ServerException,
   Session,
   UnauthorizedException,
@@ -15,6 +14,7 @@ import {
   ConfigService,
   DatabaseService,
   deleteProperties,
+  DtoRepository,
   ILogger,
   Logger,
   matchSession,
@@ -22,7 +22,6 @@ import {
   property,
   UniquenessError,
 } from '../../core';
-import { DbChanges } from '../../core/database/changes';
 import {
   calculateTotalAndPaginateList,
   matchPropList,
@@ -43,12 +42,15 @@ import {
 } from './dto';
 
 @Injectable()
-export class UserRepository {
+export class UserRepository extends DtoRepository(User) {
   constructor(
-    private readonly db: DatabaseService,
+    db: DatabaseService,
     private readonly config: ConfigService,
     @Logger('user:repository') private readonly logger: ILogger
-  ) {}
+  ) {
+    super(db);
+  }
+
   @OnIndex()
   async createIndexes() {
     // language=Cypher (for webstorm)
@@ -186,35 +188,6 @@ export class UserRepository {
       result,
       canDelete,
     };
-  }
-
-  getActualChanges(
-    input: UpdateUser,
-    user: User
-  ): Partial<Omit<UpdateUser, keyof Resource>> {
-    //shouldn't there be an await here?
-    return this.db.getActualChanges(User, user, input);
-  }
-
-  async updateProperties(
-    user: User,
-    simpleChanges: DbChanges<User>
-    // fieldToUpdate: string
-  ): Promise<void> {
-    await this.db.updateProperties({
-      type: User,
-      object: user,
-      changes: simpleChanges,
-    });
-    // if (fieldToUpdate === 'email') {
-    //   await this.db
-    //     .query()
-    //     .match([node('node', ['User', 'BaseNode'], { id: user.id })])
-    //     .apply(deleteProperties(User, 'email'))
-    //     .return('*')
-    //     .run();
-
-    // }
   }
 
   async updateEmail(

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -211,7 +211,7 @@ export class UserService {
     this.logger.debug('mutation update User', { input, session });
     const user = await this.readOne(input.id, session);
 
-    const changes = this.userRepo.getActualChanges(input, user);
+    const changes = this.userRepo.getActualChanges(user, input);
 
     if (user.id !== session.userId) {
       await this.authorizationService.verifyCanEditChanges(User, user, changes);

--- a/src/core/database/changes.ts
+++ b/src/core/database/changes.ts
@@ -84,39 +84,39 @@ type AndModifiedAt<T> = T extends { modifiedAt: DateTime }
  * Note that while ID properties to change a relationship can be passed in they
  * are assumed to always be different.
  */
-export function getChanges<
-  TResourceStatic extends ResourceShape<any>,
-  TResource extends MaybeUnsecuredInstance<TResourceStatic>,
-  Changes extends ChangesOf<TResource>
->(
-  resource: TResourceStatic,
-  existingObject: TResource,
-  changes: Changes &
-    // Ensure there are no extra props not in ChangesOf<TResource>
-    // This is needed because changes is a generic.
-    // It's a generic to ensure that if only a subset of the changes
-    // are passed in we don't declare the return type having those omitted
-    // properties.
-    Record<Exclude<keyof Changes, keyof ChangesOf<TResource>>, never>
-): Partial<Omit<Changes, keyof Resource> & AndModifiedAt<TResource>> {
-  const actual = pickBy(omit(changes, Resource.Props), (change, prop) => {
-    const key = isRelation(prop, existingObject) ? prop.slice(0, -2) : prop;
-    const existing = unwrapSecured(existingObject[key]);
-    return !isSame(change, existing);
-  });
+export const getChanges =
+  <TResourceStatic extends ResourceShape<any>>(resource: TResourceStatic) =>
+  <
+    TResource extends MaybeUnsecuredInstance<TResourceStatic>,
+    Changes extends ChangesOf<TResource>
+  >(
+    existingObject: TResource,
+    changes: Changes &
+      // Ensure there are no extra props not in ChangesOf<TResource>
+      // This is needed because changes is a generic.
+      // It's a generic to ensure that if only a subset of the changes
+      // are passed in we don't declare the return type having those omitted
+      // properties.
+      Record<Exclude<keyof Changes, keyof ChangesOf<TResource>>, never>
+  ): Partial<Omit<Changes, keyof Resource> & AndModifiedAt<TResource>> => {
+    const actual = pickBy(omit(changes, Resource.Props), (change, prop) => {
+      const key = isRelation(prop, existingObject) ? prop.slice(0, -2) : prop;
+      const existing = unwrapSecured(existingObject[key]);
+      return !isSame(change, existing);
+    });
 
-  if (
-    Object.keys(actual).length > 0 &&
-    resource.Props.includes('modifiedAt') &&
-    !actual.modifiedAt
-  ) {
-    return {
-      ...(actual as any),
-      modifiedAt: DateTime.local(),
-    };
-  }
-  return actual as any;
-}
+    if (
+      Object.keys(actual).length > 0 &&
+      resource.Props.includes('modifiedAt') &&
+      !actual.modifiedAt
+    ) {
+      return {
+        ...(actual as any),
+        modifiedAt: DateTime.local(),
+      };
+    }
+    return actual as any;
+  };
 
 /**
  * If prop ends with `Id` and existing object has `x` instead of `xId`, assume

--- a/src/core/database/common.repository.ts
+++ b/src/core/database/common.repository.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { ID, Session } from '../../common';
+import { DatabaseService } from './database.service';
+
+/**
+ * This provides a few methods out of the box.
+ */
+@Injectable()
+export class CommonRepository {
+  constructor(protected db: DatabaseService) {}
+
+  async checkDeletePermission(id: ID, session: Session | ID) {
+    return await this.db.checkDeletePermission(id, session);
+  }
+
+  async deleteNode(objectOrId: { id: ID } | ID) {
+    await this.db.deleteNode(objectOrId);
+  }
+}

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -31,7 +31,7 @@ import {
 import { ILogger, Logger, ServiceUnavailableError, UniquenessError } from '..';
 import { AbortError, retry, RetryOptions } from '../../common/retry';
 import { ConfigService } from '../config/config.service';
-import { DbChanges, getChanges } from './changes';
+import { DbChanges } from './changes';
 import { deleteBaseNode } from './query';
 import { determineSortValue } from './query.helpers';
 import { hasMore } from './results';
@@ -214,8 +214,6 @@ export class DatabaseService {
     }
     return info;
   }
-
-  getActualChanges = getChanges;
 
   async updateProperties<
     TResourceStatic extends ResourceShape<any>,

--- a/src/core/database/dto.repository.ts
+++ b/src/core/database/dto.repository.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { ID, MaybeUnsecuredInstance, ResourceShape } from '../../common';
+import { DbChanges, getChanges } from './changes';
+import { CommonRepository } from './common.repository';
+
+/**
+ * A repository for a simple DTO. This provides a few methods out of the box.
+ */
+export const DtoRepository = <TResourceStatic extends ResourceShape<any>>(
+  resource: TResourceStatic
+) => {
+  @Injectable()
+  class DtoRepositoryClass extends CommonRepository {
+    getActualChanges = getChanges(resource);
+
+    async updateProperties<
+      TObject extends Partial<MaybeUnsecuredInstance<TResourceStatic>> & {
+        id: ID;
+      }
+    >(object: TObject, changes: DbChanges<TResourceStatic['prototype']>) {
+      return await this.db.updateProperties({
+        type: resource,
+        object,
+        changes,
+      });
+    }
+  }
+
+  return DtoRepositoryClass;
+};

--- a/src/core/database/index.ts
+++ b/src/core/database/index.ts
@@ -3,3 +3,5 @@ export * from './database.service';
 export * from './errors';
 export * from './query.helpers';
 export * from './transaction';
+export * from './common.repository';
+export * from './dto.repository';


### PR DESCRIPTION
There's no need to redefine methods in every repo if they are just going to forward to the `DatabaseService`. I've abstracted these 4 simple methods that are always just forwarded.

I also split `BudgetRecordRepository` out of `BudgetRepository` which are two entirely different subjects at that level.

I also fixed `EthnologueLanguage` updates not storing history. The custom logic there was more naive than the standard db service method.