### PR TITLE
Configurable HTTP timeouts

### DIFF
--- a/src/common/temporal/duration.ts
+++ b/src/common/temporal/duration.ts
@@ -4,7 +4,10 @@ import { Mutable } from 'type-fest';
 declare module 'luxon/src/duration' {
   // eslint-disable-next-line @typescript-eslint/no-namespace -- augmenting static class method
   namespace Duration {
-    export const from: (duration: DurationLike) => Duration;
+    /**
+     * Create from ISO, Human, ms number, std object, or other Duration.
+     */
+    export const from: (duration: string | DurationLike) => Duration;
     /**
      * Parse a humanized duration string.
      * @example
@@ -17,7 +20,12 @@ declare module 'luxon/src/duration' {
   }
 }
 const D = Duration as Mutable<typeof Duration>;
-D.from = Duration.fromDurationLike;
+D.from = (input: string | DurationLike) =>
+  typeof input === 'string'
+    ? input.startsWith('P')
+      ? D.fromISO(input)
+      : D.fromHuman(input)
+    : D.fromDurationLike(input);
 
 D.fromHuman = function (input: string) {
   // Adapted from https://github.com/jkroso/parse-duration

--- a/src/common/temporal/duration.ts
+++ b/src/common/temporal/duration.ts
@@ -1,14 +1,55 @@
-import { Duration, DurationLike } from 'luxon';
+import { Duration, DurationLike, DurationLikeObject } from 'luxon';
 import { Mutable } from 'type-fest';
 
 declare module 'luxon/src/duration' {
   // eslint-disable-next-line @typescript-eslint/no-namespace -- augmenting static class method
   namespace Duration {
     export const from: (duration: DurationLike) => Duration;
+    /**
+     * Parse a humanized duration string.
+     * @example
+     * '1hour 20mins'
+     * '27,681 ms'    // numeric separators
+     * '2hr -40mins'  // negatives
+     * '2e3 secs'     // exponents
+     */
+    export const fromHuman: (duration: string) => Duration;
   }
 }
 const D = Duration as Mutable<typeof Duration>;
 D.from = Duration.fromDurationLike;
+
+D.fromHuman = function (input: string) {
+  // Adapted from https://github.com/jkroso/parse-duration
+  const durationRE =
+    /(-?(?:\d+\.?\d*|\d*\.?\d+)(?:e[-+]?\d+)?)\s*([\p{L}]*)/giu;
+  input = input.replace(/(\d)[,_](\d)/g, '$1$2');
+  const result: DurationLikeObject = {};
+  input.replace(durationRE, (_, num, unit) => {
+    result[normalizedUnit(unit)] = parseFloat(num);
+    return '';
+  });
+  return Duration.fromObject(result);
+};
+const normalizedUnit = (unit: string): keyof DurationLikeObject => {
+  unit = unit.toLowerCase();
+  // Handle specially here before plural is removed, conflicting with min/sec.
+  if (unit === '' || unit === 'ms') {
+    return 'millisecond';
+  }
+  /* eslint-disable prettier/prettier */
+  switch (unit.replace(/s$/, '')) {
+    case 'sec': case '': return 'second';
+    case 'min': case 'm': return 'minute';
+    case 'hr': case 'h': return 'hour';
+    case 'd': return 'day';
+    case 'wk': case 'w': return 'week';
+    case 'yr': case 'y': return 'year';
+  }
+  /* eslint-enable prettier/prettier */
+  // Typecasting here as Duration will do its own validation privately
+  return unit as keyof DurationLikeObject;
+};
 
 // @ts-expect-error Adding here, which will be called by pg client
 Duration.prototype.toPostgres = function (this: Duration) {

--- a/src/common/temporal/duration.ts
+++ b/src/common/temporal/duration.ts
@@ -1,27 +1,14 @@
-import { isNumber } from 'lodash';
 import { Duration, DurationLike } from 'luxon';
 import { Mutable } from 'type-fest';
 
 declare module 'luxon/src/duration' {
   // eslint-disable-next-line @typescript-eslint/no-namespace -- augmenting static class method
   namespace Duration {
-    export const from: (durationish: DurationLike) => Duration;
+    export const from: (duration: DurationLike) => Duration;
   }
 }
-(Duration as Mutable<typeof Duration>).from = function (
-  durationish: DurationLike
-) {
-  if (isNumber(durationish)) {
-    return Duration.fromMillis(durationish);
-  } else if (Duration.isDuration(durationish)) {
-    return durationish;
-  } else if (typeof durationish === 'object') {
-    return Duration.fromObject(durationish);
-  } else {
-    const _: never = durationish;
-    throw new Error();
-  }
-};
+const D = Duration as Mutable<typeof Duration>;
+D.from = Duration.fromDurationLike;
 
 // @ts-expect-error Adding here, which will be called by pg client
 Duration.prototype.toPostgres = function (this: Duration) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,8 @@ async function bootstrap() {
 
   app.setGlobalPrefix(config.globalPrefix);
 
+  config.applyTimeouts(app.getHttpServer(), config.httpTimeouts);
+
   app.enableShutdownHooks();
   await app.listen(config.port, () => {
     app


### PR DESCRIPTION
Connected HTTP server timeouts to environment variables so they can be customized at deployment.
Included parsing human like duration strings.