### PR TITLE
PnP / XLSX Refactor

### DIFF
--- a/src/common/xlsx.util.ts
+++ b/src/common/xlsx.util.ts
@@ -1,20 +1,340 @@
-import { utils } from 'xlsx';
+import { from as iterableFrom, IterableX } from 'ix/iterable';
+import { LazyGetter as Once } from 'lazy-get-decorator';
+import { assert } from 'ts-essentials';
+import {
+  CellAddress,
+  Range as LibRange,
+  WorkBook as LibWorkBook,
+  read,
+  utils,
+} from 'xlsx';
 import type { CellObject, WorkSheet } from 'xlsx';
 import { CalendarDate } from './temporal';
 
-export const cellAsNumber = (cell: CellObject) =>
-  cell && cell.t === 'n' && typeof cell.v === 'number' ? cell.v : undefined;
+export class WorkBook {
+  private readonly book: LibWorkBook;
+  private readonly sheets: Record<string, Sheet> = {};
+  protected constructor(book: LibWorkBook | WorkBook) {
+    this.book = book instanceof WorkBook ? book.book : book;
+  }
 
-export const cellAsString = (cell: CellObject) =>
-  cell && cell.t === 's' && typeof cell.v === 'string' ? cell.v : undefined;
+  static fromBuffer(buffer: Buffer) {
+    const book = read(buffer, {
+      type: 'buffer',
+      cellDates: true,
+    });
+    return new WorkBook(book);
+  }
 
-/**
- * Requires `cellDates: true` in parsing options
- */
-export const cellAsDate = (cell: CellObject) =>
-  cell && cell.t === 'd' && cell.v instanceof Date
-    ? CalendarDate.fromJSDate(cell.v)
-    : undefined;
+  sheet(name: string) {
+    return this.sheets[name] ?? (this.sheets[name] = new Sheet(this, name));
+  }
+}
 
