### PR TITLE
Product - Verse totals & verse equivalents

### DIFF
--- a/src/components/ethno-art/dto/create-ethno-art.dto.ts
+++ b/src/components/ethno-art/dto/create-ethno-art.dto.ts
@@ -2,7 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { NameField } from '../../../common';
-import { ScriptureRangeInput } from '../../scripture';
+import { ScriptureField, ScriptureRangeInput } from '../../scripture';
 import { EthnoArt } from './ethno-art.dto';
 
 @InputType()
@@ -10,9 +10,7 @@ export abstract class CreateEthnoArt {
   @NameField()
   readonly name: string;
 
-  @Field(() => [ScriptureRangeInput], { nullable: true })
-  @ValidateNested()
-  @Type(() => ScriptureRangeInput)
+  @ScriptureField({ nullable: true })
   readonly scriptureReferences?: ScriptureRangeInput[] = [];
 }
 

--- a/src/components/ethno-art/dto/create-ethno-art.dto.ts
+++ b/src/components/ethno-art/dto/create-ethno-art.dto.ts
@@ -11,7 +11,7 @@ export abstract class CreateEthnoArt {
   readonly name: string;
 
   @ScriptureField({ nullable: true })
-  readonly scriptureReferences?: ScriptureRangeInput[] = [];
+  readonly scriptureReferences?: readonly ScriptureRangeInput[] = [];
 }
 
 @InputType()

--- a/src/components/ethno-art/dto/update-ethno-art.dto.ts
+++ b/src/components/ethno-art/dto/update-ethno-art.dto.ts
@@ -14,7 +14,7 @@ export abstract class UpdateEthnoArt {
   readonly name?: string;
 
   @ScriptureField({ nullable: true })
-  readonly scriptureReferences?: ScriptureRangeInput[];
+  readonly scriptureReferences?: readonly ScriptureRangeInput[];
 }
 
 @InputType()

--- a/src/components/ethno-art/dto/update-ethno-art.dto.ts
+++ b/src/components/ethno-art/dto/update-ethno-art.dto.ts
@@ -2,7 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { ID, IdField, NameField } from '../../../common';
-import { ScriptureRangeInput } from '../../scripture';
+import { ScriptureField, ScriptureRangeInput } from '../../scripture';
 import { EthnoArt } from './ethno-art.dto';
 
 @InputType()
@@ -13,9 +13,7 @@ export abstract class UpdateEthnoArt {
   @NameField({ nullable: true })
   readonly name?: string;
 
-  @Field(() => [ScriptureRangeInput], { nullable: true })
-  @ValidateNested()
-  @Type(() => ScriptureRangeInput)
+  @ScriptureField({ nullable: true })
   readonly scriptureReferences?: ScriptureRangeInput[];
 }
 

--- a/src/components/film/dto/create-film.dto.ts
+++ b/src/components/film/dto/create-film.dto.ts
@@ -11,7 +11,7 @@ export abstract class CreateFilm {
   readonly name: string;
 
   @ScriptureField({ nullable: true })
-  readonly scriptureReferences?: ScriptureRangeInput[] = [];
+  readonly scriptureReferences?: readonly ScriptureRangeInput[] = [];
 }
 
 @InputType()

--- a/src/components/film/dto/create-film.dto.ts
+++ b/src/components/film/dto/create-film.dto.ts
@@ -2,7 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { NameField } from '../../../common';
-import { ScriptureRangeInput } from '../../scripture';
+import { ScriptureField, ScriptureRangeInput } from '../../scripture';
 import { Film } from './film.dto';
 
 @InputType()
@@ -10,9 +10,7 @@ export abstract class CreateFilm {
   @NameField()
   readonly name: string;
 
-  @Field(() => [ScriptureRangeInput], { nullable: true })
-  @ValidateNested()
-  @Type(() => ScriptureRangeInput)
+  @ScriptureField({ nullable: true })
   readonly scriptureReferences?: ScriptureRangeInput[] = [];
 }
 

--- a/src/components/film/dto/update-film.dto.ts
+++ b/src/components/film/dto/update-film.dto.ts
@@ -2,7 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { ID, IdField, NameField } from '../../../common';
-import { ScriptureRangeInput } from '../../scripture';
+import { ScriptureField, ScriptureRangeInput } from '../../scripture';
 import { Film } from './film.dto';
 
 @InputType()
@@ -13,9 +13,7 @@ export abstract class UpdateFilm {
   @NameField({ nullable: true })
   readonly name?: string;
 
-  @Field(() => [ScriptureRangeInput], { nullable: true })
-  @ValidateNested()
-  @Type(() => ScriptureRangeInput)
+  @ScriptureField({ nullable: true })
   readonly scriptureReferences?: ScriptureRangeInput[];
 }
 

--- a/src/components/film/dto/update-film.dto.ts
+++ b/src/components/film/dto/update-film.dto.ts
@@ -14,7 +14,7 @@ export abstract class UpdateFilm {
   readonly name?: string;
 
   @ScriptureField({ nullable: true })
-  readonly scriptureReferences?: ScriptureRangeInput[];
+  readonly scriptureReferences?: readonly ScriptureRangeInput[];
 }
 
 @InputType()

--- a/src/components/literacy-material/dto/create-literacy-material.dto.ts
+++ b/src/components/literacy-material/dto/create-literacy-material.dto.ts
@@ -2,7 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { NameField } from '../../../common';
-import { ScriptureRangeInput } from '../../scripture';
+import { ScriptureField, ScriptureRangeInput } from '../../scripture';
 import { LiteracyMaterial } from './literacy-material.dto';
 
 @InputType()
@@ -10,9 +10,7 @@ export abstract class CreateLiteracyMaterial {
   @NameField()
   readonly name: string;
 
-  @Field(() => [ScriptureRangeInput], { nullable: true })
-  @ValidateNested()
-  @Type(() => ScriptureRangeInput)
+  @ScriptureField({ nullable: true })
   readonly scriptureReferences?: ScriptureRangeInput[] = [];
 }
 

--- a/src/components/literacy-material/dto/create-literacy-material.dto.ts
+++ b/src/components/literacy-material/dto/create-literacy-material.dto.ts
@@ -11,7 +11,7 @@ export abstract class CreateLiteracyMaterial {
   readonly name: string;
 
   @ScriptureField({ nullable: true })
-  readonly scriptureReferences?: ScriptureRangeInput[] = [];
+  readonly scriptureReferences?: readonly ScriptureRangeInput[] = [];
 }
 
 @InputType()

--- a/src/components/literacy-material/dto/update-literacy-material.dto.ts
+++ b/src/components/literacy-material/dto/update-literacy-material.dto.ts
@@ -2,7 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { ID, IdField, NameField } from '../../../common';
-import { ScriptureRangeInput } from '../../scripture';
+import { ScriptureField, ScriptureRangeInput } from '../../scripture';
 import { LiteracyMaterial } from './literacy-material.dto';
 
 @InputType()
@@ -13,9 +13,7 @@ export abstract class UpdateLiteracyMaterial {
   @NameField({ nullable: true })
   readonly name?: string;
 
-  @Field(() => [ScriptureRangeInput], { nullable: true })
-  @ValidateNested()
-  @Type(() => ScriptureRangeInput)
+  @ScriptureField({ nullable: true })
   readonly scriptureReferences?: ScriptureRangeInput[];
 }
 

