### PR TITLE
Refactor file queries to use subqueries

### DIFF
--- a/src/components/authorization/model/resource-map.ts
+++ b/src/components/authorization/model/resource-map.ts
@@ -9,6 +9,7 @@ import {
 } from '../../engagement/dto';
 import { FieldRegion } from '../../field-region/dto';
 import { FieldZone } from '../../field-zone/dto';
+import { Directory, File, FileVersion } from '../../file/dto';
 import { Film } from '../../film/dto';
 import { FundingAccount } from '../../funding-account/dto';
 import { EthnologueLanguage, Language } from '../../language/dto';
@@ -47,11 +48,14 @@ export const ResourceMap = {
   BudgetRecord,
   Ceremony,
   Changeset,
+  Directory,
   Education,
   Engagement,
   EthnologueLanguage,
   FieldRegion,
   FieldZone,
+  File,
+  FileVersion,
   Film,
   FundingAccount,
   InternshipEngagement,

--- a/src/components/file/directory.resolver.ts
+++ b/src/components/file/directory.resolver.ts
@@ -22,7 +22,7 @@ export class DirectoryResolver {
   @Query(() => Directory)
   async directory(
     @IdArg() id: ID,
-    @AnonSession() session: Session
+    @LoggedInSession() session: Session
   ): Promise<Directory> {
     return await this.service.getDirectory(id, session);
   }

--- a/src/components/file/directory.resolver.ts
+++ b/src/components/file/directory.resolver.ts
@@ -40,7 +40,7 @@ export class DirectoryResolver {
     })
     input: FileListInput
   ): Promise<FileListOutput> {
-    return this.service.listChildren(node.id, input, session);
+    return this.service.listChildren(node, input, session);
   }
 
   @Mutation(() => Directory)

--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { contains, hasLabel, node, relation } from 'cypher-query-builder';
-import type { Pattern } from 'cypher-query-builder/dist/typings/clauses/pattern';
+import {
+  contains,
+  hasLabel,
+  node,
+  Query,
+  relation,
+} from 'cypher-query-builder';
 import { AnyConditions } from 'cypher-query-builder/dist/typings/clauses/where-utils';
 import { isEmpty } from 'lodash';
 import { DateTime } from 'luxon';
