### PR TITLE
Fix product progress extraction to be independent of pnp row index

### DIFF
--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -135,6 +135,22 @@ export class ProductRepository extends CommonRepository {
       .run();
   }
 
+  async listIdsWithProducibleNames(engagementId: ID, type?: ProducibleType) {
+    return await this.db
+      .query()
+      .match([
+        node('engagement', 'Engagement', { id: engagementId }),
+        relation('out', '', 'product', ACTIVE),
+        node('node', 'DerivativeScriptureProduct'),
+        relation('out', '', 'produces', ACTIVE),
+        node('', ['Producible', ...(type ? [type] : [])]),
+        relation('out', '', 'name', ACTIVE),
+        node('name', 'Property'),
+      ])
+      .return<{ id: ID; name: string }>(['node.id as id', 'name.value as name'])
+      .run();
+  }
+
   async getProducibleIdsByNames(
     names: readonly string[],
     type?: ProducibleType

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -701,6 +701,14 @@ export class ProductService {
     return mapFromList(productRefs, (ref) => [ref.pnpIndex, ref.id]);
   }
 
+  async loadProductIdsWithProducibleNames(
+    engagementId: ID,
+    type?: ProducibleType
+  ) {
+    const refs = await this.repo.listIdsWithProducibleNames(engagementId, type);
+    return mapFromList(refs, (ref) => [ref.name, ref.id]);
+  }
+
   protected getMethodologiesByApproach(
     approach: ProductApproach
   ): ProductMethodology[] {


### PR DESCRIPTION
Always match products of story name/scripture refs when extracting pnp progress.

This keeps pnpIndex logic isolated to just product creation/planning extract.
This allows products to be created via UI and then matched to progress extract later.
It also allows products created before this pnpIndex logic was added to still work
with progress extraction.
This partially reverts 652d046.