### PR TITLE
Add Language.firstScripture

### DIFF
--- a/src/components/language/dto/first-scripture.dto.ts
+++ b/src/components/language/dto/first-scripture.dto.ts
@@ -1,0 +1,44 @@
+import { Field, InterfaceType, ObjectType } from '@nestjs/graphql';
+import { has, ID, SecuredProperty } from '../../../common';
+
+@InterfaceType({
+  resolveType: (obj: FirstScripture) =>
+    has('engagement', obj)
+      ? InternalFirstScripture
+      : obj.hasFirst
+      ? ExternalFirstScripture
+      : NoFirstScripture,
+})
+export abstract class FirstScripture {
+  @Field({
+    description: 'Whether any scripture exists',
+  })
+  hasFirst: boolean;
+}
+
+@ObjectType({
+  implements: [FirstScripture],
+  description:
+    'First scripture that has been created but managed _outside_ of CORD. `hasFirst` will always be true.',
+})
+export abstract class ExternalFirstScripture extends FirstScripture {}
+
+@ObjectType({
+  implements: [FirstScripture],
+  description:
+    'First scripture that has been created and managed _in_ CORD. `hasFirst` will always be true.',
+})
+export abstract class InternalFirstScripture extends FirstScripture {
+  engagement: ID;
+}
+
+@ObjectType({
+  implements: [FirstScripture],
+  description: 'Defined for completeness. `hasFirst` will always be false.',
+})
+export abstract class NoFirstScripture extends FirstScripture {}
+
+@ObjectType({
+  description: SecuredProperty.descriptionFor('first scripture'),
+})
+export class SecuredFirstScripture extends SecuredProperty(FirstScripture) {}

--- a/src/components/language/dto/index.ts
+++ b/src/components/language/dto/index.ts
@@ -2,3 +2,4 @@ export * from './create-language.dto';
 export * from './list-language.dto';
 export * from './language.dto';
 export * from './update-language.dto';
+export * from './first-scripture.dto';

--- a/src/components/language/dto/language.dto.ts
+++ b/src/components/language/dto/language.dto.ts
@@ -155,6 +155,9 @@ export class Language extends Resource {
   @Field()
   readonly hasExternalFirstScripture: SecuredBoolean;
 
+  // Internal First Scripture == true via this engagement
+  readonly firstScriptureEngagement?: ID;
+
   @Field()
   readonly tags: SecuredTags;
 

--- a/src/components/language/internal-first-scripture.resolver.ts
+++ b/src/components/language/internal-first-scripture.resolver.ts
@@ -1,0 +1,20 @@
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Loader, LoaderOf } from '../../core';
+import { EngagementLoader, LanguageEngagement } from '../engagement';
+import { InternalFirstScripture } from './dto';
+
+@Resolver(InternalFirstScripture)
+export class InternalFirstScriptureResolver {
+  @ResolveField(() => LanguageEngagement, {
+    description: 'The engagement that produced the first scripture',
+  })
+  engagement(
+    @Parent() { engagement }: InternalFirstScripture,
+    @Loader(EngagementLoader) engagements: LoaderOf<EngagementLoader>
+  ) {
+    return engagements.load({
+      id: engagement,
+      view: { active: true },
+    });
+  }
+}

--- a/src/components/language/language.module.ts
+++ b/src/components/language/language.module.ts
@@ -5,6 +5,7 @@ import { LocationModule } from '../location/location.module';
 import { ProjectModule } from '../project/project.module';
 import { EthnologueLanguageService } from './ethnologue-language';
 import { EthnologueLanguageRepository } from './ethnologue-language/ethnologue-language.repository';
+import { InternalFirstScriptureResolver } from './internal-first-scripture.resolver';
 import { LanguageLoader } from './language.loader';
 import { LanguageRepository } from './language.repository';
 import { LanguageResolver } from './language.resolver';
@@ -24,6 +25,7 @@ import { LanguageService } from './language.service';
     EthnologueLanguageRepository,
     LanguageRepository,
     LanguageLoader,
+    InternalFirstScriptureResolver,
   ],
   exports: [LanguageService],
 })

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -92,10 +92,18 @@ export class LanguageRepository extends DtoRepository(Language) {
         ])
         .apply(matchProps({ nodeName: 'eth', outputVar: 'ethProps' }))
         .apply(this.isPresetInventory())
+        .optionalMatch([
+          node('node'),
+          relation('in', '', 'language', ACTIVE),
+          node('firstScriptureEngagement', 'LanguageEngagement'),
+          relation('out', '', 'firstScripture', ACTIVE),
+          node('', 'Property', { value: variable('true') }),
+        ])
         .return<{ dto: UnsecuredDto<Language> }>(
           merge('props', {
             ethnologue: 'ethProps',
             presetInventory: 'presetInventory',
+            firstScriptureEngagement: 'firstScriptureEngagement.id',
           }).as('dto')
         );
   }

--- a/src/components/language/language.resolver.ts
+++ b/src/components/language/language.resolver.ts
@@ -30,6 +30,7 @@ import {
   Language,
   LanguageListInput,
   LanguageListOutput,
+  SecuredFirstScripture,
   UpdateLanguageInput,
   UpdateLanguageOutput,
 } from './dto';
@@ -84,6 +85,17 @@ export class LanguageResolver {
         ? value ?? language.ethnologue.population.value
         : undefined,
     };
+  }
+
+  @ResolveField()
+  firstScripture(@Parent() language: Language): SecuredFirstScripture {
+    if (!language.hasExternalFirstScripture.canRead) {
+      return { canRead: false, canEdit: false };
+    }
+    const value = language.firstScriptureEngagement
+      ? { hasFirst: true, engagement: language.firstScriptureEngagement }
+      : { hasFirst: language.hasExternalFirstScripture.value! };
+    return { canRead: true, canEdit: false, value };
   }
 
   @ResolveField(() => SecuredLocationList)


### PR DESCRIPTION
This is allows this to be more easily accessed without having to go through all of the language's projects and all of the project's engagements.

Can be accessed like
```gql 
fragment Example on Language {
  firstScripture {
    canRead
    value {
      hasFirst
      ...on InternalFirstScripture {
        engagement {
          id
        }
      }
    }
  }
}
```