--- a/src/components/literacy-material/dto/update-literacy-material.dto.ts
+++ b/src/components/literacy-material/dto/update-literacy-material.dto.ts
@@ -14,7 +14,7 @@ export abstract class UpdateLiteracyMaterial {
   readonly name?: string;
 
   @ScriptureField({ nullable: true })
-  readonly scriptureReferences?: ScriptureRangeInput[];
+  readonly scriptureReferences?: readonly ScriptureRangeInput[];
 }
 
 @InputType()

--- a/src/components/product-progress/dto/index.ts
+++ b/src/components/product-progress/dto/index.ts
@@ -1,2 +1,3 @@
 export * from './progress-report.dto';
 export * from './progress-report.input';
+export * from './progress-format.enum';

--- a/src/components/product-progress/dto/progress-format.enum.ts
+++ b/src/components/product-progress/dto/progress-format.enum.ts
@@ -1,0 +1,46 @@
+import { registerEnumType } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
+
+export enum ProgressFormat {
+  Numerator = 'Numerator',
+  Decimal = 'Decimal',
+  Percent = 'Percent',
+  Verses = 'Verses',
+  VerseEquivalents = 'VerseEquivalents',
+}
+
+registerEnumType(ProgressFormat, {
+  name: 'ProgressFormat',
+  description: 'A format for a progress number',
+  valuesMap: {
+    Numerator: {
+      description: stripIndent`
+        The raw value that does not take into account the target value.
+        This will be 0 <= # <= the product's \`progressTarget\` number.
+        For example, # of Y complete
+      `,
+    },
+    Decimal: {
+      description: stripIndent`
+        A percent expressed as a decimal (0-1)
+        For example, 0.# * 100 percent complete
+      `,
+    },
+    Percent: {
+      description: stripIndent`
+        A percent which already has already been multiplied by 100
+        For example, ##.#% complete
+      `,
+    },
+    Verses: {
+      description: stripIndent`
+        The number of verses completed
+      `,
+    },
+    VerseEquivalents: {
+      description: stripIndent`
+        The number of verse equivalents completed
+      `,
+    },
+  },
+});

--- a/src/components/product-progress/dto/progress-report.dto.ts
+++ b/src/components/product-progress/dto/progress-report.dto.ts
@@ -33,6 +33,16 @@ export class ProductProgress {
       The progress of each step in this report.
       This list is ordered based order of product's steps, which is based on \`MethodologyAvailableSteps\`.
     `,
+    middleware: [
+      // Add productId so it can be accessed in StepProgress.completed resolver
+      async (ctx, next) => {
+        const value = await next();
+        for (const sp of value) {
+          sp.productId = ctx.source.productId;
+        }
+        return value;
+      },
+    ],
   })
   readonly steps: readonly StepProgress[];
 }
@@ -62,8 +72,6 @@ export class StepProgress {
   @Field({
     description: stripIndent`
       The currently completed value for the step.
-
-      This will be 0 <= \`completed\` <= the product's \`progressTarget\` number.
 
       If no progress has been reported yet this will be null,
       or this could be explicitly set to null.

--- a/src/components/product-progress/step-progress.resolver.ts
+++ b/src/components/product-progress/step-progress.resolver.ts
@@ -1,9 +1,54 @@
-import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { SecuredFloatNullable } from '../../common';
-import { StepProgress } from './dto';
+import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
+import {
+  ID,
+  mapSecuredValue,
+  SecuredFloatNullable,
+  simpleSwitch,
+} from '../../common';
+import { Loader, LoaderOf } from '../../core';
+import { ProductLoader } from '../product';
+import { ProgressFormat, StepProgress } from './dto';
 
 @Resolver(StepProgress)
 export class StepProgressResolver {
+  @ResolveField(() => SecuredFloatNullable)
+  async completed(
+    @Parent() sp: StepProgress & { productId: ID },
+    @Loader(() => ProductLoader) products: LoaderOf<ProductLoader>,
+    @Args('format', {
+      type: () => ProgressFormat,
+      defaultValue: ProgressFormat.Numerator,
+      description: stripIndent`
+        The format the progress value will be returned in
+
+        Some formats are not supported for all products, like verses in other products,
+        in these cases a null \`value\` is returned.
+      `,
+    })
+    format: ProgressFormat
+  ): Promise<SecuredFloatNullable> {
+    const product = await products.load(sp.productId);
+    if (
+      !product.progressTarget.canRead ||
+      // progress target should always be >0 so this is just a sanity check
+      !product.progressTarget.value
+    ) {
+      return { canRead: false, canEdit: false };
+    }
+    const denominator = product.progressTarget.value;
+    const factor = simpleSwitch(format, {
+      [ProgressFormat.Numerator]: denominator,
+      [ProgressFormat.Decimal]: 1,
+      [ProgressFormat.Percent]: 100,
+      [ProgressFormat.Verses]: product.totalVerses,
+      [ProgressFormat.VerseEquivalents]: product.totalVerseEquivalents,
+    });
+    return await mapSecuredValue(sp.completed, async (val) =>
+      factor != null ? (val / denominator) * factor : null
+    );
+  }
+
   @ResolveField(() => SecuredFloatNullable, {
     deprecationReason: 'Use `StepProgress.completed` instead.',
   })

--- a/src/components/product/dto/create-product.dto.ts
+++ b/src/components/product/dto/create-product.dto.ts
@@ -6,6 +6,7 @@ import { uniq } from 'lodash';
 import { DateTime } from 'luxon';
 import { ID, IdField, NameField } from '../../../common';
 import {
+  ScriptureField,
   ScriptureRangeInput,
   UnspecifiedScripturePortionInput,
 } from '../../scripture';
