### PR TITLE
Tweak comment thread deletion

### DIFF
--- a/src/components/comments/comment.service.ts
+++ b/src/components/comments/comment.service.ts
@@ -175,13 +175,8 @@ export class CommentService {
       );
     }
 
-    const commentList = await this.listCommentsByThreadId(
-      object.thread,
-      CommentListInput.defaultVal,
-      session
-    );
-
-    if (commentList.total === 1) {
+    const thread = await this.repo.threads.readOne(object.thread);
+    if (object.id === thread.firstComment.id) {
       await this.repo.threads.deleteNode(object.thread);
     }
 

--- a/src/core/database/query/deletes.ts
+++ b/src/core/database/query/deletes.ts
@@ -5,7 +5,7 @@ import { ACTIVE } from './matching';
 
 export const deleteBaseNode = (nodeVar: string) => (query: Query) =>
   query.comment`deleteBaseNode(${nodeVar})`
-    .match([
+    .optionalMatch([
       node(nodeVar),
       /**
          in this case we want to set Deleted_ labels for all properties


### PR DESCRIPTION
Change delete comment to delete thread if it's the first comment regardless of other comments in thread.

Change `deleteBaseNode` to not require props. This was causing the threads to not delete since they don't have any.