### PR TITLE
Fix several periodic report sync problems

### DIFF
--- a/src/common/temporal/date-interval.ts
+++ b/src/common/temporal/date-interval.ts
@@ -64,6 +64,10 @@ export class DateInterval extends Interval {
     const range = Interval.fromDateTimes(start, end);
     return new DateInterval({ start: range.start, end: range.end });
   }
+  static fromObject({ start, end }: { start: DateInput; end: DateInput }) {
+    const range = Interval.fromDateTimes(start, end);
+    return new DateInterval({ start: range.start, end: range.end });
+  }
   static fromISO(string: string, options?: DateTimeOptions) {
     return DateInterval.fromInterval(super.fromISO(string, options));
   }

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -182,12 +182,4 @@ export class InternshipEngagement extends Engagement {
 }
 
 export const engagementRange = (engagement: Engagement) =>
-  engagement.startDateOverride.value
-    ? DateInterval.tryFrom(
-        engagement.startDateOverride.value,
-        engagement.endDateOverride.value
-      )
-    : DateInterval.tryFrom(
-        engagement.startDate.value,
-        engagement.endDate.value
-      );
+  DateInterval.tryFrom(engagement.startDate.value, engagement.endDate.value);

--- a/src/components/periodic-report/dto/create-periodic-report.dto.ts
+++ b/src/components/periodic-report/dto/create-periodic-report.dto.ts
@@ -1,10 +1,9 @@
-import { CalendarDate, ID } from '../../../common';
+import { CalendarDate, ID, Range, Session } from '../../../common';
 import { ReportType } from './report-type.enum';
 
-export abstract class CreatePeriodicReport {
-  readonly projectOrEngagementId: ID;
+export abstract class MergePeriodicReports {
+  readonly parent: ID;
   readonly type: ReportType;
-  readonly start: CalendarDate;
-  readonly end: CalendarDate;
-  readonly skippedReason?: string;
+  readonly intervals: ReadonlyArray<Range<CalendarDate>>;
+  readonly session: Session;
 }

--- a/src/components/periodic-report/handlers/abstract-periodic-report-sync.ts
+++ b/src/components/periodic-report/handlers/abstract-periodic-report-sync.ts
@@ -1,0 +1,67 @@
+import { DateTimeUnit } from 'luxon';
+import {
+  CalendarDate,
+  DateInterval,
+  ID,
+  Range,
+  Session,
+} from '../../../common';
+import { ReportType } from '../dto';
+import { PeriodicReportService } from '../periodic-report.service';
+
+export type Intervals = [
+  updated: DateInterval | null,
+  previous: DateInterval | null
+];
+
+export abstract class AbstractPeriodicReportSync {
+  constructor(protected readonly periodicReports: PeriodicReportService) {}
+
+  protected async sync(
+    session: Session,
+    parent: ID,
+    type: ReportType,
+    diff: {
+      additions: ReadonlyArray<Range<CalendarDate>>;
+      removals: ReadonlyArray<Range<CalendarDate | null>>;
+    },
+    finalAt?: CalendarDate
+  ) {
+    if (!diff) {
+      return;
+    }
+    await this.periodicReports.delete(parent, type, diff.removals);
+
+    await this.periodicReports.merge({
+      type,
+      parent,
+      intervals: diff.additions,
+      session,
+    });
+
+    if (!finalAt) {
+      return;
+    }
+    await this.periodicReports.mergeFinalReport(parent, type, finalAt, session);
+  }
+
+  /**
+   * Diff ranges returning additions/removals by date time unit
+   */
+  protected diffBy(
+    updated: DateInterval | null | undefined,
+    previous: DateInterval | null | undefined,
+    unit: DateTimeUnit
+  ) {
+    const fullUpdated = updated?.expandToFull(unit);
+    const diff = DateInterval.compare(
+      previous?.expandToFull(unit),
+      fullUpdated
+    );
+    const splitByUnit = (range: DateInterval) => range.splitBy({ [unit]: 1 });
+    return {
+      additions: diff.additions.flatMap(splitByUnit),
+      removals: diff.removals.flatMap(splitByUnit),
+    };
+  }
+}

--- a/src/components/periodic-report/handlers/abstract-periodic-report-sync.ts
+++ b/src/components/periodic-report/handlers/abstract-periodic-report-sync.ts
@@ -61,7 +61,28 @@ export abstract class AbstractPeriodicReportSync {
     const splitByUnit = (range: DateInterval) => range.splitBy({ [unit]: 1 });
     return {
       additions: diff.additions.flatMap(splitByUnit),
-      removals: diff.removals.flatMap(splitByUnit),
+      removals: [
+        ...diff.removals.flatMap(splitByUnit),
+        ...this.invertedRange(fullUpdated),
+      ],
     };
+  }
+
+  /**
+   * Return two partial ranges representing the inverse of the given range.
+   *
+   * Why:
+   * If we have a complete date range there shouldn't be reports outside it
+   * (unless delete excludes for reasons like having a file).
+   * There could be a previous sync that missed some removals due to whatever
+   * reasons, so this is a sanity check.
+   */
+  protected invertedRange(range: DateInterval | null | undefined) {
+    return range
+      ? [
+          { start: null, end: range.start },
+          { start: range.end, end: null },
+        ]
+      : [];
   }
 }

