### PR TITLE
More Repository clean up

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -60,6 +60,16 @@ rules:
             - ServiceUnavailableException
             - GatewayTimeoutException
           message: Use our exceptions in common folder instead
+        - name: lodash
+          importNames: [Dictionary, NumericDictionary, AnyKindOfDictionary]
+          message: Use a type with strict keys instead
+        - name: ts-essentials
+          importNames: [Dictionary, SafeDictionary]
+          message: Use a type with strict keys instead
+        - name: express-serve-static-core
+          importNames: [Dictionary]
+          message: Use a type with strict keys instead
+
   no-restricted-syntax:
     - error
     - selector: NewExpression[callee.name="Logger"]

--- a/src/components/authentication/authentication.service.ts
+++ b/src/components/authentication/authentication.service.ts
@@ -28,33 +28,29 @@ interface JwtPayload {
 @Injectable()
 export class AuthenticationService {
   constructor(
-    // private readonly db: DatabaseService,
     private readonly config: ConfigService,
     private readonly crypto: CryptoService,
     private readonly email: EmailService,
     private readonly userService: UserService,
     private readonly authorizationService: AuthorizationService,
     @Logger('authentication:service') private readonly logger: ILogger,
-    private readonly authenticationRepo: AuthenticationRepository
+    private readonly repo: AuthenticationRepository
   ) {}
 
   async createToken(): Promise<string> {
     const token = this.encodeJWT();
 
-    const result = await this.authenticationRepo.createToken(token);
-    if (!result) {
-      throw new ServerException('Failed to start session');
-    }
-    return result.token;
+    await this.repo.saveSessionToken(token);
+    return token;
   }
 
   async userFromSession(session: Session): Promise<User | null> {
-    const userRes = await this.authenticationRepo.userFromSession(session);
-    if (!userRes) {
+    const userId = await this.repo.getUserFromSession(session);
+    if (!userId) {
       return null;
     }
 
-    return await this.userService.readOne(userRes.id, session);
+    return await this.userService.readOne(userId, session);
   }
 
   async register(input: RegisterInput, session?: Session): Promise<ID> {
@@ -75,29 +71,29 @@ export class AuthenticationService {
     }
 
     const passwordHash = await this.crypto.hash(input.password);
-    await this.authenticationRepo.register(userId, passwordHash);
+    await this.repo.savePasswordHashOnUser(userId, passwordHash);
 
     return userId;
   }
 
   async login(input: LoginInput, session: Session): Promise<ID> {
-    const result1 = await this.authenticationRepo.login1(input, session);
+    const hash = await this.repo.getPasswordHash(input, session);
 
-    if (!(await this.crypto.verify(result1?.pash, input.password))) {
+    if (!(await this.crypto.verify(hash, input.password))) {
       throw new UnauthenticatedException('Invalid credentials');
     }
 
-    const result2 = await this.authenticationRepo.login2(input, session);
+    const userId = await this.repo.connectSessionToUser(input, session);
 
-    if (!result2 || !result2.id) {
+    if (!userId) {
       throw new ServerException('Login failed');
     }
 
-    return result2.id;
+    return userId;
   }
 
   async logout(token: string): Promise<void> {
-    await this.authenticationRepo.logout(token);
+    await this.repo.deleteSessionToken(token);
   }
 
   async createSession(token: string): Promise<RawSession> {
@@ -105,9 +101,7 @@ export class AuthenticationService {
 
     const { iat } = this.decodeJWT(token);
 
-    // check token in db to verify the user id and owning org id.
-
-    const result = await this.authenticationRepo.createSession(token);
+    const result = await this.repo.findSessionToken(token);
 
     if (!result) {
       this.logger.debug('Failed to find active token in database', { token });
@@ -117,9 +111,9 @@ export class AuthenticationService {
       );
     }
 
-    const roles = await this.authorizationService.getUserGlobalRoles(
-      result.userId
-    );
+    const roles = result.userId
+      ? await this.authorizationService.getUserGlobalRoles(result.userId)
+      : [];
 
     const session = {
       token,
@@ -139,31 +133,28 @@ export class AuthenticationService {
     if (!oldPassword)
       throw new InputException('Old Password Required', 'oldPassword');
 
-    const result = await this.authenticationRepo.changePassword(session);
+    const hash = await this.repo.getCurrentPasswordHash(session);
 
-    if (!(await this.crypto.verify(result?.passwordHash, oldPassword))) {
+    if (!(await this.crypto.verify(hash, oldPassword))) {
       throw new UnauthenticatedException('Invalid credentials');
     }
 
     const newPasswordHash = await this.crypto.hash(newPassword);
+    await this.repo.updatePassword(newPasswordHash, session);
 
-    // inactivate all the relationships between the current user and all of their tokens except current one
-
-    await this.authenticationRepo.createNewPassword(newPasswordHash, session);
+    await this.repo.deactivateAllOtherSessions(session);
   }
 
   async forgotPassword(email: string): Promise<void> {
-    await this.authenticationRepo.forgotPasswordFindEmail(email);
-    const result = await this.authenticationRepo.forgotPasswordFindEmail(email);
-
-    if (!result) {
+    const exists = await this.repo.doesEmailAddressExist(email);
+    if (!exists) {
       this.logger.warning('Email not found; Skipping reset email', { email });
       return;
     }
 
     const token = this.encodeJWT();
 
-    await this.authenticationRepo.forgotPasswordCreateToken(email, token);
+    await this.repo.saveEmailToken(email, token);
     await this.email.send(email, ForgotPassword, {
       token,
     });
@@ -173,27 +164,23 @@ export class AuthenticationService {
     { token, password }: ResetPasswordInput,
     session: Session
   ): Promise<void> {
-    const result = await this.authenticationRepo.resetPassword(token);
-
-    if (!result) {
+    const emailToken = await this.repo.findEmailToken(token);
+    if (!emailToken) {
       throw new InputException('Token is invalid', 'TokenInvalid');
     }
-    const createdOn: DateTime = result.createdOn;
 
-    if (createdOn.diffNow().as('days') > 1) {
+    if (emailToken.createdOn.diffNow().as('days') > 1) {
       throw new InputException('Token has expired', 'TokenExpired');
     }
 
     const pash = await this.crypto.hash(password);
 
-    await this.authenticationRepo.resetPasswordRemoveOldData(
-      token,
-      result,
-      pash,
+    await this.repo.updatePasswordViaEmailToken(emailToken, pash);
+    await this.repo.deactivateAllOtherSessionsByEmail(
+      emailToken.email,
       session
     );
-
-    // remove all the email tokens and invalidate old tokens
+    await this.repo.removeAllEmailTokensForEmail(emailToken.email);
   }
 
   private encodeJWT() {

--- a/src/components/authentication/session.pipe.ts
+++ b/src/components/authentication/session.pipe.ts
@@ -1,6 +1,11 @@
 import { Injectable, PipeTransform } from '@nestjs/common';
 import { Request } from 'express';
-import type * as core from 'express-serve-static-core';
+import type {
+  Request as EsscRequest,
+  Params,
+  ParamsDictionary,
+  Query,
+} from 'express-serve-static-core';
 import { UnauthenticatedException } from '../../common';
 import { RawSession } from '../../common/session';
 import { ConfigService } from '../../core';
@@ -8,11 +13,11 @@ import { AuthenticationService } from './authentication.service';
 
 declare module 'express' {
   interface Request<
-    P extends core.Params = core.ParamsDictionary,
+    P extends Params = ParamsDictionary,
     ResBody = any,
     ReqBody = any,
-    ReqQuery = core.Query
-  > extends core.Request<P, ResBody, ReqBody, ReqQuery> {
+    ReqQuery = Query
+  > extends EsscRequest<P, ResBody, ReqBody, ReqQuery> {
     session?: RawSession;
   }
 }

--- a/src/components/authorization/authorization.module.ts
+++ b/src/components/authorization/authorization.module.ts
@@ -10,6 +10,6 @@ import { AuthorizationResolver } from './authorization.resolver';
     AuthorizationService,
     AuthorizationRepository,
   ],
-  exports: [AuthorizationService, AuthorizationRepository],
+  exports: [AuthorizationService],
 })
 export class AuthorizationModule {}

--- a/src/components/authorization/authorization.service.ts
+++ b/src/components/authorization/authorization.service.ts
@@ -56,7 +56,7 @@ export class AuthorizationService {
   constructor(
     private readonly dbConn: Connection,
     private readonly config: ConfigService,
-    private readonly authorizationRepo: AuthorizationRepository,
+    private readonly repo: AuthorizationRepository,
     @Logger('authorization:service') private readonly logger: ILogger
   ) {}
 
@@ -66,7 +66,7 @@ export class AuthorizationService {
     creatorUserId: ID
   ) {
     await this.afterTransaction(async () => {
-      await this.authorizationRepo.processNewBaseNode(
+      await this.repo.processNewBaseNode(
         resource.name,
         baseNodeId,
         creatorUserId
@@ -300,7 +300,7 @@ export class AuthorizationService {
     // iterate through all roles and assign to all SGs with that role
 
     for (const role of roles.flatMap((role) => this.mapRoleToDbRoles(role))) {
-      await this.authorizationRepo.doRoleAddedToUser(id, role);
+      await this.repo.addUserToSecurityGroup(id, role);
     }
 
     const powers = getDbRoles(roles.map(rolesForScope('global'))).flatMap(
@@ -314,10 +314,7 @@ export class AuthorizationService {
   async checkPower(power: Powers, session: Session): Promise<void> {
     const id = session.userId;
 
-    const query = this.authorizationRepo.checkPower(power, session, id);
-    const result = await query.first();
-    const hasPower = result?.hasPower ?? false;
-
+    const hasPower = await this.repo.hasPower(power, session, id);
     if (!hasPower) {
       throw new MissingPowerException(
         power,
@@ -332,7 +329,7 @@ export class AuthorizationService {
     if (session.anonymous) {
       return [];
     }
-    return await this.readPowerByUserId(session.userId);
+    return await this.repo.readPowerByUserId(session.userId);
   }
 
   async createPower(
@@ -340,8 +337,8 @@ export class AuthorizationService {
     power: Powers,
     session: Session
   ): Promise<void> {
-    const requestingUserPowers = await this.readPowerByUserId(session.userId);
-    if (!requestingUserPowers.includes(Powers.GrantPower)) {
+    const powers = await this.repo.readPowerByUserId(session.userId);
+    if (!powers.includes(Powers.GrantPower)) {
       throw new MissingPowerException(
         Powers.GrantPower,
         'user does not have the power to grant power to others'
@@ -356,8 +353,8 @@ export class AuthorizationService {
     power: Powers,
     session: Session
   ): Promise<void> {
-    const requestingUserPowers = await this.readPowerByUserId(session.userId);
-    if (!requestingUserPowers.includes(Powers.GrantPower)) {
+    const powers = await this.repo.readPowerByUserId(session.userId);
+    if (!powers.includes(Powers.GrantPower)) {
       throw new MissingPowerException(
         Powers.GrantPower,
         'user does not have the power to remove power from others'
@@ -368,41 +365,22 @@ export class AuthorizationService {
   }
 
   async grantPower(power: Powers, userId: ID | string): Promise<void> {
-    const powers = await this.readPowerByUserId(userId);
+    const powers = await this.repo.readPowerByUserId(userId);
 
     const newPowers = union(powers, [power]);
-    await this.updateUserPowers(userId, newPowers);
+    await this.repo.updateUserPowers(userId, newPowers);
   }
 
   async removePower(power: Powers, userId: ID): Promise<void> {
-    const powers = await this.readPowerByUserId(userId);
+    const powers = await this.repo.readPowerByUserId(userId);
 
     const newPowers = without(powers, power);
-    await this.updateUserPowers(userId, newPowers);
-  }
-
-  private async updateUserPowers(
-    userId: ID | string,
-    newPowers: Powers[]
-  ): Promise<void> {
-    const result = await this.authorizationRepo.updateUserPowers(
-      userId,
-      newPowers
-    );
-    if (!result) {
-      throw new ServerException('Failed to grant power');
-    }
-  }
-
-  private async readPowerByUserId(id: ID | string): Promise<Powers[]> {
-    const result = await this.authorizationRepo.readPowerByUserId(id);
-
-    return result?.powers ?? [];
+    await this.repo.updateUserPowers(userId, newPowers);
   }
 
   async getUserGlobalRoles(id: ID): Promise<ScopedRole[]> {
-    const roleQuery = await this.authorizationRepo.getUserGlobalRoles(id);
-    const roles = compact(roleQuery?.roles.map(rolesForScope('global')));
-    return roles;
+    const roles = await this.repo.getUserGlobalRoles(id);
+    const scopedRoles = compact(roles.map(rolesForScope('global')));
+    return scopedRoles;
   }
 }

--- a/src/components/authorization/authorization.service.ts
+++ b/src/components/authorization/authorization.service.ts
@@ -25,7 +25,7 @@ import {
   UnauthorizedException,
 } from '../../common';
 import { retry } from '../../common/retry';
-import { ConfigService, ILogger, Logger } from '../../core';
+import { ILogger, Logger } from '../../core';
 import { ChangesOf, isRelation } from '../../core/database/changes';
 import {
   DbPropsOfDto,
@@ -55,7 +55,6 @@ export type PermissionsOf<T> = Record<keyof T, Permission>;
 export class AuthorizationService {
   constructor(
     private readonly dbConn: Connection,
-    private readonly config: ConfigService,
     private readonly repo: AuthorizationRepository,
     @Logger('authorization:service') private readonly logger: ILogger
   ) {}

--- a/src/components/budget/budget.module.ts
+++ b/src/components/budget/budget.module.ts
@@ -35,6 +35,6 @@ import * as handlers from './handlers';
     BudgetRecordRepository,
     ...Object.values(handlers),
   ],
-  exports: [BudgetService, BudgetRepository],
+  exports: [BudgetService],
 })
 export class BudgetModule {}

--- a/src/components/budget/budget.repository.ts
+++ b/src/components/budget/budget.repository.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { node, Query, relation } from 'cypher-query-builder';
-import { Dictionary } from 'lodash';
+import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
-import { generateId, ID, Order, ServerException, Session } from '../../common';
+import { ID, NotFoundException, ServerException, Session } from '../../common';
 import {
   createBaseNode,
   DtoRepository,
@@ -16,50 +15,40 @@ import {
   permissionsOfNode,
   requestingUser,
 } from '../../core/database/query';
-import { QueryWithResult } from '../../core/database/query.overrides';
 import { DbPropsOfDto } from '../../core/database/results';
 import { ScopedRole } from '../authorization';
-import { Budget, BudgetFilters, BudgetStatus } from './dto';
+import { Budget, BudgetListInput, BudgetStatus } from './dto';
 
 @Injectable()
 export class BudgetRepository extends DtoRepository(Budget) {
-  readProject(projectId: ID, session: Session): Query {
-    const readProject = this.db
+  async doesProjectExist(projectId: ID, session: Session) {
+    const result = await this.db
       .query()
       .match(matchSession(session, { withAclRead: 'canReadProjects' }))
-      .match([node('project', 'Project', { id: projectId })]);
-    readProject.return({
-      project: [{ id: 'id', createdAt: 'createdAt' }],
-      requestingUser: [
-        {
-          canReadProjects: 'canReadProjects',
-          canCreateProject: 'canCreateProject',
-        },
-      ],
-    });
-    return readProject;
+      .match([node('project', 'Project', { id: projectId })])
+      .return('project.id')
+      .first();
+    return !!result;
   }
 
-  async createBudget(
-    projectId: ID,
-    budgetId: ID,
-    secureProps: Property[],
-    session: Session
-  ): Promise<Dictionary<any> | undefined> {
-    const createBudget = this.db
+  async create(budgetId: ID, secureProps: Property[], session: Session) {
+    const result = await this.db
       .query()
       .apply(matchRequestingUser(session))
       .apply(createBaseNode(budgetId, 'Budget', secureProps))
-      .return('node.id as id');
-    const result = await createBudget.first();
+      .return('node.id as id')
+      .asResult<{ id: ID }>()
+      .first();
     if (!result) {
-      throw new ServerException('failed to create a budget');
+      throw new ServerException('Failed to create budget');
     }
-    // connect budget to project
+  }
+
+  async connectToProject(budgetId: ID, projectId: ID) {
     await this.db
       .query()
       .matchNode('project', 'Project', { id: projectId })
-      .matchNode('budget', 'Budget', { id: result.id })
+      .matchNode('budget', 'Budget', { id: budgetId })
       .create([
         node('project'),
         relation('out', '', 'budget', {
@@ -69,23 +58,10 @@ export class BudgetRepository extends DtoRepository(Budget) {
         node('budget'),
       ])
       .run();
-    return result;
   }
 
-  async createBudgetRecord(
-    session: Session,
-    secureProps: Property[]
-  ): Promise<Query> {
-    const createBudgetRecord = this.db
-      .query()
-      .apply(matchRequestingUser(session))
-      .apply(createBaseNode(await generateId(), 'BudgetRecord', secureProps))
-      .return('node.id as id');
-    return createBudgetRecord;
-  }
-
-  readOne(id: ID, session: Session) {
-    const query = this.db
+  async readOne(id: ID, session: Session) {
+    const result = await this.db
       .query()
       .match([
         node('project', 'Project'),
@@ -97,21 +73,20 @@ export class BudgetRepository extends DtoRepository(Budget) {
       .asResult<{
         props: DbPropsOfDto<Budget, true>;
         scopedRoles: ScopedRole[];
-      }>();
+      }>()
+      .first();
+    if (!result) {
+      throw new NotFoundException('Could not find budget', 'budget.id');
+    }
 
-    return query;
+    return result;
   }
 
-  async verifyCanEdit(id: ID): Promise<
-    | {
-        status: BudgetStatus;
-      }
-    | undefined
-  > {
-    return await this.db
+  async getStatusByRecord(recordId: ID) {
+    const result = await this.db
       .query()
       .match([
-        node('budgetRecord', 'BudgetRecord', { id }),
+        node('budgetRecord', 'BudgetRecord', { id: recordId }),
         relation('in', '', 'record', { active: true }),
         node('budget', 'Budget'),
         relation('out', '', 'status', { active: true }),
@@ -120,28 +95,18 @@ export class BudgetRepository extends DtoRepository(Budget) {
       .return('status.value as status')
       .asResult<{ status: BudgetStatus }>()
       .first();
+    if (!result) {
+      throw new NotFoundException('Budget could not be found');
+    }
+    return result.status;
   }
 
-  list(
-    filter: BudgetFilters,
-    listInput: {
-      sort: keyof Budget;
-      order: Order;
-      count: number;
-      page: number;
-    },
-    session: Session
-  ): QueryWithResult<{
-    items: ID[];
-    total: number;
-  }> {
-    const label = 'Budget';
-
+  list({ filter, ...input }: BudgetListInput, session: Session) {
     const query = this.db
       .query()
       .match([
         requestingUser(session),
-        ...permissionsOfNode(label),
+        ...permissionsOfNode('Budget'),
         ...(filter.projectId
           ? [
               relation('in', '', 'budget', { active: true }),
@@ -151,7 +116,7 @@ export class BudgetRepository extends DtoRepository(Budget) {
             ]
           : []),
       ])
-      .apply(calculateTotalAndPaginateList(Budget, listInput));
+      .apply(calculateTotalAndPaginateList(Budget, input));
     return query;
   }
 }

--- a/src/components/budget/budget.resolver.ts
+++ b/src/components/budget/budget.resolver.ts
@@ -94,7 +94,7 @@ export class BudgetResolver {
   }
 
   @Mutation(() => Boolean, {
-    description: 'Delete an budget',
+    description: 'Delete a budget',
   })
   async deleteBudget(
     @LoggedInSession() session: Session,

--- a/src/components/ceremony/ceremony.module.ts
+++ b/src/components/ceremony/ceremony.module.ts
@@ -13,6 +13,6 @@ import * as handlers from './handlers';
     CeremonyRepository,
     ...Object.values(handlers),
   ],
-  exports: [CeremonyService, CeremonyRepository],
+  exports: [CeremonyService],
 })
 export class CeremonyModule {}

--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ConfigService, ILogger, Logger, Property } from '../../core';
+import { ILogger, Logger, Property } from '../../core';
 import { runListQuery } from '../../core/database/results';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { CeremonyRepository } from './ceremony.repository';
@@ -22,7 +22,6 @@ import {
 @Injectable()
 export class CeremonyService {
   constructor(
-    private readonly config: ConfigService,
     @Inject(forwardRef(() => AuthorizationService))
     private readonly authorizationService: AuthorizationService,
     private readonly ceremonyRepo: CeremonyRepository,

--- a/src/components/engagement/dto/create-engagement.dto.ts
+++ b/src/components/engagement/dto/create-engagement.dto.ts
@@ -1,6 +1,7 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
+import { keys as keysOf } from 'ts-transformer-keys';
 import { CalendarDate, DateField, ID, IdField } from '../../../common';
 import { CreateDefinedFileVersionInput } from '../../file/dto';
 import { ProductMethodology } from '../../product/dto';
@@ -36,6 +37,8 @@ export abstract class CreateEngagement {
 
 @InputType()
 export abstract class CreateLanguageEngagement extends CreateEngagement {
+  static readonly Props = keysOf<CreateLanguageEngagement>();
+
   @IdField()
   readonly languageId: ID;
 
@@ -59,6 +62,8 @@ export abstract class CreateLanguageEngagement extends CreateEngagement {
 
 @InputType()
 export abstract class CreateInternshipEngagement extends CreateEngagement {
+  static readonly Props = keysOf<CreateInternshipEngagement>();
+
   @IdField()
   readonly internId: ID;
 

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -5,6 +5,7 @@ import { MergeExclusive } from 'type-fest';
 import {
   DateInterval,
   DateTimeField,
+  DbLabel,
   ID,
   parentIdMiddleware,
   Resource,
@@ -46,6 +47,7 @@ class Engagement extends Resource {
   @Field(() => SecuredEngagementStatus, {
     middleware: [parentIdMiddleware],
   })
+  @DbLabel('EngagementStatus')
   readonly status: SecuredEngagementStatus;
 
   readonly ceremony: Secured<ID>;
@@ -155,9 +157,11 @@ export class InternshipEngagement extends Engagement {
   readonly mentor: Secured<ID>;
 
   @Field()
+  @DbLabel('InternPosition')
   readonly position: SecuredInternPosition;
 
   @Field()
+  @DbLabel('ProductMethodology')
   readonly methodologies: SecuredMethodologies;
 
   readonly growthPlan: DefinedFile;

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -420,21 +420,6 @@ export class EngagementRepository extends CommonRepository {
     });
   }
 
-  async addLabelsToNodes(
-    type: string,
-    input: UpdateInternshipEngagement
-  ): Promise<void> {
-    if (type === 'position') {
-      await this.db.addLabelsToPropNodes(input.id, 'position', [
-        'InternPosition',
-      ]);
-    } else if (type === 'methodologies') {
-      await this.db.addLabelsToPropNodes(input.id, 'methodologies', [
-        'ProductMethodology',
-      ]);
-    }
-  }
-
   // DELETE /////////////////////////////////////////////////////////
 
   async findNodeToDelete(id: ID) {

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -3,7 +3,6 @@ import { inArray, node, Node, Query, relation } from 'cypher-query-builder';
 import { Dictionary } from 'lodash';
 import { DateTime } from 'luxon';
 import {
-  CalendarDate,
   entries,
   generateId,
   getDbPropertyLabels,
@@ -520,62 +519,6 @@ export class EngagementRepository extends CommonRepository {
     const roles = await query.first();
 
     return roles?.memberRoles.map(rolesForScope('project')) ?? [];
-  }
-
-  async listEngagementsWithDateRange() {
-    return await this.db
-      .query()
-      .match(node('engagement', 'Engagement'))
-      .match([
-        node('project', 'Project'),
-        relation('out', '', 'engagement', { active: true }),
-        node('engagement'),
-      ])
-      .optionalMatch([
-        node('project'),
-        relation('out', '', 'mouStart', { active: true }),
-        node('mouStart', 'Property'),
-      ])
-      .optionalMatch([
-        node('project'),
-        relation('out', '', 'mouEnd', { active: true }),
-        node('mouEnd', 'Property'),
-      ])
-      .optionalMatch([
-        node('engagement'),
-        relation('out', '', 'startDateOverride', { active: true }),
-        node('startDateOverride', 'Property'),
-      ])
-      .optionalMatch([
-        node('engagement'),
-        relation('out', '', 'endDateOverride', { active: true }),
-        node('endDateOverride', 'Property'),
-      ])
-      .with([
-        'engagement',
-        'mouStart',
-        'mouEnd',
-        'startDateOverride',
-        'endDateOverride',
-      ])
-      .raw(
-        'WHERE (mouStart.value IS NOT NULL AND mouEnd.value IS NOT NULL) OR (startDateOverride.value IS NOT NULL AND endDateOverride.value IS NOT NULL)'
-      )
-      .return([
-        'engagement.id as engagementId',
-        'mouStart.value as startDate',
-        'mouEnd.value as endDate',
-        'startDateOverride.value as startDateOverride',
-        'endDateOverride.value as endDateOverride',
-      ])
-      .asResult<{
-        engagementId: ID;
-        startDate: CalendarDate;
-        endDate: CalendarDate;
-        startDateOverride: CalendarDate;
-        endDateOverride: CalendarDate;
-      }>()
-      .run();
   }
 
   async verifyRelationshipEligibility(

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -547,12 +547,6 @@ export class EngagementService {
     return ids.length > 0;
   }
 
-  async listEngagementsWithDateRange() {
-    const result = await this.repo.listEngagementsWithDateRange();
-
-    return result;
-  }
-
   protected async verifyRelationshipEligibility(
     projectId: ID,
     otherId: ID,

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -426,16 +426,6 @@ export class EngagementService {
       }
 
       await this.repo.updateInternshipProperties(object, simpleChanges);
-
-      // update property node labels
-      Object.keys(input).map(async (ele) => {
-        if (ele === 'position') {
-          await this.repo.addLabelsToNodes('position', input);
-        }
-        if (ele === 'methodologies') {
-          await this.repo.addLabelsToNodes('methodologies', input);
-        }
-      });
     } catch (exception) {
       this.logger.warning('Failed to update InternshipEngagement', {
         exception,

--- a/src/components/engagement/handlers/set-initial-end-date.handler.ts
+++ b/src/components/engagement/handlers/set-initial-end-date.handler.ts
@@ -4,13 +4,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../../common';
-import {
-  DatabaseService,
-  EventsHandler,
-  IEventHandler,
-  ILogger,
-  Logger,
-} from '../../../core';
+import { EventsHandler, IEventHandler, ILogger, Logger } from '../../../core';
 import { Engagement, EngagementStatus } from '../dto';
 import { EngagementService } from '../engagement.service';
 import { EngagementCreatedEvent, EngagementUpdatedEvent } from '../events';
@@ -20,7 +14,6 @@ type SubscribedEvent = EngagementCreatedEvent | EngagementUpdatedEvent;
 @EventsHandler(EngagementCreatedEvent, EngagementUpdatedEvent)
 export class SetInitialEndDate implements IEventHandler<SubscribedEvent> {
   constructor(
-    private readonly db: DatabaseService,
     private readonly engagementService: EngagementService,
     @Logger('engagement:set-initial-end-date') private readonly logger: ILogger
   ) {}

--- a/src/components/field-region/field-region.module.ts
+++ b/src/components/field-region/field-region.module.ts
@@ -13,6 +13,6 @@ import { FieldRegionService } from './field-region.service';
     forwardRef(() => UserModule),
   ],
   providers: [FieldRegionResolver, FieldRegionService, FieldRegionRepository],
-  exports: [FieldRegionService, FieldRegionRepository],
+  exports: [FieldRegionService],
 })
 export class FieldRegionModule {}

--- a/src/components/field-region/field-region.service.ts
+++ b/src/components/field-region/field-region.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ConfigService, ILogger, Logger, OnIndex } from '../../core';
+import { ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -26,8 +26,6 @@ import { FieldRegionRepository } from './field-region.repository';
 export class FieldRegionService {
   constructor(
     @Logger('field-region:service') private readonly logger: ILogger,
-    private readonly config: ConfigService,
-    // private readonly db: DatabaseService,
     @Inject(forwardRef(() => AuthorizationService))
     private readonly authorizationService: AuthorizationService,
     private readonly repo: FieldRegionRepository

--- a/src/components/field-zone/field-zone.module.ts
+++ b/src/components/field-zone/field-zone.module.ts
@@ -11,6 +11,6 @@ import { FieldZoneService } from './field-zone.service';
     forwardRef(() => UserModule),
   ],
   providers: [FieldZoneResolver, FieldZoneService, FieldZoneRepository],
-  exports: [FieldZoneService, FieldZoneRepository],
+  exports: [FieldZoneService],
 })
 export class FieldZoneModule {}

--- a/src/components/field-zone/field-zone.service.ts
+++ b/src/components/field-zone/field-zone.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ConfigService, ILogger, Logger, OnIndex } from '../../core';
+import { ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -26,8 +26,6 @@ import { FieldZoneRepository } from './field-zone.repository';
 export class FieldZoneService {
   constructor(
     @Logger('field-zone:service') private readonly logger: ILogger,
-    private readonly config: ConfigService,
-    // private readonly db: DatabaseService,
     private readonly authorizationService: AuthorizationService,
     private readonly repo: FieldZoneRepository
   ) {}

--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -14,7 +14,6 @@ import {
   UnauthorizedException,
 } from '../../common';
 import {
-  ConfigService,
   createBaseNode,
   DatabaseService,
   ILogger,
@@ -48,7 +47,6 @@ import {
 export class FileRepository {
   constructor(
     private readonly db: DatabaseService,
-    private readonly config: ConfigService,
     @Logger('file:repository') private readonly logger: ILogger
   ) {}
 

--- a/src/components/film/film.module.ts
+++ b/src/components/film/film.module.ts
@@ -8,6 +8,6 @@ import { FilmService } from './film.service';
 @Module({
   imports: [forwardRef(() => AuthorizationModule), ScriptureModule],
   providers: [FilmResolver, FilmService, FilmRepository],
-  exports: [FilmService, FilmRepository],
+  exports: [FilmService],
 })
 export class FilmModule {}

--- a/src/components/film/film.service.ts
+++ b/src/components/film/film.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ConfigService, ILogger, Logger, OnIndex } from '../../core';
+import { ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -27,8 +27,6 @@ import { FilmRepository } from './film.repository';
 export class FilmService {
   constructor(
     @Logger('film:service') private readonly logger: ILogger,
-    // private readonly db: DatabaseService,
-    private readonly config: ConfigService,
     private readonly scriptureRefService: ScriptureReferenceService,
     private readonly authorizationService: AuthorizationService,
     private readonly repo: FilmRepository

--- a/src/components/funding-account/funding-account.module.ts
+++ b/src/components/funding-account/funding-account.module.ts
@@ -11,6 +11,6 @@ import { FundingAccountService } from './funding-account.service';
     FundingAccountService,
     FundingAccountRepository,
   ],
-  exports: [FundingAccountService, FundingAccountRepository],
+  exports: [FundingAccountService],
 })
 export class FundingAccountModule {}

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ConfigService, ILogger, Logger, OnIndex } from '../../core';
+import { ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -26,7 +26,6 @@ import { FundingAccountRepository } from './funding-account.repository';
 export class FundingAccountService {
   constructor(
     @Logger('funding-account:service') private readonly logger: ILogger,
-    private readonly config: ConfigService,
     private readonly authorizationService: AuthorizationService,
     private readonly repo: FundingAccountRepository
   ) {}

--- a/src/components/language/ethnologue-language/ethnologue-language.service.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.service.ts
@@ -5,13 +5,7 @@ import {
   ServerException,
   Session,
 } from '../../../common';
-import {
-  ConfigService,
-  DatabaseService,
-  ILogger,
-  Logger,
-  Property,
-} from '../../../core';
+import { ILogger, Logger, Property } from '../../../core';
 import { parsePropList } from '../../../core/database/results';
 import { AuthorizationService } from '../../authorization/authorization.service';
 import { Powers } from '../../authorization/dto/powers';
@@ -25,8 +19,6 @@ import { EthnologueLanguageRepository } from './ethnologue-language.repository';
 @Injectable()
 export class EthnologueLanguageService {
   constructor(
-    private readonly db: DatabaseService,
-    private readonly config: ConfigService,
     private readonly authorizationService: AuthorizationService,
     @Logger('language:ethnologue:service') private readonly logger: ILogger,
     private readonly repo: EthnologueLanguageRepository

--- a/src/components/language/language.module.ts
+++ b/src/components/language/language.module.ts
@@ -23,6 +23,6 @@ import { LanguageService } from './language.service';
     EthnologueLanguageRepository,
     LanguageRepository,
   ],
-  exports: [LanguageService, LanguageRepository],
+  exports: [LanguageService],
 })
 export class LanguageModule {}

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -13,13 +13,7 @@ import {
   simpleSwitch,
   UnauthorizedException,
 } from '../../common';
-import {
-  ConfigService,
-  ILogger,
-  Logger,
-  OnIndex,
-  UniquenessError,
-} from '../../core';
+import { ILogger, Logger, OnIndex, UniquenessError } from '../../core';
 import {
   parseBaseNodeProperties,
   parsePropList,
@@ -52,8 +46,6 @@ import { LanguageRepository } from './language.repository';
 @Injectable()
 export class LanguageService {
   constructor(
-    // private readonly db: DatabaseService,
-    private readonly config: ConfigService,
     private readonly ethnologueLanguageService: EthnologueLanguageService,
     private readonly locationService: LocationService,
     private readonly projectService: ProjectService,

--- a/src/components/literacy-material/literacy-material.module.ts
+++ b/src/components/literacy-material/literacy-material.module.ts
@@ -12,6 +12,6 @@ import { LiteracyMaterialService } from './literacy-material.service';
     LiteracyMaterialService,
     LiteracyMaterialRepository,
   ],
-  exports: [LiteracyMaterialService, LiteracyMaterialRepository],
+  exports: [LiteracyMaterialService],
 })
 export class LiteracyMaterialModule {}

--- a/src/components/location/location.module.ts
+++ b/src/components/location/location.module.ts
@@ -13,6 +13,6 @@ import { LocationService } from './location.service';
     FieldRegionModule,
   ],
   providers: [LocationResolver, LocationService, LocationRepository],
-  exports: [LocationService, LocationRepository],
+  exports: [LocationService],
 })
 export class LocationModule {}

--- a/src/components/location/location.repository.ts
+++ b/src/components/location/location.repository.ts
@@ -1,8 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
-import { Dictionary } from 'lodash';
 import { DateTime } from 'luxon';
-import { generateId, ID, Session } from '../../common';
+import {
+  generateId,
+  ID,
+  NotFoundException,
+  ServerException,
+  Session,
+} from '../../common';
 import { createBaseNode, DtoRepository, matchRequestingUser } from '../../core';
 import {
   calculateTotalAndPaginateList,
@@ -15,15 +20,16 @@ import { CreateLocation, Location, LocationListInput } from './dto';
 
 @Injectable()
 export class LocationRepository extends DtoRepository(Location) {
-  async checkName(name: string) {
-    return await this.db
+  async doesNameExist(name: string) {
+    const result = await this.db
       .query()
       .match([node('name', 'LocationName', { value: name })])
       .return('name')
       .first();
+    return !!result;
   }
 
-  async create(session: Session, input: CreateLocation) {
+  async create(input: CreateLocation, session: Session) {
     const secureProps = [
       {
         key: 'name',
@@ -54,62 +60,53 @@ export class LocationRepository extends DtoRepository(Location) {
       },
     ];
 
-    // create location
     const query = this.db
       .query()
       .apply(matchRequestingUser(session))
       .apply(createBaseNode(await generateId(), 'Location', secureProps))
-      .return('node.id as id');
+      .apply((q) => {
+        if (input.fundingAccountId) {
+          q.with('node')
+            .matchNode('fundingAccount', 'FundingAccount', {
+              id: input.fundingAccountId,
+            })
+            .create([
+              node('node'),
+              relation('out', '', 'fundingAccount', {
+                active: true,
+                createdAt: DateTime.local(),
+              }),
+              node('fundingAccount'),
+            ]);
+        }
+        if (input.defaultFieldRegionId) {
+          q.with('node')
+            .matchNode('defaultFieldRegion', 'FieldRegion', {
+              id: input.defaultFieldRegionId,
+            })
+            .create([
+              node('node'),
+              relation('out', '', 'defaultFieldRegion', {
+                active: true,
+                createdAt: DateTime.local(),
+              }),
+              node('defaultFieldRegion'),
+            ]);
+        }
+      })
+      .return('node.id as id')
+      .asResult<{ id: ID }>();
 
-    return await query.first();
-  }
-
-  async createProperties(
-    type: 'fundingAccount' | 'defaultFieldRegion',
-    result: Dictionary<any> | undefined,
-    input: CreateLocation,
-    createdAt: DateTime
-  ) {
-    if (type === 'fundingAccount') {
-      await this.db
-        .query()
-        .matchNode('location', 'Location', {
-          id: result?.id,
-        })
-        .matchNode('fundingAccount', 'FundingAccount', {
-          id: input.fundingAccountId,
-        })
-        .create([
-          node('location'),
-          relation('out', '', 'fundingAccount', {
-            active: true,
-            createdAt,
-          }),
-          node('fundingAccount'),
-        ])
-        .run();
-    } else {
-      await this.db
-        .query()
-        .matchNode('location', 'Location', {
-          id: result?.id,
-        })
-        .matchNode('defaultFieldRegion', 'FieldRegion', {
-          id: input.defaultFieldRegionId,
-        })
-        .create([
-          node('location'),
-          relation('out', '', 'defaultFieldRegion', {
-            active: true,
-            createdAt,
-          }),
-          node('defaultFieldRegion'),
-        ])
-        .run();
+    const result = await query.first();
+    if (!result) {
+      throw new ServerException('Failed to create location');
     }
+
+    return result.id;
   }
-  readOne(id: ID, session: Session) {
-    return this.db
+
+  async readOne(id: ID, session: Session) {
+    const result = await this.db
       .query()
       .apply(matchRequestingUser(session))
       .match([node('node', 'Location', { id: id })])
@@ -132,85 +129,80 @@ export class LocationRepository extends DtoRepository(Location) {
           fundingAccountId: ID;
           defaultFieldRegionId: ID;
         }
-      >();
-
-    // return await query.first();
+      >()
+      .first();
+    if (!result) {
+      throw new NotFoundException('Could not find location');
+    }
+    return result;
   }
 
-  async updateLocationProperties(
-    type: 'fundingAccount' | 'defaultFieldRegion',
-    session: Session,
-    propertyId: ID,
-    locationId: ID
-  ) {
-    if (type === 'fundingAccount') {
-      const createdAt = DateTime.local();
-      await this.db
-        .query()
-        .apply(matchRequestingUser(session))
-        .matchNode('location', 'Location', { id: locationId })
-        .matchNode('newFundingAccount', 'FundingAccount', {
-          id: propertyId,
-        })
-        .optionalMatch([
-          node('location'),
-          relation('out', 'oldFundingAccountRel', 'fundingAccount', {
-            active: true,
-          }),
-          node('fundingAccount', 'FundingAccount'),
-        ])
-        .create([
-          node('location'),
-          relation('out', '', 'fundingAccount', {
-            active: true,
-            createdAt,
-          }),
-          node('newFundingAccount'),
-        ])
-        .set({
-          values: {
-            'oldFundingAccountRel.active': false,
-          },
-        })
-        .run();
-    } else {
-      const createdAt = DateTime.local();
-      await this.db
-        .query()
-        .apply(matchRequestingUser(session))
-        .matchNode('location', 'Location', { id: locationId })
-        .matchNode('newDefaultFieldRegion', 'FieldRegion', {
-          id: propertyId,
-        })
-        .optionalMatch([
-          node('location'),
-          relation('out', 'oldDefaultFieldRegionRel', 'defaultFieldRegion', {
-            active: true,
-          }),
-          node('defaultFieldRegion', 'FieldRegion'),
-        ])
-        .create([
-          node('location'),
-          relation('out', '', 'defaultFieldRegion', {
-            active: true,
-            createdAt,
-          }),
-          node('newDefaultFieldRegion'),
-        ])
-        .set({
-          values: {
-            'oldDefaultFieldRegionRel.active': false,
-          },
-        })
-        .run();
-    }
+  async updateFundingAccount(id: ID, fundingAccount: ID, session: Session) {
+    await this.db
+      .query()
+      .apply(matchRequestingUser(session))
+      .matchNode('location', 'Location', { id })
+      .matchNode('newFundingAccount', 'FundingAccount', {
+        id: fundingAccount,
+      })
+      .optionalMatch([
+        node('location'),
+        relation('out', 'oldFundingAccountRel', 'fundingAccount', {
+          active: true,
+        }),
+        node('fundingAccount', 'FundingAccount'),
+      ])
+      .create([
+        node('location'),
+        relation('out', '', 'fundingAccount', {
+          active: true,
+          createdAt: DateTime.local(),
+        }),
+        node('newFundingAccount'),
+      ])
+      .set({
+        values: {
+          'oldFundingAccountRel.active': false,
+        },
+      })
+      .run();
+  }
+
+  async updateDefaultFieldRegion(id: ID, fieldRegion: ID, session: Session) {
+    await this.db
+      .query()
+      .apply(matchRequestingUser(session))
+      .matchNode('location', 'Location', { id })
+      .matchNode('newDefaultFieldRegion', 'FieldRegion', {
+        id: fieldRegion,
+      })
+      .optionalMatch([
+        node('location'),
+        relation('out', 'oldDefaultFieldRegionRel', 'defaultFieldRegion', {
+          active: true,
+        }),
+        node('defaultFieldRegion', 'FieldRegion'),
+      ])
+      .create([
+        node('location'),
+        relation('out', '', 'defaultFieldRegion', {
+          active: true,
+          createdAt: DateTime.local(),
+        }),
+        node('newDefaultFieldRegion'),
+      ])
+      .set({
+        values: {
+          'oldDefaultFieldRegionRel.active': false,
+        },
+      })
+      .run();
   }
 
   list({ filter, ...input }: LocationListInput, session: Session) {
-    const label = 'Location';
     return this.db
       .query()
-      .match([requestingUser(session), ...permissionsOfNode(label)])
+      .match([requestingUser(session), ...permissionsOfNode('Location')])
       .apply(calculateTotalAndPaginateList(Location, input));
   }
 

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -1,5 +1,4 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
-import { DateTime } from 'luxon';
 import {
   DuplicateException,
   ID,
@@ -50,48 +49,24 @@ export class LocationService {
   }
 
   async create(input: CreateLocation, session: Session): Promise<Location> {
-    const checkName = await this.repo.checkName(input.name);
-
+    const checkName = await this.repo.doesNameExist(input.name);
     if (checkName) {
       throw new DuplicateException(
         'location.name',
         'Location with this name already exists.'
       );
     }
-    const createdAt = DateTime.local();
 
-    const result = await this.repo.create(session, input);
-
-    if (!result) {
-      throw new ServerException('failed to create location');
-    }
-
-    if (input.fundingAccountId) {
-      await this.repo.createProperties(
-        'fundingAccount',
-        result,
-        input,
-        createdAt
-      );
-    }
-
-    if (input.defaultFieldRegionId) {
-      await this.repo.createProperties(
-        'defaultFieldRegion',
-        result,
-        input,
-        createdAt
-      );
-    }
+    const id = await this.repo.create(input, session);
 
     await this.authorizationService.processNewBaseNode(
       Location,
-      result.id,
+      id,
       session.userId
     );
 
-    this.logger.debug(`location created`, { id: result.id });
-    return await this.readOne(result.id, session);
+    this.logger.debug(`location created`, { id: id });
+    return await this.readOne(id, session);
   }
 
   async readOne(id: ID, session: Session): Promise<Location> {
@@ -100,13 +75,7 @@ export class LocationService {
       userId: session.userId,
     });
 
-    const query = this.repo.readOne(id, session);
-
-    const result = await query.first();
-
-    if (!result) {
-      throw new NotFoundException('Could not find location', 'location.id');
-    }
+    const result = await this.repo.readOne(id, session);
 
     const secured = await this.authorizationService.secureProperties(
       Location,
@@ -145,20 +114,14 @@ export class LocationService {
     await this.repo.updateProperties(location, simpleChanges);
 
     if (fundingAccountId) {
-      await this.repo.updateLocationProperties(
-        'fundingAccount',
-        session,
-        fundingAccountId,
-        input.id
-      );
+      await this.repo.updateFundingAccount(input.id, fundingAccountId, session);
     }
 
     if (defaultFieldRegionId) {
-      await this.repo.updateLocationProperties(
-        'defaultFieldRegion',
-        session,
+      await this.repo.updateDefaultFieldRegion(
+        input.id,
         defaultFieldRegionId,
-        input.id
+        session
       );
     }
 

--- a/src/components/organization/organization.module.ts
+++ b/src/components/organization/organization.module.ts
@@ -12,6 +12,6 @@ import { OrganizationService } from './organization.service';
     OrganizationService,
     OrganizationRepository,
   ],
-  exports: [OrganizationService, OrganizationRepository],
+  exports: [OrganizationService],
 })
 export class OrganizationModule {}

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -33,7 +33,6 @@ export class OrganizationService {
   constructor(
     @Logger('org:service') private readonly logger: ILogger,
     private readonly config: ConfigService,
-    // private readonly db: DatabaseService,
     @Inject(forwardRef(() => AuthorizationService))
     private readonly authorizationService: AuthorizationService,
     private readonly locationService: LocationService,

--- a/src/components/partner/partner.module.ts
+++ b/src/components/partner/partner.module.ts
@@ -13,6 +13,6 @@ import { PartnerService } from './partner.service';
     forwardRef(() => UserModule),
   ],
   providers: [PartnerResolver, PartnerService, PartnerRepository],
-  exports: [PartnerService, PartnerRepository],
+  exports: [PartnerService],
 })
 export class PartnerModule {}

--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -8,7 +8,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ConfigService, ILogger, Logger, OnIndex } from '../../core';
+import { ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   parsePropList,
@@ -30,7 +30,6 @@ import { PartnerRepository } from './partner.repository';
 export class PartnerService {
   constructor(
     @Logger('partner:service') private readonly logger: ILogger,
-    private readonly config: ConfigService,
     @Inject(forwardRef(() => AuthorizationService))
     private readonly authorizationService: AuthorizationService,
     private readonly repo: PartnerRepository

--- a/src/components/partnership/partnership.module.ts
+++ b/src/components/partnership/partnership.module.ts
@@ -17,6 +17,6 @@ import { PartnershipService } from './partnership.service';
     PartnerModule,
   ],
   providers: [PartnershipResolver, PartnershipService, PartnershipRepository],
-  exports: [PartnershipService, PartnershipRepository],
+  exports: [PartnershipService],
 })
 export class PartnershipModule {}

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -1,9 +1,6 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
-import { node, Query, relation } from 'cypher-query-builder';
-import { DateTime } from 'luxon';
 import {
   DuplicateException,
-  generateId,
   ID,
   InputException,
   NotFoundException,
@@ -11,7 +8,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ConfigService, IEventBus, ILogger, Logger } from '../../core';
+import { IEventBus, ILogger, Logger } from '../../core';
 import { runListQuery } from '../../core/database/results';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { FileService } from '../file';
@@ -21,7 +18,6 @@ import {
   CreatePartnership,
   FinancialReportingType,
   Partnership,
-  PartnershipAgreementStatus,
   PartnershipListInput,
   PartnershipListOutput,
   UpdatePartnership,
@@ -37,8 +33,6 @@ import { PartnershipRepository } from './partnership.repository';
 export class PartnershipService {
   constructor(
     private readonly files: FileService,
-    // private readonly db: DatabaseService,
-    private readonly config: ConfigService,
     @Inject(forwardRef(() => ProjectService))
     private readonly projectService: ProjectService,
     private readonly partnerService: PartnerService,
@@ -50,14 +44,14 @@ export class PartnershipService {
   ) {}
 
   async create(
-    { partnerId, projectId, ...input }: CreatePartnership,
+    input: CreatePartnership,
     session: Session
   ): Promise<Partnership> {
-    const createdAt = DateTime.local();
+    const { projectId, partnerId } = input;
 
     await this.verifyRelationshipEligibility(projectId, partnerId);
 
-    const isFirstPartnership = await this.isFirstPartnership(projectId);
+    const isFirstPartnership = await this.repo.isFirstPartnership(projectId);
     const primary = isFirstPartnership ? true : input.primary;
 
     const partner = await this.partnerService.readOne(partnerId, session);
@@ -67,96 +61,20 @@ export class PartnershipService {
       partner
     );
 
-    const partnershipId = await generateId();
-    const mouId = await generateId();
-    const agreementId = await generateId();
-
-    const secureProps = [
-      {
-        key: 'agreementStatus',
-        value: input.agreementStatus || PartnershipAgreementStatus.NotAttached,
-        isPublic: false,
-        isOrgPublic: false,
-      },
-      {
-        key: 'agreement',
-        value: agreementId,
-        isPublic: false,
-        isOrgPublic: false,
-      },
-      {
-        key: 'mou',
-        value: mouId,
-        isPublic: false,
-        isOrgPublic: false,
-      },
-      {
-        key: 'mouStatus',
-        value: input.mouStatus || PartnershipAgreementStatus.NotAttached,
-        isPublic: false,
-        isOrgPublic: false,
-      },
-      {
-        key: 'mouStartOverride',
-        value: input.mouStartOverride,
-        isPublic: false,
-        isOrgPublic: false,
-      },
-      {
-        key: 'mouEndOverride',
-        value: input.mouEndOverride,
-        isPublic: false,
-        isOrgPublic: false,
-      },
-      {
-        key: 'types',
-        value: input.types,
-        isPublic: false,
-        isOrgPublic: false,
-      },
-      {
-        key: 'financialReportingType',
-        value: input.financialReportingType,
-        isPublic: false,
-        isOrgPublic: false,
-      },
-      {
-        key: 'canDelete',
-        value: true,
-        isPublic: false,
-        isOrgPublic: false,
-      },
-      {
-        key: 'primary',
-        value: primary,
-        isPublic: false,
-        isOrgPublic: false,
-      },
-    ];
-    let result;
     try {
-      const createPartnership = this.repo.create(
-        partnershipId,
-        session,
-        secureProps
+      const { id, mouId, agreementId } = await this.repo.create(
+        {
+          ...input,
+          primary,
+        },
+        session
       );
-      try {
-        result = await createPartnership.first();
-      } catch (e) {
-        this.logger.error('e :>> ', e);
-      }
-
-      if (!result) {
-        throw new ServerException('failed to create partnership');
-      }
-
-      await this.repo.connect(projectId, partnerId, createdAt, result);
 
       await this.files.createDefinedFile(
         mouId,
         `MOU`,
         session,
-        partnershipId,
+        id,
         'mou',
         input.mou,
         'partnership.mou'
@@ -166,7 +84,7 @@ export class PartnershipService {
         agreementId,
         `Partner Agreement`,
         session,
-        partnershipId,
+        id,
         'agreement',
         input.agreement,
         'partnership.agreement'
@@ -174,15 +92,15 @@ export class PartnershipService {
 
       await this.authorizationService.processNewBaseNode(
         Partnership,
-        result.id,
+        id,
         session.userId
       );
 
       if (primary) {
-        await this.removeOtherPartnershipPrimary(result.id);
+        await this.repo.removePrimaryFromOtherPartnerships(id);
       }
 
-      const partnership = await this.readOne(result.id, session);
+      const partnership = await this.readOne(id, session);
 
       await this.eventBus.publish(
         new PartnershipCreatedEvent(partnership, session)
@@ -202,12 +120,6 @@ export class PartnershipService {
     this.logger.debug('readOne', { id, userId: session.userId });
 
     const result = await this.repo.readOne(id, session);
-    if (!result) {
-      throw new NotFoundException(
-        'could not find Partnership',
-        'partnership.id'
-      );
-    }
 
     const project = await this.projectService.readOne(
       result.projectId,
@@ -239,12 +151,12 @@ export class PartnershipService {
       mouStart: {
         value: mouStart,
         canRead: canReadMouStart,
-        canEdit: false, // edit the project mou or edit the partnerhsip mou override
+        canEdit: false, // edit the project mou or edit the partnership mou override
       },
       mouEnd: {
         value: mouEnd,
         canRead: canReadMouEnd,
-        canEdit: false, // edit the project mou or edit the partnerhsip mou override
+        canEdit: false, // edit the project mou or edit the partnership mou override
       },
       types: {
         ...securedProps.types,
@@ -301,7 +213,7 @@ export class PartnershipService {
     const { mou, agreement, ...simpleChanges } = changes;
 
     if (changes.primary) {
-      await this.removeOtherPartnershipPrimary(input.id);
+      await this.repo.removePrimaryFromOtherPartnerships(input.id);
     }
 
     await this.repo.updateProperties(object, simpleChanges);
@@ -347,11 +259,8 @@ export class PartnershipService {
 
     // only primary one partnership could be removed
     if (object.primary.value) {
-      const result = await this.otherPartnershipQuery(object.id)
-        .return('otherPartnership')
-        .first();
-
-      if (result) {
+      const isOthers = await this.repo.isAnyOtherPartnerships(object.id);
+      if (isOthers) {
         throw new InputException(
           'Primary partnerships cannot be removed. Make another partnership primary first.',
           'partnership.id'
@@ -372,19 +281,17 @@ export class PartnershipService {
   }
 
   async list(
-    input: Partial<PartnershipListInput>,
+    partialInput: Partial<PartnershipListInput>,
     session: Session
   ): Promise<PartnershipListOutput> {
-    const { filter, ...listInput } = {
+    const input = {
       ...PartnershipListInput.defaultVal,
-      ...input,
+      ...partialInput,
     };
 
-    const query = this.repo.list(filter, listInput, session);
+    const query = this.repo.list(input, session);
 
-    return await runListQuery(query, listInput, (id) =>
-      this.readOne(id, session)
-    );
+    return await runListQuery(query, input, (id) => this.readOne(id, session));
   }
 
   protected verifyFinancialReportingType(
@@ -420,7 +327,7 @@ export class PartnershipService {
       partnerId
     );
 
-    if (!result?.project) {
+    if (!result.project) {
       throw new NotFoundException(
         'Could not find project',
         'partnership.projectId'
@@ -440,49 +347,5 @@ export class PartnershipService {
         'Partnership for this project and partner already exists'
       );
     }
-  }
-
-  protected async isFirstPartnership(projectId: ID): Promise<boolean> {
-    const result = await this.repo.isFirstPartnership(projectId);
-    return result?.partnership ? false : true;
-  }
-
-  protected otherPartnershipQuery(partnershipId: ID): Query {
-    return this.repo.otherPartnershipQuery(partnershipId);
-  }
-
-  /**
-   *
-   * match current primary partnership, its project, and all other partnerships
-   * set current to primary false
-   */
-  protected async removeOtherPartnershipPrimary(
-    partnershipId: ID
-  ): Promise<void> {
-    const createdAt = DateTime.local();
-
-    await this.otherPartnershipQuery(partnershipId)
-      .match([
-        node('otherPartnership'),
-        relation('out', 'oldRel', 'primary', { active: true }),
-        node('', 'Property'),
-      ])
-      .setValues({
-        'oldRel.active': false,
-      })
-      .with('otherPartnership')
-      .create([
-        node('otherPartnership'),
-        relation('out', '', 'primary', {
-          active: true,
-          createdAt,
-        }),
-        node('newProperty', 'Property', {
-          createdAt,
-          value: false,
-          sortValue: false,
-        }),
-      ])
-      .run();
   }
 }

--- a/src/components/periodic-report/periodic-report.module.ts
+++ b/src/components/periodic-report/periodic-report.module.ts
@@ -25,6 +25,6 @@ import { PeriodicReportService } from './periodic-report.service';
     PeriodicReportRepository,
     ...Object.values(handlers),
   ],
-  exports: [PeriodicReportService, PeriodicReportRepository],
+  exports: [PeriodicReportService],
 })
 export class PeriodicReportModule {}

--- a/src/components/periodic-report/periodic-report.service.ts
+++ b/src/components/periodic-report/periodic-report.service.ts
@@ -1,7 +1,6 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
-import { DateTime, Interval } from 'luxon';
+import { Interval } from 'luxon';
 import {
-  generateId,
   ID,
   NotFoundException,
   ServerException,
@@ -46,25 +45,8 @@ export class PeriodicReportService {
     input: CreatePeriodicReport,
     session: Session
   ): Promise<PeriodicReport> {
-    const id = await generateId();
-    const createdAt = DateTime.local();
-
-    const reportFileId = await generateId();
-
     try {
-      const result = await this.repo.create(
-        input,
-
-        createdAt,
-        id,
-        reportFileId
-      );
-
-      if (!result) {
-        throw new ServerException('Failed to create a periodic report');
-      }
-
-      await this.repo.createProperties(input, result);
+      const { id, reportFileId } = await this.repo.create(input);
 
       await this.files.createDefinedFile(
         reportFileId,

--- a/src/components/post/post.module.ts
+++ b/src/components/post/post.module.ts
@@ -11,6 +11,6 @@ import { PostService } from './post.service';
     forwardRef(() => AuthorizationModule),
   ],
   providers: [PostResolver, PostService, PostRepository],
-  exports: [PostService, PostRepository],
+  exports: [PostService],
 })
 export class PostModule {}

--- a/src/components/post/postable/postable.module.ts
+++ b/src/components/post/postable/postable.module.ts
@@ -11,6 +11,6 @@ import { PostableResolver } from './postable.resolver';
     forwardRef(() => AuthorizationModule),
   ],
   providers: [PostableResolver, PostService, PostRepository],
-  exports: [PostService, PostRepository],
+  exports: [PostService],
 })
 export class PostableModule {}

--- a/src/components/product/product.module.ts
+++ b/src/components/product/product.module.ts
@@ -19,6 +19,6 @@ import { ProductService } from './product.service';
     ScriptureModule,
   ],
   providers: [ProductResolver, ProductService, ProductRepository],
-  exports: [ProductService, ProductRepository],
+  exports: [ProductService],
 })
 export class ProductModule {}

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -14,7 +14,6 @@ import {
   UnauthorizedException,
 } from '../../common';
 import {
-  ConfigService,
   createBaseNode,
   ILogger,
   Logger,
@@ -51,7 +50,6 @@ import { ProductRepository } from './product.repository';
 @Injectable()
 export class ProductService {
   constructor(
-    private readonly config: ConfigService,
     private readonly film: FilmService,
     private readonly story: StoryService,
     private readonly song: SongService,

--- a/src/components/project/project-member/project-member.module.ts
+++ b/src/components/project/project-member/project-member.module.ts
@@ -15,6 +15,6 @@ import { ProjectMemberService } from './project-member.service';
     ProjectMemberService,
     ProjectMemberRepository,
   ],
-  exports: [ProjectMemberService, ProjectMemberRepository],
+  exports: [ProjectMemberService],
 })
 export class ProjectMemberModule {}

--- a/src/components/project/project.module.ts
+++ b/src/components/project/project.module.ts
@@ -5,7 +5,6 @@ import { EngagementModule } from '../engagement/engagement.module';
 import { FieldRegionModule } from '../field-region/field-region.module';
 import { FileModule } from '../file/file.module';
 import { LocationModule } from '../location/location.module';
-import { OrganizationService } from '../organization';
 import { OrganizationModule } from '../organization/organization.module';
 import { PartnerModule } from '../partner/partner.module';
 import { PartnershipModule } from '../partnership/partnership.module';
@@ -34,18 +33,12 @@ import { ProjectService } from './project.service';
   ],
   providers: [
     ProjectResolver,
-    OrganizationService,
     ProjectService,
     ProjectStepResolver,
     ProjectRules,
     ProjectRepository,
     ...Object.values(handlers),
   ],
-  exports: [
-    ProjectService,
-    ProjectMemberModule,
-    ProjectRules,
-    ProjectRepository,
-  ],
+  exports: [ProjectService, ProjectMemberModule, ProjectRules],
 })
 export class ProjectModule {}

--- a/src/components/scripture/scripture-reference.service.ts
+++ b/src/components/scripture/scripture-reference.service.ts
@@ -1,13 +1,12 @@
 import { sortBy } from 'lodash';
 import { ID, Session } from '../../common';
-import { DatabaseService, ILogger, Logger } from '../../core';
+import { ILogger, Logger } from '../../core';
 import { ScriptureRange, ScriptureRangeInput } from './dto';
 import { ScriptureReferenceRepository } from './scripture-reference.repository';
 
 export class ScriptureReferenceService {
   constructor(
     @Logger('scripture-reference:service') private readonly logger: ILogger,
-    private readonly db: DatabaseService,
     private readonly repo: ScriptureReferenceRepository
   ) {}
 

--- a/src/components/scripture/scripture.module.ts
+++ b/src/components/scripture/scripture.module.ts
@@ -11,6 +11,6 @@ import { ScriptureReferenceService } from './scripture-reference.service';
     ScriptureReferenceService,
     ScriptureReferenceRepository,
   ],
-  exports: [ScriptureReferenceService, ScriptureReferenceRepository],
+  exports: [ScriptureReferenceService],
 })
 export class ScriptureModule {}

--- a/src/components/search/search.module.ts
+++ b/src/components/search/search.module.ts
@@ -33,6 +33,6 @@ import { SearchService } from './search.service';
     FundingAccountModule,
   ],
   providers: [SearchResolver, SearchService, SearchRepository],
-  exports: [SearchService, SearchRepository],
+  exports: [SearchService],
 })
 export class SearchModule {}

--- a/src/components/search/search.service.ts
+++ b/src/components/search/search.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { compact } from 'lodash';
 import { ID, NotFoundException, ServerException, Session } from '../../common';
-import { DatabaseService } from '../../core';
 import { FieldRegionService } from '../field-region';
 import { FieldZoneService } from '../field-zone';
 import { FilmService } from '../film';
@@ -58,7 +57,6 @@ export class SearchService {
   /* eslint-enable @typescript-eslint/naming-convention */
 
   constructor(
-    private readonly db: DatabaseService,
     private readonly users: UserService,
     private readonly orgs: OrganizationService,
     private readonly partners: PartnerService,

--- a/src/components/song/song.module.ts
+++ b/src/components/song/song.module.ts
@@ -8,6 +8,6 @@ import { SongService } from './song.service';
 @Module({
   imports: [forwardRef(() => AuthorizationModule), ScriptureModule],
   providers: [SongResolver, SongService, SongRepository],
-  exports: [SongService, SongRepository],
+  exports: [SongService],
 })
 export class SongModule {}

--- a/src/components/song/song.service.ts
+++ b/src/components/song/song.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ConfigService, ILogger, Logger, OnIndex } from '../../core';
+import { ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -27,7 +27,6 @@ import { SongRepository } from './song.repository';
 export class SongService {
   constructor(
     @Logger('song:service') private readonly logger: ILogger,
-    private readonly config: ConfigService,
     private readonly scriptureRefService: ScriptureReferenceService,
     private readonly authorizationService: AuthorizationService,
     private readonly repo: SongRepository

--- a/src/components/story/story.module.ts
+++ b/src/components/story/story.module.ts
@@ -8,6 +8,6 @@ import { StoryService } from './story.service';
 @Module({
   imports: [forwardRef(() => AuthorizationModule), ScriptureModule],
   providers: [StoryResolver, StoryService, StoryRepository],
-  exports: [StoryService, StoryRepository],
+  exports: [StoryService],
 })
 export class StoryModule {}

--- a/src/components/story/story.service.ts
+++ b/src/components/story/story.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ConfigService, ILogger, Logger, OnIndex } from '../../core';
+import { ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -27,7 +27,6 @@ import { StoryRepository } from './story.repository';
 export class StoryService {
   constructor(
     @Logger('story:service') private readonly logger: ILogger,
-    private readonly config: ConfigService,
     private readonly scriptureRefService: ScriptureReferenceService,
     private readonly authorizationService: AuthorizationService,
     private readonly repo: StoryRepository

--- a/src/components/user/education/education.module.ts
+++ b/src/components/user/education/education.module.ts
@@ -7,6 +7,6 @@ import { EducationService } from './education.service';
 @Module({
   imports: [forwardRef(() => AuthorizationModule)],
   providers: [EducationResolver, EducationService, EducationRepository],
-  exports: [EducationService, EducationRepository],
+  exports: [EducationService],
 })
 export class EducationModule {}

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -6,7 +6,7 @@ import {
   ServerException,
   Session,
 } from '../../../common';
-import { ConfigService, DatabaseService, ILogger, Logger } from '../../../core';
+import { ILogger, Logger } from '../../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -25,8 +25,6 @@ import { EducationRepository } from './education.repository';
 export class EducationService {
   constructor(
     @Logger('education:service') private readonly logger: ILogger,
-    private readonly config: ConfigService,
-    private readonly db: DatabaseService,
     @Inject(forwardRef(() => AuthorizationService))
     private readonly authorizationService: AuthorizationService,
     private readonly repo: EducationRepository

--- a/src/components/user/unavailability/unavailability.module.ts
+++ b/src/components/user/unavailability/unavailability.module.ts
@@ -11,6 +11,6 @@ import { UnavailabilityService } from './unavailability.service';
     UnavailabilityService,
     UnavailabilityRepository,
   ],
-  exports: [UnavailabilityService, UnavailabilityRepository],
+  exports: [UnavailabilityService],
 })
 export class UnavailabilityModule {}

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -5,7 +5,7 @@ import {
   ServerException,
   Session,
 } from '../../../common';
-import { ConfigService, ILogger, Logger } from '../../../core';
+import { ILogger, Logger } from '../../../core';
 import { parseBaseNodeProperties } from '../../../core/database/results';
 import { AuthorizationService } from '../../authorization/authorization.service';
 import {
@@ -21,7 +21,6 @@ import { UnavailabilityRepository } from './unavailability.repository';
 export class UnavailabilityService {
   constructor(
     @Logger('unavailability:service') private readonly logger: ILogger,
-    private readonly config: ConfigService,
     @Inject(forwardRef(() => AuthorizationService))
     private readonly authorizationService: AuthorizationService,
     private readonly repo: UnavailabilityRepository

--- a/src/components/user/user.module.ts
+++ b/src/components/user/user.module.ts
@@ -26,6 +26,6 @@ import { UserService } from './user.service';
     forwardRef(() => LanguageModule),
   ],
   providers: [KnownLanguageResolver, UserResolver, UserService, UserRepository],
-  exports: [UserService, EducationModule, UnavailabilityModule, UserRepository],
+  exports: [UserService, EducationModule, UnavailabilityModule],
 })
 export class UserModule {}

--- a/src/components/user/user.repository.ts
+++ b/src/components/user/user.repository.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { inArray, node, Query, relation } from 'cypher-query-builder';
-import { Dictionary } from 'lodash';
+import { inArray, node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import {
   DuplicateException,
+  generateId,
   ID,
   NotFoundException,
   ServerException,
@@ -28,12 +28,12 @@ import {
   permissionsOfNode,
   requestingUser,
 } from '../../core/database/query';
-import { QueryWithResult } from '../../core/database/query.overrides';
 import { DbPropsOfDto, StandardReadResult } from '../../core/database/results';
 import { Role } from '../authorization';
 import {
   AssignOrganizationToUser,
   CreatePerson,
+  KnownLanguage,
   LanguageProficiency,
   RemoveOrganizationFromUser,
   UpdateUser,
@@ -70,37 +70,39 @@ export class UserRepository extends DtoRepository(User) {
       'CREATE CONSTRAINT ON ()-[r:password]-() ASSERT EXISTS(r.createdAt)',
     ];
   }
-  roleProperties = (roles?: Role[]) => {
-    return (roles || []).flatMap((role) =>
+
+  private readonly roleProperties = (roles?: Role[]) =>
+    (roles || []).flatMap((role) =>
       property('roles', role, 'user', `role${role}`)
     );
-  };
-  async create(id: string, input: CreatePerson): Promise<Dictionary<any>> {
+
+  async create(input: CreatePerson) {
+    const id = await generateId();
     const createdAt = DateTime.local();
-    const query = this.db.query();
-    query.create([
-      [
-        node('user', ['User', 'BaseNode'], {
-          id,
-          createdAt,
-        }),
-      ],
-      ...property('email', input.email, 'user', 'email', 'EmailAddress'),
-      ...property('realFirstName', input.realFirstName, 'user'),
-      ...property('realLastName', input.realLastName, 'user'),
-      ...property('displayFirstName', input.displayFirstName, 'user'),
-      ...property('displayLastName', input.displayLastName, 'user'),
-      ...property('phone', input.phone, 'user'),
-      ...property('timezone', input.timezone, 'user'),
-      ...property('about', input.about, 'user'),
-      ...property('status', input.status, 'user'),
-      ...this.roleProperties(input.roles),
-      ...property('title', input.title, 'user'),
-      ...property('canDelete', true, 'user'),
-    ]);
-    query.return({
-      user: [{ id: 'id' }],
-    });
+    const query = this.db
+      .query()
+      .create([
+        [
+          node('user', ['User', 'BaseNode'], {
+            id,
+            createdAt,
+          }),
+        ],
+        ...property('email', input.email, 'user', 'email', 'EmailAddress'),
+        ...property('realFirstName', input.realFirstName, 'user'),
+        ...property('realLastName', input.realLastName, 'user'),
+        ...property('displayFirstName', input.displayFirstName, 'user'),
+        ...property('displayLastName', input.displayLastName, 'user'),
+        ...property('phone', input.phone, 'user'),
+        ...property('timezone', input.timezone, 'user'),
+        ...property('about', input.about, 'user'),
+        ...property('status', input.status, 'user'),
+        ...this.roleProperties(input.roles),
+        ...property('title', input.title, 'user'),
+        ...property('canDelete', true, 'user'),
+      ])
+      .return('user.id as id')
+      .asResult<{ id: ID }>();
     let result;
     try {
       result = await query.first();
@@ -169,9 +171,10 @@ export class UserRepository extends DtoRepository(User) {
         //
       }
     }
-    return result;
+    return result.id;
   }
-  async readOne(id: ID, sessionOrUserId: Session | ID): Promise<any> {
+
+  async readOne(id: ID, sessionOrUserId: Session | ID) {
     const query = this.db
       .query()
       .match([node('node', 'User', { id })])
@@ -276,21 +279,15 @@ export class UserRepository extends DtoRepository(User) {
     }
   }
 
-  list(
-    input: UserListInput,
-    session: Session
-  ): QueryWithResult<{
-    items: ID[];
-    total: number;
-  }> {
+  list(input: UserListInput, session: Session) {
     return this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode('User')])
       .apply(calculateTotalAndPaginateList(User, input));
   }
 
-  listEducations(userId: ID, session: Session): Query {
-    return this.db
+  async permissionsForListProp(prop: string, userId: ID, session: Session) {
+    const result = await this.db
       .query()
       .match(matchSession(session)) // Michel Query Refactor Will Fix This
       .match([node('user', 'User', { id: userId })])
@@ -300,7 +297,7 @@ export class UserRepository extends DtoRepository(User) {
         node('readSecurityGroup', 'SecurityGroup'),
         relation('out', 'sgReadPerms', 'permission'),
         node('canRead', 'Permission', {
-          property: 'education',
+          property: prop,
           read: true,
         }),
         relation('out', 'readPermsOfBaseNode', 'baseNode'),
@@ -312,7 +309,7 @@ export class UserRepository extends DtoRepository(User) {
         node('editSecurityGroup', 'SecurityGroup'),
         relation('out', 'sgEditPerms', 'permission'),
         node('canEdit', 'Permission', {
-          property: 'education',
+          property: prop,
           edit: true,
         }),
         relation('out', 'editPermsOfBaseNode', 'baseNode'),
@@ -321,111 +318,18 @@ export class UserRepository extends DtoRepository(User) {
       .return({
         canRead: [{ read: 'canRead' }],
         canEdit: [{ edit: 'canEdit' }],
-      });
+      })
+      .asResult<{ canRead?: boolean; canEdit?: boolean }>()
+      .first();
+    if (!result) {
+      throw new NotFoundException('Could not find user', 'userId');
+    }
+    return {
+      canRead: result.canRead ?? false,
+      canCreate: result.canEdit ?? false,
+    };
   }
 
-  listOrganizations(userId: ID, session: Session): Query {
-    return this.db
-      .query()
-      .match(matchSession(session))
-      .match([node('user', 'User', { id: userId })])
-      .optionalMatch([
-        node('requestingUser'),
-        relation('in', 'memberOfReadSecurityGroup', 'member'),
-        node('readSecurityGroup', 'SecurityGroup'),
-        relation('out', 'sgReadPerms', 'permission'),
-        node('canRead', 'Permission', {
-          property: 'organization',
-          read: true,
-        }),
-        relation('out', 'readPermsOfBaseNode', 'baseNode'),
-        node('user'),
-      ])
-      .optionalMatch([
-        node('requestingUser'),
-        relation('in', 'memberOfEditSecurityGroup', 'member'),
-        node('editSecurityGroup', 'SecurityGroup'),
-        relation('out', 'sgEditPerms', 'permission'),
-        node('canEdit', 'Permission', {
-          property: 'organization',
-          edit: true,
-        }),
-        relation('out', 'editPermsOfBaseNode', 'baseNode'),
-        node('user'),
-      ])
-      .return({
-        canRead: [{ read: 'canRead' }],
-        canEdit: [{ edit: 'canEdit' }],
-      });
-  }
-  listPartners(userId: ID, session: Session): Query {
-    return this.db
-      .query()
-      .match(matchSession(session)) // Michel Query Refactor Will Fix This
-      .match([node('user', 'User', { id: userId })])
-      .optionalMatch([
-        node('requestingUser'),
-        relation('in', 'memberOfReadSecurityGroup', 'member'),
-        node('readSecurityGroup', 'SecurityGroup'),
-        relation('out', 'sgReadPerms', 'permission'),
-        node('canRead', 'Permission', {
-          property: 'partners',
-          read: true,
-        }),
-        relation('out', 'readPermsOfBaseNode', 'baseNode'),
-        node('user'),
-      ])
-      .optionalMatch([
-        node('requestingUser'),
-        relation('in', 'memberOfEditSecurityGroup', 'member'),
-        node('editSecurityGroup', 'SecurityGroup'),
-        relation('out', 'sgEditPerms', 'permission'),
-        node('canEdit', 'Permission', {
-          property: 'partners',
-          edit: true,
-        }),
-        relation('out', 'editPermsOfBaseNode', 'baseNode'),
-        node('user'),
-      ])
-      .return({
-        canRead: [{ read: 'canRead' }],
-        canEdit: [{ edit: 'canEdit' }],
-      });
-  }
-  listUnavailabilities(userId: ID, session: Session): Query {
-    return this.db
-      .query()
-      .match(matchSession(session))
-      .match([node('user', 'User', { id: userId })])
-      .optionalMatch([
-        node('requestingUser'),
-        relation('in', 'memberOfReadSecurityGroup', 'member'),
-        node('readSecurityGroup', 'SecurityGroup'),
-        relation('out', 'sgReadPerms', 'permission'),
-        node('canRead', 'Permission', {
-          property: 'unavailability',
-          read: true,
-        }),
-        relation('out', 'readPermsOfBaseNode', 'baseNode'),
-        node('user'),
-      ])
-      .optionalMatch([
-        node('requestingUser'),
-        relation('in', 'memberOfEditSecurityGroup', 'member'),
-        node('editSecurityGroup', 'SecurityGroup'),
-        relation('out', 'sgEditPerms', 'permission'),
-        node('canEdit', 'Permission', {
-          property: 'unavailability',
-          edit: true,
-        }),
-        relation('out', 'editPermsOfBaseNode', 'baseNode'),
-        node('user'),
-      ])
-      .return({
-        canRead: [{ read: 'canRead' }],
-        canEdit: [{ edit: 'canEdit' }],
-      });
-  }
   async createKnownLanguage(
     userId: ID,
     languageId: ID,
@@ -446,6 +350,7 @@ export class UserRepository extends DtoRepository(User) {
       ])
       .run();
   }
+
   async deleteKnownLanguage(
     userId: ID,
     languageId: ID,
@@ -471,15 +376,7 @@ export class UserRepository extends DtoRepository(User) {
       .run();
   }
 
-  async listKnownLanguages(
-    userId: ID,
-    session: Session
-  ): Promise<
-    Array<{
-      languageProficiency: LanguageProficiency;
-      languageId: ID;
-    }>
-  > {
+  async listKnownLanguages(userId: ID, session: Session) {
     const results = await this.db
       .query()
       .match([
@@ -490,126 +387,94 @@ export class UserRepository extends DtoRepository(User) {
       ])
       .with('collect(distinct user) as users, node, knownLanguageRel')
       .raw(`unwind users as user`)
-      .return([
-        'knownLanguageRel.value as languageProficiency',
-        'node.id as languageId',
-      ])
-      .asResult<{
-        languageProficiency: LanguageProficiency;
-        languageId: ID;
-      }>()
+      .return(['knownLanguageRel.value as proficiency', 'node.id as language'])
+      .asResult<KnownLanguage>()
       .run();
     return results;
   }
-  async checkEmail(email: string): Promise<Dictionary<any> | undefined> {
+
+  async doesEmailAddressExist(email: string) {
     const result = await this.db
       .query()
-      .raw(
-        `
-      MATCH
-      (email:EmailAddress {
-        value: $email
-      })
-      RETURN
-      email.value as email
-      `,
-        {
-          email: email,
-        }
-      )
+      .matchNode('email', 'EmailAddress', { value: email })
+      .return('email.value')
       .first();
-    return result;
+    return !!result;
   }
 
-  async assignOrganizationToUser(
-    request: AssignOrganizationToUser,
-    session: Session
-  ): Promise<Query> {
-    const querySession = this.db.query();
-    if (session.userId) {
-      querySession.match([
-        matchSession(session, { withAclEdit: 'canCreateOrg' }),
-      ]);
-    }
-
-    const primary =
-      request.primary !== null && request.primary !== undefined
-        ? request.primary
-        : false;
-
-    //2
+  async assignOrganizationToUser({
+    userId,
+    orgId,
+    primary,
+  }: AssignOrganizationToUser) {
     await this.db
       .query()
       .match([
-        node('user', 'User', {
-          id: request.userId,
-        }),
-        relation('out', 'oldRel', 'organization', {
-          active: true,
-        }),
-        node('primaryOrg', 'Organization', {
-          id: request.orgId,
-        }),
+        [node('user', 'User', { id: userId })],
+        [node('org', 'Organization', { id: orgId })],
       ])
-      .setValues({ 'oldRel.active': false })
+      .subQuery((sub) =>
+        sub
+          .with('user, org')
+          .match([
+            node('user'),
+            relation('out', 'oldRel', 'organization', { active: true }),
+            node('org'),
+          ])
+          .setValues({ 'oldRel.active': false })
+          .return('oldRel')
+          .union()
+          .return('null as oldRel')
+      )
+      .apply((q) => {
+        if (primary) {
+          q.subQuery((sub) =>
+            sub
+              .with('user, org')
+              .match([
+                node('user'),
+                relation('out', 'oldRel', 'primaryOrganization', {
+                  active: true,
+                }),
+                node('org'),
+              ])
+              .setValues({ 'oldRel.active': false })
+              .return('oldRel as oldPrimaryRel')
+              .union()
+              .return('null as oldPrimaryRel')
+          );
+        }
+      })
       .return('oldRel')
-      .first();
+      .run();
 
-    if (primary) {
-      await this.db
-        .query()
-        .match([
-          node('user', 'User', {
-            id: request.userId,
-          }),
-          relation('out', 'oldRel', 'primaryOrganization', {
-            active: true,
-          }),
-          node('primaryOrg', 'Organization', {
-            id: request.orgId,
-          }),
-        ])
-        .setValues({ 'oldRel.active': false })
-        .return('oldRel')
-        .first();
+    const userToOrg = (label: string) => [
+      node('user'),
+      relation('out', '', label, {
+        active: true,
+        createdAt: DateTime.local(),
+      }),
+      node('org'),
+    ];
+    const result = await this.db
+      .query()
+      .match([
+        [node('org', 'Organization', { id: orgId })],
+        [node('user', 'User', { id: userId })],
+      ])
+      .create([
+        userToOrg('organization'),
+        ...(primary ? [userToOrg('primaryOrganization')] : []),
+      ])
+      .return('org.id')
+      .first();
+    if (!result) {
+      throw new ServerException('Failed to assign organization to user');
     }
-    //3
-    let queryCreate;
-    if (primary) {
-      queryCreate = this.db.query().raw(
-        `
-        MATCH (primaryOrg:Organization {id: $orgId}),
-        (user:User {id: $userId})
-        CREATE (primaryOrg)<-[:primaryOrganization {active: true, createdAt: datetime()}]-(user),
-        (primaryOrg)<-[:organization {active: true, createdAt: datetime()}]-(user)
-        RETURN  user.id as id
-      `,
-        {
-          userId: request.userId,
-          orgId: request.orgId,
-        }
-      );
-    } else {
-      queryCreate = this.db.query().raw(
-        `
-        MATCH (org:Organization {id: $orgId}),
-        (user:User {id: $userId})
-        CREATE (org)<-[:organization {active: true, createdAt: datetime()}]-(user)
-        RETURN  user.id as id
-      `,
-        {
-          userId: request.userId,
-          orgId: request.orgId,
-        }
-      );
-    }
-    return queryCreate;
   }
 
-  async removeOrganizationFromUser(
-    request: RemoveOrganizationFromUser
-  ): Promise<Dictionary<any> | undefined> {
-    const removeOrg = this.db
+  async removeOrganizationFromUser(request: RemoveOrganizationFromUser) {
+    const result = await this.db
       .query()
       .match([
         node('user', 'User', {
@@ -628,15 +493,12 @@ export class UserRepository extends DtoRepository(User) {
         node('org'),
       ])
       .setValues({ 'oldRel.active': false })
-      .return({ oldRel: [{ id: 'oldId' }], primary: [{ id: 'primaryId' }] });
-    let resultOrg;
-    try {
-      resultOrg = await removeOrg.first();
-    } catch (e) {
-      throw new NotFoundException('user and org are not connected');
-    }
+      .return({ oldRel: [{ id: 'oldId' }], primary: [{ id: 'primaryId' }] })
+      .asResult<{ primaryId: ID; oldId: ID }>()
+      .first();
 
-    if (resultOrg?.primaryId) {
+    // TODO Refactor this into one query and make these two relationships independent or combine into one.
+    if (result?.primaryId) {
       const removePrimary = this.db
         .query()
         .match([
@@ -652,12 +514,7 @@ export class UserRepository extends DtoRepository(User) {
         ])
         .setValues({ 'oldRel.active': false })
         .return('oldRel');
-      try {
-        await removePrimary.first();
-      } catch {
-        this.logger.debug('not primary');
-      }
+      await removePrimary.first();
     }
-    return resultOrg;
   }
 }

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -13,8 +13,6 @@ import {
   Session,
 } from '../../common';
 import {
-  ConfigService,
-  DatabaseService,
   ILogger,
   Logger,
   OnIndex,
@@ -106,8 +104,6 @@ export class UserService {
     @Inject(forwardRef(() => PartnerService))
     private readonly partners: PartnerService,
     private readonly unavailabilities: UnavailabilityService,
-    private readonly db: DatabaseService,
-    private readonly config: ConfigService,
     @Inject(forwardRef(() => AuthorizationService))
     private readonly authorizationService: AuthorizationService,
     private readonly locationService: LocationService,

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -3,7 +3,6 @@ import { compact, difference } from 'lodash';
 import { DateTime } from 'luxon';
 import {
   DuplicateException,
-  generateId,
   ID,
   isIdLike,
   mapFromList,
@@ -147,8 +146,7 @@ export class UserService {
   };
 
   async create(input: CreatePerson, _session?: Session): Promise<ID> {
-    const id = await generateId();
-    await this.userRepo.create(id, input);
+    const id = await this.userRepo.create(input);
     input.roles &&
       (await this.authorizationService.roleAddedToUser(id, input.roles));
     await this.authorizationService.processNewBaseNode(User, id, id);
@@ -160,9 +158,6 @@ export class UserService {
       id,
       sessionOrUserId
     );
-    if (!result) {
-      throw new NotFoundException('Could not find user', 'user.id');
-    }
 
     const rolesValue = result.propList
       .filter((prop: any) => prop.property === 'roles')
@@ -271,22 +266,13 @@ export class UserService {
     input: EducationListInput,
     session: Session
   ): Promise<SecuredEducationList> {
-    const query = this.userRepo.listEducations(userId, session);
+    const perms = await this.userRepo.permissionsForListProp(
+      'education',
+      userId,
+      session
+    );
 
-    let user;
-    try {
-      user = await query.first();
-    } catch (exception) {
-      this.logger.error(`Could not find education`, {
-        exception,
-        userId: session.userId,
-      });
-      throw new ServerException('Could not find education', exception);
-    }
-    if (!user) {
-      throw new NotFoundException('Could not find user', 'userId');
-    }
-    if (!user.canRead) {
+    if (!perms.canRead) {
       return SecuredList.Redacted;
     }
     const result = await this.educations.list(
@@ -301,8 +287,7 @@ export class UserService {
     );
     return {
       ...result,
-      canRead: user.canRead,
-      canCreate: user.canEdit ?? false,
+      ...perms,
     };
   }
 
@@ -311,21 +296,13 @@ export class UserService {
     input: OrganizationListInput,
     session: Session
   ): Promise<SecuredOrganizationList> {
-    const query = this.userRepo.listOrganizations(userId, session);
-    let user;
-    try {
-      user = await query.first();
-    } catch (exception) {
-      this.logger.error(`Could not find organizations`, {
-        exception,
-        userId: session.userId,
-      });
-      throw new ServerException('Could not find organization', exception);
-    }
-    if (!user) {
-      throw new NotFoundException('Could not find user', 'userId');
-    }
-    if (!user.canRead) {
+    const perms = await this.userRepo.permissionsForListProp(
+      'organization',
+      userId,
+      session
+    );
+
+    if (!perms.canRead) {
       return SecuredList.Redacted;
     }
     const result = await this.organizations.list(
@@ -341,8 +318,7 @@ export class UserService {
 
     return {
       ...result,
-      canRead: user.canRead,
-      canCreate: user.canEdit ?? false,
+      ...perms,
     };
   }
 
@@ -351,25 +327,13 @@ export class UserService {
     input: PartnerListInput,
     session: Session
   ): Promise<SecuredPartnerList> {
-    const query = this.userRepo.listPartners(userId, session);
-    let user;
-    try {
-      user = await query.first();
-    } catch (exception) {
-      this.logger.error(`Could not find partners`, {
-        exception,
-        userId: session.userId,
-      });
-      throw new ServerException('Could not find partner', exception);
-    }
-    if (!user) {
-      throw new NotFoundException('Could not find user', 'userId');
-    }
+    const perms = await this.userRepo.permissionsForListProp(
+      'partners',
+      userId,
+      session
+    );
 
-    if (!user.canRead) {
-      this.logger.warning('Cannot read partner list', {
-        userId,
-      });
+    if (!perms.canRead) {
       return SecuredList.Redacted;
     }
     const result = await this.partners.list(
@@ -384,8 +348,7 @@ export class UserService {
     );
     return {
       ...result,
-      canRead: user.canRead,
-      canCreate: user.canEdit,
+      ...perms,
     };
   }
 
@@ -394,21 +357,13 @@ export class UserService {
     input: UnavailabilityListInput,
     session: Session
   ): Promise<SecuredUnavailabilityList> {
-    const query = this.userRepo.listUnavailabilities(userId, session);
-    let user;
-    try {
-      user = await query.first();
-    } catch (exception) {
-      this.logger.error(`Could not find unavailability`, {
-        exception,
-        userId: session.userId,
-      });
-      throw new ServerException('Could not find unavailability', exception);
-    }
-    if (!user) {
-      throw new NotFoundException('Could not find user', 'userId');
-    }
-    if (!user.canRead) {
+    const perms = await this.userRepo.permissionsForListProp(
+      'unavailability',
+      userId,
+      session
+    );
+
+    if (!perms.canRead) {
       return SecuredList.Redacted;
     }
     const result = await this.unavailabilities.list(
@@ -424,8 +379,7 @@ export class UserService {
 
     return {
       ...result,
-      canRead: user.canRead,
-      canCreate: user.canEdit ?? false,
+      ...perms,
     };
   }
 
@@ -521,52 +475,25 @@ export class UserService {
     userId: ID,
     session: Session
   ): Promise<KnownLanguage[]> {
-    const results = await this.userRepo.listKnownLanguages(userId, session);
-
-    const knownLanguages = await Promise.all(
-      results.map(async (item: any) => {
-        return {
-          language: item.languageId,
-          proficiency: item.languageProficiency,
-        };
-      })
-    );
-
-    return knownLanguages as KnownLanguage[];
+    return await this.userRepo.listKnownLanguages(userId, session);
   }
 
   async checkEmail(email: string): Promise<boolean> {
-    const result = await this.userRepo.checkEmail(email);
-    if (result) {
-      return false;
-    }
-    return true;
+    const exists = await this.userRepo.doesEmailAddressExist(email);
+    return !exists;
   }
 
   async assignOrganizationToUser(
     request: AssignOrganizationToUser,
-    session: Session
-  ): Promise<void> {
-    //TO DO: Refactor session in the future
-
-    const queryCreate = await this.userRepo.assignOrganizationToUser(
-      request,
-      session
-    );
-    const result = await queryCreate.first();
-    if (!result) {
-      throw new ServerException('Failed to assign organzation to user');
-    }
+    _session: Session
+  ) {
+    await this.userRepo.assignOrganizationToUser(request);
   }
 
   async removeOrganizationFromUser(
     request: RemoveOrganizationFromUser,
     _session: Session
   ): Promise<void> {
-    const resultOrg = await this.userRepo.removeOrganizationFromUser(request);
-
-    if (!resultOrg) {
-      throw new ServerException('Failed to assign organzation to user');
-    }
+    await this.userRepo.removeOrganizationFromUser(request);
   }
 }

--- a/src/components/workflow/workflow.repository.ts
+++ b/src/components/workflow/workflow.repository.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
-import { Dictionary } from 'lodash';
 import { generateId, ID, Session } from '../../common';
 import { DatabaseService, matchSession } from '../../core';
 import {
@@ -583,12 +582,13 @@ export class WorkflowRepository {
         state: [{ value: 'value' }],
         newState: [{ value: 'newValue' }],
       })
+      .asResult<{ value: any; newValue: any }>()
       .first();
   }
 
   async changeCurrentState(
     session: Session,
-    possibleState: Dictionary<any> | undefined,
+    possibleState: { value: any; newValue: any },
     stateIdentifier: string
   ) {
     await this.db
@@ -607,7 +607,7 @@ export class WorkflowRepository {
           node('baseNode', 'BaseNode'),
           relation('out', 'oldRel', `${stateIdentifier}`),
           node('currentState', 'CurrentState:Property', {
-            value: possibleState?.value,
+            value: possibleState.value,
           }),
         ],
       ])
@@ -623,7 +623,7 @@ export class WorkflowRepository {
             active: true,
           }),
           node('newCurrentState', 'CurrentState:Property', {
-            value: possibleState?.newValue,
+            value: possibleState.newValue,
           }),
         ],
       ])

--- a/src/components/workflow/workflow.service.ts
+++ b/src/components/workflow/workflow.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { DatabaseService, ILogger, Logger } from '../../core';
+import { ILogger, Logger } from '../../core';
 import {
   AddState,
   ChangeCurrentState,
@@ -26,7 +26,6 @@ import { WorkflowRepository } from './workflow.repository';
 @Injectable()
 export class WorkflowService {
   constructor(
-    private readonly db: DatabaseService,
     @Logger('workflow.service') private readonly logger: ILogger,
     private readonly repo: WorkflowRepository
   ) {}

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -562,28 +562,6 @@ export class DatabaseService {
     await query.run();
   }
 
-  async addLabelsToPropNodes(
-    baseNodeId: ID,
-    property: string,
-    lables: string[]
-  ): Promise<void> {
-    const addLabel = this.db
-      .query()
-      .match([node('baseNode', { active: true, id: baseNodeId })])
-      .match([
-        node('baseNode'),
-        relation('out', 'rel', property, { active: true }),
-        node('prop', 'Property', { active: true }),
-      ])
-      .set({
-        labels: {
-          prop: lables,
-        },
-      })
-      .return('baseNode');
-    await addLabel.run();
-  }
-
   assertPatternsIncludeIdentifier(
     patterns: Pattern[][],
     ...identifiers: string[]

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -30,7 +30,6 @@ import {
 } from '../../common';
 import { ILogger, Logger, ServiceUnavailableError, UniquenessError } from '..';
 import { AbortError, retry, RetryOptions } from '../../common/retry';
-import { ConfigService } from '../config/config.service';
 import { DbChanges } from './changes';
 import { deleteBaseNode } from './query';
 import { determineSortValue } from './query.helpers';
@@ -93,7 +92,6 @@ export interface ServerInfo {
 export class DatabaseService {
   constructor(
     private readonly db: Connection,
-    private readonly config: ConfigService,
     @Logger('database:service') private readonly logger: ILogger
   ) {}
 

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -8,7 +8,7 @@ import {
   relation,
 } from 'cypher-query-builder';
 import type { Pattern } from 'cypher-query-builder/dist/typings/clauses/pattern';
-import { cloneDeep, last, Many, startCase, upperFirst } from 'lodash';
+import { cloneDeep, last, Many, startCase, uniq, upperFirst } from 'lodash';
 import { DateTime } from 'luxon';
 import { Driver, Session as Neo4jSession } from 'neo4j-driver';
 import { assert } from 'ts-essentials';
@@ -50,7 +50,7 @@ export const property = (
       active: true,
       createdAt: DateTime.local(),
     }),
-    node(propVar, ['Property', ...many(extraPropLabel ?? [])], {
+    node(propVar, uniq(['Property', ...many(extraPropLabel ?? [])]), {
       value,
     }),
   ],

--- a/src/core/database/errors.ts
+++ b/src/core/database/errors.ts
@@ -135,6 +135,8 @@ export const createBetterError = (e: Error) => {
   if (!isNeo4jError(e)) {
     return e;
   }
+  e.message ??= ''; // I've seen message is null
+
   if (e.code === ServiceUnavailableError.code) {
     return ServiceUnavailableError.fromNeo(e);
   }

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -831,7 +831,7 @@ describe('Engagement e2e', () => {
         internId: intern.id,
         mentorId: mentor.id,
       })
-    ).rejects.toThrow('countryOfOriginId is invalid');
+    ).rejects.toThrow('Could not find country of origin');
 
     internshipProject = await createProject(app, {
       type: ProjectType.Internship,
@@ -857,7 +857,7 @@ describe('Engagement e2e', () => {
         internId: intern.id,
         mentorId: invalidId,
       })
-    ).rejects.toThrow('mentorId is invalid');
+    ).rejects.toThrow('Could not find mentor');
   });
 
   it('language engagement creation fails and lets you know why if your ids are bad', async () => {
@@ -970,7 +970,7 @@ describe('Engagement e2e', () => {
         firstScripture: true,
       })
     ).rejects.toThrowError(
-      'firstScripture can not be set to true if the language has hasExternalFirstScripture=true'
+      'First scripture has already been marked as having been done externally'
     );
   });
 
@@ -987,7 +987,7 @@ describe('Engagement e2e', () => {
         firstScripture: true,
       })
     ).rejects.toThrowError(
-      'firstScripture can not be set to true if it is not the only engagement for the language that has firstScripture=true'
+      'Another engagement has already been marked as having done the first scripture'
     );
   });
 


### PR DESCRIPTION
Just some weekend clean up. 

- Renamed methods to be inline with what the query is doing instead of what the surrounding business logic is.
- Split up most methods that contained multiple queries. Ideally one-for-one.
- Combined some creates into one query. (base node, props, & relationships all together. Instead of relationships being separate)
- Adjusted returns so they are never unran `Query` objects which is leaking implementation details.
- Moved "null check to throw exception" into repositories. This is an implementation detail of the database layer.
- Adjusted returns so they are always strict types instead of `Dictionary`'s which is unsafe and pretty close to `any` type.
- Banned `Dictionary` types so this doesn't happen again
- Removed `DatabaseService.addLabelsToPropNodes` 🎉 The one usage was removed due to labels being added on create, instead of directly after.
- Removed a leftover query from periodic report migration
