### PR TITLE
Expose periodic report's parent relation

### DIFF
--- a/src/components/periodic-report/periodic-report-parent.resolver.ts
+++ b/src/components/periodic-report/periodic-report-parent.resolver.ts
@@ -1,0 +1,25 @@
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Resource } from '../../common';
+import { Loader, LoaderOf } from '../../core';
+import { EngagementLoader } from '../engagement';
+import { IPeriodicReport, PeriodicReport } from '../periodic-report';
+import { ProjectLoader } from '../project';
+
+@Resolver(IPeriodicReport)
+export class PeriodicReportParentResolver {
+  @ResolveField(() => Resource)
+  async parent(
+    @Parent() report: PeriodicReport,
+    @Loader(ProjectLoader) projects: LoaderOf<ProjectLoader>,
+    @Loader(EngagementLoader) engagements: LoaderOf<EngagementLoader>
+  ) {
+    // Currently Periodic Reports can only be attached to a Project or Engagement
+    return await (report.parent.labels.includes('Project')
+      ? projects
+      : engagements
+    ).load({
+      id: report.parent.properties.id,
+      view: { active: true },
+    });
+  }
+}

--- a/src/components/periodic-report/periodic-report.module.ts
+++ b/src/components/periodic-report/periodic-report.module.ts
@@ -6,11 +6,13 @@ import { ProjectModule } from '../project/project.module';
 import * as handlers from './handlers';
 import * as migrations from './migrations';
 import { PeriodicReportEngagementConnectionResolver } from './periodic-report-engagement-connection.resolver';
+import { PeriodicReportParentResolver } from './periodic-report-parent.resolver';
 import { PeriodicReportProjectConnectionResolver } from './periodic-report-project-connection.resolver';
 import { PeriodicReportLoader } from './periodic-report.loader';
 import { PeriodicReportRepository } from './periodic-report.repository';
 import { PeriodicReportResolver } from './periodic-report.resolver';
 import { PeriodicReportService } from './periodic-report.service';
+import { ProgressReportParentResolver } from './progress-report-parent.resolver';
 
 @Module({
   imports: [
@@ -24,6 +26,8 @@ import { PeriodicReportService } from './periodic-report.service';
     PeriodicReportResolver,
     PeriodicReportProjectConnectionResolver,
     PeriodicReportEngagementConnectionResolver,
+    PeriodicReportParentResolver,
+    ProgressReportParentResolver,
     PeriodicReportRepository,
     PeriodicReportLoader,
     ...Object.values(handlers),

--- a/src/components/periodic-report/progress-report-parent.resolver.ts
+++ b/src/components/periodic-report/progress-report-parent.resolver.ts
@@ -1,0 +1,19 @@
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Loader, LoaderOf } from '../../core';
+import { Engagement, EngagementLoader } from '../engagement';
+import { LanguageEngagement } from '../engagement/dto';
+import { ProgressReport } from '../periodic-report';
+
+@Resolver(ProgressReport)
+export class ProgressReportParentResolver {
+  @ResolveField(() => LanguageEngagement)
+  async parent(
+    @Parent() report: ProgressReport,
+    @Loader(EngagementLoader) engagements: LoaderOf<EngagementLoader>
+  ): Promise<Engagement> {
+    return await engagements.load({
+      id: report.parent.properties.id,
+      view: { active: true },
+    });
+  }
+}


### PR DESCRIPTION
This will help with the push to change to only need a single ID to lookup reports