### PR TITLE
Declare Resources Dynamically

### DIFF
--- a/src/components/authorization/model/resource-map.ts
+++ b/src/components/authorization/model/resource-map.ts
@@ -108,6 +108,7 @@ export const ResourceMap = {
 } as const;
 export type ResourceMap = typeof ResourceMap;
 
+/** @deprecated Use {@link import('~/core').ResourcesHost.getByName} instead */
 export const resourceFromName = (name: string) => {
   const resource = ResourceMap[name as keyof ResourceMap];
   if (!resource) {

--- a/src/components/authorization/model/resource-map.ts
+++ b/src/components/authorization/model/resource-map.ts
@@ -55,7 +55,7 @@ import { AssignableRoles } from '../dto/assignable-roles';
 import { BetaFeatures } from '../dto/beta-features';
 
 /** @deprecated Use {@link import('~/core').ResourcesHost.getMap} instead */
-export const ResourceMap = {
+export const LegacyResourceMap = {
   Commentable,
   Budget,
   BudgetRecord,
@@ -106,6 +106,3 @@ export const ResourceMap = {
   AssignableRoles,
   BetaFeatures,
 } as const;
-
-/** @deprecated Use {@link import('~/core').ResourceMap} instead */
-export type ResourceMap = typeof ResourceMap;

--- a/src/components/authorization/model/resource-map.ts
+++ b/src/components/authorization/model/resource-map.ts
@@ -1,4 +1,3 @@
-import { ServerException } from '../../../common';
 import { Budget, BudgetRecord } from '../../budget/dto';
 import { Ceremony } from '../../ceremony/dto';
 import { Changeset } from '../../changeset/dto';
@@ -110,14 +109,3 @@ export const ResourceMap = {
 
 /** @deprecated Use {@link import('~/core').ResourceMap} instead */
 export type ResourceMap = typeof ResourceMap;
-
-/** @deprecated Use {@link import('~/core').ResourcesHost.getByName} instead */
-export const resourceFromName = (name: string) => {
-  const resource = ResourceMap[name as keyof ResourceMap];
-  if (!resource) {
-    throw new ServerException(
-      `Unable to determine resource from ResourceMap for type: ${name}`
-    );
-  }
-  return resource;
-};

--- a/src/components/authorization/model/resource-map.ts
+++ b/src/components/authorization/model/resource-map.ts
@@ -55,6 +55,7 @@ import { Unavailability } from '../../user/unavailability/dto';
 import { AssignableRoles } from '../dto/assignable-roles';
 import { BetaFeatures } from '../dto/beta-features';
 
+/** @deprecated Use {@link import('~/core').ResourcesHost.getMap} instead */
 export const ResourceMap = {
   Commentable,
   Budget,
@@ -106,6 +107,8 @@ export const ResourceMap = {
   AssignableRoles,
   BetaFeatures,
 } as const;
+
+/** @deprecated Use {@link import('~/core').ResourceMap} instead */
 export type ResourceMap = typeof ResourceMap;
 
 /** @deprecated Use {@link import('~/core').ResourcesHost.getByName} instead */

--- a/src/components/authorization/policy/builder/resource-granter.ts
+++ b/src/components/authorization/policy/builder/resource-granter.ts
@@ -1,7 +1,6 @@
 import { mapValues } from 'lodash';
 import { EnhancedResource, many, Many, ResourceShape } from '~/common';
-import type { EnhancedResourceMap } from '~/core';
-import type { ResourceMap } from '../../model/resource-map';
+import type { EnhancedResourceMap, ResourceMap } from '~/core';
 import { ResourceAction } from '../actions';
 import {
   ChildRelationshipGranter,

--- a/src/components/changeset/dto/changeset-diff.dto.ts
+++ b/src/components/changeset/dto/changeset-diff.dto.ts
@@ -1,8 +1,8 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { ValueOf } from 'type-fest';
-import { Resource } from '../../../common';
-import { ResourceMap } from '../../authorization/model/resource-map';
+import { Resource } from '~/common';
+import { ResourceMap } from '~/core';
 
 type SomeResource = ValueOf<ResourceMap>['prototype'];
 

--- a/src/components/post/post.service.ts
+++ b/src/components/post/post.service.ts
@@ -112,7 +112,7 @@ export class PostService {
   }
 
   async securedList(
-    parentType: ResourceShape<Postable>,
+    parentType: ResourceShape<any>,
     parent: Postable & Resource,
     input: PostListInput,
     session: Session

--- a/src/components/post/postable.resolver.ts
+++ b/src/components/post/postable.resolver.ts
@@ -1,14 +1,7 @@
 import { Info, Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { GraphQLResolveInfo } from 'graphql';
-import {
-  ListArg,
-  LoggedInSession,
-  Resource,
-  ResourceShape,
-  Session,
-} from '../../common';
-import { Loader, LoaderOf } from '../../core';
-import { resourceFromName } from '../authorization/model/resource-map';
+import { ListArg, LoggedInSession, Resource, Session } from '~/common';
+import { Loader, LoaderOf, ResourcesHost } from '~/core';
 import { Postable } from './dto';
 import { PostListInput, SecuredPostList } from './dto/list-posts.dto';
 import { PostLoader } from './post.loader';
@@ -16,7 +9,10 @@ import { PostService } from './post.service';
 
 @Resolver(Postable)
 export class PostableResolver {
-  constructor(private readonly service: PostService) {}
+  constructor(
+    private readonly resourcesHost: ResourcesHost,
+    private readonly service: PostService
+  ) {}
 
   @ResolveField(() => SecuredPostList, {
     description: 'List of posts belonging to the parent node.',
@@ -28,8 +24,9 @@ export class PostableResolver {
     @LoggedInSession() session: Session,
     @Loader(PostLoader) posts: LoaderOf<PostLoader>
   ): Promise<SecuredPostList> {
+    const parentType = await this.resourcesHost.getByName(info.parentType.name);
     const list = await this.service.securedList(
-      resourceFromName(info.parentType.name) as ResourceShape<Postable>,
+      parentType,
       parent,
       {
         ...input,

--- a/src/components/search/dto/search-results.dto.ts
+++ b/src/components/search/dto/search-results.dto.ts
@@ -1,7 +1,7 @@
 import { createUnionType, registerEnumType } from '@nestjs/graphql';
 import { mapValues, uniq } from 'lodash';
-import { keys, simpleSwitch } from '../../../common';
-import { ResourceMap } from '../../authorization/model/resource-map';
+import { keys, simpleSwitch } from '~/common';
+import { ResourceMap } from '~/core';
 import { EthnoArt } from '../../ethno-art/dto';
 import { FieldRegion } from '../../field-region/dto';
 import { FieldZone } from '../../field-zone/dto';

--- a/src/core/database/query/create-relationships.ts
+++ b/src/core/database/query/create-relationships.ts
@@ -3,8 +3,8 @@ import { node, Query, relation } from 'cypher-query-builder';
 import { RelationDirection } from 'cypher-query-builder/dist/typings/clauses/relation-pattern';
 import { Maybe as Nullable } from 'graphql/jsutils/Maybe';
 import { DateTime } from 'luxon';
-import { ID, many, ResourceShape } from '../../../common';
-import { ResourceMap } from '../../../components/authorization/model/resource-map';
+import { ID, many, ResourceShape } from '~/common';
+import { ResourceMap } from '~/core';
 import { Variable } from '../query-augmentation/condition-variables';
 
 type RelationshipDefinition = Record<

--- a/src/core/resources/index.ts
+++ b/src/core/resources/index.ts
@@ -2,3 +2,5 @@ export * from './resource-resolver.service';
 export { LoaderFactory } from './loader.registry';
 export * from './resource.loader';
 export * from './resources.host';
+export * from './resource.decorator';
+export * from './map';

--- a/src/core/resources/loader.registry.ts
+++ b/src/core/resources/loader.registry.ts
@@ -7,8 +7,8 @@ import {
 } from '@nestjs/common';
 import { ModulesContainer } from '@nestjs/core';
 import { ValueOf } from 'type-fest';
-import { many, Many } from '../../common';
-import { ResourceMap } from '../../components/authorization/model/resource-map';
+import { many, Many } from '~/common';
+import { ResourceMap } from '~/core';
 import { NestDataLoader, ObjectViewAwareLoader } from '../data-loader';
 
 type SomeResource = ValueOf<ResourceMap>;

--- a/src/core/resources/map.ts
+++ b/src/core/resources/map.ts
@@ -1,0 +1,16 @@
+/**
+ * @example Add to this type
+ *
+ * \@RegisterResource()
+ * class Foo {}
+ *
+ * declare module '~/core/resources/map' {
+ *   interface ResourceMap {
+ *     Foo: typeof Foo;
+ *   }
+ * }
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ResourceMap {
+  // Use interface merging to add to this interface in the owning module.
+}

--- a/src/core/resources/resource-map-holder.ts
+++ b/src/core/resources/resource-map-holder.ts
@@ -1,0 +1,3 @@
+import { ResourceShape } from '~/common';
+
+export const __privateDontUseThis: Record<string, ResourceShape<any>> = {};

--- a/src/core/resources/resource-resolver.service.ts
+++ b/src/core/resources/resource-resolver.service.ts
@@ -3,17 +3,10 @@ import { Injectable, SetMetadata } from '@nestjs/common';
 import { GraphQLSchemaHost } from '@nestjs/graphql';
 import { GraphQLObjectType } from 'graphql';
 import { ValueOf } from 'type-fest';
-import {
-  ID,
-  many,
-  Many,
-  ObjectView,
-  ServerException,
-  Session,
-} from '../../common';
-import { ResourceMap } from '../../components/authorization/model/resource-map';
+import { ID, many, Many, ObjectView, ServerException, Session } from '~/common';
 import { BaseNode } from '../database/results';
 import { ILogger, Logger } from '../logger';
+import { ResourceMap } from './map';
 
 const RESOLVE_BY_ID = 'RESOLVE_BY_ID';
 interface Shape {

--- a/src/core/resources/resource.decorator.ts
+++ b/src/core/resources/resource.decorator.ts
@@ -1,0 +1,14 @@
+import { ResourceShape } from '~/common';
+import { __privateDontUseThis } from './resource-map-holder';
+
+/**
+ * Register a resource for dynamic usage across the codebase.
+ * Be sure to add the type to the type map as well.
+ * See {@link import('./map').ResourceMap} for details on that.
+ */
+export const RegisterResource = () => {
+  return <T extends ResourceShape<any>>(target: T) => {
+    __privateDontUseThis[target.name] = target;
+    return target;
+  };
+};

--- a/src/core/resources/resource.loader.ts
+++ b/src/core/resources/resource.loader.ts
@@ -2,11 +2,11 @@ import { Injectable, Type } from '@nestjs/common';
 import { ConditionalKeys, ValueOf } from 'type-fest';
 import { ID, Many, ObjectView, ServerException } from '~/common';
 import { GqlContextHost } from '~/core/graphql';
-import { ResourceMap } from '../../components/authorization/model/resource-map';
 import { LoaderContextType, LoaderOf, NestDataLoader } from '../data-loader';
 import { NEST_LOADER_CONTEXT_KEY } from '../data-loader/constants';
 import { BaseNode } from '../database/results';
 import { ResourceLoaderRegistry } from './loader.registry';
+import { ResourceMap } from './map';
 import { ResourceResolver } from './resource-resolver.service';
 
 type SomeResourceType = ValueOf<ResourceMap>;

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { mapValues } from 'lodash';
 import { ValueOf } from 'ts-essentials';
+import { LiteralUnion } from 'type-fest';
 import { CachedOnArg, EnhancedResource, ServerException } from '~/common';
 import type { ResourceMap as LegacyResourceMap } from '../../components/authorization/model/resource-map';
 import { ResourceMap } from './map';
@@ -35,7 +36,9 @@ export class ResourcesHost {
   async getByName<K extends keyof ResourceMap>(
     name: K
   ): Promise<ValueOf<Pick<ResourceMap, K>>>;
-  async getByName(name: keyof ResourceMap): Promise<ValueOf<ResourceMap>>;
+  async getByName(
+    name: LiteralUnion<keyof ResourceMap, string>
+  ): Promise<ValueOf<ResourceMap>>;
   async getByName(name: keyof ResourceMap) {
     const map = await this.getMap();
     const resource = map[name];

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -3,7 +3,7 @@ import { mapValues } from 'lodash';
 import { ValueOf } from 'ts-essentials';
 import { LiteralUnion } from 'type-fest';
 import { CachedOnArg, EnhancedResource, ServerException } from '~/common';
-import type { ResourceMap as LegacyResourceMap } from '../../components/authorization/model/resource-map';
+import type { LegacyResourceMap } from '../../components/authorization/model/resource-map';
 import { ResourceMap } from './map';
 import { __privateDontUseThis } from './resource-map-holder';
 
@@ -23,7 +23,7 @@ export class ResourcesHost {
     // registered & type declared.
     const map: ResourceMap = {
       ...__privateDontUseThis,
-      ...(legacyPath.ResourceMap as object),
+      ...(legacyPath.LegacyResourceMap as object),
     };
     return map;
   }
@@ -72,7 +72,8 @@ export class ResourcesHost {
   }
 }
 
+type LegacyMap = typeof LegacyResourceMap;
 declare module '~/core/resources/map' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  interface ResourceMap extends LegacyResourceMap {}
+  interface ResourceMap extends LegacyMap {}
 }


### PR DESCRIPTION
We have a `ResourceMap` object & type to declare what resources are available in the system. This is used in several places both at a type level and programmatically, like for the new Policy builder.

However, the [current map](https://github.com/SeedCompany/cord-api-v3/blob/06efba6a8c82e72e531e5b7423b26506b092ac44/src/components/authorization/model/resource-map.ts#L58-L61) has some downsides.
- All resources have to take an additional step outside of their module to add themselves to this map
- This can cause import problems on bootstrap as any (value) reference to this map causes all the other resources to need to be loaded.

This migrates to a different approach.
Now all resources need to do is declare a decorator (naturally)
```ts
@RegisterResource() // 🎉 
@ObjectType()
export class TranslationProject extends Project {}
```
That attaches it for runtime use, but to make it aware for TypeScript we have do this:
```ts
// in project.dto.ts

declare module '~/core/resources/map' {
  interface ResourceMap {
    TranslationProject: typeof TranslationProject;
  }
}
```

For reading this map we now longer reference the map in the authorization module.
Instead the type is available from core:
```ts
import { ResourceMap } from '~/core';
// or
import { ResourceMap } from '~/core/resources';
```
For programatic usage we have a new service, [`ResourcesHost`](https://github.com/SeedCompany/cord-api-v3/blob/37f9f0094a3f2c6b1329fc45fe1dee321ea0c70b/src/core/resources/resources.host.ts):
```ts
import { ResourcesHost } from '~/core';
```
We have a few methods on this service, including one to get the map. Usage of this service is considered advanced though, so you probably shouldn't need to use it directly.