### PR TITLE
Integrate AWS X-Ray

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "apollo-server-core": "^2.22.2",
     "apollo-server-express": "^2.22.2",
     "argon2": "^0.27.2",
+    "aws-xray-sdk-core": "^3.3.3",
     "class-transformer": "^0.4.0",
     "class-validator": "^0.13.1",
     "cli-highlight": "^2.1.11",

--- a/src/common/mask-secrets.ts
+++ b/src/common/mask-secrets.ts
@@ -13,6 +13,18 @@ export const maskSecrets = (
       : val
   );
 
+export const dropSecrets = (
+  obj: Record<string, any>,
+  depth = 3
+): Record<string, any> =>
+  mapValues(obj, (val, key) =>
+    isSecret(key, val)
+      ? undefined
+      : isPlainObject(val) && depth > 0
+      ? dropSecrets(val, depth - 1)
+      : val
+  );
+
 const isSecret = (key: string, val: unknown): val is string =>
   typeof val === 'string' && /(password|token|key)/i.test(key);
 

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -214,6 +214,12 @@ export class ConfigService implements EmailOptionsFactory {
     };
   }
 
+  @Lazy() get xray() {
+    return {
+      daemonAddress: this.env.string('AWS_XRAY_DAEMON_ADDRESS').optional(),
+    };
+  }
+
   /**
    * @see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html
    */

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -216,7 +216,9 @@ export class ConfigService implements EmailOptionsFactory {
 
   @Lazy() get xray() {
     return {
-      daemonAddress: this.env.string('AWS_XRAY_DAEMON_ADDRESS').optional(),
+      daemonAddress: this.jest
+        ? undefined
+        : this.env.string('AWS_XRAY_DAEMON_ADDRESS').optional(),
     };
   }
 

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -5,7 +5,6 @@ import {
   APP_PIPE,
   BaseExceptionFilter,
 } from '@nestjs/core';
-import { GraphQLModule } from '@nestjs/graphql';
 import { EmailModule } from '@seedcompany/nestjs-email';
 import { ConsoleModule } from 'nestjs-console';
 import { AwsS3Factory } from './aws-s3.factory';
@@ -16,8 +15,7 @@ import { DataLoaderInterceptor } from './data-loader';
 import { DatabaseModule } from './database/database.module';
 import { EventsModule } from './events';
 import { ExceptionFilter } from './exception.filter';
-import { GraphqlLoggingPlugin } from './graphql-logging.plugin';
-import { GraphQLConfig } from './graphql.config';
+import { GraphqlModule } from './graphql';
 import { ResourceResolver } from './resources';
 import { TracingModule } from './tracing';
 import { ValidationPipe } from './validation.pipe';
@@ -29,13 +27,12 @@ import { ValidationPipe } from './validation.pipe';
     ConsoleModule,
     DatabaseModule,
     EmailModule.forRootAsync({ useExisting: ConfigService }),
-    GraphQLModule.forRootAsync({ useClass: GraphQLConfig }),
+    GraphqlModule,
     EventsModule,
     TracingModule,
   ],
   providers: [
     AwsS3Factory,
-    GraphqlLoggingPlugin,
     BaseExceptionFilter,
     { provide: APP_FILTER, useClass: ExceptionFilter },
     { provide: APP_PIPE, useClass: ValidationPipe },

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -19,6 +19,7 @@ import { ExceptionFilter } from './exception.filter';
 import { GraphqlLoggingPlugin } from './graphql-logging.plugin';
 import { GraphQLConfig } from './graphql.config';
 import { ResourceResolver } from './resources';
+import { TracingModule } from './tracing';
 import { ValidationPipe } from './validation.pipe';
 
 @Global()
@@ -30,6 +31,7 @@ import { ValidationPipe } from './validation.pipe';
     EmailModule.forRootAsync({ useExisting: ConfigService }),
     GraphQLModule.forRootAsync({ useClass: GraphQLConfig }),
     EventsModule,
+    TracingModule,
   ],
   providers: [
     AwsS3Factory,
@@ -48,6 +50,7 @@ import { ValidationPipe } from './validation.pipe';
     EmailModule,
     EventsModule,
     ResourceResolver,
+    TracingModule,
   ],
 })
 export class CoreModule {}

--- a/src/core/database/database.module.ts
+++ b/src/core/database/database.module.ts
@@ -1,6 +1,7 @@
 import { Module, OnApplicationShutdown } from '@nestjs/common';
 import { Connection } from 'cypher-query-builder';
 import { ConfigModule } from '../config/config.module';
+import { TracingModule } from '../tracing';
 import { CypherFactory } from './cypher.factory';
 import { DatabaseService } from './database.service';
 import { IndexerModule } from './indexer/indexer.module';
@@ -8,7 +9,7 @@ import { MigrationModule } from './migration/migration.module';
 import { ParameterTransformer } from './parameter-transformer.service';
 
 @Module({
-  imports: [IndexerModule, MigrationModule, ConfigModule],
+  imports: [IndexerModule, MigrationModule, ConfigModule, TracingModule],
   providers: [CypherFactory, DatabaseService, ParameterTransformer],
   exports: [CypherFactory, DatabaseService, IndexerModule],
 })

