### PR TITLE
Query.forEach

### DIFF
--- a/src/core/database/query-augmentation/SubClauseCollection.ts
+++ b/src/core/database/query-augmentation/SubClauseCollection.ts
@@ -1,0 +1,23 @@
+import { ClauseCollection, Query } from 'cypher-query-builder';
+
+export class SubClauseCollection extends ClauseCollection {
+  build() {
+    return this.clauses
+      .map((clause) => `  ${clause.build()}`.replace(/\n/g, `\n  `))
+      .join('\n');
+  }
+
+  protected wrapBuild(prefix: string, suffix: string, clauses: string) {
+    const multiline = clauses.includes('\n') || clauses.length > 80;
+    return multiline
+      ? [prefix.trim(), clauses, suffix.trim()].join('\n')
+      : [prefix, clauses.trim(), suffix].join('');
+  }
+
+  asQuery() {
+    const query = new Query();
+    // @ts-expect-error We are also a ClauseCollection, so it's all good.
+    query.clauses = this;
+    return query;
+  }
+}

--- a/src/core/database/query-augmentation/foreach.ts
+++ b/src/core/database/query-augmentation/foreach.ts
@@ -1,0 +1,64 @@
+import { Query } from 'cypher-query-builder';
+import { SubClauseCollection } from './SubClauseCollection';
+
+declare module 'cypher-query-builder/dist/typings/query' {
+  interface Query {
+    /**
+     * Creates a FOREACH clause and calls the given function
+     * to define it.
+     *
+     * @example
+     * .forEach('n', 'nodes(p)', 'SET n.marked = true')
+     *
+     * @example
+     * // In part from https://www.markhneedham.com/blog/2014/04/19/neo4j-cypher-creating-a-time-tree-down-to-the-day/
+     * .with([
+     *   'range(2011, 2014) as years',
+     *   'range(1, 12) as months',
+     * ])
+     * .forEach('year', 'years', (year) => year
+     *   .merge(node('y', 'Year', { year: variable('year') }))
+     *   .forEach('month', 'months', (month) => month
+     *     .createNode('m', 'Month', { month: variable('month') })
+     *     .merge([node('y'), relation('out', '', 'HAS_MONTH'), node('m')])
+     *   )
+     * )
+     *
+     * @see https://neo4j.com/docs/cypher-manual/current/clauses/foreach/
+     */
+    forEach(
+      variable: string,
+      list: string,
+      each: string | ((query: Query) => Query)
+    ): this;
+  }
+}
+
+Query.prototype.forEach = function forEach(
+  this: Query,
+  variable: string,
+  list: string,
+  each: string | ((query: Query) => Query)
+) {
+  const clause = new ForEachClause(variable, list);
+  const q = clause.asQuery();
+  typeof each === 'string' ? q.raw(each) : each(q);
+  return this.continueChainClause(clause);
+};
+
+class ForEachClause extends SubClauseCollection {
+  constructor(
+    private readonly variable: string,
+    private readonly list: string
+  ) {
+    super();
+  }
+
+  build() {
+    return this.wrapBuild(
+      `FOREACH (${this.variable} IN ${this.list} | `,
+      ')',
+      super.build()
+    );
+  }
+}

--- a/src/core/database/query-augmentation/index.ts
+++ b/src/core/database/query-augmentation/index.ts
@@ -3,6 +3,7 @@ import './as-result';
 import './call';
 import './comment';
 import './condition-variables';
+import './foreach';
 import './interpolate';
 import './log-it';
 import './map';


### PR DESCRIPTION
This can be used with the body as raw strings or with query builder
```ts
.forEach('n', 'nodes(p)', 'SET n.marked = true')
// FOREACH (n IN nodes(p) | SET n.marked = true)


.forEach('year', 'years', (year) => year
  .merge(node('y', 'Year', { year: variable('year') }))
)
// FOREACH (year in years |
//   MERGE (y:Year { year: year })
// )
```

Both this and subquery will be formatted as a single line if the body is a single line and less than 80 characters.
```ts
query.subQuery((sub) => sub.return(['null as changeset', '{} as changedProps']))
// CALL { RETURN null as changeset, {} as changedProps }
```