### PR TITLE
Periodic Report query improvements

### DIFF
--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -1,16 +1,20 @@
 import { Injectable } from '@nestjs/common';
 import { stripIndent } from 'common-tags';
-import { node, relation } from 'cypher-query-builder';
+import { node, Query, relation } from 'cypher-query-builder';
 import { Dictionary } from 'lodash';
 import { DateTime, Interval } from 'luxon';
-import { CalendarDate, ID, Session } from '../../common';
-import { DtoRepository, matchRequestingUser, property } from '../../core';
+import {
+  CalendarDate,
+  ID,
+  NotFoundException,
+  UnsecuredDto,
+} from '../../common';
+import { DtoRepository, property } from '../../core';
 import {
   calculateTotalAndPaginateList,
   deleteBaseNode,
-  matchPropList,
+  matchProps,
 } from '../../core/database/query';
-import { DbPropsOfDto, StandardReadResult } from '../../core/database/results';
 import {
   CreatePeriodicReport,
   FinancialReport,
@@ -74,21 +78,23 @@ export class PeriodicReportRepository extends DtoRepository(IPeriodicReport) {
       .run();
   }
 
-  async readOne(id: ID, session: Session) {
+  async readOne(id: ID) {
     const query = this.db
       .query()
-      .apply(matchRequestingUser(session))
       .match([node('node', 'PeriodicReport', { id })])
-      .apply(matchPropList)
-      .optionalMatch([
-        node('node'),
-        relation('out', '', 'reportFile', { active: true }),
-        node('reportFile', 'File'),
-      ])
-      .return('node, propList')
-      .asResult<StandardReadResult<DbPropsOfDto<PeriodicReport>>>();
+      .apply(this.hydrate())
+      .return('dto')
+      .asResult<{ dto: UnsecuredDto<PeriodicReport> }>();
 
-    return await query.first();
+    const result = await query.first();
+    if (!result) {
+      throw new NotFoundException(
+        'Could not find periodic report',
+        'periodicReport.id'
+      );
+    }
+
+    return result.dto;
   }
 
   listProjectReports(
@@ -116,29 +122,22 @@ export class PeriodicReportRepository extends DtoRepository(IPeriodicReport) {
     reportType: ReportType,
     date: CalendarDate
   ) {
-    return await this.db
+    const res = await this.db
       .query()
       .match([
         node('baseNode', 'BaseNode', { id: parentId }),
         relation('out', '', 'report', { active: true }),
         node('node', `${reportType}Report`),
       ])
-      .match([
-        node('node'),
-        relation('out', '', 'start', { active: true }),
-        node('start', 'Property'),
-      ])
-      .match([
-        node('node'),
-        relation('out', '', 'end', { active: true }),
-        node('end', 'Property'),
-      ])
-      .raw(`WHERE start.value <= $date AND end.value >= $date`, {
+      .apply(this.hydrate())
+      .raw(`WHERE dto.start <= $date AND dto.end >= $date`, {
         date,
       })
-      .return('node.id as id')
-      .asResult<{ id: ID }>()
+      .return('dto')
+      .limit(1)
+      .asResult<{ dto: UnsecuredDto<PeriodicReport> }>()
       .first();
+    return res?.dto;
   }
 
   listEngagementReports(
@@ -156,21 +155,32 @@ export class PeriodicReportRepository extends DtoRepository(IPeriodicReport) {
   }
 
   async getLatestReportSubmitted(parentId: ID, type: ReportType) {
-    return await this.db
+    const res = await this.db
       .query()
       .match([
         node('', 'BaseNode', { id: parentId }),
         relation('out', '', 'report', { active: true }),
-        node('pr', `${type}Report`),
+        node('node', `${type}Report`),
         relation('out', '', 'start', { active: true }),
         node('sn', 'Property'),
       ])
-      .raw(`where (pr)-->(:FileNode)<--(:FileVersion)`)
-      .return('pr.id as id')
+      .raw(`where (node)-->(:FileNode)<--(:FileVersion)`)
+      .with('node, sn')
       .orderBy('sn.value', 'desc')
       .limit(1)
-      .asResult<{ id: ID }>()
+      .apply(this.hydrate())
+      .return('dto')
+      .asResult<{ dto: UnsecuredDto<PeriodicReport> }>()
       .first();
+    return res?.dto;
+  }
+
+  /**
+   * Given a `(node:PeriodicReport)`
+   * output `dto as UnsecuredDto<PeriodicReport>`
+   */
+  private hydrate() {
+    return (q: Query) => q.apply(matchProps()).with('props as dto');
   }
 
   async delete(baseNodeId: ID, type: ReportType, intervals: Interval[]) {


### PR DESCRIPTION
- `getLatestReportSubmitted`
  - Doesn't need an additional `readOne` query
- `getCurrentReportDue`
  - Doesn't need a `Project.readOne` query to determine previous period
  - Doesn't need an additional `readOne` query
- `getNextReportDue`
  - Now looks ahead to the next report that is due in the future, even if that's passed the current period timeframe.
    Fixes #1931
  - Doesn't need an additional `readOne` query

This removes 3 db queries on the project overview page.