-export const sheetRange = (ws: WorkSheet) =>
-  ws['!ref'] ? utils.decode_range(ws['!ref']) : undefined;
+export class Sheet {
+  readonly book: WorkBook;
+  readonly name: string;
+  private readonly workbook: LibWorkBook;
+  private readonly sheet: WorkSheet;
+
+  constructor(sheet: Sheet);
+  constructor(workbook: WorkBook, name: string);
+  constructor(arg: WorkBook | Sheet, name?: string) {
+    if (arg instanceof Sheet) {
+      this.book = arg.book;
+      this.workbook = arg.workbook;
+      this.sheet = arg.sheet;
+      this.name = arg.name;
+    } else {
+      this.name = name!;
+      this.book = arg;
+      // @ts-expect-error yeah it's private this seems like the easiest way though
+      this.workbook = this.book.book;
+      this.sheet = this.workbook.Sheets[this.name];
+      if (!this.sheet) {
+        throw new Error(`Cannot find ${this.name} sheet`);
+      }
+    }
+  }
+
+  @Once() get hidden() {
+    return (
+      (this.workbook.Workbook?.Sheets?.find((s) => s.name === this.name)
+        ?.Hidden ?? 0) > 0
+    );
+  }
+
+  @Once() get sheetRange() {
+    const ref = this.sheet['!ref'];
+    assert(ref, 'Cannot find sheet range reference');
+    return this.range(ref);
+  }
+
+  range(a1range: string | Range | LibRange): Range;
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  range(start: Cell | string, end: Cell | string): Range;
+  range(a1start: Cell | string | Range | LibRange, a1end?: Cell | string) {
+    if (a1start instanceof Range) {
+      return new Range(this, this.cell(a1start.start), this.cell(a1start.end));
+    }
+    const { s, e } = a1end
+      ? { s: a1start as Cell | string, e: a1end }
+      : typeof a1start === 'object'
+      ? (a1start as LibRange)
+      : utils.decode_range(a1start);
+    return new Range(
+      this,
+      s instanceof Cell ? s : this.cell(s),
+      e instanceof Cell ? e : this.cell(e)
+    );
+  }
+
+  row(a1row: number) {
+    return new Row(this, a1row);
+  }
+
+  column(column: string) {
+    return new Column(this, column);
+  }
+
+  /**
+   * Grab cell from decoded range. Note that both column & row are 0-indexed
+   * here.
+   */
+  cell(columnIndex: number, rowIndex: number): Cell;
+  /**
+   * Grab cell from A1 column & A1 row (1-indexed).
+   */
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  cell(column: string | Column, a1row: number | Row): Cell;
+  /**
+   * Grab cell from an existing cell.
+   * This cell could be from another sheet, but the one returned will be
+   * for this sheet.
+   */
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  cell(address: Cell): Cell;
+  /**
+   * Grab cell from an encoded or decoded address.
+   */
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  cell(address: string | CellAddress): Cell;
+  cell(
+    column: string | number | CellAddress | Column | Cell,
+    row?: number | Row
+  ) {
+    if (column instanceof Cell) {
+      return new Cell(
+        this,
+        this.sheet,
+        this.sheet[column.toString()],
+        column.address
+      );
+    }
+    if (column instanceof Column) {
+      column = column.a1;
+    }
+    if (row != null && row instanceof Row) {
+      row = row.a1;
+    }
+    if (row == null || typeof column === 'object') {
+      const address =
+        typeof column === 'string'
+          ? utils.decode_cell(column)
+          : (column as CellAddress);
+      column = utils.encode_col(address.c);
+      row = address.r + 1;
+    } else if (typeof column === 'number') {
+      column = utils.encode_col(column);
+      row++;
+    }
+
+    const address = `${column}${row}`;
+    return new Cell(
+      this,
+      this.sheet,
+      this.sheet[address],
+      utils.decode_cell(address)
+    );
+  }
+}
+
+export class Cell {
+  constructor(
+    readonly sheet: Sheet,
+    private readonly libSheet: WorkSheet,
+    private readonly cell: CellObject | undefined,
+    readonly address: CellAddress
+  ) {}
+
+  @Once() get row() {
+    return this.sheet.row(this.address.r + 1);
+  }
+
+  @Once() get column() {
+    return this.sheet.column(utils.encode_col(this.address.c));
+  }
+
+  @Once() get hidden() {
+    const colHidden = this.libSheet['!cols']?.[this.address.c].hidden ?? false;
+    const rowHidden = this.libSheet['!rows']?.[this.address.r].hidden ?? false;
+    return colHidden || rowHidden;
+  }
+
+  get exists() {
+    return !!this.cell;
+  }
+  get isNumber() {
+    return this.cell?.t === 'n';
+  }
+  @Once() get asNumber() {
+    return this.cell && this.cell.t === 'n' && typeof this.cell.v === 'number'
+      ? this.cell.v
+      : undefined;
+  }
+  @Once() get asString() {
+    return this.cell && this.cell.t === 's' && typeof this.cell.v === 'string'
+      ? this.cell.v
+      : undefined;
+  }
+  @Once() get asDate() {
+    return this.cell && this.cell.t === 'd' && this.cell.v instanceof Date
+      ? CalendarDate.fromJSDate(this.cell.v)
+      : undefined;
+  }
+
+  toString() {
+    return `${this.column.a1}${this.row.a1}`;
+  }
+}
+
+abstract class Rangable {
+  constructor(readonly sheet: Sheet) {}
+
+  abstract get start(): Cell;
+  abstract get end(): Cell;
+
+  /**
+   * Iterate through the rows in this range.
+   * Cell column is always the starting column.
+   */
+  walkDown(): IterableX<Cell> {
+    return iterableFrom(
+      function* (this: Rangable) {
+        let current = this.start.row;
+        while (current <= this.end.row) {
+          const cell = current.cell(this.start.column);
+          if (cell.exists) {
+            yield cell;
+          }
+          current = current.next();
+        }
+      }.call(this)
+    );
+  }
+
+  /**
+   * Iterate through the columns in this range.
+   * Cell row is always the starting row.
+   */
+  walkRight(): IterableX<Cell> {
+    return iterableFrom(
+      function* (this: Rangable) {
+        let current = this.start.column;
+        while (current <= this.end.column) {
+          const cell = current.cell(this.start.row);
+          if (cell.exists) {
+            yield cell;
+          }
+          current = current.next();
+        }
+      }.call(this)
+    );
+  }
+
+  toString() {
+    return `${this.sheet.name}!${this.start.toString()}:${this.end.toString()}`;
+  }
+}
+
+export class Range extends Rangable {
+  constructor(sheet: Sheet, readonly start: Cell, readonly end: Cell) {
+    super(sheet);
+  }
+}
+
+export class Row extends Rangable {
+  /** A1 row number (1-indexed) */
+  readonly a1: number;
+  readonly index: number;
+
+  constructor(sheet: Sheet, row: number) {
+    super(sheet);
+    this.a1 = row;
+    this.index = row - 1;
+  }
+
+  @Once() get start(): Cell {
+    const full = this.sheet.sheetRange;
+    return this.sheet.cell(full.start.column, this.a1);
+  }
+
+  @Once() get end(): Cell {
+    const full = this.sheet.sheetRange;
+    return this.sheet.cell(full.start.column, this.a1);
+  }
+
+  cell(column: string | Column) {
+    return this.sheet.cell(column, this.a1);
+  }
+
+  next(over = 1) {
+    return new Row(this.sheet, this.a1 + over);
+  }
+
+  /**
+   * @internal Used for comparison operators
+   * @deprecated
+   */
+  valueOf() {
+    return this.index;
+  }
+}
+
+export class Column extends Rangable {
+  /** A1 column letter */
+  readonly a1: string;
+  readonly index: number;
+
+  constructor(sheet: Sheet, column: string) {
+    super(sheet);
+    this.a1 = column;
+    this.index = utils.decode_col(this.a1);
+  }
+
+  @Once() get start(): Cell {
+    const full = this.sheet.sheetRange;
+    return this.sheet.cell(this.a1, full.start.row);
+  }
+
+  @Once() get end(): Cell {
+    const full = this.sheet.sheetRange;
+    return this.sheet.cell(this.a1, full.start.row);
+  }
+
+  cell(row: number | Row) {
+    return this.sheet.cell(this.a1, row);
+  }
+
+  next(over = 1) {
+    return new Column(this.sheet, utils.encode_col(this.index + over));
+  }
+
+  /**
+   * @internal Used for comparison operators
+   * @deprecated
+   */
+  valueOf() {
+    return this.index;
+  }
+}

