### PR TITLE
Dynamic number & boolean product progress measurements

### DIFF
--- a/src/components/authorization/roles/administrator.role.ts
+++ b/src/components/authorization/roles/administrator.role.ts
@@ -306,6 +306,8 @@ export const Administrator = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, write, }, },
         { propertyName: 'isOverriding', permission: { read, write, }, },
         { propertyName: 'describeCompletion', permission: { read, write, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, write, }, },
+        { propertyName: 'progressTarget', permission: { read, write, }, },
       ],
       canDelete: true,
     }),

--- a/src/components/authorization/roles/administrator.role.ts
+++ b/src/components/authorization/roles/administrator.role.ts
@@ -420,7 +420,7 @@ export const Administrator = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read, write },
+          propertyName: 'completed', permission: { read, write },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/consultant-global.role.ts
+++ b/src/components/authorization/roles/consultant-global.role.ts
@@ -316,6 +316,8 @@ export const ConsultantGlobal = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/consultant-global.role.ts
+++ b/src/components/authorization/roles/consultant-global.role.ts
@@ -430,7 +430,7 @@ export const ConsultantGlobal = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/consultant-manager-global.role.ts
+++ b/src/components/authorization/roles/consultant-manager-global.role.ts
@@ -319,6 +319,8 @@ export const ConsultantManagerGlobal = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/consultant-manager-global.role.ts
+++ b/src/components/authorization/roles/consultant-manager-global.role.ts
@@ -433,7 +433,7 @@ export const ConsultantManagerGlobal = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/consultant-manager-on-project.role.ts
+++ b/src/components/authorization/roles/consultant-manager-on-project.role.ts
@@ -318,6 +318,8 @@ export const ConsultantManagerOnProject = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/consultant-manager-on-project.role.ts
+++ b/src/components/authorization/roles/consultant-manager-on-project.role.ts
@@ -432,7 +432,7 @@ export const ConsultantManagerOnProject = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/consultant-on-project.role.ts
+++ b/src/components/authorization/roles/consultant-on-project.role.ts
@@ -316,6 +316,8 @@ export const ConsultantOnProject = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/consultant-on-project.role.ts
+++ b/src/components/authorization/roles/consultant-on-project.role.ts
@@ -430,7 +430,7 @@ export const ConsultantOnProject = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/controller.role.ts
+++ b/src/components/authorization/roles/controller.role.ts
@@ -320,6 +320,8 @@ export const Controller = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/controller.role.ts
+++ b/src/components/authorization/roles/controller.role.ts
@@ -433,7 +433,7 @@ export const Controller = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/field-operations-director.role.ts
+++ b/src/components/authorization/roles/field-operations-director.role.ts
@@ -331,6 +331,8 @@ export const FieldOperationsDirector = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, write, }, },
         { propertyName: 'isOverriding', permission: { read, write, }, },
         { propertyName: 'describeCompletion', permission: { read, write, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, write, }, },
+        { propertyName: 'progressTarget', permission: { read, write, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/field-operations-director.role.ts
+++ b/src/components/authorization/roles/field-operations-director.role.ts
@@ -445,7 +445,7 @@ export const FieldOperationsDirector = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read, write },
+          propertyName: 'completed', permission: { read, write },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/financial-analyst-global.role.ts
+++ b/src/components/authorization/roles/financial-analyst-global.role.ts
@@ -319,6 +319,8 @@ export const FinancialAnalyst = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/financial-analyst-global.role.ts
+++ b/src/components/authorization/roles/financial-analyst-global.role.ts
@@ -433,7 +433,7 @@ export const FinancialAnalyst = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/financial-analyst-on-project.role.ts
+++ b/src/components/authorization/roles/financial-analyst-on-project.role.ts
@@ -318,6 +318,8 @@ export const FinancialAnalystOnProject = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/financial-analyst-on-project.role.ts
+++ b/src/components/authorization/roles/financial-analyst-on-project.role.ts
@@ -432,7 +432,7 @@ export const FinancialAnalystOnProject = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/fundraising.role.ts
+++ b/src/components/authorization/roles/fundraising.role.ts
@@ -310,6 +310,8 @@ export const Fundraising = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/fundraising.role.ts
+++ b/src/components/authorization/roles/fundraising.role.ts
@@ -423,7 +423,7 @@ export const Fundraising = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/intern.role.ts
+++ b/src/components/authorization/roles/intern.role.ts
@@ -313,6 +313,8 @@ export const Intern = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, write, }, },
         { propertyName: 'isOverriding', permission: { read, write, }, },
         { propertyName: 'describeCompletion', permission: { read, write, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, write, }, },
