### PR TITLE
Automatically run all gql mutations in neo4j transactions

### DIFF
--- a/src/core/database/database.module.ts
+++ b/src/core/database/database.module.ts
@@ -1,4 +1,5 @@
 import { Module, OnApplicationShutdown } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { Connection } from 'cypher-query-builder';
 import { ConfigModule } from '../config/config.module';
 import { ConfigService } from '../config/config.service';
@@ -8,10 +9,16 @@ import { DatabaseService } from './database.service';
 import { IndexerModule } from './indexer/indexer.module';
 import { MigrationModule } from './migration/migration.module';
 import { ParameterTransformer } from './parameter-transformer.service';
+import { TransactionalMutationsInterceptor } from './transactional-mutations.interceptor';
 
 @Module({
   imports: [IndexerModule, MigrationModule, ConfigModule, TracingModule],
-  providers: [CypherFactory, DatabaseService, ParameterTransformer],
+  providers: [
+    CypherFactory,
+    DatabaseService,
+    ParameterTransformer,
+    { provide: APP_INTERCEPTOR, useClass: TransactionalMutationsInterceptor },
+  ],
   exports: [CypherFactory, DatabaseService, IndexerModule],
 })
 export class DatabaseModule implements OnApplicationShutdown {

--- a/src/core/database/transactional-mutations.interceptor.ts
+++ b/src/core/database/transactional-mutations.interceptor.ts
@@ -1,0 +1,36 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { GqlContextType, GqlExecutionContext } from '@nestjs/graphql';
+import { Connection } from 'cypher-query-builder';
+import { GraphQLResolveInfo } from 'graphql';
+import { lastValueFrom, of } from 'rxjs';
+
+/**
+ * Run all mutations in a neo4j transaction.
+ * This allows automatic rollbacks on error.
+ */
+@Injectable()
+export class TransactionalMutationsInterceptor implements NestInterceptor {
+  constructor(private readonly db: Connection) {}
+
+  async intercept(context: ExecutionContext, next: CallHandler) {
+    if (context.getType<GqlContextType>() !== 'graphql') {
+      return next.handle();
+    }
+
+    const ctx = GqlExecutionContext.create(context);
+    const info = ctx.getInfo<GraphQLResolveInfo>();
+    if (info.operation.operation !== 'mutation') {
+      return next.handle();
+    }
+
+    const res = await this.db.runInTransaction(
+      async () => await lastValueFrom(next.handle())
+    );
+    return of(res);
+  }
+}


### PR DESCRIPTION
Previously attempted this manually in #1630 but it was blocked and got stale.
This on the other hand is much cleaner.