--- a/src/components/pnp/findStepColumns.ts
+++ b/src/components/pnp/findStepColumns.ts
@@ -1,0 +1,52 @@
+import levenshtein from 'js-levenshtein-esm';
+import { sortBy, startCase, without } from 'lodash';
+import { Column } from '../../common/xlsx.util';
+import { ProductStep as Step } from '../product';
+import { PlanningSheet } from './planning-sheet';
+import { ProgressSheet } from './progress-sheet';
+import 'ix/add/iterable-operators/filter';
+import 'ix/add/iterable-operators/map';
+import 'ix/add/iterable-operators/toarray';
+
+/**
+ * Fuzzy match available steps to their column address.
+ */
+export function findStepColumns(
+  sheet: PlanningSheet | ProgressSheet,
+  availableSteps: readonly Step[] = Object.values(Step)
+) {
+  const matchedColumns: Partial<Record<Step, Column>> = {};
+  let remainingSteps = availableSteps;
+  const possibleSteps = sheet.stepLabels
+    .walkRight()
+    .filter((cell) => !!cell.asString)
+    .map((cell) => ({ label: cell.asString!, column: cell.column }))
+    .toArray();
+  possibleSteps.forEach(({ label, column }, index) => {
+    if (index === possibleSteps.length - 1) {
+      // The last step should always be called Completed in CORD per Seth.
+      // Written PnP already match, but OBS calls it Record. This is mislabeled
+      // depending on the methodology.
+      matchedColumns[Step.Completed] = column;
+      return;
+    }
+    const distances = remainingSteps.map((step) => {
+      const humanLabel = startCase(step).replace(' And ', ' & ');
+      const distance = levenshtein(label, humanLabel);
+      return [step, distance] as const;
+    });
+    // Pick the step that is the closest fuzzy match
+    const chosen = sortBy(
+      // 5 is too far ignore those
+      distances.filter(([_, distance]) => distance < 5),
+      ([_, distance]) => distance
+    )[0]?.[0];
+    if (!chosen) {
+      return;
+    }
+    matchedColumns[chosen] = column;
+
+    remainingSteps = without(remainingSteps, chosen);
+  });
+  return matchedColumns as Record<Step, Column>;
+}

--- a/src/components/pnp/index.ts
+++ b/src/components/pnp/index.ts
@@ -1,0 +1,5 @@
+export * from './planning-sheet';
+export * from './progress-sheet';
+export * from './pnp';
+export * from './findStepColumns';
+export * from './isGoalRow';

--- a/src/components/pnp/isGoalRow.ts
+++ b/src/components/pnp/isGoalRow.ts
@@ -1,0 +1,16 @@
+import { Cell } from '../../common/xlsx.util';
+import { Book } from '../scripture/books';
+import { PlanningSheet } from './planning-sheet';
+import { ProgressSheet } from './progress-sheet';
+
+export const isGoalRow = (cell: Cell<PlanningSheet | ProgressSheet>) => {
+  if (cell.sheet.isOBS()) {
+    return !!cell.sheet.storyName(cell.row);
+  }
+  if (!cell.sheet.isWritten()) {
+    return false;
+  }
+  const book = Book.tryFind(cell.sheet.bookName(cell.row));
+  const totalVerses = cell.sheet.totalVerses(cell.row) ?? 0;
+  return !!book && totalVerses > 0 && totalVerses <= book.totalVerses;
+};

