### PR TITLE
[RFC] Add User.isSystem flag

### DIFF
--- a/src/components/user/user.resolver.ts
+++ b/src/components/user/user.resolver.ts
@@ -7,6 +7,7 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
 import {
   AnonSession,
   firstLettersOfWords,
@@ -16,6 +17,7 @@ import {
   LoggedInSession,
   Session,
 } from '../../common';
+import { ConfigService } from '../../core';
 import { LocationListInput, SecuredLocationList } from '../location';
 import {
   OrganizationListInput,
@@ -59,6 +61,7 @@ class ModifyLocationArgs {
 export class UserResolver {
   constructor(
     private readonly userService: UserService,
+    private readonly config: ConfigService,
     private readonly timeZoneService: TimeZoneService
   ) {}
 
@@ -93,6 +96,16 @@ export class UserResolver {
       ...user.timezone,
       value: tz ? zones[tz] : undefined,
     };
+  }
+
+  @ResolveField(() => Boolean, {
+    description: stripIndent`
+      Whether this user represents something done by the "system"
+      (either via migration, automation, etc.) or a "real" user
+    `,
+  })
+  isSystem(@Parent() user: User): boolean {
+    return user.id === this.config.rootAdmin.id;
   }
 
   @Query(() => UserListOutput, {


### PR DESCRIPTION
We have many objects in production that normally have users attached to them but have been migrated in where we didn't know the user.
I didn't and still don't want to make that relationship optional, esp for an edge case.

However, it would still be nice to be able to opt-in to hiding "root root" in the UI. Or somehow convey that this user is "unknown" or the action was taken by the system, etc.

So I added an `isSystem` boolean to the `User` object. Currently it's just a check to see if the user is the root admin, but it could be implemented differently in the future.

Thoughts? Is this a good idea or bad? Is there a better way to schema this?