### PR TITLE
Get rid of security groups for listing fieldZone, film, fundingAccount, and language

### DIFF
--- a/src/components/authorization/authorization.service.ts
+++ b/src/components/authorization/authorization.service.ts
@@ -131,13 +131,15 @@ export class AuthorizationService {
     resource: Resource,
     props: DbPropsOfDto<Resource['prototype']>,
     sessionOrUserId: Session | ID,
-    otherRoles?: ScopedRole[]
+    otherRoles?: ScopedRole[],
+    sensitivity?: Sensitivity
   ): Promise<SecuredResource<Resource, false>> {
     const permissions = await this.getPermissions({
       resource,
       sessionOrUserId,
       otherRoles,
       dto: props,
+      sensitivity,
     });
     // @ts-expect-error not matching for some reason but declared return type is correct
     return parseSecuredProperties(props, permissions, resource.SecuredProps);

--- a/src/components/authorization/roles/administrator.role.ts
+++ b/src/components/authorization/roles/administrator.role.ts
@@ -191,6 +191,7 @@ export const Administrator = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, write, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, write, }, },

--- a/src/components/authorization/roles/administrator.role.ts
+++ b/src/components/authorization/roles/administrator.role.ts
@@ -148,6 +148,7 @@ export const Administrator = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, write, }, },
         { propertyName: 'scriptureReferences', permission: { read, write, }, },

--- a/src/components/authorization/roles/administrator.role.ts
+++ b/src/components/authorization/roles/administrator.role.ts
@@ -118,6 +118,7 @@ export const Administrator = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, write, }, },
         { propertyName: 'name', permission: { read, write, }, },

--- a/src/components/authorization/roles/administrator.role.ts
+++ b/src/components/authorization/roles/administrator.role.ts
@@ -157,6 +157,7 @@ export const Administrator = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, write, }, },
         { propertyName: 'accountNumber', permission: { read, write, }, },

--- a/src/components/authorization/roles/consultant-global.role.ts
+++ b/src/components/authorization/roles/consultant-global.role.ts
@@ -169,6 +169,7 @@ export const ConsultantGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: false,
       properties: [
         { propertyName: 'name', permission: {}, },
         { propertyName: 'accountNumber', permission: {}, },

--- a/src/components/authorization/roles/consultant-global.role.ts
+++ b/src/components/authorization/roles/consultant-global.role.ts
@@ -160,6 +160,7 @@ export const ConsultantGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/consultant-global.role.ts
+++ b/src/components/authorization/roles/consultant-global.role.ts
@@ -130,6 +130,7 @@ export const ConsultantGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/consultant-global.role.ts
+++ b/src/components/authorization/roles/consultant-global.role.ts
@@ -203,6 +203,7 @@ export const ConsultantGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/consultant-manager-global.role.ts
+++ b/src/components/authorization/roles/consultant-manager-global.role.ts
@@ -208,6 +208,7 @@ export const ConsultantManagerGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/consultant-manager-global.role.ts
+++ b/src/components/authorization/roles/consultant-manager-global.role.ts
@@ -165,6 +165,7 @@ export const ConsultantManagerGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/consultant-manager-global.role.ts
+++ b/src/components/authorization/roles/consultant-manager-global.role.ts
@@ -174,6 +174,7 @@ export const ConsultantManagerGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/consultant-manager-global.role.ts
+++ b/src/components/authorization/roles/consultant-manager-global.role.ts
@@ -135,6 +135,7 @@ export const ConsultantManagerGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/consultant-manager-on-project.role.ts
+++ b/src/components/authorization/roles/consultant-manager-on-project.role.ts
@@ -132,6 +132,7 @@ export const ConsultantManagerOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/consultant-manager-on-project.role.ts
+++ b/src/components/authorization/roles/consultant-manager-on-project.role.ts
@@ -171,6 +171,7 @@ export const ConsultantManagerOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/consultant-manager-on-project.role.ts
+++ b/src/components/authorization/roles/consultant-manager-on-project.role.ts
@@ -162,6 +162,7 @@ export const ConsultantManagerOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/consultant-manager-on-project.role.ts
+++ b/src/components/authorization/roles/consultant-manager-on-project.role.ts
@@ -205,6 +205,7 @@ export const ConsultantManagerOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/consultant-on-project.role.ts
+++ b/src/components/authorization/roles/consultant-on-project.role.ts
@@ -132,6 +132,7 @@ export const ConsultantOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/consultant-on-project.role.ts
+++ b/src/components/authorization/roles/consultant-on-project.role.ts
@@ -162,6 +162,7 @@ export const ConsultantOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/consultant-on-project.role.ts
+++ b/src/components/authorization/roles/consultant-on-project.role.ts
@@ -171,6 +171,7 @@ export const ConsultantOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: false,
       properties: [
         { propertyName: 'name', permission: {}, },
         { propertyName: 'accountNumber', permission: {}, },

--- a/src/components/authorization/roles/consultant-on-project.role.ts
+++ b/src/components/authorization/roles/consultant-on-project.role.ts
@@ -205,6 +205,7 @@ export const ConsultantOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/controller-global.role.ts
+++ b/src/components/authorization/roles/controller-global.role.ts
@@ -205,6 +205,7 @@ export const Controller = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/controller-global.role.ts
+++ b/src/components/authorization/roles/controller-global.role.ts
@@ -162,6 +162,7 @@ export const Controller = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, write, }, },
         { propertyName: 'scriptureReferences', permission: { read, write, }, },

--- a/src/components/authorization/roles/controller-global.role.ts
+++ b/src/components/authorization/roles/controller-global.role.ts
@@ -132,6 +132,7 @@ export const Controller = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/controller-global.role.ts
+++ b/src/components/authorization/roles/controller-global.role.ts
@@ -171,6 +171,7 @@ export const Controller = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/controller-on-project.role.ts
+++ b/src/components/authorization/roles/controller-on-project.role.ts
@@ -132,6 +132,7 @@ export const ControllerOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/controller-on-project.role.ts
+++ b/src/components/authorization/roles/controller-on-project.role.ts
@@ -171,6 +171,7 @@ export const ControllerOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/controller-on-project.role.ts
+++ b/src/components/authorization/roles/controller-on-project.role.ts
@@ -205,6 +205,7 @@ export const ControllerOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/controller-on-project.role.ts
+++ b/src/components/authorization/roles/controller-on-project.role.ts
@@ -162,6 +162,7 @@ export const ControllerOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, write, }, },
         { propertyName: 'scriptureReferences', permission: { read, write, }, },

