### PR TITLE
Fix bound parameters in where clauses being duplicated

### DIFF
--- a/patches/cypher-query-builder.patch
+++ b/patches/cypher-query-builder.patch
@@ -1,3 +1,23 @@
+diff --git a/dist/cjs5.js b/dist/cjs5.js
+index 2956424bcab153c6d7a6f24f80ae7aac6a82d62a..108858d5ac65801739a3f022b07113ebb0ef68d9 100644
+--- a/dist/cjs5.js
++++ b/dist/cjs5.js
+@@ -1006,10 +1006,13 @@ var comparisions = {
+ };
+ 
+ function compare(operator, value, variable, paramName) {
++  var applied = new Map();
+   return function (params, name) {
+     var baseParamName = paramName || _last(name.split('.'));
+-
+-    var parts = [name, operator, variable ? value : params.addParam(value, baseParamName)];
++    if (!variable && !applied.has(params)) {
++      applied.set(params, params.addParam(value, baseParamName));
++    }
++    var parts = [name, operator, variable ? value : applied.get(params)];
+     return parts.join(' ');
+   };
+ }
 diff --git a/dist/typings/builder.d.ts b/dist/typings/builder.d.ts
 index 1c17b5c3f0127cd5aaf03185120e7f72321e2805..b91875030036d20f47d4dda0d9e3eeb22bb9949d 100644
 --- a/dist/typings/builder.d.ts

--- a/yarn.lock
+++ b/yarn.lock
@@ -6043,7 +6043,7 @@ cypher-query-builder@6.0.4:
 
 "cypher-query-builder@patch:cypher-query-builder@6.0.4#./patches/cypher-query-builder.patch::locator=cord-api-v3%40workspace%3A.":
   version: 6.0.4
-  resolution: "cypher-query-builder@patch:cypher-query-builder@npm%3A6.0.4#./patches/cypher-query-builder.patch::version=6.0.4&hash=71a53a&locator=cord-api-v3%40workspace%3A."
+  resolution: "cypher-query-builder@patch:cypher-query-builder@npm%3A6.0.4#./patches/cypher-query-builder.patch::version=6.0.4&hash=ac6c9b&locator=cord-api-v3%40workspace%3A."
   dependencies:
     "@types/lodash": ^4.14.136
     "@types/node": ^12.6.1
@@ -6052,7 +6052,7 @@ cypher-query-builder@6.0.4:
     node-cleanup: ^2.1.2
     rxjs: ^6.5.2
     tslib: ^1.10.0
-  checksum: 68933affb1c66b93bdaba369cd7bb697476f97d81e7e607af591268b64717a4686c6a19609858ea17a790c090c15e4dfd631a5383d672ed693e303adbca57b66
+  checksum: 65c81e68cf8f72b8fdf8c2351ecea1b819df290f764dad3b08eb49c2c85999fdd0c7410ce2daaaa2e7fed8cb9be209e5476fd3e9770366dced15d67259e9300f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
```ts
.where({ 'node.id': inArray(ids) })
```
This adds a bound parameter, `$id`, whose value is the `ids` list.

However, I noticed that there was a duplicated `$id2` parameter as well in the sent query.

It turns out these values are bound as parameters on `Query.build`.
This makes `Query.build` impure, which is unexpected.

We run the query build a couple times in our abstraction layers (for logging, tracing, etc.)

I patched this library "bug" by memoizing the parameter binding per parameter bag.
The parameter bag only changes with changes to the query.