@@ -65,11 +66,9 @@ export abstract class CreateBaseProduct {
 
 @InputType()
 export abstract class CreateDirectScriptureProduct extends CreateBaseProduct {
-  @Field(() => [ScriptureRangeInput], {
+  @ScriptureField({
     nullable: true,
   })
-  @ValidateNested()
-  @Type(() => ScriptureRangeInput)
   readonly scriptureReferences?: readonly ScriptureRangeInput[];
 
   @Field(() => UnspecifiedScripturePortionInput, {
@@ -89,7 +88,7 @@ export abstract class CreateDerivativeScriptureProduct extends CreateBaseProduct
   })
   readonly produces: ID;
 
-  @Field(() => [ScriptureRangeInput], {
+  @ScriptureField({
     nullable: true,
     description: stripIndent`
       The \`Producible\` defines a \`scriptureReferences\` list, and this is
@@ -98,8 +97,6 @@ export abstract class CreateDerivativeScriptureProduct extends CreateBaseProduct
       this property can be set (and read) to "override" the \`producible\`'s list.
     `,
   })
-  @ValidateNested()
-  @Type(() => ScriptureRangeInput)
   readonly scriptureReferencesOverride?: readonly ScriptureRangeInput[];
 }
 
@@ -117,7 +114,7 @@ export abstract class CreateProduct extends CreateBaseProduct {
   })
   readonly produces?: ID;
 
-  @Field(() => [ScriptureRangeInput], {
+  @ScriptureField({
     nullable: true,
     description: stripIndent`
       Change this list of \`scriptureReferences\` if provided.
@@ -125,11 +122,9 @@ export abstract class CreateProduct extends CreateBaseProduct {
       Note only \`DirectScriptureProduct\`s can use this field.
     `,
   })
-  @ValidateNested()
-  @Type(() => ScriptureRangeInput)
   readonly scriptureReferences?: readonly ScriptureRangeInput[];
 
-  @Field(() => [ScriptureRangeInput], {
+  @ScriptureField({
     nullable: true,
     description: stripIndent`
       The \`Producible\` defines a \`scriptureReferences\` list, and this is
@@ -140,8 +135,6 @@ export abstract class CreateProduct extends CreateBaseProduct {
       Note only \`DerivativeScriptureProduct\`s can use this field.
     `,
   })
-  @ValidateNested()
-  @Type(() => ScriptureRangeInput)
   readonly scriptureReferencesOverride?: readonly ScriptureRangeInput[];
 }
 

--- a/src/components/product/dto/product.dto.ts
+++ b/src/components/product/dto/product.dto.ts
@@ -1,4 +1,4 @@
-import { Field, InterfaceType, ObjectType } from '@nestjs/graphql';
+import { Field, Float, Int, InterfaceType, ObjectType } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { startCase } from 'lodash';
 import { keys as keysOf } from 'ts-transformer-keys';
@@ -114,6 +114,20 @@ export class DirectScriptureProduct extends Product {
   })
   @DbLabel('UnspecifiedScripturePortion')
   unspecifiedScripture: SecuredUnspecifiedScripturePortion;
+
+  @Field(() => Int, {
+    description:
+      'The total number of verses of the selected scripture in this product',
+  })
+  totalVerses: number;
+
+  @Field(() => Float, {
+    description: stripIndent`
+      The total number of verse equivalents of the selected scripture in this product.
+      Verse equivalents weight each verse based on its translation difficulty.
+    `,
+  })
+  totalVerseEquivalents: number;
 }
 
 @ObjectType({
@@ -145,6 +159,20 @@ export class DerivativeScriptureProduct extends Product {
     `,
   })
   readonly scriptureReferencesOverride: SecuredScriptureRangesOverride;
+
+  @Field(() => Int, {
+    description:
+      'The total number of verses of the selected scripture in this product',
+  })
+  totalVerses: number;
+
+  @Field(() => Float, {
+    description: stripIndent`
+      The total number of verse equivalents of the selected scripture in this product.
+      Verse equivalents weight each verse based on its translation difficulty.
+    `,
+  })
+  totalVerseEquivalents: number;
 }
 
 @ObjectType({

--- a/src/components/product/dto/update-product.dto.ts
+++ b/src/components/product/dto/update-product.dto.ts
@@ -34,7 +34,10 @@ export abstract class UpdateDirectScriptureProduct extends IntersectionType(
     'scriptureReferences',
     'unspecifiedScripture',
   ])
-) {}
+) {
+  totalVerses?: number;
+  totalVerseEquivalents?: number;
+}
 
 @InputType()
 export abstract class UpdateDerivativeScriptureProduct extends IntersectionType(
@@ -48,6 +51,9 @@ export abstract class UpdateDerivativeScriptureProduct extends IntersectionType(
     `,
   })
   readonly produces?: ID;
+
+  totalVerses?: number;
+  totalVerseEquivalents?: number;
 }
 
 /**

--- a/src/components/product/migrations/AddProductTotalVerses.migration.ts
+++ b/src/components/product/migrations/AddProductTotalVerses.migration.ts
@@ -1,8 +1,69 @@
+import { node, not, relation } from 'cypher-query-builder';
 import { BaseMigration, Migration } from '../../../core';
+import { createProperty, path } from '../../../core/database/query';
+import { DirectScriptureProduct } from '../dto';
 
 @Migration('2021-11-27T00:00:00')
 export class AddProductTotalVersesMigration extends BaseMigration {
   async up() {
-    // TODO Find all products without total verses and calculate and update
+    const res = await this.db
+      .query()
+      .match([
+        node('node', 'Product'),
+        relation('out', '', 'unspecifiedScripture'),
+        node('usp', 'UnspecifiedScripturePortion'),
+      ])
+      .where(
+        not(
+          path([
+            node('node'),
+            relation('out', '', 'totalVerses'),
+            node('', 'Property'),
+          ])
+        )
+      )
+      .apply(
+        createProperty({
+          resource: DirectScriptureProduct,
+          key: 'totalVerses',
+          variable: 'usp.totalVerses',
+          numCreatedVar: 'unspecifiedScripturePortions',
+        })
+      )
+      .with(
+        'sum(unspecifiedScripturePortions) as unspecifiedScripturePortionTotalVerses'
+      )
+      .match([
+        node('node', 'Product'),
+        relation('out'),
+        node('sr', 'ScriptureRange'),
+      ])
+      .where(
+        not(
+          path([
+            node('node'),
+            relation('out', '', 'totalVerses'),
+            node('', 'Property'),
+          ])
+        )
+      )
+      .apply(
+        createProperty({
+          resource: DirectScriptureProduct,
+          key: 'totalVerses',
+          variable: 'sr.end - sr.start + 1',
+          numCreatedVar: 'scriptureRanges',
+        })
+      )
+      .return<{ numTotalVersesPropAdded: number }>(
+        'sum(scriptureRanges) + unspecifiedScriptureTotalVerses as numTotalVersesPropAdded'
+      )
+      .first();
+
+    this.logger.info(
+      `totalVerses property added to ${
+        res?.numTotalVersesPropAdded ?? 0
+      } products`
+    );
   }
 }

--- a/src/components/product/migrations/AddProductTotalVerses.migration.ts
+++ b/src/components/product/migrations/AddProductTotalVerses.migration.ts
@@ -1,0 +1,8 @@
+import { BaseMigration, Migration } from '../../../core';
+
+@Migration('2021-11-27T00:00:00')
+export class AddProductTotalVersesMigration extends BaseMigration {
+  async up() {
+    // TODO Find all products without total verses and calculate and update
+  }
+}

--- a/src/components/product/migrations/index.ts
+++ b/src/components/product/migrations/index.ts
@@ -1,3 +1,4 @@
 export * from './AddProgressMeasurements.migration';
 export * from './SplitScriptureSpanningBooks.migration';
 export * from './ReextractPlanningPnps.migration';
+export * from './AddProductTotalVerses.migration';

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -177,7 +177,10 @@ export class ProductRepository extends CommonRepository {
   }
 
   async create(
-    input: CreateDerivativeScriptureProduct | CreateDirectScriptureProduct
+    input: (CreateDerivativeScriptureProduct | CreateDirectScriptureProduct) & {
+      totalVerses: number;
+      totalVerseEquivalents: number;
+    }
   ) {
     const isDerivative = has('produces', input);
     const Product = isDerivative
@@ -197,6 +200,8 @@ export class ProductRepository extends CommonRepository {
             isOverriding: !!input.scriptureReferencesOverride,
           }
         : {}),
+      totalVerses: input.totalVerses,
+      totalVerseEquivalents: input.totalVerseEquivalents,
     };
 
     const query = this.db

--- a/src/components/progress-summary/dto/progress-summary.dto.ts
+++ b/src/components/progress-summary/dto/progress-summary.dto.ts
@@ -18,6 +18,11 @@ export abstract class ProgressSummary {
 
   @Field(() => Float)
   actual: number;
+
+  // Total verses across all products in the engagement this summary is under
+  totalVerses?: number;
+  // Total verse equivalents across all products in the engagement this summary is under
+  totalVerseEquivalents?: number;
 }
 
 export enum SummaryPeriod {

--- a/src/components/progress-summary/progress-summary.resolver.ts
+++ b/src/components/progress-summary/progress-summary.resolver.ts
@@ -1,8 +1,50 @@
-import { Float, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Args, Float, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { ArgsOptions } from '@nestjs/graphql/dist/decorators/args.decorator';
+import { stripIndent } from 'common-tags';
+import { simpleSwitch } from '../../common';
+import { ProgressFormat } from '../product-progress/dto';
 import { ProgressSummary } from './dto';
+
+const formatArg: ArgsOptions = {
+  name: 'format',
+  type: () => ProgressFormat,
+  defaultValue: ProgressFormat.Decimal,
+  description: stripIndent`
+    The format the progress value will be returned in
+
+    Some formats are not supported, in these cases the default format will be used.
+  `,
+};
 
 @Resolver(ProgressSummary)
 export class ProgressSummaryResolver {
+  @ResolveField()
+  planned(
+    @Parent() summary: ProgressSummary,
+    @Args(formatArg) format: ProgressFormat
+  ): number {
+    return summary.planned * this.formatFactor(summary, format);
+  }
+
+  @ResolveField()
+  actual(
+    @Parent() summary: ProgressSummary,
+    @Args(formatArg) format: ProgressFormat
+  ): number {
+    return summary.actual * this.formatFactor(summary, format);
+  }
+
+  private formatFactor(summary: ProgressSummary, format: ProgressFormat) {
+    const factor = simpleSwitch(format, {
+      [ProgressFormat.Numerator]: null,
+      [ProgressFormat.Decimal]: 1,
+      [ProgressFormat.Percent]: 100,
+      [ProgressFormat.Verses]: summary.totalVerses,
+      [ProgressFormat.VerseEquivalents]: summary.totalVerseEquivalents,
+    });
+    return factor ?? 1;
+  }
+
   @ResolveField(() => Float, {
     description: 'The difference between the actual and planned values',
   })

--- a/src/components/scripture/books.ts
+++ b/src/components/scripture/books.ts
@@ -1,8 +1,9 @@
 import { LazyGetter as Once } from 'lazy-get-decorator';
 import { random, range, sumBy } from 'lodash';
 import { inspect } from 'util';
-import { ArrayItem, iterate, NotFoundException } from '../../common';
+import { iterate, NotFoundException } from '../../common';
 import { ScriptureReference } from './dto';
+import { BookDifficulty as Difficulty } from './dto/book-difficulty.enum';
 
 const generateOrdinalNameVariations = (ordinal: 1 | 2 | 3, names: string[]) => {
   const ordinalMap = {
@@ -18,7 +19,13 @@ const generateOrdinalNameVariations = (ordinal: 1 | 2 | 3, names: string[]) => {
   );
 };
 
-const books = [
+interface BookData {
+  names: readonly string[];
+  chapters: readonly number[];
+  difficulty: Difficulty;
+}
+
+const books: readonly BookData[] = [
   {
     names: 'Genesis Ge Gen'.split(' '),
     chapters: [
@@ -26,6 +33,7 @@ const books = [
       38, 18, 34, 24, 20, 67, 34, 35, 46, 22, 35, 43, 55, 32, 20, 31, 29, 43,
       36, 30, 23, 23, 57, 38, 34, 34, 28, 34, 31, 22, 33, 26,
     ],
+    difficulty: Difficulty.Normal,
   },
   {
     names: 'Exodus Ex Exo'.split(' '),
@@ -34,6 +42,7 @@ const books = [
       25, 26, 36, 31, 33, 18, 40, 37, 21, 43, 46, 38, 18, 35, 23, 35, 35, 38,
       29, 31, 43, 38,
     ],
+    difficulty: Difficulty.Normal,
   },
   {
     names: 'Leviticus Le Lev'.split(' '),
@@ -41,6 +50,7 @@ const books = [
       17, 16, 17, 35, 19, 30, 38, 36, 24, 20, 47, 8, 59, 57, 33, 34, 16, 30, 37,
       27, 24, 33, 44, 23, 55, 46, 34,
     ],
+    difficulty: Difficulty.Hard,
   },
   {
     names: 'Numbers Nu Num'.split(' '),
@@ -48,6 +58,7 @@ const books = [
       54, 34, 51, 49, 31, 27, 89, 26, 23, 36, 35, 16, 33, 45, 41, 50, 13, 32,
       22, 29, 35, 41, 30, 25, 18, 65, 23, 31, 40, 16, 54, 42, 56, 29, 34, 13,
     ],
+    difficulty: Difficulty.Normal,
   },
   {
     names: 'Deuteronomy Dt Deut Deu De'.split(' '),
@@ -55,6 +66,7 @@ const books = [
       46, 37, 29, 49, 33, 25, 26, 20, 29, 22, 32, 32, 18, 29, 23, 22, 20, 22,
       21, 20, 23, 30, 25, 22, 19, 19, 26, 68, 29, 20, 30, 52, 29, 12,
     ],
+    difficulty: Difficulty.Normal,
   },
   {
     names: 'Joshua Js Jos Jos Josh'.split(' '),
@@ -62,6 +74,7 @@ const books = [
       18, 24, 17, 24, 15, 27, 26, 35, 27, 43, 23, 24, 33, 15, 63, 10, 18, 28,
       51, 9, 45, 34, 16, 33,
     ],
+    difficulty: Difficulty.Easy,
   },
   {
     names: 'Judges Jg Jdg Ju Jdgs Judg'.split(' '),
@@ -69,10 +82,12 @@ const books = [
       36, 23, 31, 24, 31, 40, 25, 35, 57, 18, 40, 15, 25, 20, 20, 31, 13, 31,
       30, 48, 25,
     ],
+    difficulty: Difficulty.Easy,
   },
   {
     names: 'Ruth Ru Rut'.split(' '),
     chapters: [22, 23, 18, 22],
+    difficulty: Difficulty.Easy,
   },
   {
     names: generateOrdinalNameVariations(1, 'Samuel Sam'.split(' ')),
@@ -80,6 +95,7 @@ const books = [
       28, 36, 21, 22, 12, 21, 17, 22, 27, 27, 15, 25, 23, 52, 35, 23, 58, 30,
       24, 42, 15, 23, 29, 22, 44, 25, 12, 25, 11, 31, 13,
     ],
+    difficulty: Difficulty.Easy,
   },
   {
     names: generateOrdinalNameVariations(2, 'Samuel Sam'.split(' ')),
@@ -87,6 +103,7 @@ const books = [
       27, 32, 39, 12, 25, 23, 29, 18, 13, 19, 27, 31, 39, 33, 37, 23, 29, 33,
       43, 26, 22, 51, 39, 25,
     ],
+    difficulty: Difficulty.Easy,
   },
   {
     names: generateOrdinalNameVariations(
@@ -97,6 +114,7 @@ const books = [
       53, 46, 28, 34, 18, 38, 51, 66, 28, 29, 43, 33, 34, 31, 34, 34, 24, 46,
       21, 43, 29, 53,
     ],
+    difficulty: Difficulty.Easy,
   },
   {
     names: generateOrdinalNameVariations(
@@ -107,6 +125,7 @@ const books = [
       18, 25, 27, 44, 27, 33, 20, 29, 37, 36, 21, 21, 25, 29, 38, 20, 41, 37,
       37, 21, 26, 20, 37, 20, 30,
     ],
+    difficulty: Difficulty.Easy,
   },
   {
     names: generateOrdinalNameVariations(
@@ -117,6 +136,7 @@ const books = [
       54, 55, 24, 43, 26, 81, 40, 40, 44, 14, 47, 40, 14, 17, 29, 43, 27, 17,
       19, 8, 30, 19, 32, 31, 31, 32, 34, 21, 30,
     ],
+    difficulty: Difficulty.Easy,
   },
   {
     names: generateOrdinalNameVariations(
@@ -127,18 +147,22 @@ const books = [
       17, 18, 17, 22, 14, 42, 22, 18, 31, 19, 23, 16, 22, 15, 19, 14, 19, 34,
       11, 37, 20, 12, 21, 27, 28, 23, 9, 27, 36, 27, 21, 33, 25, 33, 27, 23,
     ],
+    difficulty: Difficulty.Easy,
   },
   {
     names: 'Ezra Ez Ezr'.split(' '),
     chapters: [11, 70, 13, 24, 17, 22, 28, 36, 15, 44],
+    difficulty: Difficulty.Normal,
   },
   {
     names: 'Nehemiah Ne Neh Neh Ne'.split(' '),
     chapters: [11, 20, 32, 23, 19, 19, 73, 18, 38, 39, 36, 47, 31],
+    difficulty: Difficulty.Normal,
   },
   {
     names: 'Esther Es Est Esth Ester'.split(' '),
     chapters: [22, 23, 15, 17, 14, 14, 10, 17, 32, 3],
+    difficulty: Difficulty.Easy,
   },
   {
     names: 'Job Jb Job'.split(' '),
@@ -147,6 +171,7 @@ const books = [
       29, 29, 34, 30, 17, 25, 6, 14, 23, 28, 25, 31, 40, 22, 33, 37, 16, 33, 24,
       41, 30, 24, 34, 17,
     ],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Psalm Ps Psa Pss Psalms'.split(' '),
@@ -160,6 +185,7 @@ const books = [
       7, 8, 9, 4, 8, 5, 6, 5, 6, 8, 8, 3, 18, 3, 3, 21, 26, 9, 8, 24, 13, 10, 7,
       12, 15, 21, 10, 20, 14, 9, 6,
     ],
+    difficulty: Difficulty.Hard,
   },
   {
     names: 'Proverbs Pr Prov Pro'.split(' '),
@@ -167,14 +193,17 @@ const books = [
       33, 22, 35, 27, 23, 35, 27, 36, 18, 32, 31, 28, 25, 35, 33, 33, 28, 24,
       29, 30, 31, 29, 35, 34, 28, 28, 27, 28, 27, 33, 31,
     ],
+    difficulty: Difficulty.Hard,
   },
   {
     names: 'Ecclesiastes Ec Ecc'.split(' '),
     chapters: [18, 26, 22, 16, 20, 12, 29, 17, 18, 20, 10, 14],
+    difficulty: Difficulty.Hard,
   },
   {
     names: ['Song of Solomon', 'SOS', 'Song of Songs', 'SongOfSongs', 'Sng'],
     chapters: [17, 17, 11, 16, 16, 13, 13, 14],
+    difficulty: Difficulty.Hard,
   },
   {
     names: 'Isaiah Isa'.split(' '),
@@ -184,6 +213,7 @@ const books = [
       31, 29, 25, 28, 28, 25, 13, 15, 22, 26, 11, 23, 15, 12, 17, 13, 12, 21,
       14, 21, 22, 11, 12, 19, 12, 25, 24,
     ],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Jeremiah Je Jer'.split(' '),
@@ -192,10 +222,12 @@ const books = [
       15, 18, 14, 30, 40, 10, 38, 24, 22, 17, 32, 24, 40, 44, 26, 22, 19, 32,
       21, 28, 18, 16, 18, 22, 13, 30, 5, 28, 7, 47, 39, 46, 64, 34,
     ],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Lamentations La Lam Lament'.split(' '),
     chapters: [22, 22, 66, 22, 22],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Ezekiel Ek Ezk Ezek Eze'.split(' '),
@@ -204,58 +236,72 @@ const books = [
       49, 32, 31, 49, 27, 17, 21, 36, 26, 21, 26, 18, 32, 33, 31, 15, 38, 28,
       23, 29, 49, 26, 20, 27, 31, 25, 24, 23, 35,
     ],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Daniel Da Dan Dl Dnl'.split(' '),
     chapters: [21, 49, 30, 37, 31, 28, 28, 27, 27, 21, 45, 13],
+    difficulty: Difficulty.Hard,
   },
   {
     names: 'Hosea Ho Hos'.split(' '),
     chapters: [11, 23, 5, 19, 15, 11, 16, 14, 17, 15, 12, 14, 16, 9],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Joel Jl Jol Joel Joe'.split(' '),
     chapters: [20, 32, 21],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Amos Am Amos Amo'.split(' '),
     chapters: [15, 16, 15, 13, 27, 14, 17, 14, 15],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Obadiah Ob Oba Obd Odbh'.split(' '),
     chapters: [21],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Jonah Jh Jon Jnh'.split(' '),
     chapters: [17, 10, 10, 11],
+    difficulty: Difficulty.Easy,
   },
   {
     names: 'Micah Mi Mic'.split(' '),
     chapters: [16, 13, 12, 13, 15, 16, 20],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Nahum Nam Na Nah Na'.split(' '),
     chapters: [15, 13, 19],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Habakkuk Hb Hab Hk Habk'.split(' '),
     chapters: [17, 20, 19],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Zephaniah Zp Zep Zeph Ze'.split(' '),
     chapters: [18, 15, 20],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Haggai Ha Hag Hagg'.split(' '),
     chapters: [15, 23],
+    difficulty: Difficulty.Hard,
   },
   {
     names: 'Zechariah Zc Zech Zec'.split(' '),
     chapters: [21, 13, 10, 14, 11, 15, 14, 23, 17, 12, 17, 14, 9, 21],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Malachi Ml Mal Mlc'.split(' '),
     chapters: [14, 17, 18, 6],
+    difficulty: Difficulty.Hard,
   },
   {
     names: 'Matthew Mt Matt Mat'.split(' '),
@@ -263,10 +309,12 @@ const books = [
       25, 23, 17, 25, 48, 34, 29, 34, 38, 42, 30, 50, 58, 36, 39, 28, 27, 35,
       30, 34, 46, 46, 39, 51, 46, 75, 66, 20,
     ],
+    difficulty: Difficulty.Normal,
   },
   {
     names: 'Mark Mk Mrk'.split(' '),
     chapters: [45, 28, 35, 41, 43, 56, 37, 38, 50, 52, 33, 44, 37, 72, 47, 20],
+    difficulty: Difficulty.Normal,
   },
   {
     names: 'Luke Lk Luk Lu'.split(' '),
@@ -274,6 +322,7 @@ const books = [
       80, 52, 38, 44, 39, 49, 50, 56, 62, 42, 54, 59, 35, 35, 32, 31, 37, 43,
       48, 47, 38, 71, 56, 53,
     ],
+    difficulty: Difficulty.Normal,
   },
   {
     names: 'John Jn Jhn Joh Jo'.split(' '),
@@ -281,6 +330,7 @@ const books = [
       51, 25, 36, 54, 47, 71, 53, 59, 41, 42, 57, 50, 38, 31, 27, 33, 26, 40,
       42, 31, 25,
     ],
+    difficulty: Difficulty.Hard,
   },
   {
     names: 'Acts Ac Act'.split(' '),
@@ -288,34 +338,42 @@ const books = [
       26, 47, 26, 37, 42, 15, 60, 40, 43, 48, 30, 25, 52, 28, 41, 40, 34, 28,
       41, 38, 40, 30, 35, 27, 27, 32, 44, 31,
     ],
+    difficulty: Difficulty.Normal,
   },
   {
     names: 'Romans Ro Rom Rmn Rmns'.split(' '),
     chapters: [32, 29, 31, 25, 21, 23, 25, 39, 33, 21, 36, 21, 14, 23, 33, 27],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: generateOrdinalNameVariations(1, 'Corinthians Co Cor'.split(' ')),
     chapters: [31, 16, 23, 21, 13, 20, 40, 13, 27, 33, 34, 31, 13, 40, 58, 24],
+    difficulty: Difficulty.Hard,
   },
   {
     names: generateOrdinalNameVariations(2, 'Corinthians Co Cor'.split(' ')),
     chapters: [24, 17, 18, 18, 21, 18, 16, 24, 15, 18, 33, 21, 14],
+    difficulty: Difficulty.Hard,
   },
   {
     names: 'Galatians Ga Gal Gltns'.split(' '),
     chapters: [24, 21, 29, 31, 26, 18],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Ephesians Ep Eph Ephn'.split(' '),
     chapters: [23, 22, 21, 32, 33, 24],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Philippians Php Phi Phil Phi'.split(' '),
     chapters: [30, 30, 21, 23],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'Colossians Co Col Colo Cln Clns'.split(' '),
     chapters: [29, 23, 25, 18],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: generateOrdinalNameVariations(
@@ -323,6 +381,7 @@ const books = [
       'Thessalonians Th Thess Thes'.split(' ')
     ),
     chapters: [10, 20, 13, 18, 28],
+    difficulty: Difficulty.Hard,
   },
   {
     names: generateOrdinalNameVariations(
@@ -330,54 +389,67 @@ const books = [
       'Thessalonians Th Thess Thes'.split(' ')
     ),
     chapters: [12, 17, 18],
+    difficulty: Difficulty.Hard,
   },
   {
     names: generateOrdinalNameVariations(1, 'Timothy Ti Tim'.split(' ')),
     chapters: [20, 15, 16, 16, 25, 21],
+    difficulty: Difficulty.Normal,
   },
   {
     names: generateOrdinalNameVariations(2, 'Timothy Ti Tim'.split(' ')),
     chapters: [18, 26, 17, 22],
+    difficulty: Difficulty.Normal,
   },
   {
     names: 'Titus Ti Tit Tt Ts'.split(' '),
     chapters: [16, 15, 15],
+    difficulty: Difficulty.Normal,
   },
   {
     names: 'Philemon Phm Pm Phile Philm'.split(' '),
     chapters: [25],
+    difficulty: Difficulty.Normal,
   },
   {
     names: 'Hebrews He Heb Hw'.split(' '),
     chapters: [14, 18, 19, 16, 14, 20, 28, 13, 28, 39, 40, 29, 25],
+    difficulty: Difficulty.Hardest,
   },
   {
     names: 'James Jm Jam Jas Ja'.split(' '),
     chapters: [27, 26, 18, 17, 20],
+    difficulty: Difficulty.Normal,
   },
   {
     names: generateOrdinalNameVariations(1, 'Peter Pe Pet P'.split(' ')),
     chapters: [25, 25, 22, 19, 14],
+    difficulty: Difficulty.Hard,
   },
   {
     names: generateOrdinalNameVariations(2, 'Peter Pe Pet P'.split(' ')),
     chapters: [21, 22, 18],
+    difficulty: Difficulty.Hard,
   },
   {
     names: generateOrdinalNameVariations(1, 'John Joh Jo Jn J'.split(' ')),
     chapters: [10, 29, 24, 21, 21],
+    difficulty: Difficulty.Hard,
   },
   {
     names: generateOrdinalNameVariations(2, 'John Joh Jo Jn J'.split(' ')),
     chapters: [13],
+    difficulty: Difficulty.Normal,
   },
   {
     names: generateOrdinalNameVariations(3, 'John Joh Jo Jn J'.split(' ')),
     chapters: [14],
+    difficulty: Difficulty.Normal,
   },
   {
     names: 'Jude Jud'.split(' '),
     chapters: [25],
+    difficulty: Difficulty.Normal,
   },
   {
     names: 'Revelation Re Rev Rvltn'.split(' '),
@@ -385,10 +457,9 @@ const books = [
       20, 29, 22, 11, 14, 17, 17, 13, 21, 11, 19, 17, 18, 20, 8, 21, 18, 24, 21,
       15, 27, 21,
     ],
+    difficulty: Difficulty.Normal,
   },
 ];
-
-type BookData = ArrayItem<typeof books>;
 
 const bookCache = new Map<string, BookData | null>();
 
@@ -451,6 +522,10 @@ export class Book implements Iterable<Chapter> {
 
   get name(): string {
     return this.#book.names[0];
+  }
+
+  get difficulty() {
+    return this.#book.difficulty;
   }
 
   private get index() {

--- a/src/components/scripture/dto/book-difficulty.enum.ts
+++ b/src/components/scripture/dto/book-difficulty.enum.ts
@@ -1,0 +1,13 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum BookDifficulty {
+  Easy = 'Easy',
+  Normal = 'Normal',
+  Hard = 'Hard',
+  Hardest = 'Hardest',
+}
+
+registerEnumType(BookDifficulty, {
+  name: 'BookDifficulty',
+  description: 'How hard is this book to translate?',
+});

--- a/src/components/scripture/dto/index.ts
+++ b/src/components/scripture/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './scripture-reference.dto';
 export * from './scripture-range.dto';
 export * from './unspecified-scripture-portion.dto';
+export * from './book-difficulty.enum';

--- a/src/components/scripture/dto/scripture-range.dto.ts
+++ b/src/components/scripture/dto/scripture-range.dto.ts
@@ -89,7 +89,9 @@ export abstract class ScriptureRange implements Range<ScriptureReference> {
   }
 
   static randomList(min = 2, max = 4) {
-    return times(random(min, max)).map(ScriptureRange.random);
+    return mergeScriptureRanges(
+      times(random(min, max)).map(ScriptureRange.random)
+    );
   }
 }
 

--- a/src/components/scripture/dto/scripture-range.dto.ts
+++ b/src/components/scripture/dto/scripture-range.dto.ts
@@ -1,12 +1,13 @@
 import { applyDecorators } from '@nestjs/common';
 import { Field, FieldOptions, InputType, ObjectType } from '@nestjs/graphql';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { stripIndent } from 'common-tags';
 import { random, times } from 'lodash';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { Range, SecuredPropertyList, SecuredProps } from '../../../common';
 import { Verse } from '../books';
+import { mergeScriptureRanges } from '../labels';
 import { IsValidOrder } from './scripture-range.validator';
 import {
   ScriptureReference,
@@ -34,7 +35,8 @@ export const ScriptureField = (options: FieldOptions) =>
   applyDecorators(
     Field(() => [ScriptureRangeInput], options),
     ValidateNested(),
-    Type(() => ScriptureRangeInput)
+    Type(() => ScriptureRangeInput),
+    Transform(({ value }) => (value ? mergeScriptureRanges(value) : value))
   );
 
 @InputType()

--- a/src/components/scripture/dto/scripture-range.dto.ts
+++ b/src/components/scripture/dto/scripture-range.dto.ts
@@ -45,14 +45,14 @@ export abstract class ScriptureRangeInput {
     description: 'The starting point',
   })
   @ScriptureStart()
-  start: ScriptureReferenceInput;
+  readonly start: ScriptureReferenceInput;
 
   @Field({
     description: 'The ending point',
   })
   @IsValidOrder()
   @ScriptureEnd()
-  end: ScriptureReferenceInput;
+  readonly end: ScriptureReferenceInput;
 }
 
 @ObjectType({
@@ -65,12 +65,12 @@ export abstract class ScriptureRange implements Range<ScriptureReference> {
   @Field({
     description: 'The starting point',
   })
-  start: ScriptureReference;
+  readonly start: ScriptureReference;
 
   @Field({
     description: 'The ending point',
   })
-  end: ScriptureReference;
+  readonly end: ScriptureReference;
 
   static fromIds(range: Range<number>) {
     return mapRange(range, (p) => Verse.fromId(p).reference);

--- a/src/components/scripture/dto/scripture-range.dto.ts
+++ b/src/components/scripture/dto/scripture-range.dto.ts
@@ -1,4 +1,7 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { applyDecorators } from '@nestjs/common';
+import { Field, FieldOptions, InputType, ObjectType } from '@nestjs/graphql';
+import { Type } from 'class-transformer';
+import { ValidateNested } from 'class-validator';
 import { stripIndent } from 'common-tags';
 import { random, times } from 'lodash';
 import { keys as keysOf } from 'ts-transformer-keys';
@@ -26,6 +29,13 @@ export const mapRange = <T, U = T>(
   start: mapper(input.start),
   end: mapper(input.end),
 });
+
+export const ScriptureField = (options: FieldOptions) =>
+  applyDecorators(
+    Field(() => [ScriptureRangeInput], options),
+    ValidateNested(),
+    Type(() => ScriptureRangeInput)
+  );
 
 @InputType()
 export abstract class ScriptureRangeInput {

--- a/src/components/scripture/dto/scripture-reference.dto.ts
+++ b/src/components/scripture/dto/scripture-reference.dto.ts
@@ -17,7 +17,7 @@ export abstract class ScriptureReferenceInput {
     description: 'The Bible book',
   })
   @IsValidBook()
-  book: string;
+  readonly book: string;
 
   @Field(() => Int, {
     description: stripIndent`
@@ -27,7 +27,7 @@ export abstract class ScriptureReferenceInput {
     nullable: true,
   })
   @IsValidChapter()
-  chapter: number;
+  readonly chapter: number;
 
   @Field(() => Int, {
     description: stripIndent`
@@ -37,7 +37,7 @@ export abstract class ScriptureReferenceInput {
     nullable: true,
   })
   @IsValidVerse()
-  verse: number;
+  readonly verse: number;
 }
 
 @ObjectType({
@@ -47,10 +47,10 @@ export abstract class ScriptureReference extends ScriptureReferenceInput {
   @Field(() => Int, {
     description: `The chapter number.`,
   })
-  chapter: number;
+  readonly chapter: number;
 
   @Field(() => Int, {
     description: `The verse number.`,
   })
-  verse: number;
+  readonly verse: number;
 }

--- a/src/components/scripture/dto/scripture-reference.transformer.ts
+++ b/src/components/scripture/dto/scripture-reference.transformer.ts
@@ -1,6 +1,7 @@
 import { applyDecorators } from '@nestjs/common';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
+import { Mutable } from 'type-fest';
 import { Book } from '../books';
 import { ScriptureReferenceInput } from './scripture-reference.dto';
 
@@ -25,8 +26,8 @@ class ScriptureReferenceEndInput extends ScriptureReferenceInput {
     // after this. Also ignoring errors, as the validator reports better.
     try {
       const book = Book.find(value);
-      this.chapter = book.lastChapter.chapter;
-      this.verse = book.lastChapter.lastVerse.verse;
+      (this as Mutable<this>).chapter = book.lastChapter.chapter;
+      (this as Mutable<this>).verse = book.lastChapter.lastVerse.verse;
     } catch (e) {
       // let validator will throw error
     }

--- a/src/components/scripture/verse-equivalents.ts
+++ b/src/components/scripture/verse-equivalents.ts
@@ -1,0 +1,57 @@
+import { sum, sumBy } from 'lodash';
+import { iterate, Range } from '../../common';
+import { Book, Verse } from './books';
+import {
+  BookDifficulty,
+  mapRange,
+  ScriptureRange,
+  ScriptureRangeInput,
+  UnspecifiedScripturePortion,
+} from './dto';
+
+export const getTotalVerseEquivalents = (
+  ...refs: ReadonlyArray<ScriptureRange | ScriptureRangeInput>
+) => {
+  const verses = refs
+    .map((range) => mapRange(range, Verse.fromRef))
+    .flatMap((range) => iterate(splitRangeByBook(range)))
+    .map((range) => {
+      const factor = factorOfBook(range.start.book);
+      return factor * (range.end.id - range.start.id + 1);
+    });
+  return sum(verses);
+};
+
+export const getVerseEquivalentsFromUnspecified = (
+  portion: UnspecifiedScripturePortion
+) => {
+  const factor = factorOfBook(Book.find(portion.book));
+  return factor * portion.totalVerses;
+};
+
+export const getTotalVerses = (
+  ...refs: ReadonlyArray<ScriptureRange | ScriptureRangeInput>
+) =>
+  sumBy(refs, (range) => {
+    const { start, end } = mapRange(range, Verse.fromRef);
+    return end.id - start.id + 1;
+  });
+
+function* splitRangeByBook({ start, end }: Range<Verse>) {
+  while (start.book.name !== end.book.name) {
+    yield {
+      start,
+      end: start.book.lastChapter.lastVerse,
+    };
+    start = start.book.next!.firstChapter.firstVerse;
+  }
+  yield { start, end };
+}
+
+const factorMap: Record<BookDifficulty, number> = {
+  Easy: 0.8,
+  Normal: 1,
+  Hard: 1.25,
+  Hardest: 1.5625,
+};
+const factorOfBook = (book: Book) => factorMap[book.difficulty];

--- a/src/components/scripture/verse-equivalents.ts
+++ b/src/components/scripture/verse-equivalents.ts
@@ -8,11 +8,12 @@ import {
   ScriptureRangeInput,
   UnspecifiedScripturePortion,
 } from './dto';
+import { mergeScriptureRanges } from './labels';
 
 export const getTotalVerseEquivalents = (
   ...refs: ReadonlyArray<ScriptureRange | ScriptureRangeInput>
 ) => {
-  const verses = refs
+  const verses = mergeScriptureRanges(refs)
     .map((range) => mapRange(range, Verse.fromRef))
     .flatMap((range) => iterate(splitRangeByBook(range)))
     .map((range) => {
@@ -32,7 +33,7 @@ export const getVerseEquivalentsFromUnspecified = (
 export const getTotalVerses = (
   ...refs: ReadonlyArray<ScriptureRange | ScriptureRangeInput>
 ) =>
-  sumBy(refs, (range) => {
+  sumBy(mergeScriptureRanges(refs), (range) => {
     const { start, end } = mapRange(range, Verse.fromRef);
     return end.id - start.id + 1;
   });

--- a/src/components/scripture/verse-equivalents.ts
+++ b/src/components/scripture/verse-equivalents.ts
@@ -5,13 +5,12 @@ import {
   BookDifficulty,
   mapRange,
   ScriptureRange,
-  ScriptureRangeInput,
   UnspecifiedScripturePortion,
 } from './dto';
 import { mergeScriptureRanges } from './labels';
 
 export const getTotalVerseEquivalents = (
-  ...refs: ReadonlyArray<ScriptureRange | ScriptureRangeInput>
+  ...refs: readonly ScriptureRange[]
 ) => {
   const verses = mergeScriptureRanges(refs)
     .map((range) => mapRange(range, Verse.fromRef))
@@ -30,9 +29,7 @@ export const getVerseEquivalentsFromUnspecified = (
   return factor * portion.totalVerses;
 };
 
-export const getTotalVerses = (
-  ...refs: ReadonlyArray<ScriptureRange | ScriptureRangeInput>
-) =>
+export const getTotalVerses = (...refs: readonly ScriptureRange[]) =>
   sumBy(mergeScriptureRanges(refs), (range) => {
     const { start, end } = mapRange(range, Verse.fromRef);
     return end.id - start.id + 1;

--- a/src/components/song/dto/create-song.dto.ts
+++ b/src/components/song/dto/create-song.dto.ts
@@ -2,7 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { NameField } from '../../../common';
-import { ScriptureRangeInput } from '../../scripture';
+import { ScriptureField, ScriptureRangeInput } from '../../scripture';
 import { Song } from './song.dto';
 
 @InputType()
@@ -10,9 +10,7 @@ export abstract class CreateSong {
   @NameField()
   readonly name: string;
 
-  @Field(() => [ScriptureRangeInput], { nullable: true })
-  @ValidateNested()
-  @Type(() => ScriptureRangeInput)
+  @ScriptureField({ nullable: true })
   readonly scriptureReferences?: ScriptureRangeInput[] = [];
 }
 

--- a/src/components/song/dto/create-song.dto.ts
+++ b/src/components/song/dto/create-song.dto.ts
@@ -11,7 +11,7 @@ export abstract class CreateSong {
   readonly name: string;
 
   @ScriptureField({ nullable: true })
-  readonly scriptureReferences?: ScriptureRangeInput[] = [];
+  readonly scriptureReferences?: readonly ScriptureRangeInput[] = [];
 }
 
 @InputType()

--- a/src/components/song/dto/update-song.dto.ts
+++ b/src/components/song/dto/update-song.dto.ts
@@ -14,7 +14,7 @@ export abstract class UpdateSong {
   readonly name?: string;
 
   @ScriptureField({ nullable: true })
-  readonly scriptureReferences?: ScriptureRangeInput[];
+  readonly scriptureReferences?: readonly ScriptureRangeInput[];
 }
 
 @InputType()

--- a/src/components/song/dto/update-song.dto.ts
+++ b/src/components/song/dto/update-song.dto.ts
@@ -2,7 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { ID, IdField, NameField } from '../../../common';
-import { ScriptureRangeInput } from '../../scripture';
+import { ScriptureField, ScriptureRangeInput } from '../../scripture';
 import { Song } from './song.dto';
 
 @InputType()
@@ -13,9 +13,7 @@ export abstract class UpdateSong {
   @NameField({ nullable: true })
   readonly name?: string;
 
-  @Field(() => [ScriptureRangeInput], { nullable: true })
-  @ValidateNested()
-  @Type(() => ScriptureRangeInput)
+  @ScriptureField({ nullable: true })
   readonly scriptureReferences?: ScriptureRangeInput[];
 }
 

--- a/src/components/story/dto/create-story.dto.ts
+++ b/src/components/story/dto/create-story.dto.ts
@@ -2,7 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { NameField } from '../../../common';
-import { ScriptureRangeInput } from '../../scripture';
+import { ScriptureField, ScriptureRangeInput } from '../../scripture';
 import { Story } from './story.dto';
 
 @InputType()
@@ -10,9 +10,7 @@ export abstract class CreateStory {
   @NameField()
   readonly name: string;
 
-  @Field(() => [ScriptureRangeInput], { nullable: true })
-  @ValidateNested()
-  @Type(() => ScriptureRangeInput)
+  @ScriptureField({ nullable: true })
   readonly scriptureReferences?: ScriptureRangeInput[] = [];
 }
 

--- a/src/components/story/dto/create-story.dto.ts
+++ b/src/components/story/dto/create-story.dto.ts
@@ -11,7 +11,7 @@ export abstract class CreateStory {
   readonly name: string;
 
   @ScriptureField({ nullable: true })
-  readonly scriptureReferences?: ScriptureRangeInput[] = [];
+  readonly scriptureReferences?: readonly ScriptureRangeInput[] = [];
 }
 
 @InputType()

--- a/src/components/story/dto/update-story.dto.ts
+++ b/src/components/story/dto/update-story.dto.ts
@@ -2,7 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { ID, IdField, NameField } from '../../../common';
-import { ScriptureRangeInput } from '../../scripture';
+import { ScriptureField, ScriptureRangeInput } from '../../scripture';
 import { Story } from './story.dto';
 
 @InputType()
@@ -13,9 +13,7 @@ export abstract class UpdateStory {
   @NameField({ nullable: true })
   readonly name?: string;
 
-  @Field(() => [ScriptureRangeInput], { nullable: true })
-  @ValidateNested()
-  @Type(() => ScriptureRangeInput)
+  @ScriptureField({ nullable: true })
   readonly scriptureReferences?: ScriptureRangeInput[];
 }
 

--- a/src/components/story/dto/update-story.dto.ts
+++ b/src/components/story/dto/update-story.dto.ts
@@ -14,7 +14,7 @@ export abstract class UpdateStory {
   readonly name?: string;
 
   @ScriptureField({ nullable: true })
-  readonly scriptureReferences?: ScriptureRangeInput[];
+  readonly scriptureReferences?: readonly ScriptureRangeInput[];
 }
 
 @InputType()


### PR DESCRIPTION
```gql
type DirectScriptureProduct {
  """The total number of verses of the selected scripture in this product"""
  totalVerses: Int!

  """
  The total number of verse equivalents of the selected scripture in this product.
  Verse equivalents weight each verse based on its translation difficulty.
  """
  totalVerseEquivalents: Float!
}
```
I've opted to write these calculations to the DB. It's a little bit of work to calculate these. These will be referenced in progress  data, so I wanted them to be easily accessible.

----

I ended up adding formatting here as well. I opted to do it at the field level as this lets us reuse the already fetched data and just format it different. A field can be specified multiple times with different aliases.
```gql
fragment sp on StepProgress {
  completed(format: Percent) {
    value
  }
  verses: completed(format: Verses) {
    value
  }
}

fragment ps on ProgressSummary {
  planned(format: Percent)
  actual(format: Percent)
}
```
This seems to work well in testing adhoc gql queries, but I'd like to get some confirmation from UI implementation. It could be easy for them pass in a single format arg to the operation and just refetch from the API when user wants a different format. Another optional would be to ask for each format desired all at once with aliases and swap out props used based on selector.