--- a/src/components/authorization/roles/field-operations-director.role.ts
+++ b/src/components/authorization/roles/field-operations-director.role.ts
@@ -219,6 +219,7 @@ export const FieldOperationsDirector = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/field-operations-director.role.ts
+++ b/src/components/authorization/roles/field-operations-director.role.ts
@@ -185,6 +185,7 @@ export const FieldOperationsDirector = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/field-operations-director.role.ts
+++ b/src/components/authorization/roles/field-operations-director.role.ts
@@ -146,6 +146,7 @@ export const FieldOperationsDirector = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/field-operations-director.role.ts
+++ b/src/components/authorization/roles/field-operations-director.role.ts
@@ -176,6 +176,7 @@ export const FieldOperationsDirector = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, write, }, },
         { propertyName: 'scriptureReferences', permission: { read, write, }, },

--- a/src/components/authorization/roles/financial-analyst-global.role.ts
+++ b/src/components/authorization/roles/financial-analyst-global.role.ts
@@ -205,6 +205,7 @@ export const FinancialAnalyst = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/financial-analyst-global.role.ts
+++ b/src/components/authorization/roles/financial-analyst-global.role.ts
@@ -132,6 +132,7 @@ export const FinancialAnalyst = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/financial-analyst-global.role.ts
+++ b/src/components/authorization/roles/financial-analyst-global.role.ts
@@ -162,6 +162,7 @@ export const FinancialAnalyst = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/financial-analyst-global.role.ts
+++ b/src/components/authorization/roles/financial-analyst-global.role.ts
@@ -171,6 +171,7 @@ export const FinancialAnalyst = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/financial-analyst-on-project.role.ts
+++ b/src/components/authorization/roles/financial-analyst-on-project.role.ts
@@ -206,6 +206,7 @@ export const FinancialAnalystOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/financial-analyst-on-project.role.ts
+++ b/src/components/authorization/roles/financial-analyst-on-project.role.ts
@@ -163,6 +163,7 @@ export const FinancialAnalystOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/financial-analyst-on-project.role.ts
+++ b/src/components/authorization/roles/financial-analyst-on-project.role.ts
@@ -172,6 +172,7 @@ export const FinancialAnalystOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/financial-analyst-on-project.role.ts
+++ b/src/components/authorization/roles/financial-analyst-on-project.role.ts
@@ -133,6 +133,7 @@ export const FinancialAnalystOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/fundraising-global.role.ts
+++ b/src/components/authorization/roles/fundraising-global.role.ts
@@ -162,6 +162,7 @@ export const Fundraising = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/fundraising-global.role.ts
+++ b/src/components/authorization/roles/fundraising-global.role.ts
@@ -196,6 +196,7 @@ export const Fundraising = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/fundraising-global.role.ts
+++ b/src/components/authorization/roles/fundraising-global.role.ts
@@ -123,6 +123,7 @@ export const Fundraising = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/fundraising-global.role.ts
+++ b/src/components/authorization/roles/fundraising-global.role.ts
@@ -153,6 +153,7 @@ export const Fundraising = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/fundraising-on-project.role.ts
+++ b/src/components/authorization/roles/fundraising-on-project.role.ts
@@ -124,6 +124,7 @@ export const FundraisingOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/fundraising-on-project.role.ts
+++ b/src/components/authorization/roles/fundraising-on-project.role.ts
@@ -163,6 +163,7 @@ export const FundraisingOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/fundraising-on-project.role.ts
+++ b/src/components/authorization/roles/fundraising-on-project.role.ts
@@ -197,6 +197,7 @@ export const FundraisingOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/fundraising-on-project.role.ts
+++ b/src/components/authorization/roles/fundraising-on-project.role.ts
@@ -154,6 +154,7 @@ export const FundraisingOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/intern.role.ts
+++ b/src/components/authorization/roles/intern.role.ts
@@ -198,6 +198,7 @@ export const Intern = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/intern.role.ts
+++ b/src/components/authorization/roles/intern.role.ts
@@ -155,6 +155,7 @@ export const Intern = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, write, }, },
         { propertyName: 'scriptureReferences', permission: { read, write, }, },

