### PR TITLE
Bump React to 18 & new JSX runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@nestjs/graphql": "patch:@nestjs/graphql@npm%3A10.0.22#./patches/nestjs-graphql.patch",
     "@nestjs/platform-express": "^8.4.7",
     "@patarapolw/prettyprint": "^1.0.3",
-    "@seedcompany/nestjs-email": "^2.0.5",
+    "@seedcompany/nestjs-email": "^3.0.2",
     "apollo-server-core": "^3.6.3",
     "apollo-server-express": "^3.6.3",
     "argon2": "^0.28.4",
@@ -78,6 +78,8 @@
     "p-retry": "^4.6.1",
     "pg": "^8.7.3",
     "pkg-up": "^3.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.5.4",
@@ -101,10 +103,10 @@
     "@types/jsonwebtoken": "^8.5.8",
     "@types/lodash": "^4.14.179",
     "@types/luxon": "^2.3.2",
-    "@types/mjml-react": "^2.0.3",
+    "@types/mjml-react": "^2.0.5",
     "@types/node": "^17.0.21",
     "@types/pg": "^8.6.4",
-    "@types/react": "^17.0.39",
+    "@types/react": "^18.0.17",
     "@types/stack-trace": "^0.0.29",
     "@types/triple-beam": "^1.3.2",
     "@types/validator": "^13.7.1",
