### PR TITLE
ChangesetAware.changesetDiff

### DIFF
--- a/src/components/changeset/changeset-aware.resolver.ts
+++ b/src/components/changeset/changeset-aware.resolver.ts
@@ -1,15 +1,43 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
+import { LoggedInSession, Session } from '../../common';
 import { ResourceLoader } from '../../core';
-import { Changeset, ChangesetAware } from './dto';
+import { ChangesetResolver } from './changeset.resolver';
+import { Changeset, ChangesetAware, ChangesetDiff } from './dto';
 
 @Resolver(ChangesetAware)
 export class ChangesetAwareResolver {
-  constructor(private readonly resources: ResourceLoader) {}
+  constructor(
+    private readonly resources: ResourceLoader,
+    private readonly changesetResolver: ChangesetResolver
+  ) {}
 
   @ResolveField()
   async changeset(@Parent() object: ChangesetAware): Promise<Changeset | null> {
     return object.changeset
       ? await this.resources.load(Changeset, object.changeset)
       : null;
+  }
+
+  @ResolveField(() => ChangesetDiff, {
+    nullable: true,
+    description: stripIndent`
+      The changes made within this changeset limited to this resource's sub-tree
+    `,
+  })
+  async changesetDiff(
+    @Parent() object: ChangesetAware,
+    @LoggedInSession() session: Session
+  ): Promise<ChangesetDiff | null> {
+    const changeset = await this.changeset(object);
+    if (!changeset) {
+      return null;
+    }
+    const diff = await this.changesetResolver.difference(
+      changeset,
+      session,
+      object.id
+    );
+    return diff;
   }
 }

--- a/src/components/changeset/changeset.repository.ts
+++ b/src/components/changeset/changeset.repository.ts
@@ -2,20 +2,24 @@ import { Injectable } from '@nestjs/common';
 import { hasLabel, node, not, relation } from 'cypher-query-builder';
 import { ID, NotFoundException, Session } from '../../common';
 import { DtoRepository } from '../../core';
