### PR TITLE
List Sorting Refactor

### DIFF
--- a/src/common/db-sort.decorator.ts
+++ b/src/common/db-sort.decorator.ts
@@ -1,0 +1,25 @@
+import { AbstractClassType } from './types';
+
+const DbSortSymbol = Symbol('DbSortSymbol');
+
+/**
+ * A function given a cypher variable will output cypher to transform it for sorting.
+ */
+type SortTransformer = (value: string) => string;
+
+/**
+ * Customize the way this field is sorted upon.
+ */
+export const DbSort = (transformer: SortTransformer) =>
+  Reflect.metadata(DbSortSymbol, transformer);
+
+export const getDbSortTransformer = (
+  type: AbstractClassType<unknown>,
+  property: string
+) => {
+  // @ts-expect-error property decoration is on instance of object
+  const obj = new type();
+  return Reflect.getMetadata(DbSortSymbol, obj, property) as
+    | SortTransformer
+    | undefined;
+};

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -3,6 +3,7 @@ export * from './temporal';
 export * from './context.type';
 export * from './date-filter.input';
 export * from './db-label.decorator';
+export * from './db-sort.decorator';
 export * from './exceptions';
 export * from './firstLettersOfWords';
 export * from './fiscal-year';

--- a/src/common/name-field.ts
+++ b/src/common/name-field.ts
@@ -4,9 +4,9 @@ import { MinLength } from 'class-validator';
 import { DbSort } from './db-sort.decorator';
 import { Transform } from './transform.decorator';
 
