### PR TITLE
`RichText` scalar & Dynamic scalar registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "got": "^11.8.5",
     "graphql": "^15.8.0",
     "graphql-parse-resolve-info": "^4.12.0",
+    "graphql-scalars": "^1.18.0",
     "highlightjs-cypher": "^1.1.1",
     "iso-3166-1": "^2.1.1",
     "ix": "^4.5.2",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,8 +1,6 @@
 import { Module } from '@nestjs/common';
 import { assert } from 'ts-essentials';
 import { keys } from 'ts-transformer-keys';
-import { UrlScalar } from './common';
-import { DateScalar, DateTimeScalar } from './common/luxon.graphql';
 import { AdminModule } from './components/admin/admin.module';
 import { AuthenticationModule } from './components/authentication/authentication.module';
 import { AuthorizationModule } from './components/authorization/authorization.module';
@@ -83,7 +81,5 @@ assert(
     ProductProgressModule,
     PartnershipProducingMediumModule,
   ],
-  controllers: [],
-  providers: [DateTimeScalar, DateScalar, UrlScalar],
 })
 export class AppModule {}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -35,3 +35,4 @@ export * from './id-field';
 export * from './url.field';
 export * from './base-node-labels.enum';
 export * from './object-view';
+export { RichTextField, RichTextDocument } from './rich-text.scalar';

--- a/src/common/rich-text.scalar.ts
+++ b/src/common/rich-text.scalar.ts
@@ -1,0 +1,31 @@
+import { applyDecorators } from '@nestjs/common';
+import { Field, FieldOptions } from '@nestjs/graphql';
+import { IsObject } from 'class-validator';
+import { GraphQLScalarType } from 'graphql';
+import { GraphQLJSONObject } from 'graphql-scalars';
+import { JsonObject } from 'type-fest';
+import { Transform } from './transform.decorator';
+
+/**
+ * A JSON object containing data from a block styled editor.
+ * Probably best to treat this as opaque.
+ */
+export class RichTextDocument {
+  static from(doc: JsonObject): RichTextDocument {
+    return Object.assign(new RichTextDocument(), doc);
+  }
+}
+
+export const RichTextField = (options?: FieldOptions) =>
+  applyDecorators(
+    Field(() => RichTextScalar, options),
+    IsObject(),
+    Transform(({ value }) => RichTextDocument.from(value))
+  );
+
+/** @internal */
+export const RichTextScalar = new GraphQLScalarType({
+  ...GraphQLJSONObject.toConfig(),
+  name: 'RichText',
+  description: 'A JSON object containing data from a block styled editor',
+});

--- a/src/common/rich-text.scalar.ts
+++ b/src/common/rich-text.scalar.ts
@@ -14,6 +14,26 @@ export class RichTextDocument {
   static from(doc: JsonObject): RichTextDocument {
     return Object.assign(new RichTextDocument(), doc);
   }
+
+  /** Used to identify this document stored as a string in the DB */
+  private static readonly serializedPrefix = '\0RichText\0';
+
+  static isSerialized(value: any): value is string {
+    return (
+      typeof value === 'string' &&
+      value.startsWith(RichTextDocument.serializedPrefix)
+    );
+  }
+
+  static fromSerialized(value: string) {
+    return RichTextDocument.from(
+      JSON.parse(value.slice(RichTextDocument.serializedPrefix.length))
+    );
+  }
+
+  static serialize(doc: RichTextDocument) {
+    return RichTextDocument.serializedPrefix + JSON.stringify(doc);
+  }
 }
 
 export const RichTextField = (options?: FieldOptions) =>

--- a/src/common/scalars.ts
+++ b/src/common/scalars.ts
@@ -2,6 +2,7 @@ import { Type } from '@nestjs/common';
 import { CustomScalar } from '@nestjs/graphql';
 import { GraphQLScalarType } from 'graphql';
 import { DateScalar, DateTimeScalar } from './luxon.graphql';
+import { RichTextScalar } from './rich-text.scalar';
 import { UrlScalar } from './url.field';
 
 type Scalar = GraphQLScalarType | Type<CustomScalar<any, any>>;
@@ -10,5 +11,6 @@ type Scalar = GraphQLScalarType | Type<CustomScalar<any, any>>;
 export const getRegisteredScalars = (): Scalar[] => [
   DateScalar,
   DateTimeScalar,
+  RichTextScalar,
   UrlScalar,
 ];

--- a/src/common/scalars.ts
+++ b/src/common/scalars.ts
@@ -1,0 +1,14 @@
+import { Type } from '@nestjs/common';
+import { CustomScalar } from '@nestjs/graphql';
+import { GraphQLScalarType } from 'graphql';
+import { DateScalar, DateTimeScalar } from './luxon.graphql';
+import { UrlScalar } from './url.field';
+
+type Scalar = GraphQLScalarType | Type<CustomScalar<any, any>>;
+
+// YOU SHOULD ADD SCALARS TO THIS LIST
+export const getRegisteredScalars = (): Scalar[] => [
+  DateScalar,
+  DateTimeScalar,
+  UrlScalar,
+];

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -18,6 +18,7 @@ import { ExceptionFilter } from './exception.filter';
 import { GraphqlModule } from './graphql';
 import { PostgresModule } from './postgres/postgres.module';
 import { ResourceResolver } from './resources';
+import { ScalarProviders } from './scalars.resolver';
 import { TimeoutInterceptor } from './timeout.interceptor';
 import { TracingModule } from './tracing';
 import { ValidationPipe } from './validation.pipe';
