### PR TITLE
Decouple E2E GraphQL client calls & error assertions

### DIFF
--- a/src/components/language/dto/create-language.dto.ts
+++ b/src/components/language/dto/create-language.dto.ts
@@ -79,7 +79,9 @@ export abstract class CreateLanguage {
   readonly isSignLanguage?: boolean = false;
 
   @Field({ nullable: true })
-  @Matches(/^[A-Z]{2}\d{2}$/)
+  @Matches(/^[A-Z]{2}\d{2}$/, {
+    message: 'Must be 2 uppercase letters followed by 2 digits',
+  })
   readonly signLanguageCode?: string;
 
   @SensitivityField({ nullable: true })

--- a/src/components/language/dto/update-language.dto.ts
+++ b/src/components/language/dto/update-language.dto.ts
@@ -85,7 +85,9 @@ export abstract class UpdateLanguage {
   readonly isSignLanguage?: boolean;
 
   @Field({ nullable: true })
-  @Matches(/^[A-Z]{2}\d{2}$/)
+  @Matches(/^[A-Z]{2}\d{2}$/, {
+    message: 'Must be 2 uppercase letters followed by 2 digits',
+  })
   readonly signLanguageCode?: string;
 
   @SensitivityField({ nullable: true })

--- a/src/components/partner/dto/create-partner.dto.ts
+++ b/src/components/partner/dto/create-partner.dto.ts
@@ -24,7 +24,9 @@ export abstract class CreatePartner {
   readonly financialReportingTypes?: FinancialReportingType[] = [];
 
   @Field({ nullable: true })
-  @Matches(/^[A-Z]{3}$/)
+  @Matches(/^[A-Z]{3}$/, {
+    message: 'Must be 3 uppercase letters',
+  })
   readonly pmcEntityCode?: string;
 
   @Field({ nullable: true })

--- a/src/components/partner/dto/update-partner.dto.ts
+++ b/src/components/partner/dto/update-partner.dto.ts
@@ -24,7 +24,9 @@ export abstract class UpdatePartner {
   readonly financialReportingTypes?: FinancialReportingType[];
 
   @Field({ nullable: true })
-  @Matches(/^[A-Z]{3}$/)
+  @Matches(/^[A-Z]{3}$/, {
+    message: 'Must be 3 uppercase letters',
+  })
   readonly pmcEntityCode?: string;
 
   @Field({ nullable: true })

--- a/src/core/graphql/graphql.config.ts
+++ b/src/core/graphql/graphql.config.ts
@@ -107,12 +107,14 @@ export class GraphQLConfig implements GqlOptionsFactory {
             !frame.includes('(<anonymous>)')
         )
         .map((frame: string) =>
-          frame
-            // Convert absolute path to path relative to src dir
-            .replace(matchSrcPathInTrace, (_, group1) => group1)
-            // Convert windows paths to unix for consistency
-            .replace(/\\\\/, '/')
-            .trim()
+          this.config.jest
+            ? frame // Keep full FS path, so jest can link to it
+            : frame
+                // Convert absolute path to path relative to src dir
+                .replace(matchSrcPathInTrace, (_, group1) => group1)
+                // Convert windows paths to unix for consistency
+                .replace(/\\\\/, '/')
+                .trim()
         );
     }
 

--- a/test/authentication.e2e-spec.ts
+++ b/test/authentication.e2e-spec.ts
@@ -1,6 +1,5 @@
 import { faker } from '@faker-js/faker';
 import { EmailService } from '@seedcompany/nestjs-email';
-import { gql } from 'apollo-server-core';
 import { Connection } from 'cypher-query-builder';
 import { isValidId } from '../src/common';
 import {
@@ -8,6 +7,7 @@ import {
   createTestApp,
   fragments,
   generateRegisterInput,
+  gql,
   login,
   logout,
   registerUser,

--- a/test/budget.e2e-spec.ts
+++ b/test/budget.e2e-spec.ts
@@ -1,11 +1,5 @@
 import { times } from 'lodash';
-import {
-  CalendarDate,
-  fiscalYears,
-  isValidId,
-  NotFoundException,
-  Secured,
-} from '../src/common';
+import { CalendarDate, fiscalYears, isValidId, Secured } from '../src/common';
 import { Role } from '../src/components/authorization/dto/role.dto';
 import { Budget } from '../src/components/budget';
 import { PartnerType } from '../src/components/partner';
@@ -15,6 +9,7 @@ import {
   createProject,
   createSession,
   createTestApp,
+  errors,
   fragments,
   gql,
   Raw,
@@ -96,8 +91,8 @@ describe('Budget e2e', () => {
     const actual: Budget | undefined = result.deleteBudget;
     expect(actual).toBeTruthy();
 
-    await expect(
-      app.graphql.query(
+    await app.graphql
+      .query(
         gql`
           query budget($id: ID!) {
             budget(id: $id) {
@@ -110,7 +105,7 @@ describe('Budget e2e', () => {
           id: budget.id,
         }
       )
-    ).rejects.toThrowError(new NotFoundException('Could not find budget'));
+      .expectError(errors.notFound({ message: 'Could not find budget' }));
   });
 
   it('List budget nodes', async () => {

--- a/test/budget.e2e-spec.ts
+++ b/test/budget.e2e-spec.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { times } from 'lodash';
 import {
   CalendarDate,
@@ -17,6 +16,7 @@ import {
   createSession,
   createTestApp,
   fragments,
+  gql,
   Raw,
   registerUser,
   TestApp,

--- a/test/education.e2e-spec.ts
+++ b/test/education.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { times } from 'lodash';
 import { isValidId } from '../src/common';
 import { Role } from '../src/components/authorization/dto/role.dto';
@@ -9,6 +8,7 @@ import {
   createEducation,
   createSession,
   createTestApp,
+  gql,
   registerUser,
   TestApp,
 } from './utility';

--- a/test/engagement-changeset-aware.e2e-spec.ts
+++ b/test/engagement-changeset-aware.e2e-spec.ts
@@ -15,6 +15,7 @@ import {
   createRegion,
   createSession,
   createTestApp,
+  errors,
   gql,
   registerUser,
   runAsAdmin,
@@ -421,8 +422,8 @@ describe('Engagement Changeset Aware e2e', () => {
     });
 
     // Create new engagement with changeset
-    await expect(
-      app.graphql.mutate(
+    await app.graphql
+      .mutate(
         gql`
           mutation createLanguageEngagement(
             $input: CreateLanguageEngagementInput!
@@ -445,8 +446,10 @@ describe('Engagement Changeset Aware e2e', () => {
           },
         }
       )
-    ).rejects.toThrowError(
-      'Engagement for this project and language already exists'
-    );
+      .expectError(
+        errors.duplicate({
+          message: 'Engagement for this project and language already exists',
+        })
+      );
   });
 });

--- a/test/engagement-changeset-aware.e2e-spec.ts
+++ b/test/engagement-changeset-aware.e2e-spec.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { CalendarDate, ID } from '../src/common';
 import { Role } from '../src/components/authorization';
 import { EngagementStatus } from '../src/components/engagement';
@@ -16,6 +15,7 @@ import {
   createRegion,
   createSession,
   createTestApp,
+  gql,
   registerUser,
   runAsAdmin,
   TestApp,

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { some } from 'lodash';
 import { DateTime, Interval } from 'luxon';
 import { generateId, ID, InputException } from '../src/common';
@@ -36,6 +35,7 @@ import {
   expectNotFound,
   fragments,
   getUserFromSession,
+  gql,
   Raw,
   registerUser,
   requestFileUpload,

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { some } from 'lodash';
 import { DateTime, Interval } from 'luxon';
-import { generateId, ID, InputException } from '../src/common';
+import { generateId, ID } from '../src/common';
 import { Role } from '../src/components/authorization';
 import {
   CreateInternshipEngagement,
@@ -32,7 +32,7 @@ import {
   createProject,
   createSession,
   createTestApp,
-  expectNotFound,
+  errors,
   fragments,
   getUserFromSession,
   gql,
@@ -455,8 +455,8 @@ describe('Engagement e2e', () => {
 
     const actual: boolean | undefined = result.deleteEngagement;
     expect(actual).toBeTruthy();
-    await expectNotFound(
-      app.graphql.query(
+    await app.graphql
+      .query(
         gql`
           query engagement($id: ID!) {
             engagement(id: $id) {
@@ -469,7 +469,7 @@ describe('Engagement e2e', () => {
           id: languageEngagement.id,
         }
       )
-    );
+      .expectError(errors.notFound());
   });
 
   it('returns the correct products in language engagement', async () => {
@@ -732,8 +732,8 @@ describe('Engagement e2e', () => {
       }
     );
 
-    await expectNotFound(
-      app.graphql.query(
+    await app.graphql
+      .query(
         gql`
           query ceremony($id: ID!) {
             ceremony(id: $id) {
@@ -746,7 +746,7 @@ describe('Engagement e2e', () => {
           id: ceremonyId,
         }
       )
-    );
+      .expectError(errors.notFound());
   });
 
   it('lists both language engagements and internship engagements', async () => {
@@ -810,7 +810,9 @@ describe('Engagement e2e', () => {
         internId: intern.id,
         mentorId: mentor.id,
       })
-    ).rejects.toThrow('Could not find project');
+    ).rejects.toThrowGqlError(
+      errors.notFound({ message: 'Could not find project' })
+    );
     await expect(
       createInternshipEngagement(app, {
         projectId: internshipProject.id,
@@ -818,7 +820,9 @@ describe('Engagement e2e', () => {
         internId: intern.id,
         mentorId: mentor.id,
       })
-    ).rejects.toThrow('Could not find country of origin');
+    ).rejects.toThrowGqlError(
+      errors.notFound({ message: 'Could not find country of origin' })
+    );
 
     internshipProject = await createProject(app, {
       type: ProjectType.Internship,
@@ -831,7 +835,9 @@ describe('Engagement e2e', () => {
         internId: invalidId,
         mentorId: mentor.id,
       })
-    ).rejects.toThrow('Could not find person');
+    ).rejects.toThrowGqlError(
+      errors.notFound({ message: 'Could not find person' })
+    );
 
     internshipProject = await createProject(app, {
       type: ProjectType.Internship,
@@ -844,7 +850,9 @@ describe('Engagement e2e', () => {
         internId: intern.id,
         mentorId: invalidId,
       })
-    ).rejects.toThrow('Could not find mentor');
+    ).rejects.toThrowGqlError(
+      errors.notFound({ message: 'Could not find mentor' })
+    );
   });
 
   it('language engagement creation fails and lets you know why if your ids are bad', async () => {
@@ -854,13 +862,17 @@ describe('Engagement e2e', () => {
         projectId: invalidId,
         languageId: language.id,
       })
-    ).rejects.toThrow('Could not find project');
+    ).rejects.toThrowGqlError(
+      errors.notFound({ message: 'Could not find project' })
+    );
     await expect(
       createLanguageEngagement(app, {
         projectId: project.id,
         languageId: invalidId,
       })
-    ).rejects.toThrow('Could not find language');
+    ).rejects.toThrowGqlError(
+      errors.notFound({ message: 'Could not find language' })
+    );
   });
 
   it('should return empty methodologies array even if it is null', async () => {
@@ -899,11 +911,12 @@ describe('Engagement e2e', () => {
       createInternshipEngagement(app, {
         projectId: project.id,
       })
-    ).rejects.toThrowError(
-      new InputException(
-        'Only Internship Engagements can be created on Internship Projects',
-        'engagement.projectId'
-      )
+    ).rejects.toThrowGqlError(
+      errors.input({
+        message:
+          'Only Internship Engagements can be created on Internship Projects',
+        field: 'engagement.internId',
+      })
     );
   });
 
@@ -921,8 +934,11 @@ describe('Engagement e2e', () => {
         projectId: project.id,
         languageId: language.id,
       })
-    ).rejects.toThrowError(
-      'Engagement for this project and language already exists'
+    ).rejects.toThrowGqlError(
+      errors.duplicate({
+        message: 'Engagement for this project and language already exists',
+        field: 'engagement.languageId',
+      })
     );
   });
 
@@ -942,8 +958,11 @@ describe('Engagement e2e', () => {
         projectId: project.id,
         internId: intern.id,
       })
-    ).rejects.toThrowError(
-      'Engagement for this project and person already exists'
+    ).rejects.toThrowGqlError(
+      errors.duplicate({
+        message: 'Engagement for this project and person already exists',
+        field: 'engagement.internId',
+      })
     );
   });
 
@@ -956,8 +975,12 @@ describe('Engagement e2e', () => {
         languageId: language.id,
         firstScripture: true,
       })
-    ).rejects.toThrowError(
-      'First scripture has already been marked as having been done externally'
+    ).rejects.toThrowGqlError(
+      errors.input({
+        message:
+          'First scripture has already been marked as having been done externally',
+        field: 'languageEngagement.firstScripture',
+      })
     );
   });
 
@@ -973,8 +996,12 @@ describe('Engagement e2e', () => {
         languageId: language.id,
         firstScripture: true,
       })
-    ).rejects.toThrowError(
-      'Another engagement has already been marked as having done the first scripture'
+    ).rejects.toThrowGqlError(
+      errors.input({
+        message:
+          'Another engagement has already been marked as having done the first scripture',
+        field: 'languageEngagement.firstScripture',
+      })
     );
   });
 
