### PR TITLE
Custom Resource Policy Granters

### DIFF
--- a/src/components/authorization/assignable-roles.granter.ts
+++ b/src/components/authorization/assignable-roles.granter.ts
@@ -1,0 +1,18 @@
+import { Role } from './dto';
+import { AssignableRoles } from './dto/assignable-roles';
+import { Granter, ResourceGranter } from './policy';
+
+@Granter(AssignableRoles)
+export class AssignableRolesGranter extends ResourceGranter<
+  typeof AssignableRoles
+> {
+  grant(allowed: readonly Role[]) {
+    return this.specifically((p) => p.many(...allowed).edit);
+  }
+}
+
+declare module './policy/granters' {
+  interface GrantersOverride {
+    AssignableRoles: AssignableRolesGranter;
+  }
+}

--- a/src/components/authorization/authorization.module.ts
+++ b/src/components/authorization/authorization.module.ts
@@ -1,4 +1,5 @@
 import { Global, Module } from '@nestjs/common';
+import { AssignableRolesGranter } from './assignable-roles.granter';
 import { AuthorizationResolver } from './authorization.resolver';
 import { AuthorizationService } from './authorization.service';
 import { BetaFeaturesGranter } from './dto/beta-features';
@@ -14,6 +15,7 @@ import { PolicyModule } from './policy/policy.module';
     AuthorizationService,
     ...Object.values(Policies),
     ...Object.values(migrations),
+    AssignableRolesGranter,
     BetaFeaturesGranter,
   ],
   exports: [AuthorizationService, PolicyModule],

--- a/src/components/authorization/authorization.module.ts
+++ b/src/components/authorization/authorization.module.ts
@@ -1,6 +1,7 @@
 import { Global, Module } from '@nestjs/common';
 import { AuthorizationResolver } from './authorization.resolver';
 import { AuthorizationService } from './authorization.service';
+import { BetaFeaturesGranter } from './dto/beta-features';
 import * as migrations from './migrations';
 import * as Policies from './policies';
 import { PolicyModule } from './policy/policy.module';
@@ -13,6 +14,7 @@ import { PolicyModule } from './policy/policy.module';
     AuthorizationService,
     ...Object.values(Policies),
     ...Object.values(migrations),
+    BetaFeaturesGranter,
   ],
   exports: [AuthorizationService, PolicyModule],
 })

--- a/src/components/authorization/dto/beta-features.ts
+++ b/src/components/authorization/dto/beta-features.ts
@@ -1,6 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
-import { ResourcesGranter } from '../policy';
+import { Granter, ResourceGranter } from '../policy';
 
 // TODO move somewhere else
 
@@ -14,17 +14,19 @@ export class BetaFeatures {
     projectChangeRequests: '',
   };
 
-  /**
-   * A helper to grant access to beta features in a more readable way.
-   * This should be used within a Policy.
-   */
-  static grant(
-    r: ResourcesGranter,
-    ...features: Array<keyof typeof BetaFeatures['Relations'] & string>
-  ) {
-    return r.BetaFeatures.specifically((p) => p.many(...features).edit);
-  }
-
   @Field()
   projectChangeRequests: boolean;
+}
+
+@Granter(BetaFeatures)
+export class BetaFeaturesGranter extends ResourceGranter<typeof BetaFeatures> {
+  grant(...features: Array<keyof BetaFeatures & string>) {
+    return this.specifically((p) => p.many(...features).edit);
+  }
+}
+
+declare module '../policy/granters' {
+  interface GrantersOverride {
+    BetaFeatures: BetaFeaturesGranter;
+  }
 }

--- a/src/components/authorization/dto/role.dto.ts
+++ b/src/components/authorization/dto/role.dto.ts
@@ -65,7 +65,7 @@ export namespace Role {
   export const assignable = (
     resources: ResourcesGranter,
     roles: readonly Role[]
-  ) => resources.AssignableRoles.specifically((p) => p.many(...roles).edit);
+  ) => resources.AssignableRoles.grant(roles);
 
   Object.defineProperty(Role, 'assignable', { enumerable: false });
 }

--- a/src/components/authorization/policies/by-feature/project-change-requests-beta.policy.ts
+++ b/src/components/authorization/policies/by-feature/project-change-requests-beta.policy.ts
@@ -1,4 +1,4 @@
-import { BetaFeatures, Policy, Role } from '../util';
+import { Policy, Role } from '../util';
 
 @Policy(
   [
@@ -7,6 +7,6 @@ import { BetaFeatures, Policy, Role } from '../util';
     Role.RegionalDirector,
     // TODO Who else?
   ],
-  (r) => BetaFeatures.grant(r, 'projectChangeRequests')
+  (r) => r.BetaFeatures.grant('projectChangeRequests')
 )
 export class ProjectChangeRequestsBetaPolicy {}

