### PR TITLE
Fix comparing products of different types when extracting planning pnp

### DIFF
--- a/src/components/product/handlers/extract-products-from-pnp.handler.ts
+++ b/src/components/product/handlers/extract-products-from-pnp.handler.ts
@@ -20,6 +20,7 @@ import { StoryService } from '../../story';
 import {
   CreateDerivativeScriptureProduct,
   CreateDirectScriptureProduct,
+  DerivativeScriptureProduct,
   getAvailableSteps,
   ProducibleType,
   ProgressMeasurement,
@@ -191,7 +192,10 @@ export class ExtractProductsFromPnpHandler
       : [];
 
     const storyProducts = rows[0].story
-      ? await this.products.loadProductIdsByPnpIndex(engagement.id)
+      ? await this.products.loadProductIdsByPnpIndex(
+          engagement.id,
+          DerivativeScriptureProduct.name
+        )
       : {};
 
     if (rows[0].story) {

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -119,13 +119,13 @@ export class ProductRepository extends CommonRepository {
       .run();
   }
 
-  async listIdsWithPnpIndexes(engagementId: ID) {
+  async listIdsWithPnpIndexes(engagementId: ID, type?: string) {
     return await this.db
       .query()
       .match([
         node('engagement', 'Engagement', { id: engagementId }),
         relation('out', '', 'product', ACTIVE),
-        node('node', 'Product'),
+        node('node', ['Product', ...(type ? [type] : [])]),
       ])
       .where({ 'node.pnpIndex': not(isNull()) })
       .return<{ id: ID; pnpIndex: number }>([

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -696,8 +696,11 @@ export class ProductService {
     });
   }
 
-  async loadProductIdsByPnpIndex(engagementId: ID) {
-    const productRefs = await this.repo.listIdsWithPnpIndexes(engagementId);
+  async loadProductIdsByPnpIndex(engagementId: ID, typeFilter?: string) {
+    const productRefs = await this.repo.listIdsWithPnpIndexes(
+      engagementId,
+      typeFilter
+    );
     return mapFromList(productRefs, (ref) => [ref.pnpIndex, ref.id]);
   }
 


### PR DESCRIPTION
When matching story (derivative) products by pnp index only consider derivative products

If other products of different types have been created from a different kind of pnp, they
should be ignored. That's still unexpected behavior and could have implications but this
fixes the server error.