@@ -1033,9 +1060,10 @@ describe('Engagement e2e', () => {
         'The project cannot be completed since some engagements have a non-terminal status'
       );
     });
+
     // can't complete a project if you're not an admin and transition is disabled because of non terminal engagements
-    const updateProject = async () => {
-      return await app.graphql.mutate(
+    await app.graphql
+      .mutate(
         gql`
           mutation updateProject($id: ID!, $step: ProjectStep) {
             updateProject(input: { project: { id: $id, step: $step } }) {
@@ -1057,9 +1085,8 @@ describe('Engagement e2e', () => {
           id: project.id,
           step: ProjectStep.Completed,
         }
-      );
-    };
-    await expect(updateProject).rejects.toThrow(Error);
+      )
+      .expectError();
   });
 
   it.each([
@@ -1290,7 +1317,12 @@ describe('Engagement e2e', () => {
       createLanguageEngagement(app, {
         projectId: project.id,
       })
-    ).rejects.toThrowError('The Project status is not in development');
+    ).rejects.toThrowGqlError(
+      errors.input({
+        message: 'The Project status is not in development',
+        field: 'project.status',
+      })
+    );
 
     await expect(
       app.graphql.mutate(
@@ -1305,8 +1337,11 @@ describe('Engagement e2e', () => {
           id: engagement.id,
         }
       )
-    ).rejects.toThrowError(
-      'You do not have the permission to delete this Engagement'
+    ).rejects.toThrowGqlError(
+      errors.input({
+        code: ['Unauthorized', 'Input'],
+        message: 'You do not have the permission to delete this Engagement',
+      })
     );
   });
 });

--- a/test/file.e2e-spec.ts
+++ b/test/file.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { startCase, times } from 'lodash';
 import {
   DateTime,
@@ -27,6 +26,7 @@ import {
   generateFakeFile,
   getFileNode,
   getFileNodeChildren,
+  gql,
   registerUser,
   requestFileUpload,
   runInIsolatedSession,

--- a/test/file.e2e-spec.ts
+++ b/test/file.e2e-spec.ts
@@ -21,7 +21,7 @@ import {
   createFileVersion,
   createSession,
   createTestApp,
-  expectNotFound,
+  errors,
   FakeFile,
   generateFakeFile,
   getFileNode,
@@ -79,8 +79,8 @@ async function deleteNode(app: TestApp, id: ID) {
 }
 
 async function expectNodeNotFound(app: TestApp, id: ID) {
-  await expectNotFound(
-    app.graphql.query(
+  await app.graphql
+    .query(
       gql`
         query fileNode($id: ID!) {
           fileNode(id: $id) {
@@ -92,7 +92,7 @@ async function expectNodeNotFound(app: TestApp, id: ID) {
         id,
       }
     )
-  );
+    .expectError(errors.notFound());
 }
 
 function shiftNow(duration: DurationObject) {

--- a/test/film.e2e-spec.ts
+++ b/test/film.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { times } from 'lodash';
 import { isValidId } from '../src/common';
 import { Role } from '../src/components/authorization/dto/role.dto';
@@ -10,6 +9,7 @@ import {
   createSession,
   createTestApp,
   fragments,
+  gql,
   registerUser,
   TestApp,
 } from './utility';

--- a/test/funding-account.e2e-spec.ts
+++ b/test/funding-account.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { times } from 'lodash';
 import { isValidId } from '../src/common';
 import { Role } from '../src/components/authorization/dto/role.dto';
@@ -9,6 +8,7 @@ import {
   createSession,
   createTestApp,
   fragments,
+  gql,
   registerUser,
   runAsAdmin,
   TestApp,

--- a/test/language-changeset-aware.e2e-spec.ts
+++ b/test/language-changeset-aware.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import {
   approveProjectChangeRequest,
   createFundingAccount,
@@ -11,6 +10,7 @@ import {
   createRegion,
   createSession,
   createTestApp,
+  gql,
   loginAsAdmin,
   TestApp,
 } from './utility';

--- a/test/language.e2e-spec.ts
+++ b/test/language.e2e-spec.ts
@@ -258,8 +258,7 @@ describe('Language e2e', () => {
     ).rejects.toThrowGqlError(
       errors.validation({
         'language.signLanguageCode': {
-          matches:
-            'signLanguageCode must match /^[A-Z]{2}\\d{2}$/ regular expression',
+          matches: 'Must be 2 uppercase letters followed by 2 digits',
         },
       })
     );

--- a/test/language.e2e-spec.ts
+++ b/test/language.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { times } from 'lodash';
 import { InputException, isValidId } from '../src/common';
 import { UpdateLanguage } from '../src/components/language';
@@ -11,6 +10,7 @@ import {
   createSession,
   createTestApp,
   expectNotFound,
+  gql,
   loginAsAdmin,
   TestApp,
 } from './utility';

--- a/test/literacy.e2e-spec.ts
+++ b/test/literacy.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { times } from 'lodash';
 import { isValidId } from '../src/common';
 import { Role } from '../src/components/authorization/dto/role.dto';
@@ -10,6 +9,7 @@ import {
   createSession,
   createTestApp,
   fragments,
+  gql,
   registerUser,
   TestApp,
 } from './utility';

--- a/test/location.e2e-spec.ts
+++ b/test/location.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { times } from 'lodash';
 import { generateId, isValidId } from '../src/common';
 import { Location } from '../src/components/location';
@@ -10,6 +9,7 @@ import {
   createSession,
   createTestApp,
   fragments,
+  gql,
   loginAsAdmin,
   TestApp,
 } from './utility';

--- a/test/organization.e2e-spec.ts
+++ b/test/organization.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { orderBy, times } from 'lodash';
 import { generateId, InputException, isValidId } from '../src/common';
 import { Role } from '../src/components/authorization';
@@ -9,6 +8,7 @@ import {
   createSession,
   createTestApp,
   fragments,
+  gql,
   registerUser,
   TestApp,
 } from './utility';

--- a/test/organization.e2e-spec.ts
+++ b/test/organization.e2e-spec.ts
@@ -1,12 +1,13 @@
 import { faker } from '@faker-js/faker';
 import { orderBy, times } from 'lodash';
-import { generateId, InputException, isValidId } from '../src/common';
+import { generateId, isValidId } from '../src/common';
 import { Role } from '../src/components/authorization';
 import { Organization } from '../src/components/organization';
 import {
   createOrganization,
   createSession,
   createTestApp,
+  errors,
   fragments,
   gql,
   registerUser,
@@ -31,7 +32,7 @@ describe('Organization e2e', () => {
   it.skip('should have unique name', async () => {
     const name = faker.company.name();
     await createOrganization(app, { name });
-    await expect(createOrganization(app, { name })).rejects.toThrowError();
+    await expect(createOrganization(app, { name })).rejects.toThrowGqlError();
   });
 
   // READ ORG
@@ -78,10 +79,12 @@ describe('Organization e2e', () => {
   });
 
   it.skip('create organization with mandatory field blank, mismatch or removed', async () => {
-    await expect(createOrganization(app, { name: '' })).rejects.toThrowError();
+    await expect(
+      createOrganization(app, { name: '' })
+    ).rejects.toThrowGqlError();
     await expect(
       createOrganization(app, { name: undefined })
-    ).rejects.toThrowError();
+    ).rejects.toThrowGqlError();
   });
 
   // UPDATE ORG
@@ -120,8 +123,8 @@ describe('Organization e2e', () => {
   it('update organization with blank, mismatch or invalid id', async () => {
     const newName = faker.company.name();
 
-    await expect(
-      app.graphql.mutate(
+    await app.graphql
+      .mutate(
         gql`
           mutation updateOrganization($input: UpdateOrganizationInput!) {
             updateOrganization(input: $input) {
@@ -141,10 +144,10 @@ describe('Organization e2e', () => {
           },
         }
       )
-    ).rejects.toThrowError(new InputException('Input validation failed'));
+      .expectError(errors.invalidId('organization.id'));
 
-    await expect(
-      app.graphql.mutate(
+    await app.graphql
+      .mutate(
         gql`
           mutation updateOrganization($input: UpdateOrganizationInput!) {
             updateOrganization(input: $input) {
@@ -164,10 +167,10 @@ describe('Organization e2e', () => {
           },
         }
       )
-    ).rejects.toThrowError();
+      .expectError();
 
-    await expect(
-      app.graphql.mutate(
+    await app.graphql
+      .mutate(
         gql`
           mutation updateOrganization($input: UpdateOrganizationInput!) {
             updateOrganization(input: $input) {
@@ -187,7 +190,7 @@ describe('Organization e2e', () => {
           },
         }
       )
-    ).rejects.toThrowError(new InputException('Input validation failed'));
+      .expectError(errors.invalidId('organization.id'));
   });
 
   it.skip('update organization with mismatch name', async () => {
@@ -195,8 +198,8 @@ describe('Organization e2e', () => {
 
     const newName = faker.company.name();
 
-    await expect(
-      app.graphql.mutate(
+    await app.graphql
+      .mutate(
         gql`
           mutation updateOrganization($input: UpdateOrganizationInput!) {
             updateOrganization(input: $input) {
@@ -216,7 +219,7 @@ describe('Organization e2e', () => {
           },
         }
       )
-    ).rejects.toThrowError();
+      .expectError();
   });
 
   // DELETE ORG
@@ -243,63 +246,26 @@ describe('Organization e2e', () => {
   it('delete organization with blank, mismatch, invalid id', async () => {
     const org = await createOrganization(app);
 
-    await expect(
-      app.graphql.mutate(
-        gql`
-          mutation deleteOrganization($id: ID!) {
-            deleteOrganization(id: $id) {
-              __typename
-            }
-          }
-        `,
-        {
-          id: '',
+    const DeleteOrganization = gql`
+      mutation deleteOrganization($id: ID!) {
+        deleteOrganization(id: $id) {
+          __typename
         }
-      )
-    ).rejects.toThrow('Input validation failed');
+      }
+    `;
+    await app.graphql
+      .mutate(DeleteOrganization, { id: '' })
+      .expectError(errors.invalidId());
 
-    await expect(
-      app.graphql.mutate(
-        gql`
-          mutation deleteOrganization($id: ID!) {
-            deleteOrganization(id: $id) {
-              __typename
-            }
-          }
-        `,
-        {}
-      )
-    ).rejects.toThrowError();
+    await app.graphql.mutate(DeleteOrganization).expectError(errors.schema());
 
-    await expect(
-      app.graphql.mutate(
-        gql`
-          mutation deleteOrganization($id: ID!) {
-            deleteOrganization(id: $id) {
-              __typename
-            }
-          }
-        `,
-        {
-          id5: org.id,
-        }
-      )
-    ).rejects.toThrowError();
+    await app.graphql
+      .mutate(DeleteOrganization, { id5: org.id })
+      .expectError(errors.schema());
 
-    await expect(
-      app.graphql.mutate(
-        gql`
-          mutation deleteOrganization($id: ID!) {
-            deleteOrganization(id: $id) {
-              __typename
-            }
-          }
-        `,
-        {
-          id: '!@#$%',
-        }
-      )
-    ).rejects.toThrow('Input validation failed');
+    await app.graphql
+      .mutate(DeleteOrganization, { id: '!@#$%' })
+      .expectError(errors.invalidId());
   });
 
   it('shows canEdit true when it can be edited', async () => {
@@ -323,6 +289,20 @@ describe('Organization e2e', () => {
     expect(actual.name.canEdit).toBe(true);
   });
 
+  const Organizations = gql`
+    query organizations($input: OrganizationListInput) {
+      organizations(input: $input) {
+        items {
+          id
+          name {
+            value
+          }
+        }
+        hasMore
+        total
+      }
+    }
+  `;
   it.skip('List of organizations sorted by name to be alphabetical, ignoring case sensitivity. Order: ASCENDING', async () => {
     await registerUser(app, {
       roles: [Role.FieldOperationsDirector],
@@ -341,30 +321,12 @@ describe('Organization e2e', () => {
     await createOrganization(app, {
       name: 'big Organization also' + faker.datatype.uuid(),
     });
-    const sortBy = 'name';
-    const ascOrder = 'ASC';
-    const { organizations } = await app.graphql.query(
-      gql`
-        query organizations($input: OrganizationListInput!) {
-          organizations(input: $input) {
-            hasMore
-            total
-            items {
-              id
-              name {
-                value
-              }
-            }
-          }
-        }
-      `,
-      {
-        input: {
-          sort: sortBy,
-          order: ascOrder,
-        },
-      }
-    );
+    const { organizations } = await app.graphql.query(Organizations, {
+      input: {
+        sort: 'name',
+        order: 'ASC',
+      },
+    });
     const items = organizations.items;
     const sorted = orderBy(items, (org) => org.name.value.toLowerCase(), [
       'asc',
@@ -390,30 +352,12 @@ describe('Organization e2e', () => {
     await createOrganization(app, {
       name: 'big Organization also' + faker.datatype.uuid(),
     });
-    const sortBy = 'name';
-    const descOrder = 'DESC';
-    const { organizations } = await app.graphql.query(
-      gql`
-        query organizations($input: OrganizationListInput!) {
-          organizations(input: $input) {
-            hasMore
-            total
-            items {
-              id
-              name {
-                value
-              }
-            }
-          }
-        }
-      `,
-      {
-        input: {
-          sort: sortBy,
-          order: descOrder,
-        },
-      }
-    );
+    const { organizations } = await app.graphql.query(Organizations, {
+      input: {
+        sort: 'name',
+        order: 'DESC',
+      },
+    });
     const items = organizations.items;
     const sorted = orderBy(items, (org) => org.name.value.toLowerCase(), [
       'desc',
@@ -431,145 +375,39 @@ describe('Organization e2e', () => {
       )
     );
 
-    await expect(
-      app.graphql.query(
-        gql`
-          query organizations($input: OrganizationListInput) {
-            organizations(input: $input) {
-              items {
-                ...org
-              }
-              hasMore
-              total
-            }
-          }
-          ${fragments.org}
-        `,
-        {
-          input: {
-            count1: 10,
-            page: 1,
-            sort: 'name',
-            order: 'ASC',
-            filter: {
-              name: '',
-            },
-          },
-        }
-      )
-    ).rejects.toThrowError();
+    await app.graphql
+      .query(Organizations, {
+        input: { count1: 10 },
+      })
+      .expectError();
 
-    await expect(
-      app.graphql.query(
-        gql`
-          query organizations($input: OrganizationListInput) {
-            organizations(input: $input) {
-              items {
-                ...org
-              }
-              hasMore
-              total
-            }
-          }
-          ${fragments.org}
-        `,
-        {
-          input: {
-            count: 10,
-            page1: 1,
-            sort: 'name',
-            order: 'ASC',
-            filter: {
-              name: '',
-            },
-          },
-        }
-      )
-    ).rejects.toThrowError();
+    await app.graphql
+      .query(Organizations, {
+        input: { page1: 1 },
+      })
+      .expectError();
 
-    await expect(
-      app.graphql.query(
-        gql`
-          query organizations($input: OrganizationListInput) {
-            organizations(input: $input) {
-              items {
-                ...org
-              }
-              hasMore
-              total
-            }
-          }
-          ${fragments.org}
-        `,
-        {
-          input: {
-            count: 10,
-            page: 1,
-            sort1: 'name',
-            order: 'ASC',
-            filter: {
-              name: '',
-            },
-          },
-        }
-      )
-    ).rejects.toThrowError();
+    await app.graphql
+      .query(Organizations, {
+        input: { sort1: 'name' },
+      })
+      .expectError();
 
-    await expect(
-      app.graphql.query(
-        gql`
-          query organizations($input: OrganizationListInput) {
-            organizations(input: $input) {
-              items {
-                ...org
-              }
-              hasMore
-              total
-            }
-          }
-          ${fragments.org}
-        `,
-        {
-          input: {
-            count: 10,
-            page: 1,
-            sort: 'name',
-            order1: 'ASC',
-            filter: {
-              name: '',
-            },
-          },
-        }
-      )
-    ).rejects.toThrowError();
+    await app.graphql
+      .query(Organizations, {
+        input: { order1: 'ASC' },
+      })
+      .expectError();
 
-    await expect(
-      app.graphql.query(
-        gql`
-          query organizations($input: OrganizationListInput) {
-            organizations(input: $input) {
-              items {
-                ...org
-              }
-              hasMore
-              total
-            }
-          }
-          ${fragments.org}
-        `,
-        {
-          input: {
-            count: 10,
-            page: 1,
-            sort: 'name',
-            order: 'ASC',
-            filter1: {
-              name: '',
-            },
+    await app.graphql
+      .query(Organizations, {
+        input: {
+          filter1: {
+            name: '',
           },
-        }
-      )
-    ).rejects.toThrowError();
+        },
+      })
+      .expectError();
   });
 
   it.skip('list view of organizations with invalid parameters', async () => {
@@ -582,144 +420,38 @@ describe('Organization e2e', () => {
       )
     );
 
-    await expect(
-      app.graphql.query(
-        gql`
-          query organizations($input: OrganizationListInput) {
-            organizations(input: $input) {
-              items {
-                ...org
-              }
-              hasMore
-              total
-            }
-          }
-          ${fragments.org}
-        `,
-        {
-          input: {
-            count: 0,
-            page: 1,
-            sort: 'name',
-            order: 'ASC',
-            filter: {
-              name: '',
-            },
-          },
-        }
-      )
-    ).rejects.toThrowError();
+    await app.graphql
+      .query(Organizations, {
+        input: { count: 0 },
+      })
+      .expectError();
 
-    await expect(
-      app.graphql.query(
-        gql`
-          query organizations($input: OrganizationListInput) {
-            organizations(input: $input) {
-              items {
-                ...org
-              }
-              hasMore
-              total
-            }
-          }
-          ${fragments.org}
-        `,
-        {
-          input: {
-            count: 10,
-            page: 0,
-            sort: 'name',
-            order: 'ASC',
-            filter: {
-              name: '',
-            },
-          },
-        }
-      )
-    ).rejects.toThrowError();
+    await app.graphql
+      .query(Organizations, {
+        input: { page: 0 },
+      })
+      .expectError();
 
-    await expect(
-      app.graphql.query(
-        gql`
-          query organizations($input: OrganizationListInput) {
-            organizations(input: $input) {
-              items {
-                ...org
-              }
-              hasMore
-              total
-            }
-          }
-          ${fragments.org}
-        `,
-        {
-          input: {
-            count: 10,
-            page: 1,
-            sort: 'abcd',
-            order: 'ASC',
-            filter: {
-              name: '',
-            },
-          },
-        }
-      )
-    ).rejects.toThrowError();
+    await app.graphql
+      .query(Organizations, {
+        input: { sort: 'abcd' },
+      })
+      .expectError();
 
-    await expect(
-      app.graphql.query(
-        gql`
-          query organizations($input: OrganizationListInput) {
-            organizations(input: $input) {
-              items {
-                ...org
-              }
-              hasMore
-              total
-            }
-          }
-          ${fragments.org}
-        `,
-        {
-          input: {
-            count: 10,
-            page: 1,
-            sort: 'name',
-            order: 'ASCENDING',
-            filter: {
-              name: '',
-            },
-          },
-        }
-      )
-    ).rejects.toThrowError();
+    await app.graphql
+      .query(Organizations, {
+        input: { order: 'ASCENDING' },
+      })
+      .expectError();
 
-    await expect(
-      app.graphql.query(
-        gql`
-          query organizations($input: OrganizationListInput) {
-            organizations(input: $input) {
-              items {
-                ...org
-              }
-              hasMore
-              total
-            }
-          }
-          ${fragments.org}
-        `,
-        {
-          input: {
-            count: 10,
-            page: 1,
-            sort: 'name',
-            order: 'ASC',
-            filter1: {
-              name: '',
-            },
+    await app.graphql
+      .query(Organizations, {
+        input: {
+          filter1: {
+            name: '',
           },
-        }
-      )
-    ).rejects.toThrowError();
+        },
+      })
+      .expectError();
   });
 });

--- a/test/partner.e2e-spec.ts
+++ b/test/partner.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { DuplicateException, InputException } from '../src/common';
 import { Role } from '../src/components/authorization/dto';
 import { Partner, PartnerType } from '../src/components/partner';
@@ -11,6 +10,7 @@ import {
   createSession,
   createTestApp,
   fragments,
+  gql,
   registerUser,
   TestApp,
 } from './utility';

--- a/test/partner.e2e-spec.ts
+++ b/test/partner.e2e-spec.ts
@@ -154,7 +154,7 @@ describe('Partner e2e', () => {
       ).rejects.toThrowGqlError(
         errors.validation({
           'partner.pmcEntityCode': {
-            matches: 'pmcEntityCode must match /^[A-Z]{3}$/ regular expression',
+            matches: 'Must be 3 uppercase letters',
           },
         })
       );

--- a/test/partnership-changeset-aware.e2e-spec.ts
+++ b/test/partnership-changeset-aware.e2e-spec.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { Role } from '../src/components/authorization';
 import { PartnershipAgreementStatus } from '../src/components/partnership';
 import {
@@ -12,6 +11,7 @@ import {
   createRegion,
   createSession,
   createTestApp,
+  gql,
   registerUser,
   runAsAdmin,
   TestApp,

--- a/test/partnership.e2e-spec.ts
+++ b/test/partnership.e2e-spec.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { sample, times } from 'lodash';
 import {
   CalendarDate,
@@ -22,6 +21,7 @@ import {
   createTestApp,
   expectNotFound,
   fragments,
+  gql,
   Raw,
   registerUser,
   TestApp,

--- a/test/pin.e2e-spec.ts
+++ b/test/pin.e2e-spec.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { Role } from '../src/components/authorization';
 import {
   createPin,
@@ -6,6 +5,7 @@ import {
   createSession,
   createTestApp,
   fragments,
+  gql,
   registerUser,
   TestApp,
 } from './utility';

--- a/test/product.e2e-spec.ts
+++ b/test/product.e2e-spec.ts
@@ -22,7 +22,7 @@ import {
   createSession,
   createStory,
   createTestApp,
-  expectNotFound,
+  errors,
   fragments,
   gql,
   registerUser,
@@ -639,8 +639,8 @@ describe('Product e2e', () => {
 
     const actual: boolean | undefined = result.deleteProduct;
     expect(actual).toBeTruthy();
-    await expectNotFound(
-      app.graphql.query(
+    await app.graphql
+      .query(
         gql`
           query product($id: ID!) {
             product(id: $id) {
@@ -653,7 +653,7 @@ describe('Product e2e', () => {
           id: product.id,
         }
       )
-    );
+      .expectError(errors.notFound());
   });
 
   it('List view of products', async () => {

--- a/test/product.e2e-spec.ts
+++ b/test/product.e2e-spec.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { times } from 'lodash';
 import { Merge } from 'type-fest';
 import { Secured } from '../src/common';
@@ -25,6 +24,7 @@ import {
   createTestApp,
   expectNotFound,
   fragments,
+  gql,
   registerUser,
   TestApp,
 } from './utility';

--- a/test/project-changeset-aware.e2e-spec.ts
+++ b/test/project-changeset-aware.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { CalendarDate } from '../src/common';
 import { Role } from '../src/components/authorization';
 import { PartnerType } from '../src/components/partner';
@@ -14,6 +13,7 @@ import {
   createRegion,
   createSession,
   createTestApp,
+  gql,
   registerUser,
   runAsAdmin,
   TestApp,

--- a/test/project-member.e2e-spec.ts
+++ b/test/project-member.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { times } from 'lodash';
 import { DateTime, Interval } from 'luxon';
-import { isValidId, NotFoundException } from '../src/common';
+import { isValidId } from '../src/common';
 import { Role } from '../src/components/authorization';
 import { Project, ProjectMember } from '../src/components/project';
 import {
@@ -9,6 +9,7 @@ import {
   createProjectMember,
   createSession,
   createTestApp,
+  errors,
   fragments,
   gql,
   Raw,
@@ -62,8 +63,11 @@ describe('ProjectMember e2e', () => {
         projectId: project.id,
         roles: [Role.Controller],
       })
-    ).rejects.toThrowError(
-      'Role(s) Controller cannot be assigned to this project member'
+    ).rejects.toThrowGqlError(
+      errors.input({
+        message: 'Role(s) Controller cannot be assigned to this project member',
+        field: 'input.roles',
+      })
     );
   });
 
@@ -170,8 +174,11 @@ describe('ProjectMember e2e', () => {
           id: projectMember.id,
         }
       )
-    ).rejects.toThrowError(
-      new NotFoundException('Could not find project member')
+    ).rejects.toThrowGqlError(
+      errors.notFound({
+        message: 'Could not find project member',
+        field: 'projectMember.id',
+      })
     );
   });
 
@@ -276,8 +283,11 @@ describe('ProjectMember e2e', () => {
           },
         }
       )
-    ).rejects.toThrowError(
-      'Role(s) Intern cannot be assigned to this project member'
+    ).rejects.toThrowGqlError(
+      errors.input({
+        message: 'Role(s) Intern cannot be assigned to this project member',
+        field: 'input.roles',
+      })
     );
   });
 });

--- a/test/project-member.e2e-spec.ts
+++ b/test/project-member.e2e-spec.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { times } from 'lodash';
 import { DateTime, Interval } from 'luxon';
 import { isValidId, NotFoundException } from '../src/common';
@@ -11,6 +10,7 @@ import {
   createSession,
   createTestApp,
   fragments,
+  gql,
   Raw,
   registerUser,
   runAsAdmin,

--- a/test/project-workflow.e2e-spec.ts
+++ b/test/project-workflow.e2e-spec.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { CalendarDate } from '../src/common';
 import { Role } from '../src/components/authorization';
 import { PartnerType } from '../src/components/partner';
@@ -20,6 +19,7 @@ import {
   createSession,
   createTestApp,
   fragments,
+  gql,
   registerUser,
   runAsAdmin,
   TestApp,

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -3,11 +3,9 @@ import { intersection, times } from 'lodash';
 import { DateTime } from 'luxon';
 import {
   CalendarDate,
-  DuplicateException,
   generateId,
   ID,
   isIdLike,
-  NotFoundException,
   Order,
   PaginatedListType,
   Sensitivity,
@@ -42,7 +40,7 @@ import {
   createSession,
   createTestApp,
   createZone,
-  expectNotFound,
+  errors,
   fragments,
   gql,
   Raw,
@@ -133,11 +131,11 @@ describe('Project e2e', () => {
     await createProject(app, { name, fieldRegionId: fieldRegion.id });
     await expect(
       createProject(app, { name, fieldRegionId: fieldRegion.id })
-    ).rejects.toThrowError(
-      new DuplicateException(
-        `project.name`,
-        `Project with this name already exists`
-      )
+    ).rejects.toThrowGqlError(
+      errors.duplicate({
+        message: 'Project with this name already exists',
+        field: 'project.name',
+      })
     );
   });
 
@@ -205,8 +203,11 @@ describe('Project e2e', () => {
         type: ProjectType.Translation,
         fieldRegionId: 'invalid-location-id' as ID,
       })
-    ).rejects.toThrowError(
-      new NotFoundException('Field region not found', 'project.fieldRegionId')
+    ).rejects.toThrowGqlError(
+      errors.notFound({
+        message: 'Field region not found',
+        field: 'project.fieldRegionId',
+      })
     );
   });
 
@@ -321,8 +322,8 @@ describe('Project e2e', () => {
       return deleteProject(app)(project.id);
     });
 
-    await expectNotFound(
-      app.graphql.query(
+    await app.graphql
+      .query(
         gql`
           query project($id: ID!) {
             project(id: $id) {
@@ -335,7 +336,7 @@ describe('Project e2e', () => {
           id: project.id,
         }
       )
-    );
+      .expectError(errors.notFound());
   });
 
   it('List of projects sorted by name to be alphabetical', async () => {
@@ -740,11 +741,11 @@ describe('Project e2e', () => {
     });
     await expect(
       createProject(app, { name: projName, fieldRegionId: fieldRegion.id })
-    ).rejects.toThrowError(
-      new DuplicateException(
-        `project.name`,
-        `Project with this name already exists`
-      )
+    ).rejects.toThrowGqlError(
+      errors.duplicate({
+        message: 'Project with this name already exists',
+        field: 'project.name',
+      })
     );
   });
 

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { intersection, times } from 'lodash';
 import { DateTime } from 'luxon';
 import {
@@ -45,6 +44,7 @@ import {
   createZone,
   expectNotFound,
   fragments,
+  gql,
   Raw,
   registerUser,
   runAsAdmin,

--- a/test/region.e2e-spec.ts
+++ b/test/region.e2e-spec.ts
@@ -61,7 +61,7 @@ describe('Region e2e', () => {
         name,
         fieldZoneId: fieldZone.id,
       })
-    ).rejects.toThrowError();
+    ).rejects.toThrowGqlError();
   });
 
   it('read one field region by id', async () => {

--- a/test/region.e2e-spec.ts
+++ b/test/region.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { isValidId } from '../src/common';
 import { Role } from '../src/components/authorization/dto/role.dto';
 import { FieldRegion } from '../src/components/field-region';
@@ -10,6 +9,7 @@ import {
   createSession,
   createTestApp,
   fragments,
+  gql,
   loginAsAdmin,
   TestApp,
 } from './utility';

--- a/test/security/budget.security.ts
+++ b/test/security/budget.security.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { CalendarDate, ID, Sensitivity } from '../../src/common';
 import { Role, ScopedRole } from '../../src/components/authorization';
 import { Budget } from '../../src/components/budget';
@@ -18,6 +17,7 @@ import {
   createProjectMember,
   createSession,
   createTestApp,
+  gql,
   listBudgets,
   Raw,
   readBudgetRecords,

--- a/test/song.e2e-spec.ts
+++ b/test/song.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { times } from 'lodash';
 import { isValidId } from '../src/common';
 import { Role } from '../src/components/authorization';
@@ -10,6 +9,7 @@ import {
   createSong,
   createTestApp,
   fragments,
+  gql,
   registerUser,
   TestApp,
 } from './utility';

--- a/test/story.e2e-spec.ts
+++ b/test/story.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { times } from 'lodash';
 import { isValidId } from '../src/common';
 import { Role } from '../src/components/authorization';
@@ -10,6 +9,7 @@ import {
   createStory,
   createTestApp,
   fragments,
+  gql,
   registerUser,
   TestApp,
 } from './utility';

--- a/test/unavailability.e2e-spec.ts
+++ b/test/unavailability.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { times } from 'lodash';
 import { isValidId } from '../src/common';
 import { Role } from '../src/components/authorization';
@@ -9,6 +8,7 @@ import {
   createSession,
   createTestApp,
   createUnavailability,
+  gql,
   registerUser,
   TestApp,
 } from './utility';

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { firstLettersOfWords, isValidId } from '../src/common';
 import { Role } from '../src/components/authorization';
 import { SecuredTimeZone } from '../src/components/timezone';
@@ -14,6 +13,7 @@ import {
   fragments,
   generateRegisterInput,
   generateRequireFieldsRegisterInput,
+  gql,
   login,
   loginAsAdmin,
   registerUser,

--- a/test/utility/create-app.ts
+++ b/test/utility/create-app.ts
@@ -1,13 +1,11 @@
 import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
-import { GRAPHQL_MODULE_OPTIONS } from '@nestjs/graphql/dist/graphql.constants';
 import { Test } from '@nestjs/testing';
 import { AppModule } from '../../src/app.module';
 import { LogLevel } from '../../src/core/logger';
 import { LevelMatcher } from '../../src/core/logger/level-matcher';
 import {
   createGraphqlClient,
-  getGraphQLOptions,
   GraphQLTestClient,
 } from './create-graphql-client';
 
@@ -24,8 +22,6 @@ export const createTestApp = async () => {
   const moduleFixture = await Test.createTestingModule({
     imports: [AppModule],
   })
-    .overrideProvider(GRAPHQL_MODULE_OPTIONS)
-    .useValue(getGraphQLOptions())
     .overrideProvider(LevelMatcher)
     .useValue(new LevelMatcher({}, LogLevel.ERROR))
     .compile();

--- a/test/utility/create-budget.ts
+++ b/test/utility/create-budget.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { generateId, isValidId } from '../../src/common';
 import {
   Budget,
@@ -8,6 +7,7 @@ import {
 import { Organization } from '../../src/components/organization';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function listBudgets(app: TestApp) {
   const result = await app.graphql.mutate(

--- a/test/utility/create-directory.ts
+++ b/test/utility/create-directory.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { startCase } from 'lodash';
 import { ID } from '../../src/common';
 import { loggedInSession } from '../../src/common/session';
@@ -7,6 +6,7 @@ import { AuthenticationService } from '../../src/components/authentication';
 import { FileService } from '../../src/components/file';
 import { TestApp } from './create-app';
 import { fileNode, RawDirectory } from './fragments';
+import { gql } from './gql-tag';
 
 export async function createRootDirectory(app: TestApp, name?: string) {
   name = name ?? startCase(faker.lorem.words());

--- a/test/utility/create-education.ts
+++ b/test/utility/create-education.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { upperFirst } from 'lodash';
 import { isValidId } from '../../src/common';
 import {
@@ -9,6 +8,7 @@ import {
 } from '../../src/components/user/education';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function createEducation(
   app: TestApp,

--- a/test/utility/create-engagement.ts
+++ b/test/utility/create-engagement.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { DateTime } from 'luxon';
 import { ID, isValidId } from '../../src/common';
 import {
@@ -19,6 +18,7 @@ import {
   RawInternshipEngagement,
   RawLanguageEngagement,
 } from './fragments';
+import { gql } from './gql-tag';
 import { runAsAdmin } from './login';
 
 export async function listInternshipEngagements(app: TestApp) {

--- a/test/utility/create-file.ts
+++ b/test/utility/create-file.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { assert, MarkOptional } from 'ts-essentials';
 import { ID } from '../../src/common';
 import {
@@ -13,6 +12,7 @@ import { mimeTypes } from '../../src/components/file/mimeTypes';
 import { TestApp } from './create-app';
 import { RawFile, RawFileNode, RawFileNodeChildren } from './fragments';
 import * as fragments from './fragments';
+import { gql } from './gql-tag';
 
 export const generateFakeFile = () => ({
   name: faker.system.fileName(),

--- a/test/utility/create-film.ts
+++ b/test/utility/create-film.ts
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { CreateFilm, Film } from '../../src/components/film';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function listFilms(app: TestApp) {
   const result = await app.graphql.mutate(

--- a/test/utility/create-funding-account.ts
+++ b/test/utility/create-funding-account.ts
@@ -1,11 +1,11 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import {
   CreateFundingAccount,
   FundingAccount,
 } from '../../src/components/funding-account';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function listFundingAccounts(app: TestApp) {
   const result = await app.graphql.mutate(

--- a/test/utility/create-graphql-client.ts
+++ b/test/utility/create-graphql-client.ts
@@ -6,6 +6,7 @@ import {
   GraphQLFormattedError,
   print,
 } from 'graphql';
+import './expect-gql-error';
 
 export interface GraphQLTestClient {
   query: <TData = AnyObject, TVars = AnyObject>(

--- a/test/utility/create-graphql-client.ts
+++ b/test/utility/create-graphql-client.ts
@@ -1,177 +1,118 @@
-import { INestApplicationContext } from '@nestjs/common';
-import { GqlModuleOptions, GraphQLModule } from '@nestjs/graphql';
-import { GRAPHQL_MODULE_OPTIONS } from '@nestjs/graphql/dist/graphql.constants';
-import { ApolloServerBase } from 'apollo-server-core';
-import { GraphQLResponse } from 'apollo-server-types';
-import { DocumentNode, GraphQLFormattedError } from 'graphql';
-import { GqlContextType } from '../../src/common';
-import { TracingService } from '../../src/core';
-import { GqlContextHostImpl } from '../../src/core/graphql/gql-context.host';
-import { createFakeStubOperation } from '../../src/core/graphql/graphql.config';
+import { INestApplication } from '@nestjs/common';
+import got from 'got';
+import {
+  DocumentNode,
+  FormattedExecutionResult,
+  GraphQLFormattedError,
+  print,
+} from 'graphql';
 
 export interface GraphQLTestClient {
-  query: (
-    query: DocumentNode,
-    variables?: { [name: string]: any }
-  ) => Promise<Record<string, any>>;
-  mutate: (
-    mutation: DocumentNode,
-    variables?: { [name: string]: any }
-  ) => Promise<Record<string, any>>;
+  query: <TData = AnyObject, TVars = AnyObject>(
+    query: DocumentNode | string,
+    variables?: TVars
+  ) => Promise<TData>;
+  mutate: <TData = AnyObject, TVars = AnyObject>(
+    query: DocumentNode | string,
+    variables?: TVars
+  ) => Promise<TData>;
   authToken: string;
 }
 
 export const createGraphqlClient = async (
-  app: INestApplicationContext
+  app: INestApplication
 ): Promise<GraphQLTestClient> => {
-  const server = await getServer(app);
-  const options: GqlModuleOptions & { context: GqlContextType } = app.get(
-    GRAPHQL_MODULE_OPTIONS
-  );
+  await app.listen(0);
+  const url = await app.getUrl();
 
-  const resetRequest = () => {
-    // Session data changes between requests
-    // Next request shouldn't rely on previously calculated data.
-    // It doesn't when using actual requests.
-    if (options.context?.session) {
-      delete options.context.session;
-    }
+  let authToken = '';
+
+  const execute = async <TData = AnyObject, TVars = AnyObject>(
+    query: DocumentNode | string,
+    variables?: TVars
+  ) => {
+    const result = await got
+      .post({
+        url: `${url}/graphql`,
+        throwHttpErrors: false,
+        headers: {
+          ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+        },
+        json: {
+          query: typeof query === 'string' ? query : print(query),
+          variables,
+        },
+      })
+      .json<ExecutionResult<TData>>();
+
+    validateResult(result);
+    return result.data;
   };
 
-  // ensure variables are plain JSON as they would be over the wire
-  const toPlain = (obj: unknown) =>
-    obj ? JSON.parse(JSON.stringify(obj)) : obj;
-
-  const tracing = app.get(TracingService);
-  const contextHost = app.get(GqlContextHostImpl);
   return {
-    query: async (q, variables) => {
-      return await contextHost.attachScope(async () => {
-        return await tracing.capture('query', async () => {
-          try {
-            const result = await server.executeOperation({
-              query: q,
-              variables: toPlain(variables),
-            });
-            validateResult(result);
-            return result.data;
-          } catch (e) {
-            throw adjustError(e);
-          } finally {
-            resetRequest();
-          }
-        });
-      });
-    },
-    mutate: async (mutation, variables) => {
-      return await contextHost.attachScope(async () => {
-        return await tracing.capture('mutation', async () => {
-          try {
-            const result = await server.executeOperation({
-              query: mutation,
-              variables: toPlain(variables),
-            });
-            validateResult(result);
-            return result.data;
-          } catch (e) {
-            throw adjustError(e);
-          } finally {
-            resetRequest();
-          }
-        });
-      });
-    },
+    query: execute,
+    mutate: execute,
     get authToken() {
-      return (
-        options.context.request?.headers?.authorization?.replace(
-          'Bearer ',
-          ''
-        ) || ''
-      );
+      return authToken;
     },
     set authToken(token: string) {
-      // @ts-expect-error yes I know this is a fake request
-      options.context.request = {
-        headers: {
-          ...(token && {
-            authorization: `Bearer ${token}`,
-          }),
-        },
-      };
+      authToken = token;
     },
   };
 };
 
-function validateResult(res: GraphQLResponse): asserts res is Omit<
-  GraphQLResponse,
-  'data' | 'errors'
-> & {
-  data: Record<string, any>;
+function validateResult<TData>(
+  res: ExecutionResult<TData>
+): asserts res is Omit<ExecutionResult<TData>, 'data' | 'errors'> & {
+  data: TData;
 } {
   if (res.errors && res.errors.length > 0) {
-    throw reportError(res.errors[0]);
+    throw GqlError.from(res.errors[0]);
   }
   expect(res.data).toBeTruthy();
 }
 
-const adjustError = (e: Error) => {
-  if (e.stack) {
-    const thisStack = new Error('').stack?.split('\n').slice(2);
-    if (thisStack) {
-      e.stack += '\n' + thisStack.join('\n');
+/**
+ * An error class consuming the JSON formatted GraphQL error.
+ */
+export class GqlError extends Error {
+  constructor(readonly raw: RawGqlError) {
+    super();
+  }
+
+  static from(raw: RawGqlError) {
+    const err = new GqlError(raw);
+    err.name = raw.extensions.code;
+    // must be after err constructor finishes to capture correctly.
+    let frames = err.stack!.split('\n').slice(5);
+    if (raw.extensions.exception) {
+      frames = [...raw.extensions.exception.stacktrace, ...frames];
     }
+    err.message = raw.message;
+    err.stack = `${err.name}: ${err.message}\n` + frames.join('\n');
+    return err;
   }
-  return e;
+}
+
+export type ExecutionResult<TData> = Omit<
+  FormattedExecutionResult<TData>,
+  'errors'
+> & {
+  errors?: readonly RawGqlError[];
 };
 
-const reportError = (
-  e: GraphQLFormattedError & { originalError?: Error & { response?: any } }
-) => {
-  if (e.originalError instanceof Error) {
-    const e2 = e.originalError;
-    if (
-      e2.response?.message &&
-      e2.stack?.startsWith('Error: [object Object]\n')
-    ) {
-      e2.stack = e2.stack.replace('[object Object]', e2.response.message);
-      e2.message = e2.response.message;
-    }
-    return e2;
-  }
-
-  let msg =
-    typeof e.message === 'object'
-      ? JSON.stringify(e.message, undefined, 2)
-      : e.message;
-  if (e.path) {
-    msg += `\nPath: ${e.path.join('.')}`;
-  }
-  const location = (e.locations || [])
-    .map((l) => `  - line ${l.line}, column ${l.column}`)
-    .join('\n');
-  if (location) {
-    msg += `\nLocations:\n${location}`;
-  }
-
-  const err = new Error(msg);
-  err.name = (e as any).name || 'Error';
-
-  return err;
+export type RawGqlError = Omit<GraphQLFormattedError, 'extensions'> & {
+  extensions: {
+    code: string;
+    codes: string[];
+    status: number;
+    exception?: {
+      message: string;
+      stacktrace: string[];
+    };
+  } & AnyObject;
 };
 
-export const getGraphQLOptions = (): GqlModuleOptions => {
-  const context: GqlContextType = {
-    operation: createFakeStubOperation(),
-  };
-  return {
-    path: '/graphql',
-    fieldResolverEnhancers: [],
-    autoSchemaFile: 'schema.graphql',
-    context,
-  };
-};
-
-const getServer = async (app: INestApplicationContext) => {
-  const module = app.get(GraphQLModule);
-  return (module as any).apolloServer as ApolloServerBase;
-};
+interface AnyObject {
+  [key: string]: any;
+}

--- a/test/utility/create-language.ts
+++ b/test/utility/create-language.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { CalendarDate, generateId, ID, isValidId } from '../../src/common';
 import {
   CreateEthnologueLanguage,
@@ -9,6 +8,7 @@ import {
 import { SecuredLocationList } from '../../src/components/location';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function listLanguageIds(app: TestApp) {
   const result = await app.graphql.mutate(

--- a/test/utility/create-literacy-material.ts
+++ b/test/utility/create-literacy-material.ts
@@ -1,11 +1,11 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import {
   CreateLiteracyMaterial,
   LiteracyMaterial,
 } from '../../src/components/literacy-material';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function createLiteracyMaterial(
   app: TestApp,

--- a/test/utility/create-location.ts
+++ b/test/utility/create-location.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import countries from 'iso-3166-1/dist/iso-3166';
 import { ID, isValidId } from '../../src/common';
 import {
@@ -9,6 +8,7 @@ import {
 } from '../../src/components/location';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function createLocation(
   app: TestApp,

--- a/test/utility/create-organization.ts
+++ b/test/utility/create-organization.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { createLocation } from '.';
 import { ID } from '../../src/common';
 import { SecuredLocationList } from '../../src/components/location';
@@ -9,6 +8,7 @@ import {
 } from '../../src/components/organization';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function listOrganizations(app: TestApp) {
   const result = await app.graphql.mutate(

--- a/test/utility/create-partner.ts
+++ b/test/utility/create-partner.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import {
   CreatePartner,
   Partner,
@@ -10,6 +9,7 @@ import { TestApp } from './create-app';
 import { createOrganization } from './create-organization';
 import { createPerson } from './create-person';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function readOnePartner(app: TestApp, id: string) {
   const result = await app.graphql.query(

--- a/test/utility/create-partnership.ts
+++ b/test/utility/create-partnership.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { CalendarDate, ID, isValidId } from '../../src/common';
 import { PartnerType } from '../../src/components/partner';
 import {
@@ -11,6 +10,7 @@ import { TestApp } from './create-app';
 import { createPartner } from './create-partner';
 import { createProject } from './create-project';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function listPartnerships(app: TestApp) {
   const result = await app.graphql.mutate(

--- a/test/utility/create-person.ts
+++ b/test/utility/create-person.ts
@@ -1,9 +1,9 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { generateId, isValidId } from '../../src/common';
 import { CreatePerson, User } from '../../src/components/user';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function createPerson(
   app: TestApp,

--- a/test/utility/create-pin.ts
+++ b/test/utility/create-pin.ts
@@ -1,6 +1,6 @@
-import { gql } from 'apollo-server-core';
 import { ID } from '../../src/common';
 import { TestApp } from './create-app';
+import { gql } from './gql-tag';
 
 export async function createPin(app: TestApp, id: ID, pinned?: boolean) {
   const result = await app.graphql.mutate(

--- a/test/utility/create-product-derivative.ts
+++ b/test/utility/create-product-derivative.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { isValidId } from '../../src/common';
 import {
   CreateDerivativeScriptureProduct,
@@ -8,6 +7,7 @@ import {
 } from '../../src/components/product';
 import { TestApp } from './create-app';
 import { fragments, RawProduct } from './fragments';
+import { gql } from './gql-tag';
 
 export async function createDerivativeProduct(
   app: TestApp,

--- a/test/utility/create-product-direct.ts
+++ b/test/utility/create-product-direct.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { isValidId } from '../../src/common';
 import {
   CreateDirectScriptureProduct,
@@ -8,6 +7,7 @@ import {
 } from '../../src/components/product';
 import { TestApp } from './create-app';
 import { fragments, RawProduct } from './fragments';
+import { gql } from './gql-tag';
 
 export async function createDirectProduct(
   app: TestApp,

--- a/test/utility/create-product.ts
+++ b/test/utility/create-product.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { isValidId } from '../../src/common';
 import {
   CreateProduct,
@@ -8,6 +7,7 @@ import {
 } from '../../src/components/product';
 import { TestApp } from './create-app';
 import { fragments, RawProduct } from './fragments';
+import { gql } from './gql-tag';
 
 export async function createProduct(app: TestApp, input: CreateProduct) {
   const product: CreateProduct = {

--- a/test/utility/create-project-member.ts
+++ b/test/utility/create-project-member.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { isValidId } from '../../src/common';
 import {
   CreateProjectMember,
@@ -12,6 +11,7 @@ import {
   TestApp,
 } from '../utility';
 import { getUserFromSession } from './create-session';
+import { gql } from './gql-tag';
 
 export async function listProjectMembers(app: TestApp) {
   const result = await app.graphql.mutate(

--- a/test/utility/create-project.ts
+++ b/test/utility/create-project.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { runAsAdmin } from '.';
 import {
   CalendarDate,
@@ -16,6 +15,7 @@ import {
 import { TestApp } from './create-app';
 import { createRegion } from './create-region';
 import { fragments, RawProject } from './fragments';
+import { gql } from './gql-tag';
 import { Raw } from './raw.type';
 
 export async function listProjects(app: TestApp) {

--- a/test/utility/create-region.ts
+++ b/test/utility/create-region.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { createPerson, runAsAdmin } from '.';
 import { generateId, isValidId } from '../../src/common';
 import {
@@ -9,6 +8,7 @@ import { TestApp } from './create-app';
 import { getUserFromSession } from './create-session';
 import { createZone } from './create-zone';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function listFieldRegions(app: TestApp) {
   const result = await app.graphql.mutate(

--- a/test/utility/create-session.ts
+++ b/test/utility/create-session.ts
@@ -1,6 +1,6 @@
-import { gql } from 'apollo-server-core';
 import { User } from '../../src/components/user';
 import { TestApp } from './create-app';
+import { gql } from './gql-tag';
 
 export async function createSession(app: TestApp): Promise<string> {
   const result = await app.graphql.query(gql`

--- a/test/utility/create-song.ts
+++ b/test/utility/create-song.ts
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { CreateSong, Song } from '../../src/components/song';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function createSong(
   app: TestApp,

--- a/test/utility/create-story.ts
+++ b/test/utility/create-story.ts
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { CreateStory, Story } from '../../src/components/story';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function createStory(
   app: TestApp,

--- a/test/utility/create-unavailability.ts
+++ b/test/utility/create-unavailability.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { DateTime } from 'luxon';
 import { isValidId } from '../../src/common';
 import {
@@ -8,6 +7,7 @@ import {
 } from '../../src/components/user/unavailability';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function createUnavailability(
   app: TestApp,

--- a/test/utility/create-zone.ts
+++ b/test/utility/create-zone.ts
@@ -1,9 +1,9 @@
-import { gql } from 'apollo-server-core';
 import { createPerson, getUserFromSession, runAsAdmin } from '.';
 import { generateId, isValidId } from '../../src/common';
 import { CreateFieldZone, FieldZone } from '../../src/components/field-zone';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function listFieldZones(app: TestApp) {
   const result = await app.graphql.mutate(

--- a/test/utility/error-shape-helpers.ts
+++ b/test/utility/error-shape-helpers.ts
@@ -1,0 +1,27 @@
+import { ErrorExpectations as Expectations } from './expect-gql-error';
+
+const extend =
+  (defaults: Expectations) =>
+  (extra?: Expectations): Expectations => ({
+    ...defaults,
+    ...extra,
+  });
+
+export const validation = (errors: Record<string, any>): Expectations => ({
+  code: ['Validation', 'Client'],
+  message: 'Input validation failed',
+  errors,
+});
+
+export const invalidId = (field = 'id'): Expectations =>
+  validation({
+    [field]: { IsId: 'Invalid ID' },
+  });
+
+export const input = extend({ code: 'Input' });
+
+export const duplicate = extend({ code: ['Duplicate', 'Input'] });
+
+export const notFound = extend({ code: 'NotFound' });
+
+export const schema = extend({ code: ['GraphQL', 'Client'] });

--- a/test/utility/expect-gql-error.ts
+++ b/test/utility/expect-gql-error.ts
@@ -1,0 +1,105 @@
+// noinspection JSUnusedGlobalSymbols
+
+import { stripIndent } from 'common-tags';
+import { difference, omit } from 'lodash';
+import { many, Many } from '../../src/common';
+import { GqlError } from './create-graphql-client';
+
+expect.extend({
+  toThrowGqlError(received: GqlError, expected?: ErrorExpectations) {
+    expect(received).toBeInstanceOf(GqlError);
+    const error = received.raw;
+    const { code, message, ...extensions } = expected ?? {};
+
+    const expectedObj = {
+      ...(code ? { codes: many(code) } : {}),
+      ...(message ? { message } : {}),
+      extensions,
+    };
+    const actualObj = {
+      codes: error?.extensions?.codes ?? [],
+      message: error?.message,
+      extensions: omit(
+        error?.extensions,
+        'code',
+        'codes',
+        'status',
+        'exception'
+      ),
+    };
+
+    const codesPassed = expectedObj.codes
+      ? difference(expectedObj.codes, actualObj.codes).length === 0
+      : true;
+    const messagePassed = expectedObj.message
+      ? expectedObj.message === actualObj.message
+      : true;
+    const extensionsPassed =
+      Object.keys(expectedObj.extensions).length > 0
+        ? !!this.utils.subsetEquality(
+            expectedObj.extensions,
+            actualObj.extensions
+          )
+        : true;
+    const pass = codesPassed && messagePassed && extensionsPassed;
+
+    const genMessage = () => stripIndent`
+      ${this.utils.matcherHint(`${this.isNot ? '.not' : ''}.toThrowGqlError`)}
+
+      Expected GraphQL error with${
+        this.isNot ? 'out' : ''
+      } at least the following:
+        ${
+          !codesPassed
+            ? stripIndent`
+                Codes:
+                  ${this.utils.EXPECTED_COLOR(expectedObj.codes?.join(', '))}
+                  ${this.utils.RECEIVED_COLOR(actualObj.codes?.join(', '))}
+              `.replace(/\n/g, '\n        ')
+            : ''
+        }
+        ${
+          !messagePassed
+            ? stripIndent`
+                Message:
+                  ${this.utils.EXPECTED_COLOR(expectedObj.message)}
+                  ${this.utils.RECEIVED_COLOR(actualObj.message)}
+              `.replace(/\n/g, '\n        ')
+            : ''
+        }
+        ${
+          !extensionsPassed
+            ? stripIndent`
+                Extensions:
+                  ${this.utils
+                    .diff(expectedObj.extensions, actualObj.extensions)
+                    ?.replace(/\n/g, '\n                  ')
+                    .split('\n')
+                    .slice(4, -1)
+                    .join('\n')
+                    .trim()}
+              `.replace(/\n/g, '\n        ')
+            : ''
+        }
+      `;
+
+    return { pass, message: genMessage };
+  },
+});
+
+export type ErrorExpectations = {
+  code?: Many<string>;
+  message?: string;
+} & Partial<Record<string, any>>;
+
+interface CustomMatchers<R = unknown> {
+  toThrowGqlError: (expectations?: ErrorExpectations) => R;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface Matchers<R> extends CustomMatchers<R> {}
+  }
+}

--- a/test/utility/expect-not-found.ts
+++ b/test/utility/expect-not-found.ts
@@ -1,5 +1,0 @@
-import { notFound } from './error-shape-helpers';
-
-/** @deprecated */
-export const expectNotFound = (action: PromiseLike<any>) =>
-  expect(action).rejects.toThrowGqlError(notFound());

--- a/test/utility/expect-not-found.ts
+++ b/test/utility/expect-not-found.ts
@@ -1,10 +1,5 @@
-export const expectNotFound = async (action: Promise<any>) => {
-  let thrown;
-  try {
-    await action;
-  } catch (e) {
-    thrown = e;
-  }
-  expect(thrown).toBeInstanceOf(Error);
-  expect(thrown.extensions.code).toEqual('NotFound');
-};
+import { notFound } from './error-shape-helpers';
+
+/** @deprecated */
+export const expectNotFound = (action: PromiseLike<any>) =>
+  expect(action).rejects.toThrowGqlError(notFound());

--- a/test/utility/fragments.ts
+++ b/test/utility/fragments.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { Except, Merge, MergeExclusive } from 'type-fest';
 import { ID, Secured } from '../../src/common';
 import {
@@ -17,6 +16,7 @@ import { SecuredLanguage } from '../../src/components/language/dto';
 import { Product, ProductApproach } from '../../src/components/product/dto';
 import { Project } from '../../src/components/project';
 import { User } from '../../src/components/user';
+import { gql } from './gql-tag';
 import { Raw } from './raw.type';
 
 export const org = gql`

--- a/test/utility/gql-tag.ts
+++ b/test/utility/gql-tag.ts
@@ -1,0 +1,11 @@
+/**
+ * A no-op tag to provide syntax highlighting.
+ */
+export const gql = (doc: TemplateStringsArray, ...rest: string[]) => {
+  let result = doc[0];
+  for (let i = 1, l = doc.length; i < l; i++) {
+    result += rest[i - 1];
+    result += doc[i];
+  }
+  return result;
+};

--- a/test/utility/index.ts
+++ b/test/utility/index.ts
@@ -1,3 +1,4 @@
+export * from './gql-tag';
 export * from './create-app';
 export * from './create-budget';
 export * from './create-education';

--- a/test/utility/index.ts
+++ b/test/utility/index.ts
@@ -19,6 +19,7 @@ export * from './register';
 export * from './login';
 export * from './logout';
 export * from './expect-not-found';
+export * as errors from './error-shape-helpers';
 export * as fragments from './fragments';
 export * from './raw.type';
 export * from './create-region';

--- a/test/utility/index.ts
+++ b/test/utility/index.ts
@@ -18,7 +18,6 @@ export * from './create-zone';
 export * from './register';
 export * from './login';
 export * from './logout';
-export * from './expect-not-found';
 export * as errors from './error-shape-helpers';
 export * as fragments from './fragments';
 export * from './raw.type';

--- a/test/utility/login.ts
+++ b/test/utility/login.ts
@@ -1,8 +1,8 @@
-import { gql } from 'apollo-server-core';
 import { LoginInput } from '../../src/components/authentication/dto';
 import { ConfigService } from '../../src/core';
 import { TestApp } from './create-app';
 import { createSession } from './create-session';
+import { gql } from './gql-tag';
 
 export async function login(app: TestApp, input: Partial<LoginInput> = {}) {
   return await app.graphql.mutate(

--- a/test/utility/logout.ts
+++ b/test/utility/logout.ts
@@ -1,5 +1,5 @@
-import { gql } from 'apollo-server-core';
 import { TestApp } from './create-app';
+import { gql } from './gql-tag';
 
 export async function logout(app: TestApp) {
   return await app.graphql.mutate(

--- a/test/utility/project-change-request.ts
+++ b/test/utility/project-change-request.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { ID, isValidId } from '../../src/common';
 import {
   CreateProjectChangeRequest,
@@ -8,6 +7,7 @@ import {
 } from '../../src/components/project-change-request/dto';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function createProjectChangeRequest(
   app: TestApp,

--- a/test/utility/register.ts
+++ b/test/utility/register.ts
@@ -1,11 +1,11 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { generateId, isValidId } from '../../src/common';
 import { RegisterInput } from '../../src/components/authentication';
 import { Powers, Role } from '../../src/components/authorization';
 import { User, UserStatus } from '../../src/components/user';
 import { TestApp } from './create-app';
 import { fragments, RawUser } from './fragments';
+import { gql } from './gql-tag';
 import { login, runAsAdmin, runInIsolatedSession } from './login';
 
 export async function readOneUser(app: TestApp, id: string) {

--- a/test/utility/sensitivity.ts
+++ b/test/utility/sensitivity.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import {
   createLanguage,
   createLanguageEngagement,
@@ -19,6 +18,7 @@ import {
 import { Role } from '../../src/components/authorization';
 import { Permission } from '../../src/components/authorization/authorization.service';
 import { ProjectType } from '../../src/components/project';
+import { gql } from './gql-tag';
 import { registerUser } from './register';
 
 export type ReadOneFunction<T extends ResourceShape<any>['prototype']> = (

--- a/test/utility/transition-engagement.ts
+++ b/test/utility/transition-engagement.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import {
   createFundingAccount,
   createLocation,
@@ -16,6 +15,7 @@ import {
   LanguageEngagement,
 } from '../../src/components/engagement';
 import { ProjectStep } from '../../src/components/project';
+import { gql } from './gql-tag';
 import {
   changeProjectStep,
   stepsFromEarlyConversationToBeforeActive,

--- a/test/utility/transition-project.ts
+++ b/test/utility/transition-project.ts
@@ -1,4 +1,3 @@
-import { gql } from 'apollo-server-core';
 import { ID } from '../../src/common';
 import {
   Project,
@@ -7,6 +6,7 @@ import {
   SecuredProjectStep,
 } from '../../src/components/project/dto';
 import { TestApp } from './create-app';
+import { gql } from './gql-tag';
 import { Raw } from './raw.type';
 
 export const stepsFromEarlyConversationToBeforeActive = [

--- a/test/utility/update-project.ts
+++ b/test/utility/update-project.ts
@@ -1,7 +1,7 @@
-import { gql } from 'apollo-server-core';
 import { UpdateProject } from '../../src/components/project';
 import { TestApp } from './create-app';
 import { fragments } from './fragments';
+import { gql } from './gql-tag';
 
 export async function updateProject(app: TestApp, input: UpdateProject) {
   const result = await app.graphql.mutate(

--- a/test/zone.e2e-spec.ts
+++ b/test/zone.e2e-spec.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { gql } from 'apollo-server-core';
 import { times } from 'lodash';
 import { isValidId } from '../src/common';
 import { FieldZone } from '../src/components/field-zone';
@@ -8,6 +7,7 @@ import {
   createPerson,
   createSession,
   createTestApp,
+  gql,
   loginAsAdmin,
   TestApp,
 } from './utility';

--- a/test/zone.e2e-spec.ts
+++ b/test/zone.e2e-spec.ts
@@ -44,7 +44,7 @@ describe('Field Zone e2e', () => {
     await createZone(app, { directorId: director.id, name });
     await expect(
       createZone(app, { directorId: director.id, name })
-    ).rejects.toThrowError();
+    ).rejects.toThrowGqlError();
   });
 
   it('read one field zone by id', async () => {


### PR DESCRIPTION
## GQL Operation Execution

Previously we were jumping halfway into the server execution skipping some src code (nest middlewares for one).
We in turn had to reimplement that code here (e.g. tracing) and had to fake context for request authorization.
It was a lot of work and it was tightly coupled to our src setup. 

Now instead of doing all that work, we call the API just like any consumer would, with a POST request to the `/graphql` endpoint. This is the majority of the logical changes in this PR and is encompassed in the [first commit](https://github.com/SeedCompany/cord-api-v3/pull/2509/commits/6b81102e3499a09b7ff11dc07d9a54aec55e3180).

Thankfully, CI reports this change doesn't impact performance. Part of the initial reasoning for the previous logic was to avoid unnecessary work to create the HTTP layer (server, requests, responses, etc). A great example of premature optimization.

## Error Assertions

Previously error handling was unique and unexpected. Nest's default error filter was used, which is never used in src, which converted the error to json kinda. But the error wasn't completely serialized to JSON, and we still had a ref to the original error so we used that when possible and also tried to undo Nest's default error filter because it didn't show errors well on the CLI.

Now that we only have the error JSON response we work with that. Which overall is much better because it's consistent with actual usage and uses our exception filter. It's also much less work.

With this being the case though we need a better way to assert these errors since we can't use src error classes anymore.
This new error assertions makes up the bulk of the diff.

I've written a custom matcher to simplify checking the error responses. Really all this does is expect that the given standard object is a subset of the actual error object.
```ts
await app.graphql.query(...).rejects.toThrowGqlError({
  code: 'NotFound',
  message: 'Did not find it',
  ...other expected props to assert
});
```
- `code` can be a `string | string[]` and asserts it's a subset of the `error.extensions.codes`
- `message` asserts it matches `error.message`
- All other props are asserted to be a subset of the `error.extensions` (We exclude `code`, `codes`, `status`, and `exception` here though as they are superfluous defaults, explicitly handled above)

I've written some helper functions to create these shapes, and fill in some defaults. Though in large part are trivial and probably an unnecessary complication.
```ts
.rejects.toThrowGqlError(errors.notFound(...));
```

It was important to keep throwing these errors and asserting them as above to not break our test utility functions.
But when calling the API directly I've got another shortcut now.
```ts
await app.graphql.query(...).expectError(errors.notFound());
```

## `gql` tag

I replaced the gql tag with our own no-op.
This is more performant as we don't needless parse to a document and back to a string.
The no-op tag still keeps syntax highlighting in IDEs.
This also decouples us from apollo server.