@@ -44,6 +45,7 @@ import { WaitResolver } from './wait.resolver';
     { provide: APP_INTERCEPTOR, useClass: TimeoutInterceptor },
     ResourceResolver,
     WaitResolver,
+    ...ScalarProviders,
   ],
   controllers: [CoreController],
   exports: [

--- a/src/core/database/parameter-transformer.service.ts
+++ b/src/core/database/parameter-transformer.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { mapValues } from 'lodash';
 import { DateTime, Duration } from 'luxon';
 import * as Neo from 'neo4j-driver';
-import { CalendarDate } from '../../common';
+import { CalendarDate, RichTextDocument } from '../../common';
 import { isNeoDate, isNeoDateTime, isNeoDuration } from './transformer';
 
 /**
@@ -48,6 +48,10 @@ export class ParameterTransformer {
         value.seconds,
         value.milliseconds * 1e6
       );
+    }
+
+    if (value instanceof RichTextDocument) {
+      return RichTextDocument.serialize(value);
     }
 
     if (Array.isArray(value)) {

--- a/src/core/database/transformer.ts
+++ b/src/core/database/transformer.ts
@@ -1,7 +1,7 @@
 import { Transformer } from 'cypher-query-builder';
 import { DateTime, Duration, FixedOffsetZone } from 'luxon';
 import * as Neo from 'neo4j-driver';
-import { CalendarDate } from '../../common';
+import { CalendarDate, RichTextDocument } from '../../common';
 
 // @ts-expect-error Convert private methods to protected
 class PatchedTransformer extends Transformer {
@@ -30,6 +30,9 @@ export class MyTransformer extends PatchedTransformer {
     }
     if (isNeoDuration(value)) {
       return this.transformDuration(value);
+    }
+    if (RichTextDocument.isSerialized(value)) {
+      return RichTextDocument.fromSerialized(value);
     }
 
     return super.transformValue(value);

--- a/src/core/scalars.resolver.ts
+++ b/src/core/scalars.resolver.ts
@@ -1,0 +1,41 @@
+import { Provider, Type } from '@nestjs/common';
+import { Query, Resolver } from '@nestjs/graphql';
+import {
+  SCALAR_NAME_METADATA,
+  SCALAR_TYPE_METADATA,
+} from '@nestjs/graphql/dist/graphql.constants';
+import { GraphQLScalarType } from 'graphql';
+import { getRegisteredScalars } from '../common/scalars';
+
+/**
+ * Ensure every scalar has a use in schema to prevent compilation errors.
+ * These are declared dynamically below.
+ */
+@Resolver()
+class ScalarResolver {}
+
+for (const scalar of getRegisteredScalars()) {
+  const name =
+    scalar instanceof GraphQLScalarType
+      ? scalar.name
+      : (Reflect.getMetadata(SCALAR_NAME_METADATA, scalar) as string);
+  const typeFn =
+    scalar instanceof GraphQLScalarType
+      ? () => scalar
+      : Reflect.getMetadata(SCALAR_TYPE_METADATA, scalar);
+
+  const key = `unstable_stub${name}`;
+  const cls = ScalarResolver.prototype as any;
+  cls[key] = () => null;
+  Query(typeFn, {
+    deprecationReason: 'Only here to prevent schema errors, do not use',
+    nullable: true,
+  })(cls, key, Object.getOwnPropertyDescriptor(cls, key)!);
+}
+
+export const ScalarProviders: Provider[] = [
+  ScalarResolver,
+  ...getRegisteredScalars().filter(
+    (scalar): scalar is Type => !(scalar instanceof GraphQLScalarType)
+  ),
+];

--- a/yarn.lock
+++ b/yarn.lock
@@ -5722,6 +5722,7 @@ __metadata:
     got: ^11.8.5
     graphql: ^15.8.0
     graphql-parse-resolve-info: ^4.12.0
+    graphql-scalars: ^1.18.0
     highlightjs-cypher: ^1.1.1
     husky: ^4.3.8
     iso-3166-1: ^2.1.1
@@ -7892,6 +7893,17 @@ cypher-query-builder@6.0.4:
   peerDependencies:
     graphql: ">=0.9 <0.14 || ^14.0.2 || ^15.4.0"
   checksum: d15554985407b34150a36f8526d3ce63cd97a1fa898eadd74ba5e6d099984d13929de64924332832613d59fba7946222b0a07a127e93ad58bdb82f3548cc497b
+  languageName: node
+  linkType: hard
+
+"graphql-scalars@npm:^1.18.0":
+  version: 1.18.0
+  resolution: "graphql-scalars@npm:1.18.0"
+  dependencies:
+    tslib: ~2.4.0
+  peerDependencies:
+    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: 41b545758a08d0fcf3aa49683f2694ab1397493baad56811e9f64c37d9850b485001fce8019d43a1c258ba60dc86efcd5790269af1ec984fdda49fa8c39f552e
   languageName: node
   linkType: hard
 
@@ -13954,7 +13966,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.4.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1":
+"tslib@npm:2.4.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:~2.4.0":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113


### PR DESCRIPTION
- Unify how scalars are registered & move enumeration to common/
- Ensure usage in schema to prevent compilation errors ("unstable", deprecated queries)
- Define `RichText` scalar, which is a special JSON object
- Store RichText as a string in the database
   This happens transparently in practice