### PR TITLE
Optimize project list for UI O(n) -> O(1) via engagements.total

### DIFF
--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -156,6 +156,12 @@ class Project extends PinnablePostableChangesetAwareResource {
   })
   readonly presetInventory: SecuredBoolean;
 
+  /**
+   * Optimization for {@see ProjectResolver.engagements}.
+   * This doesn't account for changesets or item filters.
+   */
+  readonly engagementTotal: number;
+
   // A list of non-global roles the requesting user has available for this object.
   // This is just a cache, to prevent extra db lookups within the same request.
   readonly scope: ScopedRole[];

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -121,6 +121,11 @@ export class ProjectRepository extends CommonRepository {
           relation('out', '', 'owningOrganization', ACTIVE),
           node('organization', 'Organization'),
         ])
+        .optionalMatch([
+          node('node'),
+          relation('out', '', 'engagement', ACTIVE),
+          node('engagement', 'Engagement'),
+        ])
         .return<{ dto: UnsecuredDto<Project> }>(
           merge('props', 'changedProps', {
             type: 'node.type',
@@ -130,6 +135,7 @@ export class ProjectRepository extends CommonRepository {
             marketingLocation: 'marketingLocation.id',
             fieldRegion: 'fieldRegion.id',
             owningOrganization: 'organization.id',
+            engagementTotal: 'count(engagement)',
             changeset: 'changeset.id',
           }).as('dto')
         );


### PR DESCRIPTION
The UI currently shows the total engagements of each project in the project list. To get that number we were listing the engagements for each project. Thus the query was `O(n+1)`.

This changes that to `O(1)` by fetching the total number in the project hydrate query, and if that's the only property requested use it instead of calling the engagement list query.

This does ignore permissions, but I think we previous determined this was ok for just the total count.