### PR TITLE
Expose more directory aggregate data

### DIFF
--- a/src/components/file/directory.resolver.ts
+++ b/src/components/file/directory.resolver.ts
@@ -6,14 +6,18 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
 import { AnonSession, ID, IdArg, LoggedInSession, Session } from '../../common';
 import { Loader, LoaderOf } from '../../core';
+import { User, UserLoader } from '../user';
 import {
   asDirectory,
   CreateDirectoryInput,
   Directory,
+  File,
   FileListInput,
   FileListOutput,
+  FileNode,
 } from './dto';
 import { FileNodeLoader } from './file-node.loader';
 import { FileService } from './file.service';
@@ -44,6 +48,34 @@ export class DirectoryResolver {
     input: FileListInput
   ): Promise<FileListOutput> {
     return await this.service.listChildren(node, input, session);
+  }
+
+  @ResolveField(() => User, {
+    description:
+      'The user who uploaded the most recent file in this directory or any subdirectories',
+  })
+  async modifiedBy(
+    @Parent() node: Directory,
+    @Loader(UserLoader) users: LoaderOf<UserLoader>
+  ): Promise<User> {
+    return await users.load(node.modifiedBy);
+  }
+
+  @ResolveField(() => File, {
+    nullable: true,
+    description: stripIndent`
+      The first file created in this directory or any subdirectories.
+
+      This can be useful to determine the time the directory was "first used".
+    `,
+  })
+  async firstFileCreated(
+    @Parent() node: Directory,
+    @Loader(FileNodeLoader) files: LoaderOf<FileNodeLoader>
+  ): Promise<FileNode | null> {
+    return node.firstFileCreated
+      ? await files.load(node.firstFileCreated)
+      : null;
   }
 
   @Mutation(() => Directory)

--- a/src/components/file/directory.resolver.ts
+++ b/src/components/file/directory.resolver.ts
@@ -7,12 +7,15 @@ import {
   Resolver,
 } from '@nestjs/graphql';
 import { AnonSession, ID, IdArg, LoggedInSession, Session } from '../../common';
+import { Loader, LoaderOf } from '../../core';
 import {
+  asDirectory,
   CreateDirectoryInput,
   Directory,
   FileListInput,
   FileListOutput,
 } from './dto';
+import { FileNodeLoader } from './file-node.loader';
 import { FileService } from './file.service';
 
 @Resolver(Directory)
@@ -22,9 +25,9 @@ export class DirectoryResolver {
   @Query(() => Directory)
   async directory(
     @IdArg() id: ID,
-    @LoggedInSession() session: Session
+    @Loader(FileNodeLoader) files: LoaderOf<FileNodeLoader>
   ): Promise<Directory> {
-    return await this.service.getDirectory(id, session);
+    return asDirectory(await files.load(id));
   }
 
   @ResolveField(() => FileListOutput, {

--- a/src/components/file/dto/node.ts
+++ b/src/components/file/dto/node.ts
@@ -76,7 +76,9 @@ abstract class BaseFile extends FileNode {
   @Field()
   readonly mimeType: string;
 
-  @Field(() => Int)
+  @Field(() => Int, {
+    description: 'The total size in bytes of this file',
+  })
   readonly size: number;
 }
 
@@ -115,6 +117,28 @@ export class Directory extends FileNode {
   static readonly SecuredProps = keysOf<SecuredProps<Directory>>();
 
   readonly type: FileNodeType.Directory;
+
+  @Field(() => Int, {
+    description:
+      'The total size in bytes of all files under this directory and all its subdirectories',
+  })
+  readonly size: number;
+
+  @Field(() => Int, {
+    description:
+      'The total number of files under this directory and all its subdirectories',
+  })
+  readonly totalFiles: number;
+
+  readonly firstFileCreated?: ID;
+
+  readonly modifiedBy: ID;
+
+  @DateTimeField({
+    description:
+      'The `DateTime` a file was most recently modified in this directory or any subdirectories',
+  })
+  readonly modifiedAt: DateTime;
 }
 
 @ObjectType({

--- a/src/components/file/dto/node.ts
+++ b/src/components/file/dto/node.ts
@@ -147,5 +147,12 @@ export const asDirectory = (node: AnyFileNode) => {
 export const isFile = (node: AnyFileNode): node is File =>
   node.type === FileNodeType.File;
 
+export const asFile = (node: AnyFileNode) => {
+  if (!isFile(node)) {
+    throw new InputException('Node is not a file');
+  }
+  return node;
+};
+
 export const isFileVersion = (node: AnyFileNode): node is FileVersion =>
   node.type === FileNodeType.FileVersion;

--- a/src/components/file/file.resolver.ts
+++ b/src/components/file/file.resolver.ts
@@ -11,6 +11,7 @@ import { AnonSession, ID, IdArg, LoggedInSession, Session } from '../../common';
 import { Loader, LoaderOf } from '../../core';
 import { User, UserLoader } from '../user';
 import {
+  asFile,
   CreateFileVersionInput,
   File,
   FileListInput,
@@ -21,6 +22,7 @@ import {
   RenameFileInput,
   RequestUploadOutput,
 } from './dto';
+import { FileNodeLoader } from './file-node.loader';
 import { FileService } from './file.service';
 
 @Resolver(File)
@@ -30,17 +32,17 @@ export class FileResolver {
   @Query(() => File)
   async file(
     @IdArg() id: ID,
-    @LoggedInSession() session: Session
+    @Loader(FileNodeLoader) files: LoaderOf<FileNodeLoader>
   ): Promise<File> {
-    return await this.service.getFile(id, session);
+    return asFile(await files.load(id));
   }
 
   @Query(() => IFileNode)
   async fileNode(
     @IdArg() id: ID,
-    @LoggedInSession() session: Session
+    @Loader(FileNodeLoader) files: LoaderOf<FileNodeLoader>
   ): Promise<FileNode> {
-    return await this.service.getFileNode(id, session);
+    return await files.load(id);
   }
 
   @ResolveField(() => User, {


### PR DESCRIPTION
Added these fields to `Directory` which will benefit CORD UI & DOMO.

```gql
type Directory {
  """
  The `DateTime` a file was most recently modified in this directory or any subdirectories
  """
  modifiedAt: DateTime!

  """
  The user who uploaded the most recent file in this directory or any subdirectories
  """
  modifiedBy: User!

  """
  The total size in bytes of all files under this directory and all its subdirectories
  """
  size: Int!

  """
  The total number of files under this directory and all its subdirectories
  """
  totalFiles: Int!

  """
  The first file created in this directory or any subdirectories.
  
  This can be useful to determine the "first modified date" of a directory.
  """
  firstFileCreated: File
}
```

## `modified*` Caveats

`modifiedAt/By` ignores actual directory nodes under the current directory. i.e. If I create a directory under another it won't affect the `modifiedAt/By` of the parent directory. This could be considered a feature or a bug...

Also `modifiedAt/By` isn't persisted if a file/directory is deleted. i.e. If I create a file in a directory, the directory will say I modified it just now. But if I then delete that file, the directory will revert to whatever it said previously.