### PR TITLE
Fix split scripture spanning multiple books migration

### DIFF
--- a/src/core/database/migration/migration-discovery.service.ts
+++ b/src/core/database/migration/migration-discovery.service.ts
@@ -1,6 +1,6 @@
 import { DiscoveryService } from '@golevelup/nestjs-discovery';
 import { Injectable } from '@nestjs/common';
-import { startCase } from 'lodash';
+import { sortBy, startCase } from 'lodash';
 import { DateTime } from 'luxon';
 import { BaseMigration } from './base-migration.service';
 import { DB_MIGRATION_KEY } from './migration.decorator';
@@ -13,7 +13,7 @@ export class MigrationDiscovery {
     const discovered = await this.discover.providersWithMetaAtKey<DateTime>(
       DB_MIGRATION_KEY
     );
-    return discovered.map((d): DiscoveredMigration => {
+    const mapped = discovered.map((d): DiscoveredMigration => {
       const instance = d.discoveredClass.instance as BaseMigration;
       const name = instance.constructor.name.replace('Migration', '');
       return {
@@ -23,6 +23,7 @@ export class MigrationDiscovery {
         humanName: startCase(name),
       };
     });
+    return sortBy(mapped, (d) => d.version);
   }
 }
 


### PR DESCRIPTION
Previously it was only checking a product contained a range that spanned multiple books, i.e. `[Genesis-Exodus]`. But we never allowed that so products actually had `[Genesis, Exodus]`. Updated query condition to check for if the product has any ranges in the current book and any ranges out of the current book.

I found 658 more products that need to be split. I bumped the version of the migration so it runs again.

I also updated the runner to log migration errors and log if it finished with errors instead of incorrectly assuming success.