### PR TITLE
Calculated decorator

### DIFF
--- a/src/common/calculated.decorator.ts
+++ b/src/common/calculated.decorator.ts
@@ -1,0 +1,15 @@
+export const CalculatedSymbol = Symbol('Calculated');
+
+/**
+ * Mark the resource or resource's property as calculated.
+ * This means the resource/property is managed by the API, instead of the user.
+ */
+export const Calculated =
+  (): PropertyDecorator & ClassDecorator =>
+  (target: any, key?: string | symbol) => {
+    if (!key) {
+      Reflect.defineMetadata(CalculatedSymbol, true, target);
+      return target;
+    }
+    Reflect.defineMetadata(CalculatedSymbol, true, target, key);
+  };

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,6 +1,7 @@
 export * from './async-pool.util';
 export * from './buffer';
 export * from './temporal';
+export * from './calculated.decorator';
 export * from './context.type';
 export * from './date-filter.input';
 export { DbLabel } from './db-label.decorator';

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { inspect } from 'util';
 import { ScopedRole } from '../components/authorization';
+import { CalculatedSymbol } from './calculated.decorator';
 import { DbLabel } from './db-label.decorator';
 import { ServerException } from './exceptions';
 import { ID, IdField } from './id-field';
@@ -208,6 +209,19 @@ export class EnhancedResource<T extends ResourceShape<any>> {
         return [name, rel];
       })
     );
+  }
+
+  @Once()
+  get isCalculated() {
+    return !!Reflect.getMetadata(CalculatedSymbol, this.type);
+  }
+
+  @Once()
+  get calculatedProps() {
+    const props = [...this.props].filter((prop) => {
+      return !!Reflect.getMetadata(CalculatedSymbol, this.type.prototype, prop);
+    });
+    return new Set(props);
   }
 }
 

--- a/src/components/authorization/policy/executor/policy-executor.ts
+++ b/src/components/authorization/policy/executor/policy-executor.ts
@@ -22,6 +22,16 @@ export class PolicyExecutor {
   constructor(private readonly policyFactory: PolicyFactory) {}
 
   resolve({ action, session, resource, prop }: ResolveParams) {
+    if (action !== 'read') {
+      if (prop) {
+        if (resource.calculatedProps.has(prop)) {
+          return false;
+        }
+      } else if (resource.isCalculated) {
+        return false;
+      }
+    }
+
     const policies = this.getPolicies(session);
     const isChildRelation = prop && resource.childKeys.has(prop);
 

--- a/src/components/ceremony/dto/ceremony.dto.ts
+++ b/src/components/ceremony/dto/ceremony.dto.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
+  Calculated,
   Resource,
   SecuredBoolean,
   SecuredDate,
@@ -11,6 +12,7 @@ import {
 } from '../../../common';
 import { CeremonyType } from './type.enum';
 
+@Calculated()
 @ObjectType({
   implements: [Resource],
 })

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { MergeExclusive } from 'type-fest';
 import {
+  Calculated,
   DateInterval,
   DateTimeField,
   DbLabel,
@@ -72,11 +73,13 @@ class Engagement extends ChangesetAwareResource {
   @Field()
   readonly disbursementCompleteDate: SecuredDateNullable;
 
+  @Calculated()
   @Field()
   // Match the project mouStart. Could need to manually set for an extension.
   // formally stage_begin.
   readonly startDate: SecuredDateNullable;
 
+  @Calculated()
   @Field()
   // Match the project mouEnd. Could need to manually set for an extension.
   // formally revised_end.

--- a/src/components/language/dto/language.dto.ts
+++ b/src/components/language/dto/language.dto.ts
@@ -4,6 +4,7 @@ import { stripIndent } from 'common-tags';
 import { GraphQLString } from 'graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
+  Calculated,
   DbLabel,
   DbUnique,
   ID,
@@ -173,6 +174,7 @@ export class Language extends Interfaces {
   @Field()
   readonly tags: SecuredTags;
 
+  @Calculated()
   @Field({
     description: stripIndent`
       Whether or not this language is a part of our "Preset Inventory".

--- a/src/components/partnership/dto/partnership.dto.ts
+++ b/src/components/partnership/dto/partnership.dto.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
+  Calculated,
   ID,
   IntersectionType,
   Resource,
@@ -57,9 +58,11 @@ export class Partnership extends IntersectionType(ChangesetAware, Resource) {
   @Field()
   readonly mouStatus: SecuredPartnershipAgreementStatus;
 
+  @Calculated()
   @Field()
   readonly mouStart: SecuredDateNullable;
 
+  @Calculated()
   @Field()
   readonly mouEnd: SecuredDateNullable;
 

--- a/src/components/periodic-report/dto/periodic-report.dto.ts
+++ b/src/components/periodic-report/dto/periodic-report.dto.ts
@@ -2,6 +2,7 @@ import { Field, InterfaceType, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { MergeExclusive } from 'type-fest';
 import {
+  Calculated,
   CalendarDate,
   Resource,
   SecuredDateNullable,
@@ -36,6 +37,7 @@ export const resolveReportType = (report: Pick<PeriodicReport, 'type'>) => {
   return type;
 };
 
+@Calculated()
 @InterfaceType({
   resolveType: resolveReportType,
   implements: [Resource],


### PR DESCRIPTION
We have several fields/lists that are "calculated" by the API. We use a secured property/list interface to be consistent and to expose whether you `canRead` the thing. But this interface also has `canEdit/canCreate/canDelete`, these don't make sense here but need to be set to a boolean. Obviously false is the natural choice, as true wouldn't make sense. We don't provide a mutation for these cases either.

Previously if we were using the authorization system we'd have to manually override the results to set false.
https://github.com/SeedCompany/cord-api-v3/blob/afa6f4f3ff542264419b5eca016650ee26b9f0d3/src/components/partnership/partnership.service.ts#L170-L177
https://github.com/SeedCompany/cord-api-v3/blob/afa6f4f3ff542264419b5eca016650ee26b9f0d3/src/components/periodic-report/periodic-report.service.ts#L143-L143

This introduces a decorator to mark the resource/property as calculated. The `Privileges` system now checks for this and returns false automatically when asking for a non-read actions on calculated things.
I've added this decorator to the current known places.

The [`PartnershipService.secure`](https://github.com/SeedCompany/cord-api-v3/blob/afa6f4f3ff542264419b5eca016650ee26b9f0d3/src/components/partnership/partnership.service.ts#L161-L183) can be a one liner:
```ts
return this.privileges.for(session, Partnership).secure(dto);
```