### PR TITLE
Rename product medium OralTranslation > TrainedStoryTellers

### DIFF
--- a/src/components/product/dto/product-medium.ts
+++ b/src/components/product/dto/product-medium.ts
@@ -12,8 +12,6 @@ export enum ProductMedium {
   EBook = 'EBook',
   App = 'App',
   TrainedStoryTellers = 'TrainedStoryTellers',
-  OBSTrainers = 'OBSTrainers',
-  OralTranslation = 'OralTranslation',
   Audio = 'Audio',
   Video = 'Video',
   Other = 'Other',


### PR DESCRIPTION
- Remove `OBSTrainers` per Seth. We have no instances of this value in the db. 