### PR TITLE
DB Query Debugging

### DIFF
--- a/src/core/database/cypher.factory.ts
+++ b/src/core/database/cypher.factory.ts
@@ -191,14 +191,18 @@ const wrapQueryRun = (
   const origRun = runner.run.bind(runner);
   return (origStatement, parameters) => {
     const statement = stripIndent(origStatement.slice(0, -1)) + ';';
-    logger.log(
-      (parameters?.logIt as LogLevel | undefined) ?? LogLevel.DEBUG,
-      'Executing query',
-      {
+    const level = (parameters?.logIt as LogLevel | undefined) ?? LogLevel.DEBUG;
+    if (parameters?.interpolated) {
+      logger.log(
+        level,
+        `Executing query: ${parameters.interpolated as string}`
+      );
+    } else {
+      logger.log(level, 'Executing query', {
         statement,
         ...parameters,
-      }
-    );
+      });
+    }
 
     const params = parameters
       ? parameterTransformer.transform(parameters)

--- a/src/core/database/query-augmentation/index.ts
+++ b/src/core/database/query-augmentation/index.ts
@@ -1,6 +1,7 @@
 import './apply';
 import './as-result';
 import './call';
+import './interpolate';
 import './log-it';
 import './map';
 import './subquery';

--- a/src/core/database/query-augmentation/interpolate.ts
+++ b/src/core/database/query-augmentation/interpolate.ts
@@ -1,0 +1,53 @@
+import { Clause } from 'cypher-query-builder';
+import { isArray, isBoolean, isNumber, isObject, isString, map } from 'lodash';
+import { DateTime, Duration } from 'luxon';
+import { CalendarDate } from '../../../common';
+
+/**
+ * Overridden to correctly interpolate null, undefined, and temporal values.
+ */
+Clause.prototype.interpolate = function interpolate() {
+  let query = this.build();
+  const params = this.getParams();
+  for (const name in params) {
+    const pattern = new RegExp(`\\$${name}(?![a-zA-Z0-9_])`, 'g');
+    query = query.replace(pattern, stringifyValue(params[name]));
+  }
+  return query;
+};
+
+function stringifyValue(value: unknown): string {
+  if (value == null) {
+    return 'null';
+  }
+  if (isNumber(value) || isBoolean(value)) {
+    // This is how it's done upstream, and it works fine.
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    return `${value}`;
+  }
+  if (isString(value)) {
+    return `'${value}'`;
+  }
+  if (isArray(value)) {
+    const str = map(value, stringifyValue).join(', ');
+    return `[${str}]`;
+  }
+  if (CalendarDate.isDate(value)) {
+    return `date('${value.toISO()}')`;
+  }
+  if (DateTime.isDateTime(value)) {
+    if (value.diffNow('minutes').minutes < 1) {
+      return `datetime()`; // assume now
+    }
+    return `datetime('${value.toISO()}')`;
+  }
+  if (Duration.isDuration(value)) {
+    return `duration('${value.toISO()}')`;
+  }
+  if (isObject(value)) {
+    const pairs = map(value, (el, key) => `${key}: ${stringifyValue(el)}`);
+    const str = pairs.join(', ');
+    return `{ ${str} }`;
+  }
+  return '';
+}

--- a/src/core/database/query-augmentation/interpolate.ts
+++ b/src/core/database/query-augmentation/interpolate.ts
@@ -1,3 +1,4 @@
+import { stripIndent } from 'common-tags';
 import { Clause } from 'cypher-query-builder';
 import { isArray, isBoolean, isNumber, isObject, isString, map } from 'lodash';
 import { DateTime, Duration } from 'luxon';
@@ -8,6 +9,7 @@ import { CalendarDate } from '../../../common';
  */
 Clause.prototype.interpolate = function interpolate() {
   let query = this.build();
+  query = stripIndent(query.slice(0, -1));
   const params = this.getParams();
   for (const name in params) {
     const pattern = new RegExp(`\\$${name}(?![a-zA-Z0-9_])`, 'g');

--- a/src/core/database/query-augmentation/log-it.ts
+++ b/src/core/database/query-augmentation/log-it.ts
@@ -15,10 +15,15 @@ Query.prototype.logIt = function logIt(this: Query, level = LogLevel.NOTICE) {
   const orig = this.buildQueryObject.bind(this);
   this.buildQueryObject = function buildQueryObject() {
     const result = orig();
+    if (process.env.NODE_ENV !== 'production') {
+      const interpolated = this.interpolate();
+      Object.defineProperty(result.params, 'interpolated', {
+        value: `\n\n${interpolated}\n\n`,
+        enumerable: false,
+      });
+    }
     Object.defineProperty(result.params, 'logIt', {
       value: level,
-      configurable: true,
-      writable: true,
       enumerable: false,
     });
     return result;


### PR DESCRIPTION
# Fixed Interpolation

I patched `Query.interpolate()` so that all temporal and null/undefined values are rendered correctly.

For example, and abbreviated create project query looked like this previously.
The `createdAt` DateTime was exploded, rendering all its properties.
The `mouEnd`'s value is null but this was just left un-rendered, leaving invalid cypher.
```cql
CREATE (node:Project:TranslationProject:BaseNode { createdAt: { ts: 1624204968472, _zone: {  }, loc: { locale: 'en-US', numberingSystem: , outputCalendar: , intl: 'en-US', weekdaysCache: { format: {  }, standalone: {  } }, monthsCache: { format: {  }, standalone: {  } }, meridiemCache: , eraCache: {  }, specifiedLocale: , fastNumbersCached:  }, invalid: , weekData: , c: { year: 2021, month: 6, day: 20, hour: 11, minute: 2, second: 48, millisecond: 472 }, o: -300, isLuxonDateTime: true }, id: '0nvMdhpv9Es', type: 'Translation' })
# Omitted createAt's here, but they also looked like the line above
CREATE (node)-[:mouEnd { active: true }]->(:Property { value: , sortValue:  })
```

Now both are correctly rendered.
```cql
CREATE (node:Project:TranslationProject:BaseNode { createdAt: datetime(), id: '2EWSsQAOzWy', type: 'Translation' })
CREATE (node)-[:mouEnd { active: true, createdAt: datetime() }]->(:Property { createdAt: datetime(), value: null, sortValue: null })
```

DateTime's that are within the same minute are assumed to "now", which should be fine for this purpose.
Any other values are rendered out like this
```cql
date('2020-03-12')
datetime('2021-06-20T11:37:56.815-05:00')
```

# `logIt()`

Previously queries were logged like this:
![image](https://user-images.githubusercontent.com/932566/122682087-1b2ead00-d1bd-11eb-93f0-699ca3990fd1.png)
Which isn't the best for copy/pasting to neo4j console.

Now while running locally queries are interpolated and logged without the `|` symbol.
![image](https://user-images.githubusercontent.com/932566/122682186-9a23e580-d1bd-11eb-9bd5-7433505d0f44.png)
Easy copy/paste! 🎉 