--- a/src/components/pnp/planning-sheet.ts
+++ b/src/components/pnp/planning-sheet.ts
@@ -1,0 +1,124 @@
+import { LazyGetter as Once } from 'lazy-get-decorator';
+import { DateInterval, expandToFullFiscalYears } from '../../common';
+import {
+  Cell,
+  Column,
+  Range,
+  Row,
+  Sheet,
+  WorkBook,
+} from '../../common/xlsx.util';
+
+export abstract class PlanningSheet extends Sheet {
+  static register(book: WorkBook) {
+    const sheet = book.sheet('Planning');
+    const isOBS = sheet.cell('P19').asString === 'Stories';
+    const custom = isOBS
+      ? new OralStoryingPlanningSheet(sheet)
+      : new WrittenScripturePlanningSheet(sheet);
+    return book.registerCustomSheet(custom);
+  }
+
+  isWritten(): this is WrittenScripturePlanningSheet {
+    return this instanceof WrittenScripturePlanningSheet;
+  }
+  isOBS(): this is OralStoryingPlanningSheet {
+    return this instanceof OralStoryingPlanningSheet;
+  }
+
+  @Once() get revision() {
+    return this.revisionCell.asDate;
+  }
+  protected abstract revisionCell: Cell;
+
+  @Once() get projectDateRange(): DateInterval {
+    const range = DateInterval.tryFrom(
+      this.projectStartDateCell.asDate,
+      this.projectEndDateCell.asDate
+    );
+    if (!range) {
+      throw new Error('Could not find project date range');
+    }
+    return range;
+  }
+  @Once() get projectFiscalYears(): DateInterval {
+    return expandToFullFiscalYears(this.projectDateRange);
+  }
+  protected abstract projectStartDateCell: Cell;
+  protected abstract projectEndDateCell: Cell;
+
+  abstract readonly stepLabels: Range;
+
+  get goals(): Range<PlanningSheet> {
+    return this.range(this.goalsStart, this.goalsEnd);
+  }
+  protected goalsStart = this.cell('Q', 23);
+  @Once() protected get goalsEnd() {
+    return this.sheetRange.end.row.cell('Q');
+  }
+
+  myNote(goalRow: Row) {
+    return (
+      this.myNotesColumn.cell(goalRow).asString ??
+      this.myNotesFallbackCell?.asString
+    );
+  }
+  protected abstract myNotesFallbackCell: Cell | undefined;
+  protected abstract myNotesColumn: Column;
+
+  totalVerses(goalRow: Row) {
+    return this.cell('T', goalRow).asNumber;
+  }
+}
+
+export class WrittenScripturePlanningSheet extends PlanningSheet {
+  protected revisionCell = this.cell('Z11');
+  protected projectStartDateCell = this.cell('Z14');
+  protected projectEndDateCell = this.cell('Z15');
+  readonly stepLabels = this.range('U18:Z18');
+  protected myNotesColumn = this.column('AI');
+  protected myNotesFallbackCell = this.cell('AI16');
+
+  bookName(goalRow: Row) {
+    return this.cell('Q', goalRow).asString;
+  }
+
+  @Once() get goalsEnd() {
+    const lastRow = super.goalsEnd.row;
+    let row = this.goalsStart.row;
+    while (
+      row < lastRow &&
+      this.bookName(row) !== 'Other Goals and Milestones'
+    ) {
+      row = row.next();
+    }
+    return super.goalsEnd.column.cell(row);
+  }
+}
+
+export class OralStoryingPlanningSheet extends PlanningSheet {
+  protected revisionCell = this.cell('X14');
+  protected projectStartDateCell = this.cell('X16');
+  protected projectEndDateCell = this.cell('X17');
+  readonly stepLabels = this.range('U20:X20');
+  protected myNotesColumn = this.column('Y');
+  protected myNotesFallbackCell = undefined;
+
+  storyName(goalRow: Row) {
+    return this.cell('Q', goalRow).asString;
+  }
+  scriptureReference(goalRow: Row) {
+    return this.cell('R', goalRow).asString;
+  }
+  composite(goalRow: Row) {
+    return this.cell('S', goalRow).asString;
+  }
+
+  readonly sustainabilityGoals = this.range('Y17:AA20');
+  sustainabilityRole(goalRow: Row) {
+    return this.cell('Y', goalRow).asString;
+  }
+  sustainabilityRoleCount(goalRow: Row) {
+    return this.cell('AA', goalRow).asString;
+  }
+}

--- a/src/components/pnp/pnp.ts
+++ b/src/components/pnp/pnp.ts
@@ -1,0 +1,37 @@
+import { WorkBook } from '../../common/xlsx.util';
+import { Downloadable } from '../file';
+import { PlanningSheet } from './planning-sheet';
+import { ProgressSheet } from './progress-sheet';
+
+const ParsedPnp = Symbol('Parsed PnP');
+
+export class Pnp {
+  constructor(protected workbook: WorkBook) {}
+
+  /**
+   * Create PnP from Downloadable.
+   * Will reuse an existing instance from a previous call.
+   */
+  static async fromDownloadable(obj: Downloadable<unknown>) {
+    const promise = obj.download() as Promise<Buffer> & { [ParsedPnp]?: Pnp };
+    if (!promise[ParsedPnp]) {
+      promise[ParsedPnp] = Pnp.fromBuffer(await promise);
+    }
+    return promise[ParsedPnp]!;
+  }
+
+  static fromBuffer(buffer: Buffer) {
+    const book = WorkBook.fromBuffer(buffer);
+    PlanningSheet.register(book);
+    ProgressSheet.register(book);
+    return new Pnp(book);
+  }
+
+  get planning() {
+    return this.workbook.sheet<PlanningSheet>('Planning');
+  }
+
+  get progress() {
+    return this.workbook.sheet<ProgressSheet>('Progress');
+  }
+}