@@ -125,6 +127,7 @@
   "resolutions": {
     "@angular-devkit/schematics-cli/minimist": "^1",
     "gonzales-pe/minimist": "^1.1.0",
+    "mjml-react/react-reconciler": "^0.29.0",
     "request/http-signature": "^1.3.6"
   },
   "jest": {

--- a/src/core/email/templates/base.tsx
+++ b/src/core/email/templates/base.tsx
@@ -17,11 +17,16 @@ import {
   Title,
   Wrapper,
 } from '@seedcompany/nestjs-email/templates';
-import * as React from 'react';
-import { ComponentProps, FC, ReactElement } from 'react';
+import { ComponentProps, ReactElement, ReactNode } from 'react';
 import { useFrontendUrl } from './frontend-url';
 
-export const EmailTemplate: FC<{ title: string }> = ({ title, children }) => (
+export const EmailTemplate = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) => (
   <Mjml lang="en">
     <Head>
       <Title>{`${title} - CORD Field`}</Title>
@@ -108,7 +113,7 @@ export const Branding = (): ReactElement => {
   );
 };
 
-export const Heading: FC<ComponentProps<typeof Text>> = (props) => (
+export const Heading = (props: ComponentProps<typeof Text>) => (
   <Section>
     <Column padding={0}>
       <Text fontSize={24} paddingTop={0} paddingBottom={0} {...props}>
@@ -120,7 +125,13 @@ export const Heading: FC<ComponentProps<typeof Text>> = (props) => (
   </Section>
 );
 
-export const Link: FC<{ href: string }> = ({ href, children }) => (
+export const Link = ({
+  href,
+  children,
+}: {
+  href: string;
+  children?: ReactNode;
+}) => (
   <Text>
     <a href={href} style={{ wordBreak: 'break-all' }}>
       {children || href}

--- a/src/core/email/templates/forgot-password.template.tsx
+++ b/src/core/email/templates/forgot-password.template.tsx
@@ -6,7 +6,6 @@ import {
   Section,
   Text,
 } from '@seedcompany/nestjs-email/templates';
-import * as React from 'react';
 import { EmailTemplate, Heading, Link, ReplyInfoFooter } from './base';
 import { useFrontendUrl } from './frontend-url';
 

--- a/src/core/email/templates/frontend-url.tsx
+++ b/src/core/email/templates/frontend-url.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { createContext, ReactElement, useContext } from 'react';
 import { ServerException } from '../../../common/exceptions';
 

--- a/src/core/email/templates/project-step-changed.template.tsx
+++ b/src/core/email/templates/project-step-changed.template.tsx
@@ -7,7 +7,6 @@ import {
 } from '@seedcompany/nestjs-email/templates';
 import { startCase } from 'lodash';
 import { DateTime } from 'luxon';
-import * as React from 'react';
 import { EmailNotification as StepChangeNotification } from '../../../components/project';
 import { fullName } from '../../../components/user';
 import { EmailTemplate, Heading } from './base';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "lib": ["ES2020"],
     "target": "es2019",
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,13 +185,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/abort-controller@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/abort-controller@npm:3.40.0"
+"@aws-sdk/abort-controller@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/abort-controller@npm:3.160.0"
   dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: bdfe98a1ddc7bd59a4c7264fe06f718ef348ee636bb74c3b8b3bd3bb2a9118f5d6a26c503aacdf555e741f6ec2c8abc2198351d7c0d7b0fae4aab042a7859393
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 6ea2d7ab2daa40f252d4aa5178b30536f2c3fcf4ba30e03025df50350b52388bf343e870d5581d44e0af52933906f3b9f57c05d63eb379621825d53752b19c6d
   languageName: node
   linkType: hard
 
@@ -284,78 +284,84 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sesv2@npm:^3.45.0":
-  version: 3.45.0
-  resolution: "@aws-sdk/client-sesv2@npm:3.45.0"
+"@aws-sdk/client-sesv2@npm:^3.154.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/client-sesv2@npm:3.160.0"
   dependencies:
     "@aws-crypto/sha256-browser": 2.0.0
     "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/client-sts": 3.45.0
-    "@aws-sdk/config-resolver": 3.45.0
-    "@aws-sdk/credential-provider-node": 3.45.0
-    "@aws-sdk/fetch-http-handler": 3.40.0
-    "@aws-sdk/hash-node": 3.40.0
-    "@aws-sdk/invalid-dependency": 3.40.0
-    "@aws-sdk/middleware-content-length": 3.40.0
-    "@aws-sdk/middleware-host-header": 3.40.0
-    "@aws-sdk/middleware-logger": 3.40.0
-    "@aws-sdk/middleware-retry": 3.40.0
-    "@aws-sdk/middleware-serde": 3.40.0
-    "@aws-sdk/middleware-signing": 3.45.0
-    "@aws-sdk/middleware-stack": 3.40.0
-    "@aws-sdk/middleware-user-agent": 3.40.0
-    "@aws-sdk/node-config-provider": 3.40.0
-    "@aws-sdk/node-http-handler": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/smithy-client": 3.41.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/url-parser": 3.40.0
-    "@aws-sdk/util-base64-browser": 3.37.0
-    "@aws-sdk/util-base64-node": 3.37.0
-    "@aws-sdk/util-body-length-browser": 3.37.0
-    "@aws-sdk/util-body-length-node": 3.37.0
-    "@aws-sdk/util-user-agent-browser": 3.40.0
-    "@aws-sdk/util-user-agent-node": 3.40.0
-    "@aws-sdk/util-utf8-browser": 3.37.0
-    "@aws-sdk/util-utf8-node": 3.37.0
-    tslib: ^2.3.0
-  checksum: dbf5619c2e302fdf0011cbaa98d4b9e5fbf26fec0d3c4d54d4672765ee9bf9e4bf94e826f39418b8521fcbcc9abb766749b9eb275632f6fdd482bd43f9216e9e
+    "@aws-sdk/client-sts": 3.160.0
+    "@aws-sdk/config-resolver": 3.160.0
+    "@aws-sdk/credential-provider-node": 3.160.0
+    "@aws-sdk/fetch-http-handler": 3.160.0
+    "@aws-sdk/hash-node": 3.160.0
+    "@aws-sdk/invalid-dependency": 3.160.0
+    "@aws-sdk/middleware-content-length": 3.160.0
+    "@aws-sdk/middleware-host-header": 3.160.0
+    "@aws-sdk/middleware-logger": 3.160.0
+    "@aws-sdk/middleware-recursion-detection": 3.160.0
+    "@aws-sdk/middleware-retry": 3.160.0
+    "@aws-sdk/middleware-serde": 3.160.0
+    "@aws-sdk/middleware-signing": 3.160.0
+    "@aws-sdk/middleware-stack": 3.160.0
+    "@aws-sdk/middleware-user-agent": 3.160.0
+    "@aws-sdk/node-config-provider": 3.160.0
+    "@aws-sdk/node-http-handler": 3.160.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/smithy-client": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/url-parser": 3.160.0
+    "@aws-sdk/util-base64-browser": 3.109.0
+    "@aws-sdk/util-base64-node": 3.55.0
+    "@aws-sdk/util-body-length-browser": 3.154.0
+    "@aws-sdk/util-body-length-node": 3.55.0
+    "@aws-sdk/util-defaults-mode-browser": 3.160.0
+    "@aws-sdk/util-defaults-mode-node": 3.160.0
+    "@aws-sdk/util-user-agent-browser": 3.160.0
+    "@aws-sdk/util-user-agent-node": 3.160.0
+    "@aws-sdk/util-utf8-browser": 3.109.0
+    "@aws-sdk/util-utf8-node": 3.109.0
+    tslib: ^2.3.1
+  checksum: 979dad1771a668cbaa0cc4a3f3340f70c9211eaff32864356a2e55d65428fb917e01638e73525950b89fffbec6c0f53436fc9d98f3d3660d4f0ced53bcc4022b
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.45.0":
-  version: 3.45.0
-  resolution: "@aws-sdk/client-sso@npm:3.45.0"
+"@aws-sdk/client-sso@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/client-sso@npm:3.160.0"
   dependencies:
     "@aws-crypto/sha256-browser": 2.0.0
     "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/config-resolver": 3.45.0
-    "@aws-sdk/fetch-http-handler": 3.40.0
-    "@aws-sdk/hash-node": 3.40.0
-    "@aws-sdk/invalid-dependency": 3.40.0
-    "@aws-sdk/middleware-content-length": 3.40.0
-    "@aws-sdk/middleware-host-header": 3.40.0
-    "@aws-sdk/middleware-logger": 3.40.0
-    "@aws-sdk/middleware-retry": 3.40.0
-    "@aws-sdk/middleware-serde": 3.40.0
-    "@aws-sdk/middleware-stack": 3.40.0
-    "@aws-sdk/middleware-user-agent": 3.40.0
-    "@aws-sdk/node-config-provider": 3.40.0
-    "@aws-sdk/node-http-handler": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/smithy-client": 3.41.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/url-parser": 3.40.0
-    "@aws-sdk/util-base64-browser": 3.37.0
-    "@aws-sdk/util-base64-node": 3.37.0
-    "@aws-sdk/util-body-length-browser": 3.37.0
-    "@aws-sdk/util-body-length-node": 3.37.0
-    "@aws-sdk/util-user-agent-browser": 3.40.0
-    "@aws-sdk/util-user-agent-node": 3.40.0
-    "@aws-sdk/util-utf8-browser": 3.37.0
-    "@aws-sdk/util-utf8-node": 3.37.0
-    tslib: ^2.3.0
-  checksum: 534c571c57a8f4f7b2a9cf0e4c5b95a238ab254d3ca79c70350a2d5fb08b30b0f939387d2f7053dab5a1967d0b0b761bc2f246082630ca887841c6fa6586c722
+    "@aws-sdk/config-resolver": 3.160.0
+    "@aws-sdk/fetch-http-handler": 3.160.0
+    "@aws-sdk/hash-node": 3.160.0
+    "@aws-sdk/invalid-dependency": 3.160.0
+    "@aws-sdk/middleware-content-length": 3.160.0
+    "@aws-sdk/middleware-host-header": 3.160.0
+    "@aws-sdk/middleware-logger": 3.160.0
+    "@aws-sdk/middleware-recursion-detection": 3.160.0
+    "@aws-sdk/middleware-retry": 3.160.0
+    "@aws-sdk/middleware-serde": 3.160.0
+    "@aws-sdk/middleware-stack": 3.160.0
+    "@aws-sdk/middleware-user-agent": 3.160.0
+    "@aws-sdk/node-config-provider": 3.160.0
+    "@aws-sdk/node-http-handler": 3.160.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/smithy-client": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/url-parser": 3.160.0
+    "@aws-sdk/util-base64-browser": 3.109.0
+    "@aws-sdk/util-base64-node": 3.55.0
+    "@aws-sdk/util-body-length-browser": 3.154.0
+    "@aws-sdk/util-body-length-node": 3.55.0
+    "@aws-sdk/util-defaults-mode-browser": 3.160.0
+    "@aws-sdk/util-defaults-mode-node": 3.160.0
+    "@aws-sdk/util-user-agent-browser": 3.160.0
+    "@aws-sdk/util-user-agent-node": 3.160.0
+    "@aws-sdk/util-utf8-browser": 3.109.0
+    "@aws-sdk/util-utf8-node": 3.109.0
+    tslib: ^2.3.1
+  checksum: 9a221578c2961d7d6f943b5faa25b0f28bffe8918c88cd7374f6000d2a4d936eec2ea23ad3b52ecf94e695e33152d1721a93434b7ef47876454ce04345114161
   languageName: node
   linkType: hard
 
@@ -397,44 +403,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sts@npm:3.45.0":
-  version: 3.45.0
-  resolution: "@aws-sdk/client-sts@npm:3.45.0"
+"@aws-sdk/client-sts@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/client-sts@npm:3.160.0"
   dependencies:
     "@aws-crypto/sha256-browser": 2.0.0
     "@aws-crypto/sha256-js": 2.0.0
-    "@aws-sdk/config-resolver": 3.45.0
-    "@aws-sdk/credential-provider-node": 3.45.0
-    "@aws-sdk/fetch-http-handler": 3.40.0
-    "@aws-sdk/hash-node": 3.40.0
-    "@aws-sdk/invalid-dependency": 3.40.0
-    "@aws-sdk/middleware-content-length": 3.40.0
-    "@aws-sdk/middleware-host-header": 3.40.0
-    "@aws-sdk/middleware-logger": 3.40.0
-    "@aws-sdk/middleware-retry": 3.40.0
-    "@aws-sdk/middleware-sdk-sts": 3.45.0
-    "@aws-sdk/middleware-serde": 3.40.0
-    "@aws-sdk/middleware-signing": 3.45.0
-    "@aws-sdk/middleware-stack": 3.40.0
-    "@aws-sdk/middleware-user-agent": 3.40.0
-    "@aws-sdk/node-config-provider": 3.40.0
-    "@aws-sdk/node-http-handler": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/smithy-client": 3.41.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/url-parser": 3.40.0
-    "@aws-sdk/util-base64-browser": 3.37.0
-    "@aws-sdk/util-base64-node": 3.37.0
-    "@aws-sdk/util-body-length-browser": 3.37.0
-    "@aws-sdk/util-body-length-node": 3.37.0
-    "@aws-sdk/util-user-agent-browser": 3.40.0
-    "@aws-sdk/util-user-agent-node": 3.40.0
-    "@aws-sdk/util-utf8-browser": 3.37.0
-    "@aws-sdk/util-utf8-node": 3.37.0
+    "@aws-sdk/config-resolver": 3.160.0
+    "@aws-sdk/credential-provider-node": 3.160.0
+    "@aws-sdk/fetch-http-handler": 3.160.0
+    "@aws-sdk/hash-node": 3.160.0
+    "@aws-sdk/invalid-dependency": 3.160.0
+    "@aws-sdk/middleware-content-length": 3.160.0
+    "@aws-sdk/middleware-host-header": 3.160.0
+    "@aws-sdk/middleware-logger": 3.160.0
+    "@aws-sdk/middleware-recursion-detection": 3.160.0
+    "@aws-sdk/middleware-retry": 3.160.0
+    "@aws-sdk/middleware-sdk-sts": 3.160.0
+    "@aws-sdk/middleware-serde": 3.160.0
+    "@aws-sdk/middleware-signing": 3.160.0
+    "@aws-sdk/middleware-stack": 3.160.0
+    "@aws-sdk/middleware-user-agent": 3.160.0
+    "@aws-sdk/node-config-provider": 3.160.0
+    "@aws-sdk/node-http-handler": 3.160.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/smithy-client": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/url-parser": 3.160.0
+    "@aws-sdk/util-base64-browser": 3.109.0
+    "@aws-sdk/util-base64-node": 3.55.0
+    "@aws-sdk/util-body-length-browser": 3.154.0
+    "@aws-sdk/util-body-length-node": 3.55.0
+    "@aws-sdk/util-defaults-mode-browser": 3.160.0
+    "@aws-sdk/util-defaults-mode-node": 3.160.0
+    "@aws-sdk/util-user-agent-browser": 3.160.0
+    "@aws-sdk/util-user-agent-node": 3.160.0
+    "@aws-sdk/util-utf8-browser": 3.109.0
+    "@aws-sdk/util-utf8-node": 3.109.0
     entities: 2.2.0
     fast-xml-parser: 3.19.0
-    tslib: ^2.3.0
-  checksum: aece21b95bda9983c5520ae8416d3bb777115ddf212b11a9dfa20ee943928ee28632a3a282d9e34a1efd6e2ad6c185744faadd72ae4638a09615ba20540b3d78
+    tslib: ^2.3.1
+  checksum: c54ab80fe384c2b2fccb8effed5ad1f78b77beb5073459204564401690fd60c6502bfe977ec35096ac285b751cb5e664d7974972a61fb855e8bf631320d08906
   languageName: node
   linkType: hard
 
@@ -481,15 +490,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/config-resolver@npm:3.45.0":
-  version: 3.45.0
-  resolution: "@aws-sdk/config-resolver@npm:3.45.0"
+"@aws-sdk/config-resolver@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/config-resolver@npm:3.160.0"
   dependencies:
-    "@aws-sdk/signature-v4": 3.45.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-config-provider": 3.40.0
-    tslib: ^2.3.0
-  checksum: 8463cd13c516b076a1352a7df1718e0eb1d2b30cb3bb38199e7883e9a5ff61138b36b6d01c8887c35f7da802e24b9792403a55175aa72dfe48cfdcf21b2c663a
+    "@aws-sdk/signature-v4": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-config-provider": 3.109.0
+    "@aws-sdk/util-middleware": 3.160.0
+    tslib: ^2.3.1
+  checksum: a707723eca6df17ff051b7bfdb47498febac2075c3cea8b7136b9c2987c210a5b8d119f57e5ef20341a6b2021a8f04681f981a7755ee48d35cef02cb2b51562a
   languageName: node
   linkType: hard
 
@@ -506,14 +516,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.40.0"
+"@aws-sdk/credential-provider-env@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.160.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 82b667752d0cfaf78c1f40f952a8027e626cc0ed6bbe1686501c76179e99289563c63bbd4809d66c4a3ee5d26ebccb790338f122c81ff22c3c6cc909bcaa1d8b
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 2ef83c94033db48a89e2353ae7309f1c7e14b86bf5723b1b2309fca278ad1507447e39a100e9a3c8a90cc0530ca3b295a922773d84d7bcefb399f117715bc50e
   languageName: node
   linkType: hard
 
@@ -528,16 +538,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-imds@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/credential-provider-imds@npm:3.40.0"
+"@aws-sdk/credential-provider-imds@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/credential-provider-imds@npm:3.160.0"
   dependencies:
-    "@aws-sdk/node-config-provider": 3.40.0
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/url-parser": 3.40.0
-    tslib: ^2.3.0
-  checksum: c6b7ab2437533debc7579f45a397c6ed44d660c071a99e24b965b74464b6ef916a05b9854b32384cbab40005cecc55669e285ad00193289beca2e21dca76f32a
+    "@aws-sdk/node-config-provider": 3.160.0
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/url-parser": 3.160.0
+    tslib: ^2.3.1
+  checksum: 1227a85e1fede3cd65168e567c300e9d3e6a89578fe12c2e9d7ea734310fe9cc9cecb766b2e6770bbb784f573d450d0123d764b21922ed80ba6d96df49b29ebc
   languageName: node
   linkType: hard
 
@@ -554,20 +564,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.45.0":
-  version: 3.45.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.45.0"
+"@aws-sdk/credential-provider-ini@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.160.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.40.0
-    "@aws-sdk/credential-provider-imds": 3.40.0
-    "@aws-sdk/credential-provider-sso": 3.45.0
-    "@aws-sdk/credential-provider-web-identity": 3.41.0
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-credentials": 3.37.0
-    tslib: ^2.3.0
-  checksum: 5614697dd59cda66c50206cc137ce9f4f19af3b46c2564b0f7f4e1e0dc57c4983187fcb21b1d7cb3e075da2d6394f883d3a8c07d40214b045dd5dbb9ef3c8e01
+    "@aws-sdk/credential-provider-env": 3.160.0
+    "@aws-sdk/credential-provider-imds": 3.160.0
+    "@aws-sdk/credential-provider-sso": 3.160.0
+    "@aws-sdk/credential-provider-web-identity": 3.160.0
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/shared-ini-file-loader": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 9d71b4ea2313650401449eebf788c2e6ad1fde666f8d1ea5fc92cd3a6c9606b234e87fc51e6351495a3cd371980e4be77c1df9c6311473865bf7a136c2ee22e1
   languageName: node
   linkType: hard
 
@@ -587,22 +596,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.45.0":
-  version: 3.45.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.45.0"
+"@aws-sdk/credential-provider-node@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.160.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": 3.40.0
-    "@aws-sdk/credential-provider-imds": 3.40.0
-    "@aws-sdk/credential-provider-ini": 3.45.0
-    "@aws-sdk/credential-provider-process": 3.40.0
-    "@aws-sdk/credential-provider-sso": 3.45.0
-    "@aws-sdk/credential-provider-web-identity": 3.41.0
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-credentials": 3.37.0
-    tslib: ^2.3.0
-  checksum: 337b8b6e8a85a3a5aa62580062c08a88c82b387c4db05852a3a1982a020d6db0f4d60a08dcddcb814e4c8d8341f17a8851fff1a466b24a687281cbbcb3f5ff0e
+    "@aws-sdk/credential-provider-env": 3.160.0
+    "@aws-sdk/credential-provider-imds": 3.160.0
+    "@aws-sdk/credential-provider-ini": 3.160.0
+    "@aws-sdk/credential-provider-process": 3.160.0
+    "@aws-sdk/credential-provider-sso": 3.160.0
+    "@aws-sdk/credential-provider-web-identity": 3.160.0
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/shared-ini-file-loader": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: c7cce22022bddcc2d19a503a786e3ae1446a366ae59b1eac16f2753c403726ee7228f034b0502e052f6950f780a9604246e4355e5eaa182752f5932225d5108c
   languageName: node
   linkType: hard
 
@@ -624,16 +632,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.40.0"
+"@aws-sdk/credential-provider-process@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.160.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-credentials": 3.37.0
-    tslib: ^2.3.0
-  checksum: 7d1c4200c36cce5efa20cd25f70a15701232b3380ff49f2c3821367c95d9edb28c39e88812359877b517901b4328997440002af75abc9fb320b0a1c81f2b90d3
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/shared-ini-file-loader": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 2157f4eb335f63b9f837775ee28ae755a4d2cca268e3ed29efcb0d59b14e9a428355afc290643a1a5b4c81a8ca1296e7efab912fb4bcd21cb157608b10a1153a
   languageName: node
   linkType: hard
 
@@ -649,17 +656,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.45.0":
-  version: 3.45.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.45.0"
+"@aws-sdk/credential-provider-sso@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.160.0"
   dependencies:
-    "@aws-sdk/client-sso": 3.45.0
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-credentials": 3.37.0
-    tslib: ^2.3.0
-  checksum: 1176f3ca1fb30ec711d6820ebdd90523b056cf74cdb2679a18bc0bb8e0b7f24cfdfa18ed62bd168214f8e3b914c646ca951fcbad68eb44df008aa55748936af7
+    "@aws-sdk/client-sso": 3.160.0
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/shared-ini-file-loader": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 491e70e7d2e2fb1505bbd81f1f2fb33ef8661c0125b546247f83f4ed361400c1c89a4a22e7f5dc18572b87026324bef7fab58d0d652a597cf502ce990e3a3554
   languageName: node
   linkType: hard
 
@@ -676,14 +682,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:3.41.0":
-  version: 3.41.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.41.0"
+"@aws-sdk/credential-provider-web-identity@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.160.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: f75e9cff6dfc1f9191b5256c6e89ad19e49d2eb45a30bb51f6db09748435322e4d1d38d9ba763b5f2e31693308d9c07eb5cb961fc484af5c2fff474f85ac5e72
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: ef6b12cf7936649277b8d89539c633ae0c3dcba9a1f4b2a8955d1a81a1ca32761f6f85933b14defa335ec7bf6f9eeba0782966bd0b7fcbc303bcc52013da5e78
   languageName: node
   linkType: hard
 
@@ -755,16 +761,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/fetch-http-handler@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/fetch-http-handler@npm:3.40.0"
+"@aws-sdk/fetch-http-handler@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/fetch-http-handler@npm:3.160.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/querystring-builder": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-base64-browser": 3.37.0
-    tslib: ^2.3.0
-  checksum: 3b7a9067469bea360705ce6a81e71fc196810352a98afde98a80613717894c3db5aa53d6dc3f7cead42a5a31b4b85007838506ad4749de1667eeb301e5d4902b
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/querystring-builder": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-base64-browser": 3.109.0
+    tslib: ^2.3.1
+  checksum: 14b509317b6881d87854b7417e1cbb3645d5745d08e1600c6107963946f669394047c4d41dd829fdaf6b5a843415817419e29b7c67643fc195c1390f4c3f26d3
   languageName: node
   linkType: hard
 
@@ -793,14 +799,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/hash-node@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/hash-node@npm:3.40.0"
+"@aws-sdk/hash-node@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/hash-node@npm:3.160.0"
   dependencies:
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-buffer-from": 3.37.0
-    tslib: ^2.3.0
-  checksum: 61a1e4d715af1122700697af8b30af38398d65fcb85fb2d81f3b3ab0205e89758b034e01952c53fd23c5396698c1026dab971977234303d473dceaed230004ca
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-buffer-from": 3.55.0
+    tslib: ^2.3.1
+  checksum: 5384b46e33d0685aa0957bcb68729e3537b6b6adbc87b6c3facd50ecc40313d90c76145e46bfbdc702cc5aa209b6d5405f2789017646ff0fa74ef182400edbef
   languageName: node
   linkType: hard
 
@@ -825,13 +831,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/invalid-dependency@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/invalid-dependency@npm:3.40.0"
+"@aws-sdk/invalid-dependency@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/invalid-dependency@npm:3.160.0"
   dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 04063f664403695507bc480f132b09d2f907f411b01e7d52a7a01cb39304548a4d13a3d0d596e7063ed23cd8eb5ae32ca50e60cca32443bd8361bac8cd3992b5
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 499b9a20094f0e16510aa9f07aaa2d4515f0a63214ec7a9b6abcafb021d26f14464b99faf392a03150ebb8cf5fdedafbcb78d42d43f1f1eeb989ccc10d155b43
   languageName: node
   linkType: hard
 
@@ -842,15 +848,6 @@ __metadata:
     "@aws-sdk/types": 3.55.0
     tslib: ^2.3.1
   checksum: 1a257fa9c005cf0ce9e6abf18a9137f23d59fbe98ec28fd05bdec519c7fbeb0319b50396d1383d89e651247dd7ab98e0c217813517ae6e3e5441a5014bb8d3c9
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/is-array-buffer@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/is-array-buffer@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 5042f7629699448447f6c19733be476c937ca8896fc8958849664f3255198ee90b905794bf224d2f77d54c953ff726babcc1eb457a9817eb44171f6dcfbc7a2c
   languageName: node
   linkType: hard
 
@@ -888,14 +885,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-content-length@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-content-length@npm:3.40.0"
+"@aws-sdk/middleware-content-length@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-content-length@npm:3.160.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: bf5a485100e8123f45e4771895d0ede5ba37a89b4d47021f21c880089adabc0ffe35f71e74adc7f21c00c0bf7fd7b47c6050c627f617a1e4133c70243cb812c5
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 9160b44ced03c7f95da2461b88bfb219147245cea5739c84c377e01711329b7ad4aacda0ae2f9f947efad55fe419a4990d6dd8552ae4d5d84f93d368fd7ba76f
   languageName: node
   linkType: hard
 
@@ -947,14 +944,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-host-header@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-host-header@npm:3.40.0"
+"@aws-sdk/middleware-host-header@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.160.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: b2b292c60c930835a95ade5df00a2064002e47e51f757536f7a2e32c1535b6e0d754e5082113229eff503d9c2b77c36b1b987705b640ec6e95eafa5dbf4d4eeb
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 9be84716aa20f6ccb57fbfc3c3b1e39fa5c3335624050a7012d800e92420b997f3d5cf44bfb6536cab13f473a3c3acdc16340314943bb2eb004867849acc26b4
   languageName: node
   linkType: hard
 
@@ -979,13 +976,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-logger@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-logger@npm:3.40.0"
+"@aws-sdk/middleware-logger@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.160.0"
   dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 18a2eb55eeffb70e82850d679c699d458d423f176c9b9d61b536f81f99d36fc5c59b64665e2f8a6f526f7efdc7262bf7861ea4a6594604724157f58e347ecad2
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 20f6e732651377946520cc0a9141d08876d0f710635f05be5afd82a42751c4d63b20088dff0fae3ab38f3e7b9b26eec55b1548c94edb19a4223a7cee5e75de52
   languageName: node
   linkType: hard
 
@@ -999,16 +996,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-retry@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-retry@npm:3.40.0"
+"@aws-sdk/middleware-recursion-detection@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.160.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/service-error-classification": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 7b162d36a10d4a28b41ac47dbb2bacbfa0900f9762e9ed1728a0965ed9ad176ef6dc4914098c01a19b547157355486a11a6d1be91455054baf1fcf234a4b3e05
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-retry@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-retry@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/service-error-classification": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-middleware": 3.160.0
+    tslib: ^2.3.1
     uuid: ^8.3.2
-  checksum: b5e676170bb0b6bbd39ac9557ca10cddfacba4154144c68307e138a7c60dc76a08325ac626e5eeecaaf94e6020e1a86e1cc9fdeec9c8a907c7fa8f9c87b2f164
+  checksum: 5927a238e104d59b5b15a38256ef5e4e4d9ae10b1d0cef1f471bcc7505802045e44de375672b8dd0326cc1b18bf4bc7cb9290e9cc4a2a5eb344a78a87d04c7a2
   languageName: node
   linkType: hard
 
@@ -1044,17 +1053,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-sts@npm:3.45.0":
-  version: 3.45.0
-  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.45.0"
+"@aws-sdk/middleware-sdk-sts@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.160.0"
   dependencies:
-    "@aws-sdk/middleware-signing": 3.45.0
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/signature-v4": 3.45.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 96e65d3680f27fe2944e29871224879a157b3a85c37ccdcb0ec3cb13e8c94e0ea37c2c3849371643b037a9eb23f0a63d15d3ec642f581c0d2ef66429f830329f
+    "@aws-sdk/middleware-signing": 3.160.0
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/signature-v4": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 53ad369ee80cba579896ed73793b0ecf40679cf264fdbec966036dd213cf0fbf92a2ce8195eb83241b3dad79338b775eaee886bfac309ef8934a4814670ee718
   languageName: node
   linkType: hard
 
@@ -1072,13 +1081,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-serde@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-serde@npm:3.40.0"
+"@aws-sdk/middleware-serde@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-serde@npm:3.160.0"
   dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 107240744c5cc2e57d0c7811657cc917e9da225402c446375f13f13495888c3e1f24526cb6a092c8fa09f9ed3c5fe2b6ff192ba3661416f1db34029276bfca63
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 9daeddc2951d86f5fc3a22fb7b21db48cd8da28322967fda7bbddaf53535ae9b7a2330ce00418b1e20612ea7dfa3add2941465d854478fbb3ff5d628e481178a
   languageName: node
   linkType: hard
 
@@ -1092,16 +1101,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-signing@npm:3.45.0":
-  version: 3.45.0
-  resolution: "@aws-sdk/middleware-signing@npm:3.45.0"
+"@aws-sdk/middleware-signing@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.160.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/signature-v4": 3.45.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 63b2f1a48331b8375ec4b1970c9efc4d2285c3ac4ca5b33b3368dd6936c8793ce98e53f3c9277e9bf7f42fa5432bf2afed423e51c86698556431445cd923df5c
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/signature-v4": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 2a29454f0ee3410ede0c3a75dc77bb3f329031648b84df8439f5a229e0efee388e8efdb587264f48a02e6ae861c509bc8d5df487a976a4a2fd729c50c2e86164
   languageName: node
   linkType: hard
 
@@ -1128,12 +1137,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-stack@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-stack@npm:3.40.0"
+"@aws-sdk/middleware-stack@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-stack@npm:3.160.0"
   dependencies:
-    tslib: ^2.3.0
-  checksum: 7edf1ae49c938647aac6f0f35267ec3c40584e0a5d36f1e366b0c5d7d830cfd6b5a91de1047b5a47e8603a7f780b2aba2af0bcf1c8e5c528dea2c0e442c90116
+    tslib: ^2.3.1
+  checksum: 37342fc5e98f8149575049eab8c4254f786cf6ff2f45eb9d0a96916814932a9f6dce4710ba23a8cb2c566f138230f376dfcd9dae50edc2b4427c44ee6156048d
   languageName: node
   linkType: hard
 
@@ -1146,14 +1155,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.40.0"
+"@aws-sdk/middleware-user-agent@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.160.0"
   dependencies:
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: d3333379810042c7497fe53374f2fb6203c0fd83706fc1fffb6da0267445957f559f81df110628968b01de6c9131335142af8e809d0dd060866c7b9531505355
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: bba8ab69cc3088646b1a137f7b69b886b77cdd17d79e33922648fde29d9aadca08b23be305c6af4029cbc5b9b4cad35f4b3c939b591a7f9c40709a19816aee2a
   languageName: node
   linkType: hard
 
@@ -1168,15 +1177,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/node-config-provider@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/node-config-provider@npm:3.40.0"
+"@aws-sdk/node-config-provider@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/node-config-provider@npm:3.160.0"
   dependencies:
-    "@aws-sdk/property-provider": 3.40.0
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: d52bbea34daaa26df431fc6ad28ce6f80a361e1af88fc4b6fbfeda08b5682d28295c43df40c6d1e11d4344f31b12a65539a05618e14e0dbb4f8beee725fb3727
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/shared-ini-file-loader": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: f81c7d291f4e56c2232a5e37c7a090385be05e26a77e3b96ace410eff497df3993cda4ebed456420088b7fc90bf393cc36769b971fb92dcf12f98d5949259729
   languageName: node
   linkType: hard
 
@@ -1192,16 +1201,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/node-http-handler@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/node-http-handler@npm:3.40.0"
+"@aws-sdk/node-http-handler@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/node-http-handler@npm:3.160.0"
   dependencies:
-    "@aws-sdk/abort-controller": 3.40.0
-    "@aws-sdk/protocol-http": 3.40.0
-    "@aws-sdk/querystring-builder": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 3a349f80fe4c70ca013d95003da111d1fbea8fdff59abb65dfa2e173bd7bbf099237a22de441b0467656ecda8669c23d8ca3bcdb7735a24f421d3088b56e44c9
+    "@aws-sdk/abort-controller": 3.160.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/querystring-builder": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 5defd4da366205b29f696348a40b170e32d3893da8000459ef8748daa27834d931c0f729d53c74ed10cd8585318533daa02c9eacf9e918f16f8b15f8fb4d387c
   languageName: node
   linkType: hard
 
@@ -1218,13 +1227,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/property-provider@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/property-provider@npm:3.40.0"
+"@aws-sdk/property-provider@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/property-provider@npm:3.160.0"
   dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 8f8adb8ed1c06155d18deacf2cfd192f4ceaa6d742c1566e72bd0cb2e348d3e37cdd32b41607317a3651377a82da516382ded1d15361f4d819f3ac9bfdaed523
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 6eafa3e4867b40a018be0f8de7ad37eb0c7707260695734578353a7cfc1429df448b794aa89fb47d582f59650bd560e124016c43f9c72843779e2a66aa2c31a9
   languageName: node
   linkType: hard
 
@@ -1238,13 +1247,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/protocol-http@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/protocol-http@npm:3.40.0"
+"@aws-sdk/protocol-http@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/protocol-http@npm:3.160.0"
   dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 238f9a26ee28455ce3920c2b59f05869c7728dfd4420d45d93b32575584cc9e08dbe1cb7d04d0bd30747f59bce2ab469212b330185f0919bf6db564ffbfbfefa
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 572cd4bb9e78c95d5dba3a4714c2b54607eebefd1c6deb9b5f0efd12b474c4bb0444b03adfe150a8ff94e3fd82e5c978b7116664e2694114c5a46978f7362b24
   languageName: node
   linkType: hard
 
@@ -1258,14 +1267,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/querystring-builder@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/querystring-builder@npm:3.40.0"
+"@aws-sdk/querystring-builder@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/querystring-builder@npm:3.160.0"
   dependencies:
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-uri-escape": 3.37.0
-    tslib: ^2.3.0
-  checksum: 63a957597e40a6e99cbb0509fb095174897ad2db50fe415d634caa3aed18748eb8e1522a6ff7d737c09bb8ba6c6108a18a1c1096261dc362fccb6028a533ab80
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-uri-escape": 3.55.0
+    tslib: ^2.3.1
+  checksum: 94a008fbc4464de3e7b9d0c4e0562f6ef07064ba2a515c0051b7b54f3633a33887fb36b3382acbd7f20731f25c69d29deaefa9b8778b8b713d524ecc95f93f8c
   languageName: node
   linkType: hard
 
@@ -1280,13 +1289,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/querystring-parser@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/querystring-parser@npm:3.40.0"
+"@aws-sdk/querystring-parser@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/querystring-parser@npm:3.160.0"
   dependencies:
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 48887361713108915b4828acc2d5ca2fc4d52dff0d9d84bba610ea71c13bbb8b8f54efd163e73177c29ee618980d43874373ab90ae0b618d86dbd67186c11c21
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: c5d8e5e965c26d2f8c701b98f3d797bba492683be0438fd358a25605914ad714b52aa108c9069cd34d2f25e96b17fc4ba3cd773e73a4fb8e904073f5dc59a6e3
   languageName: node
   linkType: hard
 
@@ -1316,26 +1325,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/service-error-classification@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/service-error-classification@npm:3.40.0"
-  checksum: 09db448bc49773bebe37128b6cb1adf2dc3d0c1a3daedfb947dd20bd7b7ad79e49dbb0d3e89bba7022a02b6400cb3e10e521c9170318232988fb9b46f31f6335
+"@aws-sdk/service-error-classification@npm:3.160.0, @aws-sdk/service-error-classification@npm:^3.4.1":
+  version: 3.160.0
+  resolution: "@aws-sdk/service-error-classification@npm:3.160.0"
+  checksum: c459f532a814da7cb40d41fce0dc3cdacff0e0ced3d23ac045a934f99a23db7fdfe3a566611ec483c26eb6baaaaf1d7126e2d58fb84596d197aee378f91cc4b0
   languageName: node
   linkType: hard
 
-"@aws-sdk/service-error-classification@npm:3.55.0, @aws-sdk/service-error-classification@npm:^3.4.1":
+"@aws-sdk/service-error-classification@npm:3.55.0":
   version: 3.55.0
   resolution: "@aws-sdk/service-error-classification@npm:3.55.0"
   checksum: 9bf676820ffcd326d75aa551b6c67bea6ad26e32b431d6e781d5a8217ed8b35ce7c09b4ab0599b2eb43e0b727d31e880418c08e2e06fa55a83e1d7528173e741
   languageName: node
   linkType: hard
 
-"@aws-sdk/shared-ini-file-loader@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.37.0"
+"@aws-sdk/shared-ini-file-loader@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.160.0"
   dependencies:
-    tslib: ^2.3.0
-  checksum: dea398c739c192d7e9b0542faa5b84d1267dde67ff5576bb8b6709ba5de9039dc8afb9e22104bf88b1b9a67526bde5f0911154dfbe380010eecdaea977e0be00
+    tslib: ^2.3.1
+  checksum: 7b78d2d8b743e03c06a8a3281c15002df9b043de0a8c99b0bcaca2113f6d56166b5121b535e656833f1dfd45fcfea23e86575aebfad612c869b3e1f81764b8e3
   languageName: node
   linkType: hard
 
@@ -1348,16 +1357,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4@npm:3.45.0":
-  version: 3.45.0
-  resolution: "@aws-sdk/signature-v4@npm:3.45.0"
+"@aws-sdk/signature-v4@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/signature-v4@npm:3.160.0"
   dependencies:
-    "@aws-sdk/is-array-buffer": 3.37.0
-    "@aws-sdk/types": 3.40.0
-    "@aws-sdk/util-hex-encoding": 3.37.0
-    "@aws-sdk/util-uri-escape": 3.37.0
-    tslib: ^2.3.0
-  checksum: aa0d3f3c24a644fd8025ce4ad9392f82e4e2d2e8a1c025a990596578bc10df2f9c350fac4d103c584e3dc1798d97710b3955615ac484c14033ef01ce1e5dbc81
+    "@aws-sdk/is-array-buffer": 3.55.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-hex-encoding": 3.109.0
+    "@aws-sdk/util-middleware": 3.160.0
+    "@aws-sdk/util-uri-escape": 3.55.0
+    tslib: ^2.3.1
+  checksum: dabbbaa5e9ea51c58c62da0d4cc2de7cae1458b717501a444d17b45c10322c132fb2ab8bb8a322c4ce8a192ce0433901f58dc9a57380d1e5a152cd5c0cec9d0f
   languageName: node
   linkType: hard
 
@@ -1375,14 +1385,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/smithy-client@npm:3.41.0":
-  version: 3.41.0
-  resolution: "@aws-sdk/smithy-client@npm:3.41.0"
+"@aws-sdk/smithy-client@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/smithy-client@npm:3.160.0"
   dependencies:
-    "@aws-sdk/middleware-stack": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: 592053189f89f99265ef379aba9ec35d66ca293edc7e7dab1bdb22af5f40eddd627dd275d4451e6a127e745bc28a682aa4a1aee73cf63d14d1a679cbbd6f8128
+    "@aws-sdk/middleware-stack": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: b46002be7dd82e2e3ce63f4cacf6c619d77e9e3fcda871db344fb38337b12c74a0600be2410025cd6f380e7109b09fc284b7c0456a94316daa7ac520a8050d65
   languageName: node
   linkType: hard
 
@@ -1397,28 +1407,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/types@npm:3.40.0"
-  checksum: 4ff073a21c6f3e75520e5100f58effab236cb79704e3e0cfc3c8c9531bd8b331c84e25a9615b64df2854f8ea7901658a16b3dabfe77e3d21bb25b4e685e117f1
+"@aws-sdk/types@npm:3.160.0, @aws-sdk/types@npm:^3.1.0, @aws-sdk/types@npm:^3.4.1":
+  version: 3.160.0
+  resolution: "@aws-sdk/types@npm:3.160.0"
+  checksum: f33abfdcd08745cfb9e0bd050f9c85228e9f0bea938c01b86875e232798473cb03394dd2846f37c5ddd087a1595613591722fa240c21bbfa1b3e8c1772d24d28
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.55.0, @aws-sdk/types@npm:^3.1.0, @aws-sdk/types@npm:^3.4.1":
+"@aws-sdk/types@npm:3.55.0":
   version: 3.55.0
   resolution: "@aws-sdk/types@npm:3.55.0"
   checksum: 99400abe556aadd851b2be0487389b9828303d9d5a3992847e0d2bcf69bfe78afc8792d67cb653b51737372d1a4568ba9b9e141b61f45b73c2bcab39e11cc2e3
   languageName: node
   linkType: hard
 
-"@aws-sdk/url-parser@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/url-parser@npm:3.40.0"
+"@aws-sdk/url-parser@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/url-parser@npm:3.160.0"
   dependencies:
-    "@aws-sdk/querystring-parser": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: e5bbcdb4c94ffd8bf4c195476b4b606e109c83128e47673700b60a50d27d7c056092c5b491ed3f3439959e1532da5b118f8f06abe8772fe406561b31cdac0dcc
+    "@aws-sdk/querystring-parser": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 1090b25cd0e7a9d77875745a4a3709f1e67f9ef8b8dd596f257ccf8567025d11ad76684f18c08f1f9148eb4aedabb5cfa5f441ba23a5631f913074f64a3b9d10
   languageName: node
   linkType: hard
 
@@ -1442,12 +1452,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-base64-browser@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-base64-browser@npm:3.37.0"
+"@aws-sdk/util-base64-browser@npm:3.109.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/util-base64-browser@npm:3.109.0"
   dependencies:
-    tslib: ^2.3.0
-  checksum: 2f2cf2dbf364acc817f9168a3638d550328af6e0166fb7e84660c171ddef25e21bd6d14dde627b10049211352ec2927a41bc0d070b743452d05d0bb853a134c6
+    tslib: ^2.3.1
+  checksum: e4fb1dc0e5ac60320d4ba05dcf03b8e641c7a304f918df3134bf46c8ccf5b09d07ee283924a4cc4e9250fef582a2636bb4dac6ba71ee36662b2678dfe49d46b2
   languageName: node
   linkType: hard
 
@@ -1457,16 +1467,6 @@ __metadata:
   dependencies:
     tslib: ^2.3.1
   checksum: d5bca44efd9188dd0ff435ace5cc2819190d2ca7855f040ba65d327c4a5b3ecf9f565de220c0d1b3687b025945761ec97b8c69cd145b97586de3c6050f602f68
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-base64-node@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-base64-node@npm:3.37.0"
-  dependencies:
-    "@aws-sdk/util-buffer-from": 3.37.0
-    tslib: ^2.3.0
-  checksum: 71fef0687ca365c480031394fecb0d990084234ea2bf0563090941a55617f1924dfb5d87ec60ef399d4c36b608ddf2de2c4a773087f766949f4246ac379410c4
   languageName: node
   linkType: hard
 
@@ -1480,12 +1480,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-body-length-browser@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-body-length-browser@npm:3.37.0"
+"@aws-sdk/util-body-length-browser@npm:3.154.0":
+  version: 3.154.0
+  resolution: "@aws-sdk/util-body-length-browser@npm:3.154.0"
   dependencies:
-    tslib: ^2.3.0
-  checksum: ad4065aa8af3ce514d57da6096f80f3e5041b1ba7518058ad17cf31879443daaca6bcb35d37b5ee51bd989bc9d11b0c265d026a73e09e93fc45846de34aacb34
+    tslib: ^2.3.1
+  checksum: 8c8de55960f2d038bddf8748896bfb322f125cc04ec994fa6610a09fdb9d302817b610a08f76ab100ae682718214e5c2296b03913e11a156de93ca3c002a3143
   languageName: node
   linkType: hard
 
@@ -1498,31 +1498,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-body-length-node@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-body-length-node@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 8cf5486b39487ccbc63f96391eff0c0382a7b32af3b7c22cdf0aab764690fb85f9f54c000ace03dfe772b1a3f1d285268efb2f803cdbccfc6136ed174e056d02
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-body-length-node@npm:3.55.0":
   version: 3.55.0
   resolution: "@aws-sdk/util-body-length-node@npm:3.55.0"
   dependencies:
     tslib: ^2.3.1
   checksum: 35ae66271b7160c53b344a2bd933b5882e9fcef4a47c579a2a9e313657da8b896ca6c674489767f75d148ea5ffb8cbde2127eae55f5f39aaa4823a7c1d98ec69
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/util-buffer-from@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-buffer-from@npm:3.37.0"
-  dependencies:
-    "@aws-sdk/is-array-buffer": 3.37.0
-    tslib: ^2.3.0
-  checksum: c28c73dd7858cfd31689ecbd2cd9ade93cb577917eea2b8694ac14a838c6365217283dc2b716032f5d51ef1e00ff7a267d2e9bfb09aa7b02fb7d248d5fb7663f
   languageName: node
   linkType: hard
 
@@ -1536,12 +1517,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-config-provider@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/util-config-provider@npm:3.40.0"
+"@aws-sdk/util-config-provider@npm:3.109.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/util-config-provider@npm:3.109.0"
   dependencies:
-    tslib: ^2.3.0
-  checksum: 8022f9fc1d7a933ae10cc06faeb03fd0c49719cc9b65682d3b41390837f40f1c9af8cefdb57027f3cce6c4412ab22d940de6993c4dfb401b65c8f0c66a000756
+    tslib: ^2.3.1
+  checksum: 99c9ef24faa555a317b46b782e211474dd9d666611e1aa76b963e93a6e7c54e32d5c20b87d9a601b9de68dfa1c7310d72667a74c335b31edb776e8494e2541af
   languageName: node
   linkType: hard
 
@@ -1566,13 +1547,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-credentials@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-credentials@npm:3.37.0"
+"@aws-sdk/util-defaults-mode-browser@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.160.0"
   dependencies:
-    "@aws-sdk/shared-ini-file-loader": 3.37.0
-    tslib: ^2.3.0
-  checksum: b5741e0960d541c79e586ca577ddeec1b1b2de914e4704898b185eb7711d54ae671fe38db1b99ba8dc8361a8feb979ff2427ac53f0cb399602eeb4926e2f3819
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    bowser: ^2.11.0
+    tslib: ^2.3.1
+  checksum: f0db97ff2d895faa6892f66a5e37d046e78d9b63136ee208c782d2dc6f4fbad6769a0e682e8566601e39314196e4d9250653b81e88da6323c422eb88ae841679
   languageName: node
   linkType: hard
 
@@ -1585,6 +1568,20 @@ __metadata:
     bowser: ^2.11.0
     tslib: ^2.3.1
   checksum: 836f881d4fb8cd467e407080192205d5d31d7a9b87e2d578d7f691b5ca6259a98d37018a0552b529010e612b5be0576115e47dfdff804692d2ab0e3405f2efd3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-defaults-mode-node@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/config-resolver": 3.160.0
+    "@aws-sdk/credential-provider-imds": 3.160.0
+    "@aws-sdk/node-config-provider": 3.160.0
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 7337799837e5c5c7b3d1d1b7694f3cd59a72986bb9e86316c4294edd8d480226d65eadf41cebf4a9b87de2fec02b9cc0818a1849dddfadd079d33ac126deb828
   languageName: node
   linkType: hard
 
@@ -1613,12 +1610,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-hex-encoding@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-hex-encoding@npm:3.37.0"
+"@aws-sdk/util-hex-encoding@npm:3.109.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/util-hex-encoding@npm:3.109.0"
   dependencies:
-    tslib: ^2.3.0
-  checksum: 484d8aa36f0880e910dae2361640dbb29dce462df831e0a771e2b0fb7637b2cf67b9b6144d78312668341b5eca7a982b5f1702ecb326f5509bfc2043bcaabbc7
+    tslib: ^2.3.1
+  checksum: 1c166b53d7f84c0271cb71da8ac0ef4a9bfd78f2d2d70e4a903921dd3c355a79a446fa66ff64522d87aa9c738f445fdfd527043980bea642ae3acbc7dd758edf
   languageName: node
   linkType: hard
 
@@ -1637,6 +1634,15 @@ __metadata:
   dependencies:
     tslib: ^2.3.0
   checksum: bd09c2ffe23ca6d1e13e6b49445a68b4920c766877535cb8b5c7d99e618ae9e225032661a60182909d082cabdf5ffbebfb2357bdf8e768550e22463c822dfce1
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-middleware@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/util-middleware@npm:3.160.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 92e4eb6f5338fe1105ec7556b7a6b67562392d1fd66be1b1478c0eb7797588881c60bdf458a0c9a20f64281f5c729b6dd0daa8b8bd92fbc95d21aeb85c67e0ee
   languageName: node
   linkType: hard
 
@@ -1669,15 +1675,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-uri-escape@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-uri-escape@npm:3.37.0"
-  dependencies:
-    tslib: ^2.3.0
-  checksum: 834f1a535ca3678d62f355bb7e32ae2fe41e789a6a5a27150eeb0089e33c20b3e32f3dbf0c5f8faffa792b3e2f95c22f695ce88103b2ea4cfddd7b73d9d426ed
-  languageName: node
-  linkType: hard
-
 "@aws-sdk/util-uri-escape@npm:3.55.0":
   version: 3.55.0
   resolution: "@aws-sdk/util-uri-escape@npm:3.55.0"
@@ -1687,14 +1684,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-browser@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/util-user-agent-browser@npm:3.40.0"
+"@aws-sdk/util-user-agent-browser@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.160.0"
   dependencies:
-    "@aws-sdk/types": 3.40.0
+    "@aws-sdk/types": 3.160.0
     bowser: ^2.11.0
-    tslib: ^2.3.0
-  checksum: 63c76d60683e52e5c9541f81bb0071458ede956bd2457898b87314dbd3797dffd6eca410c47ae61198788c83da39cc875b566f91a2ee17b8e6b298784716b64b
+    tslib: ^2.3.1
+  checksum: 344ca03f2b1d4227643d12881408e1c6bbdb7fb5d5516ad39cb404b2c5ae71148e3e9f272f5f26e5de0a22e901dc75afcbb8102f275f9aa537b98289cc588ccf
   languageName: node
   linkType: hard
 
@@ -1709,14 +1706,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:3.40.0":
-  version: 3.40.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.40.0"
+"@aws-sdk/util-user-agent-node@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.160.0"
   dependencies:
-    "@aws-sdk/node-config-provider": 3.40.0
-    "@aws-sdk/types": 3.40.0
-    tslib: ^2.3.0
-  checksum: cbbd4f9c3e7f3f3cd92e48a3aabd7514030f484d378bf89f8a27a71dabdb6e3a9441256d764282c54c3d87ff8031f73b23f7944ddddaff782de485b6f371b7eb
+    "@aws-sdk/node-config-provider": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  peerDependencies:
+    aws-crt: ">=1.0.0"
+  peerDependenciesMeta:
+    aws-crt:
+      optional: true
+  checksum: 3ae0a51810ca2807f71341930899355f035694f70807b403548698ab3a24b16a55b8771a7d5bf9c80b1a97317ab26b2d14afebb0829454f8d0a15ced624c6eb5
   languageName: node
   linkType: hard
 
@@ -1731,16 +1733,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-utf8-browser@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-utf8-browser@npm:3.37.0"
+"@aws-sdk/util-utf8-browser@npm:3.109.0, @aws-sdk/util-utf8-browser@npm:^3.0.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/util-utf8-browser@npm:3.109.0"
   dependencies:
-    tslib: ^2.3.0
-  checksum: 93e130926af873f998a7d7b0ac0c12f6878705aee939240a85452879cf4133c23d0e4e95a4ead94eee5e3d7f66c590dce2f78fc3f7e38008318e00c2ae0881de
+    tslib: ^2.3.1
+  checksum: 8311763b04261dab5995ec67abf31795f41e9c4b1ad635ed305735e14c7e3bc48e9ae349a06aab485390358a6a58e97190144ea51190983cec4ae665887b219b
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-utf8-browser@npm:3.55.0, @aws-sdk/util-utf8-browser@npm:^3.0.0":
+"@aws-sdk/util-utf8-browser@npm:3.55.0":
   version: 3.55.0
   resolution: "@aws-sdk/util-utf8-browser@npm:3.55.0"
   dependencies:
@@ -1749,13 +1751,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-utf8-node@npm:3.37.0":
-  version: 3.37.0
-  resolution: "@aws-sdk/util-utf8-node@npm:3.37.0"
+"@aws-sdk/util-utf8-node@npm:3.109.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/util-utf8-node@npm:3.109.0"
   dependencies:
-    "@aws-sdk/util-buffer-from": 3.37.0
-    tslib: ^2.3.0
-  checksum: 2699f4024c25b0a5595f0b8b8b3972b5e7061cc5a9d482844113cf9c0c55859280fb577dd945def25e794e4a41260de90ec68dfa7a3e61e414e9e02ae20d5268
+    "@aws-sdk/util-buffer-from": 3.55.0
+    tslib: ^2.3.1
+  checksum: ef706db8c0ceb014bc2fb9e5045b54369160648a9e919836132f98c5537eda82193f400fab607783ecf98a5df11b66c32256c4f2780bc689d7507ddaf2a0977b
   languageName: node
   linkType: hard
 
@@ -2615,7 +2617,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/common@npm:^7.6.4 || ^8.0.0, @nestjs/common@npm:^8.4.6":
+"@nestjs/common@npm:^7.6.4 || ^8 || ^9":
+  version: 9.0.11
+  resolution: "@nestjs/common@npm:9.0.11"
+  dependencies:
+    iterare: 1.2.1
+    tslib: 2.4.0
+    uuid: 8.3.2
+  peerDependencies:
+    cache-manager: "*"
+    class-transformer: "*"
+    class-validator: "*"
+    reflect-metadata: ^0.1.12
+    rxjs: ^7.1.0
+  peerDependenciesMeta:
+    cache-manager:
+      optional: true
+    class-transformer:
+      optional: true
+    class-validator:
+      optional: true
+  checksum: 57c6618f13e3c9d16665ba0f10318bd1fea9d46eb5b609c8d79ccf4f41ed2dd97668fa51142aeaed4da5a4cd9388aee9cad5730916f4831b6ea23ded6f0265ce
+  languageName: node
+  linkType: hard
+
+"@nestjs/common@npm:^8.4.6":
   version: 8.4.6
   resolution: "@nestjs/common@npm:8.4.6"
   dependencies:
@@ -2967,27 +2993,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@seedcompany/nestjs-email@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "@seedcompany/nestjs-email@npm:2.0.5"
+"@seedcompany/nestjs-email@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@seedcompany/nestjs-email@npm:3.0.2"
   dependencies:
-    "@aws-sdk/client-sesv2": ^3.45.0
-    "@nestjs/common": ^7.6.4 || ^8.0.0
-    emailjs: ^3.7.0
-    html-to-text: ^8.1.0
-    mjml: ^4.11.0
-    mjml-react: ^2.0.3
+    "@aws-sdk/client-sesv2": ^3.154.0
+    "@nestjs/common": ^7.6.4 || ^8 || ^9
+    emailjs: ^3.8.1
+    html-to-text: ^8.2.1
+    mjml: ^4.13.0
+    mjml-react: ^2.0.8
     open: ^8.4.0
-    react: ^17.0.2
-    react-dom: ^17.0.2
     reflect-metadata: ^0.1.13
     tempy: ^1.0.1
   peerDependencies:
-    "@nestjs/common": ^7.0.0 || ^8.0.0
-    react: ^17.0.0
-    react-dom: ^17.0.0
+    "@nestjs/common": ^7 || ^8 || ^9
+    react: ">=17.0.0"
+    react-dom: ">=17.0.0"
     reflect-metadata: ^0.1.12
-  checksum: 88db5bc3b42868c40304aa7e843f06f4b776b061fd6d4068f2a5680b3d0b6d0628aa6f44f7e74b084518df0a7b16ba766c1497d3f6a2aac8d5441f4e0d7c1d6f
+  checksum: 550c576156cdbaac75856a939fa781850337dc352e341fb6f24107a823bd402036582a7deb50d36b1da6e1a3bc554303d719b6b4906d7765c1fb23f37fcb85b0
   languageName: node
   linkType: hard
 
@@ -3358,12 +3382,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/mjml-react@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "@types/mjml-react@npm:2.0.3"
+"@types/mjml-react@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@types/mjml-react@npm:2.0.5"
   dependencies:
     "@types/react": "*"
-  checksum: 06781fecd7f05138856c4824c07c5e253137b33f2d4e04f03baa1033ee53e8f900935ccdc4bd2e927422e83ea7fe89a2458d83bc83174579b66a1f74ab0ad712
+  checksum: cc2b295208ecf713b719c7f1310f71f3e677c0fa431c0d8e58c9b15a0be3d67a002e252d4232db8a768a7f1009d589e2818aeeaa66214061a897474451f0f950
   languageName: node
   linkType: hard
 
@@ -3448,14 +3472,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:^17.0.39":
-  version: 17.0.39
-  resolution: "@types/react@npm:17.0.39"
+"@types/react@npm:*, @types/react@npm:^18.0.17":
+  version: 18.0.17
+  resolution: "@types/react@npm:18.0.17"
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: bf04d3c2894559012710d595553e12b422d3b91cd8f4f7e122d8cb044ba9c2ba17f6e8a4e09581359cc5509ddc59cd8c8fabd6774f3505a40a45393f074d6e6e
+  checksum: 18cae64f5bfd6bb58fbd8ee2ba52ec82de844f114254e26de7b513e4b86621f643f9b71d7066958cd571b0d78cb86cbceda449c5289f9349ca573df29ab69252
   languageName: node
   linkType: hard
 
@@ -5640,7 +5664,7 @@ __metadata:
     "@nestjs/testing": ^8.4.6
     "@patarapolw/prettyprint": ^1.0.3
     "@seedcompany/eslint-plugin": ^3.3.0
-    "@seedcompany/nestjs-email": ^2.0.5
+    "@seedcompany/nestjs-email": ^3.0.2
     "@types/common-tags": ^1.8.1
     "@types/cookie-parser": ^1.4.2
     "@types/express": ^4.17.13
@@ -5650,10 +5674,10 @@ __metadata:
     "@types/jsonwebtoken": ^8.5.8
     "@types/lodash": ^4.14.179
     "@types/luxon": ^2.3.2
-    "@types/mjml-react": ^2.0.3
+    "@types/mjml-react": ^2.0.5
     "@types/node": ^17.0.21
     "@types/pg": ^8.6.4
-    "@types/react": ^17.0.39
+    "@types/react": ^18.0.17
     "@types/stack-trace": ^0.0.29
     "@types/triple-beam": ^1.3.2
     "@types/validator": ^13.7.1
@@ -5702,6 +5726,8 @@ __metadata:
     p-retry: ^4.6.1
     pg: ^8.7.3
     pkg-up: ^3.1.0
+    react: ^18.2.0
+    react-dom: ^18.2.0
     reflect-metadata: ^0.1.13
     rimraf: ^3.0.2
     rxjs: ^7.5.4
@@ -6440,10 +6466,15 @@ cypher-query-builder@6.0.4:
   languageName: node
   linkType: hard
 
-"emailjs@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "emailjs@npm:3.7.0"
-  checksum: 0bca9d18e62b5d41668dd863fa934637522590b1968cad4a6efc9c4db327fe8fe9e019f4d8e099d101db1853f5109568dfac7c4b16dfee83ab766974153c5860
+"emailjs@npm:^3.8.1":
+  version: 3.8.1
+  resolution: "emailjs@npm:3.8.1"
+  peerDependencies:
+    typescript: ">=3.8.3"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: bbc6d4b969cdb78d53bc5b0edbdff94353f419fc18e3434dc9e9fa0af19fd58c6478aa0ae2a26a270a849439ef20950f8fa215506d547ae1df7cfd9be18465af
   languageName: node
   linkType: hard
 
@@ -8127,19 +8158,19 @@ cypher-query-builder@6.0.4:
   languageName: node
   linkType: hard
 
-"html-to-text@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "html-to-text@npm:8.1.0"
+"html-to-text@npm:^8.2.1":
+  version: 8.2.1
+  resolution: "html-to-text@npm:8.2.1"
   dependencies:
     "@selderee/plugin-htmlparser2": ^0.6.0
     deepmerge: ^4.2.2
     he: ^1.2.0
     htmlparser2: ^6.1.0
-    minimist: ^1.2.5
+    minimist: ^1.2.6
     selderee: ^0.6.0
   bin:
     html-to-text: bin/cli.js
-  checksum: 28554493e66759388e66ef27a1fe2786e8544479f5de925e5039e83f4dfbcbd6e60b8e568f079934327ed9141bdeaac0b0a3b790856f0388907a0d410fbde871
+  checksum: ff4cc1d355e71eed610f5e3eb89cbf1b1f394aa971ee915781feceb903f2f6690de007294d3edde23ff204b240a59d65145e2f732112d73fac6dbc560ba3d3d0
   languageName: node
   linkType: hard
 
@@ -10344,53 +10375,53 @@ cypher-query-builder@6.0.4:
   languageName: node
   linkType: hard
 
-"mjml-accordion@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-accordion@npm:4.11.0"
+"mjml-accordion@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-accordion@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: 6218a987cd6511eb4f2fed6c2cb26bb6f474f26f93ebae3a73dd41f71d4822b1361e11d8c9a1e95afb30da7dc9798c3636ffe5d581d424b788dd63b9e9fca1e8
+    mjml-core: 4.13.0
+  checksum: 14d2942e82cff13fabb55b1021533ae36c11ef77145ae77ce9bf60b7508680b021cd1682e8ac2a184c668a44b9ad024d4455d28f17cb06a680521b88e1b6e2ff
   languageName: node
   linkType: hard
 
-"mjml-body@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-body@npm:4.11.0"
+"mjml-body@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-body@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: 6b38fcd5e4796f72f4e1cbbf5d0ff78aa4bb333b0ba4d16c0ff5d5d37db21e070afa7dc397f4d9c9e5cee12c82e84b7d405c20c659f00346a0d9d8cc7b045555
+    mjml-core: 4.13.0
+  checksum: 3870394d83e93915798ddada544557c41eb795adc63b06f8e1a9b3b5d7fb1e5425ec01907e4778d0e82f224d89bec5e49b36b837235a54bb5085208e27f41c20
   languageName: node
   linkType: hard
 
-"mjml-button@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-button@npm:4.11.0"
+"mjml-button@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-button@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: a2e57293a888bb9c0991cf212ae6effe83039bce976726c65a467e9cebbe82fbe7b68a18607365c0e8b7111d17fae47ab4d535a9da30be84de3378f93c64451a
+    mjml-core: 4.13.0
+  checksum: b5254a5341138f08f78edc29bcec78600e57cb1fffe4210b1a5296d922b9716b6b9ec3f42b5f5570ad23ba84fd6fe642f52361b6b26ea64c5fc9bc1f5928e56d
   languageName: node
   linkType: hard
 
-"mjml-carousel@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-carousel@npm:4.11.0"
+"mjml-carousel@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-carousel@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: 3a792db999e859b05ab99e218fa846f9e2c0b0705ab2f0a9186f0156bada2f5af4aad2cb2b037b790c48d2a2e50a2871b0a66606557882516f3a2aaf7bd45a95
+    mjml-core: 4.13.0
+  checksum: 68cd0e4c0636211b5eb670eb9afd932c6645e2048f9dfecda1ecfae29aecec2e1172066538241280a72a63832533b8ffa144d399b7c4409291aee7c971cd34d2
   languageName: node
   linkType: hard
 
-"mjml-cli@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-cli@npm:4.11.0"
+"mjml-cli@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-cli@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     chokidar: ^3.0.0
@@ -10398,31 +10429,31 @@ cypher-query-builder@6.0.4:
     html-minifier: ^4.0.0
     js-beautify: ^1.6.14
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-    mjml-migrate: 4.11.0
-    mjml-parser-xml: 4.11.0
-    mjml-validator: 4.11.0
+    mjml-core: 4.13.0
+    mjml-migrate: 4.13.0
+    mjml-parser-xml: 4.13.0
+    mjml-validator: 4.13.0
     yargs: ^16.1.0
   bin:
     mjml-cli: bin/mjml
-  checksum: 202d2f07162ebdbceb182ec01d5112df632aa02e2002eae6114433a0499e6c613d2dbda6808bcbec4b6e9734c7808553bf38d156775b835a34fb162bd38a04b3
+  checksum: 4452718c184b0aaf73ccd819e72ca3407b19749ad50516b342869b5fe7838e0109fdb74ee3367bf7ad5bb841555d9301e53ccc98d3e8093f009d82a819394979
   languageName: node
   linkType: hard
 
-"mjml-column@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-column@npm:4.11.0"
+"mjml-column@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-column@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: 0582cee3fc826a4af0397c118001cc8ccb9679cf7dd9a42cf532a05c2b3221ab3aa44c0cee98d59757bf4ed047e7f601511fffab368bda5abe7bfec17e796ac0
+    mjml-core: 4.13.0
+  checksum: a55a95575c6180d25fdde65750af784311ae5177768187fe97658b67947102a576e7fc3a17b68be64a826a8cd3fc3fd2f9033af0771ff9217171dbbd6ef031c4
   languageName: node
   linkType: hard
 
-"mjml-core@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-core@npm:4.11.0"
+"mjml-core@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-core@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     cheerio: 1.0.0-rc.10
@@ -10431,334 +10462,334 @@ cypher-query-builder@6.0.4:
     js-beautify: ^1.6.14
     juice: ^7.0.0
     lodash: ^4.17.21
-    mjml-migrate: 4.11.0
-    mjml-parser-xml: 4.11.0
-    mjml-validator: 4.11.0
-  checksum: a22f377dcddc89bf6583a4b98d6fa9359b792d0cbacae0f5911a6cf6a8b7192faad044b26d1e6f036813b9490a1d472c175607bb720b083b3c64230b2350baeb
+    mjml-migrate: 4.13.0
+    mjml-parser-xml: 4.13.0
+    mjml-validator: 4.13.0
+  checksum: 22e9b53b5533a092ae5925f129efbfaf7cec28f28714aaafe265848ea42b0343c31bd9b2788864c763f7670c048bb3b53aef8f6ed612bb344676136fb399f7f9
   languageName: node
   linkType: hard
 
-"mjml-divider@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-divider@npm:4.11.0"
+"mjml-divider@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-divider@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: 7a813f9cb77f10b57e19d7217cd75aa16a7d5569fad50dba9cfc3ce67dc8486467f4f98e36b143f331296e7492f728ea78682f914c06e9f005f4367dd20d3a39
+    mjml-core: 4.13.0
+  checksum: 3ca46d8d9ad722df28f04117f65d0e883ca0c8bf463ec7325bd49f6649d2799a43721c48630893a4d86369c94e9ca05559923673c084a8436cfdc712dade922d
   languageName: node
   linkType: hard
 
-"mjml-group@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-group@npm:4.11.0"
+"mjml-group@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-group@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: b366c67a804bc56bbc7124d4390c26d74ba4dea01a578b73573ba0add630a012d79ceb9f38c0220f61cbb7a1a20652ecff7e246103791ec01971b01d0889c123
+    mjml-core: 4.13.0
+  checksum: c80900fb0f716403d090bd5baa519e7c96ea2da5b573fd630fe8c7343401a8b6fa2ac88693610cfcf679ee936c5a8f8c64f32f6b32523e57fe185dfc57d5c572
   languageName: node
   linkType: hard
 
-"mjml-head-attributes@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-head-attributes@npm:4.11.0"
+"mjml-head-attributes@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-head-attributes@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: 9c48cd6159027b9528ce7a181ce9810d74b22cc496e1218850c3ab5b30af81a7d01e5a4f93b90dd9123e2a59a101397701ff290da809e9e002fb9ecf8f15d305
+    mjml-core: 4.13.0
+  checksum: 6a9c9494975bb2270295cac40ced443b078cdfc7ce27e71a66c6d1b9cb799e987d37f617a8897f64d2a4342e86e45027bfeffd193bc7e08019129e826e882ccf
   languageName: node
   linkType: hard
 
-"mjml-head-breakpoint@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-head-breakpoint@npm:4.11.0"
+"mjml-head-breakpoint@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-head-breakpoint@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: c4d52bfbd0e8974203f9097a986b8673b12388b7bec0ec4cc1503da12d2e51b46da5c0d5d6334f8742b4602195728325958063e38a011782bfbd5f71522c6f28
+    mjml-core: 4.13.0
+  checksum: f85fc0c4bbf8befd8f665b81384c68cc221c7b79dbf46a6bda22ec71a8b658018e07e8c01f24692ca3a974f46215b976d6dae572547f9f9ba249914ff11c1235
   languageName: node
   linkType: hard
 
-"mjml-head-font@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-head-font@npm:4.11.0"
+"mjml-head-font@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-head-font@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: 504a208f39776318de39a360559f2e9d4bd470166924f1059ba4ec2a5090ff5eb008adf7de0e7ddf573baea588d71fd35be3d3a6675268e2b903b2b4005ee941
+    mjml-core: 4.13.0
+  checksum: b3ad43ddb3e00c14cea88b4137bb86b7ad77dff127b42b97cca0b45e89554215f25ddc3a47e93c12acb9231586099b20a32f137dd35affb8cd7d6909059594a0
   languageName: node
   linkType: hard
 
-"mjml-head-html-attributes@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-head-html-attributes@npm:4.11.0"
+"mjml-head-html-attributes@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-head-html-attributes@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: 19fcba6b6f8e02c9e748d4d850df8707a2ea54794ce46877667d2c61508576f78e39466c5dd3b0e76e453d282fba8be4322b73c8e552ef2d4876088c1039eddd
+    mjml-core: 4.13.0
+  checksum: 1e47c26a522c7aa040eda580c1534d80540515128ee114aa8b588c3932d95d7cfdb376b87937778ba6949ee5e2b99aa556aed595a06c37ff8d82937a40c5410a
   languageName: node
   linkType: hard
 
-"mjml-head-preview@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-head-preview@npm:4.11.0"
+"mjml-head-preview@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-head-preview@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: eb8abe0cfc147edc4a731c5c83f3cf350143bb8291d0b972613ccf9b83611d1f9bf8593ad9807945c6ac03c6a7fd737ea97a1719888e3459c2bcc6c6f3928889
+    mjml-core: 4.13.0
+  checksum: dc09cb2ce2c1dc008a88b2963876144f363a78aecbd831d074e60ebe2f609cb6e38e347c74564b0830b7df0323a646804546c0cbcafa47bd8a83cecf93970a20
   languageName: node
   linkType: hard
 
-"mjml-head-style@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-head-style@npm:4.11.0"
+"mjml-head-style@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-head-style@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: 2f69330f0a4e5c8e4bb854d3005a365fbd00bb54ad201119a19476437e9ec6e86360cd8b0b7745d62808ac6ef0e1a35dbbfb9520026f0a05a7dccec29f078a2c
+    mjml-core: 4.13.0
+  checksum: 861ceb9e4220138f02df34f4ab27d01ade263be6f20966cb94c75567d5297e7a35f01a7a13fcd25150fa4e7ee1f7facf20bcb30d597aea8afc43981c0607f93e
   languageName: node
   linkType: hard
 
-"mjml-head-title@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-head-title@npm:4.11.0"
+"mjml-head-title@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-head-title@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: 42e8dbc9d816bb40de815a30237fe7964bf4f85d521e209fdee5039ee4a9b31f7f556c69964054dacbaa03a5f83152d950e9483eb0e44efc98624ccc57c24a11
+    mjml-core: 4.13.0
+  checksum: 45ac1cee5f30966ff1bca620d7ad8236720a6248c6db1eedcf4816a3b3c7acd4bf9bb077974bf1096516ad78521d11db5470218e5eeac9c584cd6f108fb0b8aa
   languageName: node
   linkType: hard
 
-"mjml-head@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-head@npm:4.11.0"
+"mjml-head@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-head@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: 73613351e3b758379cae2d87295c2050e02671a9d1e33bc5302d4bfadcf1adf5fac26d56987957c7d5c09d45cf0f9137d4553983c980dfb43b9b241333eafc38
+    mjml-core: 4.13.0
+  checksum: 8fa492e72cb704d117ee3703a51c6a975ad902dfc61dc2d44d77e069c13f844897953379a3761f2f6ea26e086d1c1d50d16df0735e93ab42bafee9c625807f0d
   languageName: node
   linkType: hard
 
-"mjml-hero@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-hero@npm:4.11.0"
+"mjml-hero@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-hero@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: 20948cb052115befa09ef1a76c49d828c478990cf3ac23bf197c7a6f582fb8ea609c6981c285bbfd50b60aa04ba4394fcc64251f6db0b74d63ae23223965e9f3
+    mjml-core: 4.13.0
+  checksum: 79fd88160308e5695c9dc46cab018cafd07e6f25f4eb2b2efed4453c3a163d2ba769c9070a29afa2b06d9de2085a0f5b090ec676152d45abd575545e3a4f579d
   languageName: node
   linkType: hard
 
-"mjml-image@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-image@npm:4.11.0"
+"mjml-image@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-image@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: 53ed0481db677ea079a6833dfd458f0ea0c043d28749eec7bfed8134a015a9ee427ef89715af1b73232f563b1392c58e8507e91bc05db49af18bdf80c124bfed
+    mjml-core: 4.13.0
+  checksum: ebd7edd8d97c57f22df2d15b0a66f4a460fc52b64a4c1bf56b02092fd835ddb0397dab79a0f22c031269db2e4e2556d352f272340f6e2d7d13c73c6f1b6e888a
   languageName: node
   linkType: hard
 
-"mjml-migrate@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-migrate@npm:4.11.0"
+"mjml-migrate@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-migrate@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     js-beautify: ^1.6.14
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-    mjml-parser-xml: 4.11.0
+    mjml-core: 4.13.0
+    mjml-parser-xml: 4.13.0
     yargs: ^16.1.0
   bin:
     migrate: lib/cli.js
-  checksum: 552e9782b5a19be96d81996ea97d1a3cc1d52185e65d98fc19e01e64a4060f4b79d8344407c6a8e2a30bc3e64dda6b019274d01e135fa0e8d3ebccb032e5cc6b
+  checksum: 639e5b0f934816128322257740f1b214fd83581112472b4e7dda3b199e1d93fdd045a5e7de52c84761912985c1e32fd7ece33c6e32ab0e841d80ea306870bab8
   languageName: node
   linkType: hard
 
-"mjml-navbar@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-navbar@npm:4.11.0"
+"mjml-navbar@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-navbar@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: ca533e890c8aac633742e868230e400e4219bb0e1cbb2ab1ae904d410e247179a7b5ae3dd6be0e90ff2a91071b21ec5fef09747fb56bcb9502f68379b0622174
+    mjml-core: 4.13.0
+  checksum: 67df2b2dbc4d0346d0ea020616df252ee59b834d89beaa7053eee353cd686281227b09c0e20e510fde17d6cdefb9b7d30358658fd2ce0cb98b6b8fa55618ab3b
   languageName: node
   linkType: hard
 
-"mjml-parser-xml@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-parser-xml@npm:4.11.0"
+"mjml-parser-xml@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-parser-xml@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     detect-node: 2.0.4
     htmlparser2: ^4.1.0
     lodash: ^4.17.15
-  checksum: f32ddd65616dbcd4491f254c2fe985c89025acf41dc0391632e6faedf3f89121fd2fd1e04d09e8b56a4ec41827030abeaddcb85ad546edd35ce545c5d704a01e
+  checksum: 737ad0f24712c23db8694579dde55ffc8c36a144956b82a4a20e78487e09804be0aa7a71f7d0fc4d6c126eb5b68815d36f9baddfbdc847d7d469505a6c1ab9b8
   languageName: node
   linkType: hard
 
-"mjml-preset-core@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-preset-core@npm:4.11.0"
+"mjml-preset-core@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-preset-core@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
-    mjml-accordion: 4.11.0
-    mjml-body: 4.11.0
-    mjml-button: 4.11.0
-    mjml-carousel: 4.11.0
-    mjml-column: 4.11.0
-    mjml-divider: 4.11.0
-    mjml-group: 4.11.0
-    mjml-head: 4.11.0
-    mjml-head-attributes: 4.11.0
-    mjml-head-breakpoint: 4.11.0
-    mjml-head-font: 4.11.0
-    mjml-head-html-attributes: 4.11.0
-    mjml-head-preview: 4.11.0
-    mjml-head-style: 4.11.0
-    mjml-head-title: 4.11.0
-    mjml-hero: 4.11.0
-    mjml-image: 4.11.0
-    mjml-navbar: 4.11.0
-    mjml-raw: 4.11.0
-    mjml-section: 4.11.0
-    mjml-social: 4.11.0
-    mjml-spacer: 4.11.0
-    mjml-table: 4.11.0
-    mjml-text: 4.11.0
-    mjml-wrapper: 4.11.0
-  checksum: 8517bcc535dabba0af5ccfeae6c9472a0c6a1c5750e86cf2efde79bc3b40dede207b9e793932f6229a4b44f2a278c6cd45423a2d03c094e434a06e5919ca4d80
+    mjml-accordion: 4.13.0
+    mjml-body: 4.13.0
+    mjml-button: 4.13.0
+    mjml-carousel: 4.13.0
+    mjml-column: 4.13.0
+    mjml-divider: 4.13.0
+    mjml-group: 4.13.0
+    mjml-head: 4.13.0
+    mjml-head-attributes: 4.13.0
+    mjml-head-breakpoint: 4.13.0
+    mjml-head-font: 4.13.0
+    mjml-head-html-attributes: 4.13.0
+    mjml-head-preview: 4.13.0
+    mjml-head-style: 4.13.0
+    mjml-head-title: 4.13.0
+    mjml-hero: 4.13.0
+    mjml-image: 4.13.0
+    mjml-navbar: 4.13.0
+    mjml-raw: 4.13.0
+    mjml-section: 4.13.0
+    mjml-social: 4.13.0
+    mjml-spacer: 4.13.0
+    mjml-table: 4.13.0
+    mjml-text: 4.13.0
+    mjml-wrapper: 4.13.0
+  checksum: 0a4ff9f06a3749a7e07264b490c45fabb6ab078397df32fc862fed35cda5eda23aebcaedfec44e595641f783b1c26c11dd5ee6e89001b68ca275feec8414e0ea
   languageName: node
   linkType: hard
 
-"mjml-raw@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-raw@npm:4.11.0"
+"mjml-raw@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-raw@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: be5375a681f84b8e6ac7476e670be61e7157967c19953875124555e6aa229236fda32e2a1db729900e7920cf8988bbe1ba8331ac813bcc5597853b1b3f185c18
+    mjml-core: 4.13.0
+  checksum: d71573ee6ac0a157fa75babd5ee82c095cf3c0c577ae2cc90eaaa5c88fbbb304bd637d045a5079976dd9e342053b3e0f5c681f53e29d5fce192cb4584aeba400
   languageName: node
   linkType: hard
 
-"mjml-react@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "mjml-react@npm:2.0.3"
+"mjml-react@npm:^2.0.8":
+  version: 2.0.8
+  resolution: "mjml-react@npm:2.0.8"
   dependencies:
     "@babel/runtime": ^7.14.6
     babel-runtime: ~6.25.0
     color: ^3.1.3
     react-reconciler: ^0.26.1
   peerDependencies:
-    mjml: ^4.1.2
-    react: ^17.0.0
-    react-dom: ^17.0.0
-  checksum: c5650bebd686beaa2a3500112725ec019ecc3d3b3584d5a9d95f08412545fd9d8f8e15d2175b14a7fa04102cd8df34c5b959ce6cbce490f4c6fea582f4d56cc9
+    mjml: ^4.7.0
+    react: ^16.0.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: 595525af54747414c9d790745c4556b62ea30e1ecec4bb703ff246d4e350776e9e332173b8f84eec65ee1b361f4500baf387fd2a843c72eff8b2534f155fd0cb
   languageName: node
   linkType: hard
 
-"mjml-section@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-section@npm:4.11.0"
+"mjml-section@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-section@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: a50e5b10b2478816cd7bc350c8df3cc091b73b5eb1fa15ff8d030af030806290dd6f0ccda92b5dd6867be56c97fd22b4ce2bc97cac43a737726852ef10e9235b
+    mjml-core: 4.13.0
+  checksum: c033b9a4af9ebfa6b0aba39296cc9d098d4198fe2efad68668ae54b196903ba487922a699f965e4230085bb1729ac100a88485d8d6c49c52752ff68ac4e82f76
   languageName: node
   linkType: hard
 
-"mjml-social@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-social@npm:4.11.0"
+"mjml-social@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-social@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: 09ba55af8c83151dec65fd12b49127cea178e062e1fe12b50dd031e2e335cadd9976283be0c408078a15f5082eccb1dd6c03e228499b3c66f894472f00e71312
+    mjml-core: 4.13.0
+  checksum: f1b2d5441763efbe570f215bafb5993b8a77670f691edc987edfa2e196c3c13bd15c1fdd762b34e7e1b780b95c452d0721d9ef85f0bc1e8d6e711d78b2dbad20
   languageName: node
   linkType: hard
 
-"mjml-spacer@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-spacer@npm:4.11.0"
+"mjml-spacer@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-spacer@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: a3b7773343181de82b6d27ea3efc1615eb38036e7ed998f645efb14ce4d41812cb83900eeda9c8ffafd6063f97bed887c54b455344340034b12e605add216762
+    mjml-core: 4.13.0
+  checksum: 7d6a6b259427fd40edfc2f72a353be3a660119a7c2ac4d63c735b117e136383b89ef9027c0d0f43f2c681676b7d7467b9d0754fdd7769f37547385b5ce201c6e
   languageName: node
   linkType: hard
 
-"mjml-table@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-table@npm:4.11.0"
+"mjml-table@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-table@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: b1db3677c459d0c6a618c188e348751cfaff32773e9dbafbe292f8a81a9ee9e3c7501dfe01f8c9c0ab69fe1c08398eaa2f02da9e9892ad19129549c5a1799e1e
+    mjml-core: 4.13.0
+  checksum: fdec1341a8ad16cc68e7f8149b717ebca649605b4ec07d0de8903926c175fd27a07d2dc34c8d358d810ba47a2eca44020de4579d16ab6f038c0fef3e45d44626
   languageName: node
   linkType: hard
 
-"mjml-text@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-text@npm:4.11.0"
+"mjml-text@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-text@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-  checksum: beeecd2b3b4cf7b2e06e49d31b6913b48d33346cd1a70b290019a242412f0070e6f77143fec5f849db8d98aa86b5c46ec1a678a344772a19855181d542bd42e8
+    mjml-core: 4.13.0
+  checksum: 44da3679183beafe1d965d9ebaddac3c07a4b2df3bb6a38be53a52f072e44d4ca595bc635da2738ae594d4f7b1bdf7df4c30dae89a0b6958ec5d57e2e9a49672
   languageName: node
   linkType: hard
 
-"mjml-validator@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-validator@npm:4.11.0"
+"mjml-validator@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-validator@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
-  checksum: f88661604008d2c91b36c953d753ea4150739deb5768a26f495f765da13e9e22c2bb2cb12c161ce9d307645e818f78699ed8766629021e2dc6148cf1b993821f
+  checksum: 40397cc664ee0e1ad884ddef30e2ab1cb3b14bb3fb1730e9ba8d7a786c25a260726b4bb70bae7094aa4177a369fd46bd2bf7f8e744f9cdecd0c3ceb8881b075e
   languageName: node
   linkType: hard
 
-"mjml-wrapper@npm:4.11.0":
-  version: 4.11.0
-  resolution: "mjml-wrapper@npm:4.11.0"
+"mjml-wrapper@npm:4.13.0":
+  version: 4.13.0
+  resolution: "mjml-wrapper@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
     lodash: ^4.17.21
-    mjml-core: 4.11.0
-    mjml-section: 4.11.0
-  checksum: ad20c3be40551096251e92a98f7922e4a5c601af70c6b1b20dc5038b51b3473ddbfa0583389ae9031ead39e271cc09bd2487eac8bb78a1dd3c295616fe295ffa
+    mjml-core: 4.13.0
+    mjml-section: 4.13.0
+  checksum: ae5565f04c66b18baaded55edd9f04768c9ccd2192cb53ba90b06067a4a25c35bca80be6c80f9a62b94e6fe3b153d22d23e030d73d69c99045ea80bff118b18e
   languageName: node
   linkType: hard
 
-"mjml@npm:^4.11.0":
-  version: 4.11.0
-  resolution: "mjml@npm:4.11.0"
+"mjml@npm:^4.13.0":
+  version: 4.13.0
+  resolution: "mjml@npm:4.13.0"
   dependencies:
     "@babel/runtime": ^7.14.6
-    mjml-cli: 4.11.0
-    mjml-core: 4.11.0
-    mjml-migrate: 4.11.0
-    mjml-preset-core: 4.11.0
-    mjml-validator: 4.11.0
+    mjml-cli: 4.13.0
+    mjml-core: 4.13.0
+    mjml-migrate: 4.13.0
+    mjml-preset-core: 4.13.0
+    mjml-validator: 4.13.0
   bin:
     mjml: bin/mjml
-  checksum: 5c0892e12d0ecc0b68a80b84c920a062c75c748d9399ccd6079a388eee98fa58233ca9a29a706c971b8e354d00ec8630db354d673c7b62b7a0754681a8733276
+  checksum: 9af4e3ead8f07e177509cb666b46c3794bdd915ad7ab6dbe0282a1da8f8f0304fa831d1474e83a2bb81921c79cefae41ca4e30b1dea76a9cb8f8e825e819a3c1
   languageName: node
   linkType: hard
 
@@ -12214,16 +12245,15 @@ cypher-query-builder@6.0.4:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^17.0.2":
-  version: 17.0.2
-  resolution: "react-dom@npm:17.0.2"
+"react-dom@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react-dom@npm:18.2.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-    scheduler: ^0.20.2
+    scheduler: ^0.23.0
   peerDependencies:
-    react: 17.0.2
-  checksum: 1c1eaa3bca7c7228d24b70932e3d7c99e70d1d04e13bb0843bbf321582bc25d7961d6b8a6978a58a598af2af496d1cedcfb1bf65f6b0960a0a8161cb8dab743c
+    react: ^18.2.0
+  checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
   languageName: node
   linkType: hard
 
@@ -12241,26 +12271,24 @@ cypher-query-builder@6.0.4:
   languageName: node
   linkType: hard
 
-"react-reconciler@npm:^0.26.1":
-  version: 0.26.2
-  resolution: "react-reconciler@npm:0.26.2"
+"react-reconciler@npm:^0.29.0":
+  version: 0.29.0
+  resolution: "react-reconciler@npm:0.29.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-    scheduler: ^0.20.2
+    scheduler: ^0.23.0
   peerDependencies:
-    react: ^17.0.2
-  checksum: 2ebceace56f547f51eaf142becefef9cca980eae4f42d90ee5a966f54a375f5082d78b71b00c40bbd9bca69e0e0f698c7d4e81cc7373437caa19831fddc1d01b
+    react: ^18.2.0
+  checksum: 730db9cf451fe6b5102042fda32a029c73ef970f758707d8a0f07e11e9cc262bc973987464d920b519da99f7e20bb1fef1d1c6b05ff993ad12d59d63b004a2ab
   languageName: node
   linkType: hard
 
-"react@npm:^17.0.2":
-  version: 17.0.2
-  resolution: "react@npm:17.0.2"
+"react@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react@npm:18.2.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: b254cc17ce3011788330f7bbf383ab653c6848902d7936a87b09d835d091e3f295f7e9dd1597c6daac5dc80f90e778c8230218ba8ad599f74adcc11e33b9d61b
+  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
   languageName: node
   linkType: hard
 
@@ -12753,13 +12781,12 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.20.2":
-  version: 0.20.2
-  resolution: "scheduler@npm:0.20.2"
+"scheduler@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "scheduler@npm:0.23.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: c4b35cf967c8f0d3e65753252d0f260271f81a81e427241295c5a7b783abf4ea9e905f22f815ab66676f5313be0a25f47be582254db8f9241b259213e999b8fc
+  checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
New JSX runtime doesn't require React to be wholesale imported just to use JSX syntax. Instead it's handled at the compiler level where the runtime dictates how to transform to raw JS.

New React 18 types don't have `children` implicitly included on component props & FC is deprecated/removed. Adjust our types for these changes.

`mjml-react` is waiting on official React 18 support, but it's only a formality. Manually resolve its dependency as if it did.

This also bumps a lot of `aws-sdk` v3 packages (~3.40.0 -> 3.160.0)