### PR TITLE
URL Scalar

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { assert } from 'ts-essentials';
 import { keys } from 'ts-transformer-keys';
+import { UrlScalar } from './common';
 import { DateScalar, DateTimeScalar } from './common/luxon.graphql';
 import { AdminModule } from './components/admin/admin.module';
 import { AuthenticationModule } from './components/authentication/authentication.module';
@@ -83,6 +84,6 @@ assert(
     PartnershipProducingMediumModule,
   ],
   controllers: [],
-  providers: [DateTimeScalar, DateScalar],
+  providers: [DateTimeScalar, DateScalar, UrlScalar],
 })
 export class AppModule {}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -30,5 +30,6 @@ export * from './types';
 export * from './validators';
 export * from './name-field';
 export * from './id-field';
+export * from './url.field';
 export * from './base-node-labels.enum';
 export * from './object-view';

--- a/src/common/url.field.ts
+++ b/src/common/url.field.ts
@@ -1,0 +1,43 @@
+import { applyDecorators } from '@nestjs/common';
+import { CustomScalar, Field, FieldOptions, Scalar } from '@nestjs/graphql';
+import { IsUrl } from 'class-validator';
+import { GraphQLError, Kind, ValueNode } from 'graphql';
+import { URL } from 'url';
+import ValidatorJS from 'validator';
+
+export const UrlField = ({
+  url,
+  ...options
+}: FieldOptions & { url?: ValidatorJS.IsURLOptions } = {}) =>
+  applyDecorators(
+    Field(() => URL, options),
+    IsUrl({
+      protocols: ['http', 'https'],
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      require_protocol: true,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      require_tld: false,
+      ...url,
+    })
+  );
+
+@Scalar('URL', () => URL)
+export class UrlScalar implements CustomScalar<string, string | null> {
+  description =
+    'A field whose value conforms to the standard URL format as specified in RFC3986: https://www.ietf.org/rfc/rfc3986.txt.';
+
+  parseLiteral(ast: ValueNode): string | null {
+    if (ast.kind !== Kind.STRING) {
+      throw new GraphQLError(
+        `Can only validate strings as URLs but got a: ${ast.kind}`
+      );
+    }
+    return ast.value;
+  }
+  parseValue(value: any) {
+    return value;
+  }
+  serialize(value: any) {
+    return value;
+  }
+}

--- a/src/components/file/file-version.resolver.ts
+++ b/src/components/file/file-version.resolver.ts
@@ -1,4 +1,5 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { URL } from 'url';
 import { FileVersion } from './dto';
 import { FileService } from './file.service';
 
@@ -6,7 +7,7 @@ import { FileService } from './file.service';
 export class FileVersionResolver {
   constructor(protected readonly service: FileService) {}
 
-  @ResolveField(() => String, {
+  @ResolveField(() => URL, {
     description: 'A direct url to download the file version',
   })
   downloadUrl(@Parent() node: FileVersion): Promise<string> {

--- a/src/components/file/file.resolver.ts
+++ b/src/components/file/file.resolver.ts
@@ -7,6 +7,7 @@ import {
   Resolver,
 } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
+import { URL } from 'url';
 import { AnonSession, ID, IdArg, LoggedInSession, Session } from '../../common';
 import { Loader, LoaderOf } from '../../core';
 import { User, UserLoader } from '../user';
@@ -72,7 +73,7 @@ export class FileResolver {
     return await this.service.listChildren(node, input, session);
   }
 
-  @ResolveField(() => String, {
+  @ResolveField(() => URL, {
     description: 'A direct url to download the file',
   })
   downloadUrl(@Parent() node: File): Promise<string> {


### PR DESCRIPTION
I created a URL GQL scalar to allow our schema to be more explicit with the data type being returned. I also added validation for when it is used in inputs (webhooks).

I changed `File/FileVersion.downloadUrl` to a URL scalar. This is considered a breaking change but shouldn't require query changes for consumers.