### PR TITLE
REPL, LevelMatcher, CachedForArg tweaks 

### DIFF
--- a/src/common/weak-map-cache.ts
+++ b/src/common/weak-map-cache.ts
@@ -2,7 +2,7 @@ import { isPromise } from 'util/types';
 
 /**
  * A helper to execute some logic once and store the result for the lifespan of the object.
- * The calculate function can be async or sync.
+ * The `calculate` function can be async or sync.
  */
 export const cachedOnObject = <T extends object, R>(
   map: WeakMap<T, Awaited<R>>,
@@ -31,17 +31,18 @@ export const cachedOnObject = <T extends object, R>(
  *
  * The result does not need to be serializable.
  */
-export const CachedOnArg =
-  () =>
-  <Arg extends object, R>(
+export const CachedForArg =
+  <Weak extends boolean | undefined>(options: { weak?: Weak } = {}) =>
+  <Arg extends Weak extends true ? object : any, R>(
     staticClass: any,
     methodName: string | symbol,
     descriptor: TypedPropertyDescriptor<(...args: [Arg]) => R>
   ) => {
     const execute = descriptor.value!;
-    const staticMap = new WeakMap(); // holds WeakMap for each instance
+    const staticMap = new WeakMap(); // holds a map for each instance
+    const createMap = options.weak ? () => new WeakMap() : () => new Map();
     descriptor.value = function (arg) {
-      const instanceMap = cachedOnObject(staticMap, this, () => new WeakMap());
+      const instanceMap = cachedOnObject(staticMap, this, createMap);
       return cachedOnObject(instanceMap, arg, () => execute.call(this, arg));
     };
   };

--- a/src/components/authorization/policy/executor/policy-executor.ts
+++ b/src/components/authorization/policy/executor/policy-executor.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { identity, intersection } from 'lodash';
-import { CachedOnArg, EnhancedResource, Session } from '~/common';
+import { CachedForArg, EnhancedResource, Session } from '~/common';
 import { QueryFragment } from '~/core/database/query';
 import { withoutScope } from '../../dto/role.dto';
 import { Permission } from '../builder/perm-granter';
@@ -110,7 +110,7 @@ export class PolicyExecutor {
     };
   }
 
-  @CachedOnArg()
+  @CachedForArg({ weak: true })
   getPolicies(session: Session) {
     const policies = this.policyFactory.getPolicies().filter((policy) => {
       if (!policy.roles) {

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -1,7 +1,7 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { difference } from 'lodash';
 import {
-  CachedOnArg,
+  CachedForArg,
   DuplicateException,
   ID,
   NotFoundException,
@@ -180,7 +180,7 @@ export class UserService {
     return await mapListResults(results, (dto) => this.secure(dto, session));
   }
 
-  @CachedOnArg()
+  @CachedForArg({ weak: true })
   getAssignableRoles(session: Session) {
     const privileges = this.privileges.for(session, AssignableRoles);
     const assignableRoles = new Set(

--- a/src/core/logger/level-matcher.provider.ts
+++ b/src/core/logger/level-matcher.provider.ts
@@ -32,14 +32,7 @@ export const LevelMatcherProvider: Provider<Promise<LevelMatcher>> = {
       identity
     );
 
-    const declaredLevels = {
-      ...yamlOverrides.levels,
-      ...envLevels,
-    };
-    const levels =
-      Object.keys(declaredLevels).length === 0
-        ? defaults.levels
-        : declaredLevels;
+    const levels = [envLevels, yamlOverrides.levels ?? {}, defaults.levels];
 
     const defaultLevel =
       envDefault ?? yamlOverrides.defaultLevel ?? defaults.defaultLevel;

--- a/src/core/logger/level-matcher.ts
+++ b/src/core/logger/level-matcher.ts
@@ -11,17 +11,18 @@ interface MatcherConfig {
 /**
  * Determines whether a named logger is enabled for the given log level.
  *
- * It works similarly to the `debug` library, where loggers are named/namespace
+ * It works similarly to the `debug` library, where loggers are named/namespace,
  * and you specify which loggers you want with a single DEBUG env var.
  * Their logger doesn't have any levels, where ours does.
  *
- * In order to map the loggers to a level you provide an object mapping the
- * name(s) to a level. Each key can specify one or more names separated by comma.
- * An `*` can be used as a wild card as well matching sub namespaces.
+ * In order to map the loggers to a level, you provide an object mapping the
+ * name(s) to a level.
+ * Each key can specify one or more names separated by comma.
+ * An `*` can be used as a wild card as well that will match sub namespaces.
  * It's important to note the order of the keys matters as the first matching
  * name determines the level.
  *
- * An simple example:
+ * A simple example:
  *     {
  *       'foo:bar': LogLevel.DEBUG,
  *       'foo:*': LogLevel.INFO,
@@ -51,7 +52,8 @@ interface MatcherConfig {
  * so the default would be used.
  *
  * You can personalize the level config for your local machine by using the
- * logging.yml file in the project root. See the example file as a starting point.
+ * logging.yml file in the project root.
+ * See the example file as a starting point.
  */
 export class LevelMatcher {
   private readonly defaultLevel: LogLevel;
@@ -78,7 +80,7 @@ export class LevelMatcher {
           const exclude = namespace.startsWith('-');
           const regPart = namespace.replace(/\*/g, '.*?');
           if (exclude) {
-            matcher.exclude.push(new RegExp(`^${regPart.substr(1)}$`));
+            matcher.exclude.push(new RegExp(`^${regPart.slice(1)}$`));
           } else {
             matcher.include.push(new RegExp(`^${regPart}$`));
           }

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { mapValues } from 'lodash';
 import { ValueOf } from 'ts-essentials';
 import { LiteralUnion } from 'type-fest';
-import { CachedOnArg, EnhancedResource, ServerException } from '~/common';
+import { CachedForArg, EnhancedResource, ServerException } from '~/common';
 import type { LegacyResourceMap } from '../../components/authorization/model/resource-map';
 import { ResourceMap } from './map';
 import { __privateDontUseThis } from './resource-map-holder';
@@ -50,7 +50,7 @@ export class ResourcesHost {
     return resource;
   }
 
-  @CachedOnArg()
+  @CachedForArg()
   async getInterfaces(
     resource: EnhancedResource<any>
   ): Promise<ReadonlyArray<EnhancedResource<any>>> {
@@ -60,7 +60,7 @@ export class ResourcesHost {
     return [...resource.interfaces].filter((i) => resSet.has(i));
   }
 
-  @CachedOnArg()
+  @CachedForArg()
   async getImplementations(
     interfaceResource: EnhancedResource<any>
   ): Promise<ReadonlyArray<EnhancedResource<any>>> {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -62,6 +62,8 @@ async function bootstrap() {
     prompt: clc.green('> '),
     ignoreUndefined: true,
   });
+  replServer.on('exit', () => void app.close());
+
   assignToObject(replServer.context, context);
 
   await mkdir('.cache', { recursive: true });

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -7,7 +7,9 @@ import { mkdir } from 'fs/promises';
 import * as lodash from 'lodash';
 import { DateTime, Duration, Interval } from 'luxon';
 import { promisify } from 'util';
+import { createContext, runInContext } from 'vm';
 import {
+  bufferFromStream,
   CalendarDate,
   DateInterval,
   many,
@@ -56,6 +58,13 @@ async function bootstrap() {
     }),
     Resources,
   });
+
+  if (!process.stdin.isTTY) {
+    const input = await bufferFromStream(process.stdin);
+    runInContext(input.toString(), createContext(context));
+    await app.close();
+    return;
+  }
 
   const _repl = await Promise.resolve().then(() => import('repl'));
   const replServer = _repl.start({

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -32,26 +32,12 @@ async function bootstrap() {
   });
   await app.init();
 
-  const replContext = new ReplContext(app);
-  const _repl = await Promise.resolve().then(() => import('repl'));
-  const replServer = _repl.start({
-    prompt: clc.green('> '),
-    ignoreUndefined: true,
-  });
-  assignToObject(replServer.context, replContext.globalScope);
-
-  // Our own stuff below
-
-  await mkdir('.cache', { recursive: true });
-  await promisify(replServer.setupHistory.bind(replServer))(
-    '.cache/repl_history'
-  );
   const session = await app
     .get(AuthenticationService)
     .sessionForUser(app.get(ConfigService).rootAdmin.id);
   const Resources = await app.get(ResourcesHost).getEnhancedMap();
 
-  assignToObject(replServer.context, {
+  const context = assignToObject(new ReplContext(app).globalScope, {
     DateTime,
     Duration,
     Interval,
@@ -70,6 +56,18 @@ async function bootstrap() {
     }),
     Resources,
   });
+
+  const _repl = await Promise.resolve().then(() => import('repl'));
+  const replServer = _repl.start({
+    prompt: clc.green('> '),
+    ignoreUndefined: true,
+  });
+  assignToObject(replServer.context, context);
+
+  await mkdir('.cache', { recursive: true });
+  await promisify(replServer.setupHistory.bind(replServer))(
+    '.cache/repl_history'
+  );
 }
 bootstrap().catch((err) => {
   // eslint-disable-next-line no-console

--- a/test/utility/create-app.ts
+++ b/test/utility/create-app.ts
@@ -23,7 +23,7 @@ export const createTestApp = async () => {
     imports: [AppModule],
   })
     .overrideProvider(LevelMatcher)
-    .useValue(new LevelMatcher({}, LogLevel.ERROR))
+    .useValue(new LevelMatcher([], LogLevel.ERROR))
     .compile();
 
   const app = moduleFixture.createNestApplication<TestApp>();


### PR DESCRIPTION
I added logic so that some input could be piped into REPL which will be ran and then REPL will exit.
```bash
$ echo '$(PolicyDumper).write()' | yarn repl
```
In reality, it's not REPL at all, but it uses same context/syntax.

---

In doing this I needed some output from the app, but the bootstrap logging was getting in the way. So I wrote, 
```ts
LOG_LEVELS='*=error' yarn repl
```
But it wasn't working because another entry in my `logger.yml` was being matched first. 

So I updated the logic so that ENV levels always take precedence of over `logger.yml` and that takes precedence over `ConfigService.logging` defaults.

---

Renamed `CachedOnArg` to `CachedForArg`. And changed it to use a strong map by default with the option to be weak.
So this is how the old logic works
```ts
@CachedForArg({ weak: true })
method(session: Session) // or any object. It still has to be an object for the `WeakMap` to work.
```
```ts
@CachedForArg()
method(key: string) // string keys now work. They will be cached for the existence of the class instance.
```