### PR TITLE
Resource Resolver

### DIFF
--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -1,5 +1,6 @@
 import { Field, InterfaceType } from '@nestjs/graphql';
 import { DateTime } from 'luxon';
+import { assert } from 'ts-essentials';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { ID, IdField } from './id-field';
 import { DateTimeField } from './luxon.graphql';
@@ -7,7 +8,12 @@ import { SecuredProps, UnsecuredDto } from './secured-property';
 import { AbstractClassType } from './types';
 import { has } from './util';
 
-@InterfaceType()
+@InterfaceType({
+  resolveType: (value) => {
+    assert(typeof value.__typename === 'string');
+    return value.__typename;
+  },
+})
 export abstract class Resource {
   static readonly Props: string[] = keysOf<Resource>();
 

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -12,7 +12,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ILogger, Logger, Property } from '../../core';
+import { HandleIdLookup, ILogger, Logger, Property } from '../../core';
 import {
   parseSecuredProperties,
   runListQuery,
@@ -213,6 +213,7 @@ export class BudgetService {
     }
   }
 
+  @HandleIdLookup(Budget)
   async readOne(id: ID, session: Session): Promise<Budget> {
     this.logger.debug(`readOne budget`, {
       id,
@@ -256,6 +257,7 @@ export class BudgetService {
     };
   }
 
+  @HandleIdLookup(BudgetRecord)
   async readOneRecord(id: ID, session: Session): Promise<BudgetRecord> {
     this.logger.debug(`readOne BudgetRecord`, {
       id,

--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ILogger, Logger, Property } from '../../core';
+import { HandleIdLookup, ILogger, Logger, Property } from '../../core';
 import { runListQuery } from '../../core/database/results';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { CeremonyRepository } from './ceremony.repository';
@@ -90,6 +90,7 @@ export class CeremonyService {
     }
   }
 
+  @HandleIdLookup(Ceremony)
   async readOne(id: ID, session: Session): Promise<Ceremony> {
     this.logger.debug(`Query readOne Ceremony`, { id, userId: session.userId });
     if (!id) {

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -10,7 +10,13 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ConfigService, IEventBus, ILogger, Logger } from '../../core';
+import {
+  ConfigService,
+  HandleIdLookup,
+  IEventBus,
+  ILogger,
+  Logger,
+} from '../../core';
 import { runListQuery } from '../../core/database/results';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { CeremonyService } from '../ceremony';
@@ -210,6 +216,7 @@ export class EngagementService {
 
   // READ ///////////////////////////////////////////////////////////
 
+  @HandleIdLookup([LanguageEngagement, InternshipEngagement])
   async readOne(
     id: ID,
     session: Session

--- a/src/components/field-region/field-region.service.ts
+++ b/src/components/field-region/field-region.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ILogger, Logger, OnIndex } from '../../core';
+import { HandleIdLookup, ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -83,6 +83,7 @@ export class FieldRegionService {
     return await this.readOne(result.id, session);
   }
 
+  @HandleIdLookup(FieldRegion)
   async readOne(id: ID, session: Session): Promise<FieldRegion> {
     this.logger.debug(`Read Field Region`, {
       id: id,

--- a/src/components/field-zone/field-zone.service.ts
+++ b/src/components/field-zone/field-zone.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ILogger, Logger, OnIndex } from '../../core';
+import { HandleIdLookup, ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -76,6 +76,7 @@ export class FieldZoneService {
     return await this.readOne(result.id, session);
   }
 
+  @HandleIdLookup(FieldZone)
   async readOne(id: ID, session: Session): Promise<FieldZone> {
     this.logger.debug(`Read Field Zone`, {
       id: id,

--- a/src/components/film/film.service.ts
+++ b/src/components/film/film.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ILogger, Logger, OnIndex } from '../../core';
+import { HandleIdLookup, ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -87,6 +87,7 @@ export class FilmService {
     }
   }
 
+  @HandleIdLookup(Film)
   async readOne(id: ID, session: Session): Promise<Film> {
     this.logger.debug(`Read film`, {
       id,

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ILogger, Logger, OnIndex } from '../../core';
+import { HandleIdLookup, ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -88,6 +88,7 @@ export class FundingAccountService {
     }
   }
 
+  @HandleIdLookup(FundingAccount)
   async readOne(id: ID, session: Session): Promise<FundingAccount> {
     this.logger.info('readOne', { id, userId: session.userId });
 

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -13,7 +13,13 @@ import {
   simpleSwitch,
   UnauthorizedException,
 } from '../../common';
-import { ILogger, Logger, OnIndex, UniquenessError } from '../../core';
+import {
+  HandleIdLookup,
+  ILogger,
+  Logger,
+  OnIndex,
+  UniquenessError,
+} from '../../core';
 import { runListQuery } from '../../core/database/results';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { Powers } from '../authorization/dto/powers';
@@ -150,6 +156,7 @@ export class LanguageService {
     }
   }
 
+  @HandleIdLookup(Language)
   async readOne(langId: ID, session: Session): Promise<Language> {
     const result = await this.repo.readOne(langId, session);
     if (!result) {

--- a/src/components/literacy-material/literacy-material.service.ts
+++ b/src/components/literacy-material/literacy-material.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ILogger, Logger, OnIndex } from '../../core';
+import { HandleIdLookup, ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -94,6 +94,7 @@ export class LiteracyMaterialService {
     }
   }
 
+  @HandleIdLookup(LiteracyMaterial)
   async readOne(id: ID, session: Session): Promise<LiteracyMaterial> {
     this.logger.debug(`Read literacyMaterial`, {
       id,

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -9,7 +9,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ILogger, Logger, OnIndex } from '../../core';
+import { HandleIdLookup, ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -71,6 +71,7 @@ export class LocationService {
     return await this.readOne(id, session);
   }
 
+  @HandleIdLookup(Location)
   async readOne(id: ID, session: Session): Promise<Location> {
     this.logger.debug(`Read Location`, {
       id: id,

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -7,7 +7,13 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ConfigService, ILogger, Logger, OnIndex } from '../../core';
+import {
+  ConfigService,
+  HandleIdLookup,
+  ILogger,
+  Logger,
+  OnIndex,
+} from '../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -93,6 +99,7 @@ export class OrganizationService {
     return await this.readOne(id, session);
   }
 
+  @HandleIdLookup(Organization)
   async readOne(orgId: ID, session: Session): Promise<Organization> {
     this.logger.debug(`Read Organization`, {
       id: orgId,

--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -8,7 +8,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ILogger, Logger, OnIndex } from '../../core';
+import { HandleIdLookup, ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   parsePropList,
@@ -84,6 +84,7 @@ export class PartnerService {
     return await this.readOne(partnerId, session);
   }
 
+  @HandleIdLookup(Partner)
   async readOne(id: ID, session: Session): Promise<Partner> {
     this.logger.debug(`Read Partner by Partner Id`, {
       id: id,

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -8,7 +8,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { IEventBus, ILogger, Logger } from '../../core';
+import { HandleIdLookup, IEventBus, ILogger, Logger } from '../../core';
 import { runListQuery } from '../../core/database/results';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { FileService } from '../file';
@@ -116,6 +116,7 @@ export class PartnershipService {
     }
   }
 
+  @HandleIdLookup(Partnership)
   async readOne(id: ID, session: Session): Promise<Partnership> {
     this.logger.debug('readOne', { id, userId: session.userId });
 

--- a/src/components/periodic-report/periodic-report.service.ts
+++ b/src/components/periodic-report/periodic-report.service.ts
@@ -7,15 +7,24 @@ import {
   Session,
   UnsecuredDto,
 } from '../../common';
-import { IEventBus, ILogger, Logger, OnIndex } from '../../core';
+import {
+  HandleIdLookup,
+  IEventBus,
+  ILogger,
+  Logger,
+  OnIndex,
+} from '../../core';
 import { runListQuery } from '../../core/database/results';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { CreateDefinedFileVersionInput, FileService } from '../file';
 import {
   CreatePeriodicReport,
+  FinancialReport,
   IPeriodicReport,
+  NarrativeReport,
   PeriodicReport,
   PeriodicReportListInput,
+  ProgressReport,
   ReportType,
   SecuredPeriodicReportList,
 } from './dto';
@@ -83,6 +92,7 @@ export class PeriodicReportService {
     return report;
   }
 
+  @HandleIdLookup([FinancialReport, NarrativeReport, ProgressReport])
   async readOne(id: ID, session: Session): Promise<PeriodicReport> {
     this.logger.debug(`read one`, {
       id,

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Node, node, relation } from 'cypher-query-builder';
+import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { Except } from 'type-fest';
 import { ID, Session } from '../../common';
@@ -81,7 +81,7 @@ export class ProductRepository extends CommonRepository {
         node('producible', 'Producible'),
       ])
       .return('producible')
-      .asResult<{ producible: Node<BaseNode> }>()
+      .asResult<{ producible: BaseNode }>()
       .first();
   }
 

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -15,6 +15,7 @@ import {
 } from '../../common';
 import {
   createBaseNode,
+  HandleIdLookup,
   ILogger,
   Logger,
   matchRequestingUser,
@@ -220,6 +221,7 @@ export class ProductService {
     return await this.readOne(result.id, session);
   }
 
+  @HandleIdLookup([DirectScriptureProduct, DerivativeScriptureProduct])
   async readOne(id: ID, session: Session): Promise<AnyProduct> {
     const result = await this.repo.readOne(id, session);
 

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -17,6 +17,7 @@ import {
 import {
   ConfigService,
   DatabaseService,
+  HandleIdLookup,
   IEventBus,
   ILogger,
   Logger,
@@ -127,6 +128,7 @@ export class ProjectMemberService {
     }
   }
 
+  @HandleIdLookup(ProjectMember)
   async readOne(id: ID, session: Session): Promise<ProjectMember> {
     this.logger.debug(`read one`, {
       id,

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -126,7 +126,7 @@ export class ProjectRepository extends CommonRepository {
         'collect(distinct sensitivity.value) as languageSensitivityList',
       ])
       .asResult<{
-        node: Node<BaseNode & { type: ProjectType }>;
+        node: BaseNode & Node<{ type: ProjectType }>;
         propList: PropListDbResult<DbPropsOfDto<Project>>;
         pinnedRel?: Relation;
         primaryLocationId: ID;

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -16,6 +16,7 @@ import {
 } from '../../common';
 import {
   ConfigService,
+  HandleIdLookup,
   IEventBus,
   ILogger,
   Logger,
@@ -194,6 +195,7 @@ export class ProjectService {
     }
   }
 
+  @HandleIdLookup(TranslationProject)
   async readOneTranslation(
     id: ID,
     session: Session
@@ -205,6 +207,7 @@ export class ProjectService {
     return project as TranslationProject;
   }
 
+  @HandleIdLookup(InternshipProject)
   async readOneInternship(
     id: ID,
     session: Session

--- a/src/components/search/search.service.ts
+++ b/src/components/search/search.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { compact } from 'lodash';
 import { ID, NotFoundException, ServerException, Session } from '../../common';
+import { ResourceResolver } from '../../core';
 import { FieldRegionService } from '../field-region';
 import { FieldZoneService } from '../field-zone';
 import { FilmService } from '../film';
@@ -57,6 +58,7 @@ export class SearchService {
   /* eslint-enable @typescript-eslint/naming-convention */
 
   constructor(
+    private readonly resources: ResourceResolver,
     private readonly users: UserService,
     private readonly orgs: OrganizationService,
     private readonly partners: PartnerService,

--- a/src/components/song/song.service.ts
+++ b/src/components/song/song.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ILogger, Logger, OnIndex } from '../../core';
+import { HandleIdLookup, ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -104,6 +104,7 @@ export class SongService {
     }
   }
 
+  @HandleIdLookup(Song)
   async readOne(id: ID, session: Session): Promise<Song> {
     const result = await this.repo.readOne(id, session);
     if (!result) {

--- a/src/components/story/story.service.ts
+++ b/src/components/story/story.service.ts
@@ -7,7 +7,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ILogger, Logger, OnIndex } from '../../core';
+import { HandleIdLookup, ILogger, Logger, OnIndex } from '../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -103,6 +103,7 @@ export class StoryService {
     }
   }
 
+  @HandleIdLookup(Story)
   async readOne(id: ID, session: Session): Promise<Story> {
     this.logger.debug(`Read Story`, {
       id,

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -6,7 +6,7 @@ import {
   ServerException,
   Session,
 } from '../../../common';
-import { ILogger, Logger } from '../../../core';
+import { HandleIdLookup, ILogger, Logger } from '../../../core';
 import {
   parseBaseNodeProperties,
   runListQuery,
@@ -79,6 +79,7 @@ export class EducationService {
     return await this.readOne(result.id, session);
   }
 
+  @HandleIdLookup(Education)
   async readOne(id: ID, session: Session): Promise<Education> {
     this.logger.debug(`Read Education`, {
       id: id,

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -5,7 +5,7 @@ import {
   ServerException,
   Session,
 } from '../../../common';
-import { ILogger, Logger } from '../../../core';
+import { HandleIdLookup, ILogger, Logger } from '../../../core';
 import { parseBaseNodeProperties } from '../../../core/database/results';
 import { AuthorizationService } from '../../authorization/authorization.service';
 import {
@@ -90,6 +90,7 @@ export class UnavailabilityService {
     }
   }
 
+  @HandleIdLookup(Unavailability)
   async readOne(id: ID, session: Session): Promise<Unavailability> {
     const result = await this.repo.readOne(id, session);
     if (!result) {

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -14,6 +14,7 @@ import {
   UnsecuredDto,
 } from '../../common';
 import {
+  HandleIdLookup,
   ILogger,
   Logger,
   OnIndex,
@@ -143,6 +144,7 @@ export class UserService {
     return id;
   }
 
+  @HandleIdLookup(User)
   async readOne(id: ID, sessionOrUserId: Session | ID): Promise<User> {
     const user = await this.userRepo.readOne(id);
     return await this.secure(user, sessionOrUserId);

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -11,6 +11,7 @@ import { EventsModule } from './events';
 import { ExceptionFilter } from './exception.filter';
 import { GraphqlLoggingPlugin } from './graphql-logging.plugin';
 import { GraphQLConfig } from './graphql.config';
+import { ResourceResolver } from './resources';
 import { ValidationPipe } from './validation.pipe';
 
 @Global()
@@ -28,6 +29,7 @@ import { ValidationPipe } from './validation.pipe';
     BaseExceptionFilter,
     { provide: APP_FILTER, useClass: ExceptionFilter },
     { provide: APP_PIPE, useClass: ValidationPipe },
+    ResourceResolver,
   ],
   controllers: [CoreController],
   exports: [
@@ -36,6 +38,7 @@ import { ValidationPipe } from './validation.pipe';
     DatabaseModule,
     EmailModule,
     EventsModule,
+    ResourceResolver,
   ],
 })
 export class CoreModule {}

--- a/src/core/database/results/parse-base-node.ts
+++ b/src/core/database/results/parse-base-node.ts
@@ -2,12 +2,12 @@ import type { Node } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { ID } from '../../../common';
 
-export interface BaseNode {
+export type BaseNode = Node<{
   id: ID;
   createdAt: DateTime;
-}
+}>;
 
-export const parseBaseNodeProperties = (node: Node<BaseNode>) => {
+export const parseBaseNodeProperties = (node: BaseNode) => {
   const { id, createdAt } = node.properties;
   return { id, createdAt };
 };

--- a/src/core/database/results/types.ts
+++ b/src/core/database/results/types.ts
@@ -1,4 +1,3 @@
-import type { Node } from 'cypher-query-builder';
 import type { DateTime } from 'luxon';
 import type { UnsecuredDto } from '../../../common';
 import type { BaseNode } from './parse-base-node';
@@ -20,7 +19,10 @@ export type DbPropsOfDto<
   // Specify this as true when using new matchProps query fragment
   IncludeBaseNode extends boolean | undefined = false
 > = NativeDbProps<
-  Omit<UnsecuredDto<Dto>, IncludeBaseNode extends true ? never : keyof BaseNode>
+  Omit<
+    UnsecuredDto<Dto>,
+    IncludeBaseNode extends true ? never : keyof BaseNode['properties']
+  >
 >;
 
 export type NativeDbProps<Dto extends Record<string, any>> = {
@@ -39,6 +41,6 @@ export type NativeDbValue =
  * This is a shortcut for the standard read result based on the given DB props.
  */
 export interface StandardReadResult<DbProps> {
-  node: Node<BaseNode>;
+  node: BaseNode;
   propList: PropListDbResult<DbProps>;
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,3 +4,4 @@ export * from './core.module';
 export * from './database';
 export * from './database/indexer';
 export * from './events';
+export * from './resources';

--- a/src/core/resources/index.ts
+++ b/src/core/resources/index.ts
@@ -1,0 +1,1 @@
+export * from './resource-resolver.service';

--- a/src/core/resources/resource-resolver.service.ts
+++ b/src/core/resources/resource-resolver.service.ts
@@ -1,7 +1,6 @@
 import { DiscoveryService } from '@golevelup/nestjs-discovery';
 import { Injectable, SetMetadata } from '@nestjs/common';
 import { GraphQLSchemaHost } from '@nestjs/graphql';
-import { Node } from 'cypher-query-builder';
 import { isObjectType } from 'graphql';
 import { ValueOf } from 'type-fest';
 import { ID, many, Many, ServerException, Session } from '../../common';
@@ -52,7 +51,7 @@ export class ResourceResolver {
   /**
    * Lookup a resource from a Neo4j BaseNode.
    */
-  async lookupByBaseNode(node: Node<BaseNode>, session: Session) {
+  async lookupByBaseNode(node: BaseNode, session: Session) {
     return await this.lookup(node.labels, node.properties.id, session);
   }
 

--- a/src/core/resources/resource-resolver.service.ts
+++ b/src/core/resources/resource-resolver.service.ts
@@ -13,6 +13,8 @@ interface Shape {
   type: ReadonlyArray<keyof ResourceMap>;
 }
 
+type SomeResource = ValueOf<ResourceMap>;
+
 /**
  * Register this function as the function to use to lookup the given types.
  *
@@ -23,7 +25,7 @@ interface Shape {
  *
  * {@link ResourceResolver} can be used to invoke this function.
  */
-export const HandleIdLookup = (type: Many<ValueOf<ResourceMap>>) =>
+export const HandleIdLookup = (type: Many<SomeResource>) =>
   SetMetadata<string, Shape>(RESOLVE_BY_ID, {
     type: many(type).map((cls) => cls.name as keyof ResourceMap),
   });
@@ -60,7 +62,7 @@ export class ResourceResolver {
    *
    * It's expected that possibleTypes is or includes a _single_ concrete type.
    */
-  async lookup<TResource extends ValueOf<ResourceMap>>(
+  async lookup<TResource extends SomeResource>(
     type: TResource,
     id: ID,
     session: Session
@@ -71,15 +73,15 @@ export class ResourceResolver {
     session: Session
   ): Promise<ResourceMap[TResourceName]['prototype']>;
   async lookup(
-    possibleTypes: Many<string | ValueOf<ResourceMap>>,
+    possibleTypes: Many<string | SomeResource>,
     id: ID,
     session: Session
-  ): Promise<ValueOf<ResourceMap>>;
+  ): Promise<SomeResource>;
   async lookup(
-    possibleTypes: Many<string | ValueOf<ResourceMap>>,
+    possibleTypes: Many<string | SomeResource>,
     id: ID,
     session: Session
-  ): Promise<ValueOf<ResourceMap>> {
+  ): Promise<SomeResource> {
     const type = this.resolveType(possibleTypes);
     const discovered = await this.discover.providerMethodsWithMetaAtKey<Shape>(
       RESOLVE_BY_ID
@@ -103,9 +105,7 @@ export class ResourceResolver {
     };
   }
 
-  private resolveType(
-    types: Many<string | ValueOf<ResourceMap>>
-  ): keyof ResourceMap {
+  private resolveType(types: Many<string | SomeResource>): keyof ResourceMap {
     const names = many(types).map((t) => (typeof t === 'string' ? t : t.name));
 
     const schema = this.schemaHost.schema;

--- a/src/core/resources/resource-resolver.service.ts
+++ b/src/core/resources/resource-resolver.service.ts
@@ -1,0 +1,130 @@
+import { DiscoveryService } from '@golevelup/nestjs-discovery';
+import { Injectable, SetMetadata } from '@nestjs/common';
+import { GraphQLSchemaHost } from '@nestjs/graphql';
+import { Node } from 'cypher-query-builder';
+import { isObjectType } from 'graphql';
+import { ValueOf } from 'type-fest';
+import { ID, many, Many, ServerException, Session } from '../../common';
+import { ResourceMap } from '../../components/authorization/model/resource-map';
+import { BaseNode } from '../database/results';
+import { ILogger, Logger } from '../logger';
+
+const RESOLVE_BY_ID = 'RESOLVE_BY_ID';
+interface Shape {
+  type: ReadonlyArray<keyof ResourceMap>;
+}
+
+/**
+ * Register this function as the function to use to lookup the given types.
+ *
+ * WARNING: It's required that the function signature be:
+ * ```
+ * (id: ID, session: Session) => Promise<Resource>
+ * ```
+ *
+ * {@link ResourceResolver} can be used to invoke this function.
+ */
+export const HandleIdLookup = (type: Many<ValueOf<ResourceMap>>) =>
+  SetMetadata<string, Shape>(RESOLVE_BY_ID, {
+    type: many(type).map((cls) => cls.name as keyof ResourceMap),
+  });
+
+/**
+ * Allows looking up GraphQL objects from DB Nodes.
+ *
+ * A direct DB lookup should always be used when possible.
+ * When an extra read query is needed anyways this can be used.
+ *
+ * This will only work for resources that have a
+ * {@link HandleIdLookup @HandleIdLookup} defined.
+ *
+ * As long as the concrete type is known
+ * or there's a list with a concrete type mixed with interfaces
+ */
+@Injectable()
+export class ResourceResolver {
+  constructor(
+    private readonly discover: DiscoveryService,
+    private readonly schemaHost: GraphQLSchemaHost,
+    @Logger('resource-resolver') private readonly logger: ILogger
+  ) {}
+
+  /**
+   * Lookup a resource from a Neo4j BaseNode.
+   */
+  async lookupByBaseNode(node: Node<BaseNode>, session: Session) {
+    return await this.lookup(node.labels, node.properties.id, session);
+  }
+
+  /**
+   * Lookup a resource by type and ID.
+   *
+   * It's expected that possibleTypes is or includes a _single_ concrete type.
+   */
+  async lookup<TResource extends ValueOf<ResourceMap>>(
+    type: TResource,
+    id: ID,
+    session: Session
+  ): Promise<TResource['prototype']>;
+  async lookup<TResourceName extends keyof ResourceMap>(
+    type: TResourceName,
+    id: ID,
+    session: Session
+  ): Promise<ResourceMap[TResourceName]['prototype']>;
+  async lookup(
+    possibleTypes: Many<string | ValueOf<ResourceMap>>,
+    id: ID,
+    session: Session
+  ): Promise<ValueOf<ResourceMap>>;
+  async lookup(
+    possibleTypes: Many<string | ValueOf<ResourceMap>>,
+    id: ID,
+    session: Session
+  ): Promise<ValueOf<ResourceMap>> {
+    const type = this.resolveType(possibleTypes);
+    const discovered = await this.discover.providerMethodsWithMetaAtKey<Shape>(
+      RESOLVE_BY_ID
+    );
+    const filtered = discovered.filter((f) => f.meta.type.includes(type));
+    if (filtered.length === 0) {
+      throw new ServerException(`Could find resolver for type: ${type}`);
+    }
+    if (filtered.length > 1) {
+      this.logger.warning(`Found more than one resolver for ${type}`);
+    }
+    const method = filtered[0].discoveredMethod;
+    const result = await method.handler.call(
+      method.parentClass.instance,
+      id,
+      session
+    );
+    return {
+      __typename: type,
+      ...result,
+    };
+  }
+
+  private resolveType(
+    types: Many<string | ValueOf<ResourceMap>>
+  ): keyof ResourceMap {
+    const names = many(types).map((t) => (typeof t === 'string' ? t : t.name));
+
+    const schema = this.schemaHost.schema;
+    const resolved = names.filter((name) => isObjectType(schema.getType(name)));
+
+    if (resolved.length === 1) {
+      // This is mostly true...
+      return resolved[0] as keyof ResourceMap;
+    }
+
+    const namesStr = names.join(', ');
+    if (resolved.length === 0) {
+      throw new ServerException(
+        `Could not determine GraphQL object from type: ${namesStr}`
+      );
+    }
+    throw new ServerException(
+      `Could not decide which GraphQL object type to choose from: ${namesStr}`
+    );
+  }
+}


### PR DESCRIPTION
This allows us to look up any resource in the codebase by ID. (Poorly named because it's not a GQL resolver).

# What
This can be used directly with a type:
```ts
const resources: ResourceResolver; // Injected
const project = await resources.lookup(TranslationProject, "knlvkajsdnv", session);
```
This could be easier than importing the remote module to do a read one.
Though indirect reads are always discouraged if the necessary data can be directly matched and used in a single DB query.

This can also be used dynamically:
```ts
const baseNode = query('match (node:BaseNode { id: "knlvkajsdnv" } return node').first();
const resource = resources.lookupByBaseNode(baseNode, session);
```
This is great for decoupled features like search, changesets, etc.

# How
All that needs to be done for this to work is:
1. Define the object as an `@ObjectType()` for GraphQL schema
1. Define the object in the [`ResourceMap`](https://github.com/SeedCompany/cord-api-v3/blob/develop/src/components/authorization/model/resource-map.ts#L42)
1. Decorate a method with the `@HandleIDLookup()` with the given types the method handles.
    https://github.com/SeedCompany/cord-api-v3/blob/3e9972af06cd425d716ab9e13ad4890e112c9f8a/src/components/organization/organization.service.ts#L102-L103
   Note that the method must take an ID first, then a Session next, (and optional changeset ID third (soon)).
1. Profit 😉 

# Caveats

The concrete type must be given/included in the types available. The service knows how to ignore interfaces, but it can't _yet_ resolve an interface to concrete even if we do it else where.

For example,
```ts
resources.lookup([Engagement, LanguageEngagement], 'id', session);
```
It knows to ignore `Engagement` here and select `LanguageEngagement` ✅ 

```ts
resources.lookup(IProject, 'id', session);
resources.lookup(Engagement, 'id', session);
```
It does not know how to resolve either of these to their concrete types ❌ 
Even though we tell GraphQL how to do this.