### PR TITLE
Fields Pipe & Id Shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "fast-safe-stringify": "^2.1.1",
     "got": "^11.8.2",
     "graphql": "^15.8.0",
+    "graphql-parse-resolve-info": "^4.12.0",
     "highlightjs-cypher": "^1.1.1",
     "iso-3166-1": "^2.1.1",
     "ix": "^4.5.2",

--- a/src/common/fields.pipe.ts
+++ b/src/common/fields.pipe.ts
@@ -56,14 +56,24 @@ const getInterfacesDeep = (
 ];
 
 /**
+ * Converts the field info to a boolean if the only fields asked for are in this list.
+ * @example
+ * ```
+ * @Info(Fields, IsOnly(['id'])) onlyId: boolean
+ * ```
+ */
+export const IsOnly = <T>(
+  fields: Array<keyof T & string>
+): PipeTransform<FieldInfo<T>, boolean> => ({
+  transform: (requested) =>
+    difference(Object.keys(requested), fields).length === 0,
+});
+
+/**
  * Converts the field info to a boolean if the only field asked for is the ID.
  * @example
  * ```
  * @Info(Fields, IsOnlyId) onlyId: boolean
  * ```
  */
-export const IsOnlyId: PipeTransform<FieldInfo<any>, boolean> = {
-  transform(fields: FieldInfo<any>, _metadata: ArgumentMetadata) {
-    return difference(Object.keys(fields), ['id']).length === 0;
-  },
-};
+export const IsOnlyId = IsOnly(['id']);

--- a/src/common/fields.pipe.ts
+++ b/src/common/fields.pipe.ts
@@ -1,0 +1,69 @@
+import { ArgumentMetadata, PipeTransform } from '@nestjs/common';
+import {
+  getNamedType,
+  GraphQLInterfaceType,
+  GraphQLResolveInfo,
+  isAbstractType,
+  isCompositeType,
+  isInterfaceType,
+} from 'graphql';
+import { parseResolveInfo, ResolveTree } from 'graphql-parse-resolve-info';
+import { difference, pick } from 'lodash';
+
+export type FieldInfo<T> = Partial<Record<keyof T, ResolveTree>>;
+
+/**
+ * Returns the fields requested by the operation (requester).
+ * @example
+ * ```
+ * @Info(Fields) fields: FieldInfo<Foo>
+ * ```
+ */
+export class Fields<T>
+  implements PipeTransform<GraphQLResolveInfo, FieldInfo<T>>
+{
+  transform(info: GraphQLResolveInfo, _metadata: ArgumentMetadata) {
+    const { fieldsByTypeName } = parseResolveInfo(info) as ResolveTree;
+
+    // Below is our own implementation of simplifyParsedResolveInfoFragmentWithType
+    // Ours includes all fields from all possible output types
+    const strippedType = getNamedType(info.returnType);
+    if (!isCompositeType(strippedType)) {
+      return {};
+    }
+    const parents = isInterfaceType(strippedType)
+      ? getInterfacesDeep(strippedType).map((t) => t.name)
+      : [];
+    const children = isAbstractType(strippedType)
+      ? info.schema.getPossibleTypes(strippedType).map((t) => t.name)
+      : [];
+    const allTypes = [strippedType.name, ...parents, ...children];
+
+    const fieldsByFilteredTypes = pick(fieldsByTypeName, allTypes);
+    const merged = Object.assign({}, ...Object.values(fieldsByFilteredTypes));
+
+    return merged;
+  }
+}
+
+// Not sure if this is entirely necessary, I think each interface has a
+// flat list of parents. But just to be safe...
+const getInterfacesDeep = (
+  type: GraphQLInterfaceType
+): GraphQLInterfaceType[] => [
+  type,
+  ...type.getInterfaces().flatMap(getInterfacesDeep),
+];
+
+/**
+ * Converts the field info to a boolean if the only field asked for is the ID.
+ * @example
+ * ```
+ * @Info(Fields, IsOnlyId) onlyId: boolean
+ * ```
+ */
+export const IsOnlyId: PipeTransform<FieldInfo<any>, boolean> = {
+  transform(fields: FieldInfo<any>, _metadata: ArgumentMetadata) {
+    return difference(Object.keys(fields), ['id']).length === 0;
+  },
+};

--- a/src/common/fields.pipe.ts
+++ b/src/common/fields.pipe.ts
@@ -9,6 +9,8 @@ import {
 } from 'graphql';
 import { parseResolveInfo, ResolveTree } from 'graphql-parse-resolve-info';
 import { difference, pick } from 'lodash';
+import type { ChangesetAware } from '../components/changeset/dto';
+import type { Resource } from './resource.dto';
 
 export type FieldInfo<T> = Partial<Record<keyof T, ResolveTree>>;
 
