### PR TITLE
New createNode & createRelationships fragments

### DIFF
--- a/src/common/db-label.decorator.ts
+++ b/src/common/db-label.decorator.ts
@@ -1,5 +1,6 @@
 import { uniq, without } from 'lodash';
 import { getParentTypes } from './parent-types';
+import { isResourceClass } from './resource.dto';
 import { AbstractClassType } from './types';
 
 const DbLabelSymbol = Symbol('DbLabelSymbol');
@@ -27,7 +28,9 @@ export const getDbClassLabels = (
   const labels =
     decorated?.flatMap((l) => l.split(':')) ??
     without(
-      getParentTypes(type).map((t) => t.name),
+      getParentTypes(type)
+        .filter(isResourceClass)
+        .map((t) => t.name),
       'Resource'
     );
   return uniq([...labels, 'BaseNode']);

--- a/src/common/db-label.decorator.ts
+++ b/src/common/db-label.decorator.ts
@@ -1,4 +1,5 @@
-import { uniq } from 'lodash';
+import { uniq, without } from 'lodash';
+import { getParentTypes } from './parent-types';
 import { AbstractClassType } from './types';
 
 const DbLabelSymbol = Symbol('DbLabelSymbol');
@@ -12,6 +13,22 @@ export const getDbPropertyLabels = (
 ) => {
   // @ts-expect-error property decoration is on instance of object
   const obj = new type();
-  const labels = Reflect.getMetadata(DbLabelSymbol, obj, property);
-  return uniq([...(labels ?? []), 'Property']);
+  const labels = Reflect.getMetadata(DbLabelSymbol, obj, property) as
+    | string[]
+    | undefined;
+  const normalized = labels?.flatMap((l) => l.split(':'));
+  return uniq([...(normalized ?? []), 'Property']);
+};
+
+export const getDbClassLabels = (
+  type: AbstractClassType<unknown>
+): readonly string[] => {
+  const decorated: string[] | null = Reflect.getMetadata(DbLabelSymbol, type);
+  const labels =
+    decorated?.flatMap((l) => l.split(':')) ??
+    without(
+      getParentTypes(type).map((t) => t.name),
+      'Resource'
+    );
+  return uniq([...labels, 'BaseNode']);
 };

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -5,6 +5,7 @@ import { ID, IdField } from './id-field';
 import { DateTimeField } from './luxon.graphql';
 import { SecuredProps, UnsecuredDto } from './secured-property';
 import { AbstractClassType } from './types';
+import { has } from './util';
 
 @InterfaceType()
 export abstract class Resource {
@@ -34,6 +35,11 @@ export type ResourceShape<T> = AbstractClassType<T> & {
   BaseNodeProps?: string[];
   Relations?: Record<string, any>;
 };
+
+export const isResourceClass = <T>(
+  cls: AbstractClassType<T>
+): cls is ResourceShape<T> =>
+  has('Props', cls) && Array.isArray(cls.Props) && cls.Props.length > 0;
 
 export type MaybeUnsecuredInstance<TResourceStatic extends ResourceShape<any>> =
   TResourceStatic['prototype'] | UnsecuredDto<TResourceStatic['prototype']>;

--- a/src/components/authorization/authorization.service.ts
+++ b/src/components/authorization/authorization.service.ts
@@ -11,9 +11,9 @@ import {
 } from 'lodash';
 import {
   getParentTypes,
-  has,
   ID,
   isIdLike,
+  isResourceClass,
   isSecured,
   keys,
   mapFromList,
@@ -206,9 +206,7 @@ export class AuthorizationService {
     // convert resource to a list of resource names to check
     const resources = getParentTypes(resource)
       // if parent defines Props include it in mapping
-      .filter(
-        (r) => has('Props', r) && Array.isArray(r.Props) && r.Props.length > 0
-      )
+      .filter(isResourceClass)
       .map((r) => r.name);
 
     const normalizeGrants = (role: DbRole) =>

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -176,7 +176,7 @@ export class EngagementRepository extends CommonRepository {
       .query()
       .apply(await createNode(LanguageEngagement, { initialProps }))
       .apply(
-        createRelationships({
+        createRelationships(LanguageEngagement, {
           in: { Project: { engagement: projectId } },
           out: { Language: { language: languageId } },
         })
@@ -217,7 +217,7 @@ export class EngagementRepository extends CommonRepository {
       .query()
       .apply(await createNode(InternshipEngagement, { initialProps }))
       .apply(
-        createRelationships({
+        createRelationships(InternshipEngagement, {
           in: { Project: { engagement: projectId } },
           out: {
             User: { intern: internId, mentor: mentorId },

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -176,13 +176,9 @@ export class EngagementRepository extends CommonRepository {
       .query()
       .apply(await createNode(LanguageEngagement, { initialProps }))
       .apply(
-        createRelationships('in', {
-          Project: { engagement: projectId },
-        })
-      )
-      .apply(
-        createRelationships('out', {
-          Language: { language: languageId },
+        createRelationships({
+          in: { Project: { engagement: projectId } },
+          out: { Language: { language: languageId } },
         })
       )
       .return<{ id: ID }>('node.id as id');
@@ -221,14 +217,12 @@ export class EngagementRepository extends CommonRepository {
       .query()
       .apply(await createNode(InternshipEngagement, { initialProps }))
       .apply(
-        createRelationships('in', {
-          Project: { engagement: projectId },
-        })
-      )
-      .apply(
-        createRelationships('out', {
-          User: { intern: internId, mentor: mentorId },
-          Location: { countryOfOrigin: countryOfOriginId },
+        createRelationships({
+          in: { Project: { engagement: projectId } },
+          out: {
+            User: { intern: internId, mentor: mentorId },
+            Location: { countryOfOrigin: countryOfOriginId },
+          },
         })
       )
       .return<{ id: ID }>('node.id as id');

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -175,13 +175,11 @@ export class EngagementRepository extends CommonRepository {
     const query = this.db
       .query()
       .apply(await createNode(LanguageEngagement, { initialProps }))
-      .with('node') // needed between a create & match
       .apply(
         createRelationships('in', {
           Project: { engagement: projectId },
         })
       )
-      .with('node')
       .apply(
         createRelationships('out', {
           Language: { language: languageId },
@@ -222,13 +220,11 @@ export class EngagementRepository extends CommonRepository {
     const query = this.db
       .query()
       .apply(await createNode(InternshipEngagement, { initialProps }))
-      .with('node') // needed between a create & match
       .apply(
         createRelationships('in', {
           Project: { engagement: projectId },
         })
       )
-      .with('node')
       .apply(
         createRelationships('out', {
           User: { intern: internId, mentor: mentorId },

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -3,9 +3,7 @@ import { inArray, node, Node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { MergeExclusive } from 'type-fest';
 import {
-  entries,
   generateId,
-  getDbPropertyLabels,
   ID,
   mapFromList,
   NotFoundException,
@@ -13,16 +11,19 @@ import {
   ServerException,
   Session,
 } from '../../common';
-import { CommonRepository, property } from '../../core';
+import { CommonRepository } from '../../core';
 import { DbChanges, getChanges } from '../../core/database/changes';
 import {
   calculateTotalAndPaginateList,
+  createNode,
+  createRelationships,
   matchPropsAndProjectSensAndScopedRoles,
   permissionsOfNode,
   requestingUser,
 } from '../../core/database/query';
 import { DbPropsOfDto } from '../../core/database/results';
 import { Role, rolesForScope, ScopedRole } from '../authorization';
+import { FileId } from '../file';
 import { ProjectType } from '../project';
 import {
   CreateInternshipEngagement,
@@ -156,11 +157,9 @@ export class EngagementRepository extends CommonRepository {
   // CREATE ///////////////////////////////////////////////////////////
 
   async createLanguageEngagement(input: CreateLanguageEngagement) {
-    const id = await generateId();
-    const createdAt = DateTime.local();
-    const pnpId = await generateId();
+    const pnpId = (await generateId()) as FileId;
 
-    const { projectId, languageId, ...initial } = {
+    const { projectId, languageId, ...initialProps } = {
       ...mapFromList(CreateLanguageEngagement.Props, (k) => [k, undefined]),
       ...input,
       status: input.status || EngagementStatus.InDevelopment,
@@ -169,60 +168,45 @@ export class EngagementRepository extends CommonRepository {
       statusModifiedAt: undefined,
       lastSuspendedAt: undefined,
       lastReactivatedAt: undefined,
-      modifiedAt: createdAt,
+      modifiedAt: DateTime.local(),
       canDelete: true,
     };
 
     const query = this.db
       .query()
-      .match([node('project', 'Project', { id: projectId })])
-      .match([node('language', 'Language', { id: languageId })])
-      .create([
-        [
-          node('node', ['LanguageEngagement', 'Engagement', 'BaseNode'], {
-            createdAt,
-            id,
-          }),
-        ],
-        ...entries(initial).flatMap(([prop, val]) =>
-          property(
-            prop,
-            val,
-            'node',
-            prop,
-            getDbPropertyLabels(LanguageEngagement, prop)
-          )
-        ),
-      ])
-      .create([
-        node('project'),
-        relation('out', 'engagementRel', 'engagement', {
-          active: true,
-          createdAt,
-        }),
-        node('node'),
-      ])
-      .create([
-        node('language'),
-        relation('in', 'languageRel', 'language', { active: true, createdAt }),
-        node('node'),
-      ])
-      .return('node');
+      .apply(await createNode(LanguageEngagement, { initialProps }))
+      .with('node') // needed between a create & match
+      .apply(
+        createRelationships('in', {
+          Project: { engagement: projectId },
+        })
+      )
+      .with('node')
+      .apply(
+        createRelationships('out', {
+          Language: { language: languageId },
+        })
+      )
+      .return<{ id: ID }>('node.id as id');
 
     const result = await query.first();
     if (!result) {
       throw new ServerException('Could not create Language Engagement');
     }
 
-    return { id, pnpId };
+    return { id: result.id, pnpId };
   }
 
   async createInternshipEngagement(input: CreateInternshipEngagement) {
-    const id = await generateId();
-    const createdAt = DateTime.local();
-    const growthPlanId = await generateId();
+    const growthPlanId = (await generateId()) as FileId;
 
-    const { projectId, internId, mentorId, countryOfOriginId, ...initial } = {
+    const {
+      projectId,
+      internId,
+      mentorId,
+      countryOfOriginId,
+      ...initialProps
+    } = {
       ...mapFromList(CreateInternshipEngagement.Props, (k) => [k, undefined]),
       ...input,
       status: input.status || EngagementStatus.InDevelopment,
@@ -231,82 +215,33 @@ export class EngagementRepository extends CommonRepository {
       statusModifiedAt: undefined,
       lastSuspendedAt: undefined,
       lastReactivatedAt: undefined,
-      modifiedAt: createdAt,
+      modifiedAt: DateTime.local(),
       canDelete: true,
     };
 
     const query = this.db
       .query()
-      .match(node('project', 'Project', { id: projectId }))
-      .match(node('intern', 'User', { id: internId }))
-      .apply((q) => {
-        if (mentorId) {
-          q.match(node('mentor', 'User', { id: mentorId }));
-        }
-        if (countryOfOriginId) {
-          q.match([
-            node('countryOfOrigin', 'Location', {
-              id: countryOfOriginId,
-            }),
-          ]);
-        }
-      })
-      .create([
-        [
-          node('node', ['InternshipEngagement', 'Engagement', 'BaseNode'], {
-            createdAt,
-            id,
-          }),
-        ],
-        ...entries(initial).flatMap(([prop, val]) =>
-          property(
-            prop,
-            val,
-            'node',
-            prop,
-            getDbPropertyLabels(InternshipEngagement, prop)
-          )
-        ),
-      ])
-      .create([
-        node('project'),
-        relation('out', 'engagementRel', 'engagement', {
-          active: true,
-          createdAt,
-        }),
-        node('node'),
-      ])
-      .create([
-        node('intern'),
-        relation('in', 'internRel', 'intern', { active: true, createdAt }),
-        node('node'),
-      ])
-      .apply((q) => {
-        if (mentorId) {
-          q.create([
-            node('mentor'),
-            relation('in', 'mentorRel', 'mentor', { active: true, createdAt }),
-            node('node'),
-          ]);
-        }
-        if (countryOfOriginId) {
-          q.create([
-            node('countryOfOrigin'),
-            relation('in', 'countryRel', 'countryOfOrigin', {
-              active: true,
-              createdAt,
-            }),
-            node('node'),
-          ]);
-        }
-      })
-      .return('node');
+      .apply(await createNode(InternshipEngagement, { initialProps }))
+      .with('node') // needed between a create & match
+      .apply(
+        createRelationships('in', {
+          Project: { engagement: projectId },
+        })
+      )
+      .with('node')
+      .apply(
+        createRelationships('out', {
+          User: { intern: internId, mentor: mentorId },
+          Location: { countryOfOrigin: countryOfOriginId },
+        })
+      )
+      .return<{ id: ID }>('node.id as id');
     const result = await query.first();
     if (!result) {
       throw new NotFoundException();
     }
 
-    return { id, growthPlanId };
+    return { id: result.id, growthPlanId };
   }
 
   // UPDATE ///////////////////////////////////////////////////////////

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -189,7 +189,6 @@ export class ProjectRepository extends CommonRepository {
           }
         )
       )
-      .with('node') // needed between a create & match
       .apply(
         createRelationships('out', {
           FieldRegion: { fieldRegion: fieldRegionId },

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -190,7 +190,7 @@ export class ProjectRepository extends CommonRepository {
         )
       )
       .apply(
-        createRelationships('out', {
+        createRelationships(IProject, 'out', {
           FieldRegion: { fieldRegion: fieldRegionId },
           Location: {
             primaryLocation: primaryLocationId,

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -149,7 +149,7 @@ export class ConfigService implements EmailOptionsFactory {
 
   @Lazy() get defaultOrg() {
     return {
-      id: '5c4278da9503d5cd78e82f02',
+      id: '5c4278da9503d5cd78e82f02' as ID,
       name: 'Seed Company',
     };
   }

--- a/src/core/database/query-augmentation/index.ts
+++ b/src/core/database/query-augmentation/index.ts
@@ -3,4 +3,5 @@ import './as-result';
 import './call';
 import './log-it';
 import './map';
+import './pattern-formatting';
 import './subquery';

--- a/src/core/database/query-augmentation/pattern-formatting.ts
+++ b/src/core/database/query-augmentation/pattern-formatting.ts
@@ -1,0 +1,10 @@
+import { Create, Match, Merge } from 'cypher-query-builder';
+
+// Add line breaks for each pattern when there's multiple per statement
+for (const Cls of [Match, Create, Merge]) {
+  const origBuild = Cls.prototype.build;
+  Cls.prototype.build = function build() {
+    const str = origBuild.call(this);
+    return str.split(', ').join(',\n    ');
+  };
+}

--- a/src/core/database/query.helpers.ts
+++ b/src/core/database/query.helpers.ts
@@ -2,9 +2,14 @@ import { node, Query, relation } from 'cypher-query-builder';
 import { deburr } from 'lodash';
 import { DateTime } from 'luxon';
 import { ID, ResourceShape, Session } from '../../common';
+// eslint-disable-next-line @seedcompany/no-unused-vars -- used in jsdoc
+import { createNode } from './query';
 
 // CREATE clauses //////////////////////////////////////////////////////
 
+/**
+ * @deprecated Use {@link createNode} instead
+ */
 export interface Property {
   key: string;
   value: any;
@@ -14,17 +19,12 @@ export interface Property {
   isDeburrable?: boolean;
 }
 
-export interface AllNodeProperties {
-  createdAt: DateTime;
-  value: any;
-  sortValue: string;
-}
-
 export const determineSortValue = (value: unknown) =>
   typeof value === 'string' ? deburr(value) : value;
 
-// assumes 'requestingUser', and 'publicSG' cypher identifiers have been matched
-// add baseNodeProps and editableProps
+/**
+ * @deprecated Use {@link createNode} instead
+ */
 export const createBaseNode =
   (
     id: ID,

--- a/src/core/database/query/create-node.ts
+++ b/src/core/database/query/create-node.ts
@@ -1,0 +1,72 @@
+import { node, Query, relation } from 'cypher-query-builder';
+import { DateTime } from 'luxon';
+import {
+  // eslint-disable-next-line @seedcompany/no-unused-vars -- used in jsdoc
+  DbLabel,
+  entries,
+  generateId,
+  getDbClassLabels,
+  getDbPropertyLabels,
+  ResourceShape,
+  UnsecuredDto,
+} from '../../../common';
+import { determineSortValue } from '../query.helpers';
+
+interface CreateNodeOptions<TResourceStatic extends ResourceShape<any>> {
+  initialProps?: Partial<UnsecuredDto<TResourceStatic['prototype']>>;
+  baseNodeProps?: Record<string, any>;
+}
+
+/**
+ * This aids in composing create statements for a new base node and its initial properties.
+ *
+ * id & createdAt properties are generated and applied automatically.
+ * BaseNode labels are pulled from the resource's class hierarchy or manually
+ * defined with {@link DbLabel @DbLabel()}
+ *
+ * Any unique labels for properties are pulled from {@link DbLabel @DbLabel()}
+ * decoration on the resource's properties.
+ *
+ * Note that we need to define all properties at create even if they are null/undefined.
+ * This allows matches to work easier. This does not handle missing keys from user
+ * input, so it's encouraged to manually define initialValues key/value pairs passed in here.
+ *
+ * @example
+ * query()
+ * .apply(await createNode(User, {
+ *   initialProps: {
+ *     email: input.email,
+ *     ...
+ *   },
+ * })
+ */
+export const createNode = async <TResourceStatic extends ResourceShape<any>>(
+  resource: TResourceStatic,
+  { initialProps = {}, baseNodeProps = {} }: CreateNodeOptions<TResourceStatic>
+) => {
+  const {
+    id = baseNodeProps.id ?? (await generateId()),
+    createdAt = baseNodeProps.createdAt ?? DateTime.local(),
+    ...restInitialProps
+  } = initialProps;
+
+  return (query: Query) =>
+    query.create([
+      [
+        node('node', getDbClassLabels(resource), {
+          ...baseNodeProps,
+          createdAt,
+          id,
+        }),
+      ],
+      ...entries(restInitialProps).map(([prop, value]) => [
+        node('node'),
+        relation('out', '', prop, { active: true, createdAt }),
+        node('', getDbPropertyLabels(resource, prop), {
+          createdAt,
+          value,
+          sortValue: determineSortValue(value),
+        }),
+      ]),
+    ]);
+};

--- a/src/core/database/query/create-node.ts
+++ b/src/core/database/query/create-node.ts
@@ -51,22 +51,26 @@ export const createNode = async <TResourceStatic extends ResourceShape<any>>(
   } = initialProps;
 
   return (query: Query) =>
-    query.create([
-      [
-        node('node', getDbClassLabels(resource), {
-          ...baseNodeProps,
-          createdAt,
-          id,
-        }),
-      ],
-      ...entries(restInitialProps).map(([prop, value]) => [
-        node('node'),
-        relation('out', '', prop, { active: true, createdAt }),
-        node('', getDbPropertyLabels(resource, prop), {
-          createdAt,
-          value,
-          sortValue: determineSortValue(value),
-        }),
-      ]),
-    ]);
+    query.subQuery((sub) =>
+      sub
+        .create([
+          [
+            node('node', getDbClassLabels(resource), {
+              ...baseNodeProps,
+              createdAt,
+              id,
+            }),
+          ],
+          ...entries(restInitialProps).map(([prop, value]) => [
+            node('node'),
+            relation('out', '', prop, { active: true, createdAt }),
+            node('', getDbPropertyLabels(resource, prop), {
+              createdAt,
+              value,
+              sortValue: determineSortValue(value),
+            }),
+          ]),
+        ])
+        .return('node')
+    );
 };

--- a/src/core/database/query/create-relationships.ts
+++ b/src/core/database/query/create-relationships.ts
@@ -1,0 +1,52 @@
+import { node, Query, relation } from 'cypher-query-builder';
+import { RelationDirection } from 'cypher-query-builder/dist/typings/clauses/relation-pattern';
+import { Maybe as Nullable } from 'graphql/jsutils/Maybe';
+import { DateTime } from 'luxon';
+import { ID } from '../../../common';
+import { ResourceMap } from '../../../components/authorization/model/resource-map';
+
+/**
+ * Creates relationships to/from `node` to/from other base nodes.
+ *
+ * If the ID value is nil then the match & create is skipped.
+ *
+ * @example
+ * createRelationships('out', {
+ *   FundingAccount: { // base node label to match
+ *     fundingAccount: // label of the relationship to create
+ *      input.fundingAccountId, // id of the base node to match
+ *   },
+ *   User: { createdBy: input.creatorId } // simple one liner
+ * })
+ * // This above yields the below cypher
+ * MATCH (fundingAccount:FundingAccount { id: $fundingAccountId })
+ * CREATE (node)-[:fundingAccount]->(fundingAccount)
+ * MATCH (createdBy:User { id: $creatorId })
+ * CREATE (node)-[:createdBy]->(createdBy)
+ */
+export const createRelationships =
+  (
+    direction: RelationDirection,
+    labelsToRelationships: Partial<
+      Record<keyof ResourceMap, Record<string, Nullable<ID>>>
+    >
+  ) =>
+  (query: Query) => {
+    for (const [label, relationships] of Object.entries(
+      labelsToRelationships
+    )) {
+      for (const [prop, id] of Object.entries(relationships ?? {})) {
+        if (!id) {
+          continue;
+        }
+        query.match([node(prop, label, { id })]).create([
+          node('node'),
+          relation(direction, '', prop, {
+            active: true,
+            createdAt: DateTime.local(),
+          }),
+          node(prop),
+        ]);
+      }
+    }
+  };

--- a/src/core/database/query/create-relationships.ts
+++ b/src/core/database/query/create-relationships.ts
@@ -5,6 +5,13 @@ import { DateTime } from 'luxon';
 import { ID, many } from '../../../common';
 import { ResourceMap } from '../../../components/authorization/model/resource-map';
 
+type RelationshipDefinition = Partial<
+  Record<keyof ResourceMap, Record<string, Nullable<ID> | readonly ID[]>>
+>;
+type AnyDirectionalDefinition = Partial<
+  Record<RelationDirection, RelationshipDefinition>
+>;
+
 /**
  * Creates relationships to/from `node` to/from other base nodes.
  *
@@ -23,29 +30,52 @@ import { ResourceMap } from '../../../components/authorization/model/resource-ma
  *       (createdBy:User { id: $creatorId })
  * CREATE (node)-[:fundingAccount]->(fundingAccount),
  *        (node)-[:createdBy]->(createdBy)
+ *
+ * @example
+ * // Multiple directions can be given this way
+ * createRelationships({
+ *   in: {
+ *     Organization: { owningOrganization: orgId }
+ *   },
+ *   out: {
+ *     User: { createdBy: input.creatorId }
+ *   },
+ * })
  */
-export const createRelationships =
-  (
-    direction: RelationDirection,
-    labelsToRelationships: Partial<
-      Record<keyof ResourceMap, Record<string, Nullable<ID> | readonly ID[]>>
-    >
-  ) =>
-  (query: Query) => {
-    const flattened = Object.entries(labelsToRelationships).flatMap(
-      ([nodeLabel, relationships]) =>
-        Object.entries(relationships ?? {}).flatMap(([prop, ids]) =>
-          many(ids ?? []).map((id, i) => ({
-            nodeLabel,
-            id,
-            relLabel: prop,
-            variable: Array.isArray(ids) ? `${prop}${i}` : prop,
-          }))
-        )
-    );
+export function createRelationships(
+  direction: RelationDirection,
+  labelsToRelationships: RelationshipDefinition
+): (query: Query) => Query;
+export function createRelationships(
+  definition: AnyDirectionalDefinition
+): (query: Query) => Query;
+export function createRelationships(
+  directionOrDefinition: RelationDirection | AnyDirectionalDefinition,
+  maybeLabelsToRelationships?: RelationshipDefinition
+) {
+  const normalizedArgs =
+    typeof directionOrDefinition === 'string'
+      ? { [directionOrDefinition]: maybeLabelsToRelationships }
+      : directionOrDefinition;
 
-    const createdAt = DateTime.local();
-    return query.subQuery((sub) =>
+  const flattened = Object.entries(normalizedArgs).flatMap(
+    ([direction, labelsToRelationships]) =>
+      Object.entries(labelsToRelationships ?? {}).flatMap(
+        ([nodeLabel, relationships]) =>
+          Object.entries(relationships ?? {}).flatMap(([prop, ids]) =>
+            many(ids ?? []).map((id, i) => ({
+              nodeLabel,
+              id,
+              direction: direction as RelationDirection,
+              relLabel: prop,
+              variable: Array.isArray(ids) ? `${prop}${i}` : prop,
+            }))
+          )
+      )
+  );
+  const createdAt = DateTime.local();
+  return (query: Query) =>
+    query.subQuery((sub) =>
       sub
         .with('node')
         .match(
@@ -54,7 +84,7 @@ export const createRelationships =
           ])
         )
         .create(
-          flattened.map(({ relLabel, variable }) => [
+          flattened.map(({ direction, relLabel, variable }) => [
             node('node'),
             relation(direction, '', relLabel, { active: true, createdAt }),
             node(variable),
@@ -62,4 +92,4 @@ export const createRelationships =
         )
         .return(flattened.map((f) => f.variable))
     );
-  };
+}

--- a/src/core/database/query/create-relationships.ts
+++ b/src/core/database/query/create-relationships.ts
@@ -45,17 +45,21 @@ export const createRelationships =
     );
 
     const createdAt = DateTime.local();
-    return query
-      .match(
-        flattened.map(({ variable, nodeLabel, id }) => [
-          node(variable, nodeLabel, { id }),
-        ])
-      )
-      .create(
-        flattened.map(({ relLabel, variable }) => [
-          node('node'),
-          relation(direction, '', relLabel, { active: true, createdAt }),
-          node(variable),
-        ])
-      );
+    return query.subQuery((sub) =>
+      sub
+        .with('node')
+        .match(
+          flattened.map(({ variable, nodeLabel, id }) => [
+            node(variable, nodeLabel, { id }),
+          ])
+        )
+        .create(
+          flattened.map(({ relLabel, variable }) => [
+            node('node'),
+            relation(direction, '', relLabel, { active: true, createdAt }),
+            node(variable),
+          ])
+        )
+        .return(flattened.map((f) => f.variable))
+    );
   };

--- a/src/core/database/query/create-relationships.ts
+++ b/src/core/database/query/create-relationships.ts
@@ -2,7 +2,7 @@ import { node, Query, relation } from 'cypher-query-builder';
 import { RelationDirection } from 'cypher-query-builder/dist/typings/clauses/relation-pattern';
 import { Maybe as Nullable } from 'graphql/jsutils/Maybe';
 import { DateTime } from 'luxon';
-import { ID } from '../../../common';
+import { ID, many } from '../../../common';
 import { ResourceMap } from '../../../components/authorization/model/resource-map';
 
 /**
@@ -28,18 +28,20 @@ export const createRelationships =
   (
     direction: RelationDirection,
     labelsToRelationships: Partial<
-      Record<keyof ResourceMap, Record<string, Nullable<ID>>>
+      Record<keyof ResourceMap, Record<string, Nullable<ID> | readonly ID[]>>
     >
   ) =>
   (query: Query) => {
     const flattened = Object.entries(labelsToRelationships).flatMap(
       ([nodeLabel, relationships]) =>
-        Object.entries(relationships ?? {}).flatMap(([prop, id]) => ({
-          nodeLabel,
-          id,
-          relLabel: prop,
-          variable: prop,
-        }))
+        Object.entries(relationships ?? {}).flatMap(([prop, ids]) =>
+          many(ids ?? []).map((id, i) => ({
+            nodeLabel,
+            id,
+            relLabel: prop,
+            variable: Array.isArray(ids) ? `${prop}${i}` : prop,
+          }))
+        )
     );
 
     const createdAt = DateTime.local();

--- a/src/core/database/query/create-relationships.ts
+++ b/src/core/database/query/create-relationships.ts
@@ -2,7 +2,7 @@ import { node, Query, relation } from 'cypher-query-builder';
 import { RelationDirection } from 'cypher-query-builder/dist/typings/clauses/relation-pattern';
 import { Maybe as Nullable } from 'graphql/jsutils/Maybe';
 import { DateTime } from 'luxon';
-import { ID, many } from '../../../common';
+import { ID, many, ResourceShape } from '../../../common';
 import { ResourceMap } from '../../../components/authorization/model/resource-map';
 
 type RelationshipDefinition = Partial<
@@ -42,14 +42,17 @@ type AnyDirectionalDefinition = Partial<
  *   },
  * })
  */
-export function createRelationships(
+export function createRelationships<TResourceStatic extends ResourceShape<any>>(
+  resource: TResourceStatic,
   direction: RelationDirection,
   labelsToRelationships: RelationshipDefinition
 ): (query: Query) => Query;
-export function createRelationships(
+export function createRelationships<TResourceStatic extends ResourceShape<any>>(
+  resource: TResourceStatic,
   definition: AnyDirectionalDefinition
 ): (query: Query) => Query;
-export function createRelationships(
+export function createRelationships<TResourceStatic extends ResourceShape<any>>(
+  resource: TResourceStatic,
   directionOrDefinition: RelationDirection | AnyDirectionalDefinition,
   maybeLabelsToRelationships?: RelationshipDefinition
 ) {

--- a/src/core/database/query/index.ts
+++ b/src/core/database/query/index.ts
@@ -1,3 +1,4 @@
+export * from './create-node';
 export * from './cypher-functions';
 export * from './lists';
 export * from './mapping';

--- a/src/core/database/query/index.ts
+++ b/src/core/database/query/index.ts
@@ -1,4 +1,5 @@
 export * from './create-node';
+export * from './create-relationships';
 export * from './cypher-functions';
 export * from './lists';
 export * from './mapping';


### PR DESCRIPTION
# `createNode`
`createBaseNode` has gone through a few iterations. Most of its intended functionality has been scratched. It's property list is unnecessarily verbose. `isPublic` & `isOrgPublic` are required but are unused.

## Current/Previous
```ts
const secureProps: Property[] = [
  {
    key: 'status',
    value: BudgetStatus.Pending,
    isPublic: false,
    isOrgPublic: false,
    label: 'BudgetStatus',
  },
  {
    key: 'universalTemplateFile',
    value: await generateId(),
    isPublic: false,
    isOrgPublic: false,
  },
  {
    key: 'canDelete',
    value: true,
    isPublic: false,
    isOrgPublic: false,
  },
];
const result = await this.db
  .query()
  .apply(createBaseNode(await generateId(), 'Budget', secureProps))
  .return<{ id: ID }>('node.id as id')
  .first();
```

## New
Here's an example of the new function:
```ts
const initialProps = {
  status: BudgetStatus.Pending,
  universalTemplateFile: await generateId(),
  canDelete: true,
};
const result = await this.db
  .query()
  .apply(await createNode(Budget, { initialProps }))
  .return<{ id: ID }>('node.id as id')
  .first();
```
- Initial property values are a simple object.
- We give the function the resource class. With this class it can lookup the DB labels needed for both the BaseNode and for properties. See [here](https://github.com/SeedCompany/cord-api-v3/blob/develop/src/components/budget/dto/budget.dto.ts#L25) that status has a label.
- The function is async so it can generate the ID for us
- With the resource class and the options object this new function should be able to sustain us over a few iterations

# `createRelationships`

Relationship creation between _BaseNodes_ has never been attempted to be abstracted, yet it's pretty much the same everywhere.
1. If ID is given, match that ID. 
2. Create relationship between node and matched relationship node

With that in mind, I've created a `createRelationships` function. It works like this:
```ts
createRelationships(Location, 'out', {
  FundingAccount: { // base node label to match
    fundedBy: // label of the relationship to create 
      input.fundingAccountId, // id of the base node to match 
  }, 
  User: { createdBy: input.creatorId } // simple one liner
})
```
This creates two relationships labeled `fundedBy` & `createdBy` from the previously matched `(node: Location)` to the `FundingAccount` and `User` by their IDs.

- Zero or more IDs can be given to under the relationship label.
  - Zero (`[]/null/undefined`) omits the match & create clauses.
  - 1+ matches all and creates all
- The BaseNode resources being connected to a strictly keyed from the `ResourceMap` object
- Passing the resource is future proofing. Not having this in other query fragments, like `createBaseNode`, renders them needing to be replaced.
  - The near future use could be strictly typing the relationship names from the `Relationships` static prop on the DTO. Currently any string is allowed there.

While this does look very different from the cypher produced, I'd argue that it is not any less readable.

The biggest caveat here is that the IDs given here must exist in DB. If not then the query result will return an empty set, which would be bad for `createNode` as we'd say the resource failed to create but the base node part created fine. Using a transaction would also fix this.



# Real App Example
https://github.com/SeedCompany/cord-api-v3/blob/ba056d3bf3ccbf40dde73ddcbbe25deb144b998f/src/components/engagement/engagement.repository.ts#L217-L228
```cql
CALL {
  CREATE (node:InternshipEngagement:Engagement:BaseNode { createdAt: datetime(), id: '8i5sKkr4m5g' }),
      (node)-[:position { active: true, createdAt: datetime() }]->(:InternPosition:Property { createdAt: datetime(), value: null, sortValue: null }),
      (node)-[:methodologies { active: true, createdAt: datetime() }]->(:ProductMethodology:Property { createdAt: datetime(), value: null, sortValue: null }),
      (node)-[:growthPlan { active: true, createdAt: datetime() }]->(:Property { createdAt: datetime(), value: 'AX5OOZB60No', sortValue: 'AX5OOZB60No' }),
      (node)-[:completeDate { active: true, createdAt: datetime() }]->(:Property { createdAt: datetime(), value: null, sortValue: null }),
      (node)-[:disbursementCompleteDate { active: true, createdAt: datetime() }]->(:Property { createdAt: datetime(), value: null, sortValue: null }),
      (node)-[:communicationsCompleteDate { active: true, createdAt: datetime() }]->(:Property { createdAt: datetime(), value: null, sortValue: null }),
      (node)-[:startDateOverride { active: true, createdAt: datetime() }]->(:Property { createdAt: datetime(), value: null, sortValue: null }),
      (node)-[:endDateOverride { active: true, createdAt: datetime() }]->(:Property { createdAt: datetime(), value: null, sortValue: null }),
      (node)-[:status { active: true, createdAt: datetime() }]->(:EngagementStatus:Property { createdAt: datetime(), value: 'InDevelopment', sortValue: 'InDevelopment' }),
      (node)-[:initialEndDate { active: true, createdAt: datetime() }]->(:Property { createdAt: datetime(), value: null, sortValue: null }),
      (node)-[:statusModifiedAt { active: true, createdAt: datetime() }]->(:Property { createdAt: datetime(), value: null, sortValue: null }),
      (node)-[:lastSuspendedAt { active: true, createdAt: datetime() }]->(:Property { createdAt: datetime(), value: null, sortValue: null }),
      (node)-[:lastReactivatedAt { active: true, createdAt: datetime() }]->(:Property { createdAt: datetime(), value: null, sortValue: null }),
      (node)-[:modifiedAt { active: true, createdAt: datetime() }]->(:Property { createdAt: datetime(), value: datetime(), sortValue: datetime() }),
      (node)-[:canDelete { active: true, createdAt: datetime() }]->(:Property { createdAt: datetime(), value: true, sortValue: true })
  RETURN node
}
CALL {
  WITH node
  MATCH (engagement:Project { id: 'y9IBRDZnUIN' }),
      (intern:User { id: 'T8DJ28wpSrW' })
  CREATE (node)<-[:engagement { active: true, createdAt: datetime() }]-(engagement),
      (node)-[:intern { active: true, createdAt: datetime() }]->(intern)
  RETURN engagement, intern
}
RETURN node.id as id
```
(BTW this query output is straight from log, I didn't tweak the formatting at all when pasting here ☺️)
Notice the base node labels are determined automatically, and some properties have special labels.
country of origin & mentor ID's were omitted from API mutation & thus not in the DB query.

# End Result
Here we can see how much of a line saving it is. That reduced number of lines helps with cognitive overhead.
```
 src/components/engagement/engagement.repository.ts | 151 +++++++++++++++++++++++++-----------------------------------------------------------------------
 src/components/project/project.repository.ts       |  77 ++++++++++++++++++++++++++++++++++++++++++++++---
 src/components/project/project.service.ts          | 295 +++++++++++++++++++++++++-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 3 files changed, 150 insertions(+), 373 deletions(-)
```