--- a/src/core/database/query-augmentation/log-it.ts
+++ b/src/core/database/query-augmentation/log-it.ts
@@ -38,11 +38,10 @@ Query.prototype.logIt = function logIt(
         enumerable: false,
       });
     }
-    const trace = (this as any).__stacktrace as string[] | undefined;
-    const frame = trace?.[0] ? /at (.+) \(/.exec(trace[0]) : undefined;
-    if (frame?.[1]) {
+    const name = (this as any).name as string | undefined;
+    if (name) {
       Object.defineProperty(result.params, '__origin', {
-        value: frame[1],
+        value: name,
         enumerable: false,
       });
     }

--- a/src/core/graphql/graphql-logging.plugin.ts
+++ b/src/core/graphql/graphql-logging.plugin.ts
@@ -7,8 +7,8 @@ import {
 import { TracingFormat } from 'apollo-tracing';
 import { GraphQLError } from 'graphql';
 import { Neo4jError } from 'neo4j-driver';
-import { maskSecrets } from '../common/mask-secrets';
-import { ILogger, Logger } from './logger';
+import { maskSecrets } from '../../common/mask-secrets';
+import { ILogger, Logger } from '../logger';
 
 /**
  * Logging for GraphQL errors that are not handled anywhere else

--- a/src/core/graphql/graphql-tracing.plugin.ts
+++ b/src/core/graphql/graphql-tracing.plugin.ts
@@ -20,6 +20,7 @@ export class GraphqlTracingPlugin implements ApolloPlugin<ContextType> {
         // Change url to be something meaningful since all gql requests hit a single http endpoint
         // @ts-expect-error xray library types suck
         segment.http.request.url = `/${segment.name}`;
+        segment.addAnnotation(reqContext.operation.operation, true);
 
         return {
           executionDidEnd: (err) => {

--- a/src/core/graphql/graphql-tracing.plugin.ts
+++ b/src/core/graphql/graphql-tracing.plugin.ts
@@ -1,0 +1,77 @@
+import { FieldMiddleware, Plugin } from '@nestjs/graphql';
+import {
+  ApolloServerPlugin as ApolloPlugin,
+  GraphQLRequestExecutionListener as ExecutionListener,
+  GraphQLRequestListener as Listener,
+} from 'apollo-server-plugin-base';
+import { GraphQLResolveInfo as ResolveInfo, ResponsePath } from 'graphql';
+import { GqlContextType as ContextType } from '../../common';
+import { TracingService } from '../tracing';
+
+@Plugin()
+export class GraphqlTracingPlugin implements ApolloPlugin<ContextType> {
+  constructor(private readonly tracing: TracingService) {}
+
+  requestDidStart(): Listener<ContextType> {
+    return {
+      executionDidStart: (reqContext): ExecutionListener<ContextType> => {
+        const segment = this.tracing.rootSegment;
+        segment.name = reqContext.operationName ?? reqContext.queryHash;
+        // Change url to be something meaningful since all gql requests hit a single http endpoint
+        // @ts-expect-error xray library types suck
+        segment.http.request.url = `/${segment.name}`;
+
+        return {
+          executionDidEnd: (err) => {
+            const userId = reqContext.context.session?.userId;
+            if (userId) {
+              segment.setUser(userId);
+            }
+
+            if (err) {
+              segment.addError(err);
+            }
+          },
+        };
+      },
+    };
+  }
+
+  fieldMiddleware(): FieldMiddleware {
+    return ({ info, args }, next) => {
+      const path = fieldPathFromInfo(info);
+      return this.tracing.capture(path, async (sub) => {
+        // Add info just for queries right now
+        if (info.operation.operation === 'query') {
+          const annotations =
+            args.input && Object.keys(args).length === 1 ? args.input : args;
+          for (const [key, value] of Object.entries(annotations)) {
+            if (['string', 'number', 'boolean'].includes(typeof value)) {
+              sub.addAnnotation(key, value as string | number | boolean);
+            } else {
+              sub.addMetadata(key, value);
+            }
+          }
+        }
+
+        await next();
+
+        // Drop segments that took less than 10ms
+        // We'll assume we don't have real logic attached to them.
+        if (Date.now() / 1000 - sub.start_time < 0.01) {
+          sub.parent?.removeSubsegment(sub);
+        }
+      });
+    };
+  }
+}
+
+export const fieldPathFromInfo = (info: ResolveInfo) => {
+  let path: ResponsePath | undefined = info.path;
+  const segments: Array<number | string> = [];
+  while (path) {
+    segments.unshift(path.key);
+    path = path.prev;
+  }
+  return segments.join('.');
+};

--- a/src/core/graphql/graphql.config.ts
+++ b/src/core/graphql/graphql.config.ts
@@ -14,6 +14,7 @@ import { sep } from 'path';
 import { GqlContextType } from '../../common';
 import { ConfigService } from '../config/config.service';
 import { VersionService } from '../config/version.service';
+import { GraphqlTracingPlugin } from './graphql-tracing.plugin';
 
 const escapedSep = sep === '/' ? '\\/' : '\\\\';
 const matchSrcPathInTrace = RegExp(
@@ -24,6 +25,7 @@ const matchSrcPathInTrace = RegExp(
 export class GraphQLConfig implements GqlOptionsFactory {
   constructor(
     private readonly config: ConfigService,
+    private readonly tracing: GraphqlTracingPlugin,
     private readonly versionService: VersionService
   ) {}
 
@@ -49,6 +51,9 @@ export class GraphQLConfig implements GqlOptionsFactory {
       formatError: this.formatError,
       debug: this.debug,
       sortSchema: true,
+      buildSchemaOptions: {
+        fieldMiddleware: [this.tracing.fieldMiddleware()],
+      },
     };
   }
 

--- a/src/core/graphql/graphql.config.ts
+++ b/src/core/graphql/graphql.config.ts
@@ -11,9 +11,9 @@ import { Request, Response } from 'express';
 import { GraphQLError, GraphQLFormattedError } from 'graphql';
 import { intersection } from 'lodash';
 import { sep } from 'path';
-import { GqlContextType } from '../common';
-import { ConfigService } from './config/config.service';
-import { VersionService } from './config/version.service';
+import { GqlContextType } from '../../common';
+import { ConfigService } from '../config/config.service';
+import { VersionService } from '../config/version.service';
 
 const escapedSep = sep === '/' ? '\\/' : '\\\\';
 const matchSrcPathInTrace = RegExp(

--- a/src/core/graphql/graphql.module.ts
+++ b/src/core/graphql/graphql.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
 import { GraphQLModule as NestGraphqlModule } from '@nestjs/graphql';
+import { TracingModule } from '../tracing';
 import { GraphqlLoggingPlugin } from './graphql-logging.plugin';
+import { GraphqlTracingPlugin } from './graphql-tracing.plugin';
 import { GraphQLConfig } from './graphql.config';
 
 @Module({
-  providers: [GraphQLConfig, GraphqlLoggingPlugin],
+  imports: [TracingModule],
+  providers: [GraphQLConfig, GraphqlLoggingPlugin, GraphqlTracingPlugin],
   exports: [GraphQLConfig],
 })
 export class GraphqlConfigModule {}

--- a/src/core/graphql/graphql.module.ts
+++ b/src/core/graphql/graphql.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { GraphQLModule as NestGraphqlModule } from '@nestjs/graphql';
+import { GraphqlLoggingPlugin } from './graphql-logging.plugin';
+import { GraphQLConfig } from './graphql.config';
+
+@Module({
+  providers: [GraphQLConfig, GraphqlLoggingPlugin],
+  exports: [GraphQLConfig],
+})
+export class GraphqlConfigModule {}
+
+@Module({
+  imports: [
+    NestGraphqlModule.forRootAsync({
+      useExisting: GraphQLConfig,
+      imports: [GraphqlConfigModule],
+    }),
+  ],
+  exports: [NestGraphqlModule],
+})
+export class GraphqlModule {}

--- a/src/core/graphql/index.ts
+++ b/src/core/graphql/index.ts
@@ -1,0 +1,1 @@
+export * from './graphql.module';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,3 +5,4 @@ export * from './database';
 export * from './events';
 export * from './resources';
 export * from './data-loader';
+export * from './tracing';

--- a/src/core/tracing/index.ts
+++ b/src/core/tracing/index.ts
@@ -1,0 +1,2 @@
+export * from './tracing.service';
+export * from './tracing.module';

--- a/src/core/tracing/sampler.ts
+++ b/src/core/tracing/sampler.ts
@@ -1,0 +1,14 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Segment } from './tracing.service';
+
+export abstract class Sampler {
+  /**
+   * Should this execution be traced?
+   *
+   * Returns a boolean or a specific rule name indicating why true.
+   */
+  abstract shouldTrace(
+    context: ExecutionContext,
+    segment: Segment
+  ): Promise<string | boolean>;
+}

--- a/src/core/tracing/tracing.module.ts
+++ b/src/core/tracing/tracing.module.ts
@@ -1,0 +1,92 @@
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  OnModuleInit,
+} from '@nestjs/common';
+import * as XRay from 'aws-xray-sdk-core';
+import { Request, Response } from 'express';
+import { ConfigService } from '../config/config.service';
+import { VersionService } from '../config/version.service';
+import { ILogger, Logger, LoggerModule, LogLevel } from '../logger';
+import { TracingService } from './tracing.service';
+
+@Module({
+  imports: [LoggerModule],
+  providers: [TracingService],
+  exports: [TracingService],
+})
+export class TracingModule implements OnModuleInit, NestModule {
+  constructor(
+    @Logger('xray') private readonly logger: ILogger,
+    private readonly tracing: TracingService,
+    private readonly config: ConfigService,
+    private readonly version: VersionService
+  ) {}
+
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply((req: Request, res: Response, next: () => void) => {
+        const traceData = XRay.utils.processTraceData(
+          req.header('x-amzn-trace-id')
+        );
+        const root = new XRay.Segment('cord', traceData.root, traceData.parent);
+        const reqData = new XRay.middleware.IncomingRequestData(req);
+        root.addIncomingRequestData(reqData);
+
+        res.setHeader('x-amzn-trace-id', `Root=${root.trace_id};Sampled=1`);
+
+        res.on('finish', () => {
+          const status = res.statusCode.toString();
+          if (status.startsWith('4')) {
+            root.addErrorFlag();
+          } else if (status.startsWith('5')) {
+            root.addFaultFlag();
+          } else if (res.statusCode === 429) {
+            root.addThrottleFlag();
+          }
+
+          // @ts-expect-error xray library types suck
+          root.http.close(res);
+          root.close();
+          root.flush();
+        });
+
+        this.tracing.segmentStorage.run(root, next);
+      })
+      .forRoutes('*');
+  }
+
+  async onModuleInit() {
+    // Don't use cls-hooked lib. It's old and Node has AsyncLocalStorage now.
+    XRay.enableManualMode();
+
+    // XR.setStreamingThreshold(50); // default 100
+
+    XRay.config([XRay.plugins.ECSPlugin]);
+
+    XRay.SegmentUtils.setServiceData({
+      name: this.config.hostUrl,
+      version: (await this.version.version).toString(),
+      runtime: process.release?.name ?? 'unknown',
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      runtime_version: process.version,
+    });
+
+    const log =
+      (level: LogLevel): XRay.Logger[keyof XRay.Logger] =>
+      (msg: string, err: Error | string) => {
+        if (err instanceof Error) {
+          this.logger.log(level, msg, { exception: err });
+        } else {
+          this.logger.log(level, err ? `${msg} ${err}` : msg);
+        }
+      };
+    XRay.setLogger({
+      info: log(LogLevel.INFO),
+      debug: log(LogLevel.DEBUG),
+      error: log(LogLevel.ERROR),
+      warn: log(LogLevel.WARNING),
+    });
+  }
+}

