### PR TITLE
Allow DtoRepository to define concrete shape from interface DTO

### DIFF
--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -36,7 +36,8 @@ import {
 @Injectable()
 export class PeriodicReportRepository extends DtoRepository<
   typeof IPeriodicReport,
-  [session: Session]
+  [session: Session],
+  PeriodicReport
 >(IPeriodicReport) {
   async merge(input: MergePeriodicReports) {
     const Report = resolveReportType(input);


### PR DESCRIPTION
Allow DtoRepository to accept a different dto shape from the resource class

Useful for interface repos that work with concretes