### PR TITLE
Add ExactLength validator

### DIFF
--- a/src/common/validators/exactLength.ts
+++ b/src/common/validators/exactLength.ts
@@ -1,0 +1,6 @@
+import { Length } from 'class-validator';
+
+export const ExactLength = (length: number) =>
+  Length(length, length, {
+    message: `Must be exactly ${length} characters long`,
+  });

--- a/src/components/language/dto/create-language.dto.ts
+++ b/src/components/language/dto/create-language.dto.ts
@@ -5,7 +5,6 @@ import {
   IsLowercase,
   IsNumberString,
   IsPositive,
-  Length,
   Matches,
   ValidateNested,
 } from 'class-validator';
@@ -17,6 +16,7 @@ import {
   Sensitivity,
   SensitivityField,
 } from '../../../common';
+import { ExactLength } from '../../../common/validators/exactLength';
 import { Language } from './language.dto';
 
 @InputType()
@@ -24,13 +24,13 @@ export abstract class CreateEthnologueLanguage {
   @NameField({ nullable: true })
   @IsAlpha()
   @IsLowercase()
-  @Length(3)
+  @ExactLength(3)
   readonly code?: string;
 
   @NameField({ nullable: true })
   @IsAlpha()
   @IsLowercase()
-  @Length(3)
+  @ExactLength(3)
   readonly provisionalCode?: string;
 
   @NameField({ nullable: true })
@@ -65,7 +65,7 @@ export abstract class CreateLanguage {
   readonly populationOverride: number;
 
   @NameField({ nullable: true })
-  @Length(5)
+  @ExactLength(5)
   @IsNumberString()
   readonly registryOfDialectsCode?: string;
 

--- a/src/components/language/dto/update-language.dto.ts
+++ b/src/components/language/dto/update-language.dto.ts
@@ -5,7 +5,6 @@ import {
   IsLowercase,
   IsNumberString,
   IsPositive,
-  Length,
   Matches,
   ValidateNested,
 } from 'class-validator';
@@ -19,6 +18,7 @@ import {
   Sensitivity,
   SensitivityField,
 } from '../../../common';
+import { ExactLength } from '../../../common/validators/exactLength';
 import { Language } from './language.dto';
 
 @InputType()
@@ -26,13 +26,13 @@ export abstract class UpdateEthnologueLanguage {
   @NameField({ nullable: true })
   @IsAlpha()
   @IsLowercase()
-  @Length(3)
+  @ExactLength(3)
   readonly code?: string;
 
   @NameField({ nullable: true })
   @IsAlpha()
   @IsLowercase()
-  @Length(3)
+  @ExactLength(3)
   readonly provisionalCode?: string;
 
   @NameField({ nullable: true })
@@ -70,7 +70,7 @@ export abstract class UpdateLanguage {
   readonly populationOverride: number;
 
   @Field({ nullable: true })
-  @Length(5)
+  @ExactLength(5)
   @IsNumberString()
   readonly registryOfDialectsCode?: string;
 


### PR DESCRIPTION
Add `ExactLength` validator to ensure that properties like `code`, `provisionalCode` and `registryOfDialectsCode` have the proper length.