@@ -76,4 +78,4 @@ export const IsOnly = <T>(
  * @Info(Fields, IsOnlyId) onlyId: boolean
  * ```
  */
-export const IsOnlyId = IsOnly(['id']);
+export const IsOnlyId = IsOnly<Resource & ChangesetAware>(['id', 'changeset']);

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -8,6 +8,7 @@ export * from './db-sort.decorator';
 export * from './db-unique.decorator';
 export * from './mutation-placeholder.output';
 export * from './exceptions';
+export * from './fields.pipe';
 export * from './firstLettersOfWords';
 export * from './fiscal-year';
 export * from './generate-id';

--- a/src/components/periodic-report/progress-report-parent.resolver.ts
+++ b/src/components/periodic-report/progress-report-parent.resolver.ts
@@ -1,6 +1,7 @@
-import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Info, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Fields, IsOnlyId } from '../../common';
 import { Loader, LoaderOf } from '../../core';
-import { Engagement, EngagementLoader } from '../engagement';
+import { EngagementLoader } from '../engagement';
 import { LanguageEngagement } from '../engagement/dto';
 import { ProgressReport } from '../periodic-report';
 
@@ -8,9 +9,13 @@ import { ProgressReport } from '../periodic-report';
 export class ProgressReportParentResolver {
   @ResolveField(() => LanguageEngagement)
   async parent(
+    @Info(Fields, IsOnlyId) onlyId: boolean,
     @Parent() report: ProgressReport,
     @Loader(EngagementLoader) engagements: LoaderOf<EngagementLoader>
-  ): Promise<Engagement> {
+  ) {
+    if (onlyId) {
+      return { id: report.parent.properties.id };
+    }
     return await engagements.load({
       id: report.parent.properties.id,
       view: { active: true },

--- a/src/components/project/engagement-connection.resolver.ts
+++ b/src/components/project/engagement-connection.resolver.ts
@@ -1,17 +1,28 @@
-import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { viewOfChangeset } from '../../common';
+import { Info, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Fields, IsOnlyId, viewOfChangeset } from '../../common';
 import { Loader, LoaderOf } from '../../core';
 import { IEngagement } from '../engagement';
-import { IProject } from './dto';
+import { IProject, ProjectType } from './dto';
 import { ProjectLoader } from './project.loader';
 
 @Resolver(IEngagement)
 export class ProjectEngagementConnectionResolver {
   @ResolveField(() => IProject)
   async project(
+    @Info(Fields, IsOnlyId) onlyId: boolean,
     @Parent() engagement: IEngagement,
     @Loader(ProjectLoader) projects: LoaderOf<ProjectLoader>
   ) {
+    if (onlyId) {
+      return {
+        id: engagement.project,
+        // Used in Project.resolveType to resolve the concrete type
+        type:
+          engagement.__typename === 'LanguageEngagement'
+            ? ProjectType.Translation
+            : ProjectType.Internship,
+      };
+    }
     return await projects.load({
       id: engagement.project,
       view: viewOfChangeset(engagement.changeset),

--- a/src/components/project/engagement-connection.resolver.ts
+++ b/src/components/project/engagement-connection.resolver.ts
@@ -16,6 +16,7 @@ export class ProjectEngagementConnectionResolver {
     if (onlyId) {
       return {
         id: engagement.project,
+        changeset: engagement.changeset,
         // Used in Project.resolveType to resolve the concrete type
         type:
           engagement.__typename === 'LanguageEngagement'

--- a/yarn.lock
+++ b/yarn.lock
@@ -5819,6 +5819,7 @@ __metadata:
     fast-safe-stringify: ^2.1.1
     got: ^11.8.2
     graphql: ^15.8.0
+    graphql-parse-resolve-info: ^4.12.0
     highlightjs-cypher: ^1.1.1
     husky: ^4.3.8
     iso-3166-1: ^2.1.1
@@ -8091,6 +8092,18 @@ cypher-query-builder@6.0.4:
   version: 4.2.9
   resolution: "graceful-fs@npm:4.2.9"
   checksum: 68ea4e07ff2c041ada184f9278b830375f8e0b75154e3f080af6b70f66172fabb4108d19b3863a96b53fc068a310b9b6493d86d1291acc5f3861eb4b79d26ad6
+  languageName: node
+  linkType: hard
+
+"graphql-parse-resolve-info@npm:^4.12.0":
+  version: 4.12.0
+  resolution: "graphql-parse-resolve-info@npm:4.12.0"
+  dependencies:
+    debug: ^4.1.1
+    tslib: ^2.0.1
+  peerDependencies:
+    graphql: ">=0.9 <0.14 || ^14.0.2 || ^15.4.0"
+  checksum: d15554985407b34150a36f8526d3ce63cd97a1fa898eadd74ba5e6d099984d13929de64924332832613d59fba7946222b0a07a127e93ad58bdb82f3548cc497b
   languageName: node
   linkType: hard
 
@@ -14441,7 +14454,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.3.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.0, tslib@npm:~2.3.0":
+"tslib@npm:2.3.1, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.0, tslib@npm:~2.3.0":
   version: 2.3.1
   resolution: "tslib@npm:2.3.1"
   checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9


### PR DESCRIPTION
- Created `Fields` pipe to grab info for fields requested out of GraphQL's resolve info.
- Created `IsOnlyId` pipe to simplify above to a boolean if only the object's `id` is requested.
- Skip going back to the DB for these relations if we don't need extra info:
  - `ProgressReport.engagement`
  - `Engagement.project`