--- a/src/components/authorization/roles/intern.role.ts
+++ b/src/components/authorization/roles/intern.role.ts
@@ -164,6 +164,7 @@ export const Intern = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/intern.role.ts
+++ b/src/components/authorization/roles/intern.role.ts
@@ -125,6 +125,7 @@ export const Intern = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/lead-financial-analyst-global.role.ts
+++ b/src/components/authorization/roles/lead-financial-analyst-global.role.ts
@@ -205,6 +205,7 @@ export const LeadFinancialAnalystGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/lead-financial-analyst-global.role.ts
+++ b/src/components/authorization/roles/lead-financial-analyst-global.role.ts
@@ -132,6 +132,7 @@ export const LeadFinancialAnalystGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/lead-financial-analyst-global.role.ts
+++ b/src/components/authorization/roles/lead-financial-analyst-global.role.ts
@@ -162,6 +162,7 @@ export const LeadFinancialAnalystGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/lead-financial-analyst-global.role.ts
+++ b/src/components/authorization/roles/lead-financial-analyst-global.role.ts
@@ -171,6 +171,7 @@ export const LeadFinancialAnalystGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/lead-financial-analyst-on-project.role.ts
+++ b/src/components/authorization/roles/lead-financial-analyst-on-project.role.ts
@@ -161,6 +161,7 @@ export const LeadFinancialAnalystOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/lead-financial-analyst-on-project.role.ts
+++ b/src/components/authorization/roles/lead-financial-analyst-on-project.role.ts
@@ -131,6 +131,7 @@ export const LeadFinancialAnalystOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/lead-financial-analyst-on-project.role.ts
+++ b/src/components/authorization/roles/lead-financial-analyst-on-project.role.ts
@@ -170,6 +170,7 @@ export const LeadFinancialAnalystOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/lead-financial-analyst-on-project.role.ts
+++ b/src/components/authorization/roles/lead-financial-analyst-on-project.role.ts
@@ -204,6 +204,7 @@ export const LeadFinancialAnalystOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/leadership.role.ts
+++ b/src/components/authorization/roles/leadership.role.ts
@@ -160,6 +160,7 @@ export const Leadership = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/leadership.role.ts
+++ b/src/components/authorization/roles/leadership.role.ts
@@ -151,6 +151,7 @@ export const Leadership = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/leadership.role.ts
+++ b/src/components/authorization/roles/leadership.role.ts
@@ -121,6 +121,7 @@ export const Leadership = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/leadership.role.ts
+++ b/src/components/authorization/roles/leadership.role.ts
@@ -194,6 +194,7 @@ export const Leadership = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/liaison.role.ts
+++ b/src/components/authorization/roles/liaison.role.ts
@@ -154,6 +154,7 @@ export const Liaison = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/liaison.role.ts
+++ b/src/components/authorization/roles/liaison.role.ts
@@ -163,6 +163,7 @@ export const Liaison = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: false,
       properties: [
         { propertyName: 'name', permission: {}, },
         { propertyName: 'accountNumber', permission: {}, },

--- a/src/components/authorization/roles/liaison.role.ts
+++ b/src/components/authorization/roles/liaison.role.ts
@@ -124,6 +124,7 @@ export const Liaison = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: false,
       properties: [
         { propertyName: 'director', permission: {}, },
         { propertyName: 'name', permission: {}, },

--- a/src/components/authorization/roles/liaison.role.ts
+++ b/src/components/authorization/roles/liaison.role.ts
@@ -197,6 +197,7 @@ export const Liaison = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/marketing-global.role.ts
+++ b/src/components/authorization/roles/marketing-global.role.ts
@@ -155,6 +155,7 @@ export const Marketing = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/marketing-global.role.ts
+++ b/src/components/authorization/roles/marketing-global.role.ts
@@ -198,6 +198,7 @@ export const Marketing = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/marketing-global.role.ts
+++ b/src/components/authorization/roles/marketing-global.role.ts
@@ -125,6 +125,7 @@ export const Marketing = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/marketing-global.role.ts
+++ b/src/components/authorization/roles/marketing-global.role.ts
@@ -164,6 +164,7 @@ export const Marketing = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/marketing-on-project.role.ts
+++ b/src/components/authorization/roles/marketing-on-project.role.ts
@@ -198,6 +198,7 @@ export const MarketingOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/marketing-on-project.role.ts
+++ b/src/components/authorization/roles/marketing-on-project.role.ts
@@ -155,6 +155,7 @@ export const MarketingOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/marketing-on-project.role.ts
+++ b/src/components/authorization/roles/marketing-on-project.role.ts
@@ -125,6 +125,7 @@ export const MarketingOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/marketing-on-project.role.ts
+++ b/src/components/authorization/roles/marketing-on-project.role.ts
@@ -164,6 +164,7 @@ export const MarketingOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/mentor.role.ts
+++ b/src/components/authorization/roles/mentor.role.ts
@@ -163,6 +163,7 @@ export const Mentor = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/mentor.role.ts
+++ b/src/components/authorization/roles/mentor.role.ts
@@ -124,6 +124,7 @@ export const Mentor = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: false,
       properties: [
         { propertyName: 'director', permission: {}, },
         { propertyName: 'name', permission: {}, },

--- a/src/components/authorization/roles/mentor.role.ts
+++ b/src/components/authorization/roles/mentor.role.ts
@@ -197,6 +197,7 @@ export const Mentor = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/mentor.role.ts
+++ b/src/components/authorization/roles/mentor.role.ts
@@ -154,6 +154,7 @@ export const Mentor = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/project-manager-global.role.ts
+++ b/src/components/authorization/roles/project-manager-global.role.ts
@@ -156,6 +156,7 @@ export const ProjectManagerGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, write, }, },
         { propertyName: 'scriptureReferences', permission: { read, write, }, },

--- a/src/components/authorization/roles/project-manager-global.role.ts
+++ b/src/components/authorization/roles/project-manager-global.role.ts
@@ -199,6 +199,7 @@ export const ProjectManagerGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/project-manager-global.role.ts
+++ b/src/components/authorization/roles/project-manager-global.role.ts
@@ -165,6 +165,7 @@ export const ProjectManagerGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/project-manager-global.role.ts
+++ b/src/components/authorization/roles/project-manager-global.role.ts
@@ -374,6 +374,7 @@ export const ProjectManagerGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, write, }, },
         { propertyName: 'name', permission: { read, write, }, },

--- a/src/components/authorization/roles/project-manager-on-project.role.ts
+++ b/src/components/authorization/roles/project-manager-on-project.role.ts
@@ -155,6 +155,7 @@ export const ProjectManagerOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, write, }, },
         { propertyName: 'scriptureReferences', permission: { read, write, }, },

--- a/src/components/authorization/roles/project-manager-on-project.role.ts
+++ b/src/components/authorization/roles/project-manager-on-project.role.ts
@@ -198,6 +198,7 @@ export const ProjectManagerOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/project-manager-on-project.role.ts
+++ b/src/components/authorization/roles/project-manager-on-project.role.ts
@@ -372,6 +372,7 @@ export const ProjectManagerOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, write, }, },
         { propertyName: 'name', permission: { read, write, }, },