--- a/src/components/pnp/progress-sheet.ts
+++ b/src/components/pnp/progress-sheet.ts
@@ -1,0 +1,91 @@
+import { LazyGetter as Once } from 'lazy-get-decorator';
+import { Column, Range, Row, Sheet, WorkBook } from '../../common/xlsx.util';
+
+export abstract class ProgressSheet extends Sheet {
+  static register(book: WorkBook) {
+    const sheet = book.sheet('Progress');
+    const isOBS = sheet.cell('P19').asString === 'Stories';
+    const custom = isOBS
+      ? new OralStoryingProgressSheet(sheet)
+      : new WrittenScriptureProgressSheet(sheet);
+    return book.registerCustomSheet(custom);
+  }
+
+  isWritten(): this is WrittenScriptureProgressSheet {
+    return this instanceof WrittenScriptureProgressSheet;
+  }
+  isOBS(): this is OralStoryingProgressSheet {
+    return this instanceof OralStoryingProgressSheet;
+  }
+
+  get stepLabels() {
+    return this.range('R19:AB19');
+  }
+
+  get goals(): Range<ProgressSheet> {
+    return this.range(this.goalsStart, this.goalsEnd);
+  }
+  @Once() protected get goalsStart() {
+    return this.book.namedRange('ProgDraft').start;
+  }
+  @Once() protected get goalsEnd() {
+    return this.sheetRange.end;
+  }
+
+  @Once() get totalVerseEquivalents() {
+    const total = this.book.namedRange('VE').start.asNumber;
+    if (!total) {
+      throw new Error('Unable to find total verse equivalents in pnp file');
+    }
+    return total;
+  }
+
+  get summaryFiscalYears() {
+    return this.namedRange('PrcntFinishedYears');
+  }
+
+  columnForQuarterSummary(fiscalQuarter: number) {
+    return this.book.namedRange(`Q${fiscalQuarter}Column`).start.column;
+  }
+  get columnsForFiscalYear(): readonly [planned: Column, actual: Column] {
+    const q4 = this.book.namedRange('Q4Column').start.column;
+    return [q4.next(), q4.next(2)];
+  }
+  get columnsForCumulative(): readonly [planned: Column, actual: Column] {
+    const q4 = this.book.namedRange('Q4Column').start.column;
+    return [q4.next(3), q4.next(4)];
+  }
+}
+
+export class WrittenScriptureProgressSheet extends ProgressSheet {
+  @Once() get goalsEnd() {
+    const lastRow = super.goalsEnd.row;
+    let row = this.goalsStart.row;
+    while (
+      row < lastRow &&
+      this.bookName(row) !== 'Other Goals and Milestones'
+    ) {
+      row = row.next();
+    }
+    return super.goalsEnd.column.cell(row);
+  }
+
+  bookName(goalRow: Row) {
+    return this.cell('P', goalRow).asString;
+  }
+  totalVerses(goalRow: Row) {
+    return this.cell('Q', goalRow).asNumber;
+  }
+}
+
+export class OralStoryingProgressSheet extends ProgressSheet {
+  storyName(goalRow: Row) {
+    return this.cell('Q', goalRow).asString;
+  }
+  scriptureReference(goalRow: Row) {
+    return this.cell('R', goalRow).asString;
+  }
+  composite(goalRow: Row) {
+    return this.cell('S', goalRow).asString;
+  }
+}

--- a/src/components/product-progress/handlers/extract-pnp-progress.handler.ts
+++ b/src/components/product-progress/handlers/extract-pnp-progress.handler.ts
@@ -20,7 +20,17 @@ export class ExtractPnpProgressHandler {
     }
 
     // parse progress data from pnp spreadsheet
-    const progressRows = await this.extractor.extract(event.file);
+    let progressRows;
+    try {
+      progressRows = await this.extractor.extract(event.file);
+    } catch (e) {
+      this.logger.warning(e.message, {
+        name: event.file.name,
+        id: event.file.id,
+        exception: e,
+      });
+      return;
+    }
     if (progressRows.length === 0) {
       return;
     }

--- a/src/components/product-progress/step-progress-extractor.service.ts
+++ b/src/components/product-progress/step-progress-extractor.service.ts
@@ -3,8 +3,7 @@ import { MergeExclusive } from 'type-fest';
 import { CellObject, read, WorkSheet } from 'xlsx';
 import { entries } from '../../common';
 import { cellAsNumber, cellAsString, sheetRange } from '../../common/xlsx.util';
-import { ILogger, Logger } from '../../core';
-import { Downloadable, FileNode } from '../file';
+import { Downloadable } from '../file';
 import { ProductStep as Step } from '../product';
 import { findStepColumns } from '../product/product-extractor.service';
 import { Book } from '../scripture/books';