-export const NameField = (options?: FieldOptions) =>
+export const NameField = (options: FieldOptions = {}) =>
   applyDecorators(
-    Field(() => String, options),
+    Field(options),
     Transform(({ value }) => value?.trim()),
     DbSort((value) => `toLower(${value})`),
     MinLength(1)

--- a/src/common/name-field.ts
+++ b/src/common/name-field.ts
@@ -8,6 +8,6 @@ export const NameField = (options: FieldOptions = {}) =>
   applyDecorators(
     Field(options),
     Transform(({ value }) => value?.trim()),
-    DbSort((value) => `toLower(${value})`),
+    DbSort((value) => `apoc.text.clean(${value})`),
     MinLength(1)
   );

--- a/src/common/name-field.ts
+++ b/src/common/name-field.ts
@@ -1,11 +1,13 @@
 import { applyDecorators } from '@nestjs/common';
 import { Field, FieldOptions } from '@nestjs/graphql';
 import { MinLength } from 'class-validator';
+import { DbSort } from './db-sort.decorator';
 import { Transform } from './transform.decorator';
 
 export const NameField = (options?: FieldOptions) =>
   applyDecorators(
     Field(() => String, options),
     Transform(({ value }) => value?.trim()),
+    DbSort((value) => `toLower(${value})`),
     MinLength(1)
   );

--- a/src/common/sensitivity.enum.ts
+++ b/src/common/sensitivity.enum.ts
@@ -1,4 +1,5 @@
-import { registerEnumType } from '@nestjs/graphql';
+import { applyDecorators } from '@nestjs/common';
+import { Field, FieldOptions, registerEnumType } from '@nestjs/graphql';
 
 export enum Sensitivity {
   Low = 'Low',
@@ -9,3 +10,6 @@ export enum Sensitivity {
 registerEnumType(Sensitivity, {
   name: 'Sensitivity',
 });
+
+export const SensitivityField = (options: FieldOptions = {}) =>
+  applyDecorators(Field(() => Sensitivity, options));

--- a/src/common/sensitivity.enum.ts
+++ b/src/common/sensitivity.enum.ts
@@ -1,5 +1,7 @@
 import { applyDecorators } from '@nestjs/common';
 import { Field, FieldOptions, registerEnumType } from '@nestjs/graphql';
+import { rankSens } from '../core/database/query';
+import { DbSort } from './db-sort.decorator';
 
 export enum Sensitivity {
   Low = 'Low',
@@ -12,4 +14,7 @@ registerEnumType(Sensitivity, {
 });
 
 export const SensitivityField = (options: FieldOptions = {}) =>
-  applyDecorators(Field(() => Sensitivity, options));
+  applyDecorators(
+    Field(() => Sensitivity, options),
+    DbSort(rankSens)
+  );

--- a/src/components/budget/dto/budget-record.dto.ts
+++ b/src/components/budget/dto/budget-record.dto.ts
@@ -9,6 +9,7 @@ import {
   SecuredInt,
   SecuredProps,
   Sensitivity,
+  SensitivityField,
 } from '../../../common';
 import { ScopedRole } from '../../authorization';
 import { ChangesetAware } from '../../changeset/dto';
@@ -28,7 +29,7 @@ export class BudgetRecord extends IntersectionType(ChangesetAware, Resource) {
   @Field()
   readonly amount: SecuredFloatNullable;
 
-  @Field(() => Sensitivity, {
+  @SensitivityField({
     description: "Based on the project's sensitivity",
   })
   readonly sensitivity: Sensitivity;

--- a/src/components/budget/dto/budget.dto.ts
+++ b/src/components/budget/dto/budget.dto.ts
@@ -7,6 +7,7 @@ import {
   SecuredProperty,
   SecuredProps,
   Sensitivity,
+  SensitivityField,
 } from '../../../common';
 import { ScopedRole } from '../../authorization';
 import { ChangesetAware } from '../../changeset/dto';
@@ -33,7 +34,7 @@ export class Budget extends IntersectionType(ChangesetAware, Resource) {
 
   readonly universalTemplateFile: DefinedFile;
 
-  @Field(() => Sensitivity, {
+  @SensitivityField({
     description: "Based on the project's sensitivity",
   })
   readonly sensitivity: Sensitivity;

--- a/src/components/ceremony/dto/ceremony.dto.ts
+++ b/src/components/ceremony/dto/ceremony.dto.ts
@@ -7,6 +7,7 @@ import {
   SecuredProperty,
   SecuredProps,
   Sensitivity,
+  SensitivityField,
 } from '../../../common';
 import { CeremonyType } from './type.enum';
 
@@ -29,7 +30,7 @@ export class Ceremony extends Resource {
   @Field()
   readonly actualDate: SecuredDate;
 
-  @Field(() => Sensitivity, {
+  @SensitivityField({
     description: "Based on the project's sensitivity",
   })
   readonly sensitivity: Sensitivity;

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -18,6 +18,7 @@ import {
   SecuredProps,
   SecuredString,
   Sensitivity,
+  SensitivityField,
 } from '../../../common';
 import { ScopedRole } from '../../authorization';
 import { ChangesetAware } from '../../changeset/dto';
@@ -83,7 +84,7 @@ class Engagement extends ChangesetAwareResource {
   @Field()
   readonly endDateOverride: SecuredDateNullable;
 
-  @Field(() => Sensitivity, {
+  @SensitivityField({
     description: "Based on the project's sensitivity",
   })
   readonly sensitivity: Sensitivity;

--- a/src/components/field-region/dto/field-region.dto.ts
+++ b/src/components/field-region/dto/field-region.dto.ts
@@ -1,7 +1,8 @@
-import { Field, ObjectType } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
   ID,
+  NameField,
   Resource,
   Secured,
   SecuredProperty,
@@ -16,7 +17,7 @@ export class FieldRegion extends Resource {
   static readonly Props = keysOf<FieldRegion>();
   static readonly SecuredProps = keysOf<SecuredProps<FieldRegion>>();
 
-  @Field()
+  @NameField()
   readonly name: SecuredString;
 
   readonly fieldZone: Secured<ID>;

--- a/src/components/field-zone/dto/field-zone.dto.ts
+++ b/src/components/field-zone/dto/field-zone.dto.ts
@@ -1,7 +1,8 @@
-import { Field, ObjectType } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
   ID,
+  NameField,
   Resource,
   Secured,
   SecuredProperty,
@@ -16,7 +17,7 @@ export class FieldZone extends Resource {
   static readonly Props = keysOf<FieldZone>();
   static readonly SecuredProps = keysOf<SecuredProps<FieldZone>>();
 
-  @Field()
+  @NameField()
   readonly name: SecuredString;
 
   readonly director: Secured<ID>;

--- a/src/components/file/dto/node.ts
+++ b/src/components/file/dto/node.ts
@@ -6,6 +6,7 @@ import { ConditionalExcept, MergeExclusive, Opaque } from 'type-fest';
 import {
   DateTimeField,
   ID,
+  NameField,
   Resource,
   Secured,
   SecuredProperty,
@@ -41,7 +42,7 @@ abstract class FileNode extends Resource {
   @Field(() => FileNodeType)
   readonly type: FileNodeType;
 
-  @Field({
+  @NameField({
     description: stripIndent`
       The name of the node.
       This is user defined but does not necessarily need to be url safe.

--- a/src/components/film/dto/film.dto.ts
+++ b/src/components/film/dto/film.dto.ts
@@ -1,6 +1,11 @@
-import { Field, ObjectType } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
-import { Resource, SecuredProps, SecuredString } from '../../../common';
+import {
+  NameField,
+  Resource,
+  SecuredProps,
+  SecuredString,
+} from '../../../common';
 import { Producible, ProducibleType } from '../../product/dto';
 
 declare module '../../product/dto' {
@@ -18,6 +23,6 @@ export class Film extends Producible {
   static readonly Props = keysOf<Film>();
   static readonly SecuredProps = keysOf<SecuredProps<Film>>();
 
-  @Field()
+  @NameField()
   readonly name: SecuredString;
 }

--- a/src/components/funding-account/dto/funding-account.dto.ts
+++ b/src/components/funding-account/dto/funding-account.dto.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
+  NameField,
   Resource,
   SecuredInt,
   SecuredProperty,
@@ -15,7 +16,7 @@ export class FundingAccount extends Resource {
   static readonly Props = keysOf<FundingAccount>();
   static readonly SecuredProps = keysOf<SecuredProps<FundingAccount>>();
 
-  @Field()
+  @NameField()
   readonly name: SecuredString;
 
   @Field()

--- a/src/components/language/dto/create-language.dto.ts
+++ b/src/components/language/dto/create-language.dto.ts
@@ -15,6 +15,7 @@ import {
   DateField,
   NameField,
   Sensitivity,
+  SensitivityField,
 } from '../../../common';
 import { Language } from './language.dto';
 
@@ -81,7 +82,7 @@ export abstract class CreateLanguage {
   @Matches(/^[A-Z]{2}\d{2}$/)
   readonly signLanguageCode?: string;
 
-  @Field(() => Sensitivity, { nullable: true })
+  @SensitivityField({ nullable: true })
   readonly sensitivity?: Sensitivity = Sensitivity.High;
 
   @DateField({ nullable: true })

--- a/src/components/language/dto/language.dto.ts
+++ b/src/components/language/dto/language.dto.ts
@@ -14,6 +14,7 @@ import {
   SecuredProps,
   SecuredString,
   Sensitivity,
+  SensitivityField,
 } from '../../../common';
 import { SetChangeType } from '../../../core/database/changes';
 import { Location } from '../../location/dto';
@@ -55,7 +56,7 @@ export class EthnologueLanguage {
   @Field()
   readonly canDelete: boolean;
 
-  @Field(() => Sensitivity, {
+  @SensitivityField({
     description: "Based on the language's sensitivity",
   })
   readonly sensitivity: Sensitivity;
@@ -132,7 +133,7 @@ export class Language extends Resource {
   readonly sponsorEstimatedEndDate: SecuredDate;
 
   // Calculated. Not settable.
-  @Field(() => Sensitivity, {
+  @SensitivityField({
     description: stripIndent`
       The language's sensitivity.
       It's based on its most sensitive location.

--- a/src/components/language/dto/language.dto.ts
+++ b/src/components/language/dto/language.dto.ts
@@ -4,6 +4,7 @@ import { GraphQLString } from 'graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
   ID,
+  NameField,
   Resource,
   SecuredBoolean,
   SecuredDate,
@@ -45,7 +46,7 @@ export class EthnologueLanguage {
   })
   readonly provisionalCode: SecuredString;
 
-  @Field()
+  @NameField()
   readonly name: SecuredString;
 
   @Field()
@@ -71,12 +72,12 @@ export class Language extends Resource {
     locations: [Location],
   };
 
-  @Field({
+  @NameField({
     description: `The real language name`,
   })
   readonly name: SecuredString;
 
-  @Field({
+  @NameField({
     description: stripIndent`
       The public name which will be used/shown when real name
       is unauthorized to be viewed/read.

--- a/src/components/language/dto/update-language.dto.ts
+++ b/src/components/language/dto/update-language.dto.ts
@@ -17,6 +17,7 @@ import {
   IdField,
   NameField,
   Sensitivity,
+  SensitivityField,
 } from '../../../common';
 import { Language } from './language.dto';
 
@@ -86,7 +87,7 @@ export abstract class UpdateLanguage {
   @Matches(/^[A-Z]{2}\d{2}$/)
   readonly signLanguageCode?: string;
 
-  @Field(() => Sensitivity, { nullable: true })
+  @SensitivityField({ nullable: true })
   readonly sensitivity?: Sensitivity;
 
   @DateField({ nullable: true })

--- a/src/components/literacy-material/dto/literacy-material.dto.ts
+++ b/src/components/literacy-material/dto/literacy-material.dto.ts
@@ -1,7 +1,8 @@
-import { Field, ObjectType } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
   DbLabel,
+  NameField,
   Resource,
   SecuredProps,
   SecuredString,
@@ -23,7 +24,7 @@ export class LiteracyMaterial extends Producible {
   static readonly Props = keysOf<LiteracyMaterial>();
   static readonly SecuredProps = keysOf<SecuredProps<LiteracyMaterial>>();
 
-  @Field()
+  @NameField()
   @DbLabel('LiteracyName')
   readonly name: SecuredString;
 }

--- a/src/components/location/dto/location.dto.ts
+++ b/src/components/location/dto/location.dto.ts
@@ -2,6 +2,7 @@ import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
   ID,
+  NameField,
   Resource,
   Secured,
   SecuredEnum,
@@ -24,7 +25,7 @@ export class Location extends Resource {
   static readonly Props = keysOf<Location>();
   static readonly SecuredProps = keysOf<SecuredProps<Location>>();
 
-  @Field()
+  @NameField()
   readonly name: SecuredString;
 
   @Field()

--- a/src/components/organization/dto/organization.dto.ts
+++ b/src/components/organization/dto/organization.dto.ts
@@ -2,6 +2,7 @@ import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
   DbLabel,
+  NameField,
   Resource,
   SecuredProperty,
   SecuredProps,
@@ -19,7 +20,7 @@ export class Organization extends Resource {
     locations: [Location],
   };
 
-  @Field()
+  @NameField()
   @DbLabel('OrgName')
   readonly name: SecuredString;
 

--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -10,9 +10,9 @@ import {
 } from '../../common';
 import { HandleIdLookup, ILogger, Logger, OnIndex } from '../../core';
 import {
+  mapListResults,
   parseBaseNodeProperties,
   parsePropList,
-  runListQuery,
 } from '../../core/database/results';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { FinancialReportingType } from '../partnership/dto/financial-reporting-type';
@@ -186,12 +186,11 @@ export class PartnerService {
   }
 
   async list(
-    { filter, ...input }: PartnerListInput,
+    input: PartnerListInput,
     session: Session
   ): Promise<PartnerListOutput> {
-    const query = this.repo.list({ filter, ...input }, session);
-
-    return await runListQuery(query, input, (id) => this.readOne(id, session));
+    const results = await this.repo.list(input, session);
+    return await mapListResults(results, (id) => this.readOne(id, session));
   }
 
   protected verifyFinancialReportingType(

--- a/src/components/partnership/dto/partnership.dto.ts
+++ b/src/components/partnership/dto/partnership.dto.ts
@@ -10,6 +10,7 @@ import {
   SecuredEnum,
   SecuredProps,
   Sensitivity,
+  SensitivityField,
 } from '../../../common';
 import { ScopedRole } from '../../authorization';
 import { ChangesetAware } from '../../changeset/dto';
@@ -81,7 +82,7 @@ export class Partnership extends IntersectionType(ChangesetAware, Resource) {
   @Field()
   readonly primary: SecuredBoolean;
 
-  @Field(() => Sensitivity, {
+  @SensitivityField({
     description: "Based on the project's sensitivity",
   })
   readonly sensitivity: Sensitivity;

--- a/src/components/partnership/partnership.repository.ts
+++ b/src/components/partnership/partnership.repository.ts
@@ -329,7 +329,6 @@ export class PartnershipRepository extends DtoRepository(Partnership) {
         node('newProperty', 'Property', {
           createdAt: DateTime.local(),
           value: false,
-          sortValue: false,
         }),
       ])
       .run();

--- a/src/components/product/dto/product.dto.ts
+++ b/src/components/product/dto/product.dto.ts
@@ -8,6 +8,7 @@ import {
   SecuredProps,
   SecuredStringNullable,
   Sensitivity,
+  SensitivityField,
 } from '../../../common';
 import { SetChangeType } from '../../../core/database/changes';
 import { SecuredScriptureRangesOverride } from '../../scripture';
@@ -38,7 +39,7 @@ export class Product extends Producible {
   @DbLabel('ProductMethodology')
   readonly methodology: SecuredMethodology;
 
-  @Field(() => Sensitivity, {
+  @SensitivityField({
     description: "Based on the project's sensitivity",
   })
   readonly sensitivity: Sensitivity;

--- a/src/components/project/dto/create-project.dto.ts
+++ b/src/components/project/dto/create-project.dto.ts
@@ -12,6 +12,7 @@ import {
   IsId,
   NameField,
   Sensitivity,
+  SensitivityField,
 } from '../../../common';
 import { ReportPeriod } from '../../periodic-report/dto';
 import { IProject, Project } from './project.dto';
@@ -63,7 +64,7 @@ export abstract class CreateProject {
   @Field(() => ProjectStep, { nullable: true })
   readonly step?: ProjectStep;
 
-  @Field(() => Sensitivity, {
+  @SensitivityField({
     description: 'Defaults to High, only available on internship projects',
     nullable: true,
   })

--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -9,6 +9,7 @@ import {
   DbLabel,
   ID,
   IntersectionType,
+  NameField,
   parentIdMiddleware,
   Resource,
   Secured,
@@ -82,7 +83,7 @@ class Project extends PinnablePostableChangesetAwareResource {
   @Field(() => Sensitivity)
   readonly sensitivity: Sensitivity;
 
-  @Field()
+  @NameField()
   @DbLabel('ProjectName')
   readonly name: SecuredString;
 

--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -19,6 +19,7 @@ import {
   SecuredString,
   SecuredStringNullable,
   Sensitivity,
+  SensitivityField,
   UnsecuredDto,
 } from '../../../common';
 import { ScopedRole } from '../../authorization/dto';
@@ -80,7 +81,7 @@ class Project extends PinnablePostableChangesetAwareResource {
   @Field(() => ProjectType)
   readonly type: ProjectType;
 
-  @Field(() => Sensitivity)
+  @SensitivityField()
   readonly sensitivity: Sensitivity;
 
   @NameField()

--- a/src/components/project/dto/update-project.dto.ts
+++ b/src/components/project/dto/update-project.dto.ts
@@ -11,6 +11,7 @@ import {
   IdField,
   NameField,
   Sensitivity,
+  SensitivityField,
 } from '../../../common';
 import { ReportPeriod } from '../../periodic-report/dto';
 import { IProject, Project } from './project.dto';
@@ -56,7 +57,7 @@ export abstract class UpdateProject {
   @Field(() => ProjectStep, { nullable: true })
   readonly step?: ProjectStep;
 
-  @Field(() => Sensitivity, {
+  @SensitivityField({
     description: 'Update only available to internship projects',
     nullable: true,
   })

--- a/src/components/project/project-member/dto/project-member.dto.ts
+++ b/src/components/project/project-member/dto/project-member.dto.ts
@@ -6,6 +6,7 @@ import {
   Resource,
   SecuredProps,
   Sensitivity,
+  SensitivityField,
 } from '../../../../common';
 import { SecuredRoles } from '../../../authorization';
 import { SecuredUser } from '../../../user';
@@ -23,7 +24,7 @@ export class ProjectMember extends Resource {
   @Field()
   readonly roles: SecuredRoles;
 
-  @Field(() => Sensitivity, {
+  @SensitivityField({
     description: "Based on the project's sensitivity",
   })
   readonly sensitivity: Sensitivity;

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -271,8 +271,7 @@ export class ProjectRepository extends CommonRepository {
         sorting(IProject, input, {
           sensitivity: (query) =>
             query
-              .with('node, node as project')
-              .apply(matchProjectSens())
+              .apply(matchProjectSens('node'))
               .return<{ sortValue: string }>('sensitivity as sortValue'),
         })
       )

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -22,7 +22,7 @@ import {
   OnIndex,
   UniquenessError,
 } from '../../core';
-import { runListQuery } from '../../core/database/results';
+import { mapListResults } from '../../core/database/results';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { rolesForScope, ScopedRole } from '../authorization/dto';
 import { Powers } from '../authorization/dto/powers';
@@ -405,20 +405,11 @@ export class ProjectService {
   }
 
   async list(
-    { filter, ...input }: ProjectListInput,
+    input: ProjectListInput,
     session: Session
   ): Promise<ProjectListOutput> {
-    const label = `${filter.type ?? ''}Project`;
-    const projectSortMap: Partial<Record<typeof input.sort, string>> = {
-      name: 'toLower(prop.sortValue)',
-      sensitivity: 'sensitivityValue',
-    };
-
-    const sortBy = projectSortMap[input.sort] ?? 'prop.value';
-
-    const query = this.repo.list(label, sortBy, { filter, ...input }, session);
-
-    return await runListQuery(query, input, (id) => this.readOne(id, session));
+    const results = await this.repo.list(input, session);
+    return await mapListResults(results, (id) => this.readOne(id, session));
   }
 
   async listEngagements(

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -409,7 +409,7 @@ export class ProjectService {
     session: Session
   ): Promise<ProjectListOutput> {
     const results = await this.repo.list(input, session);
-    return await mapListResults(results, (id) => this.readOne(id, session));
+    return await mapListResults(results, (dto) => this.secure(dto, session));
   }
 
   async listEngagements(

--- a/src/components/song/dto/song.dto.ts
+++ b/src/components/song/dto/song.dto.ts
@@ -1,6 +1,11 @@
-import { Field, ObjectType } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
-import { Resource, SecuredProps, SecuredString } from '../../../common';
+import {
+  NameField,
+  Resource,
+  SecuredProps,
+  SecuredString,
+} from '../../../common';
 import { Producible, ProducibleType } from '../../product/dto';
 
 declare module '../../product/dto' {
@@ -18,6 +23,6 @@ export class Song extends Producible {
   static readonly Props = keysOf<Song>();
   static readonly SecuredProps = keysOf<SecuredProps<Song>>();
 
-  @Field()
+  @NameField()
   readonly name: SecuredString;
 }

--- a/src/components/story/dto/story.dto.ts
+++ b/src/components/story/dto/story.dto.ts
@@ -1,6 +1,11 @@
-import { Field, ObjectType } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
-import { Resource, SecuredProps, SecuredString } from '../../../common';
+import {
+  NameField,
+  Resource,
+  SecuredProps,
+  SecuredString,
+} from '../../../common';
 import { Producible, ProducibleType } from '../../product/dto';
 
 declare module '../../product/dto' {
@@ -18,6 +23,6 @@ export class Story extends Producible {
   static readonly Props = keysOf<Story>();
   static readonly SecuredProps = keysOf<SecuredProps<Story>>();
 
-  @Field()
+  @NameField()
   readonly name: SecuredString;
 }

--- a/src/components/user/dto/user.dto.ts
+++ b/src/components/user/dto/user.dto.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
+  NameField,
   Resource,
   SecuredEnum,
   SecuredProperty,
@@ -37,16 +38,16 @@ export class User extends Resource {
   @Field()
   email: SecuredString;
 
-  @Field()
+  @NameField()
   realFirstName: SecuredString;
 
-  @Field()
+  @NameField()
   realLastName: SecuredString;
 
-  @Field()
+  @NameField()
   displayFirstName: SecuredString;
 
-  @Field()
+  @NameField()
   displayLastName: SecuredString;
 
   @Field()

--- a/src/components/user/education/dto/education.dto.ts
+++ b/src/components/user/education/dto/education.dto.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
+  NameField,
   Resource,
   SecuredEnum,
   SecuredProperty,
@@ -34,9 +35,9 @@ export class Education extends Resource {
   @Field()
   readonly degree: SecuredDegree;
 
-  @Field()
+  @NameField()
   readonly major: SecuredString;
 
-  @Field()
+  @NameField()
   readonly institution: SecuredString;
 }

--- a/src/components/user/user.repository.ts
+++ b/src/components/user/user.repository.ts
@@ -24,13 +24,13 @@ import {
 } from '../../core';
 import {
   collect,
-  defaultSorter,
   deleteProperties,
   matchProps,
   merge,
   paginate,
   permissionsOfNode,
   requestingUser,
+  sorting,
 } from '../../core/database/query';
 import { Role } from '../authorization';
 import {
@@ -300,7 +300,7 @@ export class UserRepository extends DtoRepository(User) {
     const result = await this.db
       .query()
       .match([requestingUser(session), ...permissionsOfNode('User')])
-      .apply(defaultSorter(User, input))
+      .apply(sorting(User, input))
       .apply(paginate(input, this.hydrate()))
       .first();
     return result!; // result from paginate() will always have 1 row.

--- a/src/core/database/query.helpers.ts
+++ b/src/core/database/query.helpers.ts
@@ -1,5 +1,4 @@
 import { node, Query, relation } from 'cypher-query-builder';
-import { deburr } from 'lodash';
 import { DateTime } from 'luxon';
 import { ID, Session } from '../../common';
 // eslint-disable-next-line @seedcompany/no-unused-vars -- used in jsdoc
@@ -18,9 +17,6 @@ export interface Property {
   label?: string;
   isDeburrable?: boolean;
 }
-
-export const determineSortValue = (value: unknown) =>
-  typeof value === 'string' ? deburr(value) : value;
 
 /**
  * @deprecated Use {@link createNode} instead
@@ -61,7 +57,6 @@ export const createBaseNode =
       const nodeProps = {
         createdAt,
         value: prop.value,
-        sortValue: determineSortValue(prop.value),
       };
 
       query.create([

--- a/src/core/database/query/create-node.ts
+++ b/src/core/database/query/create-node.ts
@@ -10,7 +10,6 @@ import {
   ResourceShape,
   UnsecuredDto,
 } from '../../../common';
-import { determineSortValue } from '../query.helpers';
 
 interface CreateNodeOptions<TResourceStatic extends ResourceShape<any>> {
   initialProps?: Partial<UnsecuredDto<TResourceStatic['prototype']>>;
@@ -67,7 +66,6 @@ export const createNode = async <TResourceStatic extends ResourceShape<any>>(
             node('', getDbPropertyLabels(resource, prop), {
               createdAt,
               value,
-              sortValue: determineSortValue(value),
             }),
           ]),
         ])

--- a/src/core/database/query/create-property.ts
+++ b/src/core/database/query/create-property.ts
@@ -10,7 +10,6 @@ import {
   UnwrapSecured,
 } from '../../../common';
 import { DbChanges } from '../changes';
-import { determineSortValue } from '../query.helpers';
 
 export type CreatePropertyOptions<
   TResourceStatic extends ResourceShape<any>,
@@ -93,9 +92,7 @@ export const createProperty =
           }),
           node('newPropNode', propLabels, {
             createdAt,
-            ...(variable
-              ? { value: varRef(variable), sortValue: varRef(variable) }
-              : { value, sortValue: determineSortValue(value) }),
+            value: variable ? varRef(variable) : value,
           }),
           ...(changeset
             ? [

--- a/src/core/database/query/match-project-based-props.ts
+++ b/src/core/database/query/match-project-based-props.ts
@@ -64,7 +64,7 @@ export const matchPropsAndProjectSensAndScopedRoles =
         )
     );
 
-const rankSens = (variable: string) => oneLine`
+export const rankSens = (variable: string) => oneLine`
   case ${variable}
     when 'High' then 2
     when 'Medium' then 1

--- a/src/core/database/query/match-project-based-props.ts
+++ b/src/core/database/query/match-project-based-props.ts
@@ -32,24 +32,11 @@ export const matchPropsAndProjectSensAndScopedRoles =
               ])
             : q
         )
-        .match([
-          node('project'),
-          relation('out', '', 'sensitivity', { active: true }),
-          node('projSens', 'Property'),
-        ])
-        .optionalMatch([
-          node('project'),
-          relation('out', '', 'engagement', { active: true }),
-          node('', 'LanguageEngagement'),
-          relation('out', '', 'language', { active: true }),
-          node('', 'Language'),
-          relation('out', '', 'sensitivity', { active: true }),
-          node('langSens', 'Property'),
-        ])
+        .apply(matchProjectSens())
         .return(
           [
             merge(propsOptions?.outputVar ?? 'props', {
-              sensitivity: determineSensitivity,
+              sensitivity: 'sensitivity',
             }).as(propsOptions?.outputVar ?? 'props'),
             session
               ? `
@@ -63,6 +50,28 @@ export const matchPropsAndProjectSensAndScopedRoles =
           ].join(',\n')
         )
     );
+
+export const matchProjectSens = () => (query: Query) =>
+  query.comment`
+      matchProjectSens()
+    `.subQuery(['node', 'project'], (sub) =>
+    sub
+      .match([
+        node('project'),
+        relation('out', '', 'sensitivity', { active: true }),
+        node('projSens', 'Property'),
+      ])
+      .optionalMatch([
+        node('project'),
+        relation('out', '', 'engagement', { active: true }),
+        node('', 'LanguageEngagement'),
+        relation('out', '', 'language', { active: true }),
+        node('', 'Language'),
+        relation('out', '', 'sensitivity', { active: true }),
+        node('langSens', 'Property'),
+      ])
+      .return(`${determineSensitivity} as sensitivity`)
+  );
 
 export const rankSens = (variable: string) => oneLine`
   case ${variable}

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { gql } from 'apollo-server-core';
 import { Connection } from 'cypher-query-builder';
 import * as faker from 'faker';
-import { compact, intersection, times } from 'lodash';
+import { intersection, times } from 'lodash';
 import { DateTime } from 'luxon';
 import {
   CalendarDate,
@@ -491,8 +491,8 @@ describe('Project e2e', () => {
       sensitivity: Sensitivity.Medium,
     });
 
-    //Create two translation projects, one without langauge engagements and one with 1 med and 1 low sensitivity eng
-    //translation projec without engagements
+    // Create two translation projects, one without language engagements and
+    // one with 1 med and 1 low sensitivity eng translation project without engagements
     await createProject(app);
 
     //with engagements, low and med sensitivity, project should eval to med
@@ -536,18 +536,9 @@ describe('Project e2e', () => {
           },
         }
       );
-    const getSortedSensitivities = (projects: any) => {
-      let sensitivity = '';
-
-      const sensitivities = projects.items.map((item: any) => {
-        if (item.sensitivity !== sensitivity) {
-          return (sensitivity = item.sensitivity);
-        }
-        return undefined;
-      });
-
-      return compact(sensitivities);
-    };
+    const getSortedSensitivities = (
+      projects: PaginatedListType<Raw<Project>>
+    ) => projects.items.map((project) => project.sensitivity);
 
     const { projects: ascendingProjects } = await getSensitivitySortedProjects(
       'ASC'

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -1,14 +1,17 @@
 import { gql } from 'apollo-server-core';
 import { Connection } from 'cypher-query-builder';
 import * as faker from 'faker';
-import { compact, orderBy, times } from 'lodash';
+import { compact, intersection, times } from 'lodash';
 import { DateTime } from 'luxon';
 import {
   CalendarDate,
   DuplicateException,
   generateId,
   ID,
+  isIdLike,
   NotFoundException,
+  Order,
+  PaginatedListType,
   Sensitivity,
 } from '../src/common';
 import { Powers } from '../src/components/authorization/dto/powers';
@@ -21,6 +24,7 @@ import { CreatePartnership } from '../src/components/partnership';
 import {
   CreateProject,
   Project,
+  ProjectListInput,
   ProjectStep,
   ProjectType,
   Role,
@@ -47,6 +51,7 @@ import {
   getUserFromSession,
   login,
   loginAsAdmin,
+  Raw,
   registerUser,
   registerUserWithPower,
   runAsAdmin,
@@ -57,6 +62,41 @@ import {
   changeProjectStep,
   stepsFromEarlyConversationToBeforeActive,
 } from './utility/transition-project';
+
+const deleteProject =
+  (app: TestApp) => async (id: ID | string | { id: ID | string }) =>
+    await app.graphql.mutate(
+      gql`
+        mutation DeleteProject($id: ID!) {
+          deleteProject(id: $id)
+        }
+      `,
+      {
+        id: isIdLike(id) || typeof id === 'string' ? id : id.id,
+      }
+    );
+
+const listProjects = async (
+  app: TestApp,
+  input?: Partial<ProjectListInput>
+) => {
+  const { projects } = await app.graphql.query(
+    gql`
+      query ProjectList($input: ProjectListInput) {
+        projects(input: $input) {
+          items {
+            ...project
+          }
+          hasMore
+          total
+        }
+      }
+      ${fragments.project}
+    `,
+    { input }
+  );
+  return projects as PaginatedListType<Raw<Project>>;
+};
 
 describe('Project e2e', () => {
   let app: TestApp;
@@ -307,19 +347,9 @@ describe('Project e2e', () => {
   it('delete project', async () => {
     const project = await createProject(app);
     expect(project.id).toBeTruthy();
-    const result = await app.graphql.mutate(
-      gql`
-        mutation deleteProject($id: ID!) {
-          deleteProject(id: $id)
-        }
-      `,
-      {
-        id: project.id,
-      }
-    );
 
-    const actual: boolean | undefined = result.deleteProject;
-    expect(actual).toBeTruthy();
+    await deleteProject(app)(project.id);
+
     await expectNotFound(
       app.graphql.query(
         gql`
@@ -337,148 +367,65 @@ describe('Project e2e', () => {
     );
   });
 
-  it('List of projects sorted by name to be alphabetical, ignoring case sensitivity. Order: ASCENDING', async () => {
+  it('List of projects sorted by name to be alphabetical', async () => {
     await registerUserWithPower(
       app,
       [Powers.CreateProject, Powers.DeleteProject],
       { displayFirstName: 'Tammy' }
     );
-    //Create three projects with mixed cases.
-    await createProject(app, {
-      name: 'a project 2' + faker.datatype.uuid(),
-      type: ProjectType.Translation,
-    });
-    await createProject(app, {
-      name: 'Another project 2' + faker.datatype.uuid(),
-      type: ProjectType.Translation,
-    });
-    await createProject(app, {
-      name: 'Big project 2' + faker.datatype.uuid(),
-      type: ProjectType.Translation,
-    });
-    await createProject(app, {
-      name: 'big project also 2' + faker.datatype.uuid(),
-      type: ProjectType.Translation,
-    });
-    const sortBy = 'name';
-    const ascOrder = 'ASC';
-    const { projects } = await app.graphql.query(
-      gql`
-        query projects($input: ProjectListInput!) {
-          projects(input: $input) {
-            hasMore
-            total
-            items {
-              id
-              name {
-                value
-              }
-            }
-          }
-        }
-      `,
-      {
-        input: {
-          sort: sortBy,
-          order: ascOrder,
-          filter: {
-            mine: true,
-          },
-        },
-      }
-    );
-    const items = projects.items;
-    const sorted = orderBy(items, (proj) => proj.name.value.toLowerCase(), [
-      'asc',
-    ]);
-    expect(sorted).toEqual(items);
-    //delete all projects that Tammy has access to
-    await Promise.all(
-      projects.items.map(async (item: { id: any }) => {
-        return await app.graphql.mutate(
-          gql`
-            mutation deleteProject($id: ID!) {
-              deleteProject(id: $id)
-            }
-          `,
-          {
-            id: item.id,
-          }
-        );
-      })
-    );
-  });
 
-  it('List of projects sorted by name to be alphabetical, ignoring case sensitivity. Order: DESCENDING', async () => {
-    await registerUserWithPower(
-      app,
-      [Powers.CreateProject, Powers.DeleteProject],
-      { displayFirstName: 'Tammy' }
+    const unsorted = [
+      'A ignore spaces',
+      'ABC',
+      '[a!-ignore-punctuation]',
+      'Ñot a project',
+      'another project 2',
+      'zap zap',
+      'never a project',
+    ];
+    const sorted = [
+      'ABC',
+      '[a!-ignore-punctuation]', // ignores punctuation & case sensitivity
+      'A ignore spaces', // ignores spaces
+      'another project 2',
+      'never a project',
+      'Ñot a project', // ignores special characters
+      'zap zap',
+    ];
+
+    const created = await Promise.all(
+      unsorted.map((name) =>
+        createProject(app, {
+          name,
+          type: ProjectType.Translation,
+        })
+      )
     );
-    //Create three projects, each beginning with lower or upper-cases.
-    await createProject(app, {
-      name: 'a project 2' + faker.datatype.uuid(),
-      type: ProjectType.Translation,
-    });
-    await createProject(app, {
-      name: 'Another project 2' + faker.datatype.uuid(),
-      type: ProjectType.Translation,
-    });
-    await createProject(app, {
-      name: 'Big project 2' + faker.datatype.uuid(),
-      type: ProjectType.Translation,
-    });
-    await createProject(app, {
-      name: 'big project also 2' + faker.datatype.uuid(),
-      type: ProjectType.Translation,
-    });
-    const sortBy = 'name';
-    const ascOrder = 'DESC';
-    const { projects } = await app.graphql.query(
-      gql`
-        query projects($input: ProjectListInput!) {
-          projects(input: $input) {
-            hasMore
-            total
-            items {
-              id
-              name {
-                value
-              }
-            }
-          }
-        }
-      `,
-      {
-        input: {
-          sort: sortBy,
-          order: ascOrder,
-          filter: {
-            mine: true,
-          },
-        },
-      }
-    );
-    const items = projects.items;
-    const sorted = orderBy(items, (proj) => proj.name.value.toLowerCase(), [
-      'desc',
-    ]);
-    expect(sorted).toEqual(items);
-    //delete all projects
-    await Promise.all(
-      projects.items.map(async (item: { id: any }) => {
-        return await app.graphql.mutate(
-          gql`
-            mutation deleteProject($id: ID!) {
-              deleteProject(id: $id)
-            }
-          `,
-          {
-            id: item.id,
-          }
-        );
-      })
-    );
+
+    // only be concerned with projects listed here,
+    // ignore other ones that have slipped in from other tests
+    const filterNames = (list: PaginatedListType<Raw<Project>>) =>
+      intersection(
+        list.items.map((p) => p.name.value),
+        unsorted
+      );
+
+    try {
+      const ascProjects = await listProjects(app, {
+        sort: 'name',
+        order: Order.ASC,
+      });
+      expect(filterNames(ascProjects)).toEqual(sorted);
+
+      const descProjects = await listProjects(app, {
+        sort: 'name',
+        order: Order.DESC,
+      });
+      expect(filterNames(descProjects)).toEqual(sorted.slice().reverse());
+    } finally {
+      //delete all projects that Tammy has access to
+      await Promise.all(created.map(deleteProject(app)));
+    }
   });
 
   it('List view of projects', async () => {
@@ -514,20 +461,7 @@ describe('Project e2e', () => {
     expect(projects.items.length).toBeGreaterThanOrEqual(numProjects);
 
     //delete all projects
-    await Promise.all(
-      projects.items.map(async (item: { id: any }) => {
-        return await app.graphql.mutate(
-          gql`
-            mutation deleteProject($id: ID!) {
-              deleteProject(id: $id)
-            }
-          `,
-          {
-            id: item.id,
-          }
-        );
-      })
-    );
+    await Promise.all(projects.items.map(deleteProject(app)));
   });
 
   it('List of projects sorted by Sensitivity', async () => {
@@ -671,20 +605,7 @@ describe('Project e2e', () => {
 
     expect(projects.items.length).toBeGreaterThanOrEqual(numProjects);
     //delete all projects
-    await Promise.all(
-      projects.items.map(async (item: { id: any }) => {
-        return await app.graphql.mutate(
-          gql`
-            mutation deleteProject($id: ID!) {
-              deleteProject(id: $id)
-            }
-          `,
-          {
-            id: item.id,
-          }
-        );
-      })
-    );
+    await Promise.all(projects.items.map(deleteProject(app)));
   });
 
   it('List view of pinned/unpinned projects', async () => {
@@ -839,16 +760,7 @@ describe('Project e2e', () => {
     );
 
     //clean up
-    await app.graphql.mutate(
-      gql`
-        mutation deleteProject($id: ID!) {
-          deleteProject(id: $id)
-        }
-      `,
-      {
-        id: project.id,
-      }
-    );
+    await deleteProject(app)(project);
   });
 
   it('List view of project members by projectId', async () => {

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -549,6 +549,8 @@ describe('Project e2e', () => {
     expect(getSortedSensitivities(ascendingProjects)).toEqual([
       Sensitivity.Low,
       Sensitivity.Medium,
+      Sensitivity.Medium,
+      Sensitivity.High,
       Sensitivity.High,
     ]);
 
@@ -558,6 +560,8 @@ describe('Project e2e', () => {
 
     expect(getSortedSensitivities(descendingProjects)).toEqual([
       Sensitivity.High,
+      Sensitivity.High,
+      Sensitivity.Medium,
       Sensitivity.Medium,
       Sensitivity.Low,
     ]);


### PR DESCRIPTION
Got on a roll with #2015 and couldn't help myself. This depends on #2015

# Highlights
- `sorting` function (formerly `defaultSorter`) now lets you customize how the sortValue is matched per field
  - This is only matching; after `sorting()` gets the value back from this custom matcher it applies the `ORDER BY` clause so it doesn't have to be repeated.
- A fields sort value can further be transformed with a new `@DbSort()` decorator
  - Having this separate lets us match fields independently determining how the value should be sorted.
  - New `@SensitivityField()` applies a sort transformer to convert `Sensitivity` to a number with Neo4j can order.
     It is defined once, instead of every time we want to sort on a sensitivity field
- All name fields now use a `apoc.text.clean()` transformer. This removes the need to store a `sortValue` for every property.
- Removed all references to a property's `sortValue`. This property can be safely wiped from DB after this PR goes live.