--- a/src/components/periodic-report/handlers/sync-periodic-report-to-project.handler.ts
+++ b/src/components/periodic-report/handlers/sync-periodic-report-to-project.handler.ts
@@ -40,19 +40,12 @@ export class SyncPeriodicReportsToProjectDateRange
       diff.removals
     );
 
-    await Promise.all(
-      diff.additions.map((interval) =>
-        this.periodicReports.create(
-          {
-            start: interval.start,
-            end: interval.end,
-            type: ReportType.Financial,
-            projectOrEngagementId: project.id,
-          },
-          event.session
-        )
-      )
-    );
+    await this.periodicReports.merge({
+      type: ReportType.Financial,
+      parent: project.id,
+      intervals: diff.additions,
+      session: event.session,
+    });
 
     if (project.mouEnd) {
       await this.periodicReports.mergeFinalReport(
@@ -72,19 +65,12 @@ export class SyncPeriodicReportsToProjectDateRange
       diff.removals
     );
 
-    await Promise.all(
-      diff.additions.map((interval) =>
-        this.periodicReports.create(
-          {
-            start: interval.start,
-            end: interval.end,
-            type: ReportType.Narrative,
-            projectOrEngagementId: event.updated.id,
-          },
-          event.session
-        )
-      )
-    );
+    await this.periodicReports.merge({
+      type: ReportType.Narrative,
+      parent: event.updated.id,
+      intervals: diff.additions,
+      session: event.session,
+    });
 
     if (event.updated.mouEnd) {
       await this.periodicReports.mergeFinalReport(

--- a/src/components/periodic-report/handlers/sync-periodic-report-to-project.handler.ts
+++ b/src/components/periodic-report/handlers/sync-periodic-report-to-project.handler.ts
@@ -82,15 +82,7 @@ export class SyncPeriodicReportsToProjectDateRange
       additions: reportRanges(projectMou, newInterval),
       removals: [
         ...reportRanges(projectRange(previous), prevInterval),
-        // If we have a complete date range also remove reports outside it.
-        // Since there could be a previous date change that wasn't accounted for
-        // due to the financial report period constraint not being met at the time.
-        ...(projectMou
-          ? [
-              { start: null, end: projectMou.start },
-              { start: projectMou.end, end: null },
-            ]
-          : []),
+        ...this.invertedRange(projectMou),
       ],
     };
   }

--- a/src/components/periodic-report/handlers/sync-periodic-report-to-project.handler.ts
+++ b/src/components/periodic-report/handlers/sync-periodic-report-to-project.handler.ts
@@ -117,10 +117,7 @@ export class SyncPeriodicReportsToProjectDateRange
         ?.expandToFull(unit)
         .splitBy({ [unit]: 1 }) || [];
 
-    const prevInterval: DateTimeUnit =
-      previous.financialReportPeriod === ReportPeriod.Monthly
-        ? 'month'
-        : 'quarter';
+    const prevInterval = newInterval !== 'month' ? 'month' : 'quarter';
     return {
       interval: newInterval,
       additions: reportRanges(project, newInterval),

--- a/src/components/periodic-report/handlers/sync-progress-report-to-engagement.handler.ts
+++ b/src/components/periodic-report/handlers/sync-progress-report-to-engagement.handler.ts
@@ -80,22 +80,15 @@ export class SyncProgressReportToEngagementDateRange
 
   private async createReports(
     engagementId: ID,
-    range: Interval[],
+    intervals: Interval[],
     session: Session
   ) {
-    await Promise.all(
-      range.map((interval) =>
-        this.periodicReports.create(
-          {
-            start: interval.start,
-            end: interval.end,
-            type: ReportType.Progress,
-            projectOrEngagementId: engagementId,
-          },
-          session
-        )
-      )
-    );
+    await this.periodicReports.merge({
+      type: ReportType.Progress,
+      parent: engagementId,
+      intervals,
+      session,
+    });
   }
 
   private diff(event: SubscribedEvent) {

--- a/src/components/periodic-report/migrations/RemoveDuplicatePeriodicReports.migration.ts
+++ b/src/components/periodic-report/migrations/RemoveDuplicatePeriodicReports.migration.ts
@@ -1,0 +1,48 @@
+import { BaseMigration, Migration } from '../../../core';
+
+@Migration('2022-01-05T00:00:00')
+export class RemoveDuplicatePeriodicReportsMigration extends BaseMigration {
+  async up() {
+    await this.db
+      .query()
+      .raw(
+        `
+          match (parent:BaseNode)-[:report { active: true }]->(report:PeriodicReport),
+                (report)-[:type { active: true }]->(type),
+                (report)-[:start { active: true }]->(start),
+                (report)-[:end { active: true }]->(end)
+          // type, start, end to strings
+          with parent, report, type.value as type,
+            apoc.temporal.format(start.value, "date") + "/" + apoc.temporal.format(end.value, "date") as label
+          // group by parent, type, & label
+          with parent, type, label, collect(report) as reports
+          // filter to only duplicate reports
+          where size(reports) > 1
+          call {
+            with reports
+            unwind reports as report
+            // for each report figure out if it has a file uploaded
+            call {
+              with report
+              match (report)-[:reportFileNode]->(:File)<-[:parent { active: true }]-(file:FileVersion)
+              return count(file) > 0 as hasFile
+            }
+            // order reports with files first, then chronologically
+            with report, hasFile
+            order by hasFile desc, report.createdAt asc
+            // group back up in this order to maintain the sets of duplicates
+            return collect(report) as ordered
+          }
+          with ordered
+          // Remove (to keep) the first report in each set,
+          // and unwind to flat list of reports
+          // This isn't perfect because it could still delete reports with files
+          // But I checked and currently there's not more than one report with a file
+          unwind ordered[1..] as report
+          // Delete report
+          detach delete report
+        `
+      )
+      .run();
+  }
+}

--- a/src/components/periodic-report/migrations/index.ts
+++ b/src/components/periodic-report/migrations/index.ts
@@ -1,2 +1,3 @@
 export * from './AddFinalReport.migration';
 export * from './AddSkippedReason.migration';
+export * from './RemoveDuplicatePeriodicReports.migration';

--- a/src/components/periodic-report/periodic-report.service.ts
+++ b/src/components/periodic-report/periodic-report.service.ts
@@ -1,10 +1,10 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
-import { Interval } from 'luxon';
 import {
   CalendarDate,
   ID,
   NotFoundException,
   ObjectView,
+  Range,
   ServerException,
   Session,
   UnsecuredDto,
@@ -199,13 +199,18 @@ export class PeriodicReportService {
     return report ? await this.secure(report, session) : undefined;
   }
 
-  async delete(baseNodeId: ID, type: ReportType, intervals: Interval[]) {
+  async delete(
+    parent: ID,
+    type: ReportType,
+    intervals: ReadonlyArray<Range<CalendarDate | null>>
+  ) {
+    intervals = intervals.filter((i) => i.start || i.end);
     if (intervals.length === 0) {
       return;
     }
-    const result = await this.repo.delete(baseNodeId, type, intervals);
+    const result = await this.repo.delete(parent, type, intervals);
 
-    this.logger.debug('Deleted reports', { baseNodeId, type, ...result });
+    this.logger.info('Deleted reports', { parent, type, ...result });
   }
 
   async getFinalReport(

--- a/src/components/periodic-report/periodic-report.service.ts
+++ b/src/components/periodic-report/periodic-report.service.ts
@@ -226,6 +226,10 @@ export class PeriodicReportService {
     const report = await this.repo.getFinalReport(parentId, type, session);
 
     if (report) {
+      if (+report.start === +at) {
+        // no change
+        return;
+      }
       await this.repo.updateProperties(report, {
         start: at,
         end: at,

--- a/src/core/database/query-augmentation/pattern-formatting.ts
+++ b/src/core/database/query-augmentation/pattern-formatting.ts
@@ -6,6 +6,7 @@ import {
   Match,
   Merge,
   Raw,
+  Return,
   With,
 } from 'cypher-query-builder';
 import type { PatternClause as TSPatternClause } from 'cypher-query-builder/dist/typings/clauses/pattern-clause';
@@ -63,6 +64,17 @@ TermListClause.prototype.stringifyTerm = function stringifyTerm(term: Term) {
   }
   return origStringifyTerm.call(this, stripped);
 };
+
+// If the term list clause has no terms render empty string instead of broken cypher
+for (const Cls of [With, Return]) {
+  const origBuild = Cls.prototype.build;
+  Cls.prototype.build = function build(this: TSTermListClause) {
+    if (TermListClause.prototype.build.call(this) === '') {
+      return '';
+    }
+    return origBuild.call(this);
+  };
+}
 
 // Strip indents from `raw` clauses
 Raw.prototype.build = function build() {

--- a/src/core/database/query/create-property.ts
+++ b/src/core/database/query/create-property.ts
@@ -61,11 +61,7 @@ export const createProperty =
         // They'll get them when they are applied for real.
         ['Property'];
 
-    const imports = [
-      nodeName,
-      // Try to pull the root variable referenced from expression https://regex101.com/r/atshF5
-      (variable ? /(?:.+\()?([^.]+)\.?.*/.exec(variable)?.[1] : null) ?? '',
-    ];
+    const imports = [nodeName, variable ? importVarFromVar(variable) : ''];
     return query.comment`
       createProperty(${nodeName}.${key})
     `.subQuery(imports, (sub) =>
@@ -101,3 +97,7 @@ export const createProperty =
         .return(`count(newPropNode) as ${numCreatedVar}`)
     );
   };
+
+// Try to pull the root variable referenced from expression https://regex101.com/r/atshF5
+export const importVarFromVar = (variable: string) =>
+  /(?:.+\()?([^.]+)\.?.*/.exec(variable)?.[1] ?? '';


### PR DESCRIPTION
Fixes #2326

- (fce34bd) Don't create reports if they "shouldn't" exist, but do.
  - A report could be pre-existing for a handful of reasons.
  - Had a file attached, so it was never deleted
  - Date range was changed before financial reporting period was set,
    when the period is set, the previous range doesn't account for all former changes.
  - Transient errors?

- (11d3d79) Fix periodic report deletes match on both start & end dates, not just start
  - 1/1-3/1 != 1/1-1/31
  - This matters for financial reports which can switch between periods

- (c0f9784) Fix attempting to remove quarterly reports when financial report period is initially set & set to quarterly

- (a113d01, e568c67) Delete reports outside the current project/engagement range on sync
  - There could be a previous date change that wasn't accounted for
    due to the financial report period constraint not being met at the time.
  - I ended up applying it everywhere as it's a good sanity check.
  - Reports with files are never deleted.

- Fix logic for syncing engagements with override dates
  - (ab0a87d) Fix incorrect assumption that a start date override also needs an end override to have a valid range.
  - (93991ba) Fix individual engagement override dates not being taken into account when a project's date range changes.
    This would cause reports to be created/deleted within the project range but outside the engagement range.

- (fce34bd) Performance: Create all reports requested at once instead of one by one.
  - Example for perspective: Monthly financial reports for 2 years is 48 reports.
    So that was 48 queries now down to 1.

- (e43e946) Add migration to delete duplicate reports
  - This isn't the same as a re-sync, but it was easy to do in one query.
