### PR TITLE
Data Loaders part 2

### DIFF
--- a/src/components/language/language.resolver.ts
+++ b/src/components/language/language.resolver.ts
@@ -19,8 +19,10 @@ import {
   SecuredInt,
   Session,
 } from '../../common';
+import { Loader, LoaderOf } from '../../core';
 import { LocationListInput, SecuredLocationList } from '../location';
-import { ProjectListInput, SecuredProjectList } from '../project/dto';
+import { ProjectLoader } from '../project';
+import { IProject, ProjectListInput, SecuredProjectList } from '../project/dto';
 import {
   CreateLanguageInput,
   CreateLanguageOutput,
@@ -117,9 +119,12 @@ export class LanguageResolver {
       type: () => ProjectListInput,
       defaultValue: ProjectListInput.defaultVal,
     })
-    input: ProjectListInput
+    input: ProjectListInput,
+    @Loader(IProject) loader: LoaderOf<ProjectLoader>
   ): Promise<SecuredProjectList> {
-    return this.langService.listProjects(language, input, session);
+    const list = await this.langService.listProjects(language, input, session);
+    loader.primeAll(list.items);
+    return list;
   }
 
   @Query(() => LanguageListOutput, {

--- a/src/components/project/engagement-connection.resolver.ts
+++ b/src/components/project/engagement-connection.resolver.ts
@@ -1,18 +1,20 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { AnonSession, Session } from '../../common';
+import { viewOfChangeset } from '../../common';
+import { Loader, LoaderOf } from '../../core';
 import { IEngagement } from '../engagement';
 import { IProject } from './dto';
-import { ProjectService } from './project.service';
+import { ProjectLoader } from './project.loader';
 
 @Resolver(IEngagement)
 export class ProjectEngagementConnectionResolver {
-  constructor(private readonly projects: ProjectService) {}
-
   @ResolveField(() => IProject)
   async project(
     @Parent() engagement: IEngagement,
-    @AnonSession() session: Session
+    @Loader(IProject) projects: LoaderOf<ProjectLoader>
   ) {
-    return await this.projects.readOne(engagement.project, session);
+    return await projects.load({
+      id: engagement.project,
+      view: viewOfChangeset(engagement.changeset),
+    });
   }
 }

--- a/src/components/project/index.ts
+++ b/src/components/project/index.ts
@@ -4,3 +4,4 @@ export * from './project.service';
 export * from './project-member';
 export * from './query.helpers';
 export * from './project.rules';
+export * from './project.loader';

--- a/src/components/project/project.loader.ts
+++ b/src/components/project/project.loader.ts
@@ -1,0 +1,19 @@
+import { Injectable, Scope } from '@nestjs/common';
+import { ID, ObjectView } from '../../common';
+import { ObjectViewAwareLoader } from '../../core';
+import { IProject, Project } from './dto';
+import { ProjectService } from './project.service';
+
+@Injectable({ scope: Scope.REQUEST })
+export class ProjectLoader extends ObjectViewAwareLoader<IProject> {
+  constructor(private readonly projects: ProjectService) {
+    super();
+  }
+
+  async loadManyByView(
+    ids: readonly ID[],
+    view: ObjectView
+  ): Promise<readonly Project[]> {
+    return await this.projects.readMany(ids, this.session, view);
+  }
+}

--- a/src/components/project/project.module.ts
+++ b/src/components/project/project.module.ts
@@ -14,6 +14,7 @@ import * as handlers from './handlers';
 import * as migrations from './migrations';
 import { ProjectMemberModule } from './project-member/project-member.module';
 import { ProjectStepResolver } from './project-step.resolver';
+import { ProjectLoader } from './project.loader';
 import { ProjectRepository } from './project.repository';
 import { ProjectResolver } from './project.resolver';
 import { ProjectRules } from './project.rules';
@@ -40,6 +41,7 @@ import { ProjectService } from './project.service';
     ProjectStepResolver,
     ProjectRules,
     ProjectRepository,
+    ProjectLoader,
     ...Object.values(handlers),
     ...Object.values(migrations),
   ],

--- a/src/components/project/project.resolver.ts
+++ b/src/components/project/project.resolver.ts
@@ -18,7 +18,7 @@ import {
   SecuredDateRange,
   Session,
 } from '../../common';
-import { DataLoader, Loader } from '../../core';
+import { DataLoader, Loader, LoaderOf } from '../../core';
 import { SecuredBudget } from '../budget';
 import { IdsAndView, IdsAndViewArg } from '../changeset/dto';
 import { EngagementListInput, SecuredEngagementList } from '../engagement';
@@ -50,6 +50,7 @@ import {
   ProjectMemberListInput,
   SecuredProjectMemberList,
 } from './project-member/dto';
+import { ProjectLoader } from './project.loader';
 import { ProjectService } from './project.service';
 
 @ArgsType()
@@ -74,16 +75,10 @@ export class ProjectResolver {
     description: 'Look up a project by its ID',
   })
   async project(
-    @LoggedInSession() session: Session,
-    @IdsAndViewArg() { id, view }: IdsAndView
+    @Loader(IProject) projects: LoaderOf<ProjectLoader>,
+    @IdsAndViewArg() key: IdsAndView
   ): Promise<Project> {
-    const project = await this.projectService.readOneUnsecured(
-      id,
-      session,
-      view.changeset
-    );
-    const secured = await this.projectService.secure(project, session);
-    return secured;
+    return await projects.load(key);
   }
 
   @Query(() => ProjectListOutput, {

--- a/src/components/project/project.resolver.ts
+++ b/src/components/project/project.resolver.ts
@@ -92,9 +92,11 @@ export class ProjectResolver {
       defaultValue: ProjectListInput.defaultVal,
     })
     input: ProjectListInput,
+    @Loader(IProject) projects: LoaderOf<ProjectLoader>,
     @AnonSession() session: Session
   ): Promise<ProjectListOutput> {
     const list = await this.projectService.list(input, session);
+    projects.primeAll(list.items);
     return list;
   }
 

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -230,7 +230,17 @@ export class ProjectService {
     const userId = isIdLike(sessionOrUserId)
       ? sessionOrUserId
       : sessionOrUserId.userId;
-    return await this.repo.readOneUnsecured(id, userId, changeset);
+    return await this.repo.readOne(id, userId, changeset);
+  }
+
+  async readMany(
+    ids: readonly ID[],
+    session: Session,
+    view: ObjectView
+  ): Promise<readonly Project[]> {
+    this.logger.debug('read many', { ids, view });
+    const projects = await this.repo.readMany(ids, session, view?.changeset);
+    return await Promise.all(projects.map((dto) => this.secure(dto, session)));
   }
 
   async secure(

--- a/src/core/data-loader/index.ts
+++ b/src/core/data-loader/index.ts
@@ -2,3 +2,4 @@ export * from './data-loader.interceptor';
 export * from './loader.decorator';
 export * from './ordered-data-loader';
 export * from './single-item.loader';
+export * from './object-view-aware.loader';

--- a/src/core/data-loader/loader.decorator.ts
+++ b/src/core/data-loader/loader.decorator.ts
@@ -27,6 +27,17 @@ export type DataLoader<T, Key = ID, CachedKey = Key> = DataLoaderLib<
 >;
 
 /**
+ * An actual DataLoader for the given loader factory
+ */
+export type LoaderOf<Factory> = Factory extends NestDataLoader<
+  infer T,
+  infer Key,
+  infer CachedKey
+>
+  ? DataLoader<T, Key, CachedKey>
+  : never;
+
+/**
  * This interface will be used to generate the initial data loader.
  * The concrete implementation should be added as a provider to your module.
  */

--- a/src/core/data-loader/loader.decorator.ts
+++ b/src/core/data-loader/loader.decorator.ts
@@ -20,17 +20,23 @@ import { DataLoaderInterceptor } from './data-loader.interceptor';
  *
  * The object type is first generic and key generic defaults to ID.
  */
-export type DataLoader<T, Key = ID> = DataLoaderLib<Key, T>;
+export type DataLoader<T, Key = ID, CachedKey = Key> = DataLoaderLib<
+  Key,
+  T,
+  CachedKey
+>;
 
 /**
  * This interface will be used to generate the initial data loader.
  * The concrete implementation should be added as a provider to your module.
  */
-export interface NestDataLoader<T, Key = ID> {
+export interface NestDataLoader<T, Key = ID, CachedKey = Key> {
   /**
    * Should return a new instance of dataloader each time
    */
-  generateDataLoader: (context: GqlContextType) => DataLoader<T, Key>;
+  generateDataLoader: (
+    context: GqlContextType
+  ) => DataLoader<T, Key, CachedKey>;
 }
 
 /**

--- a/src/core/data-loader/loader.decorator.ts
+++ b/src/core/data-loader/loader.decorator.ts
@@ -24,7 +24,12 @@ export type DataLoader<T, Key = ID, CachedKey = Key> = DataLoaderLib<
   Key,
   T,
   CachedKey
->;
+> & {
+  /**
+   * Shortcut for {@link prime}.
+   */
+  primeAll: (items: readonly T[]) => DataLoader<T, Key, CachedKey>;
+};
 
 /**
  * An actual DataLoader for the given loader factory

--- a/src/core/data-loader/object-view-aware.loader.ts
+++ b/src/core/data-loader/object-view-aware.loader.ts
@@ -1,0 +1,56 @@
+import { groupBy } from 'lodash';
+import { ID, ObjectView } from '../../common';
+import { ChangesetAware } from '../../components/changeset/dto';
+import {
+  OrderedNestDataLoader as Loader,
+  OrderedNestDataLoaderOptions as LoaderOptions,
+} from './ordered-data-loader';
+
+interface Key {
+  id: ID;
+  view: ObjectView;
+}
+
+/**
+ * A loader that can handle loading ObjectView aware objects.
+ * "Handles" by grouping items to be loaded by their ObjectView.
+ * This works well with our DB queries which are dynamic based on view, but
+ * able to ask for multiple objects with a specific view.
+ */
+export abstract class ObjectViewAwareLoader<
+  T extends ChangesetAware
+> extends Loader<T, Key, string> {
+  abstract loadManyByView(
+    ids: readonly ID[],
+    view: ObjectView
+  ): Promise<readonly T[]>;
+
+  async loadMany(keys: readonly Key[]): Promise<readonly T[]> {
+    const grouped = Object.values(groupBy(keys, (key) => viewId(key.view)));
+
+    const items = await Promise.all(
+      grouped.map(async (keys) => {
+        return await this.loadManyByView(
+          keys.map((key) => key.id),
+          keys[0].view
+        );
+      })
+    );
+    return items.flat();
+  }
+
+  getOptions(): LoaderOptions<T, Key, string> {
+    const parent = super.getOptions();
+    return {
+      ...parent,
+      propertyKey: (obj: T) =>
+        `${obj.id}=${
+          obj.changeset ? `changeset=${obj.changeset}` : `active=true`
+        }`,
+      cacheKeyFn: ({ id, view }) => `${id}=${viewId(view)}`,
+    };
+  }
+}
+
+const viewId = (view: ObjectView) =>
+  view.changeset ? `changeset=${view.changeset}` : 'active=true';

--- a/src/core/data-loader/object-view-aware.loader.ts
+++ b/src/core/data-loader/object-view-aware.loader.ts
@@ -1,5 +1,5 @@
 import { groupBy } from 'lodash';
-import { ID, ObjectView } from '../../common';
+import { ID, ObjectView, viewOfChangeset } from '../../common';
 import { ChangesetAware } from '../../components/changeset/dto';
 import {
   OrderedNestDataLoader as Loader,
@@ -43,10 +43,10 @@ export abstract class ObjectViewAwareLoader<
     const parent = super.getOptions();
     return {
       ...parent,
-      propertyKey: (obj: T) =>
-        `${obj.id}=${
-          obj.changeset ? `changeset=${obj.changeset}` : `active=true`
-        }`,
+      propertyKey: (obj: T) => ({
+        id: obj.id,
+        view: viewOfChangeset(obj.changeset),
+      }),
       cacheKeyFn: ({ id, view }) => `${id}=${viewId(view)}`,
     };
   }

--- a/src/core/data-loader/ordered-data-loader.ts
+++ b/src/core/data-loader/ordered-data-loader.ts
@@ -9,9 +9,9 @@ import { NestDataLoader } from './loader.decorator';
 export interface OrderedNestDataLoaderOptions<T, Key = ID> {
   /**
    * How should the object be identified?
-   * A property key. Defaults to `id`
+   * An function to do so or a property key. Defaults to `id`
    */
-  propertyKey?: keyof T;
+  propertyKey?: keyof T | ((obj: T) => string);
 
   /**
    * How to describe the object in errors.
@@ -58,7 +58,10 @@ export abstract class OrderedNestDataLoader<T, Key = ID>
       options.typeName ??
       startCase(this.constructor.name.replace('Loader', '')).toLowerCase();
 
-    const getKey = (obj: T) => obj[(options.propertyKey ?? 'id') as keyof T];
+    const getKey =
+      typeof options.propertyKey === 'function'
+        ? options.propertyKey
+        : (obj: T) => obj[(options.propertyKey ?? 'id') as keyof T];
 
     const batchFn: DataLoader.BatchLoadFn<Key, T> = async (keys) => {
       const docs = await this.loadMany(keys);

--- a/src/core/data-loader/single-item.loader.ts
+++ b/src/core/data-loader/single-item.loader.ts
@@ -1,5 +1,8 @@
 import { ID, NotFoundException } from '../../common';
-import { OrderedNestDataLoader } from './ordered-data-loader';
+import {
+  OrderedNestDataLoader as DataLoader,
+  OrderedNestDataLoaderOptions as LoaderOptions,
+} from './ordered-data-loader';
 
 /**
  * An loader that will load each item one by one.
@@ -7,10 +10,7 @@ import { OrderedNestDataLoader } from './ordered-data-loader';
  * Using this is only encouraged to adopt the DataLoader pattern, which can provide
  * caching even without batching.
  */
-export abstract class SingleItemLoader<
-  T,
-  Key = ID
-> extends OrderedNestDataLoader<T, Key> {
+export abstract class SingleItemLoader<T, Key = ID> extends DataLoader<T, Key> {
   abstract loadOne(key: Key): Promise<T>;
 
   async loadMany(keys: readonly Key[]): Promise<readonly T[]> {
@@ -27,5 +27,14 @@ export abstract class SingleItemLoader<
       })
     );
     return items.flat() as T[];
+  }
+
+  getOptions(): LoaderOptions<T, Key> {
+    return {
+      ...super.getOptions(),
+      // Batching is worthless here since we load each item individually anyways
+      // This skips the wait time and fires immediately.
+      batch: false,
+    };
   }
 }

--- a/src/core/data-loader/single-item.loader.ts
+++ b/src/core/data-loader/single-item.loader.ts
@@ -5,7 +5,7 @@ import {
 } from './ordered-data-loader';
 
 /**
- * An loader that will load each item one by one.
+ * A loader that will load each item one by one.
  * This is not ideal because it will make at least N requests to DB instead of 1.
  * Using this is only encouraged to adopt the DataLoader pattern, which can provide
  * caching even without batching.


### PR DESCRIPTION
- Added abstraction for `DataLoaders` for `ObjectView` aware objects
- Added `DataLoader.primeAll` shortcut so list results can manually prime cache easily. See 1aa0189 for example.
- Created `ProjectLoader` based on this abstraction & using all new changes.