-import { ACTIVE } from '../../core/database/query';
+import {
+  ACTIVE,
+  matchParentToSelfOrChildNode,
+} from '../../core/database/query';
 import { BaseNode } from '../../core/database/results';
 import { ProjectChangeRequestStatus } from '../project-change-request/dto';
 import { Changeset, ChangesetDiff } from './dto';
 
 @Injectable()
 export class ChangesetRepository extends DtoRepository(Changeset) {
-  async difference(id: ID, _session: Session) {
+  async difference(id: ID, _session: Session, parent: ID) {
     const result = await this.db
       .query()
       .match([node('changeset', 'Changeset', { id })])
+      .match([node('parent', { id: parent })])
       .subQuery((sub) =>
         sub
-          .with('changeset')
+          .with(['changeset', 'parent'])
           .match([
             node('changeset'),
             relation('out', '', [], ACTIVE),
@@ -27,22 +31,36 @@ export class ChangesetRepository extends DtoRepository(Changeset) {
           // These are not directly modified by user, and could be left over
           // if a user made a change and then reverted it.
           .where(not({ prop: hasLabel('modifiedAt') }))
-          .return('collect(distinct node) as changed')
+          .apply(matchParentToSelfOrChildNode())
+          .return('collect(distinct selfOrChild) as changed')
       )
       .subQuery((sub) =>
         sub
-          .with('changeset')
+          .with(['changeset', 'parent'])
           .match([
             node('changeset'),
             relation('out', '', [], { deleting: true }),
             node('node'),
           ])
-          .return('collect(distinct node) as removed')
+          .apply(matchParentToSelfOrChildNode())
+          .return('collect(distinct selfOrChild) as removed')
+      )
+      .subQuery((sub) =>
+        sub
+          .with(['changeset', 'parent'])
+          .match([
+            node('changeset'),
+            relation('out', 'changeType', 'changeset', { ACTIVE }),
+            node('node', 'BaseNode'),
+          ])
+          .raw('WHERE changeType.deleting IS NULL')
+          .apply(matchParentToSelfOrChildNode())
+          .return('collect(distinct selfOrChild) as added')
       )
       .return<Record<keyof ChangesetDiff, readonly BaseNode[]>>([
         'changed',
         'removed',
-        '[(changeset)-[changeType:changeset { active: true }]->(node:BaseNode) WHERE changeType.deleting IS NULL | node] as added',
+        'added',
       ])
       .first();
     if (!result) {

--- a/src/components/changeset/changeset.resolver.ts
+++ b/src/components/changeset/changeset.resolver.ts
@@ -23,7 +23,13 @@ export class ChangesetResolver {
   async difference(
     @Parent() changeset: Changeset,
     @LoggedInSession() session: Session,
-    parent: ID
+    @IdArg({
+      name: 'resource',
+      nullable: true,
+      description:
+        'Optionally limit to only changes of this resource and its (grand)children',
+    })
+    parent?: ID
   ): Promise<ChangesetDiff> {
     const isApproved = await this.repo.isApproved(changeset.id, session);
     const diff = await this.repo.difference(changeset.id, session, parent);

--- a/src/components/changeset/changeset.resolver.ts
+++ b/src/components/changeset/changeset.resolver.ts
@@ -22,10 +22,11 @@ export class ChangesetResolver {
   })
   async difference(
     @Parent() changeset: Changeset,
-    @LoggedInSession() session: Session
+    @LoggedInSession() session: Session,
+    parent: ID
   ): Promise<ChangesetDiff> {
     const isApproved = await this.repo.isApproved(changeset.id, session);
-    const diff = await this.repo.difference(changeset.id, session);
+    const diff = await this.repo.difference(changeset.id, session, parent);
     const load = (node: BaseNode, view?: ObjectView) =>
       this.resources.loadByBaseNode(node, view ?? { changeset: changeset.id });
     const [added, removed, changed] = await Promise.all([

--- a/src/core/database/query/match-project-based-props.ts
+++ b/src/core/database/query/match-project-based-props.ts
@@ -18,6 +18,24 @@ import {
 } from './cypher-functions';
 import { ACTIVE, matchProps, MatchPropsOptions } from './matching';
 
+export const matchParentToSelfOrChildNode =
+  () =>
+  <R>(query: Query<R>) =>
+    query.comment`
+    matchSelfOrChildNode()
+  `.subQuery((sub) =>
+      sub
+        .with(['node', 'parent'])
+        .with(['node', 'parent'])
+        .raw('WHERE node.id = parent.id')
+        .return({ node: 'selfOrChild' })
+        .union()
+        .with(['node', 'parent'])
+        .with(['node', 'parent'])
+        .raw('WHERE node.id <> parent.id AND (parent) -[*]-> (node)')
+        .return({ node: 'selfOrChild' })
+    );
+
 export const matchPropsAndProjectSensAndScopedRoles =
   (session?: Session | ID | Variable, propsOptions?: MatchPropsOptions) =>
   <R>(query: Query<R>) =>

--- a/src/core/database/query/match-project-based-props.ts
+++ b/src/core/database/query/match-project-based-props.ts
@@ -18,24 +18,6 @@ import {
 } from './cypher-functions';
 import { ACTIVE, matchProps, MatchPropsOptions } from './matching';
 
-export const matchParentToSelfOrChildNode =
-  () =>
-  <R>(query: Query<R>) =>
-    query.comment`
-    matchSelfOrChildNode()
-  `.subQuery((sub) =>
-      sub
-        .with(['node', 'parent'])
-        .with(['node', 'parent'])
-        .raw('WHERE node.id = parent.id')
-        .return({ node: 'selfOrChild' })
-        .union()
-        .with(['node', 'parent'])
-        .with(['node', 'parent'])
-        .raw('WHERE node.id <> parent.id AND (parent) -[*]-> (node)')
-        .return({ node: 'selfOrChild' })
-    );
-
 export const matchPropsAndProjectSensAndScopedRoles =
   (session?: Session | ID | Variable, propsOptions?: MatchPropsOptions) =>
   <R>(query: Query<R>) =>


### PR DESCRIPTION
This allows every (changeset aware) resource to ask for their own difference which will return only the changes for their sub tree.

This is still a flat list, so re-creating the sub-tree client side is not possible yet. More to come.