### PR TITLE
Project.engagement.project resolvers & revert ProductProgress being a Resource

### DIFF
--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -52,6 +52,8 @@ class Engagement extends ChangesetAwareResource {
 
   readonly __typename: 'LanguageEngagement' | 'InternshipEngagement';
 
+  readonly project: ID;
+
   @Field(() => SecuredEngagementStatus, {
     middleware: [parentIdMiddleware],
   })

--- a/src/components/engagement/engagement.module.ts
+++ b/src/components/engagement/engagement.module.ts
@@ -16,6 +16,7 @@ import * as handlers from './handlers';
 import { InternshipEngagementResolver } from './internship-engagement.resolver';
 import { InternshipPositionResolver } from './internship-position.resolver';
 import { LanguageEngagementResolver } from './language-engagement.resolver';
+import { EngagementProductConnectionResolver } from './product-connection.resolver';
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { LanguageEngagementResolver } from './language-engagement.resolver';
     InternshipEngagementResolver,
     EngagementStatusResolver,
     InternshipPositionResolver,
+    EngagementProductConnectionResolver,
     EngagementRules,
     EngagementService,
     EngagementRepository,

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -124,6 +124,7 @@ export class EngagementRepository extends CommonRepository {
       .return<{ dto: UnsecuredDto<LanguageEngagement & InternshipEngagement> }>(
         merge('props', 'changedProps', {
           __typename: `[l in labels(node) where l in ['LanguageEngagement', 'InternshipEngagement']][0]`,
+          project: 'project.id',
           language: 'language.id',
           ceremony: 'ceremony.id',
           intern: 'intern.id',
@@ -149,23 +150,6 @@ export class EngagementRepository extends CommonRepository {
     }
 
     return result.dto;
-  }
-
-  async getProjectIdByEngagement(id: ID) {
-    const result = await this.db
-      .query()
-      .match([
-        node('engagement', 'Engagement', { id }),
-        relation('in', '', 'engagement'),
-        node('project', 'Project'),
-      ])
-      .return('project.id as projectId')
-      .asResult<{ projectId: ID }>()
-      .first();
-    if (!result) {
-      throw new NotFoundException('Could not find project');
-    }
-    return result.projectId;
   }
 
   // CREATE ///////////////////////////////////////////////////////////

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -463,8 +463,7 @@ export class EngagementService {
         'You do not have the permission to delete this Engagement'
       );
 
-    const projectId = await this.repo.getProjectIdByEngagement(id);
-    await this.verifyProjectStatus(projectId, session);
+    await this.verifyProjectStatus(object.project, session);
 
     await this.eventBus.publish(new EngagementWillDeleteEvent(object, session));
 

--- a/src/components/engagement/product-connection.resolver.ts
+++ b/src/components/engagement/product-connection.resolver.ts
@@ -1,0 +1,18 @@
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { AnonSession, Session } from '../../common';
+import { Product } from '../product';
+import { LanguageEngagement } from './dto';
+import { EngagementService } from './engagement.service';
+
+@Resolver(Product)
+export class EngagementProductConnectionResolver {
+  constructor(private readonly engagements: EngagementService) {}
+
+  @ResolveField(() => LanguageEngagement)
+  async engagement(
+    @Parent() product: Product,
+    @AnonSession() session: Session
+  ) {
+    return await this.engagements.readOne(product.engagement, session);
+  }
+}

--- a/src/components/product-progress/dto/progress-report.dto.ts
+++ b/src/components/product-progress/dto/progress-report.dto.ts
@@ -1,5 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
+import { DateTime } from 'luxon';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { Merge } from 'type-fest';
 import {
@@ -13,11 +14,16 @@ import { MethodologyStep } from '../../product';
 
 @ObjectType({
   description: 'The progress of a product for a given report',
-  implements: [Resource],
 })
-export class ProductProgress extends Resource {
+export class ProductProgress {
   static readonly Props = keysOf<ProductProgress>();
   static readonly SecuredProps = keysOf<SecuredProps<ProductProgress>>();
+
+  // Both of these only exist if progress has been reported for the product/report pair.
+  // This object is really just a container/grouping of StepProgress nodes.
+  // I have these here to show that they can exist in the DB, but they are private to the API.
+  readonly id?: ID;
+  readonly createdAt?: DateTime;
 
   readonly productId: ID;
 

--- a/src/components/product-progress/product-progress.repository.ts
+++ b/src/components/product-progress/product-progress.repository.ts
@@ -148,6 +148,7 @@ export class ProductProgressRepository {
                 .return(collect('step').as('steps'))
             )
             .return<{ dto: UnsecuredProductProgress }>(
+              // FYI `progress` is nullable, so this could include its props or not.
               merge('progress', {
                 productId: 'product.id',
                 reportId: 'report.id',

--- a/src/components/product-progress/product-progress.service.ts
+++ b/src/components/product-progress/product-progress.service.ts
@@ -95,7 +95,6 @@ export class ProductProgressService {
     return {
       ...progress,
       steps,
-      canDelete: false, // Created automatically when needed, so no deletes
     };
   }
 }

--- a/src/components/product/dto/producible.dto.ts
+++ b/src/components/product/dto/producible.dto.ts
@@ -1,6 +1,5 @@
 import { Field, InterfaceType, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
-import { SetRequired } from 'type-fest';
 import { Resource, SecuredProperty, SecuredProps } from '../../../common';
 import { SecuredScriptureRanges } from '../../scripture/dto';
 
@@ -25,7 +24,7 @@ export abstract class Producible extends Resource {
 // via declaration merging
 export enum ProducibleType {}
 
-export type ProducibleResult = SetRequired<Partial<Producible>, 'id'> & {
+export type ProducibleResult = Producible & {
   __typename: ProducibleType;
 };
 

--- a/src/components/product/dto/product.dto.ts
+++ b/src/components/product/dto/product.dto.ts
@@ -28,6 +28,8 @@ export class Product extends Producible {
   static readonly Props: string[] = keysOf<Product>();
   static readonly SecuredProps: string[] = keysOf<SecuredProps<Product>>();
 
+  readonly engagement: ID;
+
   @Field()
   @DbLabel('ProductMedium')
   readonly mediums: SecuredProductMediums;

--- a/src/components/product/dto/product.dto.ts
+++ b/src/components/product/dto/product.dto.ts
@@ -11,6 +11,7 @@ import {
   SensitivityField,
 } from '../../../common';
 import { SetChangeType } from '../../../core/database/changes';
+import { ScopedRole } from '../../authorization';
 import { SecuredScriptureRangesOverride } from '../../scripture';
 import { SecuredMethodologySteps } from './methodology-step.enum';
 import { Producible, SecuredProducible } from './producible.dto';
@@ -58,6 +59,10 @@ export class Product extends Producible {
     `,
   })
   readonly describeCompletion: SecuredStringNullable;
+
+  // A list of non-global roles the requesting user has available for this object.
+  // This is just a cache, to prevent extra db lookups within the same request.
+  readonly scope?: ScopedRole[];
 }
 
 @ObjectType({

--- a/src/components/product/product.module.ts
+++ b/src/components/product/product.module.ts
@@ -1,23 +1,12 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { AuthorizationModule } from '../authorization/authorization.module';
-import { FilmModule } from '../film/film.module';
-import { LiteracyMaterialModule } from '../literacy-material/literacy-material.module';
 import { ScriptureModule } from '../scripture/scripture.module';
-import { SongModule } from '../song/song.module';
-import { StoryModule } from '../story/story.module';
 import { ProductRepository } from './product.repository';
 import { ProductResolver } from './product.resolver';
 import { ProductService } from './product.service';
 
 @Module({
-  imports: [
-    forwardRef(() => AuthorizationModule),
-    FilmModule,
-    LiteracyMaterialModule,
-    StoryModule,
-    SongModule,
-    ScriptureModule,
-  ],
+  imports: [forwardRef(() => AuthorizationModule), ScriptureModule],
   providers: [ProductResolver, ProductService, ProductRepository],
   exports: [ProductService],
 })

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -61,7 +61,7 @@ export class ProductRepository extends CommonRepository {
       .match([
         node('project', 'Project'),
         relation('out', '', 'engagement', { active: true }),
-        node('', 'Engagement'),
+        node('engagement', 'Engagement'),
         relation('out', '', 'product', { active: true }),
         node('node', 'Product', { id }),
       ])
@@ -95,6 +95,7 @@ export class ProductRepository extends CommonRepository {
           >;
         }>(
           merge('props', {
+            engagement: 'engagement.id',
             scope: 'scopedRoles',
             produces: 'produces',
           }).as('dto')

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -1,21 +1,28 @@
 import { Injectable } from '@nestjs/common';
-import { node, relation } from 'cypher-query-builder';
+import { node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
-import { Except } from 'type-fest';
-import { getDbClassLabels, ID, ServerException, Session } from '../../common';
+import { Except, Merge } from 'type-fest';
+import {
+  getDbClassLabels,
+  ID,
+  NotFoundException,
+  ServerException,
+  Session,
+  UnsecuredDto,
+} from '../../common';
 import { CommonRepository } from '../../core';
 import { DbChanges, getChanges } from '../../core/database/changes';
 import {
   createNode,
   createRelationships,
   matchPropsAndProjectSensAndScopedRoles,
+  merge,
   paginate,
   permissionsOfNode,
   requestingUser,
   sorting,
 } from '../../core/database/query';
-import { BaseNode, DbPropsOfDto } from '../../core/database/results';
-import { ScopedRole } from '../authorization';
+import { BaseNode } from '../../core/database/results';
 import { ScriptureRange, ScriptureRangeInput } from '../scripture';
 import {
   CreateProduct,
@@ -58,32 +65,40 @@ export class ProductRepository extends CommonRepository {
         relation('out', '', 'product', { active: true }),
         node('node', 'Product', { id }),
       ])
-      .apply(matchPropsAndProjectSensAndScopedRoles(session))
-      .return(['props', 'scopedRoles'])
-      .asResult<{
-        props: DbPropsOfDto<
-          DirectScriptureProduct &
-            DerivativeScriptureProduct & {
-              isOverriding: boolean;
-            },
-          true
-        >;
-        scopedRoles: ScopedRole[];
-      }>();
-    return await query.first();
+      .apply(this.hydrate(session));
+    const result = await query.first();
+    if (!result) {
+      throw new NotFoundException('Could not find product');
+    }
+    return result.dto;
   }
 
-  async connectedProducible(id: ID) {
-    return await this.db
-      .query()
-      .match([
-        node('product', 'Product', { id }),
-        relation('out', 'produces', { active: true }),
-        node('producible', 'Producible'),
-      ])
-      .return('producible')
-      .asResult<{ producible: BaseNode }>()
-      .first();
+  protected hydrate(session: Session) {
+    return (query: Query) =>
+      query
+        .apply(matchPropsAndProjectSensAndScopedRoles(session))
+        .optionalMatch([
+          node('node'),
+          relation('out', '', 'produces', { active: true }),
+          node('produces', 'Producible'),
+        ])
+        .return<{
+          dto: Merge<
+            Omit<
+              UnsecuredDto<DirectScriptureProduct & DerivativeScriptureProduct>,
+              'scriptureReferences' | 'scriptureReferencesOverride'
+            >,
+            {
+              isOverriding: boolean;
+              produces: BaseNode | null;
+            }
+          >;
+        }>(
+          merge('props', {
+            scope: 'scopedRoles',
+            produces: 'produces',
+          }).as('dto')
+        );
   }
 
   getActualDirectChanges = getChanges(DirectScriptureProduct);

--- a/src/components/project/engagement-connection.resolver.ts
+++ b/src/components/project/engagement-connection.resolver.ts
@@ -1,0 +1,18 @@
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { AnonSession, Session } from '../../common';
+import { IEngagement } from '../engagement';
+import { IProject } from './dto';
+import { ProjectService } from './project.service';
+
+@Resolver(IEngagement)
+export class ProjectEngagementConnectionResolver {
+  constructor(private readonly projects: ProjectService) {}
+
+  @ResolveField(() => IProject)
+  async project(
+    @Parent() engagement: IEngagement,
+    @AnonSession() session: Session
+  ) {
+    return await this.projects.readOne(engagement.project, session);
+  }
+}

--- a/src/components/project/project.module.ts
+++ b/src/components/project/project.module.ts
@@ -10,6 +10,7 @@ import { PartnerModule } from '../partner/partner.module';
 import { PartnershipModule } from '../partnership/partnership.module';
 import { ProjectChangeRequestModule } from '../project-change-request/project-change-request.module';
 import { UserModule } from '../user/user.module';
+import { ProjectEngagementConnectionResolver } from './engagement-connection.resolver';
 import * as handlers from './handlers';
 import { ProjectMemberModule } from './project-member/project-member.module';
 import { ProjectStepResolver } from './project-step.resolver';
@@ -35,17 +36,13 @@ import { ProjectService } from './project.service';
   ],
   providers: [
     ProjectResolver,
+    ProjectEngagementConnectionResolver,
     ProjectService,
     ProjectStepResolver,
     ProjectRules,
     ProjectRepository,
     ...Object.values(handlers),
   ],
-  exports: [
-    ProjectService,
-    ProjectMemberModule,
-    ProjectRules,
-    ProjectRepository,
-  ],
+  exports: [ProjectService, ProjectMemberModule, ProjectRules],
 })
 export class ProjectModule {}


### PR DESCRIPTION
We now expose a `Product`'s `engagement` on it, and an `Engagement`'s `project` on it. So now only the product ID is needed in a GQL query to also retrieve the project & engagement.

I also found that I needed to revert making `ProductProgress` a `Resource`, which has an `id` and `createdAt`. Both of these properties are generated lazily when progress is reported. Therefore it's possible for us to query for progress and receive "empty containers" which will not have these two properties. We want to return these containers even when no `StepProgress` exists to show that it exists. For example, product A has these X reports which it can report progress on. Or vise-versa report B has these Y products it can report progress on.

Anyways that's a breaking change, but it's not live yet. I've left the createdAt & id generation in the update query as it make be useful in the future even if we don't expose it to the API.