### PR TITLE
Don't fail request if there's no tracing segment

### DIFF
--- a/src/core/graphql/graphql-tracing.plugin.ts
+++ b/src/core/graphql/graphql-tracing.plugin.ts
@@ -6,7 +6,7 @@ import {
 } from 'apollo-server-plugin-base';
 import { GraphQLResolveInfo as ResolveInfo, ResponsePath } from 'graphql';
 import { GqlContextType as ContextType } from '../../common';
-import { TracingService } from '../tracing';
+import { Segment, TracingService } from '../tracing';
 
 @Plugin()
 export class GraphqlTracingPlugin implements ApolloPlugin<ContextType> {
@@ -17,7 +17,13 @@ export class GraphqlTracingPlugin implements ApolloPlugin<ContextType> {
       executionDidStart: async (
         reqContext
       ): Promise<ExecutionListener<ContextType>> => {
-        const segment = this.tracing.rootSegment;
+        let segment: Segment;
+        try {
+          segment = this.tracing.rootSegment;
+        } catch (e) {
+          return {};
+        }
+
         segment.name = reqContext.operationName ?? reqContext.queryHash;
         segment.addAnnotation(reqContext.operation.operation, true);
 

--- a/src/core/tracing/xray.middleware.ts
+++ b/src/core/tracing/xray.middleware.ts
@@ -70,7 +70,13 @@ export class XRayMiddleware implements NestMiddleware, NestInterceptor {
    * context has much richer info than the raw request.
    */
   async intercept(context: ExecutionContext, next: CallHandler) {
-    const rootSegment = this.tracing.rootSegment;
+    let rootSegment;
+    try {
+      rootSegment = this.tracing.rootSegment;
+    } catch (e) {
+      return next.handle();
+    }
+
     const root = rootSegment as unknown as XRay.Segment | XRay.Subsegment;
     // @ts-expect-error we added it in middleware, so we don't have to parse it again
     // Don't assume though, i.e. tests don't run through middleware above.


### PR DESCRIPTION
I tried to set up the middleware, so that requests always have a (root) segment.
This way the tracing functions could operate normally and if tracing was not
enabled for the request then the trace data would just be discarded.

This line however seems to be failing while debugging locally
https://github.com/SeedCompany/cord-api-v3/blob/40fa9424c8a4a78f87492550a4c61e129bfee4e0/src/core/tracing/xray.middleware.ts#L63-L63
Ideally this shouldn't happen. I think in the end though it's better to ignore
and move than fail. AWS still runs correctly, so that's really all that matters.