### PR TITLE
Fix latest report submitted query

### DIFF
--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -159,7 +159,7 @@ export class PeriodicReportRepository extends DtoRepository(IPeriodicReport) {
     return await this.db
       .query()
       .match([
-        node('', '', { id: parentId }),
+        node('', 'BaseNode', { id: parentId }),
         relation('out', '', 'report', { active: true }),
         node('pr', `${type}Report`),
         relation('out', '', 'start', { active: true }),


### PR DESCRIPTION
CQB doesn't like empty string for missing label, but rather undefined.
Better to match BaseNode label anyways.