### PR TITLE
Report list query & progress optimization

### DIFF
--- a/src/components/periodic-report/dto/list-periodic-reports.dto.ts
+++ b/src/components/periodic-report/dto/list-periodic-reports.dto.ts
@@ -1,10 +1,12 @@
 import { InputType, ObjectType } from '@nestjs/graphql';
 import {
+  ID,
   PaginatedList,
   SecuredList,
   SortablePaginationInput,
 } from '../../../common';
 import { IPeriodicReport, PeriodicReport } from './periodic-report.dto';
+import { ReportType } from './report-type.enum';
 
 @InputType()
 export class PeriodicReportListInput extends SortablePaginationInput<
@@ -12,6 +14,10 @@ export class PeriodicReportListInput extends SortablePaginationInput<
 >({
   defaultSort: 'end',
 }) {
+  readonly type?: ReportType;
+
+  readonly parent?: ID;
+
   static defaultVal = new PeriodicReportListInput();
 }
 

--- a/src/components/periodic-report/dto/list-periodic-reports.dto.ts
+++ b/src/components/periodic-report/dto/list-periodic-reports.dto.ts
@@ -1,4 +1,5 @@
-import { InputType, ObjectType } from '@nestjs/graphql';
+import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
 import {
   ID,
   PaginatedList,
@@ -14,6 +15,13 @@ export class PeriodicReportListInput extends SortablePaginationInput<
 >({
   defaultSort: 'end',
 }) {
+  @Field(() => ReportType, {
+    description: stripIndent`
+      Limit reports to this type.
+      Not applicable in fields for concrete report types.
+    `,
+    nullable: true,
+  })
   readonly type?: ReportType;
 
   readonly parent?: ID;

--- a/src/components/periodic-report/periodic-report-engagement-connection.resolver.ts
+++ b/src/components/periodic-report/periodic-report-engagement-connection.resolver.ts
@@ -25,12 +25,11 @@ export class PeriodicReportEngagementConnectionResolver {
     @Loader(PeriodicReportLoader)
     periodicReports: LoaderOf<PeriodicReportLoader>
   ): Promise<SecuredPeriodicReportList> {
-    const list = await this.service.list(
-      engagement.id,
-      ReportType.Progress,
-      input,
-      session
-    );
+    const list = await this.service.list(session, {
+      ...input,
+      parent: engagement.id,
+      type: ReportType.Progress,
+    });
     periodicReports.primeAll(list.items);
     return list;
   }

--- a/src/components/periodic-report/periodic-report-project-connection.resolver.ts
+++ b/src/components/periodic-report/periodic-report-project-connection.resolver.ts
@@ -26,12 +26,11 @@ export class PeriodicReportProjectConnectionResolver {
     @Loader(PeriodicReportLoader)
     periodicReports: LoaderOf<PeriodicReportLoader>
   ): Promise<SecuredPeriodicReportList> {
-    const list = await this.service.list(
-      project.id,
-      ReportType.Financial,
-      input,
-      session
-    );
+    const list = await this.service.list(session, {
+      ...input,
+      parent: project.id,
+      type: ReportType.Financial,
+    });
     periodicReports.primeAll(list.items);
     return list;
   }
@@ -44,12 +43,11 @@ export class PeriodicReportProjectConnectionResolver {
     @Loader(PeriodicReportLoader)
     periodicReports: LoaderOf<PeriodicReportLoader>
   ): Promise<SecuredPeriodicReportList> {
-    const list = await this.service.list(
-      project.id,
-      ReportType.Narrative,
-      input,
-      session
-    );
+    const list = await this.service.list(session, {
+      ...input,
+      parent: project.id,
+      type: ReportType.Narrative,
+    });
     periodicReports.primeAll(list.items);
     return list;
   }

--- a/src/components/periodic-report/periodic-report.service.ts
+++ b/src/components/periodic-report/periodic-report.service.ts
@@ -144,17 +144,10 @@ export class PeriodicReportService {
   }
 
   async list(
-    parentId: ID,
-    reportType: ReportType,
-    input: PeriodicReportListInput,
-    session: Session
+    session: Session,
+    input: PeriodicReportListInput
   ): Promise<SecuredPeriodicReportList> {
-    const results = await this.repo.listReports(
-      parentId,
-      reportType,
-      input,
-      session
-    );
+    const results = await this.repo.list(input, session);
 
     return {
       ...(await mapListResults(results, (dto) => this.secure(dto, session))),

--- a/src/components/product-progress/product-connection.resolver.ts
+++ b/src/components/product-progress/product-connection.resolver.ts
@@ -1,7 +1,9 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { AnonSession, ID, IdArg, Session } from '../../common';
+import { Loader, LoaderOf } from '../../core';
 import { Product } from '../product';
 import { ProductProgress } from './dto';
+import { ProductProgressByProductLoader } from './product-progress-by-product.loader';
 import { ProductProgressService } from './product-progress.service';
 
 @Resolver(Product)
@@ -13,9 +15,10 @@ export class ProductConnectionResolver {
   })
   async progressReports(
     @Parent() product: Product,
-    @AnonSession() session: Session
+    @Loader(ProductProgressByProductLoader)
+    loader: LoaderOf<ProductProgressByProductLoader>
   ): Promise<readonly ProductProgress[]> {
-    return await this.service.readAllByProduct(product, session);
+    return (await loader.load(product)).progress;
   }
 
   @ResolveField(() => ProductProgress, {

--- a/src/components/product-progress/product-progress-by-product.loader.ts
+++ b/src/components/product-progress/product-progress-by-product.loader.ts
@@ -1,0 +1,29 @@
+import { Injectable, Scope } from '@nestjs/common';
+import { ID } from '../../common';
+import { LoaderOptionsOf, OrderedNestDataLoader } from '../../core';
+import { Product } from '../product';
+import { ProductProgress } from './dto';
+import { ProductProgressService } from './product-progress.service';
+
+@Injectable({ scope: Scope.REQUEST })
+export class ProductProgressByProductLoader extends OrderedNestDataLoader<
+  { product: Product; progress: readonly ProductProgress[] },
+  Product,
+  ID
+> {
+  constructor(private readonly service: ProductProgressService) {
+    super();
+  }
+
+  getOptions(): LoaderOptionsOf<ProductProgressByProductLoader> {
+    return {
+      ...super.getOptions(),
+      propertyKey: (result) => result.product,
+      cacheKeyFn: (report) => report.id,
+    };
+  }
+
+  async loadMany(products: readonly Product[]) {
+    return await this.service.readAllForManyProducts(products, this.session);
+  }
+}

--- a/src/components/product-progress/product-progress-by-report.loader.ts
+++ b/src/components/product-progress/product-progress-by-report.loader.ts
@@ -1,0 +1,29 @@
+import { Injectable, Scope } from '@nestjs/common';
+import { ID } from '../../common';
+import { LoaderOptionsOf, OrderedNestDataLoader } from '../../core';
+import { ProgressReport } from '../periodic-report';
+import { ProductProgress } from './dto';
+import { ProductProgressService } from './product-progress.service';
+
+@Injectable({ scope: Scope.REQUEST })
+export class ProductProgressByReportLoader extends OrderedNestDataLoader<
+  { report: ProgressReport; progress: readonly ProductProgress[] },
+  ProgressReport,
+  ID
+> {
+  constructor(private readonly service: ProductProgressService) {
+    super();
+  }
+
+  getOptions(): LoaderOptionsOf<ProductProgressByReportLoader> {
+    return {
+      ...super.getOptions(),
+      propertyKey: (result) => result.report,
+      cacheKeyFn: (report) => report.id,
+    };
+  }
+
+  async loadMany(reports: readonly ProgressReport[]) {
+    return await this.service.readAllForManyReports(reports, this.session);
+  }
+}

--- a/src/components/product-progress/product-progress.module.ts
+++ b/src/components/product-progress/product-progress.module.ts
@@ -4,6 +4,7 @@ import { PeriodicReportModule } from '../periodic-report/periodic-report.module'
 import { ProductModule } from '../product/product.module';
 import * as handlers from './handlers';
 import { ProductConnectionResolver } from './product-connection.resolver';
+import { ProductProgressByReportLoader } from './product-progress-by-report.loader';
 import { ProductProgressRepository } from './product-progress.repository';
 import { ProductProgressResolver } from './product-progress.resolver';
 import { ProductProgressService } from './product-progress.service';
@@ -18,6 +19,7 @@ import { StepProgressResolver } from './step-progress.resolver';
     ProductProgressResolver,
     StepProgressResolver,
     ProductConnectionResolver,
+    ProductProgressByReportLoader,
     ProductProgressService,
     ProductProgressRepository,
     StepProgressExtractor,

--- a/src/components/product-progress/product-progress.module.ts
+++ b/src/components/product-progress/product-progress.module.ts
@@ -4,6 +4,7 @@ import { PeriodicReportModule } from '../periodic-report/periodic-report.module'
 import { ProductModule } from '../product/product.module';
 import * as handlers from './handlers';
 import { ProductConnectionResolver } from './product-connection.resolver';
+import { ProductProgressByProductLoader } from './product-progress-by-product.loader';
 import { ProductProgressByReportLoader } from './product-progress-by-report.loader';
 import { ProductProgressRepository } from './product-progress.repository';
 import { ProductProgressResolver } from './product-progress.resolver';
@@ -19,6 +20,7 @@ import { StepProgressResolver } from './step-progress.resolver';
     ProductProgressResolver,
     StepProgressResolver,
     ProductConnectionResolver,
+    ProductProgressByProductLoader,
     ProductProgressByReportLoader,
     ProductProgressService,
     ProductProgressRepository,

--- a/src/components/product-progress/product-progress.service.ts
+++ b/src/components/product-progress/product-progress.service.ts
@@ -3,6 +3,7 @@ import {
   ID,
   InputException,
   isIdLike,
+  mapFromList,
   Sensitivity,
   Session,
   UnauthorizedException,
@@ -26,15 +27,32 @@ export class ProductProgressService {
     private readonly repo: ProductProgressRepository
   ) {}
 
-  async readAllByReport(
-    report: ProgressReport,
+  async readAllForManyReports(
+    reports: readonly ProgressReport[],
     session: Session
-  ): Promise<readonly ProductProgress[]> {
-    const progress = await this.repo.readAllProgressReportsByReport(report.id);
-    return await this.secureAll(
-      progress,
-      addScope(session, report.scope),
-      report.sensitivity
+  ) {
+    if (reports.length === 0) {
+      return [];
+    }
+    const reportMap = mapFromList(reports, (r) => [r.id, r]);
+    const progressForManyReports =
+      await this.repo.readAllProgressReportsForManyReports(
+        reports.map((report) => report.id)
+      );
+    return await Promise.all(
+      progressForManyReports.map(async ({ reportId, progressList }) => {
+        const report = reportMap[reportId];
+        const progress = await Promise.all(
+          progressList.map((progress) =>
+            this.secure(
+              progress,
+              addScope(session, report.scope),
+              report.sensitivity
+            )
+          )
+        );
+        return { report, progress };
+      })
     );
   }
 

--- a/src/components/product-progress/progress-report-connection.resolver.ts
+++ b/src/components/product-progress/progress-report-connection.resolver.ts
@@ -1,20 +1,19 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { AnonSession, Session } from '../../common';
+import { Loader, LoaderOf } from '../../core';
 import { ProgressReport } from '../periodic-report/dto';
 import { ProductProgress } from './dto';
-import { ProductProgressService } from './product-progress.service';
+import { ProductProgressByReportLoader } from './product-progress-by-report.loader';
 
 @Resolver(ProgressReport)
 export class ProgressReportConnectionResolver {
-  constructor(private readonly service: ProductProgressService) {}
-
   @ResolveField(() => [ProductProgress], {
     description: 'Progress for all products in this report',
   })
   async progress(
     @Parent() report: ProgressReport,
-    @AnonSession() session: Session
+    @Loader(ProductProgressByReportLoader)
+    loader: LoaderOf<ProductProgressByReportLoader>
   ): Promise<readonly ProductProgress[]> {
-    return await this.service.readAllByReport(report, session);
+    return (await loader.load(report)).progress;
   }
 }

--- a/src/components/progress-summary/dto/progress-summary.dto.ts
+++ b/src/components/progress-summary/dto/progress-summary.dto.ts
@@ -1,7 +1,7 @@
 import { Field, Float, ObjectType } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { keys as keysOf } from 'ts-transformer-keys';
-import { SecuredProps } from '../../../common';
+import { ID, SecuredProps } from '../../../common';
 
 @ObjectType({
   description: stripIndent`
@@ -30,3 +30,11 @@ export enum SummaryPeriod {
   FiscalYearSoFar = 'FiscalYearSoFar',
   Cumulative = 'Cumulative',
 }
+
+export type FetchedSummaries = {
+  reportId: ID;
+  // Total verses across all products in the engagement this summary is under
+  totalVerses?: number;
+  // Total verse equivalents across all products in the engagement this summary is under
+  totalVerseEquivalents?: number;
+} & Record<SummaryPeriod, ProgressSummary | undefined>;

--- a/src/components/progress-summary/progress-report-connection.resolver.ts
+++ b/src/components/progress-summary/progress-report-connection.resolver.ts
@@ -1,21 +1,21 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Loader, LoaderOf } from '../../core';
 import { ProgressReport } from '../periodic-report';
 import { ProgressSummary, SummaryPeriod } from './dto';
-import { ProgressSummaryRepository } from './progress-summary.repository';
+import { ProgressSummaryLoader } from './progress-summary.loader';
 
 @Resolver(ProgressReport)
 export class ProgressReportConnectionResolver {
-  constructor(private readonly repo: ProgressSummaryRepository) {}
-
   @ResolveField(() => ProgressSummary, {
     nullable: true,
     description:
       'Progress of the engagement (all products/goals) made _only during this reporting period_',
   })
   async periodSummary(
+    @Loader(ProgressSummaryLoader) loader: LoaderOf<ProgressSummaryLoader>,
     @Parent() report: ProgressReport
   ): Promise<ProgressSummary | undefined> {
-    return await this.repo.readOne(report.id, SummaryPeriod.ReportPeriod);
+    return await this.fetch(loader, report, SummaryPeriod.ReportPeriod);
   }
 
   @ResolveField(() => ProgressSummary, {
@@ -24,9 +24,10 @@ export class ProgressReportConnectionResolver {
       'Progress of the engagement (all products/goals) made from the beginning of _this fiscal year_ until this report',
   })
   async fiscalYearSummary(
+    @Loader(ProgressSummaryLoader) loader: LoaderOf<ProgressSummaryLoader>,
     @Parent() report: ProgressReport
   ): Promise<ProgressSummary | undefined> {
-    return await this.repo.readOne(report.id, SummaryPeriod.FiscalYearSoFar);
+    return await this.fetch(loader, report, SummaryPeriod.FiscalYearSoFar);
   }
 
   @ResolveField(() => ProgressSummary, {
@@ -35,9 +36,10 @@ export class ProgressReportConnectionResolver {
       'Progress of the engagement (all products/goals) made from the beginning of _the engagement_ until this report',
   })
   async cumulativeSummary(
+    @Loader(ProgressSummaryLoader) loader: LoaderOf<ProgressSummaryLoader>,
     @Parent() report: ProgressReport
   ): Promise<ProgressSummary | undefined> {
-    return await this.repo.readOne(report.id, SummaryPeriod.Cumulative);
+    return await this.fetch(loader, report, SummaryPeriod.Cumulative);
   }
 
   @ResolveField(() => ProgressSummary, {
@@ -45,8 +47,25 @@ export class ProgressReportConnectionResolver {
     deprecationReason: 'Use `ProgressReport.cumulativeSummary` instead',
   })
   async summary(
+    @Loader(ProgressSummaryLoader) loader: LoaderOf<ProgressSummaryLoader>,
     @Parent() report: ProgressReport
   ): Promise<ProgressSummary | undefined> {
-    return await this.cumulativeSummary(report);
+    return await this.fetch(loader, report, SummaryPeriod.Cumulative);
+  }
+
+  private async fetch(
+    loader: LoaderOf<ProgressSummaryLoader>,
+    report: ProgressReport,
+    period: SummaryPeriod
+  ): Promise<ProgressSummary | undefined> {
+    const fetched = await loader.load(report.id);
+    if (!fetched[period]) {
+      return undefined;
+    }
+    return {
+      ...fetched[period]!,
+      totalVerses: fetched.totalVerses,
+      totalVerseEquivalents: fetched.totalVerseEquivalents,
+    };
   }
 }

--- a/src/components/progress-summary/progress-summary.loader.ts
+++ b/src/components/progress-summary/progress-summary.loader.ts
@@ -1,0 +1,26 @@
+import { Injectable, Scope } from '@nestjs/common';
+import { ID } from '../../common';
+import {
+  OrderedNestDataLoader,
+  OrderedNestDataLoaderOptions,
+} from '../../core';
+import { FetchedSummaries } from './dto';
+import { ProgressSummaryRepository } from './progress-summary.repository';
+
+@Injectable({ scope: Scope.REQUEST })
+export class ProgressSummaryLoader extends OrderedNestDataLoader<FetchedSummaries> {
+  constructor(private readonly repo: ProgressSummaryRepository) {
+    super();
+  }
+
+  getOptions(): OrderedNestDataLoaderOptions<FetchedSummaries, ID, ID> {
+    return {
+      ...super.getOptions(),
+      propertyKey: 'reportId',
+    };
+  }
+
+  async loadMany(ids: readonly ID[]) {
+    return await this.repo.readMany(ids);
+  }
+}

--- a/src/components/progress-summary/progress-summary.loader.ts
+++ b/src/components/progress-summary/progress-summary.loader.ts
@@ -1,9 +1,6 @@
 import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import {
-  OrderedNestDataLoader,
-  OrderedNestDataLoaderOptions,
-} from '../../core';
+import { LoaderOptionsOf, OrderedNestDataLoader } from '../../core';
 import { FetchedSummaries } from './dto';
 import { ProgressSummaryRepository } from './progress-summary.repository';
 
@@ -13,7 +10,7 @@ export class ProgressSummaryLoader extends OrderedNestDataLoader<FetchedSummarie
     super();
   }
 
-  getOptions(): OrderedNestDataLoaderOptions<FetchedSummaries, ID, ID> {
+  getOptions(): LoaderOptionsOf<ProgressSummaryLoader> {
     return {
       ...super.getOptions(),
       propertyKey: 'reportId',

--- a/src/components/progress-summary/progress-summary.module.ts
+++ b/src/components/progress-summary/progress-summary.module.ts
@@ -6,6 +6,7 @@ import * as migrations from './migrations';
 import { ProgressReportConnectionResolver } from './progress-report-connection.resolver';
 import { ProgressSummaryEngagementConnectionResolver } from './progress-summary-engagement-connection.resolver';
 import { ProgressSummaryExtractor } from './progress-summary.extractor';
+import { ProgressSummaryLoader } from './progress-summary.loader';
 import { ProgressSummaryRepository } from './progress-summary.repository';
 import { ProgressSummaryResolver } from './progress-summary.resolver';
 
@@ -15,6 +16,7 @@ import { ProgressSummaryResolver } from './progress-summary.resolver';
     ProgressReportConnectionResolver,
     ProgressSummaryEngagementConnectionResolver,
     ProgressSummaryResolver,
+    ProgressSummaryLoader,
     ProgressSummaryRepository,
     ProgressSummaryExtractor,
     ...Object.values(handlers),

--- a/src/core/data-loader/ordered-data-loader.ts
+++ b/src/core/data-loader/ordered-data-loader.ts
@@ -21,6 +21,18 @@ export interface OrderedNestDataLoaderOptions<T, Key = ID, CachedKey = Key>
   typeName?: string;
 }
 
+/**
+ * Shortcut to reference options of class name instead of having to duplicate
+ * these generic values.
+ */
+export type LoaderOptionsOf<Factory> = Factory extends NestDataLoader<
+  infer T,
+  infer Key,
+  infer CachedKey
+>
+  ? OrderedNestDataLoaderOptions<T, Key, CachedKey>
+  : never;
+
 export abstract class OrderedNestDataLoader<T, Key = ID, CachedKey = Key>
   implements NestDataLoader<T, Key, CachedKey>
 {

--- a/src/core/database/query/cypher-functions.ts
+++ b/src/core/database/query/cypher-functions.ts
@@ -58,13 +58,25 @@ export const merge = (...expressions: ExpressionInput[]) => {
 
 export const apoc = {
   map: {
+    /**
+     * Creates an object/map from input list.
+     * @example
+     * fromValues([key1, value1, key2, value2, ...])
+     */
     fromValues: fn1('apoc.map.fromValues'),
   },
   coll: {
     flatten: fn1('apoc.coll.flatten'),
   },
+  convert: {
+    /** Converts Neo4j node to object/map of the node's properties */
+    toMap: fn1('apoc.convert.toMap'),
+  },
 };
 
+/**
+ * Joins each expression given with a `+` character.
+ */
 export const listConcat = (...items: ExpressionInput[]) =>
   exp(
     items


### PR DESCRIPTION
- Added `periodicReports` query to list reports unrestricted from a single parent.
- Load multiple progress summaries at once (with all periods).
  This takes DB queries from `O(3n)` to `O(1)` (when all 3 periods are requested).
- Load progress list for multiple reports at once. `O(n)` to `O(1)`
- Load progress list for multiple products at once. `O(n)` to `O(1)`
