### PR TITLE
Treat null scripture input as empty array

### DIFF
--- a/src/components/scripture/dto/scripture-range.dto.ts
+++ b/src/components/scripture/dto/scripture-range.dto.ts
@@ -37,8 +37,14 @@ export const ScriptureField = (options: FieldOptions) =>
     ValidateNested(),
     Type(() => ScriptureRangeInput),
     Transform(({ value }) => {
+      if (value === undefined) {
+        return undefined;
+      }
+      if (value === null) {
+        return [];
+      }
       try {
-        return value ? mergeScriptureRanges(value) : value;
+        return mergeScriptureRanges(value);
       } catch (e) {
         return value;
       }


### PR DESCRIPTION
This is consistent with other value handling, even for arrays. User.roles treats null as empty array too via `uniq()` transform.

This fixes `isScriptureEqual` being passed an unexpected null here: https://github.com/SeedCompany/cord-api-v3/blob/5b5fae84facb9da06fbb8d2ecb8af708c0d5a1c8/src/components/product/product.service.ts#L454-L455



┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3466516427) by [Unito](https://www.unito.io)
