### PR TITLE
Timeout Responses

### DIFF
--- a/src/common/context.type.ts
+++ b/src/common/context.type.ts
@@ -5,7 +5,7 @@ import { RawSession } from './session';
  * The type for graphql @Context() decorator
  */
 export interface GqlContextType {
-  request: Request;
-  response: Response;
+  request?: Request;
+  response?: Response;
   session?: RawSession;
 }

--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -5,3 +5,4 @@ export * from './not-found.exception';
 export * from './not-implemented.exception';
 export * from './unauthenticated.exception';
 export * from './unauthorized.exception';
+export * from './service-unavailable.exception';

--- a/src/common/exceptions/service-unavailable.exception.ts
+++ b/src/common/exceptions/service-unavailable.exception.ts
@@ -1,0 +1,11 @@
+import { HttpStatus } from '@nestjs/common';
+import { ServerException } from './exception';
+
+export class TransientException extends ServerException {}
+
+export class ServiceUnavailableException extends TransientException {
+  readonly status = HttpStatus.SERVICE_UNAVAILABLE;
+  constructor(message: string, previous?: Error) {
+    super(message ?? 'Service Unavailable', previous);
+  }
+}

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -8,7 +8,7 @@ export const maybeMany = <T>(
   item: Many<T> | null | undefined
 ): readonly T[] | undefined => (item != null ? many(item) : undefined);
 
-export const sleep = (duration: DurationLike) =>
+export const sleep = (duration: string | DurationLike) =>
   new Promise((resolve) =>
     setTimeout(resolve, Duration.from(duration).toMillis())
   );

--- a/src/components/authentication/session.interceptor.ts
+++ b/src/components/authentication/session.interceptor.ts
@@ -52,7 +52,7 @@ export class SessionInterceptor implements NestInterceptor {
     );
   }
 
