### PR TITLE
Sub query import vars shortcut

### DIFF
--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -312,9 +312,8 @@ export class DatabaseService {
       .match(node('node', label, { id }))
       // Deactivate existing prop(s) & adjust labels as needed
       // This is an optional step
-      .subQuery((sub) =>
+      .subQuery('node', (sub) =>
         sub
-          .with('node')
           .match([
             node('node'),
             relation('out', 'oldToProp', key, { active: !changeset }),
@@ -333,9 +332,8 @@ export class DatabaseService {
           .apply(prefixNodeLabelsWithDeleted('oldPropVar'))
           .return(['count(oldPropVar) as numPropsDeactivated'])
       )
-      .subQuery((sub) =>
+      .subQuery('node', (sub) =>
         sub
-          .with('node')
           .apply((q) =>
             changeset
               ? q

--- a/src/core/database/query-augmentation/subquery.ts
+++ b/src/core/database/query-augmentation/subquery.ts
@@ -1,4 +1,5 @@
 import { ClauseCollection, Query } from 'cypher-query-builder';
+import { Many } from '../../../common';
 
 declare module 'cypher-query-builder/dist/typings/query' {
   interface Query {
@@ -13,18 +14,34 @@ declare module 'cypher-query-builder/dist/typings/query' {
      *   .return('x * 10 as y')
      * )
      * .return(['x', 'y'])
+     *
+     * @example
+     * .unwind([0, 1, 2], 'x')
+     * .subQuery('x', (sub) => sub
+     *   .return('x * 10 as y')
+     * )
+     * .return(['x', 'y'])
      */
     subQuery(sub: (query: this) => void): this;
+    subQuery(importVars: Many<string>, sub: (query: this) => void): this;
   }
 }
 
-Query.prototype.subQuery = function subQuery(sub: (query: Query) => void) {
+Query.prototype.subQuery = function subQuery(
+  subOrImport: Many<string> | ((query: Query) => void),
+  maybeSub?: (query: Query) => void
+) {
   const subQ = new Query();
   const subClause = new SubQueryClause();
   // @ts-expect-error yeah it's private, but it'll be ok.
-  // SubQueryClause is also a ClauseCollection so it's all good.
+  // SubQueryClause is also a ClauseCollection, so it's all good.
   subQ.clauses = subClause;
-  sub(subQ);
+  if (typeof subOrImport === 'function') {
+    subOrImport(subQ);
+  } else {
+    subQ.with(subOrImport);
+    maybeSub!(subQ);
+  }
 
   this.addClause(subClause);
 

--- a/src/core/database/query/create-relationships.ts
+++ b/src/core/database/query/create-relationships.ts
@@ -83,9 +83,8 @@ export function createRelationships<TResourceStatic extends ResourceShape<any>>(
 
   const createdAt = DateTime.local();
   return (query: Query) =>
-    query.subQuery((sub) =>
+    query.subQuery('node', (sub) =>
       sub
-        .with('node')
         .match(
           flattened.map(({ variable, nodeLabel, id }) => [
             node(variable, nodeLabel, { id }),

--- a/src/core/database/query/deletes.ts
+++ b/src/core/database/query/deletes.ts
@@ -48,9 +48,8 @@ export const deleteProperties =
       return query;
     }
     const deletedAt = DateTime.local();
-    return query.subQuery((sub) =>
+    return query.subQuery('node', (sub) =>
       sub
-        .with('node')
         .match([
           node('node'),
           relation('out', 'propertyRel', relationLabels, { active: true }),
@@ -67,9 +66,8 @@ export const deleteProperties =
   };
 
 export const prefixNodeLabelsWithDeleted = (node: string) => (query: Query) =>
-  query.subQuery((sub) =>
+  query.subQuery(node, (sub) =>
     sub
-      .with(node) // import node
       .with([
         node,
         // Mpa current labels to have deleted prefix (operation is idempotent).

--- a/src/core/database/query/match-project-based-props.ts
+++ b/src/core/database/query/match-project-based-props.ts
@@ -6,9 +6,8 @@ import { matchProps, MatchPropsOptions } from './matching';
 export const matchPropsAndProjectSensAndScopedRoles =
   (session?: Session | ID, propsOptions?: MatchPropsOptions) =>
   (query: Query) =>
-    query.subQuery((sub) =>
+    query.subQuery(['node', 'project'], (sub) =>
       sub
-        .with(['node', 'project'])
         .apply(matchProps(propsOptions))
         .apply((q) =>
           session

--- a/src/core/database/query/matching.ts
+++ b/src/core/database/query/matching.ts
@@ -81,9 +81,8 @@ export const matchProps =
     excludeBaseProps = false,
   }: MatchPropsOptions = {}) =>
   (query: Query) =>
-    query.subQuery((sub) =>
+    query.subQuery(nodeName, (sub) =>
       sub
-        .with(nodeName)
         .match(
           [
             node(nodeName),


### PR DESCRIPTION
This adds an optional parameter to `subQuery()` to import variables.

```diff
- query.subQuery((sub) => sub
-   .with('node')
+ query.subQuery('node', (sub) => sub
```

Importing vars is a common use case and this is shorter.

Downside is it deviates more from the Neo4j doc examples. Weirdly though this `with` clauses used as the import into the sub query is different from normal `with` clauses. It can't do anything other than plainly reference an existing variable; no `as` aliasing or function calls allowed.

Thoughts?