### PR TITLE
@LoaderFactory()

### DIFF
--- a/src/components/budget/budget.loader.ts
+++ b/src/components/budget/budget.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID, ObjectView } from '../../common';
-import { ObjectViewAwareLoader } from '../../core';
+import { LoaderFactory, ObjectViewAwareLoader } from '../../core';
 import { BudgetService } from './budget.service';
 import { Budget } from './dto';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => Budget)
 export class BudgetLoader extends ObjectViewAwareLoader<Budget> {
   constructor(private readonly budgets: BudgetService) {
     super();

--- a/src/components/ceremony/ceremony.loader.ts
+++ b/src/components/ceremony/ceremony.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
 import { CeremonyService } from './ceremony.service';
 import { Ceremony } from './dto';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => Ceremony)
 export class CeremonyLoader extends OrderedNestDataLoader<Ceremony> {
   constructor(private readonly ceremonies: CeremonyService) {
     super();

--- a/src/components/changeset/changeset.loader.ts
+++ b/src/components/changeset/changeset.loader.ts
@@ -1,6 +1,5 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { ResourceResolver, SingleItemLoader } from '../../core';
+import { LoaderFactory, ResourceResolver, SingleItemLoader } from '../../core';
 import { ProjectChangeRequest } from '../project-change-request/dto';
 import { Changeset } from './dto';
 
@@ -8,7 +7,7 @@ import { Changeset } from './dto';
  * Since we are really just using this for caching, SingleItemLoader should be fine.
  * We don't have a use case currently for asking for multiple different changesets.
  */
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => Changeset)
 export class ChangesetLoader extends SingleItemLoader<Changeset> {
   constructor(private readonly resources: ResourceResolver) {
     super();

--- a/src/components/engagement/engagement.loader.ts
+++ b/src/components/engagement/engagement.loader.ts
@@ -1,10 +1,14 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID, ObjectView } from '../../common';
-import { ObjectViewAwareLoader } from '../../core';
-import { Engagement } from './dto';
+import { LoaderFactory, ObjectViewAwareLoader } from '../../core';
+import {
+  Engagement,
+  IEngagement,
+  InternshipEngagement,
+  LanguageEngagement,
+} from './dto';
 import { EngagementService } from './engagement.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => [IEngagement, LanguageEngagement, InternshipEngagement])
 export class EngagementLoader extends ObjectViewAwareLoader<Engagement> {
   constructor(private readonly engagements: EngagementService) {
     super();

--- a/src/components/ethno-art/ethno-art.loader.ts
+++ b/src/components/ethno-art/ethno-art.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
 import { EthnoArt } from './dto';
 import { EthnoArtService } from './ethno-art.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => EthnoArt)
 export class EthnoArtLoader extends OrderedNestDataLoader<EthnoArt> {
   constructor(private readonly ethnoArt: EthnoArtService) {
     super();

--- a/src/components/field-region/field-region.loader.ts
+++ b/src/components/field-region/field-region.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
 import { FieldRegion } from './dto';
 import { FieldRegionService } from './field-region.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => FieldRegion)
 export class FieldRegionLoader extends OrderedNestDataLoader<FieldRegion> {
   constructor(private readonly fieldRegions: FieldRegionService) {
     super();

--- a/src/components/field-zone/field-zone.loader.ts
+++ b/src/components/field-zone/field-zone.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
 import { FieldZone } from './dto';
 import { FieldZoneService } from './field-zone.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => FieldZone)
 export class FieldZoneLoader extends OrderedNestDataLoader<FieldZone> {
   constructor(private readonly fieldZones: FieldZoneService) {
     super();

--- a/src/components/file/file-node.loader.ts
+++ b/src/components/file/file-node.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
-import { FileNode } from './dto';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
+import { Directory, File, FileNode, FileVersion } from './dto';
 import { FileService } from './file.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => [Directory, File, FileVersion])
 export class FileNodeLoader extends OrderedNestDataLoader<FileNode> {
   constructor(private readonly files: FileService) {
     super();

--- a/src/components/film/film.loader.ts
+++ b/src/components/film/film.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
 import { Film } from './dto';
 import { FilmService } from './film.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => Film)
 export class FilmLoader extends OrderedNestDataLoader<Film> {
   constructor(private readonly films: FilmService) {
     super();

--- a/src/components/funding-account/funding-account.loader.ts
+++ b/src/components/funding-account/funding-account.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
 import { FundingAccount } from './dto';
 import { FundingAccountService } from './funding-account.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => FundingAccount)
 export class FundingAccountLoader extends OrderedNestDataLoader<FundingAccount> {
   constructor(private readonly fundingAccounts: FundingAccountService) {
     super();

--- a/src/components/language/language.loader.ts
+++ b/src/components/language/language.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID, ObjectView } from '../../common';
-import { ObjectViewAwareLoader } from '../../core';
+import { LoaderFactory, ObjectViewAwareLoader } from '../../core';
 import { Language } from './dto';
 import { LanguageService } from './language.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => Language)
 export class LanguageLoader extends ObjectViewAwareLoader<Language> {
   constructor(private readonly languages: LanguageService) {
     super();

--- a/src/components/location/location.loader.ts
+++ b/src/components/location/location.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
 import { Location } from './dto';
 import { LocationService } from './location.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => Location)
 export class LocationLoader extends OrderedNestDataLoader<Location> {
   constructor(private readonly locations: LocationService) {
     super();

--- a/src/components/organization/organization.loader.ts
+++ b/src/components/organization/organization.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
 import { Organization } from './dto';
 import { OrganizationService } from './organization.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => Organization)
 export class OrganizationLoader extends OrderedNestDataLoader<Organization> {
   constructor(private readonly organizations: OrganizationService) {
     super();

--- a/src/components/partner/partner.loader.ts
+++ b/src/components/partner/partner.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
 import { Partner } from './dto';
 import { PartnerService } from './partner.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => Partner)
 export class PartnerLoader extends OrderedNestDataLoader<Partner> {
   constructor(private readonly partners: PartnerService) {
     super();

--- a/src/components/partnership/partnership.loader.ts
+++ b/src/components/partnership/partnership.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID, ObjectView } from '../../common';
-import { ObjectViewAwareLoader } from '../../core';
+import { LoaderFactory, ObjectViewAwareLoader } from '../../core';
 import { Partnership } from './dto';
 import { PartnershipService } from './partnership.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => Partnership)
 export class PartnershipLoader extends ObjectViewAwareLoader<Partnership> {
   constructor(private readonly partnerships: PartnershipService) {
     super();

--- a/src/components/periodic-report/periodic-report.loader.ts
+++ b/src/components/periodic-report/periodic-report.loader.ts
@@ -1,10 +1,20 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
-import { PeriodicReport } from './dto';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
+import {
+  FinancialReport,
+  IPeriodicReport,
+  NarrativeReport,
+  PeriodicReport,
+  ProgressReport,
+} from './dto';
 import { PeriodicReportService } from './periodic-report.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => [
+  IPeriodicReport,
+  FinancialReport,
+  NarrativeReport,
+  ProgressReport,
+])
 export class PeriodicReportLoader extends OrderedNestDataLoader<PeriodicReport> {
   constructor(private readonly periodicReports: PeriodicReportService) {
     super();

--- a/src/components/post/post.loader.ts
+++ b/src/components/post/post.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
 import { Post } from './dto';
 import { PostService } from './post.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory()
 export class PostLoader extends OrderedNestDataLoader<Post> {
   constructor(private readonly posts: PostService) {
     super();

--- a/src/components/product-progress/product-progress-by-product.loader.ts
+++ b/src/components/product-progress/product-progress-by-product.loader.ts
@@ -1,11 +1,14 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { LoaderOptionsOf, OrderedNestDataLoader } from '../../core';
+import {
+  LoaderFactory,
+  LoaderOptionsOf,
+  OrderedNestDataLoader,
+} from '../../core';
 import { Product } from '../product';
 import { ProductProgress } from './dto';
 import { ProductProgressService } from './product-progress.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory()
 export class ProductProgressByProductLoader extends OrderedNestDataLoader<
   { product: Product; progress: readonly ProductProgress[] },
   Product,

--- a/src/components/product-progress/product-progress-by-report.loader.ts
+++ b/src/components/product-progress/product-progress-by-report.loader.ts
@@ -1,11 +1,14 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { LoaderOptionsOf, OrderedNestDataLoader } from '../../core';
+import {
+  LoaderFactory,
+  LoaderOptionsOf,
+  OrderedNestDataLoader,
+} from '../../core';
 import { ProgressReport } from '../periodic-report';
 import { ProductProgress } from './dto';
 import { ProductProgressService } from './product-progress.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory()
 export class ProductProgressByReportLoader extends OrderedNestDataLoader<
   { report: ProgressReport; progress: readonly ProductProgress[] },
   ProgressReport,

--- a/src/components/product/product.loader.ts
+++ b/src/components/product/product.loader.ts
@@ -1,10 +1,20 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
-import { AnyProduct } from './dto';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
+import {
+  AnyProduct,
+  DerivativeScriptureProduct,
+  DirectScriptureProduct,
+  OtherProduct,
+  Product,
+} from './dto';
 import { ProductService } from './product.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => [
+  Product,
+  DirectScriptureProduct,
+  DerivativeScriptureProduct,
+  OtherProduct,
+])
 export class ProductLoader extends OrderedNestDataLoader<AnyProduct> {
   constructor(private readonly products: ProductService) {
     super();

--- a/src/components/progress-summary/progress-summary.loader.ts
+++ b/src/components/progress-summary/progress-summary.loader.ts
@@ -1,10 +1,13 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { LoaderOptionsOf, OrderedNestDataLoader } from '../../core';
+import {
+  LoaderFactory,
+  LoaderOptionsOf,
+  OrderedNestDataLoader,
+} from '../../core';
 import { FetchedSummaries } from './dto';
 import { ProgressSummaryRepository } from './progress-summary.repository';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory()
 export class ProgressSummaryLoader extends OrderedNestDataLoader<FetchedSummaries> {
   constructor(private readonly repo: ProgressSummaryRepository) {
     super();

--- a/src/components/project-change-request/project-change-request.loader.ts
+++ b/src/components/project-change-request/project-change-request.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
 import { ProjectChangeRequest } from './dto';
 import { ProjectChangeRequestService } from './project-change-request.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => ProjectChangeRequest)
 export class ProjectChangeRequestLoader extends OrderedNestDataLoader<ProjectChangeRequest> {
   constructor(
     private readonly projectChangeRequests: ProjectChangeRequestService

--- a/src/components/project/project-member/project-member.loader.ts
+++ b/src/components/project/project-member/project-member.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../../common';
-import { OrderedNestDataLoader } from '../../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../../core';
 import { ProjectMember } from './dto';
 import { ProjectMemberService } from './project-member.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => ProjectMember)
 export class ProjectMemberLoader extends OrderedNestDataLoader<ProjectMember> {
   constructor(private readonly projectMembers: ProjectMemberService) {
     super();

--- a/src/components/project/project.loader.ts
+++ b/src/components/project/project.loader.ts
@@ -1,11 +1,15 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID, ObjectView } from '../../common';
-import { ObjectViewAwareLoader } from '../../core';
-import { IProject, Project } from './dto';
+import { LoaderFactory, ObjectViewAwareLoader } from '../../core';
+import {
+  InternshipProject,
+  IProject,
+  Project,
+  TranslationProject,
+} from './dto';
 import { ProjectService } from './project.service';
 
-@Injectable({ scope: Scope.REQUEST })
-export class ProjectLoader extends ObjectViewAwareLoader<IProject> {
+@LoaderFactory(() => [IProject, TranslationProject, InternshipProject])
+export class ProjectLoader extends ObjectViewAwareLoader<Project> {
   constructor(private readonly projects: ProjectService) {
     super();
   }

--- a/src/components/story/story.loader.ts
+++ b/src/components/story/story.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
 import { Story } from './dto';
 import { StoryService } from './story.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => Story)
 export class StoryLoader extends OrderedNestDataLoader<Story> {
   constructor(private readonly stories: StoryService) {
     super();

--- a/src/components/user/education/education.loader.ts
+++ b/src/components/user/education/education.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../../common';
-import { OrderedNestDataLoader } from '../../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../../core';
 import { Education } from './dto';
 import { EducationService } from './education.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => Education)
 export class EducationLoader extends OrderedNestDataLoader<Education> {
   constructor(private readonly educations: EducationService) {
     super();

--- a/src/components/user/unavailability/unavailability.loader.ts
+++ b/src/components/user/unavailability/unavailability.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../../common';
-import { OrderedNestDataLoader } from '../../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../../core';
 import { Unavailability } from './dto';
 import { UnavailabilityService } from './unavailability.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => Unavailability)
 export class UnavailabilityLoader extends OrderedNestDataLoader<Unavailability> {
   constructor(private readonly unavailabilities: UnavailabilityService) {
     super();

--- a/src/components/user/user.loader.ts
+++ b/src/components/user/user.loader.ts
@@ -1,10 +1,9 @@
-import { Injectable, Scope } from '@nestjs/common';
 import { ID } from '../../common';
-import { OrderedNestDataLoader } from '../../core';
+import { LoaderFactory, OrderedNestDataLoader } from '../../core';
 import { User } from './dto';
 import { UserService } from './user.service';
 
-@Injectable({ scope: Scope.REQUEST })
+@LoaderFactory(() => User)
 export class UserLoader extends OrderedNestDataLoader<User> {
   constructor(private readonly users: UserService) {
     super();

--- a/src/core/resources/index.ts
+++ b/src/core/resources/index.ts
@@ -1,1 +1,2 @@
 export * from './resource-resolver.service';
+export { LoaderFactory } from './loader.registry';

--- a/src/core/resources/loader.registry.ts
+++ b/src/core/resources/loader.registry.ts
@@ -1,0 +1,51 @@
+import { Injectable, Scope, SetMetadata } from '@nestjs/common';
+import { ValueOf } from 'type-fest';
+import { Many } from '../../common';
+import { ResourceMap } from '../../components/authorization/model/resource-map';
+import { NestDataLoader, ObjectViewAwareLoader } from '../data-loader';
+
+type SomeResource = ValueOf<ResourceMap>;
+
+const LOADER_OF_RESOURCE = Symbol('LOADER_OF_RESOURCE');
+
+interface MetadataShape extends LoaderOptions {
+  resource?: () => Many<SomeResource>;
+}
+
+interface LoaderOptions {
+  /**
+   * Whether the loader is aware of ObjectViews.
+   *
+   * This means the loader key needs to be in the shape of
+   * {@link import('../data-loader/object-view-aware.loader').Key Key}
+   *
+   * This defaults to true if the class extends ObjectViewAwareLoader.
+   */
+  objectViewAware?: boolean;
+}
+
+type DataLoaderCtor = new (...args: any[]) => NestDataLoader<any, any>;
+
+/**
+ * Register this class as a DataLoader for the given resource(s)
+ *
+ * @param resource Connect this loader to this resource, so it can be accessed dynamically.
+ * @param options
+ */
+export const LoaderFactory =
+  (
+    resource?: () => Many<SomeResource>,
+    options?: LoaderOptions
+  ): (<LoaderCtor extends DataLoaderCtor>(target: LoaderCtor) => void) =>
+  (target) => {
+    Injectable({ scope: Scope.REQUEST })(target);
+
+    const metadata: MetadataShape = {
+      resource,
+      ...options,
+      objectViewAware:
+        options?.objectViewAware ??
+        Object.getPrototypeOf(target) === ObjectViewAwareLoader,
+    };
+    SetMetadata(LOADER_OF_RESOURCE, metadata)(target);
+  };


### PR DESCRIPTION
Previously we had no way of associating a resource with a loader for it; one had to explicitly reference `UserLoader` to get users.

Now we "assign" resources to the loader while registering them.
I'll build upon this in a later PR, but I wanted to get this codebase wide change in separately.