+        { propertyName: 'progressTarget', permission: { read, write, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/intern.role.ts
+++ b/src/components/authorization/roles/intern.role.ts
@@ -427,7 +427,7 @@ export const Intern = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/lead-financial-analyst-global.role.ts
+++ b/src/components/authorization/roles/lead-financial-analyst-global.role.ts
@@ -319,6 +319,8 @@ export const LeadFinancialAnalystGlobal = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/lead-financial-analyst-global.role.ts
+++ b/src/components/authorization/roles/lead-financial-analyst-global.role.ts
@@ -433,7 +433,7 @@ export const LeadFinancialAnalystGlobal = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/lead-financial-analyst-on-project.role.ts
+++ b/src/components/authorization/roles/lead-financial-analyst-on-project.role.ts
@@ -318,6 +318,8 @@ export const LeadFinancialAnalystOnProject = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/lead-financial-analyst-on-project.role.ts
+++ b/src/components/authorization/roles/lead-financial-analyst-on-project.role.ts
@@ -432,7 +432,7 @@ export const LeadFinancialAnalystOnProject = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/leadership.role.ts
+++ b/src/components/authorization/roles/leadership.role.ts
@@ -309,6 +309,8 @@ export const Leadership = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/leadership.role.ts
+++ b/src/components/authorization/roles/leadership.role.ts
@@ -421,7 +421,7 @@ export const Leadership = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/liaison.role.ts
+++ b/src/components/authorization/roles/liaison.role.ts
@@ -312,6 +312,8 @@ export const Liaison = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/liaison.role.ts
+++ b/src/components/authorization/roles/liaison.role.ts
@@ -424,7 +424,7 @@ export const Liaison = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/marketing.role.ts
+++ b/src/components/authorization/roles/marketing.role.ts
@@ -313,6 +313,8 @@ export const Marketing = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/marketing.role.ts
+++ b/src/components/authorization/roles/marketing.role.ts
@@ -425,7 +425,7 @@ export const Marketing = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/mentor.role.ts
+++ b/src/components/authorization/roles/mentor.role.ts
@@ -312,6 +312,8 @@ export const Mentor = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/mentor.role.ts
+++ b/src/components/authorization/roles/mentor.role.ts
@@ -424,7 +424,7 @@ export const Mentor = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/project-manager-global.role.ts
+++ b/src/components/authorization/roles/project-manager-global.role.ts
@@ -316,6 +316,8 @@ export const ProjectManagerGlobal = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, write, }, },
         { propertyName: 'isOverriding', permission: { read, write, }, },
         { propertyName: 'describeCompletion', permission: { read, write, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, write, }, },
+        { propertyName: 'progressTarget', permission: { read, write, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/project-manager-global.role.ts
+++ b/src/components/authorization/roles/project-manager-global.role.ts
@@ -447,7 +447,7 @@ export const ProjectManagerGlobal = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/project-manager-on-project.role.ts
+++ b/src/components/authorization/roles/project-manager-on-project.role.ts
@@ -315,6 +315,8 @@ export const ProjectManagerOnProject = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, write, }, },
         { propertyName: 'isOverriding', permission: { read, write, }, },
         { propertyName: 'describeCompletion', permission: { read, write, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, write, }, },
+        { propertyName: 'progressTarget', permission: { read, write, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/project-manager-on-project.role.ts
+++ b/src/components/authorization/roles/project-manager-on-project.role.ts
@@ -445,7 +445,7 @@ export const ProjectManagerOnProject = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read, write },
+          propertyName: 'completed', permission: { read, write },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/regional-communications-coordinator.role.ts
+++ b/src/components/authorization/roles/regional-communications-coordinator.role.ts
@@ -312,6 +312,8 @@ export const RegionalCommunicationsCoordinator = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/regional-communications-coordinator.role.ts
+++ b/src/components/authorization/roles/regional-communications-coordinator.role.ts
@@ -424,7 +424,7 @@ export const RegionalCommunicationsCoordinator = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/regional-director-global.role.ts
+++ b/src/components/authorization/roles/regional-director-global.role.ts
@@ -332,6 +332,8 @@ export const RegionalDirectorGlobal = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/regional-director-global.role.ts
+++ b/src/components/authorization/roles/regional-director-global.role.ts
@@ -444,7 +444,7 @@ export const RegionalDirectorGlobal = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/regional-director-on-project.role.ts
+++ b/src/components/authorization/roles/regional-director-on-project.role.ts
@@ -332,6 +332,8 @@ export const RegionalDirectorOnProject = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, write, }, },
         { propertyName: 'isOverriding', permission: { read, write, }, },
         { propertyName: 'describeCompletion', permission: { read, write, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, write, }, },