--- a/src/components/authorization/roles/project-manager-on-project.role.ts
+++ b/src/components/authorization/roles/project-manager-on-project.role.ts
@@ -164,6 +164,7 @@ export const ProjectManagerOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/regional-communications-coordinator.role.ts
+++ b/src/components/authorization/roles/regional-communications-coordinator.role.ts
@@ -163,6 +163,7 @@ export const RegionalCommunicationsCoordinator = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: false,
       properties: [
         { propertyName: 'name', permission: {}, },
         { propertyName: 'accountNumber', permission: {}, },

--- a/src/components/authorization/roles/regional-communications-coordinator.role.ts
+++ b/src/components/authorization/roles/regional-communications-coordinator.role.ts
@@ -197,6 +197,7 @@ export const RegionalCommunicationsCoordinator = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/regional-communications-coordinator.role.ts
+++ b/src/components/authorization/roles/regional-communications-coordinator.role.ts
@@ -154,6 +154,7 @@ export const RegionalCommunicationsCoordinator = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/regional-communications-coordinator.role.ts
+++ b/src/components/authorization/roles/regional-communications-coordinator.role.ts
@@ -124,6 +124,7 @@ export const RegionalCommunicationsCoordinator = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: false,
       properties: [
         { propertyName: 'director', permission: {}, },
         { propertyName: 'name', permission: {}, },

--- a/src/components/authorization/roles/regional-director-global.role.ts
+++ b/src/components/authorization/roles/regional-director-global.role.ts
@@ -175,6 +175,7 @@ export const RegionalDirectorGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/regional-director-global.role.ts
+++ b/src/components/authorization/roles/regional-director-global.role.ts
@@ -184,6 +184,7 @@ export const RegionalDirectorGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/regional-director-global.role.ts
+++ b/src/components/authorization/roles/regional-director-global.role.ts
@@ -218,6 +218,7 @@ export const RegionalDirectorGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/regional-director-global.role.ts
+++ b/src/components/authorization/roles/regional-director-global.role.ts
@@ -145,6 +145,7 @@ export const RegionalDirectorGlobal = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/regional-director-on-project.role.ts
+++ b/src/components/authorization/roles/regional-director-on-project.role.ts
@@ -183,6 +183,7 @@ export const RegionalDirectorOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/regional-director-on-project.role.ts
+++ b/src/components/authorization/roles/regional-director-on-project.role.ts
@@ -217,6 +217,7 @@ export const RegionalDirectorOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/regional-director-on-project.role.ts
+++ b/src/components/authorization/roles/regional-director-on-project.role.ts
@@ -144,6 +144,7 @@ export const RegionalDirectorOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/regional-director-on-project.role.ts
+++ b/src/components/authorization/roles/regional-director-on-project.role.ts
@@ -174,6 +174,7 @@ export const RegionalDirectorOnProject = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, write, }, },
         { propertyName: 'scriptureReferences', permission: { read, write, }, },

--- a/src/components/authorization/roles/staff-member.role.ts
+++ b/src/components/authorization/roles/staff-member.role.ts
@@ -122,6 +122,7 @@ export const StaffMember = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: true,
       properties: [
         { propertyName: 'director', permission: { read, }, },
         { propertyName: 'name', permission: { read, }, },

--- a/src/components/authorization/roles/staff-member.role.ts
+++ b/src/components/authorization/roles/staff-member.role.ts
@@ -161,6 +161,7 @@ export const StaffMember = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'accountNumber', permission: { read, }, },

