### PR TITLE
added parent to comments list

### DIFF
--- a/src/components/comments/comment.service.ts
+++ b/src/components/comments/comment.service.ts
@@ -201,9 +201,13 @@ export class CommentService {
     await this.verifyCanView(parent, session);
 
     const results = await this.repo.threads.list(parent.id, input, session);
-    return await mapListResults(results, (dto) =>
-      this.secureThread(dto, session)
-    );
+
+    return {
+      ...(await mapListResults(results, (dto) =>
+        this.secureThread(dto, session)
+      )),
+      parent,
+    };
   }
 
   async listCommentsByThreadId(

--- a/src/components/comments/dto/list-comment-thread.dto.ts
+++ b/src/components/comments/dto/list-comment-thread.dto.ts
@@ -1,6 +1,7 @@
-import { InputType, ObjectType } from '@nestjs/graphql';
+import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Order, PaginatedList, SortablePaginationInput } from '../../../common';
 import { CommentThread } from './comment-thread.dto';
+import { Commentable } from './commentable.dto';
 
 @InputType()
 export class CommentThreadListInput extends SortablePaginationInput<
@@ -13,4 +14,7 @@ export class CommentThreadListInput extends SortablePaginationInput<
 }
 
 @ObjectType()
-export class CommentThreadList extends PaginatedList(CommentThread) {}
+export class CommentThreadList extends PaginatedList(CommentThread) {
+  @Field()
+  readonly parent: Commentable;
+}


### PR DESCRIPTION
When working on the RichText feature for the UI (https://github.com/SeedCompany/cord-field/issues/1150) we ended up needing to pass the parent of a comments list.

This change will enable proper caching in the UI application.