### PR TITLE
Fix product extraction not creating when there are multiple new products

### DIFF
--- a/src/components/product/product-extractor.service.ts
+++ b/src/components/product/product-extractor.service.ts
@@ -26,7 +26,7 @@ export class ProductExtractor {
   async extract(
     file: Downloadable<Pick<File, 'id'>>,
     availableSteps: readonly Step[]
-  ) {
+  ): Promise<readonly ExtractedRow[]> {
     const buffer = await file.download();
     const pnp = read(buffer, { type: 'buffer', cellDates: true });
 
@@ -128,7 +128,7 @@ const parseProductRow =
     stepColumns: Record<Step, string>,
     noteFallback?: string
   ) =>
-  (row: number) => {
+  (row: number): ExtractedRow => {
     const bookName = cellAsString(sheet[`Q${row}`])!; // Asserting bc loop verified this
     const totalVerses = cellAsNumber(sheet[`T${row}`])!;
     // include step if it references a fiscal year within the project
@@ -144,3 +144,10 @@ const parseProductRow =
     const note = cellAsString(sheet[`AI${row}`]) ?? noteFallback;
     return { bookName, totalVerses, steps, note };
   };
+
+export interface ExtractedRow {
+  bookName: string;
+  totalVerses: number;
+  steps: readonly Step[];
+  note: string | undefined;
+}

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -1,12 +1,5 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
-import {
-  has as hasPath,
-  intersection,
-  isEqual,
-  set,
-  sumBy,
-  uniq,
-} from 'lodash';
+import { intersection, isEqual, sumBy, uniq } from 'lodash';
 import {
   has,
   ID,
@@ -598,7 +591,7 @@ export class ProductService {
     const productRefs = await this.repo.listIdsAndScriptureRefs(engagementId);
 
     const productIds: {
-      [Book in string]?: { [TotalVerses in number | string]?: ID };
+      [Book in string]?: Map<number, ID>;
     } = {};
 
     for (const productRef of productRefs) {
@@ -630,14 +623,17 @@ export class ProductService {
       }
       const book: string = books[0];
 
-      if (hasPath(productIds, [book, totalVerses])) {
+      if (productIds[book]?.has(totalVerses)) {
         warn(
           'Product references a book & verse count that has already been assigned to another product'
         );
         continue;
       }
 
-      set(productIds, [book, totalVerses], productRef.id);
+      (productIds[book] ?? (productIds[book] = new Map())).set(
+        totalVerses,
+        productRef.id
+      );
     }
 
     return productIds;


### PR DESCRIPTION
- We'd give up previously when we finding multiple rows of same book. Now we create products for these rows as long as there's not any other products for these books that haven't already been matched to existing total verses.
- We also still handle a single row that has changed the total verse count, but now this works with multiple rows of the same book as long as the other rows have matched their totals exactly.
  So `[14 verses of Mark, 20 verses of Mark]` can change to `[14 verses of Mark, 30 verses of Mark]`.