--- a/src/components/authorization/roles/staff-member.role.ts
+++ b/src/components/authorization/roles/staff-member.role.ts
@@ -195,6 +195,7 @@ export const StaffMember = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/authorization/roles/staff-member.role.ts
+++ b/src/components/authorization/roles/staff-member.role.ts
@@ -152,6 +152,7 @@ export const StaffMember = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/translator.role.ts
+++ b/src/components/authorization/roles/translator.role.ts
@@ -154,6 +154,7 @@ export const Translator = new DbRole({
     }),
     new DbBaseNodeGrant<DbFilm>({
       __className: 'DbFilm',
+      canList: true,
       properties: [
         { propertyName: 'name', permission: { read, }, },
         { propertyName: 'scriptureReferences', permission: { read, }, },

--- a/src/components/authorization/roles/translator.role.ts
+++ b/src/components/authorization/roles/translator.role.ts
@@ -124,6 +124,7 @@ export const Translator = new DbRole({
     }),
     new DbBaseNodeGrant<DbFieldZone>({
       __className: 'DbFieldZone',
+      canList: false,
       properties: [
         { propertyName: 'director', permission: {}, },
         { propertyName: 'name', permission: {}, },

--- a/src/components/authorization/roles/translator.role.ts
+++ b/src/components/authorization/roles/translator.role.ts
@@ -163,6 +163,7 @@ export const Translator = new DbRole({
     }),
     new DbBaseNodeGrant<DbFundingAccount>({
       __className: 'DbFundingAccount',
+      canList: false,
       properties: [
         { propertyName: 'name', permission: {}, },
         { propertyName: 'accountNumber', permission: {}, },

--- a/src/components/authorization/roles/translator.role.ts
+++ b/src/components/authorization/roles/translator.role.ts
@@ -197,6 +197,7 @@ export const Translator = new DbRole({
     }),
     new DbBaseNodeGrant<DbLanguage>({
       __className: 'DbLanguage',
+      canList: true,
       properties: [
         { propertyName: 'displayName', permission: { read, }, },
         { propertyName: 'displayNamePronunciation', permission: { read, }, },

--- a/src/components/field-zone/field-zone.repository.ts
+++ b/src/components/field-zone/field-zone.repository.ts
@@ -10,7 +10,6 @@ import {
   matchProps,
   merge,
   paginate,
-  permissionsOfNode,
   requestingUser,
   sorting,
 } from '../../core/database/query';
@@ -117,10 +116,10 @@ export class FieldZoneRepository extends DtoRepository(FieldZone) {
   }
 
   async list({ filter, ...input }: FieldZoneListInput, session: Session) {
-    const label = 'FieldZone';
     const result = await this.db
       .query()
-      .match([requestingUser(session), ...permissionsOfNode(label)])
+      .match(requestingUser(session))
+      .match(node('node', 'FieldZone'))
       .apply(sorting(FieldZone, input))
       .apply(paginate(input, this.hydrate()))
       .first();

--- a/src/components/field-zone/field-zone.service.ts
+++ b/src/components/field-zone/field-zone.service.ts
@@ -4,6 +4,7 @@ import {
   ID,
   NotFoundException,
   ObjectView,
+  SecuredList,
   ServerException,
   Session,
   UnauthorizedException,
@@ -141,7 +142,11 @@ export class FieldZoneService {
     input: FieldZoneListInput,
     session: Session
   ): Promise<FieldZoneListOutput> {
-    const results = await this.repo.list(input, session);
-    return await mapListResults(results, (dto) => this.secure(dto, session));
+    if (await this.authorizationService.canList(FieldZone, session)) {
+      const results = await this.repo.list(input, session);
+      return await mapListResults(results, (dto) => this.secure(dto, session));
+    } else {
+      return SecuredList.Redacted;
+    }
   }
 }

--- a/src/components/film/film.repository.ts
+++ b/src/components/film/film.repository.ts
@@ -5,7 +5,6 @@ import { DtoRepository, matchRequestingUser } from '../../core';
 import {
   createNode,
   paginate,
-  permissionsOfNode,
   requestingUser,
   sorting,
 } from '../../core/database/query';
@@ -62,7 +61,8 @@ export class FilmRepository extends DtoRepository(Film) {
   async list({ filter, ...input }: FilmListInput, session: Session) {
     const result = await this.db
       .query()
-      .match([requestingUser(session), ...permissionsOfNode('Film')])
+      .match(requestingUser(session))
+      .match(node('node', 'Film'))
       .apply(sorting(Film, input))
       .apply(paginate(input, this.hydrate()))
       .first();

--- a/src/components/film/film.service.ts
+++ b/src/components/film/film.service.ts
@@ -4,6 +4,7 @@ import {
   ID,
   NotFoundException,
   ObjectView,
+  SecuredList,
   ServerException,
   Session,
   UnauthorizedException,
@@ -151,7 +152,11 @@ export class FilmService {
   }
 
   async list(input: FilmListInput, session: Session): Promise<FilmListOutput> {
-    const results = await this.repo.list(input, session);
-    return await mapListResults(results, (dto) => this.secure(dto, session));
+    if (await this.authorizationService.canList(Film, session)) {
+      const results = await this.repo.list(input, session);
+      return await mapListResults(results, (dto) => this.secure(dto, session));
+    } else {
+      return SecuredList.Redacted;
+    }
   }
 }

--- a/src/components/funding-account/funding-account.repository.ts
+++ b/src/components/funding-account/funding-account.repository.ts
@@ -5,7 +5,6 @@ import { DtoRepository, matchRequestingUser } from '../../core';
 import {
   createNode,
   paginate,
-  permissionsOfNode,
   requestingUser,
   sorting,
 } from '../../core/database/query';
@@ -66,10 +65,10 @@ export class FundingAccountRepository extends DtoRepository(FundingAccount) {
   }
 
   async list(input: FundingAccountListInput, session: Session) {
-    const label = 'FundingAccount';
     const result = await this.db
       .query()
-      .match([requestingUser(session), ...permissionsOfNode(label)])
+      .match(requestingUser(session))
+      .match(node('node', 'FundingAccount'))
       .apply(sorting(FundingAccount, input))
       .apply(paginate(input, this.hydrate()))
       .first();

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -4,6 +4,7 @@ import {
   ID,
   NotFoundException,
   ObjectView,
+  SecuredList,
   ServerException,
   Session,
   UnauthorizedException,
@@ -147,7 +148,11 @@ export class FundingAccountService {
     input: FundingAccountListInput,
     session: Session
   ): Promise<FundingAccountListOutput> {
-    const results = await this.repo.list(input, session);
-    return await mapListResults(results, (dto) => this.secure(dto, session));
+    if (await this.authorizationService.canList(FundingAccount, session)) {
+      const results = await this.repo.list(input, session);
+      return await mapListResults(results, (dto) => this.secure(dto, session));
+    } else {
+      return SecuredList.Redacted;
+    }
   }
 }

--- a/src/components/language/dto/language.dto.ts
+++ b/src/components/language/dto/language.dto.ts
@@ -171,6 +171,9 @@ export class Language extends Resource {
     `,
   })
   readonly presetInventory: SecuredBoolean;
+
+  // Not returned, only used to cache the sensitivity for determining permissions
+  readonly effectiveSensitivity: Sensitivity;
 }
 
 @ObjectType({

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -9,14 +9,18 @@ import {
   createNode,
   createRelationships,
   exp,
+  matchProjectScopedRoles,
+  matchProjectSens,
+  matchProjectSensToLimitedScopeMap,
   matchProps,
   merge,
   paginate,
-  permissionsOfNode,
+  rankSens,
   requestingUser,
   sorting,
   variable,
 } from '../../core/database/query';
+import { AuthSensitivityMapping } from '../authorization/authorization.service';
 import { ProjectStatus } from '../project';
 import { CreateLanguage, Language, LanguageListInput } from './dto';
 import { languageListFilter } from './query.helpers';
@@ -61,7 +65,7 @@ export class LanguageRepository extends DtoRepository(Language) {
       .query()
       .apply(matchRequestingUser(session))
       .match([node('node', 'Language', { id: langId })])
-      .apply(this.hydrate());
+      .apply(this.hydrate(session));
 
     const result = await query.first();
     if (!result) {
@@ -76,15 +80,45 @@ export class LanguageRepository extends DtoRepository(Language) {
       .apply(matchRequestingUser(session))
       .matchNode('node', 'Language')
       .where({ 'node.id': inArray(ids.slice()) })
-      .apply(this.hydrate())
+      .apply(this.hydrate(session))
       .map('dto')
       .run();
   }
 
-  protected hydrate() {
+  protected hydrate(session: Session) {
     return (query: Query) =>
       query
         .apply(matchProps())
+        .optionalMatch([
+          node('project', 'Project'),
+          relation('out', '', 'engagement', ACTIVE),
+          node('', 'LanguageEngagement'),
+          relation('out', '', 'engagement'),
+          node('node'),
+        ])
+        .apply(matchProjectScopedRoles({ session }))
+        .with([
+          'props',
+          'node',
+          'collect(project) as projList',
+          'keys(apoc.coll.frequenciesAsMap(apoc.coll.flatten(collect(scopedRoles)))) as scopedRoles',
+        ])
+        // get lowest sensitivity across all projects associated with each language.
+        .subQuery((sub) =>
+          sub
+            .with('projList')
+            .raw('UNWIND projList as project')
+            .apply(matchProjectSens())
+            .with('sensitivity')
+            .orderBy(rankSens('sensitivity'), 'ASC')
+            .raw('LIMIT 1')
+            .return('sensitivity as effectiveSensitivity')
+            .union()
+            .with('projList, props')
+            .with('projList, props')
+            .raw('WHERE size(projList) = 0')
+            .return(`props.sensitivity as effectiveSensitivity`)
+        )
         .match([
           node('node'),
           relation('out', '', 'ethnologue'),
@@ -104,17 +138,35 @@ export class LanguageRepository extends DtoRepository(Language) {
             ethnologue: 'ethProps',
             presetInventory: 'presetInventory',
             firstScriptureEngagement: 'firstScriptureEngagement.id',
+            scope: 'scopedRoles',
           }).as('dto')
         );
   }
 
-  async list(input: LanguageListInput, session: Session) {
+  async list(
+    input: LanguageListInput,
+    session: Session,
+    limitedScope?: AuthSensitivityMapping
+  ) {
     const result = await this.db
       .query()
-      .match([requestingUser(session), ...permissionsOfNode('Language')])
+      .match([
+        ...(limitedScope
+          ? [
+              node('project', 'Project'),
+              relation('out', '', 'engagement', ACTIVE),
+              node('', 'LanguageEngagement'),
+              relation('out', '', 'engagement'),
+            ]
+          : []),
+        node('node', 'Language'),
+      ])
+      // match requesting user once (instead of once per row)
+      .match(requestingUser(session))
+      .apply(matchProjectSensToLimitedScopeMap(limitedScope))
       .apply(languageListFilter(input.filter, this))
       .apply(sorting(Language, input))
-      .apply(paginate(input, this.hydrate()))
+      .apply(paginate(input, this.hydrate(session)))
       .first();
     return result!; // result from paginate() will always have 1 row.
   }

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -127,7 +127,9 @@ export class LanguageService {
     const securedProps = await this.authorizationService.secureProperties(
       Language,
       dto,
-      session
+      session,
+      undefined,
+      dto.effectiveSensitivity
     );
 
     const ethnologue = await this.ethnologueLanguageService.secure(
@@ -207,7 +209,10 @@ export class LanguageService {
     input: LanguageListInput,
     session: Session
   ): Promise<LanguageListOutput> {
-    const results = await this.repo.list(input, session);
+    const limited = (await this.authorizationService.canList(Language, session))
+      ? undefined
+      : await this.authorizationService.getListRoleSensitivityMapping(Language);
+    const results = await this.repo.list(input, session, limited);
     return await mapListResults(results, (dto) => this.secure(dto, session));
   }
 

--- a/test/security/fieldZone.security.ts
+++ b/test/security/fieldZone.security.ts
@@ -1,0 +1,112 @@
+import { Connection } from 'cypher-query-builder';
+import { Powers, Role } from '../../src/components/authorization';
+import { FieldZone } from '../../src/components/field-zone';
+import {
+  createSession,
+  createTestApp,
+  createZone,
+  listFieldZones,
+  readOneZone,
+  registerUser,
+  registerUserWithPower,
+  runInIsolatedSession,
+  TestApp,
+} from '../utility';
+import { resetDatabase } from '../utility/reset-database';
+import { testRole } from '../utility/roles';
+
+describe('Partnership Security e2e', () => {
+  let app: TestApp;
+  let db: Connection;
+  let testFieldZone: FieldZone;
+  beforeAll(async () => {
+    app = await createTestApp();
+    db = app.get(Connection);
+    await createSession(app);
+    await registerUserWithPower(app, [
+      Powers.CreateFieldZone,
+      Powers.CreateProject,
+    ]);
+    testFieldZone = await createZone(app);
+  });
+
+  afterAll(async () => {
+    await resetDatabase(db);
+    await app.close();
+  });
+
+  describe('Restricted by role', () => {
+    describe.each`
+      role
+      ${Role.Administrator}
+      ${Role.Consultant}
+      ${Role.ConsultantManager}
+      ${Role.Controller}
+      ${Role.FieldOperationsDirector}
+      ${Role.FinancialAnalyst}
+      ${Role.Fundraising}
+      ${Role.Intern}
+      ${Role.LeadFinancialAnalyst}
+      ${Role.Leadership}
+      ${Role.Liaison}
+      ${Role.Marketing}
+      ${Role.Mentor}
+      ${Role.ProjectManager}
+      ${Role.RegionalCommunicationsCoordinator}
+    `('Global $role', ({ role }) => {
+      test.each`
+        property      | readFunction   | staticResource
+        ${'director'} | ${readOneZone} | ${FieldZone}
+        ${'name'}     | ${readOneZone} | ${FieldZone}
+      `(
+        ' reading $staticResource.name $property',
+        async ({ property, readFunction, staticResource }) => {
+          await testRole({
+            app: app,
+            resource: testFieldZone,
+            staticResource: staticResource,
+            role: role,
+            readOneFunction: readFunction,
+            propToTest: property,
+            skipEditCheck: false,
+          });
+        }
+      );
+    });
+  });
+  describe('Listing is secure', () => {
+    describe.each`
+      role                                      | globalCanList
+      ${Role.Administrator}                     | ${true}
+      ${Role.Consultant}                        | ${true}
+      ${Role.ConsultantManager}                 | ${true}
+      ${Role.Controller}                        | ${true}
+      ${Role.FieldOperationsDirector}           | ${true}
+      ${Role.FinancialAnalyst}                  | ${true}
+      ${Role.Fundraising}                       | ${true}
+      ${Role.Intern}                            | ${true}
+      ${Role.LeadFinancialAnalyst}              | ${true}
+      ${Role.Leadership}                        | ${true}
+      ${Role.Liaison}                           | ${false}
+      ${Role.Marketing}                         | ${true}
+      ${Role.Mentor}                            | ${false}
+      ${Role.ProjectManager}                    | ${true}
+      ${Role.RegionalCommunicationsCoordinator} | ${false}
+      ${Role.RegionalDirector}                  | ${true}
+      ${Role.StaffMember}                       | ${true}
+      ${Role.Translator}                        | ${false}
+    `('$role', ({ role, globalCanList }) => {
+      it(`Global canList: ${globalCanList as string}`, async () => {
+        const read = await runInIsolatedSession(app, async () => {
+          await registerUser(app, { roles: role });
+          return await listFieldZones(app);
+        });
+        if (!globalCanList) {
+          expect(read).toHaveLength(0);
+        } else {
+          expect(read).not.toHaveLength(0);
+        }
+      });
+    });
+  });
+});

--- a/test/security/film.security.ts
+++ b/test/security/film.security.ts
@@ -1,0 +1,109 @@
+import { Connection } from 'cypher-query-builder';
+import { Powers, Role } from '../../src/components/authorization';
+import { Film } from '../../src/components/film';
+import {
+  createFilm,
+  createSession,
+  createTestApp,
+  listFilms,
+  readOneFilm,
+  registerUser,
+  registerUserWithPower,
+  runInIsolatedSession,
+  TestApp,
+} from '../utility';
+import { resetDatabase } from '../utility/reset-database';
+import { testRole } from '../utility/roles';
+
+describe('Film Security e2e', () => {
+  let app: TestApp;
+  let db: Connection;
+  let testFilm: Film;
+  beforeAll(async () => {
+    app = await createTestApp();
+    db = app.get(Connection);
+    await createSession(app);
+    await registerUserWithPower(app, [Powers.CreateFilm, Powers.CreateProject]);
+    testFilm = await createFilm(app);
+  });
+
+  afterAll(async () => {
+    await resetDatabase(db);
+    await app.close();
+  });
+
+  describe('Restricted by role', () => {
+    describe.each`
+      role
+      ${Role.Administrator}
+      ${Role.Consultant}
+      ${Role.ConsultantManager}
+      ${Role.Controller}
+      ${Role.FieldOperationsDirector}
+      ${Role.FinancialAnalyst}
+      ${Role.Fundraising}
+      ${Role.Intern}
+      ${Role.LeadFinancialAnalyst}
+      ${Role.Leadership}
+      ${Role.Liaison}
+      ${Role.Marketing}
+      ${Role.Mentor}
+      ${Role.ProjectManager}
+      ${Role.RegionalCommunicationsCoordinator}
+    `('Global $role', ({ role }) => {
+      test.each`
+        property                 | readFunction   | staticResource
+        ${'scriptureReferences'} | ${readOneFilm} | ${Film}
+        ${'name'}                | ${readOneFilm} | ${Film}
+      `(
+        ' reading $staticResource.name $property',
+        async ({ property, readFunction, staticResource }) => {
+          await testRole({
+            app: app,
+            resource: testFilm,
+            staticResource: staticResource,
+            role: role,
+            readOneFunction: readFunction,
+            propToTest: property,
+            skipEditCheck: false,
+          });
+        }
+      );
+    });
+  });
+  describe('Listing is secure', () => {
+    describe.each`
+      role                                      | globalCanList
+      ${Role.Administrator}                     | ${true}
+      ${Role.Consultant}                        | ${true}
+      ${Role.ConsultantManager}                 | ${true}
+      ${Role.Controller}                        | ${true}
+      ${Role.FieldOperationsDirector}           | ${true}
+      ${Role.FinancialAnalyst}                  | ${true}
+      ${Role.Fundraising}                       | ${true}
+      ${Role.Intern}                            | ${true}
+      ${Role.LeadFinancialAnalyst}              | ${true}
+      ${Role.Leadership}                        | ${true}
+      ${Role.Liaison}                           | ${true}
+      ${Role.Marketing}                         | ${true}
+      ${Role.Mentor}                            | ${true}
+      ${Role.ProjectManager}                    | ${true}
+      ${Role.RegionalCommunicationsCoordinator} | ${true}
+      ${Role.RegionalDirector}                  | ${true}
+      ${Role.StaffMember}                       | ${true}
+      ${Role.Translator}                        | ${true}
+    `('$role', ({ role, globalCanList }) => {
+      it(`Global canList: ${globalCanList as string}`, async () => {
+        const read = await runInIsolatedSession(app, async () => {
+          await registerUser(app, { roles: role });
+          return await listFilms(app);
+        });
+        if (!globalCanList) {
+          expect(read).toHaveLength(0);
+        } else {
+          expect(read).not.toHaveLength(0);
+        }
+      });
+    });
+  });
+});

--- a/test/security/fundingAccount.security.ts
+++ b/test/security/fundingAccount.security.ts
@@ -1,0 +1,112 @@
+import { Connection } from 'cypher-query-builder';
+import { Powers, Role } from '../../src/components/authorization';
+import { FundingAccount } from '../../src/components/funding-account';
+import {
+  createFundingAccount,
+  createSession,
+  createTestApp,
+  listFundingAccounts,
+  readOneFundingAccount,
+  registerUser,
+  registerUserWithPower,
+  runInIsolatedSession,
+  TestApp,
+} from '../utility';
+import { resetDatabase } from '../utility/reset-database';
+import { testRole } from '../utility/roles';
+
+describe('Funding Account Security e2e', () => {
+  let app: TestApp;
+  let db: Connection;
+  let testFundingAccount: FundingAccount;
+  beforeAll(async () => {
+    app = await createTestApp();
+    db = app.get(Connection);
+    await createSession(app);
+    await registerUserWithPower(app, [
+      Powers.CreateFundingAccount,
+      Powers.CreateProject,
+    ]);
+    testFundingAccount = await createFundingAccount(app);
+  });
+
+  afterAll(async () => {
+    await resetDatabase(db);
+    await app.close();
+  });
+
+  describe('Restricted by role', () => {
+    describe.each`
+      role
+      ${Role.Administrator}
+      ${Role.Consultant}
+      ${Role.ConsultantManager}
+      ${Role.Controller}
+      ${Role.FieldOperationsDirector}
+      ${Role.FinancialAnalyst}
+      ${Role.Fundraising}
+      ${Role.Intern}
+      ${Role.LeadFinancialAnalyst}
+      ${Role.Leadership}
+      ${Role.Liaison}
+      ${Role.Marketing}
+      ${Role.Mentor}
+      ${Role.ProjectManager}
+      ${Role.RegionalCommunicationsCoordinator}
+    `('Global $role', ({ role }) => {
+      test.each`
+        property           | readFunction             | staticResource
+        ${'accountNumber'} | ${readOneFundingAccount} | ${FundingAccount}
+        ${'name'}          | ${readOneFundingAccount} | ${FundingAccount}
+      `(
+        ' reading $staticResource.name $property',
+        async ({ property, readFunction, staticResource }) => {
+          await testRole({
+            app: app,
+            resource: testFundingAccount,
+            staticResource: staticResource,
+            role: role,
+            readOneFunction: readFunction,
+            propToTest: property,
+            skipEditCheck: false,
+          });
+        }
+      );
+    });
+  });
+  describe('Listing is secure', () => {
+    describe.each`
+      role                                      | globalCanList
+      ${Role.Administrator}                     | ${true}
+      ${Role.Consultant}                        | ${false}
+      ${Role.ConsultantManager}                 | ${true}
+      ${Role.Controller}                        | ${true}
+      ${Role.FieldOperationsDirector}           | ${true}
+      ${Role.FinancialAnalyst}                  | ${true}
+      ${Role.Fundraising}                       | ${true}
+      ${Role.Intern}                            | ${true}
+      ${Role.LeadFinancialAnalyst}              | ${true}
+      ${Role.Leadership}                        | ${true}
+      ${Role.Liaison}                           | ${false}
+      ${Role.Marketing}                         | ${true}
+      ${Role.Mentor}                            | ${true}
+      ${Role.ProjectManager}                    | ${true}
+      ${Role.RegionalCommunicationsCoordinator} | ${false}
+      ${Role.RegionalDirector}                  | ${true}
+      ${Role.StaffMember}                       | ${true}
+      ${Role.Translator}                        | ${false}
+    `('$role', ({ role, globalCanList }) => {
+      it(`Global canList: ${globalCanList as string}`, async () => {
+        const read = await runInIsolatedSession(app, async () => {
+          await registerUser(app, { roles: role });
+          return await listFundingAccounts(app);
+        });
+        if (!globalCanList) {
+          expect(read).toHaveLength(0);
+        } else {
+          expect(read).not.toHaveLength(0);
+        }
+      });
+    });
+  });
+});

--- a/test/utility/create-film.ts
+++ b/test/utility/create-film.ts
@@ -4,6 +4,41 @@ import { CreateFilm, Film } from '../../src/components/film';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
 
+export async function listFilms(app: TestApp) {
+  const result = await app.graphql.mutate(
+    gql`
+      query {
+        films(input: {}) {
+          items {
+            ...film
+          }
+        }
+      }
+      ${fragments.film}
+    `
+  );
+  const films = result.films.items;
+  expect(films).toBeTruthy();
+  return films;
+}
+
+export async function readOneFilm(app: TestApp, id: string) {
+  const result = await app.graphql.query(
+    gql`
+      query readOneFilm($id: ID!) {
+        film(id: $id) {
+          ...film
+        }
+      }
+      ${fragments.film}
+    `,
+    { id }
+  );
+  const actual = result.film;
+  expect(actual).toBeTruthy();
+  return actual;
+}
+
 export async function createFilm(
   app: TestApp,
   input: Partial<CreateFilm> = {}

--- a/test/utility/create-funding-account.ts
+++ b/test/utility/create-funding-account.ts
@@ -7,6 +7,41 @@ import {
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
 
+export async function listFundingAccounts(app: TestApp) {
+  const result = await app.graphql.mutate(
+    gql`
+      query {
+        fundingAccounts(input: {}) {
+          items {
+            ...fundingAccount
+          }
+        }
+      }
+      ${fragments.fundingAccount}
+    `
+  );
+  const fundingAccounts = result.fundingAccounts.items;
+  expect(fundingAccounts).toBeTruthy();
+  return fundingAccounts;
+}
+
+export async function readOneFundingAccount(app: TestApp, id: string) {
+  const result = await app.graphql.query(
+    gql`
+      query readOneFundingAccount($id: ID!) {
+        fundingAccount(id: $id) {
+          ...fundingAccount
+        }
+      }
+      ${fragments.fundingAccount}
+    `,
+    { id }
+  );
+  const actual = result.fundingAccount;
+  expect(actual).toBeTruthy();
+  return actual;
+}
+
 export async function createFundingAccount(
   app: TestApp,
   input: Partial<CreateFundingAccount> = {}

--- a/test/utility/create-language.ts
+++ b/test/utility/create-language.ts
@@ -10,6 +10,23 @@ import { SecuredLocationList } from '../../src/components/location';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
 
+export async function listLanguageIds(app: TestApp) {
+  const result = await app.graphql.mutate(
+    gql`
+      query {
+        languages(input: {}) {
+          items {
+            id
+          }
+        }
+      }
+    `
+  );
+  const languages = result.languages.items;
+  expect(languages).toBeTruthy();
+  return languages;
+}
+
 export async function readOneLanguageLocation(
   app: TestApp,
   langId: string

--- a/test/utility/create-zone.ts
+++ b/test/utility/create-zone.ts
@@ -5,6 +5,41 @@ import { CreateFieldZone, FieldZone } from '../../src/components/field-zone';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
 
+export async function listFieldZones(app: TestApp) {
+  const result = await app.graphql.mutate(
+    gql`
+      query {
+        fieldZones(input: {}) {
+          items {
+            ...fieldZone
+          }
+        }
+      }
+      ${fragments.fieldZone}
+    `
+  );
+  const zones = result.fieldZones.items;
+  expect(zones).toBeTruthy();
+  return zones;
+}
+
+export async function readOneZone(app: TestApp, id: string) {
+  const result = await app.graphql.query(
+    gql`
+      query readOneZone($id: ID!) {
+        fieldZone(id: $id) {
+          ...fieldZone
+        }
+      }
+      ${fragments.fieldZone}
+    `,
+    { id }
+  );
+  const actual = result.fieldZone;
+  expect(actual).toBeTruthy();
+  return actual;
+}
+
 export async function createZone(
   app: TestApp,
   input: Partial<CreateFieldZone> = {}

--- a/test/utility/fragments.ts
+++ b/test/utility/fragments.ts
@@ -882,6 +882,10 @@ export const fieldZone = gql`
   fragment fieldZone on FieldZone {
     id
     createdAt
+    director {
+      canRead
+      canEdit
+    }
     name {
       value
       canEdit


### PR DESCRIPTION
Also, refactor the language hydrate() function to check all associated projects for lowest sensitivity and return an `effectiveSensitivity` that is used to determine security for the language component. Needed `effectiveSensitivity` because we also need to return the Language's sensitivity prop.