### PR TITLE
Couple DB query tweaks

### DIFF
--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -17,7 +17,13 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { DatabaseService, ILogger, Logger, matchSession } from '../../core';
+import {
+  DatabaseService,
+  ILogger,
+  Logger,
+  matchSession,
+  OnIndex,
+} from '../../core';
 import {
   ACTIVE,
   createNode,
@@ -45,6 +51,11 @@ export class FileRepository {
     private readonly db: DatabaseService,
     @Logger('file:repository') private readonly logger: ILogger
   ) {}
+
+  @OnIndex()
+  async createIndexes() {
+    return ['CREATE CONSTRAINT ON (n:FileNode) ASSERT n.id IS UNIQUE'];
+  }
 
   async getById(id: ID, _session: Session): Promise<FileNode> {
     const result = await this.db

--- a/src/core/database/query/matching.ts
+++ b/src/core/database/query/matching.ts
@@ -62,7 +62,7 @@ export const matchProps = (options: MatchPropsOptions = {}) => {
     const lookupProps = (query: Query) =>
       query.match([
         node(nodeName),
-        relation('out', 'r', { active: !view.changeset }),
+        relation('out', 'r', view.changeset ? INACTIVE : ACTIVE),
         node('prop', labelForView('Property', view)),
         ...(view.changeset
           ? [


### PR DESCRIPTION
- Create index for FileNode IDs
- Update authentication queries so bound variables containing sensitive info are masked
- Change `matchProps` to not use bound parameter for changeset active condition