--- a/src/components/authorization/policies/by-role/administrator.policy.ts
+++ b/src/components/authorization/policies/by-role/administrator.policy.ts
@@ -1,6 +1,4 @@
-import { Policy, Role } from '../util';
+import { allowAll, Policy, Role } from '../util';
 
-@Policy(Role.Administrator, (resources) =>
-  Object.values(resources).map((resource) => resource.edit.create.delete)
-)
+@Policy(Role.Administrator, allowAll('read', 'edit', 'create', 'delete'))
 export class AdministratorPolicy {}

--- a/src/components/authorization/policies/by-role/leadership.policy.ts
+++ b/src/components/authorization/policies/by-role/leadership.policy.ts
@@ -1,7 +1,5 @@
-import { Policy, Role } from '../util';
+import { allowAll, Policy, Role } from '../util';
 
 // NOTE: There could be other permissions for this role from other policies
-@Policy(Role.Leadership, (r) =>
-  Object.values(r).map((resource) => resource.read)
-)
+@Policy(Role.Leadership, allowAll('read'))
 export class LeadershipPolicy {}

--- a/src/components/authorization/policies/util.ts
+++ b/src/components/authorization/policies/util.ts
@@ -1,6 +1,6 @@
 // File exists to simplify imports for policy definitions.
 export { Role } from '../dto/role.dto';
-export { Policy, inherit } from '../policy';
+export { Policy, inherit, allowAll, allowActions } from '../policy';
 export { Policy as BuiltPolicy } from '../policy/policy.factory';
 export { any, all } from '../policy/conditions';
 export * from './conditions';

--- a/src/components/authorization/policies/util.ts
+++ b/src/components/authorization/policies/util.ts
@@ -1,6 +1,5 @@
 // File exists to simplify imports for policy definitions.
 export { Role } from '../dto/role.dto';
-export { BetaFeatures } from '../dto/beta-features';
 export { Policy, inherit } from '../policy';
 export { Policy as BuiltPolicy } from '../policy/policy.factory';
 export { any, all } from '../policy/conditions';

--- a/src/components/authorization/policy/builder/allow-all.helper.ts
+++ b/src/components/authorization/policy/builder/allow-all.helper.ts
@@ -1,0 +1,21 @@
+import { ValueOf } from 'type-fest';
+import { ResourceAction } from '../actions';
+import { ResourcesGranter } from '../granters';
+import { asNormalized } from './as-normalized.helper';
+import { action } from './perm-granter';
+
+/**
+ * A helper to allow these actions for all resources
+ */
+export const allowAll =
+  (...actions: ResourceAction[]) =>
+  (r: Partial<ResourcesGranter>) =>
+    Object.values(r).map((res) => allowActions(res, ...actions));
+
+/**
+ * A helper to allow these actions for this resource.
+ */
+export const allowActions = (
+  granter: ValueOf<ResourcesGranter>,
+  ...actions: ResourceAction[]
+) => asNormalized(granter, (g) => g[action](...actions));

--- a/src/components/authorization/policy/builder/as-normalized.helper.ts
+++ b/src/components/authorization/policy/builder/as-normalized.helper.ts
@@ -1,0 +1,15 @@
+import { ValueOf } from 'type-fest';
+import { ResourcesGranter } from '../granters';
+import { ResourceGranter } from './resource-granter';
+
+/**
+ * A helper to execute actions on a granter with the "normalized" / base class type.
+ * I'd like to instead enforce that the granter overrides extend ResourceGranter,
+ * but I'm having trouble. So instead we'll confirm at runtime and use this to ease
+ * with typecasting.
+ */
+export const asNormalized = (
+  granter: ValueOf<ResourcesGranter>,
+  fn: (granter: ResourceGranter<any>) => ResourceGranter<any>
+): ValueOf<ResourcesGranter> =>
+  fn(granter as ResourceGranter<any>) as ValueOf<ResourcesGranter>;

