### PR TITLE
Change `member` condition to ignore roles

### DIFF
--- a/src/components/authorization/dto/role.dto.ts
+++ b/src/components/authorization/dto/role.dto.ts
@@ -43,7 +43,7 @@ export type AuthScope = GlobalScope | ProjectScope;
 export type ProjectScopedRole = `${ProjectScope}:${Role}`;
 export type GlobalScopedRole = `${GlobalScope}:${Role}`;
 
-export type ScopedRole = `${AuthScope}:${Role}`;
+export type ScopedRole = `${AuthScope}:${Role}` | 'member:true';
 
 // A helper to create a bunch of scoped roles for a given scope
 export const rolesForScope =

--- a/src/components/authorization/policies/conditions/member.condition.ts
+++ b/src/components/authorization/policies/conditions/member.condition.ts
@@ -17,32 +17,16 @@ import {
 
 const CQL_VAR = 'membershipRoles';
 
-class MemberCondition<
-  TResourceStatic extends ResourceShape<any> & {
-    // Make non-nullable to enforce that resource has its own scope to use this condition.
-    prototype: { scope?: readonly ScopedRole[] };
-  }
-> implements Condition<TResourceStatic>
+type ResourceWithScope = ResourceShape<any> & {
+  // Make non-nullable to enforce that resource has its own scope to use this condition.
+  prototype: { scope?: readonly ScopedRole[] };
+};
+
+class MemberCondition<TResourceStatic extends ResourceWithScope>
+  implements Condition<TResourceStatic>
 {
-  constructor(private readonly roles?: readonly Role[]) {}
-
   isAllowed({ object }: IsAllowedParams<TResourceStatic>): boolean {
-    if (!object) {
-      throw new Error("Needed object's scoped roles but object wasn't given");
-    }
-
-    const scope: ScopedRole[] =
-      Reflect.get(object, ScopedRoles) ?? object?.scope ?? [];
-
-    if (!this.roles) {
-      return scope.includes('member:true');
-    }
-
-    const actual = scope
-      .map(splitScope)
-      .filter(([scope, _]) => scope === 'project')
-      .map(([_, role]) => role);
-    return intersection(this.roles, actual).length > 0;
+    return getScope(object).includes('member:true');
   }
 
   setupCypherContext(
@@ -50,20 +34,44 @@ class MemberCondition<
     prevApplied: Set<any>,
     other: AsCypherParams<TResourceStatic>
   ) {
-    const cacheKey = this.roles ? 'membership-roles' : 'membership';
-    if (prevApplied.has(cacheKey)) {
+    if (prevApplied.has('membership')) {
       return query;
     }
-    prevApplied.add(cacheKey);
+    prevApplied.add('membership');
 
-    if (!this.roles) {
-      const param = query.params.addParam(
-        other.session.userId,
-        'requestingUser'
-      );
-      Reflect.set(other, CQL_VAR, param);
+    const param = query.params.addParam(other.session.userId, 'requestingUser');
+    Reflect.set(other, CQL_VAR, param);
+    return query;
+  }
+
+  asCypherCondition(query: Query, other: AsCypherParams<TResourceStatic>) {
+    const requester = String(Reflect.get(other, CQL_VAR));
+    return `exists((project)-[:member { active: true }]->(:ProjectMember)-[:user]->(:User { id: ${requester} }))`;
+  }
+
+  [inspect.custom](_depth: number, _options: InspectOptionsStylized) {
+    return 'Member';
+  }
+}
+
+class MemberWithRolesCondition<TResourceStatic extends ResourceWithScope>
+  implements Condition<TResourceStatic>
+{
+  constructor(private readonly roles: readonly Role[]) {}
+
+  isAllowed({ object }: IsAllowedParams<TResourceStatic>): boolean {
+    const actual = getScope(object)
+      .map(splitScope)
+      .filter(([scope, _]) => scope === 'project')
+      .map(([_, role]) => role);
+    return intersection(this.roles, actual).length > 0;
+  }
+
+  setupCypherContext(query: Query, prevApplied: Set<any>) {
+    if (prevApplied.has('membership-roles')) {
       return query;
     }
+    prevApplied.add('membership-roles');
 
     return query.apply(
       matchProjectScopedRoles({
@@ -73,12 +81,7 @@ class MemberCondition<
     );
   }
 
-  asCypherCondition(query: Query, other: AsCypherParams<TResourceStatic>) {
-    if (!this.roles) {
-      const requester = String(Reflect.get(other, CQL_VAR));
-      return `exists((project)-[:member { active: true }]->(:ProjectMember)-[:user]->(:User { id: ${requester} }))`;
-    }
-
+  asCypherCondition(query: Query) {
     const required = query.params.addParam(
       this.roles.map(rolesForScope('project')),
       'requiredMemberRoles'
@@ -87,7 +90,7 @@ class MemberCondition<
   }
 
   [inspect.custom](_depth: number, _options: InspectOptionsStylized) {
-    return 'Member';
+    return `Member with ${this.roles.join(', ')}`;
   }
 }
 
@@ -104,7 +107,8 @@ export const member = new MemberCondition();
  * NOTE that the policy roles are filtered before this, so only a subset of the
  * policy's roles can effectively be used here.
  */
-export const memberWith = (...roles: Role[]) => new MemberCondition(roles);
+export const memberWith = (...roles: Role[]) =>
+  new MemberWithRolesCondition(roles);
 
 /**
  * Specify roles that should be used for the membership condition.
@@ -122,5 +126,15 @@ export const withScope = <T extends object>(obj: T, roles: ScopedRole[]) =>
     value: roles,
     enumerable: false,
   });
+
+export const getScope = (
+  object: IsAllowedParams<ResourceWithScope>['object']
+): ScopedRole[] => {
+  if (!object) {
+    throw new Error("Needed object's scoped roles but object wasn't given");
+  }
+
+  return Reflect.get(object, ScopedRoles) ?? object?.scope ?? [];
+};
 
 const ScopedRoles = Symbol('ScopedRoles');

--- a/src/components/authorization/policies/conditions/member.condition.ts
+++ b/src/components/authorization/policies/conditions/member.condition.ts
@@ -10,7 +10,6 @@ import {
   splitScope,
 } from '../../dto/role.dto';
 import { Condition, IsAllowedParams } from '../../policy/conditions';
-import { BuiltPolicy } from '../util';
 
 const CQL_VAR = 'membershipRoles';
 
@@ -22,10 +21,6 @@ class MemberCondition<
 > implements Condition<TResourceStatic>
 {
   constructor(private readonly roles?: readonly Role[]) {}
-
-  attachPolicy(policy: BuiltPolicy): MemberCondition<TResourceStatic> {
-    return this.roles ? this : new MemberCondition(policy.roles);
-  }
 
   isAllowed({ object }: IsAllowedParams<TResourceStatic>): boolean {
     if (!object) {
@@ -79,8 +74,7 @@ class MemberCondition<
 }
 
 /**
- * The following actions only apply if the requester has any "member" scoped roles
- * with this policy's defined roles.
+ * The following actions only apply if the requester has any "member" scoped roles.
  * This usually is implemented as a member of the related project.
  */
 export const member = new MemberCondition();

--- a/src/components/authorization/policies/conditions/member.condition.ts
+++ b/src/components/authorization/policies/conditions/member.condition.ts
@@ -29,16 +29,15 @@ class MemberCondition<
 
     const scope: ScopedRole[] =
       Reflect.get(object, ScopedRoles) ?? object?.scope ?? [];
+
+    if (!this.roles) {
+      return scope.includes('member:true');
+    }
+
     const actual = scope
       .map(splitScope)
       .filter(([scope, _]) => scope === 'project')
       .map(([_, role]) => role);
-
-    // If policy is for any roles, just confirm that there's at least one member role.
-    if (!this.roles) {
-      return actual.length > 0;
-    }
-
     return intersection(this.roles, actual).length > 0;
   }
 

--- a/src/core/database/query/match-project-based-props.ts
+++ b/src/core/database/query/match-project-based-props.ts
@@ -80,13 +80,17 @@ export const matchProjectScopedRoles =
               node('rolesProp', 'Property'),
             ],
           ])
+          .with(collect('rolesProp.value').as('memberRoleProps'))
           .return<{ [K in Output]: ScopedRole[] }>(
-            reduce(
-              'scopedRoles',
-              [],
-              apoc.coll.flatten(collect('rolesProp.value')),
-              'role',
-              listConcat('scopedRoles', [`"project:" + role`])
+            listConcat(
+              'case size(memberRoleProps) > 0 when true then ["member:true"] else [] end',
+              reduce(
+                'scopedRoles',
+                [],
+                apoc.coll.flatten('memberRoleProps'),
+                'role',
+                listConcat('scopedRoles', [`"project:" + role`])
+              )
             ).as(outputVar)
           )
           .union()


### PR DESCRIPTION
The logic in the old system was a user with X role "scoped" to project membership. As the new auth system unwound this logic, it makes more sense to completely separate these concepts. Policies are only considered if the user has the role globally and then if they are a member at all they get X permissions. I've confirmed this with @sethmcknight so here it is.

To facilitate this I added a `member:true` to the `ScopedRole` type and returned it in [`matchProjectScopedRoles`](https://github.com/SeedCompany/cord-api-v3/compare/improve/member-condition#diff-2a99be5f26d1bb73f22d61738715b3c13760d0601500a7f14f1074fa05e0f7a3).
When executing the condition in cypher it's easier too since we can just check for a path existence.

---

I also fixed the stack trace for trailing condition errors when using `.when` wrappers.

---

I also allowed policies to return multilevel arrays to help facilitate abstractions.
This now works without having to spread each line:
```ts
@Policy('all', r => [
  inherit(...),
  Object.values(r),
])
```
The less syntax the better in these policies.