### PR TITLE
Full text search

### DIFF
--- a/src/components/search/search.repository.ts
+++ b/src/components/search/search.repository.ts
@@ -1,47 +1,70 @@
 import { Injectable } from '@nestjs/common';
-import { node, regexp, relation } from 'cypher-query-builder';
+import { node, Query, relation } from 'cypher-query-builder';
 import { ID, Session } from '../../common';
 import {
   DatabaseService,
   matchRequestingUser,
-  matchUserPermissions,
+  OnIndex,
+  OnIndexParams,
 } from '../../core';
-import { ACTIVE } from '../../core/database/query';
+import {
+  ACTIVE,
+  escapeLuceneSyntax,
+  fullTextQuery,
+} from '../../core/database/query';
 import { SearchInput, SearchResultMap } from './dto';
 
 @Injectable()
 export class SearchRepository {
   constructor(private readonly db: DatabaseService) {}
 
-  async search(
-    input: SearchInput,
-    session: Session,
-    typeFromLabels: string,
-    types: string[]
-  ) {
-    // Search for nodes based on input, only returning their id and "type"
-    // which is based on their first valid search label.
+  @OnIndex('schema')
+  protected async applyIndexes({ db }: OnIndexParams) {
+    await db.createFullTextIndex('propValue', ['Property'], ['value'], {
+      analyzer: 'standard-folding',
+    });
+  }
+
+  /**
+   * Search for nodes based on input, only returning their id and "type"
+   * which is based on their first valid search label.
+   */
+  async search(input: SearchInput, session: Session) {
+    const escaped = escapeLuceneSyntax(input.query);
+    // Emphasize exact matches but allow fuzzy as well
+    const lucene = `"${escaped}"^2 ${escaped}*`;
+
     const query = this.db
       .query()
       .apply(matchRequestingUser(session))
-      .apply(matchUserPermissions)
-      .match([
-        node('node'),
-        relation('out', 'r', ACTIVE),
-        node('property', 'Property'),
+      .raw('', {
+        types: input.type ?? [],
+        query: lucene,
+      })
+      .apply(fullTextQuery('propValue', '$query', ['node as property']))
+      .apply(propToBaseNode())
+      .apply(filterToRequestedAndAllowed())
+      .returnDistinct<{ id: ID; type: keyof SearchResultMap }>([
+        'node.id as id',
+        `[l in labels(node) where l in $types][0] as type`,
       ])
-      // reduce to nodes with a label of one of the specified types
-      .raw('WHERE size([l in labels(node) where l in $types | 1]) > 0', {
-        types,
-      })
-      .with(['node', 'property'])
-      .where({
-        property: { value: regexp(`.*${input.query}.*`, true) },
-      })
-      .returnDistinct(['node.id as id', typeFromLabels])
-      .limit(input.count)
-      .asResult<{ id: ID; type: keyof SearchResultMap }>();
+      .limit(input.count);
 
     return await query.run();
   }
 }
+
+const propToBaseNode = () => (query: Query) =>
+  query.match([node('node'), relation('out', 'r', ACTIVE), node('property')]);
+
+const filterToRequestedAndAllowed = () => (query: Query) =>
+  query.raw(
+    `
+      WHERE size([l in labels(node) where l in $types | 1]) > 0
+        AND exists(
+          (node)<-[:baseNode]-(:Permission { property: type(r), read: true })
+                <-[:permission]-(:SecurityGroup)
+                 -[:member]->(requestingUser)
+        )
+    `
+  );

--- a/src/components/search/search.service.ts
+++ b/src/components/search/search.service.ts
@@ -30,9 +30,6 @@ type HydratorMap = {
 };
 type Hydrator<R> = (id: ID, session: Session) => Promise<R>;
 
-const labels = JSON.stringify(SearchResultTypes);
-const typeFromLabels = `[l in labels(node) where l in ${labels}][0] as type`;
-
 @Injectable()
 export class SearchService {
   // mapping of base nodes to functions that,
@@ -83,17 +80,12 @@ export class SearchService {
       ...inputTypes,
       // Add Organization label when searching for Partners we can search for
       // Partner by organization name
-      ...(inputTypes.includes('Partner') ? ['Organization'] : []),
+      ...(inputTypes.includes('Partner') ? (['Organization'] as const) : []),
     ];
 
     // Search for nodes based on input, only returning their id and "type"
     // which is based on their first valid search label.
-    const results = await this.repo.search(
-      input,
-      session,
-      typeFromLabels,
-      types
-    );
+    const results = await this.repo.search({ ...input, type: types }, session);
 
     // Individually convert each result (id & type) to its search result
     // based on this.hydrators

--- a/src/core/database/query-augmentation/interpolate.ts
+++ b/src/core/database/query-augmentation/interpolate.ts
@@ -55,7 +55,7 @@ function stringifyValue(value: unknown): string {
   if (isObject(value)) {
     const pairs = map(
       value,
-      (el, key) => `${escapeKey(key)}: ${stringifyValue(el)}`
+      (el, key) => `${quoteKey(key)}: ${stringifyValue(el)}`
     );
     const str = pairs.join(', ');
     return `{ ${str} }`;
@@ -63,7 +63,8 @@ function stringifyValue(value: unknown): string {
   return '';
 }
 
-const escapeKey = (key: string) => (SAFE_KEY.exec(key) ? key : `\`${key}\``);
+export const quoteKey = (key: string): string =>
+  SAFE_KEY.exec(key) ? key : `\`${key}\``;
 const SAFE_KEY = /^[a-zA-Z][a-zA-Z0-9]*$/;
 
 const isNeoInteger = (value: unknown): value is Integer =>

--- a/src/core/database/query.helpers.ts
+++ b/src/core/database/query.helpers.ts
@@ -1,26 +1,5 @@
-import { node, Query, relation } from 'cypher-query-builder';
+import { Query } from 'cypher-query-builder';
 import { Session } from '../../common';
-
-export function matchUserPermissions(
-  query: Query,
-  label?: string,
-  id?: string
-) {
-  query.match([
-    node('requestingUser'),
-    relation('in', 'memberOfSecurityGroup', 'member', {}, [1]),
-    node('security', 'SecurityGroup'),
-    relation('out', 'sgPerms', 'permission'),
-    node('perms', 'Permission'),
-    relation('out', 'permsOfBaseNode', 'baseNode'),
-    label ? node('node', label) : node('node'),
-  ]);
-  if (id) {
-    query.where({ node: { id } });
-  }
-
-  query.with(`collect(perms) as permList, node, requestingUser`);
-}
 
 export const matchRequestingUser =
   ({ userId }: Pick<Session, 'userId'>) =>

--- a/src/core/database/query/cypher-expression.ts
+++ b/src/core/database/query/cypher-expression.ts
@@ -1,4 +1,5 @@
 import { Many, ServerException } from '../../../common';
+import { quoteKey } from '../query-augmentation/interpolate';
 
 export type ExpressionInput =
   | Many<string | boolean | number | null | undefined>
@@ -70,7 +71,7 @@ const buildExp = (exp: ExpressionInput): string => {
   }
 
   const pairs = Object.entries(exp).flatMap(([key, value]) =>
-    value !== undefined ? `${key}: ${buildExp(value)}` : []
+    value !== undefined ? `${quoteKey(key)}: ${buildExp(value)}` : []
   );
   return shouldMultiline(pairs)
     ? `{${makeMultiline(pairs)}}`

--- a/test/project-workflow.e2e-spec.ts
+++ b/test/project-workflow.e2e-spec.ts
@@ -9,7 +9,6 @@ import {
   ProjectType,
 } from '../src/components/project';
 import {
-  createBudget,
   createFundingAccount,
   createLanguageEngagement,
   createLocation,
@@ -190,28 +189,6 @@ describe('Project-Workflow e2e', () => {
       });
       expect(result.estimatedSubmission.value).toBe('2020-01-01');
 
-      // Enter Field budget
-      const budget = await createBudget(app, { projectId: project.id });
-      result = await app.graphql.query(
-        gql`
-          query project($id: ID!) {
-            project(id: $id) {
-              ...project
-              budget {
-                value {
-                  ...budget
-                }
-              }
-            }
-          }
-          ${fragments.project}
-          ${fragments.budget}
-        `,
-        {
-          id: project.id,
-        }
-      );
-      expect(result.project.budget.value.id).toBe(budget.id);
       expect(result.project.step.value).toBe(ProjectStep.EarlyConversations);
 
       // TODO: Upload mock UBT file


### PR DESCRIPTION
Rewrite search query to use a full text index instead of scanning with regex.

It was previously incorrectly querying all Security Groups as well without even checking for `read`.
Now it correctly only looks for `read` perms for the nodes that have been matched by the full text index.
This should be a much smaller set to further improve performance.

A later iteration can replace SecurityGroup logic once a sane strategy is determined.