### PR TITLE
New Paginate fragment

### DIFF
--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -20,7 +20,7 @@ import {
   OnIndex,
   UniquenessError,
 } from '../../core';
-import { runListQuery } from '../../core/database/results';
+import { mapListResults } from '../../core/database/results';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { Powers } from '../authorization/dto/powers';
 import { EngagementService, EngagementStatus } from '../engagement';
@@ -239,12 +239,11 @@ export class LanguageService {
   }
 
   async list(
-    { filter, ...input }: LanguageListInput,
+    input: LanguageListInput,
     session: Session
   ): Promise<LanguageListOutput> {
-    const query = this.repo.list({ filter, ...input }, session);
-
-    return await runListQuery(query, input, (id) => this.readOne(id, session));
+    const results = await this.repo.list(input, session);
+    return await mapListResults(results, (id) => this.readOne(id, session));
   }
 
   async listLocations(

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -22,7 +22,7 @@ import {
   Transactional,
   UniquenessError,
 } from '../../core';
-import { runListQuery } from '../../core/database/results';
+import { mapListResults } from '../../core/database/results';
 import { Role } from '../authorization';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { Powers } from '../authorization/dto/powers';
@@ -244,8 +244,8 @@ export class UserService {
   }
 
   async list(input: UserListInput, session: Session): Promise<UserListOutput> {
-    const query = this.userRepo.list(input, session);
-    return await runListQuery(query, input, (id) => this.readOne(id, session));
+    const users = await this.userRepo.list(input, session);
+    return await mapListResults(users, (user) => this.secure(user, session));
   }
 
   async listEducations(

--- a/src/core/database/query/lists.ts
+++ b/src/core/database/query/lists.ts
@@ -2,11 +2,64 @@ import { node, Query, relation } from 'cypher-query-builder';
 import {
   ID,
   Order,
+  PaginatedListType,
+  PaginationInput,
   Resource,
   ResourceShape,
   SortablePaginationInput,
 } from '../../../common';
+import { collect } from './cypher-functions';
 
+/**
+ * Adds pagination to a query based on input.
+ *
+ * Expects a `node` query variable for all available items.
+ * Expects filtering and sorting to already be applied.
+ *
+ * Optionally hydrate each item of the page requested with the hydrate() function.
+ * It expects a `dto` output variable.
+ * If it's omitted, then by default only the IDs are returned.
+ * Note that only `node` is available in this function.
+ */
+export const paginate =
+  <R = ID>(
+    { count, page }: PaginationInput,
+    hydrate?: (query: Query) => Query<{ dto: R }>
+  ) =>
+  (query: Query) => {
+    let list = 'list';
+    const params: Record<string, any> = {
+      limit: count,
+    };
+    if (page !== 1) {
+      params.offset = ((page ?? 1) - 1) * count;
+      list = `list[$offset..]`;
+    }
+
+    return query.comment`paginate()`
+      .with('collect(distinct node) as list')
+      .raw(`WITH list, ${list}[..$limit] as page`, params)
+      .subQuery('page', (sub) =>
+        sub
+          .raw('UNWIND page as node')
+          .comment('Hydrating node')
+          .apply(hydrate ?? ((q) => q.with('node.id as dto')))
+          // Using collect in sub query ensures that unwinding an empty list
+          // and then collecting in the return will maintain the one row outside
+          // this sub query so that total and other pagination info is returned.
+          .return(collect('dto').as('hydratedPage'))
+      )
+      .return<PaginatedListType<R>>([
+        'hydratedPage as items',
+        'size(list) as total',
+        // We use list & page here as comparison needs to be done with neo4j nodes
+        'size(page) > 0 and page[-1] <> list[-1] as hasMore',
+      ]);
+  };
+
+/**
+ * @deprecated Use {@link paginate} instead.
+ */
 export const calculateTotalAndPaginateList =
   <TResourceStatic extends ResourceShape<any>>(
     resource: TResourceStatic,

--- a/src/core/database/query/lists.ts
+++ b/src/core/database/query/lists.ts
@@ -74,7 +74,7 @@ export const calculateTotalAndPaginateList =
       ])
       .raw(`unwind nodes as node`)
       // .with(['node', 'total']) TODO needed?
-      .apply(sorter ?? defaultSorter(resource, sort, order))
+      .apply(sorter ?? defaultSorter(resource, { sort, order }))
       .with([
         `collect(distinct node.id)[${(page - 1) * count}..${
           page * count
@@ -86,8 +86,7 @@ export const calculateTotalAndPaginateList =
 export const defaultSorter =
   <TResourceStatic extends ResourceShape<any>>(
     resource: TResourceStatic,
-    sortInput: string,
-    order: Order
+    { sort: sortInput, order }: { sort: string; order: Order }
   ) =>
   (q: Query) => {
     // The properties that are stored as strings

--- a/src/core/database/results/lists.ts
+++ b/src/core/database/results/lists.ts
@@ -1,6 +1,19 @@
 import { Query } from 'cypher-query-builder';
-import { ID, PaginationInput } from '../../../common';
+import { ID, PaginatedListType, PaginationInput } from '../../../common';
+// eslint-disable-next-line @seedcompany/no-unused-vars -- used in jsdoc below.
+import { paginate } from '../query';
 
+export const mapListResults = async <T, R>(
+  results: PaginatedListType<T>,
+  mapper: (item: T) => Promise<R>
+) => ({
+  ...results,
+  items: await Promise.all(results.items.map(mapper)),
+});
+
+/**
+ * @deprecated Use new {@link paginate} function (optionally with {@link mapListResults})
+ */
 export async function runListQuery<T>(
   query: Query<{ items: ID[]; total: number }>,
   input: PaginationInput,


### PR DESCRIPTION
My cypher-fu is stronger now 😎 
This deprecates ~`calculateTotalAndPaginateList()`~ for `paginate()`

# Differences
- Always returns a single row.
  `.first()` is used now instead of having to call via ~`runListQuery()`~ which handled the "no matches" case.
- Doesn't involve sorting.
   For simplicity's sake & separation of concerns this doesn't give a sorter option or call the `defaultSorter`.
   `defaultSorter` can easily be called explicitly before calling `paginate()`.
- (Best for last) Allows hydrating each item in the requested page. This allows for a single DB query for data instead of "ID list then readOne for each ID".

# Outline to follow
I've updated user list (8424773) to use new abstractions. This represents the best case scenario as it is 1 call to the database.
Steps:
1. `UserRepository` provides a `hydrate` fragment function which given a `(node:User)` emits a `dto` object representing an `UnsecuredDto<User>`.
2. Both the repositories `readOne` & `list` queries use this fragment after matching the relevant node(s).
3. `UserService` provides a "secure" method to secure a user via a session
   ```js
   secure(dto: UnsecuredDto<User>, session: Session): Promise<User>
   ```
4. Given the results from the repository, the `UserService` secures these unsecured User node(s)


# Shortcut

I've also updated language list (3313f21) to use new function calls. This shows that the new hydration process isn't required to use the new abstraction. Note that this list query shouldn't have a significant performance difference. It still needs work to reduce it down to one call. If we wanted to take it in two passes though we could.
