### PR TITLE
Progress Report Summary

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,6 +24,7 @@ import { PinModule } from './components/pin/pin.module';
 import { PostModule } from './components/post/post.module';
 import { PostableModule } from './components/post/postable/postable.module';
 import { ProductModule } from './components/product/product.module';
+import { ProgressSummaryModule } from './components/progress-summary/progress-summary.module';
 import { ProjectModule } from './components/project/project.module';
 import { ScriptureModule } from './components/scripture/scripture.module';
 import { SearchModule } from './components/search/search.module';
@@ -73,6 +74,7 @@ assert(
     PostModule,
     PostableModule,
     PeriodicReportModule,
+    ProgressSummaryModule,
   ],
   controllers: [],
   providers: [DateTimeScalar, DateScalar],

--- a/src/common/exceptions/not-implemented.exception.ts
+++ b/src/common/exceptions/not-implemented.exception.ts
@@ -4,4 +4,13 @@ export class NotImplementedException extends ServerException {
   constructor(message?: string, previous?: Error) {
     super(message ?? 'Not implemented', previous);
   }
+
+  /**
+   * Used to mark that variables will be used eventually, but are not right now.
+   * Helps make the linter happy.
+   */
+  // eslint-disable-next-line @seedcompany/no-unused-vars
+  with(...unused: unknown[]) {
+    return this;
+  }
 }

--- a/src/common/fiscal-year.ts
+++ b/src/common/fiscal-year.ts
@@ -6,3 +6,8 @@ export const fiscalYear = (dt: DateTime) =>
 
 export const fiscalYears = (start?: DateTime, end?: DateTime) =>
   start && end ? range(fiscalYear(start), fiscalYear(end) + 1) : [];
