### PR TITLE
[RFC] Database Query Exception Handling

### DIFF
--- a/src/core/database/exceptions.ts
+++ b/src/core/database/exceptions.ts
@@ -1,0 +1,11 @@
+import { ServerException } from '~/common';
+
+/**
+ * A DB error.
+ * Separate hierarchy from Neo4j because they are managed by us instead of driver.
+ */
+export class DatabaseException extends ServerException {}
+
+export class NoRows extends DatabaseException {}
+
+export class ExcessiveRows extends DatabaseException {}

--- a/src/core/database/index.ts
+++ b/src/core/database/index.ts
@@ -1,6 +1,7 @@
 export * from './transactional.decorator';
 export * from './database.service';
 export * from './errors';
+export * from './exceptions';
 export * from './transaction';
 export * from './common.repository';
 export * from './dto.repository';

--- a/src/core/database/query-augmentation/exactly-one.ts
+++ b/src/core/database/query-augmentation/exactly-one.ts
@@ -1,0 +1,34 @@
+import { Query } from 'cypher-query-builder';
+import { ExcessiveRows, NoRows } from '~/core/database';
+
+declare module 'cypher-query-builder/dist/typings/query' {
+  interface Query<Result = unknown> {
+    /**
+     * Execute the query and return the single expected row.
+     * If there are no rows or multiple rows exceptions are thrown.
+     *
+     * @example
+     * await this.db.query()
+     *   ...
+     *   .exactlyOne();
+     *
+     * @throws NoRows
+     * @throws ExcessiveRows
+     */
+    exactlyOne(): Promise<Result>;
+  }
+}
+
+Query.prototype.exactlyOne = async function exactlyOne() {
+  const rows = await this.run();
+  if (!rows[0]) {
+    throw new NoRows('No rows returned, but we were expecting 1.');
+  }
+  if (rows.length > 1) {
+    throw new ExcessiveRows(
+      `Database returned ${rows.length}, however we were only expecting 1.
+Database query should be adjusted to limit to 1 row.`
+    );
+  }
+  return rows[0];
+};

--- a/src/core/database/query-augmentation/index.ts
+++ b/src/core/database/query-augmentation/index.ts
@@ -3,6 +3,7 @@ import './as-result';
 import './call';
 import './comment';
 import './condition-variables';
+import './exactly-one';
 import './foreach';
 import './interpolate';
 import './log-it';


### PR DESCRIPTION
## Premise
In ~65% of our DB queries we are only looking for a single row. We use `Query.first()` to execute the query and return the first row. However that return type is nullable, since the result could be empty. We have these categories of use cases for handling that null:

1. Ignore it. _list_ queries not-null `!` assert it and move on.
    https://github.com/SeedCompany/cord-api-v3/blob/08c2f0a265737f403ce982f0dcb9011a01814fb3/src/components/user/user.repository.ts#L211-L212
1. throw a `NotFoundException` with a custom message (bad user input)
    https://github.com/SeedCompany/cord-api-v3/blob/08c2f0a265737f403ce982f0dcb9011a01814fb3/src/components/user/unavailability/unavailability.service.ts#L100-L105
1. throw a `ServerException` with a custom message (bad DB query or something)
   https://github.com/SeedCompany/cord-api-v3/blob/08c2f0a265737f403ce982f0dcb9011a01814fb3/src/components/user/user.repository.ts#L101-L103 https://github.com/SeedCompany/cord-api-v3/blob/08c2f0a265737f403ce982f0dcb9011a01814fb3/src/components/user/user.repository.ts#L351-L354
1. Wrap a single DB query to provide a nicer & known message
    https://github.com/SeedCompany/cord-api-v3/blob/08c2f0a265737f403ce982f0dcb9011a01814fb3/src/components/user/user.repository.ts#L99-L99
1. Wrap multiple DB queries & service methods
   https://github.com/SeedCompany/cord-api-v3/blob/08c2f0a265737f403ce982f0dcb9011a01814fb3/src/components/story/story.service.ts#L59-L66
   Similar to above however if create fails to set some data that the read query is expecting, the read query could return no rows, and in this case we know that problem is actually with the create query.

## Analysis
1. I'm comfortable with this. Though it would be good to make it runtime safe.
1. Necessary. We need to throw these specific errors somehow/somewhere.
1. I think the check is good, but I'm not sure the custom message is necessary.
     Esp during dev & query authoring this could happen.
     I believe in the beginning, when this pattern was established, we weren't capturing stack traces correctly on database queries. Now we do, so a standardized/generic throw could still give enough info to debug.
1. Similar to above I'm not sure the custom message adds value. i.e.
    `mutation createUser` -> `{ code: "Server", message: "Failed to create user"  }`
    `mutation createUser` -> `{ code: "Server", message: "Server Error"  }`
     I think we can just infer the first error message. If we are worried about what is shown to users, that should probably be a static custom message in the UI codebase.
     On the flip side, is the first error message nicer? Yes. 
     It's also could be possible to just do this automatically based on the mutation name.
     Also something to think about for both this and # 3 is if they are ever hit. These are unexpected server errors, I'd like to think that this is a very rare occurrence.
1. This actually makes a logical difference because we want to send back a server error, not a client one. Though this doesn't feel like the best way to do it. If this is just to confirm a DB query is written correctly it should probably be done with a test instead.

## Solution?
1. ```ts
    Query.exactlyOne()
    ```
     which throws if there's not 1 row. Easy swap.
1. I think if we were to do anything different here it should be a unique shortcut method for a "single row or not found". Maybe:
    ```ts
     Query.firstOrNotFound(label?: 'user', field?: 'internId')
     ```
1. `exactlyOne()` will work here too. Custom message handling can be addressed in # 4
1. I can't decide.
1. Round trip in tests and move read queries out of try/catch and address custom message in # 4. There are a few cases where we do _lots_ of things in the try/catch block, like several event handlers. I think even in this context it still makes sense to not wrap it.



┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3466518780) by [Unito](https://www.unito.io)