--- a/src/components/authorization/policy/builder/child-relationship-granter.ts
+++ b/src/components/authorization/policy/builder/child-relationship-granter.ts
@@ -7,7 +7,7 @@ import {
 import { ChildListAction, ChildSingleAction } from '../actions';
 import { Condition } from '../conditions';
 import { createLazyRecord } from '../lazy-record';
-import { extract, PermGranter } from './perm-granter';
+import { action, extract, PermGranter } from './perm-granter';
 
 export abstract class ChildRelationshipGranter<
   TResourceStatic extends ResourceShape<any>,
@@ -60,14 +60,14 @@ export class ChildSingleGranter<
    * The requester can read this relationship.
    */
   get read() {
-    return this.action('read');
+    return this[action]('read');
   }
 
   /**
    * The requester can swap this relationship edge to another resource.
    */
   get edit() {
-    return this.action('read', 'edit');
+    return this[action]('read', 'edit');
   }
 }
 
@@ -82,28 +82,28 @@ export class ChildListGranter<
    * The requester can read this relationship.
    */
   get read() {
-    return this.action('read');
+    return this[action]('read');
   }
 
   /**
    * A shortcut for read, create, delete.
    */
   get edit() {
-    return this.action('read', 'create', 'delete');
+    return this[action]('read', 'create', 'delete');
   }
 
   /**
    * The requester can create an instance of this resource & associate it on this edge.
    */
   get create() {
-    return this.action('create');
+    return this[action]('create');
   }
 
   /**
    * The requester can delete an instance of this resource that is associated on this edge.
    */
   get delete() {
-    return this.action('delete');
+    return this[action]('delete');
   }
 }
 

--- a/src/components/authorization/policy/builder/child-relationship-granter.ts
+++ b/src/components/authorization/policy/builder/child-relationship-granter.ts
@@ -7,7 +7,7 @@ import {
 import { ChildListAction, ChildSingleAction } from '../actions';
 import { Condition } from '../conditions';
 import { createLazyRecord } from '../lazy-record';
-import { PermGranter } from './perm-granter';
+import { extract, PermGranter } from './perm-granter';
 
 export abstract class ChildRelationshipGranter<
   TResourceStatic extends ResourceShape<any>,
@@ -22,9 +22,9 @@ export abstract class ChildRelationshipGranter<
     super(stagedCondition);
   }
 
