### PR TITLE
Merge Scripture labels & testaments

### DIFF
--- a/src/components/scripture/labels.ts
+++ b/src/components/scripture/labels.ts
@@ -1,4 +1,5 @@
 import { uniq } from 'lodash';
+import { Range } from '../../common';
 import { Verse } from './books';
 import { mapRange, ScriptureRange, ScriptureReference } from './dto';
 
@@ -79,6 +80,11 @@ export const labelOfScriptureRanges = (refs: readonly ScriptureRange[]) => {
   if (refs.length === 1) {
     return labelOfScriptureRange(refs[0]);
   }
+  refs = mergeScriptureRanges(refs);
+  if (refs.length === 1) {
+    return labelOfScriptureRange(refs[0]);
+  }
+
   const hasSame = (key: keyof ScriptureReference) =>
     uniq(refs.flatMap((ref) => [ref.start[key], ref.end[key]])).length === 1;
   const same = hasSame('book')
@@ -98,4 +104,45 @@ export const labelOfScriptureRanges = (refs: readonly ScriptureRange[]) => {
     prefix += ' ';
   }
   return `${prefix}${labels}`;
+};
+
+/**
+ * Merges ScriptureRanges into a equivalent minimal set of ScriptureRanges.
+ * Combines overlapping and adjacent ScriptureRanges.
+ * Also sorts them.
+ */
+export const mergeScriptureRanges = (
+  ranges: readonly ScriptureRange[]
+): readonly ScriptureRange[] => {
+  // Adapted from Luxon's Interval.merge logic
+  const [found, final] = ranges
+    .map(ScriptureRange.fromReferences)
+    .sort((a, b) => a.start - b.start)
+    .reduce(
+      ([sofar, current], item) => {
+        if (!current) {
+          return [sofar, item];
+        }
+        // if current overlaps item or current's end is adjacent to item's start
+        if (
+          (current.end > item.start && current.start < item.end) ||
+          current.end === item.start - 1
+        ) {
+          return [
+            sofar,
+            // Merge current & item
+            {
+              start: current.start < item.start ? current.start : item.start,
+              end: current.end > item.end ? current.end : item.end,
+            },
+          ];
+        }
+        return [[...sofar, current], item];
+      },
+      [[], null] as [Array<Range<number>>, Range<number> | null]
+    );
+  if (final) {
+    found.push(final);
+  }
+  return found.map(ScriptureRange.fromIds);
 };


### PR DESCRIPTION
When labeling scripture ranges we now merge the ranges to an equivalent minimal set before hand.
Scripture range label now accounts for complete testaments as well.

# Exhibit A
### Before
![Screen Shot 2021-10-14 at 2 16 40 PM](https://user-images.githubusercontent.com/932566/137381853-99210249-8c6d-483e-92b2-a5b78ba1e801.png)
### After
![Screen Shot 2021-10-14 at 2 15 18 PM](https://user-images.githubusercontent.com/932566/137381856-7c189df5-c351-40f3-a6ac-8c95a7818adc.png)

# Exhibit B
### Before
![Screen Shot 2021-10-14 at 2 20 54 PM](https://user-images.githubusercontent.com/932566/137382084-3e08ebf8-eb9a-40a1-8968-0af29d25d670.png)
### After
![Screen Shot 2021-10-14 at 2 32 00 PM](https://user-images.githubusercontent.com/932566/137383421-d587f5bc-f81d-4eae-bbf7-eee9ff069e5a.png)