@@ -10,7 +15,6 @@ import {
   ServerException,
   Session,
   UnauthorizedException,
-  UnsecuredDto,
 } from '../../common';
 import {
   DatabaseService,
@@ -21,20 +25,21 @@ import {
 } from '../../core';
 import {
   ACTIVE,
-  collect,
-  count,
   createNode,
   matchProps,
   merge,
+  paginate,
+  sorting,
 } from '../../core/database/query';
-import { hasMore } from '../../core/database/results';
 import {
-  BaseNode,
   Directory,
   File,
   FileListInput,
+  FileNode,
+  FileNodeType,
   FileVersion,
   IFileNode,
+  resolveFileNode,
 } from './dto';
 
 @Injectable()
@@ -44,176 +49,185 @@ export class FileRepository {
     @Logger('file:repository') private readonly logger: ILogger
   ) {}
 
-  async getBaseNodeById(id: ID, session: Session): Promise<BaseNode> {
-    return await this.getBaseNodeBy(session, [
-      [node('node', 'FileNode', { id })],
-      matchName(),
-    ]);
+  async getById(id: ID, _session: Session): Promise<FileNode> {
+    const result = await this.db
+      .query()
+      .matchNode('node', 'FileNode', { id })
+      .apply(this.hydrate())
+      .map('dto')
+      .run();
+    return first(result);
   }
 
-  async getBaseNodeByName(
+  async getByName(
     parentId: ID,
     name: string,
-    session: Session
-  ): Promise<BaseNode> {
-    return await this.getBaseNodeBy(session, [
-      [
+    _session: Session
+  ): Promise<FileNode> {
+    const result = await this.db
+      .query()
+      .match([
         node('parent', 'FileNode', { id: parentId }),
         relation('in', '', 'parent', ACTIVE),
         node('node', 'FileNode'),
         relation('out', '', 'name', ACTIVE),
         node('name', 'Property', { value: name }),
-      ],
-    ]);
+      ])
+      .apply(this.hydrate())
+      .map('dto')
+      .run();
+    return first(result);
   }
 
-  async getParentsById(id: ID, session: Session): Promise<readonly BaseNode[]> {
-    const query = this.getBaseNodeQuery(session, [
-      [
+  async getParentsById(
+    id: ID,
+    _session: Session
+  ): Promise<readonly FileNode[]> {
+    const result = await this.db
+      .query()
+      .match([
         node('start', 'FileNode', { id }),
         relation('out', 'parent', 'parent', ACTIVE, '*'),
         node('node', 'FileNode'),
-      ],
-      matchName(),
-    ]);
-    query.orderBy('size(parent)');
-    return await query.run();
+      ])
+      .with('node, parent')
+      .orderBy('size(parent)')
+      // Using paginate to maintain order through hydration
+      .apply(paginate({ page: 1, count: 100 }, this.hydrate()))
+      .first();
+    return result!.items;
   }
 
-  async getChildrenById(
-    session: Session,
-    nodeId: ID,
-    options: FileListInput | undefined
-  ) {
-    options = options ?? FileListInput.defaultVal;
-    const query = this.db
+  async getChildrenById(parent: FileNode, input?: FileListInput) {
+    input ??= FileListInput.defaultVal;
+    const result = await this.db
       .query()
       .match([
-        matchSession(session),
-        [
-          node('start', 'FileNode', { id: nodeId }),
-          relation('in', '', 'parent', ACTIVE),
-          node('node', 'FileNode'),
-        ],
-        matchCreatedBy(),
-        matchName(),
+        node('start', 'FileNode', { id: parent.id }),
+        relation('in', '', 'parent', ACTIVE),
+        node('node', 'FileNode'),
       ])
       .apply((q) => {
         const conditions: AnyConditions = {};
-        if (options?.filter?.name) {
-          conditions['name.value'] = contains(options.filter.name);
+        if (input?.filter?.name) {
+          q.match([
+            node('node'),
+            relation('out', '', 'name', ACTIVE),
+            node('name', 'Property'),
+          ]);
+          conditions['name.value'] = contains(input.filter.name);
         }
-        if (options?.filter?.type) {
-          conditions.node = hasLabel(options.filter.type);
+        if (input?.filter?.type) {
+          conditions.node = hasLabel(input.filter.type);
         }
         return isEmpty(conditions) ? q : q.where(conditions);
       })
-      .with([
-        collect({
-          id: 'node.id',
-          createdAt: 'node.createdAt',
-          type: typeFromLabel('node'),
-          name: 'name.value',
-          createdById: 'createdBy.id',
-        }).as('nodes'),
-        count('DISTINCT node').as('total'),
-      ])
-      .raw('unwind nodes as node')
-      .return(['node', 'total'])
-      .orderBy('node.' + options.sort, options.order)
-      .skip((options.page - 1) * options.count)
-      .limit(options.count)
-      .asResult<{ node: BaseNode; total: number }>();
-
-    const result = await query.run();
-    const total = result[0]?.total ?? 0;
-    const children = result.map((r) => r.node);
-
-    return {
-      children,
-      total,
-      hasMore: hasMore(options, total),
-    };
-  }
-
-  private async getBaseNodeBy(
-    session: Session,
-    patterns: Pattern[][]
-  ): Promise<BaseNode> {
-    const nodes = await this.getBaseNodesBy(session, patterns);
-    return first(nodes);
-  }
-
-  private async getBaseNodesBy(
-    session: Session,
-    patterns: Pattern[][]
-  ): Promise<readonly BaseNode[]> {
-    const query = this.getBaseNodeQuery(session, patterns);
-    const results = await query.run();
-    return results;
-  }
-
-  private getBaseNodeQuery(session: Session, patterns: Pattern[][]) {
-    this.db.assertPatternsIncludeIdentifier(patterns, 'node', 'name');
-
-    const query = this.db
-      .query()
-      .match([matchSession(session), ...patterns, matchCreatedBy()])
-      .return([
-        `${typeFromLabel('node')} as type`,
-        {
-          node: [{ id: 'id', createdAt: 'createdAt' }],
-          name: [{ value: 'name' }],
-          createdBy: [{ id: 'createdById' }],
-        },
-      ])
-      .asResult<BaseNode>();
-    return query;
-  }
-
-  async getLatestVersionId(fileId: ID): Promise<ID> {
-    const latestVersionResult = await this.db
-      .query()
-      .match([
-        node('node', 'FileNode', { id: fileId }),
-        relation('in', '', 'parent', ACTIVE),
-        node('fv', 'FileVersion'),
-      ])
-      .return<{ id: ID }>('fv.id as id')
-      .orderBy('fv.createdAt', 'DESC')
-      .limit(1)
+      .apply(sorting(resolveFileNode(parent), input))
+      .apply(paginate(input, this.hydrate()))
       .first();
-    if (!latestVersionResult) {
-      throw new NotFoundException();
-    }
-    return latestVersionResult.id;
+    return result!;
   }
 
-  async getVersionDetails(id: ID, session: Session): Promise<FileVersion> {
-    const query = this.db
-      .query()
-      .match(node('node', 'FileVersion', { id }))
-      .apply(matchProps())
-      .match([
-        node('node'),
-        relation('out', '', 'createdBy', ACTIVE),
-        node('createdBy'),
-      ])
-      .return<{ dto: UnsecuredDto<FileVersion> }>(
-        merge('props', {
-          type: typeFromLabel('node'),
-          createdById: 'createdBy.id',
-        }).as('dto')
-      );
+  private hydrate() {
+    return (query: Query) =>
+      query
+        .subQuery((sub) =>
+          sub
+            .with('node')
+            .with('node')
+            .where({ node: hasLabel(FileNodeType.File) })
+            .apply(this.hydrateFile())
+            .union()
+            .with('node')
+            .with('node')
+            .where({ node: hasLabel(FileNodeType.FileVersion) })
+            .apply(this.hydrateFileVersion())
+            .union()
+            .with('node')
+            .with('node')
+            .where({ node: hasLabel(FileNodeType.Directory) })
+            .apply(this.hydrateDirectory())
+        )
+        .return<{ dto: FileNode }>('dto');
+  }
 
-    const result = await query.first();
-    if (!result) {
-      throw new NotFoundException('Could not find file version');
-    }
-    return {
-      ...result.dto,
-      canDelete: await this.db.checkDeletePermission(id, session),
-    };
+  private hydrateFile() {
+    return (query: Query) =>
+      query
+        .apply(this.matchLatestVersion())
+        .apply(matchProps())
+        .apply(matchProps({ nodeName: 'version', outputVar: 'versionProps' }))
+        .match([
+          node('node'),
+          relation('out', '', 'createdBy', ACTIVE),
+          node('createdBy'),
+        ])
+        .match([
+          node('version'),
+          relation('out', '', 'createdBy', ACTIVE),
+          node('modifiedBy'),
+        ])
+        .return<{ dto: File }>(
+          merge('versionProps', 'props', {
+            type: `"${FileNodeType.File}"`,
+            latestVersionId: 'version.id',
+            modifiedById: 'modifiedBy.id',
+            modifiedAt: 'version.createdAt',
+            createdById: 'createdBy.id',
+            canDelete: true,
+          }).as('dto')
+        );
+  }
+
+  private hydrateDirectory() {
+    return (query: Query) =>
+      query
+        .apply(matchProps())
+        .match([
+          node('node'),
+          relation('out', '', 'createdBy', ACTIVE),
+          node('createdBy'),
+        ])
+        .return<{ dto: Directory }>(
+          merge('props', {
+            type: `"${FileNodeType.Directory}"`,
+            createdById: 'createdBy.id',
+            canDelete: true,
+          }).as('dto')
+        );
+  }
+
+  private hydrateFileVersion() {
+    return (query: Query) =>
+      query
+        .apply(matchProps())
+        .match([
+          node('node'),
+          relation('out', '', 'createdBy', ACTIVE),
+          node('createdBy'),
+        ])
+        .return<{ dto: FileVersion }>(
+          merge('props', {
+            type: `"${FileNodeType.FileVersion}"`,
+            createdById: 'createdBy.id',
+            canDelete: true,
+          }).as('dto')
+        );
+  }
+
+  private matchLatestVersion() {
+    return (query: Query) =>
+      query.subQuery('node', (sub) =>
+        sub
+          .match([
+            node('node', 'FileNode'),
+            relation('in', '', 'parent', ACTIVE),
+            node('version', 'FileVersion'),
+          ])
+          .return('version')
+          .orderBy('version.createdAt', 'DESC')
+          .raw('LIMIT 1')
+      );
   }
 
   async createDirectory(
@@ -359,7 +373,7 @@ export class FileRepository {
       .run();
   }
 
-  async rename(fileNode: BaseNode, newName: string): Promise<void> {
+  async rename(fileNode: FileNode, newName: string): Promise<void> {
     // TODO Do you have permission to rename the file?
     try {
       await this.db.updateProperty({
@@ -403,7 +417,7 @@ export class FileRepository {
     }
   }
 
-  async delete(fileNode: BaseNode, session: Session): Promise<void> {
+  async delete(fileNode: FileNode, session: Session): Promise<void> {
     const canDelete = await this.db.checkDeletePermission(fileNode.id, session);
 
     if (!canDelete)
@@ -420,17 +434,6 @@ export class FileRepository {
   }
 }
 
-const matchName = () => [
-  node('node'),
-  relation('out', '', 'name', ACTIVE),
-  node('name', 'Property'),
-];
-const matchCreatedBy = () => [
-  node('node'),
-  relation('out', '', 'createdBy', ACTIVE),
-  node('createdBy', 'User'),
-];
-
 function first<T>(nodes: readonly T[]): T {
   const node = nodes[0];
   if (!node) {
@@ -438,6 +441,3 @@ function first<T>(nodes: readonly T[]): T {
   }
   return node;
 }
-
-const typeFromLabel = (variable: string) =>
-  `[l in labels(${variable}) where l in ['FileVersion', 'File', 'Directory']][0]`;

--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -26,6 +26,7 @@ import {
   paginate,
   sorting,
 } from '../../core/database/query';
+import { BaseNode } from '../../core/database/results';
 import {
   Directory,
   File,
@@ -223,6 +224,15 @@ export class FileRepository {
           .orderBy('version.createdAt', 'DESC')
           .raw('LIMIT 1')
       );
+  }
+
+  async getBaseNode(id: ID) {
+    return await this.db
+      .query()
+      .matchNode('node', 'FileNode', { id })
+      .return<{ node: BaseNode }>('node')
+      .map('node')
+      .first();
   }
 
   async createDirectory(

--- a/src/components/file/file.resolver.ts
+++ b/src/components/file/file.resolver.ts
@@ -30,14 +30,17 @@ export class FileResolver {
   ) {}
 
   @Query(() => File)
-  async file(@IdArg() id: ID, @AnonSession() session: Session): Promise<File> {
+  async file(
+    @IdArg() id: ID,
+    @LoggedInSession() session: Session
+  ): Promise<File> {
     return await this.service.getFile(id, session);
   }
 
   @Query(() => IFileNode)
   async fileNode(
     @IdArg() id: ID,
-    @AnonSession() session: Session
+    @LoggedInSession() session: Session
   ): Promise<FileNode> {
     return await this.service.getFileNode(id, session);
   }

--- a/src/components/file/file.resolver.ts
+++ b/src/components/file/file.resolver.ts
@@ -65,7 +65,7 @@ export class FileResolver {
     })
     input: FileListInput
   ): Promise<FileListOutput> {
-    return this.service.listChildren(node.id, input, session);
+    return this.service.listChildren(node, input, session);
   }
 
   @ResolveField(() => String, {

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -15,7 +15,6 @@ import { AuthorizationService } from '../authorization/authorization.service';
 import { Powers } from '../authorization/dto/powers';
 import { FileBucket } from './bucket';
 import {
-  BaseNode,
   CreateDefinedFileVersionInput,
   CreateFileVersionInput,
   DefinedFile,
@@ -24,14 +23,10 @@ import {
   FileListInput,
   FileListOutput,
   FileNode,
-  FileNodeType,
   FileVersion,
   isDirectory,
-  isDirectoryNode,
   isFile,
-  isFileNode,
   isFileVersion,
-  isFileVersionNode,
   MoveFileInput,
   RenameFileInput,
   RequestUploadOutput,
@@ -76,36 +71,7 @@ export class FileService {
 
   async getFileNode(id: ID, session: Session): Promise<FileNode> {
     this.logger.debug(`getNode`, { id, userId: session.userId });
-    const base = await this.repo.getBaseNodeById(id, session);
-    return await this.adaptBaseNodeToFileNode(base, session);
-  }
-
-  private async adaptBaseNodeToFileNode(
-    node: BaseNode,
-    session: Session
-  ): Promise<FileNode> {
-    if (node.type === FileNodeType.Directory) {
-      return {
-        ...node,
-        type: FileNodeType.Directory,
-      };
-    }
-
-    if (node.type === FileNodeType.FileVersion) {
-      const version = await this.repo.getVersionDetails(node.id, session);
-      return version;
-    }
-
-    const latestVersionId = await this.repo.getLatestVersionId(node.id);
-    const version = await this.repo.getVersionDetails(latestVersionId, session);
-    return {
-      ...version,
-      ...node,
-      type: FileNodeType.File,
-      latestVersionId,
-      modifiedAt: version.createdAt,
-      modifiedById: version.createdById,
-    };
+    return await this.repo.getById(id, session);
   }
 
   /**
@@ -145,38 +111,15 @@ export class FileService {
   }
 
   async getParents(nodeId: ID, session: Session): Promise<readonly FileNode[]> {
-    const parents = await this.repo.getParentsById(nodeId, session);
-    return await Promise.all(
-      parents.map((node) => this.adaptBaseNodeToFileNode(node, session))
-    );
+    return await this.repo.getParentsById(nodeId, session);
   }
 
   async listChildren(
-    parentId: ID,
+    parent: FileNode,
     input: FileListInput | undefined,
-    session: Session
+    _session: Session
   ): Promise<FileListOutput> {
-    const result = await this.repo.getChildrenById(session, parentId, input);
-    const items = (
-      await Promise.all(
-        result.children.map(async (node) => {
-          try {
-            return await this.adaptBaseNodeToFileNode(node, session);
-          } catch (e) {
-            if (e instanceof NotFoundException) {
-              // If no active versions pretend the file doesn't exist.
-              return [];
-            }
-            throw e;
-          }
-        })
-      )
-    ).flatMap((n) => n);
-    return {
-      items: items,
-      total: result.total,
-      hasMore: result.hasMore,
-    };
+    return await this.repo.getChildrenById(parent, input);
   }
 
   async createDirectory(
@@ -188,14 +131,14 @@ export class FileService {
     if (parentId) {
       // Enforce parent exists and is a directory
       const parent = await this.getParentNode(parentId, session);
-      if (!isDirectoryNode(parent)) {
+      if (!isDirectory(parent)) {
         throw new InputException(
           'Directories can only be created under directories',
           'parentId'
         );
       }
       try {
-        await this.repo.getBaseNodeByName(parentId, name, session);
+        await this.repo.getByName(parentId, name, session);
         throw new DuplicateException(
           'name',
           'Node with this name already exists in this directory'
@@ -277,14 +220,14 @@ export class FileService {
     }
 
     const parent = await this.getParentNode(parentId, session);
-    if (isFileVersionNode(parent)) {
+    if (isFileVersion(parent)) {
       throw new InputException(
         'Only files and directories can be parents of a file version',
         'parentId'
       );
     }
 
-    const fileId = isFileNode(parent)
+    const fileId = isFile(parent)
       ? parent.id
       : await this.getOrCreateFileByName(parent.id, name, session);
     this.logger.debug('Creating file version', {
@@ -324,7 +267,7 @@ export class FileService {
 
   private async getParentNode(id: ID, session: Session) {
     try {
-      return await this.repo.getBaseNodeById(id, session);
+      return await this.repo.getById(id, session);
     } catch (e) {
       if (e instanceof NotFoundException) {
         throw new NotFoundException('Could not find parent');
@@ -339,7 +282,7 @@ export class FileService {
     session: Session
   ) {
     try {
-      const node = await this.repo.getBaseNodeByName(parentId, name, session);
+      const node = await this.repo.getByName(parentId, name, session);
       this.logger.debug('Using existing file matching given name', {
         parentId,
         fileName: name,
@@ -477,12 +420,12 @@ export class FileService {
   }
 
   async rename(input: RenameFileInput, session: Session): Promise<void> {
-    const fileNode = await this.repo.getBaseNodeById(input.id, session);
+    const fileNode = await this.repo.getById(input.id, session);
     await this.repo.rename(fileNode, input.name);
   }
 
   async move(input: MoveFileInput, session: Session): Promise<FileNode> {
-    const fileNode = await this.repo.getBaseNodeById(input.id, session);
+    const fileNode = await this.repo.getById(input.id, session);
 
     if (input.name) {
       await this.repo.rename(fileNode, input.name);
@@ -494,7 +437,7 @@ export class FileService {
   }
 
   async delete(id: ID, session: Session): Promise<void> {
-    const fileNode = await this.repo.getBaseNodeById(id, session);
+    const fileNode = await this.repo.getById(id, session);
     await this.repo.delete(fileNode, session);
   }
 }

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -8,7 +8,6 @@ import {
   regexp,
   relation,
 } from 'cypher-query-builder';
-import type { Pattern } from 'cypher-query-builder/dist/typings/clauses/pattern';
 import {
   cloneDeep,
   isEmpty,
@@ -570,22 +569,5 @@ export class DatabaseService {
       .apply(deleteBaseNode('baseNode'))
       .return('*');
     await query.run();
-  }
-
-  assertPatternsIncludeIdentifier(
-    patterns: Pattern[][],
-    ...identifiers: string[]
-  ) {
-    if (process.env.NODE_ENV === 'production') {
-      return;
-    }
-    for (const identifier of identifiers) {
-      assert(
-        patterns.some((nodes) =>
-          nodes.some((node) => node.getNameString() === identifier)
-        ),
-        `Patterns must define identifier: "${identifier}"`
-      );
-    }
   }
 }


### PR DESCRIPTION
DB query reduction:
- `getFileNode`: 2 -> 1
- `getParents`: N+1 -> 1
- `listChildren`: N+1 -> 1

This refactor also brings the queries inline with the rest of the codebase and the queries are more readable.