### PR TITLE
Some GQL schema tweaks

### DIFF
--- a/src/components/engagement/product-connection.resolver.ts
+++ b/src/components/engagement/product-connection.resolver.ts
@@ -1,4 +1,5 @@
-import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Info, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Fields, IsOnlyId } from '../../common';
 import { Loader, LoaderOf } from '../../core';
 import { Product } from '../product';
 import { LanguageEngagement } from './dto';
@@ -9,11 +10,14 @@ export class EngagementProductConnectionResolver {
   @ResolveField(() => LanguageEngagement)
   async engagement(
     @Parent() product: Product,
-    @Loader(EngagementLoader) engagements: LoaderOf<EngagementLoader>
+    @Loader(EngagementLoader) engagements: LoaderOf<EngagementLoader>,
+    @Info(Fields, IsOnlyId) onlyId: boolean
   ) {
-    return await engagements.load({
-      id: product.engagement,
-      view: { active: true },
-    });
+    return onlyId
+      ? { id: product.engagement }
+      : await engagements.load({
+          id: product.engagement,
+          view: { active: true },
+        });
   }
 }

--- a/src/components/periodic-report/periodic-report.resolver.ts
+++ b/src/components/periodic-report/periodic-report.resolver.ts
@@ -9,14 +9,13 @@ import {
 import {
   AnonSession,
   CalendarDate,
-  ID,
-  IdArg,
   ListArg,
   LoggedInSession,
   Session,
   UnauthorizedException,
 } from '../../common';
 import { Loader, LoaderOf } from '../../core';
+import { IdsAndView, IdsAndViewArg } from '../changeset/dto';
 import { FileNodeLoader, resolveDefinedFile, SecuredFile } from '../file';
 import {
   IPeriodicReport,
@@ -25,7 +24,7 @@ import {
   UpdatePeriodicReportInput,
   UploadPeriodicReportInput,
 } from './dto';
-import { PeriodicReportLoader } from './periodic-report.loader';
+import { PeriodicReportLoader as ReportLoader } from './periodic-report.loader';
 import { PeriodicReportService } from './periodic-report.service';
 
 @Resolver(IPeriodicReport)
@@ -36,11 +35,10 @@ export class PeriodicReportResolver {
     description: 'Read a periodic report by id.',
   })
   async periodicReport(
-    @Loader(PeriodicReportLoader)
-    periodicReports: LoaderOf<PeriodicReportLoader>,
-    @IdArg() id: ID
+    @Loader(ReportLoader) reports: LoaderOf<ReportLoader>,
+    @IdsAndViewArg() { id }: IdsAndView
   ): Promise<IPeriodicReport> {
-    return await periodicReports.load(id);
+    return await reports.load(id);
   }
 
   @Query(() => PeriodicReportListOutput, {
@@ -49,7 +47,7 @@ export class PeriodicReportResolver {
   async periodicReports(
     @AnonSession() session: Session,
     @ListArg(PeriodicReportListInput) input: PeriodicReportListInput,
-    @Loader(PeriodicReportLoader) loader: LoaderOf<PeriodicReportLoader>
+    @Loader(ReportLoader) loader: LoaderOf<ReportLoader>
   ): Promise<PeriodicReportListOutput> {
     // Only let admins do this for now.
     if (!session.roles.includes('global:Administrator')) {

--- a/src/components/product/dto/product.dto.ts
+++ b/src/components/product/dto/product.dto.ts
@@ -48,6 +48,7 @@ export class Product extends Producible {
   static readonly SecuredProps: string[] = keysOf<SecuredProps<Product>>();
 
   readonly engagement: ID;
+  readonly project: ID;
 
   @Field()
   @DbLabel('ProductMedium')

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -236,6 +236,7 @@ export class ProductRepository extends CommonRepository {
         .return<{ dto: HydratedProductRow }>(
           merge('props', {
             engagement: 'engagement.id',
+            project: 'project.id',
             produces: 'produces',
             unspecifiedScripture:
               'unspecifiedScripture { .book, .totalVerses }',

--- a/src/components/product/product.resolver.ts
+++ b/src/components/product/product.resolver.ts
@@ -17,6 +17,7 @@ import {
   Session,
 } from '../../common';
 import { Loader, LoaderOf } from '../../core';
+import { IdsAndView, IdsAndViewArg } from '../changeset/dto';
 import {
   AvailableStepsOptions,
   CreateDerivativeScriptureProduct,
@@ -56,7 +57,7 @@ export class ProductResolver {
   })
   async product(
     @Loader(ProductLoader) products: LoaderOf<ProductLoader>,
-    @IdArg() id: ID
+    @IdsAndViewArg() { id }: IdsAndView
   ): Promise<AnyProduct> {
     return await products.load(id);
   }

--- a/src/components/product/product.resolver.ts
+++ b/src/components/product/product.resolver.ts
@@ -29,6 +29,7 @@ import {
   UpdateDerivativeScriptureProduct,
   UpdateDirectScriptureProduct,
 } from '../product';
+import { ProjectLoader, TranslationProject } from '../project';
 import { Book, labelOfScriptureRanges } from '../scripture';
 import {
   AnyProduct,
@@ -73,6 +74,14 @@ export class ProductResolver {
     const list = await this.productService.list(input, session);
     products.primeAll(list.items);
     return list;
+  }
+
+  @ResolveField(() => TranslationProject)
+  async project(
+    @Parent() product: AnyProduct,
+    @Loader(() => ProjectLoader) projects: LoaderOf<ProjectLoader>
+  ) {
+    return await projects.load({ id: product.project, view: { active: true } });
   }
 
   @ResolveField(() => ProductApproach, { nullable: true })

--- a/src/components/product/product.resolver.ts
+++ b/src/components/product/product.resolver.ts
@@ -1,5 +1,6 @@
 import {
   Args,
+  Info,
   Mutation,
   Parent,
   Query,
@@ -10,8 +11,10 @@ import { stripIndent } from 'common-tags';
 import { startCase } from 'lodash';
 import {
   AnonSession,
+  Fields,
   ID,
   IdArg,
+  IsOnlyId,
   ListArg,
   LoggedInSession,
   Session,
@@ -79,9 +82,12 @@ export class ProductResolver {
   @ResolveField(() => TranslationProject)
   async project(
     @Parent() product: AnyProduct,
-    @Loader(() => ProjectLoader) projects: LoaderOf<ProjectLoader>
+    @Loader(() => ProjectLoader) projects: LoaderOf<ProjectLoader>,
+    @Info(Fields, IsOnlyId) onlyId: boolean
   ) {
-    return await projects.load({ id: product.project, view: { active: true } });
+    return onlyId
+      ? { id: product.project }
+      : await projects.load({ id: product.project, view: { active: true } });
   }
 
   @ResolveField(() => ProductApproach, { nullable: true })


### PR DESCRIPTION
Added stubbed `changeset` arg for product & report queries.
```gql
product(id: "", changeset: "")
periodicReport(id: "", changeset: "")
```
Caller can pass these in now, which we'll ignore until we implement it.

Expose project relation on product, so caller need to go through engagement.
```gql
product {
  project { ... }
}
```