-  private getTokenFromAuthHeader(req: Request): string | null {
+  private getTokenFromAuthHeader(req: Request | undefined): string | null {
     const header = req?.headers?.authorization;
 
     if (!header) {
@@ -65,7 +65,7 @@ export class SessionInterceptor implements NestInterceptor {
     return header.replace('Bearer ', '');
   }
 
-  private getTokenFromCookie(req: Request): string | null {
+  private getTokenFromCookie(req: Request | undefined): string | null {
     return req?.cookies?.[this.config.sessionCookie.name] || null;
   }
 }

--- a/src/components/authentication/session.resolver.ts
+++ b/src/components/authentication/session.resolver.ts
@@ -8,7 +8,11 @@ import {
   Resolver,
 } from '@nestjs/graphql';
 import { DateTime } from 'luxon';
-import { GqlContextType, UnauthenticatedException } from '../../common';
+import {
+  GqlContextType,
+  ServerException,
+  UnauthenticatedException,
+} from '../../common';
 import { anonymousSession } from '../../common/session';
 import { ConfigService, ILogger, Loader, LoaderOf, Logger } from '../../core';
 import { AuthorizationService } from '../authorization/authorization.service';
@@ -71,6 +75,11 @@ export class SessionResolver {
 
     if (browser) {
       const { name, expires, ...options } = this.config.sessionCookie;
+      if (!context.response) {
+        throw new ServerException(
+          'Cannot use cookie session without a response object'
+        );
+      }
       context.response.cookie(name, token, {
         ...options,
         expires: expires

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -18,6 +18,7 @@ import { ExceptionFilter } from './exception.filter';
 import { GraphqlModule } from './graphql';
 import { PostgresModule } from './postgres/postgres.module';
 import { ResourceResolver } from './resources';
+import { TimeoutInterceptor } from './timeout.interceptor';
 import { TracingModule } from './tracing';
 import { ValidationPipe } from './validation.pipe';
 
@@ -39,6 +40,7 @@ import { ValidationPipe } from './validation.pipe';
     { provide: APP_FILTER, useClass: ExceptionFilter },
     { provide: APP_PIPE, useClass: ValidationPipe },
     { provide: APP_INTERCEPTOR, useClass: DataLoaderInterceptor },
+    { provide: APP_INTERCEPTOR, useClass: TimeoutInterceptor },
     ResourceResolver,
   ],
   controllers: [CoreController],

--- a/src/core/exception.filter.ts
+++ b/src/core/exception.filter.ts
@@ -12,11 +12,7 @@ import {
 } from '@nestjs/common';
 /* eslint-enable no-restricted-imports */
 import { BaseExceptionFilter } from '@nestjs/core';
-import {
-  GqlArgumentsHost,
-  GqlContextType,
-  GqlExceptionFilter,
-} from '@nestjs/graphql';
+import { GqlContextType, GqlExceptionFilter } from '@nestjs/graphql';
 import { compact, mapValues, uniq } from 'lodash';
 import { Neo4jError } from 'neo4j-driver';
 import {
@@ -40,7 +36,6 @@ export class ExceptionFilter implements GqlExceptionFilter {
   ) {}
 
   catch(exception: Error, restHost: ArgumentsHost): any {
-    const _host = GqlArgumentsHost.create(restHost); // when needed
     let ex: ExceptionInfo;
     try {
       ex = this.catchGql(exception);

--- a/src/core/graphql/graphql.config.ts
+++ b/src/core/graphql/graphql.config.ts
@@ -89,7 +89,7 @@ export class GraphQLConfig implements GqlOptionsFactory {
             frame.startsWith('    at') &&
             !frame.includes('node_modules') &&
             !frame.includes('(internal/') &&
-            !frame.includes('(node:internal/') &&
+            !frame.includes('(node:') &&
             !frame.includes('(<anonymous>)')
         )
         .map((frame: string) =>

--- a/src/core/logger/formatters.ts
+++ b/src/core/logger/formatters.ts
@@ -119,7 +119,7 @@ const formatStackFrame = (t: StackFrame) => {
     !absolute ||
     absolute.includes('node_modules') ||
     absolute.startsWith('internal/') ||
-    absolute.startsWith('node:internal/') ||
+    absolute.startsWith('node:') ||
     absolute.includes('<anonymous>')
   ) {
     return null;

--- a/src/core/timeout.interceptor.ts
+++ b/src/core/timeout.interceptor.ts
@@ -1,0 +1,39 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import {
+  GqlExecutionContext,
+  GqlContextType as GqlExeType,
+} from '@nestjs/graphql';
+import { Response } from 'express';
+import { fromEvent, Observable, race } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { GqlContextType, ServiceUnavailableException } from '../common';
+
+/**
+ * Throws error when response timeouts.
+ * This is configured independently on HTTP server via HTTP_SOCKET_TIMEOUT
+ */
+@Injectable()
+export class TimeoutInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const response =
+      context.getType<GqlExeType>() !== 'graphql'
+        ? context.switchToHttp().getResponse<Response>()
+        : GqlExecutionContext.create(context).getContext<GqlContextType>()
+            .response;
+
+    const timeout$ = fromEvent(response, 'timeout').pipe(
+      map(() => {
+        throw new ServiceUnavailableException(
+          'Unable to fulfill request in a timely manner'
+        );
+      })
+    );
+
+    return race(timeout$, next.handle());
+  }
+}

--- a/src/core/timeout.interceptor.ts
+++ b/src/core/timeout.interceptor.ts
@@ -26,6 +26,10 @@ export class TimeoutInterceptor implements NestInterceptor {
         : GqlExecutionContext.create(context).getContext<GqlContextType>()
             .response;
 
+    if (!response) {
+      return next.handle();
+    }
+
     const timeout$ = fromEvent(response, 'timeout').pipe(
       map(() => {
         throw new ServiceUnavailableException(

--- a/src/core/tracing/xray.middleware.ts
+++ b/src/core/tracing/xray.middleware.ts
@@ -98,9 +98,9 @@ export class XRayMiddleware implements NestMiddleware, NestInterceptor {
       context.getType<GqlExeType>() === 'graphql'
         ? GqlExecutionContext.create(context).getContext<GqlContextType>()
             .response
-        : context.switchToHttp().getResponse();
+        : context.switchToHttp().getResponse<Response>();
 
-    if (root instanceof XRay.Segment) {
+    if (res && root instanceof XRay.Segment) {
       res.setHeader(
         'x-amzn-trace-id',
         `Root=${root.trace_id};Sampled=${sampled ? '1' : '0'}`


### PR DESCRIPTION
We are still not responding correctly when our responses take too long. ALB gives up and returns generic HTML response. Which our clients then fail to parse as JSON and give up.

This now listens for the response timeout event and throws an exception (which we log & convert same as we do all exceptions).

This should allow us to give correct error response when a timeout happens. Assuming `HTTP_SOCKET_TIMEOUT` env var is less than ALB timeout.

Related to #2381 