### PR TITLE
Improve project & engagement GraphQL DX for concrete types

### DIFF
--- a/src/components/engagement/dto/list-engagements.dto.ts
+++ b/src/components/engagement/dto/list-engagements.dto.ts
@@ -7,7 +7,12 @@ import {
   SecuredList,
   SortablePaginationInput,
 } from '../../../common';
-import { Engagement, IEngagement } from './engagement.dto';
+import {
+  Engagement,
+  IEngagement,
+  InternshipEngagement,
+  LanguageEngagement,
+} from './engagement.dto';
 
 @InputType()
 export abstract class EngagementFilters {
@@ -53,3 +58,25 @@ export abstract class SecuredEngagementList extends SecuredList<
 >(IEngagement, {
   itemsDescription: PaginatedList.itemDescriptionFor('engagements'),
 }) {}
+
+@ObjectType({
+  description: SecuredList.descriptionFor('language engagements'),
+})
+export abstract class SecuredLanguageEngagementList extends SecuredList(
+  LanguageEngagement,
+  {
+    itemsDescription: PaginatedList.itemDescriptionFor('language engagements'),
+  }
+) {}
+
+@ObjectType({
+  description: SecuredList.descriptionFor('internship engagements'),
+})
+export abstract class SecuredInternshipEngagementList extends SecuredList(
+  InternshipEngagement,
+  {
+    itemsDescription: PaginatedList.itemDescriptionFor(
+      'internship engagements'
+    ),
+  }
+) {}

--- a/src/components/language/language.resolver.ts
+++ b/src/components/language/language.resolver.ts
@@ -24,7 +24,7 @@ import { Loader, LoaderOf } from '../../core';
 import { IdsAndView, IdsAndViewArg } from '../changeset/dto';
 import { LocationListInput, SecuredLocationList } from '../location';
 import { LocationLoader } from '../location/location.loader';
-import { ProjectLoader } from '../project';
+import { ProjectLoader, SecuredTranslationProjectList } from '../project';
 import { ProjectListInput, SecuredProjectList } from '../project/dto';
 import {
   CreateLanguageInput,
@@ -128,7 +128,7 @@ export class LanguageResolver {
     return await this.langService.sponsorStartDate(language, session);
   }
 
-  @ResolveField(() => SecuredProjectList, {
+  @ResolveField(() => SecuredTranslationProjectList, {
     description: 'The list of projects the language is engagement in.',
   })
   async projects(

--- a/src/components/project/dto/list-projects.dto.ts
+++ b/src/components/project/dto/list-projects.dto.ts
@@ -10,7 +10,12 @@ import {
   Sensitivity,
   SortablePaginationInput,
 } from '../../../common';
-import { IProject, Project } from './project.dto';
+import {
+  InternshipProject,
+  IProject,
+  Project,
+  TranslationProject,
+} from './project.dto';
 import { ProjectStatus } from './status.enum';
 import { ProjectStep } from './step.enum';
 import { ProjectType } from './type.enum';
@@ -110,6 +115,22 @@ export class ProjectListOutput extends PaginatedList<IProject, Project>(
   IProject,
   {
     itemsDescription: PaginatedList.itemDescriptionFor('projects'),
+  }
+) {}
+
+@ObjectType()
+export class TranslationProjectListOutput extends PaginatedList(
+  TranslationProject,
+  {
+    itemsDescription: PaginatedList.itemDescriptionFor('translation projects'),
+  }
+) {}
+
+@ObjectType()
+export class InternshipProjectListOutput extends PaginatedList(
+  InternshipProject,
+  {
+    itemsDescription: PaginatedList.itemDescriptionFor('internship projects'),
   }
 ) {}
 

--- a/src/components/project/dto/list-projects.dto.ts
+++ b/src/components/project/dto/list-projects.dto.ts
@@ -143,3 +143,23 @@ export abstract class SecuredProjectList extends SecuredList<IProject, Project>(
     itemsDescription: PaginatedList.itemDescriptionFor('projects'),
   }
 ) {}
+
+@ObjectType({
+  description: SecuredList.descriptionFor('translation projects'),
+})
+export abstract class SecuredTranslationProjectList extends SecuredList(
+  TranslationProject,
+  {
+    itemsDescription: PaginatedList.itemDescriptionFor('translation projects'),
+  }
+) {}
+
+@ObjectType({
+  description: SecuredList.descriptionFor('internship projects'),
+})
+export abstract class SecuredInternshipProjectList extends SecuredList(
+  InternshipProject,
+  {
+    itemsDescription: PaginatedList.itemDescriptionFor('internship projects'),
+  }
+) {}

--- a/src/components/project/internship-project.resolver.ts
+++ b/src/components/project/internship-project.resolver.ts
@@ -1,0 +1,44 @@
+import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
+import { AnonSession, Session } from '../../common';
+import { Loader, LoaderOf } from '../../core';
+import {
+  EngagementListInput,
+  SecuredEngagementList,
+  SecuredInternshipEngagementList,
+} from '../engagement/dto';
+import { EngagementLoader } from '../engagement/engagement.loader';
+import { InternshipProject, Project, ProjectService } from './index';
+
+@Resolver(InternshipProject)
+export class InternshipProjectResolver {
+  constructor(private readonly projects: ProjectService) {}
+
+  @ResolveField(() => SecuredInternshipEngagementList, {
+    description: stripIndent`
+      Same as \`engagements\` field just typed as a list of concrete InternshipEngagements instead of the interface.
+      InternshipProjects will only have InternshipEngagements.
+    `,
+  })
+  async internshipEngagements(
+    @AnonSession() session: Session,
+    @Parent() project: Project,
+    @Args({
+      name: 'input',
+      type: () => EngagementListInput,
+      nullable: true,
+      defaultValue: EngagementListInput.defaultVal,
+    })
+    input: EngagementListInput,
+    @Loader(EngagementLoader) engagements: LoaderOf<EngagementLoader>
+  ): Promise<SecuredEngagementList> {
+    const list = await this.projects.listEngagements(
+      project,
+      input,
+      session,
+      project.changeset ? { changeset: project.changeset } : { active: true }
+    );
+    engagements.primeAll(list.items);
+    return list;
+  }
+}

--- a/src/components/project/project.module.ts
+++ b/src/components/project/project.module.ts
@@ -11,6 +11,7 @@ import { ProjectChangeRequestModule } from '../project-change-request/project-ch
 import { UserModule } from '../user/user.module';
 import { ProjectEngagementConnectionResolver } from './engagement-connection.resolver';
 import * as handlers from './handlers';
+import { InternshipProjectResolver } from './internship-project.resolver';
 import * as migrations from './migrations';
 import { ProjectMemberModule } from './project-member/project-member.module';
 import { ProjectStepResolver } from './project-step.resolver';
@@ -19,6 +20,7 @@ import { ProjectRepository } from './project.repository';
 import { ProjectResolver } from './project.resolver';
 import { ProjectRules } from './project.rules';
 import { ProjectService } from './project.service';
+import { TranslationProjectResolver } from './translation-project.resolver';
 
 @Module({
   imports: [
@@ -36,6 +38,8 @@ import { ProjectService } from './project.service';
   ],
   providers: [
     ProjectResolver,
+    TranslationProjectResolver,
+    InternshipProjectResolver,
     ProjectEngagementConnectionResolver,
     ProjectService,
     ProjectStepResolver,

--- a/src/components/project/project.resolver.ts
+++ b/src/components/project/project.resolver.ts
@@ -50,10 +50,13 @@ import {
   CreateProjectInput,
   CreateProjectOutput,
   DeleteProjectOutput,
+  InternshipProjectListOutput,
   IProject,
   Project,
   ProjectListInput,
   ProjectListOutput,
+  ProjectType,
+  TranslationProjectListOutput,
   UpdateProjectInput,
   UpdateProjectOutput,
 } from './dto';
@@ -103,6 +106,62 @@ export class ProjectResolver {
     @AnonSession() session: Session
   ): Promise<ProjectListOutput> {
     const list = await this.projectService.list(input, session);
+    projects.primeAll(list.items);
+    return list;
+  }
+
+  @Query(() => TranslationProjectListOutput, {
+    description: 'Look up translation projects',
+  })
+  async translationProjects(
+    @Args({
+      name: 'input',
+      type: () => ProjectListInput,
+      nullable: true,
+      defaultValue: ProjectListInput.defaultVal,
+    })
+    input: ProjectListInput,
+    @Loader(ProjectLoader) projects: LoaderOf<ProjectLoader>,
+    @AnonSession() session: Session
+  ): Promise<ProjectListOutput> {
+    const list = await this.projectService.list(
+      {
+        ...input,
+        filter: {
+          ...input.filter,
+          type: ProjectType.Translation,
+        },
+      },
+      session
+    );
+    projects.primeAll(list.items);
+    return list;
+  }
+
+  @Query(() => InternshipProjectListOutput, {
+    description: 'Look up internship projects',
+  })
+  async internshipProjects(
+    @Args({
+      name: 'input',
+      type: () => ProjectListInput,
+      nullable: true,
+      defaultValue: ProjectListInput.defaultVal,
+    })
+    input: ProjectListInput,
+    @Loader(ProjectLoader) projects: LoaderOf<ProjectLoader>,
+    @AnonSession() session: Session
+  ): Promise<ProjectListOutput> {
+    const list = await this.projectService.list(
+      {
+        ...input,
+        filter: {
+          ...input.filter,
+          type: ProjectType.Internship,
+        },
+      },
+      session
+    );
     projects.primeAll(list.items);
     return list;
   }

--- a/src/components/project/translation-project.resolver.ts
+++ b/src/components/project/translation-project.resolver.ts
@@ -1,0 +1,44 @@
+import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
+import { AnonSession, Session } from '../../common';
+import { Loader, LoaderOf } from '../../core';
+import {
+  EngagementListInput,
+  SecuredEngagementList,
+  SecuredLanguageEngagementList,
+} from '../engagement/dto';
+import { EngagementLoader } from '../engagement/engagement.loader';
+import { Project, ProjectService, TranslationProject } from './index';
+
+@Resolver(TranslationProject)
+export class TranslationProjectResolver {
+  constructor(private readonly projects: ProjectService) {}
+
+  @ResolveField(() => SecuredLanguageEngagementList, {
+    description: stripIndent`
+      Same as \`engagements\` field just typed as a list of concrete LanguageEngagements instead of the interface.
+      TranslationProjects will only have LanguageEngagements.
+    `,
+  })
+  async languageEngagements(
+    @AnonSession() session: Session,
+    @Parent() project: Project,
+    @Args({
+      name: 'input',
+      type: () => EngagementListInput,
+      nullable: true,
+      defaultValue: EngagementListInput.defaultVal,
+    })
+    input: EngagementListInput,
+    @Loader(EngagementLoader) engagements: LoaderOf<EngagementLoader>
+  ): Promise<SecuredEngagementList> {
+    const list = await this.projects.listEngagements(
+      project,
+      input,
+      session,
+      project.changeset ? { changeset: project.changeset } : { active: true }
+    );
+    engagements.primeAll(list.items);
+    return list;
+  }
+}


### PR DESCRIPTION
Many times we only want to work with translation projects & language engagements. This makes that easier
```gql
query {
  translationProjects {
    items {
      languageEngagements {
        items {
          language { value {
            name { value }
          }
        }}
      }
    }
  }
}
```

I changed `Language.projects` as well to be a secured translation project list. This is technically a breaking change hence the failure, but in practice we never reference this type directly and the structure hasn't changed in a breaking way. 
```gql
query {
  language(id: "") {
    projects {
      items {
        languageEngagements {
          total
        }
      }
    }
  }
}
```