### PR TITLE
Policy Dumper

### DIFF
--- a/src/common/exceptions/unauthorized.exception.ts
+++ b/src/common/exceptions/unauthorized.exception.ts
@@ -82,7 +82,7 @@ export class UnauthorizedException extends InputException {
     const edgeName = edge ? lowerCase(edge) : undefined;
     const edges =
       edge && edgeName
-        ? (resource.childListKeys as Set<string>).has(edge)
+        ? resource.childListKeys.has(edge as never)
           ? edgeName // assume child lists are already plural
           : pluralize(edgeName, 2)
         : undefined;

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -170,7 +170,7 @@ export class EnhancedResource<T extends ResourceShape<any>> {
   @Once()
   get extraPropsFromRelations() {
     return this.relNamesIf<ExtraPropsFromRelationsKey<T>>(
-      (rel) => !!rel.resource && !rel.resource.hasParent
+      (rel) => !rel.resource || !rel.resource.hasParent
     );
   }
 

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -132,7 +132,7 @@ export class EnhancedResource<T extends ResourceShape<any>> {
    * i.e. {@link import('@nestjs/graphql').IntersectionType}
    */
   @Once()
-  get interfaces() {
+  get interfaces(): ReadonlySet<EnhancedResource<any>> {
     return new Set(
       getParentTypes(this.type)
         .slice(1) // not self
@@ -146,22 +146,24 @@ export class EnhancedResource<T extends ResourceShape<any>> {
   }
 
   @Once()
-  get securedPropsPlusExtra() {
+  get securedPropsPlusExtra(): ReadonlySet<
+    SecuredResourceKey<T, false> | ExtraPropsFromRelationsKey<T>
+  > {
     return new Set([...this.securedProps, ...this.extraPropsFromRelations]);
   }
 
   @Once()
-  get props() {
+  get props(): ReadonlySet<keyof T['prototype'] & string> {
     return new Set<keyof T['prototype'] & string>(this.type.Props as any);
   }
 
   @Once()
-  get securedProps() {
+  get securedProps(): ReadonlySet<SecuredResourceKey<T, false>> {
     return new Set<SecuredResourceKey<T, false>>(this.type.SecuredProps as any);
   }
 
   @Once()
-  get childKeys() {
+  get childKeys(): ReadonlySet<ChildSinglesKey<T> | ChildListsKey<T>> {
     return new Set([...this.childSingleKeys, ...this.childListKeys]);
   }
 
@@ -186,7 +188,9 @@ export class EnhancedResource<T extends ResourceShape<any>> {
     );
   }
 
-  private relNamesIf<K>(predicate: (rel: EnhancedRelation<any>) => boolean) {
+  private relNamesIf<K>(
+    predicate: (rel: EnhancedRelation<any>) => boolean
+  ): ReadonlySet<K> {
     return new Set<K>(
       [...this.relations.values()].flatMap((rel) =>
         predicate(rel) ? (rel.name as K) : []
@@ -218,7 +222,7 @@ export class EnhancedResource<T extends ResourceShape<any>> {
   }
 
   @Once()
-  get calculatedProps() {
+  get calculatedProps(): ReadonlySet<keyof T['prototype'] & string> {
     const props = [...this.props].filter((prop) => {
       return !!Reflect.getMetadata(CalculatedSymbol, this.type.prototype, prop);
     });

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -20,11 +20,12 @@ export const simpleSwitch = <T, K extends string = string>(
 
 /** Converts list to map given a function that returns a [key, value] tuple. */
 export const mapFromList = <T, S = T, K extends string | number = string>(
-  list: readonly T[] | Set<T>,
+  list: readonly T[] | ReadonlySet<T>,
   mapper: (item: T) => readonly [K, S] | null
 ): Record<K, S> => {
   const out: Partial<Record<K, S>> = {};
-  return (list instanceof Set ? [...list] : list).reduce((acc, item) => {
+  list = list instanceof Set ? [...list] : (list as T[]);
+  return list.reduce((acc, item) => {
     const res = mapper(item);
     if (!res) {
       return acc;

--- a/src/components/authorization/dto/assignable-roles.ts
+++ b/src/components/authorization/dto/assignable-roles.ts
@@ -1,5 +1,5 @@
 import { keys as keysOf } from 'ts-transformer-keys';
-import { mapFromList, ResourceShape } from '~/common';
+import { mapFromList } from '~/common';
 import { Role } from './role.dto';
 
 /**
@@ -14,19 +14,11 @@ import { Role } from './role.dto';
  *   ])
  * ])
  */
-export const AssignableRoles = {
-  // Stuff actually needed at runtime.
-  name: 'AssignableRoles',
-  Relations: mapFromList(keysOf<Record<Role, boolean>>(), (role) => [
+export class AssignableRoles {
+  static Props = [];
+  static SecuredProps = [];
+  static Relations = mapFromList(keysOf<Record<Role, boolean>>(), (role) => [
     role,
     undefined,
-  ]),
-  Props: [],
-  SecuredProps: [],
-} as unknown as Omit<
-  ResourceShape<Record<Role, boolean>>,
-  'prototype' | 'Relations'
-> & {
-  prototype: Record<Role, boolean>;
-  Relations: Record<Role, boolean>;
-};
+  ]);
+}

--- a/src/components/authorization/dto/assignable-roles.ts
+++ b/src/components/authorization/dto/assignable-roles.ts
@@ -1,5 +1,5 @@
 import { keys as keysOf } from 'ts-transformer-keys';
-import { mapFromList } from '~/common';
+import { Calculated, mapFromList } from '~/common';
 import { Role } from './role.dto';
 
 /**
@@ -14,6 +14,7 @@ import { Role } from './role.dto';
  *   ])
  * ])
  */
+@Calculated()
 export class AssignableRoles {
   static Props = [];
   static SecuredProps = [];

--- a/src/components/authorization/dto/beta-features.ts
+++ b/src/components/authorization/dto/beta-features.ts
@@ -1,9 +1,11 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { Calculated } from '~/common';
 import { Granter, ResourceGranter } from '../policy';
 
 // TODO move somewhere else
 
+@Calculated()
 @ObjectType()
 export class BetaFeatures {
   static readonly Props = keysOf<BetaFeatures>();

--- a/src/components/authorization/policies/conditions/member.condition.ts
+++ b/src/components/authorization/policies/conditions/member.condition.ts
@@ -74,10 +74,7 @@ class MemberCondition<
   }
 
   [inspect.custom](_depth: number, _options: InspectOptionsStylized) {
-    if (this.roles) {
-      return `Membership ${inspect({ roles: this.roles })}`;
-    }
-    return 'Membership';
+    return 'Member';
   }
 }
 

--- a/src/components/authorization/policies/conditions/sensitivity.condition.ts
+++ b/src/components/authorization/policies/conditions/sensitivity.condition.ts
@@ -54,7 +54,12 @@ export class SensitivityCondition<
   }
 
   [inspect.custom](_depth: number, _options: InspectOptionsStylized) {
-    return `Sensitivity { ${this.access} }`;
+    const map = {
+      High: 'Any',
+      Medium: 'Medium/Low',
+      Low: 'Low',
+    };
+    return `Sens ${map[this.access]}`;
   }
 }
 

--- a/src/components/authorization/policy/conditions/aggregate.condition.ts
+++ b/src/components/authorization/policy/conditions/aggregate.condition.ts
@@ -1,5 +1,4 @@
 import { Query } from 'cypher-query-builder';
-import { startCase } from 'lodash';
 import { inspect, InspectOptionsStylized } from 'util';
 import { ResourceShape } from '~/common';
 import { Policy } from '../policy.factory';
@@ -58,7 +57,13 @@ export abstract class AggregateConditions<
   }
 
   [inspect.custom](_depth: number, _options: InspectOptionsStylized) {
-    return `${startCase(this.constructor.name)} ${inspect(this.conditions)}`;
+    const name = this instanceof AndConditions ? ' AND ' : ' OR ';
+    return this.conditions
+      .map((c) => {
+        const l = inspect(c);
+        return c instanceof AggregateConditions ? `(${l})` : l;
+      })
+      .join(name);
   }
 }
 

--- a/src/components/authorization/policy/executor/policy-dumper.ts
+++ b/src/components/authorization/policy/executor/policy-dumper.ts
@@ -14,7 +14,7 @@ import {
   ResourceAction,
 } from '../actions';
 import { Permission } from '../builder/perm-granter';
-import { PolicyExecutor } from './policy-executor';
+import { CalculatedCondition, PolicyExecutor } from './policy-executor';
 
 interface DumpedRow {
   resource: EnhancedResource<any>;
@@ -79,6 +79,9 @@ export class PolicyDumper {
           if (v instanceof EnhancedResource) {
             return startCase(v.name);
           }
+          if (v instanceof CalculatedCondition) {
+            return null;
+          }
           return inspect(v);
         }),
         (_, k) => (headerMap as any)[k] ?? k
@@ -90,7 +93,7 @@ export class PolicyDumper {
     session: Session,
     resource: EnhancedResource<any>
   ): DumpedRow[] {
-    const opts = { session, resource };
+    const opts = { session, resource, calculatedAsCondition: true };
     return [
       {
         resource,

--- a/src/components/authorization/policy/executor/policy-dumper.ts
+++ b/src/components/authorization/policy/executor/policy-dumper.ts
@@ -1,0 +1,121 @@
+import { Injectable } from '@nestjs/common';
+import { mapKeys, mapValues, sortBy, startCase } from 'lodash';
+import { keys as keysOf } from 'ts-transformer-keys';
+import { inspect } from 'util';
+import xlsx from 'xlsx';
+import { EnhancedResource, mapFromList, Session } from '~/common';
+import { ConfigService, ResourcesHost } from '~/core';
+import { AuthenticationService } from '../../../authentication';
+import { Role } from '../../dto';
+import {
+  ChildListAction,
+  ChildSingleAction,
+  PropAction,
+  ResourceAction,
+} from '../actions';
+import { Permission } from '../builder/perm-granter';
+import { PolicyExecutor } from './policy-executor';
+
+interface DumpedRow {
+  resource: EnhancedResource<any>;
+  edge?: string;
+  read: Permission;
+  edit?: Permission;
+  create?: Permission;
+  delete?: Permission;
+}
+
+@Injectable()
+export class PolicyDumper {
+  constructor(
+    private readonly resources: ResourcesHost,
+    private readonly executor: PolicyExecutor,
+    private readonly auth: AuthenticationService,
+    private readonly config: ConfigService
+  ) {}
+
+  async write(filename?: string) {
+    const book = xlsx.utils.book_new();
+
+    for (const role of Object.keys(Role) as Role[]) {
+      const data = await this.dumpFor(role);
+      const sheet = xlsx.utils.json_to_sheet(data);
+      xlsx.utils.book_append_sheet(book, sheet, startCase(role).slice(0, 31));
+    }
+
+    xlsx.writeFile(book, filename ?? 'permissions.xlsx');
+  }
+
+  private async dumpFor(role: Role) {
+    const session: Session = {
+      ...(await this.auth.sessionForUser(this.config.rootAdmin.id)),
+      roles: [`global:${role}`],
+    };
+
+    const map = await this.resources.getEnhancedMap();
+    const data = sortBy(Object.values(map), (r) => r.name).flatMap((resource) =>
+      this.dumpRes(session, resource)
+    );
+    const headerMap = {
+      resource: 'Resource',
+      edge: 'Property/Relationship',
+      read: 'Read',
+      edit: 'Update',
+      create: 'Create',
+      delete: 'Delete',
+    };
+    return data.map((row) =>
+      mapKeys(
+        mapValues(row, (v) => {
+          if (v == null || typeof v === 'string') {
+            return v;
+          }
+          if (v === true) {
+            return 'Yes';
+          }
+          if (v === false) {
+            return 'No';
+          }
+          if (v instanceof EnhancedResource) {
+            return startCase(v.name);
+          }
+          return inspect(v);
+        }),
+        (_, k) => (headerMap as any)[k] ?? k
+      )
+    );
+  }
+
+  private dumpRes(
+    session: Session,
+    resource: EnhancedResource<any>
+  ): DumpedRow[] {
+    const opts = { session, resource };
+    return [
+      {
+        resource,
+        edge: undefined,
+        ...mapFromList(keysOf<Record<ResourceAction, boolean>>(), (action) => [
+          action,
+          this.executor.resolve({ ...opts, action }),
+        ]),
+      },
+      ...(
+        [
+          [resource.securedPropsPlusExtra, keysOf<Record<PropAction, ''>>()],
+          [resource.childSingleKeys, keysOf<Record<ChildSingleAction, ''>>()],
+          [resource.childListKeys, keysOf<Record<ChildListAction, ''>>()],
+        ] as const
+      ).flatMap(([set, actions]) =>
+        [...set].map((prop) => ({
+          resource,
+          edge: startCase(prop),
+          ...mapFromList(actions, (action) => [
+            action,
+            this.executor.resolve({ ...opts, action, prop }),
+          ]),
+        }))
+      ),
+    ];
+  }
+}

--- a/src/components/authorization/policy/lazy-record.ts
+++ b/src/components/authorization/policy/lazy-record.ts
@@ -7,7 +7,7 @@ export const createLazyRecord = <T extends object>({
   getKeys,
   base,
 }: {
-  getKeys: () => Array<keyof T & string> | Set<keyof T & string>;
+  getKeys: () => Array<keyof T & string> | ReadonlySet<keyof T & string>;
   calculate: (key: keyof T & string, object: Partial<T>) => T[keyof T & string];
   base?: Partial<T>;
 }) => {

--- a/src/components/authorization/policy/policy.module.ts
+++ b/src/components/authorization/policy/policy.module.ts
@@ -1,11 +1,18 @@
 import { Module } from '@nestjs/common';
+import { PolicyDumper } from './executor/policy-dumper';
 import { PolicyExecutor } from './executor/policy-executor';
 import { Privileges } from './executor/privileges';
 import { GrantersFactory } from './granters.factory';
 import { PolicyFactory } from './policy.factory';
 
 @Module({
-  providers: [GrantersFactory, PolicyFactory, PolicyExecutor, Privileges],
+  providers: [
+    GrantersFactory,
+    PolicyFactory,
+    PolicyExecutor,
+    Privileges,
+    PolicyDumper,
+  ],
   exports: [Privileges],
 })
 export class PolicyModule {}


### PR DESCRIPTION
This adds a service to dump our privileges to an xlsx file.
```
$ yarn repl
> await $(PolicyDumper).write()
```

Also cleaned up a few things & made most sets returned readonly.