-  extract() {
+  [extract]() {
     return {
-      ...super.extract(),
+      ...super[extract](),
       resource: this.resource,
       relationNames: this.relationNames,
     };

--- a/src/components/authorization/policy/builder/granter.decorator.ts
+++ b/src/components/authorization/policy/builder/granter.decorator.ts
@@ -1,0 +1,51 @@
+import { DiscoveryService } from '@golevelup/nestjs-discovery';
+import { SetMetadata } from '@nestjs/common';
+import { EnhancedResource, Many, ResourceShape } from '~/common';
+import { ResourceGranter } from './resource-granter';
+
+/**
+ * Declare custom granter for resource(s).
+ * @example Extending from ResourceGranter
+ * \@GranterFactory(Foo)
+ * export class FooGranter extends ResourceGranter {
+ *   get customGrant() { ... }
+ *
+ *   // don't touch the constructor
+ * }
+ *
+ * @example Using a function instead to create the granter instance
+ * \@GranterFactory(Foo, (res) => {
+ *   // customize somehow returning...
+ *   return new ResourceGranter(res);
+ * })
+ * export class FooGranterFactory {}
+ *
+ * @example Be sure to declare for TypeScript
+ * declare module './path/to/components/authorization/policy/granters' {
+ *   interface GrantersOverride {
+ *     Foo: FooGranter;
+ *   }
+ * }
+ */
+export const Granter = (
+  resources: GranterMetadata['resources'],
+  factory?: GranterMetadata['factory']
+): ClassDecorator =>
+  SetMetadata<any, GranterMetadata>(GRANTER_FACTORY_METADATA_KEY, {
+    resources,
+    factory,
+  });
+
+export const discover = (discovery: DiscoveryService) =>
+  discovery.providersWithMetaAtKey<GranterMetadata>(
+    GRANTER_FACTORY_METADATA_KEY
+  );
+
+const GRANTER_FACTORY_METADATA_KEY = Symbol('GranterFactory');
+
+interface GranterMetadata {
+  resources: Many<ResourceShape<any>>;
+  factory?: <TResourceStatic extends ResourceShape<any>>(
+    resource: EnhancedResource<TResourceStatic>
+  ) => ResourceGranter<TResourceStatic>;
+}

--- a/src/components/authorization/policy/builder/inherit-resource.helper.ts
+++ b/src/components/authorization/policy/builder/inherit-resource.helper.ts
@@ -1,4 +1,4 @@
-import { ResourceGranter, ResourceGranterImpl } from './resource-granter';
+import { ResourceGranter, withOther } from './resource-granter';
 
 /**
  * This merges the permissions from the first granter, into the other ones.
@@ -26,7 +26,8 @@ export function inherit(
   theInterface: ResourceGranter<any>,
   ...implementations: Array<ResourceGranter<any>>
 ): Array<ResourceGranter<any>> {
-  const start = theInterface as ResourceGranterImpl<any>;
-  const impls = implementations as Array<ResourceGranterImpl<any>>;
-  return [start, ...impls.map((granter) => granter.withOther(start))];
+  return [
+    theInterface,
+    ...implementations.map((granter) => granter[withOther](theInterface)),
+  ];
 }

--- a/src/components/authorization/policy/builder/perm-granter.ts
+++ b/src/components/authorization/policy/builder/perm-granter.ts
@@ -6,6 +6,11 @@ export type Permissions<TAction extends string> = {
 };
 export type Permission = Condition<any> | boolean;
 
+/**
+ * Extract permissions from granter.
+ */
+export const extract = Symbol('PermGranter.extract');
+
 export abstract class PermGranter<
   TResourceStatic extends ResourceShape<any>,
   TAction extends string
@@ -90,7 +95,7 @@ export abstract class PermGranter<
     return cloned;
   }
 
-  protected extract() {
+  [extract]() {
     if (this.trailingCondition) {
       throw this.trailingCondition;
     }

--- a/src/components/authorization/policy/builder/perm-granter.ts
+++ b/src/components/authorization/policy/builder/perm-granter.ts
@@ -7,6 +7,11 @@ export type Permissions<TAction extends string> = {
 export type Permission = Condition<any> | boolean;
 
 /**
+ * Add allowed actions.
+ */
+export const action = Symbol('PermGranter.action');
+
+/**
  * Extract permissions from granter.
  */
 export const extract = Symbol('PermGranter.extract');
@@ -35,9 +40,8 @@ export abstract class PermGranter<
 
   /**
    * Return grant with these actions added.
-   * Maybe expose publicly...
    */
-  protected action(...actions: TAction[]): this {
+  [action](...actions: TAction[]): this {
     const cloned = this.clone();
     cloned.trailingCondition = undefined;
     const perm = cloned.stagedCondition ?? true;

--- a/src/components/authorization/policy/builder/policy.decorator.ts
+++ b/src/components/authorization/policy/builder/policy.decorator.ts
@@ -1,11 +1,12 @@
 import { SetMetadata } from '@nestjs/common';
+import { ValueOf } from 'type-fest';
 import { Many } from '~/common';
 import { Role } from '../../dto/role.dto';
-import type { ResourceGranter, ResourcesGranter } from './resource-granter';
+import type { ResourcesGranter } from '../granters';
 
 type ResourceGranterFn = (
   resourcesGranter: ResourcesGranter
-) => Many<ResourceGranter<any>>;
+) => Many<ValueOf<ResourcesGranter>>;
 
 export const POLICY_METADATA_KEY = Symbol('Policy');
 

--- a/src/components/authorization/policy/builder/prop-granter.ts
+++ b/src/components/authorization/policy/builder/prop-granter.ts
@@ -6,9 +6,9 @@ import {
 import { PropAction } from '../actions';
 import { Condition } from '../conditions';
 import { createLazyRecord } from '../lazy-record';
-import { PermGranter } from './perm-granter';
+import { extract, PermGranter } from './perm-granter';
 
-export abstract class PropGranter<
+export class PropGranter<
   TResourceStatic extends ResourceShape<any>
 > extends PermGranter<TResourceStatic, PropAction> {
   constructor(
@@ -32,14 +32,10 @@ export abstract class PropGranter<
   get edit() {
     return this.action('read', 'edit');
   }
-}
 
-export class PropGranterImpl<
-  TResourceStatic extends ResourceShape<any>
-> extends PropGranter<TResourceStatic> {
-  extract() {
+  [extract]() {
     return {
-      ...super.extract(),
+      ...super[extract](),
       resource: this.resource,
       properties: this.properties,
     };
@@ -52,11 +48,10 @@ export class PropGranterImpl<
     const granter = createLazyRecord<PropsGranter<TResourceStatic>>({
       getKeys: () => resource.securedPropsPlusExtra,
       calculate: (prop) =>
-        new PropGranterImpl(resource, [prop], stagedCondition) as any,
+        new PropGranter(resource, [prop], stagedCondition) as any,
       // @ts-expect-error IDK why this is failing
       base: {
-        many: (...props) =>
-          new PropGranterImpl(resource, props, stagedCondition),
+        many: (...props) => new PropGranter(resource, props, stagedCondition),
       },
     });
     return granter;

--- a/src/components/authorization/policy/builder/prop-granter.ts
+++ b/src/components/authorization/policy/builder/prop-granter.ts
@@ -6,7 +6,7 @@ import {
 import { PropAction } from '../actions';
 import { Condition } from '../conditions';
 import { createLazyRecord } from '../lazy-record';
-import { extract, PermGranter } from './perm-granter';
+import { action, extract, PermGranter } from './perm-granter';
 
 export class PropGranter<
   TResourceStatic extends ResourceShape<any>
@@ -23,14 +23,14 @@ export class PropGranter<
    * The requester can read this.
    */
   get read() {
-    return this.action('read');
+    return this[action]('read');
   }
 
   /**
    * The requester can read & modify this.
    */
   get edit() {
-    return this.action('read', 'edit');
+    return this[action]('read', 'edit');
   }
 
   [extract]() {

--- a/src/components/authorization/policy/builder/resource-granter.ts
+++ b/src/components/authorization/policy/builder/resource-granter.ts
@@ -4,7 +4,7 @@ import {
   ChildRelationshipGranter,
   ChildRelationshipsGranter,
 } from './child-relationship-granter';
-import { extract, PermGranter } from './perm-granter';
+import { action, extract, PermGranter } from './perm-granter';
 import { PropGranter, PropsGranter } from './prop-granter';
 
 export const withOther = Symbol('ResourceGranter.withOther');
@@ -126,7 +126,7 @@ export class DefaultResourceGranter<
    * and can read all props not specifically defined.
    */
   get read() {
-    return this.action('read');
+    return this[action]('read');
   }
 
   /**
@@ -134,21 +134,21 @@ export class DefaultResourceGranter<
    * {@link read} is implied.
    */
   get edit() {
-    return this.action('read', 'edit');
+    return this[action]('read', 'edit');
   }
 
   /**
    * The requester can create a new instance of this resource.
    */
   get create() {
-    return this.action('create');
+    return this[action]('create');
   }
 
   /**
    * The requester can delete this object.
    */
   get delete() {
-    return this.action('delete');
+    return this[action]('delete');
   }
 
   specifically(grants: PropsGranterFn<TResourceStatic>): this {

--- a/src/components/authorization/policy/builder/resource-granter.ts
+++ b/src/components/authorization/policy/builder/resource-granter.ts
@@ -1,6 +1,4 @@
-import { mapValues } from 'lodash';
 import { EnhancedResource, many, Many, ResourceShape } from '~/common';
-import type { EnhancedResourceMap, ResourceMap } from '~/core';
 import { ResourceAction } from '../actions';
 import {
   ChildRelationshipGranter,
@@ -120,13 +118,6 @@ export class ResourceGranter<
     return cloned;
   }
 
-  static create(map: EnhancedResourceMap): ResourcesGranter {
-    return mapValues(
-      map,
-      (resource: EnhancedResource<any>) => new ResourceGranter(resource)
-    ) as any;
-  }
-
   [withOther](other: ResourceGranter<TResourceStatic>): this {
     const cloned = this.clone();
     cloned.perms = [...this.perms, ...other.perms];
@@ -156,7 +147,3 @@ export class ResourceGranter<
     return cloned;
   }
 }
-
-export type ResourcesGranter = {
-  [K in keyof ResourceMap]: ResourceGranter<ResourceMap[K]>;
-};

--- a/src/components/authorization/policy/granters.factory.ts
+++ b/src/components/authorization/policy/granters.factory.ts
@@ -1,0 +1,44 @@
+import { DiscoveryService } from '@golevelup/nestjs-discovery';
+import { Injectable } from '@nestjs/common';
+import { mapValues } from 'lodash';
+import { EnhancedResource, many, mapFromList } from '~/common';
+import { ResourcesHost } from '~/core/resources';
+import { discover } from './builder/granter.decorator';
+import { ResourceGranter } from './builder/resource-granter';
+import { ResourcesGranter } from './granters';
+
+@Injectable()
+export class GrantersFactory {
+  constructor(
+    private readonly discovery: DiscoveryService,
+    private readonly resourcesHost: ResourcesHost
+  ) {}
+
+  async makeGranters() {
+    const discoveredGranters = await discover(this.discovery);
+
+    const custom = Object.assign(
+      {},
+      ...discoveredGranters.map(
+        ({ meta: { resources, factory }, discoveredClass }) => {
+          return mapFromList(many(resources), (raw) => {
+            const res = EnhancedResource.of(raw);
+            const granter =
+              factory?.(res) ?? new discoveredClass.dependencyType(res);
+            return [res.name, granter];
+          });
+        }
+      )
+    );
+
+    const ResourceMap = await this.resourcesHost.getEnhancedMap();
+
+    const resGranter: ResourcesGranter = mapValues(
+      ResourceMap,
+      (resource: EnhancedResource<any>) =>
+        custom[resource.name] ?? new ResourceGranter(resource)
+    ) as any;
+
+    return resGranter;
+  }
+}

--- a/src/components/authorization/policy/granters.factory.ts
+++ b/src/components/authorization/policy/granters.factory.ts
@@ -4,7 +4,10 @@ import { mapValues } from 'lodash';
 import { EnhancedResource, many, mapFromList } from '~/common';
 import { ResourcesHost } from '~/core/resources';
 import { discover } from './builder/granter.decorator';
-import { ResourceGranter } from './builder/resource-granter';
+import {
+  DefaultResourceGranter,
+  ResourceGranter,
+} from './builder/resource-granter';
 import { ResourcesGranter } from './granters';
 
 @Injectable()
@@ -36,7 +39,7 @@ export class GrantersFactory {
     const resGranter: ResourcesGranter = mapValues(
       ResourceMap,
       (resource: EnhancedResource<any>) =>
-        custom[resource.name] ?? new ResourceGranter(resource)
+        custom[resource.name] ?? new DefaultResourceGranter(resource)
     ) as any;
 
     return resGranter;

--- a/src/components/authorization/policy/granters.factory.ts
+++ b/src/components/authorization/policy/granters.factory.ts
@@ -28,6 +28,11 @@ export class GrantersFactory {
             const res = EnhancedResource.of(raw);
             const granter =
               factory?.(res) ?? new discoveredClass.dependencyType(res);
+            if (!(granter instanceof ResourceGranter)) {
+              throw new Error(
+                `Granter for ${res.name} must extend ResourceGranter class`
+              );
+            }
             return [res.name, granter];
           });
         }

--- a/src/components/authorization/policy/granters.ts
+++ b/src/components/authorization/policy/granters.ts
@@ -1,10 +1,10 @@
 import { Merge } from 'type-fest';
 import { ResourceMap } from '~/core/resources';
-import { ResourceGranter } from './builder/resource-granter';
+import { DefaultResourceGranter } from './builder/resource-granter';
 
 export type ResourcesGranter = Merge<
   {
-    [K in keyof ResourceMap]: ResourceGranter<ResourceMap[K]>;
+    [K in keyof ResourceMap]: DefaultResourceGranter<ResourceMap[K]>;
   },
   GrantersOverride
 >;

--- a/src/components/authorization/policy/granters.ts
+++ b/src/components/authorization/policy/granters.ts
@@ -1,0 +1,21 @@
+import { Merge } from 'type-fest';
+import { ResourceMap } from '~/core/resources';
+import { ResourceGranter } from './builder/resource-granter';
+
+export type ResourcesGranter = Merge<
+  {
+    [K in keyof ResourceMap]: ResourceGranter<ResourceMap[K]>;
+  },
+  GrantersOverride
+>;
+
+/**
+ * Only use to define custom granter with interface merging.
+ * See {@link Granter} for more info on that.
+ *
+ * For usage, use {@link ResourcesGranter} instead.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface GrantersOverride {
+  // Use interface merging to add to this interface in the owning module.
+}

--- a/src/components/authorization/policy/index.ts
+++ b/src/components/authorization/policy/index.ts
@@ -1,7 +1,10 @@
 export { Policy } from './builder/policy.decorator';
 export { ResourcesGranter } from './granters';
 export { Granter } from './builder/granter.decorator';
-export { ResourceGranter } from './builder/resource-granter';
+export {
+  ResourceGranter,
+  DefaultResourceGranter,
+} from './builder/resource-granter';
 export * from './builder/inherit-resource.helper';
 export * from './executor/privileges';
 export * from './executor/resource-privileges';

--- a/src/components/authorization/policy/index.ts
+++ b/src/components/authorization/policy/index.ts
@@ -5,6 +5,7 @@ export {
   ResourceGranter,
   DefaultResourceGranter,
 } from './builder/resource-granter';
+export * from './builder/allow-all.helper';
 export * from './builder/as-normalized.helper';
 export * from './builder/inherit-resource.helper';
 export * from './executor/privileges';

--- a/src/components/authorization/policy/index.ts
+++ b/src/components/authorization/policy/index.ts
@@ -5,6 +5,7 @@ export {
   ResourceGranter,
   DefaultResourceGranter,
 } from './builder/resource-granter';
+export * from './builder/as-normalized.helper';
 export * from './builder/inherit-resource.helper';
 export * from './executor/privileges';
 export * from './executor/resource-privileges';

--- a/src/components/authorization/policy/index.ts
+++ b/src/components/authorization/policy/index.ts
@@ -1,5 +1,7 @@
 export { Policy } from './builder/policy.decorator';
-export { ResourcesGranter } from './builder/resource-granter';
+export { ResourcesGranter } from './granters';
+export { Granter } from './builder/granter.decorator';
+export { ResourceGranter } from './builder/resource-granter';
 export * from './builder/inherit-resource.helper';
 export * from './executor/privileges';
 export * from './executor/resource-privileges';

--- a/src/components/authorization/policy/policy.factory.ts
+++ b/src/components/authorization/policy/policy.factory.ts
@@ -11,15 +11,12 @@ import { ResourcesHost } from '~/core/resources';
 import { Powers as Power } from '../dto/powers';
 import { Role } from '../dto/role.dto';
 import { ChildListAction, ChildSingleAction } from './actions';
-import { Permission, Permissions } from './builder/perm-granter';
+import { extract, Permission, Permissions } from './builder/perm-granter';
 import {
   POLICY_METADATA_KEY,
   PolicyMetadata,
 } from './builder/policy.decorator';
-import {
-  ResourceGranterImpl,
-  ResourcesGranter,
-} from './builder/resource-granter';
+import { ResourceGranter, ResourcesGranter } from './builder/resource-granter';
 import { all, any, Condition } from './conditions';
 
 interface ResourceGrants {
@@ -64,7 +61,7 @@ export class PolicyFactory implements OnModuleInit {
       );
 
     const ResourceMap = await this.resourcesHost.getEnhancedMap();
-    const resGranter = ResourceGranterImpl.create(ResourceMap);
+    const resGranter = ResourceGranter.create(ResourceMap);
 
     this.policies = await Promise.all(
       discoveredPolicies.map((discovered) =>
@@ -81,9 +78,8 @@ export class PolicyFactory implements OnModuleInit {
     const grants: WritableGrants = new Map();
     const resultList = many(meta.def(resGranter));
     for (const resourceGrant of resultList) {
-      const { resource, perms, props, childRelationships } = (
-        resourceGrant as ResourceGranterImpl<any>
-      ).extract();
+      const { resource, perms, props, childRelationships } =
+        resourceGrant[extract]();
       if (!grants.has(resource)) {
         grants.set(resource, {
           objectLevel: {},

--- a/src/components/authorization/policy/policy.factory.ts
+++ b/src/components/authorization/policy/policy.factory.ts
@@ -16,8 +16,9 @@ import {
   POLICY_METADATA_KEY,
   PolicyMetadata,
 } from './builder/policy.decorator';
-import { ResourceGranter, ResourcesGranter } from './builder/resource-granter';
 import { all, any, Condition } from './conditions';
+import { ResourcesGranter } from './granters';
+import { GrantersFactory } from './granters.factory';
 
 interface ResourceGrants {
   objectLevel: Permissions<string>;
@@ -43,6 +44,7 @@ export class PolicyFactory implements OnModuleInit {
   private policies?: Policy[];
 
   constructor(
+    private readonly grantersFactory: GrantersFactory,
     private readonly discovery: DiscoveryService,
     private readonly resourcesHost: ResourcesHost
   ) {}
@@ -60,8 +62,7 @@ export class PolicyFactory implements OnModuleInit {
         POLICY_METADATA_KEY
       );
 
-    const ResourceMap = await this.resourcesHost.getEnhancedMap();
-    const resGranter = ResourceGranter.create(ResourceMap);
+    const resGranter = await this.grantersFactory.makeGranters();
 
     this.policies = await Promise.all(
       discoveredPolicies.map((discovered) =>

--- a/src/components/authorization/policy/policy.module.ts
+++ b/src/components/authorization/policy/policy.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { PolicyExecutor } from './executor/policy-executor';
 import { Privileges } from './executor/privileges';
+import { GrantersFactory } from './granters.factory';
 import { PolicyFactory } from './policy.factory';
 
 @Module({
-  providers: [PolicyFactory, PolicyExecutor, Privileges],
+  providers: [GrantersFactory, PolicyFactory, PolicyExecutor, Privileges],
   exports: [Privileges],
 })
 export class PolicyModule {}


### PR DESCRIPTION
# Backstory
With this new policy system, and even more so with the old system, we have constraints that we have to fit within. We have resources & edges ("edges" meaning properties or relations), each have their set of actions and their fallback rules.

There are times however, when we need to be able to express more within this system.
e..g "Which roles can be assigned to `User.roles`?" 

A path that revealed itself was to create helper "resources" to define the answers to the specific permission questions.
They would define edges that would provide granular points to grant permissions for.
These still have to fit within our constraints above, so essentially this meant that we'd overlay a different meaning on top of the what system expresses.
What does this mean?... ⬇️ 

## Use case: Assignable Roles
Well `AssignableRoles` was created to answer the example question previously stated.
It has edges for each `Role`. We then say if you have `edit` permission on the edge/role you can assign it to the user.
(This happens to work well for Administrator role too, which grants edit access to this object, and all edges would fallback to this giving Administrator permission to assign all roles.)

So in policies this looked like:
```ts
r.AssignableRoles.specifically(p => p.StaffMember.edit),
```
Not the most readable or intuitive. So I created a wrapper function `Role.assignable`. Now it looks like
```ts
Role.assignable(r, [Role.StaffMember]),
```
Which is close enough, I think, to infer what's going on. At least it's easier on the eyes.

In usage we don't have any helpers to make this more idiomatic. However, I am much less concerned about this as it's done in one spot vs several policies.

# Problem?

Sounds like a solved problem, right? Well one of my goals for the new policies was to reduce imports / direct connections from the modules to these policies. All of these helper resources would end up having wrapper functions/objects to make their function idiomatic within policies. It makes sense for these functions to live within their associated module. This could lead to circular dependencies on JS import, which are headache inducing. It's also less intuitive as you have to know the wrapper exists to use it.

# Custom Granters

So the (next iteration) to solve this problem is custom granters.

Modules can now register granters for their resources, and these override the default one.
```ts
@Granter(AssignableRoles)
export class AssignableRolesGranter extends ResourceGranter<
  typeof AssignableRoles
> {
  grant(allowed: readonly Role[]) {
    return this.specifically((p) => p.many(...allowed).edit);
  }
}

// Declare custom granter for TypeScript
// Note the relative path here, so this changes based on where this is defined.
// I'm thinking about moving `PolicyModule` into `~/core`.
declare module './policy/granters' {
  interface GrantersOverride {
    AssignableRoles: AssignableRolesGranter;
  }
}

// Register in module
@Module({
  providers: [AssignableRolesGranter]
})
```
Now it can be used in policies just like normal
```ts
@Policy('all', r => [
  r.AssignableRoles.grant([
    Role.Staff,
  ])
])
```
Note: I'm still keeping `Role.assignable` since it's being used and is inside of `Role` whose type is already used in policies.

This solves the current problem by providing a more intuitive granter API in policies, while remaining consistent and no needing to import these helper APIs from across the codebase.

# Other Notes

Previously some granter methods were protected or hidden behind an implementation subclass. The whole goal with that was to hide them for policies. I've replaced that with public symbol methods, which is much easier. You can access them as long as you import and use the symbol, which is very intentional vs `.x`.

Since `.edit/read` are no longer exposed on every granter, Administrator & Leadership policies had errors trying to grant read or edit access to everything. I've added some helper methods to work around this: [`allowAll`](https://github.com/SeedCompany/cord-api-v3/blob/3cd0a112a86ffe8905db01c85486c2af48296263/src/components/authorization/policy/builder/allow-all.helper.ts#L7-L13), [`allowActions`](https://github.com/SeedCompany/cord-api-v3/blob/3cd0a112a86ffe8905db01c85486c2af48296263/src/components/authorization/policy/builder/allow-all.helper.ts#L15-L21), [`asNormalized`](https://github.com/SeedCompany/cord-api-v3/blob/3cd0a112a86ffe8905db01c85486c2af48296263/src/components/authorization/policy/builder/as-normalized.helper.ts).