--- a/src/core/tracing/tracing.module.ts
+++ b/src/core/tracing/tracing.module.ts
@@ -55,6 +55,10 @@ export class TracingModule implements OnModuleInit, NestModule {
       runtime_version: process.version,
     });
 
+    if (this.config.xray.daemonAddress) {
+      XRay.setDaemonAddress(this.config.xray.daemonAddress);
+    }
+
     const log =
       (level: LogLevel): XRay.Logger[keyof XRay.Logger] =>
       (msg: string, err: Error | string) => {

--- a/src/core/tracing/tracing.module.ts
+++ b/src/core/tracing/tracing.module.ts
@@ -5,56 +5,26 @@ import {
   OnModuleInit,
 } from '@nestjs/common';
 import * as XRay from 'aws-xray-sdk-core';
-import { Request, Response } from 'express';
 import { ConfigService } from '../config/config.service';
 import { VersionService } from '../config/version.service';
 import { ILogger, Logger, LoggerModule, LogLevel } from '../logger';
 import { TracingService } from './tracing.service';
+import { XRayMiddleware } from './xray.middleware';
 
 @Module({
   imports: [LoggerModule],
-  providers: [TracingService],
+  providers: [TracingService, XRayMiddleware],
   exports: [TracingService],
 })
 export class TracingModule implements OnModuleInit, NestModule {
   constructor(
     @Logger('xray') private readonly logger: ILogger,
-    private readonly tracing: TracingService,
     private readonly config: ConfigService,
     private readonly version: VersionService
   ) {}
 
   configure(consumer: MiddlewareConsumer) {
-    consumer
-      .apply((req: Request, res: Response, next: () => void) => {
-        const traceData = XRay.utils.processTraceData(
-          req.header('x-amzn-trace-id')
-        );
-        const root = new XRay.Segment('cord', traceData.root, traceData.parent);
-        const reqData = new XRay.middleware.IncomingRequestData(req);
-        root.addIncomingRequestData(reqData);
-
-        res.setHeader('x-amzn-trace-id', `Root=${root.trace_id};Sampled=1`);
-
-        res.on('finish', () => {
-          const status = res.statusCode.toString();
-          if (status.startsWith('4')) {
-            root.addErrorFlag();
-          } else if (status.startsWith('5')) {
-            root.addFaultFlag();
-          } else if (res.statusCode === 429) {
-            root.addThrottleFlag();
-          }
-
-          // @ts-expect-error xray library types suck
-          root.http.close(res);
-          root.close();
-          root.flush();
-        });
-
-        this.tracing.segmentStorage.run(root, next);
-      })
-      .forRoutes('*');
+    consumer.apply(XRayMiddleware).forRoutes('*');
   }
 
   async onModuleInit() {

--- a/src/core/tracing/tracing.module.ts
+++ b/src/core/tracing/tracing.module.ts
@@ -43,6 +43,10 @@ export class TracingModule implements OnModuleInit, NestModule {
 
     XRay.config([XRay.plugins.ECSPlugin]);
 
+    if (process.env.NODE_ENV !== 'production') {
+      XRay.middleware.disableCentralizedSampling();
+    }
+
     XRay.SegmentUtils.setServiceData({
       name: this.config.hostUrl,
       version: (await this.version.version).toString(),

--- a/src/core/tracing/tracing.module.ts
+++ b/src/core/tracing/tracing.module.ts
@@ -4,16 +4,24 @@ import {
   NestModule,
   OnModuleInit,
 } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import * as XRay from 'aws-xray-sdk-core';
 import { ConfigService } from '../config/config.service';
 import { VersionService } from '../config/version.service';
 import { ILogger, Logger, LoggerModule, LogLevel } from '../logger';
+import { Sampler } from './sampler';
 import { TracingService } from './tracing.service';
+import { XraySampler } from './xray-sampler';
 import { XRayMiddleware } from './xray.middleware';
 
 @Module({
   imports: [LoggerModule],
-  providers: [TracingService, XRayMiddleware],
+  providers: [
+    TracingService,
+    { provide: Sampler, useClass: XraySampler },
+    XRayMiddleware,
+    { provide: APP_INTERCEPTOR, useExisting: XRayMiddleware },
+  ],
   exports: [TracingService],
 })
 export class TracingModule implements OnModuleInit, NestModule {

--- a/src/core/tracing/tracing.service.ts
+++ b/src/core/tracing/tracing.service.ts
@@ -1,0 +1,119 @@
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { AsyncLocalStorage } from 'async_hooks';
+import * as XR from 'aws-xray-sdk-core';
+import { ServerException } from '../../common';
+
+@Injectable()
+export class TracingService implements OnModuleDestroy {
+  readonly segmentStorage = new AsyncLocalStorage<XR.Segment | XR.Subsegment>();
+
+  capture<R>(name: string, cb: (sub: Segment) => Promise<R>) {
+    const seg =
+      this.segmentStorage.getStore()?.addNewSubsegment(name) ??
+      new XR.Subsegment(name);
+    return this.segmentStorage.run(seg, async () => {
+      try {
+        const res = await cb(seg as any);
+        if (!seg.isClosed()) {
+          seg.close();
+        }
+        return res;
+      } catch (e) {
+        if (!seg.isClosed()) {
+          seg.close(e);
+        }
+        throw e;
+      }
+    });
+  }
+
+  /**
+   * The current segment in the current async context.
+   */
+  get segment() {
+    const current = this.segmentStorage.getStore();
+    if (!current) {
+      throw new ServerException(
+        'Cannot get segment outside of defined context'
+      );
+    }
+    return current as unknown as Segment;
+  }
+
+  /**
+   * The current root segment in the current async context.
+   */
+  get rootSegment() {
+    const segment = this.segment;
+    return (segment.segment ?? segment)!;
+  }
+
+  onModuleDestroy() {
+    this.segmentStorage.disable();
+  }
+}
+
+/* eslint-disable @typescript-eslint/method-signature-style */
+
+/**
+ * This is a re-type of xray's Subsegment simplified and documented for use across the app.
+ *
+ * More type info here
+ * @see https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html
+ */
+export interface Segment {
+  name: string;
+
+  /** start time in seconds but with millisecond precision */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  start_time: number;
+
+  parent?: Segment;
+  /** root */
+  segment?: Segment;
+
+  namespace?: 'remote' | 'aws';
+
+  /** Define SQL info */
+  sql?: Record<string, any>;
+
+  /**
+   * Add annotation to segment.
+   * Annotations are aggregate-able, index-able tags and there for need to be
+   * simple values.
+   */
+  addAnnotation(key: string, value: string | number | boolean): void;
+
+  /**
+   * Add metadata to segment.
+   * Metadata is for per-trace data, for individual reflection.
+   * It cannot be searched on but can be viewed individually.
+   * Complex (json-able) data is allowed here.
+   */
+  addMetadata(key: string, value: unknown): void;
+
+  /**
+   * Faults are server problems
+   */
+  addFaultFlag(): void;
+
+  /**
+   * Errors are client problems
+   */
+  addErrorFlag(): void;
+
+  addThrottleFlag(): void;
+
+  setUser(userId: string): void;
+
+  addError(err: Error | string, remote?: boolean): void;
+
+  isClosed(): boolean;
+
+  /**
+   * Close segment and optionally call addError with error if given.
+   */
+  close(err?: Error | string | null, remote?: boolean): void;
+
+  removeSubsegment(subsegment: Segment): void;
+}

--- a/src/core/tracing/tracing.service.ts
+++ b/src/core/tracing/tracing.service.ts
@@ -104,7 +104,7 @@ export interface Segment {
 
   addThrottleFlag(): void;
 
-  setUser(userId: string): void;
+  setUser?: (userId: string) => void;
 
   addError(err: Error | string, remote?: boolean): void;
 

--- a/src/core/tracing/xray-sampler.ts
+++ b/src/core/tracing/xray-sampler.ts
@@ -1,0 +1,39 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import {
+  GqlExecutionContext,
+  GqlContextType as GqlExeType,
+} from '@nestjs/graphql';
+import * as XRay from 'aws-xray-sdk-core';
+import { GqlContextType } from '../../common';
+import { Sampler } from './sampler';
+import { Segment } from './tracing.service';
+
+/**
+ * Sampling provided by X-Ray library/service.
+ */
+@Injectable()
+export class XraySampler implements Sampler {
+  async shouldTrace(context: ExecutionContext, segment: Segment) {
+    // Pretty specific to configuration outside of this module...
+    const req =
+      context.getType<GqlExeType>() === 'graphql'
+        ? GqlExecutionContext.create(context).getContext<GqlContextType>()
+            .request
+        : context.switchToHttp().getRequest();
+
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    const rule: String | string | boolean | null | undefined =
+      // @ts-expect-error not typed but it exists
+      XRay.middleware.sampler.shouldSample({
+        host: req.headers.host,
+        httpMethod: req.method,
+        urlPath: req.url,
+        serviceName: segment.name,
+      });
+
+    // Including this because lib checks for it so normalizing to be safe.
+    // https://github.com/aws/aws-xray-sdk-node/blob/a9d0cf9/packages/core/lib/middleware/mw_utils.js#L103
+    // Also doing falsy check here to further narrow output type
+    return rule instanceof String ? rule.toString() : rule || false;
+  }
+}

--- a/src/core/tracing/xray.middleware.ts
+++ b/src/core/tracing/xray.middleware.ts
@@ -1,0 +1,38 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import * as XRay from 'aws-xray-sdk-core';
+import { Request, Response } from 'express';
+import { TracingService } from './tracing.service';
+
+@Injectable()
+export class XRayMiddleware implements NestMiddleware {
+  constructor(private readonly tracing: TracingService) {}
+
+  use(req: Request, res: Response, next: () => void) {
+    const traceData = XRay.utils.processTraceData(
+      req.header('x-amzn-trace-id')
+    );
+    const root = new XRay.Segment('cord', traceData.root, traceData.parent);
+    const reqData = new XRay.middleware.IncomingRequestData(req);
+    root.addIncomingRequestData(reqData);
+
+    res.setHeader('x-amzn-trace-id', `Root=${root.trace_id};Sampled=1`);
+
+    res.on('finish', () => {
+      const status = res.statusCode.toString();
+      if (status.startsWith('4')) {
+        root.addErrorFlag();
+      } else if (status.startsWith('5')) {
+        root.addFaultFlag();
+      } else if (res.statusCode === 429) {
+        root.addThrottleFlag();
+      }
+
+      // @ts-expect-error xray library types suck
+      root.http.close(res);
+      root.close();
+      root.flush();
+    });
+
+    this.tracing.segmentStorage.run(root, next);
+  }
+}

--- a/src/core/tracing/xray.middleware.ts
+++ b/src/core/tracing/xray.middleware.ts
@@ -12,6 +12,7 @@ import {
 import * as XRay from 'aws-xray-sdk-core';
 import { Request, Response } from 'express';
 import { GqlContextType } from '../../common';
+import { ConfigService } from '../config/config.service';
 import { Sampler } from './sampler';
 import { TracingService } from './tracing.service';
 
@@ -19,7 +20,8 @@ import { TracingService } from './tracing.service';
 export class XRayMiddleware implements NestMiddleware, NestInterceptor {
   constructor(
     private readonly tracing: TracingService,
-    private readonly sampler: Sampler
+    private readonly sampler: Sampler,
+    private readonly config: ConfigService
   ) {}
 
   /**
@@ -78,7 +80,7 @@ export class XRayMiddleware implements NestMiddleware, NestInterceptor {
 
     // If no explicit address, disable tracing.
     // Otherwise traces will be buffered leading to memory leak
-    if (!process.env.AWS_XRAY_DAEMON_ADDRESS) {
+    if (!this.config.xray.daemonAddress) {
       sampled = false;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1361,7 +1361,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/service-error-classification@npm:3.29.0":
+"@aws-sdk/service-error-classification@npm:3.29.0, @aws-sdk/service-error-classification@npm:^3.4.1":
   version: 3.29.0
   resolution: "@aws-sdk/service-error-classification@npm:3.29.0"
   checksum: 25bb0eebcc37c18817ba0111bb00d7df45ebb3f9c6b502d8a52c8a87d49efaa3c42c0c5e4cc0352147ad78e45a1a7314ab554ad0dd4fd98df3a873459e8b41be
@@ -1441,7 +1441,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.29.0, @aws-sdk/types@npm:^3.1.0":
+"@aws-sdk/types@npm:3.29.0, @aws-sdk/types@npm:^3.1.0, @aws-sdk/types@npm:^3.4.1":
   version: 3.29.0
   resolution: "@aws-sdk/types@npm:3.29.0"
   checksum: e3773cb842695653b06f7fb4feedf9ddff77e679cf5cba397976ade2e736987ef0666136ef4ed6d00944132456a8b78a1f84e659ff95ddac25aa4edb04f8b208
@@ -2969,6 +2969,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cls-hooked@npm:^4.3.3":
+  version: 4.3.3
+  resolution: "@types/cls-hooked@npm:4.3.3"
+  dependencies:
+    "@types/node": "*"
+  checksum: 335dedfad8ca00dd0a02d3227dcb96ba06e4c34be5fa2599e1f9c98255f732acc83b06ed5f561a42664fb2ff4bdbb20a7fde1c0343b14b9a3300c6a2f70656ba
+  languageName: node
+  linkType: hard
+
 "@types/color-name@npm:^1.1.1":
   version: 1.1.1
   resolution: "@types/color-name@npm:1.1.1"
@@ -4407,6 +4416,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async-hook-jl@npm:^1.7.6":
+  version: 1.7.6
+  resolution: "async-hook-jl@npm:1.7.6"
+  dependencies:
+    stack-chain: ^1.3.7
+  checksum: fe41eaf51c7737fcf9b23183903637556a353fb05190ffcb601bf448834ba7fa19abfaa360ce842ef47a1fa731c945172e92bb50d00c5fe5e8abefda26dcd480
+  languageName: node
+  linkType: hard
+
 "async-limiter@npm:~1.0.0":
   version: 1.0.1
   resolution: "async-limiter@npm:1.0.1"
@@ -4453,10 +4471,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"atomic-batcher@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "atomic-batcher@npm:1.0.2"
+  checksum: 80af23754ca64557d876a090b06fd2517c2f9ba603473b90fa75e39cedb716011d0728089c0634a5a50fbf62950a6772592d38caea1abad444a122b1dfd9ede6
+  languageName: node
+  linkType: hard
+
 "aws-sign2@npm:~0.7.0":
   version: 0.7.0
   resolution: "aws-sign2@npm:0.7.0"
   checksum: 7162b9b8fbd4cf451bd889b0ed27fc895f88e6a6cb5c5609de49759ea1a6e31646f86ca8e18d90bea0455c4caa466fc9692c1098a1784d2372a358cb68c1eea6
+  languageName: node
+  linkType: hard
+
+"aws-xray-sdk-core@npm:^3.3.3":
+  version: 3.3.3
+  resolution: "aws-xray-sdk-core@npm:3.3.3"
+  dependencies:
+    "@aws-sdk/service-error-classification": ^3.4.1
+    "@aws-sdk/types": ^3.4.1
+    "@types/cls-hooked": ^4.3.3
+    atomic-batcher: ^1.0.2
+    cls-hooked: ^4.2.2
+    semver: ^5.3.0
+  checksum: 710ebd280de27ab532ec5aca1a9a327f2971087e25faccf8298c69e4e6a5084e4a93744423472a7552c8a3cdc5dafb414e6b496958337c17f606c2cb8fe42448
   languageName: node
   linkType: hard
 
@@ -5224,6 +5263,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cls-hooked@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "cls-hooked@npm:4.2.2"
+  dependencies:
+    async-hook-jl: ^1.7.6
+    emitter-listener: ^1.0.1
+    semver: ^5.4.1
+  checksum: 35c463d18808821fc9c077c137ea9ff5d6f56a84b8debb5e7848290bb4cb043550515a421cdc8cc845481dc5f64f2761eedaa21b34879502d79c5bcdd554f392
+  languageName: node
+  linkType: hard
+
 "co@npm:^4.6.0":
   version: 4.6.0
   resolution: "co@npm:4.6.0"
@@ -5577,6 +5627,7 @@ __metadata:
     apollo-server-express: ^2.22.2
     apollo-server-testing: ^2.22.2
     argon2: ^0.27.2
+    aws-xray-sdk-core: ^3.3.3
     class-transformer: ^0.4.0
     class-validator: ^0.13.1
     cli-highlight: ^2.1.11
@@ -6405,6 +6456,15 @@ cypher-query-builder@6.0.4:
   version: 3.5.0
   resolution: "emailjs@npm:3.5.0"
   checksum: a11934896b3a35d86dad598dd5aca140e2a3ff201a6bbcb41103019d718409561560bb06adac10637640af546df4014145c0d9437ae9773f4af5bd718dbb3d9a
+  languageName: node
+  linkType: hard
+
+"emitter-listener@npm:^1.0.1":
+  version: 1.1.2
+  resolution: "emitter-listener@npm:1.1.2"
+  dependencies:
+    shimmer: ^1.2.0
+  checksum: 3dec4c92d9a0b573e321f304acc259db53cdf068873dd524e7bf27f205971b8b1bacb4eb0d42dae084a9a841ec519bede5246d04805f1689da306d995316a6a4
   languageName: node
   linkType: hard
 
@@ -12813,7 +12873,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.4.1, semver@npm:^5.5.0, semver@npm:^5.6.0, semver@npm:^5.7.1":
+"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.3.0, semver@npm:^5.4.1, semver@npm:^5.5.0, semver@npm:^5.6.0, semver@npm:^5.7.1":
   version: 5.7.1
   resolution: "semver@npm:5.7.1"
   bin:
@@ -12971,6 +13031,13 @@ resolve@^2.0.0-next.3:
   version: 0.1.1
   resolution: "shellwords@npm:0.1.1"
   checksum: 3559ff550917ece921d252edf42eb54827540e9676e537137ace236df8f9b78e48c542ae0b3f8876fea0faf5826c97629d5b8cb9ac7dee287260e9804fb8132c
+  languageName: node
+  linkType: hard
+
+"shimmer@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "shimmer@npm:1.2.1"
+  checksum: 23431fc4c5cf2df4c4ffca20a415ac18fbc989bdec595b97b541c65b08cf04da55c5b4e1d7b7ea73d17fc92d4c33bd6e97e4da356adbf0349e06813068263d87
   languageName: node
   linkType: hard
 
@@ -13266,6 +13333,13 @@ resolve@^2.0.0-next.3:
   dependencies:
     minipass: ^3.1.1
   checksum: 97964745a80846b4a50d4506b10b08d35384c3cec482d687cae5f4b7c842afe239c8c368d620f5d7d92642ab75379b409aa809072c2b8e94ec15d9c70d843da5
+  languageName: node
+  linkType: hard
+
+"stack-chain@npm:^1.3.7":
+  version: 1.3.7
+  resolution: "stack-chain@npm:1.3.7"
+  checksum: 5d30ff35c5d6d795cbb87e39168643ba14e5ac633b0e7ea71478760dda38551b3f614ff52ebc9c7e372cf4f0868acc159ada9cee41c88604e33666e3420cfeb9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Look Shiny! ✨
![Trace Timeline](https://user-images.githubusercontent.com/932566/133329724-2f45f1e8-88e6-422f-8517-19b015c6274b.png)
![Trace Map](https://user-images.githubusercontent.com/932566/133329728-b4ef421b-0bc0-489e-90ff-fbea33f0304e.png)


# Background
This was originally driven by the need to upgrade to Apollo Server v3 which has support for [`graphql-ws`](https://github.com/enisdenjo/graphql-ws), a newer subscription implementation.

[v3 removed its built in-tracing plugin](https://www.apollographql.com/docs/apollo-server/migration/#tracing). We used this to [log resolver durations](https://github.com/SeedCompany/cord-api-v3/blob/f9c6a6dede2e02fa70aa7220cb97f3ced5095bef/src/core/graphql/graphql-logging.plugin.ts#L53-L69), a crude way of tracking performance.

We really need to have this info as we are optimizing our DB queries. With this built in plugin gone I looked for other solutions.

The first being Apollo Studio, which conveniently still has integrated tracing support via a different avenue. To access this info in Studio you need at least a _Team_ plan which is a draw dropping $50/month/seat 💰 😱 .

Shifting away from that, I decided to look at X-Ray again which has [reasonable pay-per-use pricing](https://aws.amazon.com/xray/pricing/). The downside here is it is AWS, and its barrier to entry is high due to verbose docs that communicate everything you don't need and NodeJS libraries which always seem 5 years behind.

After briefly looking at other SaaS products that do this, I decided AWS was the best for month cost. I just needed to bite the bullet on implementation.

# Implementation Notes
- [`aws-xray-sdk-core`](https://github.com/aws/aws-xray-sdk-node/tree/master/packages/core) library is configured & connected to our logger in [`TracingModule`](https://github.com/SeedCompany/cord-api-v3/blob/xray/src/core/tracing/tracing.module.ts)
- We are not using the library's segment capturing abstractions.
  - They are based on the [`cls-hooked`](https://github.com/Jeff-Lewis/cls-hooked) library. This library was last published 4 years ago, and more importantly isn't needed anymore with Node 12.17+, 14+ which has [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#async_context_class_asynclocalstorage) - a faster native solution doing the same thing.
  - Instead our injectable [`TracingService`](https://github.com/SeedCompany/cord-api-v3/blob/xray/src/core/tracing/tracing.service.ts) provides segment storage & capturing segments across async contexts.
- We are not using the library's _express_ middleware. Instead, we define our own with [`XRayMiddleware`](https://github.com/SeedCompany/cord-api-v3/blob/xray/src/core/tracing/xray.middleware.ts). This allows us:
  - To bind the root segment for the request to our async context
  - There's only a couple of points we give the library the _express_ request/response objects ([#1](https://github.com/SeedCompany/cord-api-v3/blob/f9c6a6dede2e02fa70aa7220cb97f3ced5095bef/src/core/tracing/xray.middleware.ts#L35), [#2](https://github.com/SeedCompany/cord-api-v3/blob/f9c6a6dede2e02fa70aa7220cb97f3ced5095bef/src/core/tracing/xray.middleware.ts#L54)). These just add some more request/response info to the segment. These could easily be swapped out if/when we decide to swap the underlying HTTP platform off of _express_.
  - _Sampling_ is decoupled from request/response cycle via a NestJS `Interceptor`.
- Sampling, a.k.a. whether the request/execution should be traced, is determined by a [`Sampler`](https://github.com/SeedCompany/cord-api-v3/blob/xray/src/core/tracing/sampler.ts) implementation.
  - It is given an `ExecutionContext` which allows for different execution types to be handled: HTTP, WS, RPC, GraphQL.
  - Currently we just use [`XraySampler`](https://github.com/SeedCompany/cord-api-v3/blob/xray/src/core/tracing/xray-sampler.ts). It pulls the request from either an HTTP or GraphQL context and forwards it to the xray library. XRay has a whole rule engine around this, so I didn't want to neglect it right off the bat. However, it's mostly designed around HTTP, so it might need some hacks to integrate more tightly with GraphQL.
- [`GraphqlTracingPlugin`](https://github.com/SeedCompany/cord-api-v3/blob/xray/src/core/graphql/graphql-tracing.plugin.ts) provides tracing info for GraphQL requests
  - It provides GraphQL operation info to the root segment via Apollo `ServerPlugin` (though this piece could be done in an NestJS' `Interceptor`)
  - It captures subsegments for each significant field via NestJS' `FieldMiddleware`
- Database queries have also been captured [here](https://github.com/SeedCompany/cord-api-v3/blob/xray/src/core/database/cypher.factory.ts#L175-L188)

### Other Notes
- I did look at [`nest-xray`](https://github.com/narando/nest-xray) to integrate. I decided I wanted more control than the library gave. It still uses Nest v7, doesn't use `AsyncLocalStorage`, uses xray's express middleware.
- X-Ray requires you to run a daemon yourself to proxy between your app and AWS. I believe this allows the app to communicate via a UDP socket which is more efficient/performant. Then the daemon batches these traces up and sends them to AWS. This will need to be setup separately ([ECS guide](https://docs.aws.amazon.com/xray/latest/devguide/xray-daemon-ecs.html)).