@@ -33,21 +32,13 @@ type ExtractedRow = MergeExclusive<
 
 @Injectable()
 export class StepProgressExtractor {
-  constructor(
-    @Logger('step-progress:extractor') private readonly logger: ILogger
-  ) {}
-
-  async extract(file: Downloadable<FileNode>) {
+  async extract(file: Downloadable<unknown>) {
     const buffer = await file.download();
     const pnp = read(buffer, { type: 'buffer' });
 
     const sheet = pnp.Sheets.Progress;
     if (!sheet) {
-      this.logger.warning('Unable to find progress sheet in pnp file', {
-        name: file.name,
-        id: file.id,
-      });
-      return [];
+      throw new Error('Unable to find progress sheet in pnp file');
     }
 
     const isOBS = cellAsString(sheet.P19) === 'Stories';

--- a/src/components/product-progress/step-progress-extractor.service.ts
+++ b/src/components/product-progress/step-progress-extractor.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { MergeExclusive } from 'type-fest';
-import { CellObject, read, WorkSheet } from 'xlsx';
 import { entries } from '../../common';
-import { cellAsNumber, cellAsString, sheetRange } from '../../common/xlsx.util';
+import { Column, Row, WorkBook } from '../../common/xlsx.util';
 import { Downloadable } from '../file';
 import { ProductStep as Step } from '../product';
 import { findStepColumns } from '../product/product-extractor.service';
@@ -34,69 +33,57 @@ type ExtractedRow = MergeExclusive<
 export class StepProgressExtractor {
   async extract(file: Downloadable<unknown>) {
     const buffer = await file.download();
-    const pnp = read(buffer, { type: 'buffer' });
+    const pnp = WorkBook.fromBuffer(buffer);
 
-    const sheet = pnp.Sheets.Progress;
-    if (!sheet) {
-      throw new Error('Unable to find progress sheet in pnp file');
-    }
+    const sheet = pnp.sheet('Progress');
 
-    const isOBS = cellAsString(sheet.P19) === 'Stories';
+    const isOBS = sheet.cell('P19').asString === 'Stories';
 
-    const stepColumns = findStepColumns(sheet, 'R19:AB19');
+    const stepColumns = findStepColumns(sheet.range('R19:AB19'));
 
-    const startingRow = 23;
+    const startingRow = sheet.row(23);
 
-    return findProductProgressRows(sheet, isOBS, startingRow).map(
-      parseProgressRow(sheet, stepColumns, isOBS, startingRow)
+    return findProductProgressRows(startingRow, isOBS).map(
+      parseProgressRow(stepColumns, isOBS, startingRow)
     );
   }
 }
 
-function findProductProgressRows(
-  sheet: WorkSheet,
-  isOBS: boolean,
-  startingRow: number
-) {
-  const lastRow = sheetRange(sheet)?.e.r ?? 200;
+function findProductProgressRows(startingRow: Row, isOBS: boolean) {
+  const lastRow = startingRow.sheet.sheetRange.end.row;
   const matchedRows = [];
   let row = startingRow;
   while (
     row < lastRow &&
-    cellAsString(sheet[`P${row}`]) !== 'Other Goals and Milestones'
+    row.cell('P').asString !== 'Other Goals and Milestones'
   ) {
-    if (isProductRow(sheet, isOBS, row)) {
+    if (isProductRow(row, isOBS)) {
       matchedRows.push(row);
     }
-    row++;
+    row = row.next();
   }
   return matchedRows;
 }
 
-const isProductRow = (sheet: WorkSheet, isOBS: boolean, row: number) => {
+const isProductRow = (row: Row, isOBS: boolean) => {
   if (isOBS) {
-    return !!cellAsString(sheet[`Q${row}`]);
+    return !!row.cell('Q').asString;
   }
-  const book = Book.tryFind(cellAsString(sheet[`P${row}`]));
-  const totalVerses = cellAsNumber(sheet[`Q${row}`]) ?? 0;
+  const book = Book.tryFind(row.cell('P').asString);
+  const totalVerses = row.cell('Q').asNumber ?? 0;
   return book && totalVerses > 0 && totalVerses <= book.totalVerses;
 };
 
 const parseProgressRow =
-  (
-    sheet: WorkSheet,
-    stepColumns: Record<Step, string>,
-    isOBS: boolean,
-    startingRow: number
-  ) =>
-  (row: number, index: number): ExtractedRow => {
-    const progress = (column: string) => {
-      const cell: CellObject = sheet[`${column}${row}`];
-      if (cellAsString(cell)?.startsWith('Q')) {
+  (stepColumns: Record<Step, Column>, isOBS: boolean, startingRow: Row) =>
+  (row: Row, index: number): ExtractedRow => {
+    const progress = (column: Column) => {
+      const cell = row.cell(column);
+      if (cell.asString?.startsWith('Q')) {
         // Q# means completed that quarter
         return 100;
       }
-      const percentDecimal = cellAsNumber(cell);
+      const percentDecimal = cell.asNumber;
       return percentDecimal ? percentDecimal * 100 : undefined;
     };
     const steps = entries(stepColumns).map(
@@ -106,15 +93,15 @@ const parseProgressRow =
       })
     );
     const common = {
-      rowIndex: row - startingRow + 1,
+      rowIndex: row.a1 - startingRow.a1 + 1,
       order: index + 1,
       steps,
     };
     if (isOBS) {
-      const story = cellAsString(sheet[`Q${row}`])!; // Asserting bc loop verified this
+      const story = row.cell('Q').asString!; // Asserting bc loop verified this
       return { ...common, story };
     }
-    const bookName = cellAsString(sheet[`P${row}`])!; // Asserting bc loop verified this
-    const totalVerses = cellAsNumber(sheet[`Q${row}`])!; // Asserting bc loop verified this
+    const bookName = row.cell('P').asString!; // Asserting bc loop verified this
+    const totalVerses = row.cell('Q').asNumber!; // Asserting bc loop verified this
     return { ...common, bookName, totalVerses };
   };

--- a/src/components/product/handlers/extract-products-from-pnp.handler.ts
+++ b/src/components/product/handlers/extract-products-from-pnp.handler.ts
@@ -64,7 +64,16 @@ export class ExtractProductsFromPnpHandler
     const availableSteps = getAvailableSteps({
       methodology,
     });
-    const productRows = await this.extractor.extract(file, availableSteps);
+    let productRows;
+    try {
+      productRows = await this.extractor.extract(file, availableSteps);
+    } catch (e) {
+      this.logger.warning(e.message, {
+        id: file.id,
+        exception: e,
+      });
+      return;
+    }
     if (productRows.length === 0) {
       return;
     }

--- a/src/components/product/product-extractor.service.ts
+++ b/src/components/product/product-extractor.service.ts
@@ -16,8 +16,7 @@ import {
   cellAsString,
   sheetRange,
 } from '../../common/xlsx.util';
-import { ILogger, Logger } from '../../core';
-import { Downloadable, File } from '../file';
+import { Downloadable } from '../file';
 import { ScriptureRange } from '../scripture';
 import { Book } from '../scripture/books';
 import { parseScripture } from '../scripture/parser';
@@ -25,10 +24,8 @@ import { ProductStep as Step } from './dto';
 
 @Injectable()
 export class ProductExtractor {
-  constructor(@Logger('product:extractor') private readonly logger: ILogger) {}
-
   async extract(
-    file: Downloadable<Pick<File, 'id'>>,
+    file: Downloadable<unknown>,
     availableSteps: readonly Step[]
   ): Promise<readonly ExtractedRow[]> {
     const buffer = await file.download();
@@ -36,10 +33,7 @@ export class ProductExtractor {
 
     const sheet = pnp.Sheets.Planning;
     if (!sheet) {
-      this.logger.warning('Unable to find planning sheet', {
-        id: file.id,
-      });
-      return [] as const;
+      throw new Error('Unable to find planning sheet');
     }
 
     const isOBS = cellAsString(sheet.P19) === 'Stories';
@@ -48,10 +42,7 @@ export class ProductExtractor {
       ? DateInterval.tryFrom(cellAsDate(sheet.X16), cellAsDate(sheet.X17))
       : DateInterval.tryFrom(cellAsDate(sheet.Z14), cellAsDate(sheet.Z15));
     if (!interval) {
-      this.logger.warning('Unable to find project date range', {
-        id: file.id,
-      });
-      return [];
+      throw new Error('Unable to find project date range');
     }
 
     const stepColumns = findStepColumns(

--- a/src/components/progress-summary/handlers/extract-pnp-file-on-upload.handler.ts
+++ b/src/components/progress-summary/handlers/extract-pnp-file-on-upload.handler.ts
@@ -23,13 +23,18 @@ export class ExtractPnpFileOnUploadHandler {
       userId: event.session.userId,
       fileId: event.file.id,
     });
-    const workbook = await this.extractor.readWorkbook(event.file);
 
-    const extracted = this.extractor.extract(
-      workbook,
-      event.file,
-      event.report.start
-    );
+    let extracted;
+    try {
+      extracted = await this.extractor.extract(event.file, event.report.start);
+    } catch (e) {
+      this.logger.warning(e.message, {
+        name: event.file.name,
+        id: event.file.id,
+        exception: e,
+      });
+      return;
+    }
     this.logger.info('Extracted progress summary', {
       ...extracted,
       report: event.report.id,

--- a/src/components/progress-summary/progress-summary.extractor.ts
+++ b/src/components/progress-summary/progress-summary.extractor.ts
@@ -1,87 +1,53 @@
 import { Injectable } from '@nestjs/common';
-import { memoize } from 'lodash';
 import { CalendarDate, fiscalQuarter, fiscalYear } from '../../common';
-import { Row, Sheet, WorkBook } from '../../common/xlsx.util';
+import { Column, Row } from '../../common/xlsx.util';
 import { Downloadable } from '../file';
+import { Pnp, ProgressSheet } from '../pnp';
 import { ProgressSummary as Progress } from './dto';
+import 'ix/add/iterable-operators/find';
 
 @Injectable()
 export class ProgressSummaryExtractor {
   async extract(file: Downloadable<unknown>, date: CalendarDate) {
-    const buffer = await file.download();
-    const pnp = WorkBook.fromBuffer(buffer);
-    const sheet = pnp.sheet('Progress');
+    const pnp = await Pnp.fromDownloadable(file);
+    const sheet = pnp.progress;
 
-    const isOBS = sheet.cell('P19').asString === 'Stories';
-
-    const yearRow = findFiscalYearRow(sheet, fiscalYear(date), isOBS);
-
-    const convertToPercent = percentConverter(() => {
-      const total = sheet.cell('AG18').asNumber;
-      if (total) {
-        return total;
-      }
-      throw new Error('Unable to find total verse equivalents in pnp file');
-    });
-
-    const quarterCol = ['AH', 'AI', 'AJ', 'AK'][fiscalQuarter(date) - 1];
+    const yearRow = findFiscalYearRow(sheet, fiscalYear(date));
+    const quarterCol = sheet.columnForQuarterSummary(fiscalQuarter(date));
     return {
-      reportPeriod: convertToPercent(
-        this.summaryFrom(yearRow, quarterCol, quarterCol)
-      ),
-      fiscalYear: convertToPercent(this.summaryFrom(yearRow, 'AL', 'AM')),
-      cumulative: convertToPercent(this.summaryFrom(yearRow, 'AN', 'AO')),
+      reportPeriod: summaryFrom(yearRow, quarterCol, quarterCol),
+      fiscalYear: summaryFrom(yearRow, ...sheet.columnsForFiscalYear),
+      cumulative: summaryFrom(yearRow, ...sheet.columnsForCumulative),
     };
-  }
-
-  private summaryFrom(
-    fiscalYear: Row,
-    plannedColumn: string,
-    actualColumn: string
-  ): Progress | null {
-    const planned = fiscalYear.cell(plannedColumn).asNumber;
-    const actual = fiscalYear.cell(actualColumn).asNumber;
-    return planned && actual ? { planned, actual } : null;
   }
 }
 
-const findFiscalYearRow = (
-  sheet: Sheet,
-  fiscalYear: number,
-  isOBS: boolean
-) => {
-  let row = sheet.row(isOBS ? 28 : 20);
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const cell = row.cell('AG');
+const findFiscalYearRow = (sheet: ProgressSheet, fiscalYear: number) => {
+  for (const cell of sheet.summaryFiscalYears.walkDown()) {
     if (cell.asNumber === fiscalYear) {
-      return row;
+      return cell.row;
     }
-    if (!cell.isNumber) {
-      throw new Error('Unable to find fiscal year in pnp file');
-    }
-    row = row.next();
   }
+  throw new Error('Unable to find fiscal year in pnp file');
 };
 
-/**
- * The PnP has the macro option to do calculations as percents or verse equivalents.
- * We need to standardize as percents here.
- */
-const percentConverter = (getTotalVerseEquivalents: () => number) => {
-  const memoTotalVerseEquivalents = memoize(getTotalVerseEquivalents);
-  return (summary: Progress | null) => {
-    if (!summary) {
-      return null;
-    }
-    if (summary.planned <= 1) {
-      // Already a percent so no conversion needed
-      return summary;
-    }
-    const totalVerseEquivalents = memoTotalVerseEquivalents();
+const summaryFrom = (
+  fiscalYear: Row<ProgressSheet>,
+  plannedColumn: Column,
+  actualColumn: Column
+): Progress | null => {
+  const planned = fiscalYear.cell(plannedColumn).asNumber;
+  const actual = fiscalYear.cell(actualColumn).asNumber;
+  if (!planned || !actual) {
+    return null;
+  }
+  if (planned > 1) {
+    // The PnP has the macro option to do calculations as percents or verse equivalents.
+    // We need to standardize as percents here.
     return {
-      planned: summary.planned / totalVerseEquivalents,
-      actual: summary.actual / totalVerseEquivalents,
+      planned: planned / fiscalYear.sheet.totalVerseEquivalents,
+      actual: actual / fiscalYear.sheet.totalVerseEquivalents,
     };
-  };
+  }
+  return { planned, actual };
 };


### PR DESCRIPTION
- Created OO wrapper around XLSX. This allows traversal much more expressively and should be easier to read.
  Objects for `WorkBook, Sheet, Row, Column, Range, Cell`
- Decoupled extraction logic from cell addresses. This helps with current variations between OBS & Written PnPs. And it should help in future if we need to handle different revisions of the PnP without having to bother the extraction business logic.
- Added support for named ranges & reference them were possible instead of hardcoded columns/rows. This also helps with differences between OBS & Written variants and will hopefully help normalize revisions too.
  - Named ranges used: `ProgDraft`, `VE`, `PrcntFinishedYears`, `Q1-4Column`.