### PR TITLE
ProductProgress.steps null placeholders

### DIFF
--- a/src/components/product-progress/dto/progress-report.dto.ts
+++ b/src/components/product-progress/dto/progress-report.dto.ts
@@ -5,7 +5,6 @@ import { keys as keysOf } from 'ts-transformer-keys';
 import { Merge } from 'type-fest';
 import {
   ID,
-  Resource,
   SecuredFloatNullable,
   SecuredProps,
   UnsecuredDto,
@@ -32,7 +31,7 @@ export class ProductProgress {
   @Field(() => [StepProgress], {
     description: stripIndent`
       The progress of each step in this report.
-      If a step doesn't have a reported value (or it was set to null) it will be omitted from this list.
+      This list is ordered based order of product's steps, which is based on \`MethodologyAvailableSteps\`.
     `,
   })
   readonly steps: readonly StepProgress[];
@@ -47,17 +46,25 @@ export type UnsecuredProductProgress = Merge<
 
 @ObjectType({
   description: `The progress of a product's step for a given report`,
-  implements: [Resource],
 })
-export class StepProgress extends Resource {
+export class StepProgress {
   static readonly Props = keysOf<StepProgress>();
   static readonly SecuredProps = keysOf<SecuredProps<StepProgress>>();
+
+  // Both of these only exist if progress has been reported (or explicitly set to null).
+  // I have these here to show that they can exist in the DB, but they are private to the API.
+  readonly id?: ID;
+  readonly createdAt?: DateTime;
 
   @Field(() => MethodologyStep)
   readonly step: MethodologyStep;
 
   @Field({
-    description: 'The percent (0-100) complete for the step',
+    description: stripIndent`
+      The percent (0-100) complete for the step.
+      If no progress has been reported yet this will be null,
+      or this could be explicitly set to null.
+    `,
   })
   readonly percentDone: SecuredFloatNullable;
 }

--- a/src/components/product-progress/product-progress.repository.ts
+++ b/src/components/product-progress/product-progress.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { stripIndent } from 'common-tags';
 import { node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import {
@@ -144,15 +145,32 @@ export class ProductProgressRepository {
                   node('stepNode', 'StepProgress'),
                 ])
                 .apply(matchProps({ nodeName: 'stepNode', outputVar: 'step' }))
-                .raw('WITH * WHERE step.percentDone IS NOT NULL')
                 .return(collect('step').as('steps'))
             )
+            .match([
+              node('product'),
+              relation('out', '', 'steps', { active: true }),
+              node('declaredSteps', 'Property'),
+            ])
+            .with([
+              '*',
+              // Convert StepProgress list to a map keyed by step
+              'apoc.map.fromPairs([sp in steps | [sp.step, sp]]) as progressStepMap',
+            ])
             .return<{ dto: UnsecuredProductProgress }>(
               // FYI `progress` is nullable, so this could include its props or not.
               merge('progress', {
                 productId: 'product.id',
                 reportId: 'report.id',
-                steps: 'steps',
+                // Convert the products step strings into actual StepProgress
+                // or fallback to a placeholder. This ensures that the list is
+                // in the correct order and indicates which steps still need
+                // progress reported.
+                steps: stripIndent`
+                  [step in declaredSteps.value |
+                    apoc.map.get(progressStepMap, step, { step: step, percentDone: null })
+                  ]
+                `,
               }).as('dto')
             )
       );

--- a/src/components/product-progress/product-progress.service.ts
+++ b/src/components/product-progress/product-progress.service.ts
@@ -88,7 +88,6 @@ export class ProductProgressService {
         return {
           ...step,
           ...secured,
-          canDelete: false, // Created automatically when needed, so no deletes
         };
       })
     );

--- a/src/core/database/query/matching.ts
+++ b/src/core/database/query/matching.ts
@@ -39,15 +39,15 @@ export interface MatchPropsOptions {
  * This is executed in a sub-query so other variables in scope are passed-through
  * transparently.
  */
-export const matchProps =
-  ({
+export const matchProps = (options: MatchPropsOptions = {}) => {
+  const {
     nodeName = 'node',
     outputVar = 'props',
     optional = false,
     changeset,
     excludeBaseProps = false,
-  }: MatchPropsOptions = {}) =>
-  (query: Query) =>
+  } = options;
+  return (query: Query) =>
     query.comment`matchProps(${nodeName})`.subQuery(nodeName, (sub) =>
       sub
         .match(
@@ -75,3 +75,4 @@ export const matchProps =
           ).as(outputVar)
         )
     );
+};


### PR DESCRIPTION
Change ProductProgress.steps to include null placeholders.
Also ensured steps are ordered appropriately.

It's much easier to filter out nulls on consumption rather
than having to compose the list based on product's steps & defaulting there.
This just makes more sense.

Because of this id & createdAt have to be excluded. Related to #2039