+
+export const fiscalQuarter = (dt: DateTime) => {
+  const fiscalMonth = dt.plus({ month: 3 }).month;
+  return Math.floor((fiscalMonth + 2) / 3);
+};

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -138,8 +138,7 @@ export class LanguageEngagement extends Engagement {
 
   readonly pnp: DefinedFile;
 
-  @Field({ nullable: true })
-  readonly pnpData?: PnpData;
+  readonly pnpData?: PnpData; // TODO Remove from here and resolve with new summary in mind
 
   @Field()
   readonly historicGoal: SecuredString;

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -19,7 +19,6 @@ import {
 import { DefinedFile } from '../../file/dto';
 import { Product, SecuredMethodologies } from '../../product/dto';
 import { SecuredInternPosition } from './intern-position.enum';
-import { PnpData } from './pnp-data.dto';
 import { SecuredEngagementStatus } from './status.enum';
 
 /**
@@ -137,8 +136,6 @@ export class LanguageEngagement extends Engagement {
   readonly paratextRegistryId: SecuredString;
 
   readonly pnp: DefinedFile;
-
-  readonly pnpData?: PnpData; // TODO Remove from here and resolve with new summary in mind
 
   @Field()
   readonly historicGoal: SecuredString;

--- a/src/components/engagement/engagement.module.ts
+++ b/src/components/engagement/engagement.module.ts
@@ -16,7 +16,6 @@ import * as handlers from './handlers';
 import { InternshipEngagementResolver } from './internship-engagement.resolver';
 import { InternshipPositionResolver } from './internship-position.resolver';
 import { LanguageEngagementResolver } from './language-engagement.resolver';
-import { PnpExtractor } from './pnp-extractor.service';
 
 @Module({
   imports: [
@@ -38,7 +37,6 @@ import { PnpExtractor } from './pnp-extractor.service';
     EngagementRules,
     EngagementService,
     EngagementRepository,
-    PnpExtractor,
     ...Object.values(handlers),
   ],
   exports: [EngagementService],

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -20,7 +20,6 @@ import {
   InternshipEngagement,
   LanguageEngagement,
   OngoingEngagementStatuses,
-  PnpData,
   UpdateInternshipEngagement,
 } from './dto';
 
@@ -118,11 +117,6 @@ export class EngagementRepository extends CommonRepository {
         relation('out', '', 'mentor', { active: true }),
         node('mentor'),
       ])
-      .optionalMatch([
-        node('node'),
-        relation('out', '', 'pnpData', { active: true }),
-        node('pnpData'),
-      ])
       .return([
         'props',
         'project.id as project',
@@ -132,7 +126,6 @@ export class EngagementRepository extends CommonRepository {
         'intern.id as intern',
         'countryOfOrigin.id as countryOfOrigin',
         'mentor.id as mentor',
-        'pnpData',
         'scopedRoles',
       ])
       .asResult<{
@@ -141,7 +134,6 @@ export class EngagementRepository extends CommonRepository {
           | '__typename'
           | 'ceremony'
           | 'language'
-          | 'pnpData'
           | 'countryOfOrigin'
           | 'intern'
           | 'mentor'
@@ -153,7 +145,6 @@ export class EngagementRepository extends CommonRepository {
         intern: ID;
         countryOfOrigin: ID;
         mentor: ID;
-        pnpData?: Node<PnpData>;
         scopedRoles: ScopedRole[];
       }>();
   }

--- a/src/components/periodic-report/events/index.ts
+++ b/src/components/periodic-report/events/index.ts
@@ -1,0 +1,1 @@
+export * from './periodic-report-uploaded.event';

--- a/src/components/periodic-report/events/periodic-report-uploaded.event.ts
+++ b/src/components/periodic-report/events/periodic-report-uploaded.event.ts
@@ -1,0 +1,14 @@
+import { Session } from '../../../common';
+import { FileVersion } from '../../file';
+import { PeriodicReport } from '../dto';
+
+/**
+ * Dispatched when a new file is uploaded for a periodic report
+ */
+export class PeriodicReportUploadedEvent {
+  constructor(
+    readonly report: PeriodicReport,
+    readonly file: FileVersion,
+    readonly session: Session
+  ) {}
+}

--- a/src/components/periodic-report/periodic-report-engagement-connection.resolver.ts
+++ b/src/components/periodic-report/periodic-report-engagement-connection.resolver.ts
@@ -48,6 +48,25 @@ export class PeriodicReportEngagementConnectionResolver {
   }
 
   @ResolveField(() => SecuredPeriodicReport, {
+    description: 'The latest progress report that has a report submitted',
+  })
+  async latestProgressReportSubmitted(
+    @AnonSession() session: Session,
+    @Parent() engagement: Engagement
+  ): Promise<SecuredPeriodicReport> {
+    const value = await this.service.getLatestReportSubmitted(
+      engagement.id,
+      ReportType.Progress,
+      session
+    );
+    return {
+      canEdit: false,
+      canRead: true,
+      value,
+    };
+  }
+
+  @ResolveField(() => SecuredPeriodicReport, {
     description:
       'The progress report due next. This is the period currently in progress.',
   })

--- a/src/components/periodic-report/periodic-report.module.ts
+++ b/src/components/periodic-report/periodic-report.module.ts
@@ -2,8 +2,9 @@ import { forwardRef, Module } from '@nestjs/common';
 import { DatabaseModule } from '../../core/database/database.module';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { EngagementModule } from '../engagement/engagement.module';
-import { PnpExtractor } from '../engagement/pnp-extractor.service';
 import { FileModule } from '../file/file.module';
+import { ProgressExtractor } from '../progress-summary/progress-extractor.service';
+import { ProgressSummaryRepository } from '../progress-summary/progress-summary.repository';
 import { ProjectModule } from '../project/project.module';
 import { UserModule } from '../user/user.module';
 import * as handlers from './handlers';
@@ -28,7 +29,8 @@ import { PeriodicReportService } from './periodic-report.service';
     PeriodicReportProjectConnectionResolver,
     PeriodicReportEngagementConnectionResolver,
     PeriodicReportRepository,
-    PnpExtractor, // Remove after periodic report migration
+    ProgressExtractor, // Remove after periodic report migration
+    ProgressSummaryRepository, // Remove after periodic report migration
     ...Object.values(handlers),
   ],
   exports: [PeriodicReportService, PeriodicReportRepository],

--- a/src/components/periodic-report/periodic-report.resolver.ts
+++ b/src/components/periodic-report/periodic-report.resolver.ts
@@ -5,6 +5,9 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
+import { Node, node, relation } from 'cypher-query-builder';
+import { first, orderBy, uniqWith } from 'lodash';
+import { DateTime } from 'luxon';
 import {
   AnonSession,
   CalendarDate,
@@ -14,11 +17,17 @@ import {
   Session,
 } from '../../common';
 import { DatabaseService, ILogger, Logger } from '../../core';
-import { EngagementService, LanguageEngagement } from '../engagement';
-import { PnpExtractor } from '../engagement/pnp-extractor.service';
-import { FileService, SecuredFile } from '../file';
+import { EngagementService, LanguageEngagement, PnpData } from '../engagement';
+import { FileService, FileVersion, SecuredFile } from '../file';
+import { ProgressExtractor } from '../progress-summary/progress-extractor.service';
+import { ProgressSummaryRepository } from '../progress-summary/progress-summary.repository';
 import { ProjectService } from '../project';
-import { IPeriodicReport, ReportType, UploadPeriodicReportInput } from './dto';
+import {
+  IPeriodicReport,
+  ProgressReport,
+  ReportType,
+  UploadPeriodicReportInput,
+} from './dto';
 import { PeriodicReportService } from './periodic-report.service';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import asyncPool = require('tiny-async-pool');
@@ -32,7 +41,8 @@ export class PeriodicReportResolver {
     private readonly files: FileService,
     private readonly db: DatabaseService,
     @Logger('periodic-report:migration') private readonly logger: ILogger,
-    private readonly pnp: PnpExtractor
+    private readonly extractor: ProgressExtractor,
+    private readonly summaryRepo: ProgressSummaryRepository
   ) {}
 
   @ResolveField(() => CalendarDate, {
@@ -96,14 +106,30 @@ export class PeriodicReportResolver {
       }
       // can't generate reports with no dates
       if (!mouStart || !mouEnd) return;
+      let narrativeIntervals = [] as any[];
+      let financialIntervals = [] as any[];
+      try {
+        narrativeIntervals = DateInterval.tryFrom(mouStart, mouEnd)
+          .expandToFull('quarters')
+          .splitBy({ quarters: 1 });
+      } catch (exception) {
+        this.logger.error('Error creating narrative intervals', {
+          exception,
+          projectId,
+        });
+      }
 
-      const narrativeIntervals = DateInterval.tryFrom(mouStart, mouEnd)
-        .expandToFull('quarters')
-        .splitBy({ quarters: 1 });
+      try {
+        financialIntervals = DateInterval.tryFrom(mouStart, mouEnd)
+          .expandToFull('months')
+          .splitBy({ months: 1 });
+      } catch (exception) {
+        this.logger.error('Error creating financial intervals', {
+          exception,
+          projectId,
+        });
+      }
 
-      const financialIntervals = DateInterval.tryFrom(mouStart, mouEnd)
-        .expandToFull('months')
-        .splitBy({ months: 1 });
       for (const interval of financialIntervals) {
         try {
           await this.service.create(
@@ -143,7 +169,7 @@ export class PeriodicReportResolver {
       }
     };
     this.logger.info(`starting project sync`);
-    await asyncPool(10, projects, syncProject);
+    await asyncPool(20, projects, syncProject);
     this.logger.info(`project sync finished`);
     return true;
   }
@@ -230,11 +256,18 @@ export class PeriodicReportResolver {
 
       const end =
         useEndOverride && !deleteBothOverrides ? endDateOverride : endDate;
-
-      // dependant booleans of start, end check for non-nullishness already
-      const intervals = DateInterval.tryFrom(start!, end!)
-        .expandToFull('quarters')
-        .splitBy({ quarters: 1 });
+      let intervals = [] as any[];
+      try {
+        // dependant booleans of start, end check for non-nullishness already
+        intervals = DateInterval.tryFrom(start!, end!)
+          .expandToFull('quarters')
+          .splitBy({ quarters: 1 });
+      } catch (exception) {
+        this.logger.error('Error creating progress intervals', {
+          exception,
+          engagementId,
+        });
+      }
 
       for (const interval of intervals) {
         try {
@@ -258,255 +291,369 @@ export class PeriodicReportResolver {
 
     const engagements = await this.engagements.listEngagementsWithDateRange();
     this.logger.info(`starting engagement sync`);
-    await asyncPool(10, engagements, syncEngagement);
+    await asyncPool(20, engagements, syncEngagement);
     this.logger.info(`finished engagement sync`);
 
     return true;
   }
   // Remove after periodic report migration
-  // @Mutation(() => Boolean, {
-  //   description: 'Move P&P files from old schema to new periodic report schema',
-  // })
-  // async migratePnps(@LoggedInSession() session: Session) {
-  //   const migratePnp = async ({
-  //     year: fileNameYear,
-  //     quarter: fileNameQuarter,
-  //     engagementId,
-  //     pnpName,
-  //   }: {
-  //     year: number;
-  //     quarter: number;
-  //     engagementId: ID;
-  //     pnpName: string;
-  //   }) => {
-  //     const getMostRecentFileVersionId = async (eId: ID) => {
-  //       const { mostRecentPnpFileVersionId } = (await this.db
-  //         .query()
-  //         .raw(
-  //           `
-  //           match(e {id: $id})-[:pnpNode { active: true }]->()<-[:parent { active: true }]-(pnpFileVersion)
-  //           return pnpFileVersion.id as mostRecentPnpFileVersionId
-  //           order by pnpFileVersion.createdAt desc
-  //           limit 1
-  //           `,
-  //           { id: eId }
-  //         )
-  //         .asResult<{ mostRecentPnpFileVersionId: ID }>()
-  //         .first()) ?? { mostRecentPnpFileVersionId: null };
-  //       return mostRecentPnpFileVersionId;
-  //     };
-  //     let extractedYear;
-  //     let extractedQuarter;
+  @Mutation(() => Boolean, {
+    description: 'Move P&P files from old schema to new periodic report schema',
+  })
+  async migratePnps() {
+    let count = 1;
+    const migratePnp = async ({
+      year,
+      quarter,
+      planned,
+      actual,
+      variance,
+      latestPnpVersionId,
+      engagementId,
+      extract,
+    }: {
+      year: number;
+      quarter: number;
+      planned: number;
+      actual: number;
+      variance: number;
+      latestPnpVersionId: ID;
+      engagementId: ID;
+      extract: boolean;
+    }) => {
+      count++;
+      if (count % 100 === 0) {
+        this.logger.info(`${count} of ${mapped.length} pnps synced`);
+      }
+      if (!year || !quarter) {
+        this.logger.info({
+          message: 'no year or quarter',
+          engagementId,
+          year,
+          quarter,
+        });
+        return;
+      }
 
-  //     if (!fileNameYear || !fileNameQuarter) {
-  //       const mostRecentId = await getMostRecentFileVersionId(engagementId);
-  //       if (!mostRecentId) {
-  //         this.logger.log({ message: 'no pnp version', engagementId });
-  //         return;
-  //       }
-  //       // this goes into the file itself to see if it can find FY/Q if we're missing it in the file name
-  //       const res = await this.pnp.extractFyAndQuarter(
-  //         { uploadId: mostRecentId },
-  //         session
-  //       );
-  //       extractedYear = res.extractedYear;
-  //       extractedQuarter = res.extractedQuarter;
-  //     }
+      if (!planned && !actual) {
+        this.logger.info({
+          message: 'no progress data',
+          engagementId,
+          planned,
+          actual,
+          variance,
+        });
+        return;
+      }
+      // non-fiscal date
+      const startDate = `${quarter === 1 ? year - 1 : year}-${
+        quarter === 1
+          ? '10'
+          : quarter === 2
+          ? '01'
+          : quarter === 3
+          ? '04'
+          : '07'
+      }-01`;
 
-  //     const year = fileNameYear || extractedYear;
-  //     const quarter = fileNameQuarter || extractedQuarter;
-  //     if (!year || !quarter) {
-  //       this.logger.log({
-  //         message: 'no year or quarter',
-  //         engagementId,
-  //         pnpName,
-  //         year,
-  //         quarter,
-  //       });
-  //       return;
-  //     }
-  //     // non-fiscal date
-  //     const startDate = `${quarter === 1 ? year - 1 : year}-${
-  //       quarter === 1
-  //         ? '10'
-  //         : quarter === 2
-  //         ? '01'
-  //         : quarter === 3
-  //         ? '04'
-  //         : '07'
-  //     }-01`;
+      const pnpDate = CalendarDate.fromISO(startDate);
 
-  //     const pnpDateMillis = CalendarDate.fromISO(startDate).toMillis();
+      // if pnpDate is after end, then assign that pnp to the last reporting period
+      let startToUse;
 
-  //     // if pnpDate is after end, then assign that pnp to the last reporting period
-  //     let startToUse;
+      const { matchingStart } = (await this.db
+        .query()
+        .raw(
+          `match(e:Engagement {id: $id})-[:report { active: true }]->(pr:ProgressReport)-[:start { active: true }]->(start:Property {value: date($startDate)})`,
+          { id: engagementId, startDate }
+        )
+        .return('start.value as matchingStart')
+        .first()) ?? { matchingStart: null };
 
-  //     const { matchingStart } = (await this.db
-  //       .query()
-  //       .raw(
-  //         `match(e:Engagement {id: $id})-[:report { active: true }]->(pr:ProgressReport)-[:start { active: true }]->(start:Property {value: date($startDate)})`,
-  //         { id: engagementId, startDate }
-  //       )
-  //       .return('start.value as matchingStart')
-  //       .first()) ?? { matchingStart: null };
+      if (!matchingStart) {
+        // the start and end of the last reporting period –– if the pnp is from after the PR end
+        // then we map the P&P to that (the last) reporting period
+        const { latestPrStart, latestPrEnd } = (await this.db
+          .query()
+          .match([
+            node('', 'Engagement', { id: engagementId }),
+            relation('out', '', 'report', { active: true }),
+            node('rn', 'PeriodicReport'),
+            relation('out', '', 'start', { active: true }),
+            node('sn', 'Property'),
+          ])
+          .match([
+            node('rn'),
+            relation('out', '', 'end', { active: true }),
+            node('en', 'Property'),
+          ])
+          .return('sn.value as latestStart, en.value as latestEnd')
+          .orderBy('sn.value', 'desc')
+          .limit(1)
+          .asResult<{
+            latestPrStart?: CalendarDate;
+            latestPrEnd?: CalendarDate;
+          }>()
+          .first()) ?? { latestPrStart: undefined, latestPrEnd: undefined };
+        // if we can't match it, leave the P&P where it was and move on
+        if (!latestPrStart || !latestPrEnd) return;
 
-  //     if (!matchingStart) {
-  //       // the start and end of the last reporting period –– if the pnp is from after the PR end
-  //       // then we map the P&P to that (the last) reporting period
-  //       const { latestPrStart, latestPrEnd } = (await this.db
-  //         .query()
-  //         .match([
-  //           node('', 'Engagement', { id: engagementId }),
-  //           relation('out', '', 'report', { active: true }),
-  //           node('rn', 'PeriodicReport'),
-  //           relation('out', '', 'start', { active: true }),
-  //           node('sn', 'Property'),
-  //         ])
-  //         .match([
-  //           node('rn'),
-  //           relation('out', '', 'end', { active: true }),
-  //           node('en', 'Property'),
-  //         ])
-  //         .return('sn.value as latestStart, en.value as latestEnd')
-  //         .orderBy('sn.value', 'desc')
-  //         .limit(1)
-  //         .asResult<{
-  //           latestPrStart?: CalendarDate;
-  //           latestPrEnd?: CalendarDate;
-  //         }>()
-  //         .first()) ?? { latestPrStart: undefined, latestPrEnd: undefined };
-  //       // if we can't match it, leave the P&P where it was and move on
-  //       if (!latestPrStart || !latestPrEnd) return;
+        startToUse = latestPrEnd < pnpDate ? latestPrStart : null;
+      } else {
+        startToUse = matchingStart;
+      }
 
-  //       startToUse =
-  //         latestPrEnd.toMillis() < pnpDateMillis ? latestPrStart : null;
-  //     } else {
-  //       startToUse = matchingStart;
-  //     }
+      // we cannot match a P&P to a report period, so we leave it where it is
+      if (!startToUse) {
+        this.logger.info({ message: 'no start to match on', engagementId });
+        return;
+      }
 
-  //     // we cannot match a P&P to a report period, so we leave it where it is
-  //     if (!startToUse) {
-  //       this.logger.log({ message: 'no start to match on', engagementId });
-  //       return;
-  //     }
+      const existing = await this.db
+        .query()
+        .raw(
+          `
+          match(e {id: $id})-[:report]->(rn)-[:start { active: true }]->({ value: date($startDate) })
+          where (rn)-->(:FileNode)<--(:FileVersion)
+          return rn
+          `,
+          {
+            id: engagementId,
+            startDate: startToUse,
+          }
+        )
+        .first();
+      // if a file has been uploaded to this periodic report, don't move the pnp there, but extract later
+      if (existing) {
+        return;
+      }
 
-  //     // move pnp node file versions to the matching periodic report file node
-  //     // and remove the old parent relationships
-  //     const { reportFileNodeId } = (await this.db
-  //       .query()
-  //       .raw(
-  //         `
-  //         match(e { id: $id })-[:pnpNode { active: true }]->()<-[pnpParentRel:parent { active: true }]-(pnpFileVersion)
-  //         match(e)-[:report]->(rn)-[:start { active: true }]->({ value: date($startDate) })
-  //         match(rn)-[:reportFileNode { active: true }]->(reportFileNode)
-  //         create(pnpFileVersion)-[:parent { active: true, createdAt: pnpFileVersion.createdAt }]->(reportFileNode)
-  //         delete pnpParentRel
-  //         return reportFileNode.id as reportFileNodeId
-  //         `,
-  //         { id: engagementId, startDate: startToUse }
-  //       )
-  //       .first()) ?? { reportFileNodeId: null };
+      // move latest pnp node file version to the matching periodic report file node
+      // and remove the old parent relationship
+      const { reportFileNodeId, periodicReportId } = (await this.db
+        .query()
+        .raw(
+          `
+          match(e { id: $id })-[:pnpNode { active: true }]->(file)<-[pnpParentRel:parent { active: true }]-(pnpFileVersion {id: $latestPnpVersionId})
+          match(e)-[:report]->(rn)-[:start { active: true }]->({ value: date($startDate) })
+          match(rn)-[:reportFileNode { active: true }]->(reportFileNode)
+          create(pnpFileVersion)-[:parent { active: true, createdAt: pnpFileVersion.createdAt }]->(reportFileNode)
+          set pnpFileVersion.originalParentId = file.id
+          delete pnpParentRel
+          return reportFileNode.id as reportFileNodeId, rn.id as periodicReportId
+          `,
+          { id: engagementId, startDate: startToUse, latestPnpVersionId }
+        )
+        .first()) ?? { reportFileNodeId: null, periodicReportId: null };
 
-  //     // deactivate the default PR name node
-  //     await this.db
-  //       .query()
-  //       .raw(
-  //         `
-  //         match(reportFileNode { id: $reportFileNodeId })-[nameRel:name { active: true }]->(name)
-  //         set nameRel.active = false, name:Deleted_Property
-  //         remove name:Property
-  //         return *
-  //         `,
-  //         { reportFileNodeId }
-  //       )
-  //       .run();
+      // deactivate the default PR name node
+      await this.db
+        .query()
+        .raw(
+          `
+          match(reportFileNode { id: $reportFileNodeId })-[nameRel:name { active: true }]->(name)
+          set nameRel.active = false, name:Deleted_Property
+          remove name:Property
+          return *
+          `,
+          { reportFileNodeId }
+        )
+        .run();
 
-  //     // move pnp node name properties to periodic report
-  //     // this is the history of file version names
-  //     await this.db
-  //       .query()
-  //       .raw(
-  //         `
-  //         match(e { id: $id })-[:pnpNode { active: true }]->()-[pnpNameRel:name]->(pnpName)
-  //         match(reportFileNode { id: $reportFileNodeId })
-  //         where not pnpName.value =~ "PNP"
-  //         create(reportFileNode)-[:name { active: pnpNameRel.active, createdAt: pnpName.createdAt }]->(pnpName)
-  //         delete pnpNameRel
-  //         return *
-  //         `,
-  //         { id: engagementId, reportFileNodeId }
-  //       )
-  //       .run();
+      // move most recent (active) pnp node name property to periodic report file node
+      await this.db
+        .query()
+        .raw(
+          `
+          match(e { id: $id })-[:pnpNode { active: true }]->(file)-[pnpNameRel:name {active: true}]->(pnpName)
+          match(reportFileNode { id: $reportFileNodeId })
+          create(reportFileNode)-[:name { active: pnpNameRel.active, createdAt: pnpName.createdAt }]->(pnpName)
+          set pnpName.originalParentId = file.id
+          delete pnpNameRel
+          return *
+          `,
 
-  //     // set default pnp name to active = true
-  //     // it's the only name node left after the previous query
-  //     await this.db
-  //       .query()
-  //       .raw(
-  //         `
-  //         match(e { id: $id })-[p:pnpNode { active: true }]->()-[pnpNameRel:name]->(pnpName)
-  //         set pnpNameRel.active = true, pnpName:Property
-  //         remove pnpName:Deleted_Property
-  //         return *
-  //         `,
-  //         { id: engagementId }
-  //       )
-  //       .run();
-  //   };
+          { id: engagementId, reportFileNodeId }
+        )
+        .run();
 
-  //   // MATCH (e:Engagement)-[:pnpNode { active: true }]->(pn:FileNode)-[:name { active: true }]->(na:Property)
-  //   // where (pn)<--(:FileVersion) and (e)-[:report { active: true }]->(:ProgressReport)
-  //   // RETURN na.value as pnpName, e.id as engagementId
-  //   // get all engagements with previously uploaded P&Ps in the former designated location
+      // set next most recent pnp name to active
+      await this.db
+        .query()
+        .raw(
+          `
+          match(e { id: $id })-[p:pnpNode { active: true }]->()-[pnpNameRel:name]->(pnpName)
+          with e, pnpNameRel, pnpName
+          order by pnpName.createdAt desc limit 1
+          set pnpNameRel.active = true, pnpName:Property
+          remove pnpName:Deleted_Property
+          return *
+          `,
+          { id: engagementId }
+        )
+        .run();
 
-  //   // group P&P file versions by periodic report before moving
-  //   const ress = this.db
-  //     .query()
-  //     .match([
-  //       node('e', 'Engagement'),
-  //       relation('out', '', 'pnpNode', { active: true }),
-  //       node('pn', 'FileNode'),
-  //       relation('out', '', 'name', { active: true }),
-  //       node('na', 'Property'),
-  //     ])
-  //     // ensure the engagement has periodic reports generated
-  //     // we didn't generate them if project is missing one of its dates (per Seth)
-  //     .match([
-  //       node('e'),
-  //       relation('out', '', 'report', { active: true }),
-  //       node('rn', 'ProgressReport'),
-  //     ])
-  //     // these are engagements that have a previously uploaded P&P
-  //     .raw(`where (pn)<--(:FileVersion)`)
-  //     .with(
-  //       `
-  //       {
-  //         pnpName: na.value,
-  //         engagementId: e.id
-  //       } as engagementData
-  //       `
-  //     )
-  //     .return('distinct(engagementData)')
-  //     .asResult<{
-  //       engagementData: {
-  //         pnpName: string;
-  //         engagementId: ID;
-  //       };
-  //     }>();
+      // we create this after the fact if we have more than one pnp data node with the same year and quarter
+      if (!extract) {
+        const createdAt = DateTime.local();
 
-  //   const res = await ress.run();
+        // write pnp data to new progress node
+        await this.db
+          .query()
+          .raw(
+            `
+        match(pr{id:$periodicReportId})
+        create(pr)-[:summary{active: true, createdAt: $createdAt}]->(:ProgressSummary{planned: $planned, actual: $actual, variance: $variance})
+      `,
+            {
+              periodicReportId,
+              createdAt,
+              planned: planned,
+              actual: actual,
+              variance,
+            }
+          )
+          .run();
+      }
 
-  //   const mapped = res.map(({ engagementData }) => {
-  //     const { year, quarter } = this.pnp.parseYearAndQuarter(
-  //       engagementData.pnpName
-  //     );
-  //     return { ...engagementData, year, quarter };
-  //   });
+      // delete old pnp data node
+      await this.db
+        .query()
+        .match([
+          node('e', 'Engagement', { id: engagementId }),
+          relation('out', 'pdr', 'pnpData', { active: true }),
+          node('pd'),
+        ])
+        .raw(
+          `
+          set pdr.active = false, pd:Deleted_PnpData
+          remove pd:PnpData
+        `
+        )
+        .run();
 
-  //   await asyncPool(30, mapped, migratePnp);
+      // steps to reverse pnp migration
+      // 1. Move migrated file version nodes back to original parent using originalParentId on file version node
+      // 2. Deactivate active name on pnpNode (this would be the previous version when the migrated file version was present before)
+      // 3. Move migrated name to original parent using same method as 1
+      // 4. Reactivate default report file node name property
+      // 5. Detach/Delete all (:ProgressSummary) nodes
+      // 6. Restore all pnpData nodes that were marked with label (:Deleted_PnpData) and set pnpData relationships to active
+    };
 
-  //   return true;
-  // }
+    const res = await this.db
+      .query()
+      .match([
+        node('e', 'Engagement'),
+        relation('out', '', 'pnpData', { active: true }),
+        node('pn', 'PnpData'),
+      ])
+      // ensure engagement has progress reports
+      .raw(`where (e)-->(:ProgressReport)`)
+      .with('e, collect(pn) as pnpDataNodes')
+      .subQuery((sub) =>
+        sub
+          .with('e')
+          .match([
+            node('e'),
+            relation('out', '', 'pnpNode', { active: true }),
+            node('', 'FileNode'),
+            relation('in', '', 'parent', { active: true }),
+            node('fv', 'FileVersion'),
+          ])
+          .return('fv.id as latestPnpVersionId')
+          .orderBy('fv.createdAt', 'desc')
+          .limit(1)
+      )
+      .return('pnpDataNodes, e.id as engagementId, latestPnpVersionId')
+      .asResult<{
+        engagementId: ID;
+        latestPnpVersionId: ID;
+        pnpDataNodes: Array<Node<PnpData>>;
+      }>()
+      .run();
+    const mapped = res.map(({ pnpDataNodes, ...rest }) => {
+      const pnpProps = pnpDataNodes.map((n) => n.properties);
+
+      const dups = uniqWith(
+        pnpProps,
+        (a, b) => a.year === b.year && a.quarter === b.quarter
+      );
+
+      const latestPnpData = first(
+        orderBy(pnpProps, ['year', 'quarter'], ['desc', 'desc'])
+      )!;
+
+      return {
+        planned: latestPnpData.progressPlanned,
+        actual: latestPnpData.progressActual,
+        extract: dups.length !== pnpProps.length,
+        ...latestPnpData,
+        ...rest,
+      };
+    });
+
+    this.logger.info(`starting pnp migration`);
+    await asyncPool(5, mapped, migratePnp);
+    this.logger.info(`finished pnp migration`);
+
+    return true;
+  }
+
+  // Remove after periodic report migration
+  @Mutation(() => Boolean, {
+    description:
+      'Extract progress from P&Ps attached to reports that have no Progress Summary',
+  })
+  async extractProgress() {
+    const pnpsToExtract = await this.db
+      .query()
+      .match([
+        node('e', 'Engagement'),
+        relation('out', '', 'report', { active: true }),
+        node('pr', 'ProgressReport'),
+      ])
+      .raw(
+        `where (pr)-->(:FileNode)<--(:FileVersion) and not (pr)-->(:ProgressSummary)`
+      )
+      .subQuery((sub) =>
+        sub
+          .with('pr')
+          .match([
+            node('pr'),
+            relation('out', '', 'reportFileNode', { active: true }),
+            node('', 'FileNode'),
+            relation('in', '', 'parent', { active: true }),
+            node('fv', 'FileVersion'),
+          ])
+          .return('fv.id as latestFileVersionId')
+          .orderBy('fv.createdAt', 'desc')
+          .limit(1)
+      )
+      .return('pr.id as reportId, latestFileVersionId')
+      .asResult<{ reportId: ID; latestFileVersionId: ID }>()
+      .run();
+
+    for (const pnp of pnpsToExtract) {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const extracted = await this.extractor.extract({
+        id: pnp.latestFileVersionId,
+        // the extracting only requires the id
+      } as FileVersion);
+      // do nothing
+      if (!extracted) {
+        return;
+      }
+
+      await this.summaryRepo.save(
+        // as above, we only need the id to save the data
+        { id: pnp.reportId } as unknown as ProgressReport,
+        extracted
+      );
+    }
+
+    return true;
+  }
 
   @ResolveField(() => SecuredFile)
   async reportFile(

--- a/src/components/periodic-report/periodic-report.service.ts
+++ b/src/components/periodic-report/periodic-report.service.ts
@@ -5,7 +5,6 @@ import {
   generateId,
   ID,
   NotFoundException,
-  NotImplementedException,
   ServerException,
   Session,
 } from '../../common';
@@ -218,8 +217,11 @@ export class PeriodicReportService {
     type: ReportType,
     session: Session
   ): Promise<PeriodicReport | undefined> {
-    // TODO
-    throw new NotImplementedException().with(parentId, type, session);
+    const res = await this.repo.getLatestReportSubmitted(parentId, type);
+    if (!res) {
+      return undefined;
+    }
+    return await this.readOne(res.id, session);
   }
 
   async listEngagementReports(

--- a/src/components/periodic-report/periodic-report.service.ts
+++ b/src/components/periodic-report/periodic-report.service.ts
@@ -5,6 +5,7 @@ import {
   generateId,
   ID,
   NotFoundException,
+  NotImplementedException,
   ServerException,
   Session,
 } from '../../common';
@@ -210,6 +211,15 @@ export class PeriodicReportService {
       CalendarDate.local(),
       session
     );
+  }
+
+  async getLatestReportSubmitted(
+    parentId: ID,
+    type: ReportType,
+    session: Session
+  ): Promise<PeriodicReport | undefined> {
+    // TODO
+    throw new NotImplementedException().with(parentId, type, session);
   }
 
   async listEngagementReports(

--- a/src/components/progress-summary/dto/index.ts
+++ b/src/components/progress-summary/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './progress-summary.dto';

--- a/src/components/progress-summary/dto/progress-summary.dto.ts
+++ b/src/components/progress-summary/dto/progress-summary.dto.ts
@@ -1,0 +1,24 @@
+import { Field, Float, ObjectType } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
+import { keys as keysOf } from 'ts-transformer-keys';
+import { SecuredProps } from '../../../common';
+
+@ObjectType({
+  description: stripIndent`
+    Product progress summary data for the a given progress report.
+    Currently parsed out of the pnp report file.
+  `,
+})
+export abstract class ProgressSummary {
+  static readonly Props = keysOf<ProgressSummary>();
+  static readonly SecuredProps = keysOf<SecuredProps<ProgressSummary>>();
+
+  @Field(() => Float)
+  planned: number;
+
+  @Field(() => Float)
+  actual: number;
+
+  @Field(() => Float)
+  variance: number;
+}

--- a/src/components/progress-summary/handlers/extract-pnp-file-on-upload.handler.ts
+++ b/src/components/progress-summary/handlers/extract-pnp-file-on-upload.handler.ts
@@ -1,7 +1,6 @@
 import { EventsHandler } from '../../../core';
 import { ReportType } from '../../periodic-report/dto';
 import { PeriodicReportUploadedEvent } from '../../periodic-report/events';
-import { ProgressSummary } from '../dto';
 import { ProgressExtractor } from '../progress-extractor.service';
 import { ProgressSummaryRepository } from '../progress-summary.repository';
 
@@ -17,15 +16,11 @@ export class ExtractPnpFileOnUploadHandler {
       return;
     }
 
-    const extracted: ProgressSummary | null = await this.extractor.extract(
-      event.file.id,
-      event.session
-    );
-
-    if (!extracted) {
+    const summary = await this.extractor.extract(event.file);
+    if (!summary) {
       return; // error already logged
     }
 
-    await this.repo.save(event.report, extracted);
+    await this.repo.save(event.report, summary);
   }
 }

--- a/src/components/progress-summary/handlers/extract-pnp-file-on-upload.handler.ts
+++ b/src/components/progress-summary/handlers/extract-pnp-file-on-upload.handler.ts
@@ -1,0 +1,24 @@
+import { EventsHandler } from '../../../core';
+import { ReportType } from '../../periodic-report/dto';
+import { PeriodicReportUploadedEvent } from '../../periodic-report/events';
+import { ProgressSummary } from '../dto';
+import { ProgressSummaryRepository } from '../progress-summary.repository';
+
+@EventsHandler(PeriodicReportUploadedEvent)
+export class ExtractPnpFileOnUploadHandler {
+  constructor(private readonly repo: ProgressSummaryRepository) {}
+
+  async handle(event: PeriodicReportUploadedEvent) {
+    if (event.report.type !== ReportType.Progress) {
+      return;
+    }
+
+    const extracted: ProgressSummary | null = null; // TODO
+
+    if (!extracted) {
+      return; // error already logged
+    }
+
+    await this.repo.save(event.report, extracted);
+  }
+}

--- a/src/components/progress-summary/handlers/extract-pnp-file-on-upload.handler.ts
+++ b/src/components/progress-summary/handlers/extract-pnp-file-on-upload.handler.ts
@@ -2,18 +2,25 @@ import { EventsHandler } from '../../../core';
 import { ReportType } from '../../periodic-report/dto';
 import { PeriodicReportUploadedEvent } from '../../periodic-report/events';
 import { ProgressSummary } from '../dto';
+import { ProgressExtractor } from '../progress-extractor.service';
 import { ProgressSummaryRepository } from '../progress-summary.repository';
 
 @EventsHandler(PeriodicReportUploadedEvent)
 export class ExtractPnpFileOnUploadHandler {
-  constructor(private readonly repo: ProgressSummaryRepository) {}
+  constructor(
+    private readonly repo: ProgressSummaryRepository,
+    private readonly extractor: ProgressExtractor
+  ) {}
 
   async handle(event: PeriodicReportUploadedEvent) {
     if (event.report.type !== ReportType.Progress) {
       return;
     }
 
-    const extracted: ProgressSummary | null = null; // TODO
+    const extracted: ProgressSummary | null = await this.extractor.extract(
+      event.file.id,
+      event.session
+    );
 
     if (!extracted) {
       return; // error already logged

--- a/src/components/progress-summary/handlers/index.ts
+++ b/src/components/progress-summary/handlers/index.ts
@@ -1,0 +1,1 @@
+export * from './extract-pnp-file-on-upload.handler';

--- a/src/components/progress-summary/progress-extractor.service.ts
+++ b/src/components/progress-summary/progress-extractor.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { read, utils, WorkBook } from 'xlsx';
-import { ID, Session } from '../../common';
 import { ILogger, Logger } from '../../core';
 import { FileService, FileVersion } from '../file';
 import { ProgressSummary } from './dto';
@@ -35,17 +34,9 @@ export class ProgressExtractor {
     return { extractedYear: 0, extractedQuarter: 0 };
   }
 
-  async extract(
-    versionId: ID,
-    session: Session
-  ): Promise<ProgressSummary | null> {
-    const file = await this.files.getFileVersion(versionId, session);
+  async extract(file: FileVersion): Promise<ProgressSummary | null> {
     const pnp = await this.downloadWorkbook(file);
-    const workbookData = this.parseWorkbook(pnp, file);
-    if (!workbookData) {
-      return null;
-    }
-    return workbookData;
+    return this.parseWorkbook(pnp, file);
   }
 
   private parseWorkbook(pnp: WorkBook, file: FileVersion) {

--- a/src/components/progress-summary/progress-extractor.service.ts
+++ b/src/components/progress-summary/progress-extractor.service.ts
@@ -10,29 +10,6 @@ export class ProgressExtractor {
     private readonly files: FileService,
     @Logger('progress:extractor') private readonly logger: ILogger
   ) {}
-  // Remove after periodic report migration
-  async extractFyAndQuarter(
-    input: CreateDefinedFileVersionInput,
-    session: Session
-  ): Promise<{ extractedYear: number; extractedQuarter: number }> {
-    const file = await this.files.getFileVersion(input.uploadId, session);
-    const pnp = await this.downloadWorkbook(file);
-    const sheet = pnp.Sheets.Progress;
-
-    const rows = utils.sheet_to_json<any>(sheet, {
-      header: 'A',
-      raw: false,
-    });
-    for (const row of rows) {
-      if (row?.AE === 'Verse Equivalents in Project     =======>') {
-        return {
-          extractedYear: Number(row.AB),
-          extractedQuarter: Number(row.AA.replace('Q', '')),
-        };
-      }
-    }
-    return { extractedYear: 0, extractedQuarter: 0 };
-  }
 
   async extract(file: FileVersion): Promise<ProgressSummary | null> {
     const pnp = await this.downloadWorkbook(file);

--- a/src/components/progress-summary/progress-report-connection.resolver.ts
+++ b/src/components/progress-summary/progress-report-connection.resolver.ts
@@ -1,0 +1,17 @@
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { AnonSession, NotImplementedException, Session } from '../../common';
+import { ProgressReport } from '../periodic-report';
+import { ProgressSummary } from './dto';
+
+@Resolver(ProgressReport)
+export class ProgressReportConnectionResolver {
+  @ResolveField(() => ProgressSummary, {
+    nullable: true,
+  })
+  async summary(
+    @Parent() report: ProgressReport,
+    @AnonSession() session: Session
+  ): Promise<ProgressSummary | null> {
+    throw new NotImplementedException().with(report, session);
+  }
+}

--- a/src/components/progress-summary/progress-report-connection.resolver.ts
+++ b/src/components/progress-summary/progress-report-connection.resolver.ts
@@ -1,5 +1,4 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { AnonSession, Session } from '../../common';
 import { ProgressReport } from '../periodic-report';
 import { ProgressSummary } from './dto';
 import { ProgressSummaryRepository } from './progress-summary.repository';
@@ -12,9 +11,8 @@ export class ProgressReportConnectionResolver {
     nullable: true,
   })
   async summary(
-    @Parent() report: ProgressReport,
-    @AnonSession() session: Session
+    @Parent() report: ProgressReport
   ): Promise<ProgressSummary | undefined> {
-    return await this.repo.readOne(report.id, session);
+    return await this.repo.readOne(report.id);
   }
 }

--- a/src/components/progress-summary/progress-report-connection.resolver.ts
+++ b/src/components/progress-summary/progress-report-connection.resolver.ts
@@ -1,17 +1,20 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { AnonSession, NotImplementedException, Session } from '../../common';
+import { AnonSession, Session } from '../../common';
 import { ProgressReport } from '../periodic-report';
 import { ProgressSummary } from './dto';
+import { ProgressSummaryRepository } from './progress-summary.repository';
 
 @Resolver(ProgressReport)
 export class ProgressReportConnectionResolver {
+  constructor(private readonly repo: ProgressSummaryRepository) {}
+
   @ResolveField(() => ProgressSummary, {
     nullable: true,
   })
   async summary(
     @Parent() report: ProgressReport,
     @AnonSession() session: Session
-  ): Promise<ProgressSummary | null> {
-    throw new NotImplementedException().with(report, session);
+  ): Promise<ProgressSummary | undefined> {
+    return await this.repo.readOne(report.id, session);
   }
 }

--- a/src/components/progress-summary/progress-summary-engagement-connection.resolver.ts
+++ b/src/components/progress-summary/progress-summary-engagement-connection.resolver.ts
@@ -29,7 +29,7 @@ export class ProgressSummaryEngagementConnectionResolver {
       return undefined;
     }
 
-    const summary = await this.repo.readOne(report.id, session);
+    const summary = await this.repo.readOne(report.id);
     if (!summary) {
       return undefined;
     }

--- a/src/components/progress-summary/progress-summary-engagement-connection.resolver.ts
+++ b/src/components/progress-summary/progress-summary-engagement-connection.resolver.ts
@@ -1,0 +1,45 @@
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { AnonSession, fiscalQuarter, fiscalYear, Session } from '../../common';
+import { LanguageEngagement, PnpData } from '../engagement';
+import { PeriodicReportService, ReportType } from '../periodic-report';
+import { ProgressSummaryRepository } from './progress-summary.repository';
+
+@Resolver(LanguageEngagement)
+export class ProgressSummaryEngagementConnectionResolver {
+  constructor(
+    private readonly repo: ProgressSummaryRepository,
+    private readonly reports: PeriodicReportService
+  ) {}
+
+  @ResolveField(() => PnpData, {
+    nullable: true,
+    deprecationReason:
+      'Use LanguageEngagement.latestProgressReportSubmitted.summary instead',
+  })
+  async pnpData(
+    @Parent() engagement: LanguageEngagement,
+    @AnonSession() session: Session
+  ): Promise<PnpData | undefined> {
+    const report = await this.reports.getLatestReportSubmitted(
+      engagement.id,
+      ReportType.Progress,
+      session
+    );
+    if (!report) {
+      return undefined;
+    }
+
+    const summary = await this.repo.readOne(report.id, session);
+    if (!summary) {
+      return undefined;
+    }
+
+    return {
+      progressPlanned: summary.planned,
+      progressActual: summary.actual,
+      variance: summary.variance,
+      year: fiscalYear(report.start),
+      quarter: fiscalQuarter(report.start),
+    };
+  }
+}

--- a/src/components/progress-summary/progress-summary.module.ts
+++ b/src/components/progress-summary/progress-summary.module.ts
@@ -1,11 +1,15 @@
 import { Module } from '@nestjs/common';
+import { PeriodicReportModule } from '../periodic-report/periodic-report.module';
 import * as handlers from './handlers';
 import { ProgressReportConnectionResolver } from './progress-report-connection.resolver';
+import { ProgressSummaryEngagementConnectionResolver } from './progress-summary-engagement-connection.resolver';
 import { ProgressSummaryRepository } from './progress-summary.repository';
 
 @Module({
+  imports: [PeriodicReportModule],
   providers: [
     ProgressReportConnectionResolver,
+    ProgressSummaryEngagementConnectionResolver,
     ProgressSummaryRepository,
     ...Object.values(handlers),
   ],

--- a/src/components/progress-summary/progress-summary.module.ts
+++ b/src/components/progress-summary/progress-summary.module.ts
@@ -1,16 +1,19 @@
 import { Module } from '@nestjs/common';
+import { FileModule } from '../file/file.module';
 import { PeriodicReportModule } from '../periodic-report/periodic-report.module';
 import * as handlers from './handlers';
+import { ProgressExtractor } from './progress-extractor.service';
 import { ProgressReportConnectionResolver } from './progress-report-connection.resolver';
 import { ProgressSummaryEngagementConnectionResolver } from './progress-summary-engagement-connection.resolver';
 import { ProgressSummaryRepository } from './progress-summary.repository';
 
 @Module({
-  imports: [PeriodicReportModule],
+  imports: [PeriodicReportModule, FileModule],
   providers: [
     ProgressReportConnectionResolver,
     ProgressSummaryEngagementConnectionResolver,
     ProgressSummaryRepository,
+    ProgressExtractor,
     ...Object.values(handlers),
   ],
 })

--- a/src/components/progress-summary/progress-summary.module.ts
+++ b/src/components/progress-summary/progress-summary.module.ts
@@ -1,7 +1,13 @@
 import { Module } from '@nestjs/common';
+import * as handlers from './handlers';
 import { ProgressReportConnectionResolver } from './progress-report-connection.resolver';
+import { ProgressSummaryRepository } from './progress-summary.repository';
 
 @Module({
-  providers: [ProgressReportConnectionResolver],
+  providers: [
+    ProgressReportConnectionResolver,
+    ProgressSummaryRepository,
+    ...Object.values(handlers),
+  ],
 })
 export class ProgressSummaryModule {}

--- a/src/components/progress-summary/progress-summary.module.ts
+++ b/src/components/progress-summary/progress-summary.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { ProgressReportConnectionResolver } from './progress-report-connection.resolver';
+
+@Module({
+  providers: [ProgressReportConnectionResolver],
+})
+export class ProgressSummaryModule {}

--- a/src/components/progress-summary/progress-summary.repository.ts
+++ b/src/components/progress-summary/progress-summary.repository.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { NotImplementedException } from '../../common';
+import { DtoRepository } from '../../core';
+import { ProgressReport } from '../periodic-report/dto';
+import { ProgressSummary } from './dto';
+
+@Injectable()
+export class ProgressSummaryRepository extends DtoRepository(ProgressSummary) {
+  async save(report: ProgressReport, data: ProgressSummary) {
+    throw new NotImplementedException().with(report, data);
+  }
+}

--- a/src/components/progress-summary/progress-summary.repository.ts
+++ b/src/components/progress-summary/progress-summary.repository.ts
@@ -1,11 +1,18 @@
 import { Injectable } from '@nestjs/common';
-import { NotImplementedException } from '../../common';
+import { ID, NotImplementedException, Session } from '../../common';
 import { DtoRepository } from '../../core';
 import { ProgressReport } from '../periodic-report/dto';
 import { ProgressSummary } from './dto';
 
 @Injectable()
 export class ProgressSummaryRepository extends DtoRepository(ProgressSummary) {
+  async readOne(
+    reportId: ID,
+    session: Session
+  ): Promise<ProgressSummary | undefined> {
+    throw new NotImplementedException().with(reportId, session);
+  }
+
   async save(report: ProgressReport, data: ProgressSummary) {
     throw new NotImplementedException().with(report, data);
   }

--- a/src/components/progress-summary/progress-summary.repository.ts
+++ b/src/components/progress-summary/progress-summary.repository.ts
@@ -22,20 +22,14 @@ export class ProgressSummaryRepository extends DtoRepository(ProgressSummary) {
   }
 
   async save(report: ProgressReport, data: ProgressSummary) {
-    const query = this.db.query();
-    data
-      ? query.merge([
-          node('', 'ProgressReport', { id: report.id }),
-          relation('out', '', 'summary', { active: true }),
-          node('', 'ProgressSummary', data),
-        ])
-      : query
-          .match([
-            node('', 'ProgressReport', { id: report.id }),
-            relation('out', '', 'summary', { active: true }),
-            node('ps', 'ProgressSummary'),
-          ])
-          .detachDelete('ps');
-    await query.run();
+    await this.db
+      .query()
+      .merge([
+        node('', 'ProgressReport', { id: report.id }),
+        relation('out', '', 'summary', { active: true }),
+        node('summary', 'ProgressSummary'),
+      ])
+      .setValues({ summary: data })
+      .run();
   }
 }


### PR DESCRIPTION
This moves parsing and storing of pnp progress summary data from
 ```
LanguageEngagement -> PnpData
``` 
to 
```
ProgressReport -> ProgressSummary
```

Backwards compatibility is maintained for reading. However, new files uploaded to engagement.pnp no longer have their summary data parsed. Instead this is only done for progress report files. 

--- 

Wait to merge & deploy until after Blake's pnp migration is ran.