+        { propertyName: 'progressTarget', permission: { read, write, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/regional-director-on-project.role.ts
+++ b/src/components/authorization/roles/regional-director-on-project.role.ts
@@ -445,7 +445,7 @@ export const RegionalDirectorOnProject = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read, write },
+          propertyName: 'completed', permission: { read, write },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/staff-member.role.ts
+++ b/src/components/authorization/roles/staff-member.role.ts
@@ -310,6 +310,8 @@ export const StaffMember = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/staff-member.role.ts
+++ b/src/components/authorization/roles/staff-member.role.ts
@@ -422,7 +422,7 @@ export const StaffMember = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/authorization/roles/translator.role.ts
+++ b/src/components/authorization/roles/translator.role.ts
@@ -312,6 +312,8 @@ export const Translator = new DbRole({
         { propertyName: 'scriptureReferencesOverride', permission: { read, }, },
         { propertyName: 'isOverriding', permission: { read, }, },
         { propertyName: 'describeCompletion', permission: { read, }, },
+        { propertyName: 'progressStepMeasurement', permission: { read, }, },
+        { propertyName: 'progressTarget', permission: { read, }, },
       ],
       canDelete: false,
     }),

--- a/src/components/authorization/roles/translator.role.ts
+++ b/src/components/authorization/roles/translator.role.ts
@@ -424,7 +424,7 @@ export const Translator = new DbRole({
       __className: 'DbStepProgress',
       properties: [
         {
-          propertyName: 'percentDone', permission: { read },
+          propertyName: 'completed', permission: { read },
         }
       ],
       canDelete: false,

--- a/src/components/product-progress/dto/progress-report.dto.ts
+++ b/src/components/product-progress/dto/progress-report.dto.ts
@@ -61,10 +61,13 @@ export class StepProgress {
 
   @Field({
     description: stripIndent`
-      The percent (0-100) complete for the step.
+      The currently completed value for the step.
+
+      This will be 0 <= \`completed\` <= the product's \`progressTarget\` number.
+
       If no progress has been reported yet this will be null,
       or this could be explicitly set to null.
     `,
   })
-  readonly percentDone: SecuredFloatNullable;
+  readonly completed: SecuredFloatNullable;
 }

--- a/src/components/product-progress/dto/progress-report.input.ts
+++ b/src/components/product-progress/dto/progress-report.input.ts
@@ -41,8 +41,20 @@ export abstract class StepProgressInput {
     nullable: true,
     description:
       'The new percent (0-100) complete for the step or null to remove the current value.',
+    deprecationReason: 'Use `StepProgressInput.percentDone` instead.',
   })
   @Min(0)
   @Max(100)
-  readonly percentDone: number | null;
+  readonly percentDone?: number | null;
+
+  @Field(() => Float, {
+    nullable: true,
+    description: stripIndent`
+      The new completed value for the step or null to remove the current value.
+
+      This should be 0 <= \`completed\` <= the product's \`progressTarget\` number.
+    `,
+  })
+  @Min(0)
+  readonly completed?: number | null;
 }

--- a/src/components/product-progress/product-progress.module.ts
+++ b/src/components/product-progress/product-progress.module.ts
@@ -7,12 +7,14 @@ import { ProductProgressRepository } from './product-progress.repository';
 import { ProductProgressResolver } from './product-progress.resolver';
 import { ProductProgressService } from './product-progress.service';
 import { ProgressReportConnectionResolver } from './progress-report-connection.resolver';
