### PR TITLE
Path Aliases & Unified TS plugins

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -75,6 +75,21 @@ rules:
         - name: dataloader
           message: Import DataLoader from our core folder instead
 
+  '@seedcompany/no-restricted-imports':
+    - error
+    # Guard against ts hints trying to insert "src/" paths.
+    # It does that with basePath configured which is required for path aliases, even though it's never what we want.
+    - path: src/common
+      replacement: { path: ~/common }
+    - pattern: src/common/*
+      replacement: { path: '~/common/{path}' }
+    - path: src/core
+      replacement: { path: ~/core }
+    - pattern: src/core/*
+      replacement: { path: '~/core/{path}' }
+    - pattern: src/*
+      message: Use relative import instead
+
   no-restricted-syntax:
     - error
     - selector: NewExpression[callee.name="Logger"]

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,6 +10,9 @@ logFilters:
   # discard these messages that flood the build log
   - { code: YN0013, level: '${VERBOSE_YARN_LOG:-info}' } # fetching package
   - { code: YN0019, level: '${VERBOSE_YARN_LOG:-info}' } # unused cache entry
+  # discard skipped build script message.
+  # You think we'd know that since we went through the trouble explicitly disabling the package. smh.
+  - { code: YN0005, level: discard }
 
 packageExtensions:
   "@nestjs/graphql@*":

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,10 +3,5 @@
   "sourceRoot": "src/components",
   "generateOptions": {
     "spec": false
-  },
-  "compilerOptions": {
-    "plugins": [
-      "../tools/ts-transformer-keys"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
+    "postinstall": "ts-patch install || true",
     "build": "nest build",
-    "console": "node -r ./tools/ts-node-register src/console.ts",
+    "console": "ts-node src/console.ts",
     "console:prod": "node dist/console.js",
     "docker:build": "scripts/docker-build.sh",
     "docker:run": "scripts/docker-run.sh",
@@ -118,6 +119,7 @@
     "madge": "^5.0.1",
     "ts-jest": "^26.5.6",
     "ts-node": "^10.9.1",
+    "ts-patch": "^2.0.2",
     "tsconfig-paths": "*",
     "type-fest": "^2.19.0",
     "typescript": "^4.8.2"
@@ -132,15 +134,6 @@
     "roots": [
       "<rootDir>/src"
     ],
-    "testEnvironment": "node",
-    "globals": {
-      "ts-jest": {
-        "astTransformers": {
-          "before": [
-            "./tools/jest-ts-transformer-keys"
-          ]
-        }
-      }
-    }
+    "testEnvironment": "node"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest",
+    "test:debug": "node --inspect-brk -r ts-node/register node_modules/.bin/jest",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "test:security": "jest --config ./test/jest-security.json",
     "madge": "madge --extensions ts,tsx --ts-config=tsconfig.json src",
@@ -121,9 +121,9 @@
     "ts-jest": "^26.5.6",
     "ts-node": "^10.9.1",
     "ts-patch": "^2.0.2",
-    "tsconfig-paths": "*",
     "type-fest": "^2.19.0",
-    "typescript": "^4.8.2"
+    "typescript": "^4.8.2",
+    "typescript-transform-paths": "^3.3.1"
   },
   "resolutions": {
     "@angular-devkit/schematics-cli/minimist": "^1",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,9 @@
     },
     "core-js-pure": {
       "built": false
+    },
+    "typescript": {
+      "unplugged": true
     }
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prebuild": "rimraf dist",
     "postinstall": "ts-patch install || true",
     "build": "nest build",
+    "clean": "rimraf dist",
     "console": "ts-node src/console.ts",
     "console:prod": "node dist/console.js",
     "docker:build": "scripts/docker-build.sh",

--- a/package.json
+++ b/package.json
@@ -129,6 +129,20 @@
     "gonzales-pe/minimist": "^1.1.0",
     "request/http-signature": "^1.3.6"
   },
+  "dependenciesMeta": {
+    "@apollo/protobufjs": {
+      "built": false
+    },
+    "@nestjs/core": {
+      "built": false
+    },
+    "core-js": {
+      "built": false
+    },
+    "core-js-pure": {
+      "built": false
+    }
+  },
   "jest": {
     "preset": "ts-jest",
     "roots": [

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -5,12 +5,5 @@
   "roots": ["<rootDir>/test"],
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
-  "setupFiles": ["reflect-metadata", "./src/app.module.ts", "./test/jest.d.ts"],
-  "globals": {
-    "ts-jest": {
-      "astTransformers": {
-        "before": ["./tools/jest-ts-transformer-keys"]
-      }
-    }
-  }
+  "setupFiles": ["reflect-metadata", "./src/app.module.ts", "./test/jest.d.ts"]
 }

--- a/test/jest-security.json
+++ b/test/jest-security.json
@@ -5,12 +5,5 @@
   "roots": ["<rootDir>/test/security"],
   "testEnvironment": "node",
   "testRegex": ".security.ts$",
-  "setupFiles": ["reflect-metadata", "./src/app.module.ts"],
-  "globals": {
-    "ts-jest": {
-      "astTransformers": {
-        "before": ["./tools/jest-ts-transformer-keys"]
-      }
-    }
-  }
+  "setupFiles": ["reflect-metadata", "./src/app.module.ts"]
 }

--- a/tools/jest-ts-transformer-keys.js
+++ b/tools/jest-ts-transformer-keys.js
@@ -1,5 +1,0 @@
-const transformer = require('ts-transformer-keys/transformer').default;
-
-module.exports.name = 'ts-transformer-keys';
-module.exports.version = 1; // increment when changes are made below
-module.exports.factory = (cs) => transformer(cs.tsCompiler.program);

--- a/tools/ts-node-register.js
+++ b/tools/ts-node-register.js
@@ -1,7 +1,0 @@
-require('ts-node').register({
-  transformers: program => ({
-    before: [
-      require('ts-transformer-keys/transformer').default(program),
-    ],
-  }),
-});

--- a/tools/ts-transformer-keys.js
+++ b/tools/ts-transformer-keys.js
@@ -1,2 +1,0 @@
-const transformer = require('ts-transformer-keys/transformer').default;
-module.exports.before = (options, program) => transformer(program);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,15 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "noImplicitReturns": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/common": ["./src/common"],
+      "~/common/*": ["./src/common/*"],
+      "~/core": ["./src/core"],
+      "~/core/*": ["./src/core/*"],
+    },
     "plugins": [
+      { "transform": "typescript-transform-paths" },
       { "transform": "ts-transformer-keys/transformer" },
     ],
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,10 @@
     "skipLibCheck": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
-    "noImplicitReturns": true
+    "noImplicitReturns": true,
+    "plugins": [
+      { "transform": "ts-transformer-keys/transformer" },
+    ],
   },
   "include": ["src", "test"],
   "exclude": ["node_modules", "dist"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4781,6 +4781,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"brace-expansion@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "brace-expansion@npm:2.0.1"
+  dependencies:
+    balanced-match: ^1.0.0
+  checksum: a61e7cd2e8a8505e9f0036b3b6108ba5e926b4b55089eeb5550cd04a471fe216c96d4fe7e4c7f995c728c554ae20ddfc4244cad10aef255e72b62930afd233d1
+  languageName: node
+  linkType: hard
+
 "braces@npm:^2.3.1":
   version: 2.3.2
   resolution: "braces@npm:2.3.2"
@@ -5709,6 +5718,7 @@ __metadata:
     ts-essentials: ^9.1.2
     ts-jest: ^26.5.6
     ts-node: ^10.9.1
+    ts-patch: ^2.0.2
     ts-transformer-keys: ^0.4.3
     tsconfig-paths: "*"
     type-fest: ^2.19.0
@@ -7806,6 +7816,30 @@ cypher-query-builder@6.0.4:
   languageName: node
   linkType: hard
 
+"glob@npm:^8.0.3":
+  version: 8.0.3
+  resolution: "glob@npm:8.0.3"
+  dependencies:
+    fs.realpath: ^1.0.0
+    inflight: ^1.0.4
+    inherits: 2
+    minimatch: ^5.0.1
+    once: ^1.3.0
+  checksum: 50bcdea19d8e79d8de5f460b1939ffc2b3299eac28deb502093fdca22a78efebc03e66bf54f0abc3d3d07d8134d19a32850288b7440d77e072aa55f9d33b18c5
+  languageName: node
+  linkType: hard
+
+"global-prefix@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "global-prefix@npm:3.0.0"
+  dependencies:
+    ini: ^1.3.5
+    kind-of: ^6.0.2
+    which: ^1.3.1
+  checksum: 8a82fc1d6f22c45484a4e34656cc91bf021a03e03213b0035098d605bfc612d7141f1e14a21097e8a0413b4884afd5b260df0b6a25605ce9d722e11f1df2881d
+  languageName: node
+  linkType: hard
+
 "globals@npm:^11.1.0":
   version: 11.12.0
   resolution: "globals@npm:11.12.0"
@@ -8347,7 +8381,7 @@ cypher-query-builder@6.0.4:
   languageName: node
   linkType: hard
 
-"ini@npm:^1.3.4, ini@npm:~1.3.0":
+"ini@npm:^1.3.4, ini@npm:^1.3.5, ini@npm:~1.3.0":
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
   checksum: dfd98b0ca3a4fc1e323e38a6c8eb8936e31a97a918d3b377649ea15bdb15d481207a0dda1021efbd86b464cae29a0d33c1d7dcaf6c5672bee17fa849bc50a1b3
@@ -10286,6 +10320,15 @@ cypher-query-builder@6.0.4:
   dependencies:
     brace-expansion: ^1.1.7
   checksum: c154e566406683e7bcb746e000b84d74465b3a832c45d59912b9b55cd50dee66e5c4b1e5566dba26154040e51672f9aa450a9aef0c97cfc7336b78b7afb9540a
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^5.0.1":
+  version: 5.1.0
+  resolution: "minimatch@npm:5.1.0"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: 15ce53d31a06361e8b7a629501b5c75491bc2b59712d53e802b1987121d91b433d73fcc5be92974fde66b2b51d8fb28d75a9ae900d249feb792bb1ba2a4f0a90
   languageName: node
   linkType: hard
 
@@ -12521,7 +12564,7 @@ cypher-query-builder@6.0.4:
   languageName: node
   linkType: hard
 
-"resolve@^1.1.6, resolve@^1.10.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@npm:^1.22.0":
+"resolve@^1.1.6, resolve@^1.10.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@npm:^1.22.0, resolve@npm:^1.22.1":
   version: 1.22.1
   resolution: "resolve@npm:1.22.1"
   dependencies:
@@ -12544,7 +12587,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.18.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.1.6#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.18.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>":
   version: 1.22.1
   resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
   dependencies:
@@ -12938,7 +12981,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"shelljs@npm:0.8.5":
+"shelljs@npm:0.8.5, shelljs@npm:^0.8.5":
   version: 0.8.5
   resolution: "shelljs@npm:0.8.5"
   dependencies:
@@ -13891,6 +13934,25 @@ resolve@^2.0.0-next.3:
     ts-node-transpile-only: dist/bin-transpile.js
     ts-script: dist/bin-script-deprecated.js
   checksum: 090adff1302ab20bd3486e6b4799e90f97726ed39e02b39e566f8ab674fd5bd5f727f43615debbfc580d33c6d9d1c6b1b3ce7d8e3cca3e20530a145ffa232c35
+  languageName: node
+  linkType: hard
+
+"ts-patch@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "ts-patch@npm:2.0.2"
+  dependencies:
+    chalk: ^4.1.2
+    glob: ^8.0.3
+    global-prefix: ^3.0.0
+    minimist: ^1.2.6
+    resolve: ^1.22.1
+    shelljs: ^0.8.5
+    strip-ansi: ^6.0.1
+  peerDependencies:
+    typescript: ">=4.0.0"
+  bin:
+    ts-patch: bin/cli.js
+  checksum: 5db52fc32311ce8a7f23136eb304011a509841e07746dd8358a4429413ccf92f335fd250dd9db1c6f30b87b615bfa574fa8645043ed08dad716b9a175f432e23
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5734,6 +5734,8 @@ __metadata:
       built: false
     core-js-pure:
       built: false
+    typescript:
+      unplugged: true
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5720,9 +5720,9 @@ __metadata:
     ts-node: ^10.9.1
     ts-patch: ^2.0.2
     ts-transformer-keys: ^0.4.3
-    tsconfig-paths: "*"
     type-fest: ^2.19.0
     typescript: ^4.8.2
+    typescript-transform-paths: ^3.3.1
     winston: ^3.6.0
     xlsx: ^0.18.2
   dependenciesMeta:
@@ -9611,7 +9611,7 @@ cypher-query-builder@6.0.4:
   languageName: node
   linkType: hard
 
-"json5@npm:2.x, json5@npm:^2.1.0, json5@npm:^2.2.1":
+"json5@npm:2.x, json5@npm:^2.1.0":
   version: 2.2.1
   resolution: "json5@npm:2.2.1"
   bin:
@@ -13987,17 +13987,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"tsconfig-paths@npm:*":
-  version: 4.1.0
-  resolution: "tsconfig-paths@npm:4.1.0"
-  dependencies:
-    json5: ^2.2.1
-    minimist: ^1.2.6
-    strip-bom: ^3.0.0
-  checksum: e4b101f81b2abd95499d8145e0aa73144e857c2c359191058486cef101b7accae22a69114e5d5814a13d5ab3b0bae70dd0c85bcdb7e829bbe1bfda5c9067c9b1
-  languageName: node
-  linkType: hard
-
 "tsconfig-paths@npm:3.14.1, tsconfig-paths@npm:^3.14.1, tsconfig-paths@npm:^3.9.0":
   version: 3.14.1
   resolution: "tsconfig-paths@npm:3.14.1"
@@ -14148,6 +14137,17 @@ resolve@^2.0.0-next.3:
   version: 0.0.6
   resolution: "typedarray@npm:0.0.6"
   checksum: 33b39f3d0e8463985eeaeeacc3cb2e28bc3dfaf2a5ed219628c0b629d5d7b810b0eb2165f9f607c34871d5daa92ba1dc69f49051cf7d578b4cbd26c340b9d1b1
+  languageName: node
+  linkType: hard
+
+"typescript-transform-paths@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "typescript-transform-paths@npm:3.3.1"
+  dependencies:
+    minimatch: ^3.0.4
+  peerDependencies:
+    typescript: ">=3.6.5"
+  checksum: aa4d36c2767ae3c8801b03ecfc8cb2a1ca164f82b4abb34f14b20d5184fc62310d02ed34298d68934ba976e281cd7e6ba26ff7e89467e1dca2f561b3e88b306d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5725,6 +5725,15 @@ __metadata:
     typescript: ^4.8.2
     winston: ^3.6.0
     xlsx: ^0.18.2
+  dependenciesMeta:
+    "@apollo/protobufjs":
+      built: false
+    "@nestjs/core":
+      built: false
+    core-js:
+      built: false
+    core-js-pure:
+      built: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
`core/` & `common/` can now be referenced with absolutely with the `~` prefix. This is helpful since all of the codebase uses these.

Now using ts-patch to apply TS transformer plugins via tsconfig.json instead of needing to specify them at every entrypoint (nest, jest, ts-node, etc.)