### PR TITLE
DB query logging (at a glance)

### DIFF
--- a/src/core/database/cypher.factory.ts
+++ b/src/core/database/cypher.factory.ts
@@ -170,11 +170,11 @@ export const CypherFactory: FactoryProvider<Connection> = {
 
       (q as any).__stacktrace = stack;
       const frame = stack?.[0] ? /at (.+) \(/.exec(stack[0]) : undefined;
-      const name = ((q as any).name = frame?.[1].replace('Repository', ''));
+      (q as any).name = frame?.[1].replace('Repository', '');
 
       const orig = q.run.bind(q);
       q.run = async () => {
-        return await tracing.capture(name ?? 'Query', (sub) => {
+        return await tracing.capture((q as any).name ?? 'Query', (sub) => {
           // Show this segment separately in service map
           sub.namespace = 'remote';
           // Help ID the segment as being for a database
@@ -197,7 +197,7 @@ export const CypherFactory: FactoryProvider<Connection> = {
           writable: true,
         });
         Object.defineProperty(result.params, '__origin', {
-          value: name,
+          value: (q as any).name,
           enumerable: false,
           configurable: true,
           writable: true,

--- a/src/core/database/cypher.factory.ts
+++ b/src/core/database/cypher.factory.ts
@@ -240,10 +240,14 @@ const wrapQueryRun = (
       parameters?.interpolated
         ? { [AFTER_MESSAGE]: parameters.interpolated }
         : {
-            statement:
-              process.env.NODE_ENV !== 'production'
-                ? highlight(statement, { language: 'cypher' })
-                : statement,
+            ...(parameters?.logIt
+              ? {
+                  statement:
+                    process.env.NODE_ENV !== 'production'
+                      ? highlight(statement, { language: 'cypher' })
+                      : statement,
+                }
+              : {}),
             ...parameters,
           }
     );

--- a/src/core/database/cypher.factory.ts
+++ b/src/core/database/cypher.factory.ts
@@ -196,6 +196,12 @@ export const CypherFactory: FactoryProvider<Connection> = {
           configurable: true,
           writable: true,
         });
+        Object.defineProperty(result.params, '__origin', {
+          value: name,
+          enumerable: false,
+          configurable: true,
+          writable: true,
+        });
         return result;
       };
       return q;
@@ -230,7 +236,7 @@ const wrapQueryRun = (
     const level = (parameters?.logIt as LogLevel | undefined) ?? LogLevel.DEBUG;
     logger.log(
       level,
-      `Executing ${(parameters?.__origin as string | undefined) ?? 'query'}`,
+      (parameters?.__origin as string | undefined) ?? 'Query',
       parameters?.interpolated
         ? { [AFTER_MESSAGE]: parameters.interpolated }
         : {

--- a/src/core/database/indexer/indexer.module.ts
+++ b/src/core/database/indexer/indexer.module.ts
@@ -80,7 +80,7 @@ export class IndexerModule implements OnModuleInit {
             )
           : statement
       );
-      for (const statement of statements) {
+      for (const [i, statement] of Object.entries(statements)) {
         if (
           serverInfo.edition === 'community' &&
           statement.toUpperCase().includes('IS UNIQUE')
@@ -93,7 +93,11 @@ export class IndexerModule implements OnModuleInit {
         }
 
         try {
-          await this.db.query().raw(statement).run();
+          const q = this.db.query();
+          (q as any).name = `${parentClass.name}.${methodName}${
+            Number(i) > 0 ? ` #${Number(i) + 1}` : ''
+          }`;
+          await q.raw(statement).run();
         } catch (e) {
           if (
             e instanceof Neo4jError &&

--- a/src/core/database/query-augmentation/log-it.ts
+++ b/src/core/database/query-augmentation/log-it.ts
@@ -38,13 +38,6 @@ Query.prototype.logIt = function logIt(
         enumerable: false,
       });
     }
-    const name = (this as any).name as string | undefined;
-    if (name) {
-      Object.defineProperty(result.params, '__origin', {
-        value: name,
-        enumerable: false,
-      });
-    }
 
     Object.defineProperty(result.params, 'logIt', {
       value: level,


### PR DESCRIPTION
Allow viewing DB queries executed to be viewed at a glance.

Set `database:query` to _debug_ level
```yaml
# logging.yaml
levels:
  database:query: debug
```

View queries ran by introspected name with their given parameters:
![Screen Shot 2022-02-18 at 6 36 12 PM](https://user-images.githubusercontent.com/932566/154778509-3e4f26a2-8fb3-4be5-855f-f5c5c801ff43.png)