+import { StepProgressResolver } from './step-progress.resolver';
 
 @Module({
   imports: [ProductModule, PeriodicReportModule, AuthorizationModule],
   providers: [
     ProgressReportConnectionResolver,
     ProductProgressResolver,
+    StepProgressResolver,
     ProductConnectionResolver,
     ProductProgressService,
     ProductProgressRepository,

--- a/src/components/product-progress/product-progress.repository.ts
+++ b/src/components/product-progress/product-progress.repository.ts
@@ -297,7 +297,18 @@ export class ProductProgressRepository {
       ])
       .apply(matchProjectScopedRoles({ session }))
       .apply(matchProjectSens())
-      .return(['sensitivity', 'scopedRoles']);
+      .subQuery('product', (sub) =>
+        sub
+          .match([
+            node('product'),
+            relation('out', '', 'progressTarget', { active: true }),
+            node('progressTarget', 'Property'),
+          ])
+          .return<{ progressTarget: number }>(
+            'progressTarget.value as progressTarget'
+          )
+      )
+      .return(['sensitivity', 'scopedRoles', 'progressTarget']);
     const result = await query.first();
     if (!result) {
       throw new NotFoundException('Could not find product');

--- a/src/components/product-progress/product-progress.repository.ts
+++ b/src/components/product-progress/product-progress.repository.ts
@@ -168,7 +168,7 @@ export class ProductProgressRepository {
                 // progress reported.
                 steps: stripIndent`
                   [step in declaredSteps.value |
-                    apoc.map.get(progressStepMap, step, { step: step, percentDone: null })
+                    apoc.map.get(progressStepMap, step, { step: step, completed: null })
                   ]
                 `,
               }).as('dto')
@@ -250,16 +250,16 @@ export class ProductProgressRepository {
               })
               .return('stepNode')
           ).raw`
-            // Update percents that have changed
+            // Update current completed values that have changed
             WITH *
-            WHERE NOT (stepNode)-[:percentDone { active: true }]->(:Property { value: stepInput.percentDone })
+            WHERE NOT (stepNode)-[:completed { active: true }]->(:Property { value: stepInput.completed })
           `
           .apply(
             updateProperty({
               nodeName: 'stepNode',
               resource: StepProgress,
-              key: 'percentDone',
-              variable: 'stepInput.percentDone',
+              key: 'completed',
+              variable: 'stepInput.completed',
             })
           )
           .return([

--- a/src/components/product-progress/product-progress.service.ts
+++ b/src/components/product-progress/product-progress.service.ts
@@ -57,13 +57,20 @@ export class ProductProgressService {
       otherRoles: scope.scopedRoles,
       sessionOrUserId: session,
     });
-    if (!perms.percentDone.canEdit) {
+    if (!perms.completed.canEdit) {
       throw new UnauthorizedException(
         `You do not have permission to update this product's progress`
       );
     }
 
-    const progress = await this.repo.update(input);
+    const progress = await this.repo.update({
+      ...input,
+      steps: input.steps.map((sp) => ({
+        step: sp.step,
+        // Handle BC change with field rename
+        completed: sp.completed ?? sp.percentDone ?? null,
+      })),
+    });
     return await this.secure(progress, session);
   }
 

--- a/src/components/product-progress/step-progress.resolver.ts
+++ b/src/components/product-progress/step-progress.resolver.ts
@@ -1,0 +1,13 @@
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { SecuredFloatNullable } from '../../common';
+import { StepProgress } from './dto';
+
+@Resolver(StepProgress)
+export class StepProgressResolver {
+  @ResolveField(() => SecuredFloatNullable, {
+    deprecationReason: 'Use `StepProgress.completed` instead.',
+  })
+  percentDone(@Parent() { completed }: StepProgress) {
+    return completed;
+  }
+}

--- a/src/components/product/dto/create-product.dto.ts
+++ b/src/components/product/dto/create-product.dto.ts
@@ -1,6 +1,6 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { Field, Float, InputType, ObjectType } from '@nestjs/graphql';
 import { Transform, Type } from 'class-transformer';
-import { ValidateNested } from 'class-validator';
+import { IsPositive, ValidateNested } from 'class-validator';
 import { stripIndent } from 'common-tags';
 import { uniq } from 'lodash';
 import { ID, IdField } from '../../../common';
@@ -10,6 +10,7 @@ import { ProductMedium } from './product-medium';
 import { ProductMethodology } from './product-methodology';
 import { ProductPurpose } from './product-purpose';
 import { AnyProduct, Product } from './product.dto';
+import { ProgressMeasurement } from './progress-measurement.enum';
 
 @InputType()
 export abstract class CreateProduct {
@@ -71,6 +72,22 @@ export abstract class CreateProduct {
 
   @Field({ nullable: true })
   readonly describeCompletion?: string;
+
+  @Field(() => ProgressMeasurement, {
+    description: 'How will progress for each step be measured?',
+  })
+  readonly progressStepMeasurement?: ProgressMeasurement =
+    ProgressMeasurement.Percent;
+
+  @Field(() => Float, {
+    nullable: true,
+    description: stripIndent`
+      The target number that \`StepProgress\` is working towards.
+      This input is only considered if \`progressStepMeasurement\` is \`Number\`
+    `,
+  })
+  @IsPositive()
+  readonly progressTarget?: number;
 }
 
 @InputType()

--- a/src/components/product/dto/index.ts
+++ b/src/components/product/dto/index.ts
@@ -11,3 +11,4 @@ export * from './list-product.dto';
 export * from './methodology-step.enum';
 export * from './available-methodology-steps';
 export * from './completion-description.dto';
+export * from './progress-measurement.enum';

--- a/src/components/product/dto/product.dto.ts
+++ b/src/components/product/dto/product.dto.ts
@@ -5,6 +5,7 @@ import { MergeExclusive } from 'type-fest';
 import {
   DbLabel,
   ID,
+  SecuredFloat,
   SecuredProps,
   SecuredStringNullable,
   Sensitivity,
@@ -18,6 +19,7 @@ import { Producible, SecuredProducible } from './producible.dto';
 import { SecuredProductMediums } from './product-medium';
 import { SecuredMethodology } from './product-methodology';
 import { SecuredProductPurposes } from './product-purpose';
+import { SecuredProgressMeasurement } from './progress-measurement.enum';
 
 @InterfaceType({
   resolveType: (product: AnyProduct) =>
@@ -61,6 +63,23 @@ export class Product extends Producible {
     `,
   })
   readonly describeCompletion: SecuredStringNullable;
+
+  @Field({
+    description: 'How will progress for each step be measured?',
+  })
+  readonly progressStepMeasurement: SecuredProgressMeasurement;
+
+  @Field({
+    description: stripIndent`
+      The target number that \`StepProgress\` is working towards.
+
+      If \`Product.progressStepMeasurement\` is:
+        - \`Percent\`: this will always be _100.0_
+        - \`Boolean\`: this will always be _1.0_
+        - \`Number\`: this can be any positive number
+    `,
+  })
+  readonly progressTarget: SecuredFloat;
 
   // A list of non-global roles the requesting user has available for this object.
   // This is just a cache, to prevent extra db lookups within the same request.

--- a/src/components/product/dto/progress-measurement.enum.ts
+++ b/src/components/product/dto/progress-measurement.enum.ts
@@ -1,0 +1,20 @@
+import { ObjectType, registerEnumType } from '@nestjs/graphql';
+import { SecuredEnum } from '../../../common';
+
+export enum ProgressMeasurement {
+  Percent = 'Percent',
+  Number = 'Number',
+  Boolean = 'Boolean',
+}
+
+registerEnumType(ProgressMeasurement, {
+  name: 'ProgressMeasurement',
+  description: 'Measurement units for reporting progress',
+});
+
+@ObjectType({
+  description: SecuredEnum.descriptionFor('progress measurement'),
+})
+export class SecuredProgressMeasurement extends SecuredEnum(
+  ProgressMeasurement
+) {}

--- a/src/components/product/model/product.model.db.ts
+++ b/src/components/product/model/product.model.db.ts
@@ -13,4 +13,6 @@ export class DbProduct extends DbBaseNode {
   scriptureReferencesOverride: any = null;
   isOverriding: any = null;
   describeCompletion: any = null;
+  progressStepMeasurement: any = null;
+  progressTarget: any = null;
 }

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -36,6 +36,7 @@ import {
   ProductListInput,
   UpdateProduct,
 } from './dto';
+import { ProgressMeasurement } from './dto/progress-measurement.enum';
 
 @Injectable()
 export class ProductRepository extends CommonRepository {
@@ -98,11 +99,19 @@ export class ProductRepository extends CommonRepository {
             }
           >;
         }>(
-          merge('props', {
-            engagement: 'engagement.id',
-            scope: 'scopedRoles',
-            produces: 'produces',
-          }).as('dto')
+          merge(
+            {
+              // BC with existing products
+              progressStepMeasurement: `"${ProgressMeasurement.Percent}"`,
+              progressTarget: 100,
+            },
+            'props',
+            {
+              engagement: 'engagement.id',
+              scope: 'scopedRoles',
+              produces: 'produces',
+            }
+          ).as('dto')
         );
   }
 


### PR DESCRIPTION
Part of #1737

- Add `Product.progressStepMeasurement` to declare that the product's step progress is measured by a _number_, _boolean_, or _percent_.
- Add `Product.progressTarget` to allow a dynamic target for the progress to end at. This is hardcoded to 100/1 for percent/boolean measurements.
- Rename `StepProgress.percentDone` to `completed` as the number may not be a "percent" now.
- Validate that `StepProgress.completed` is <= `Product.progressTarget`

For "migration":
- Kept `percentDone` as a deprecated field on input/output so this isn't a GQL breaking change.
- Existing products will default to their measurement to percents.
- This is a breaking change for all existing product progress. I didn't bother writing a DB migration since this is only in dev so far.

@sethmcknight These changes sound like what you are expecting / what's needed for new tracking?
