### PR TITLE
Commentable GQL Query + more

### DIFF
--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -6,3 +6,4 @@ export * from './not-implemented.exception';
 export * from './unauthenticated.exception';
 export * from './unauthorized.exception';
 export * from './service-unavailable.exception';
+export * from './invalid-id-for-type.exception';

--- a/src/common/exceptions/invalid-id-for-type.exception.ts
+++ b/src/common/exceptions/invalid-id-for-type.exception.ts
@@ -1,0 +1,10 @@
+import { ClientException } from './exception';
+
+/**
+ * Indicate the ID from request is attached to a resource whose type is unexpected.
+ */
+export class InvalidIdForTypeException extends ClientException {
+  constructor(message?: string, previous?: Error) {
+    super(message ?? 'ID references an unexpected type', previous);
+  }
+}

--- a/src/components/authorization/authorization.service.ts
+++ b/src/components/authorization/authorization.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import {
+  EnhancedResource,
   ResourceShape,
   SecuredResource,
   Sensitivity,
@@ -106,7 +107,7 @@ export class AuthorizationService {
     dto = {},
     sensitivity,
   }: {
-    resource: Resource;
+    resource: Resource | EnhancedResource<Resource>;
     sessionOrUserId: Session;
     otherRoles?: ScopedRole[];
     dto?: Resource['prototype'];

--- a/src/components/comments/comment.service.ts
+++ b/src/components/comments/comment.service.ts
@@ -96,7 +96,7 @@ export class CommentService {
     const parentType = await this.resourcesHost.getByName(parent.__typename);
     const parentInterfaces = await this.resourcesHost.getInterfaces(parentType);
     if (!parentInterfaces.includes(EnhancedResource.of(Commentable))) {
-      throw new InvalidIdForTypeException('Resource is not commentable');
+      throw new NonCommentableType('Resource does not implement Commentable');
     }
     return parent as Commentable;
   }
@@ -186,3 +186,5 @@ export class CommentService {
     );
   }
 }
+
+class NonCommentableType extends InvalidIdForTypeException {}

--- a/src/components/comments/comment.service.ts
+++ b/src/components/comments/comment.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { ConditionalKeys } from 'type-fest';
 import {
   ID,
   isIdLike,
@@ -11,13 +10,7 @@ import {
   UnsecuredDto,
 } from '~/common';
 import { isAdmin } from '~/common/session';
-import {
-  ILogger,
-  Logger,
-  ResourceLoader,
-  ResourceMap,
-  ResourcesHost,
-} from '~/core';
+import { ILogger, Logger, ResourceLoader, ResourcesHost } from '~/core';
 import { BaseNode, isBaseNode, mapListResults } from '~/core/database/results';
 import { AuthorizationService } from '../authorization/authorization.service';
 import { CommentRepository } from './comment.repository';
@@ -78,9 +71,9 @@ export class CommentService {
 
   async getPermissionsFromResource(resource: CommentableRef, session: Session) {
     const parent = await this.loadCommentable(resource);
-    const parentType: typeof Commentable = await this.resourcesHost.getByName(
+    const parentType = await this.resourcesHost.getByName(
       // I'd like to type this prop as this but somehow blows everything up.
-      parent.__typename as ConditionalKeys<ResourceMap, Commentable>
+      parent.__typename as 'Commentable'
     );
     const { commentThreads: perms } =
       await this.authorizationService.getPermissions<typeof Commentable>({

--- a/src/components/comments/comment.service.ts
+++ b/src/components/comments/comment.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import {
+  EnhancedResource,
   ID,
+  InvalidIdForTypeException,
   isIdLike,
   NotFoundException,
   Resource,
@@ -109,6 +111,12 @@ export class CommentService {
     const parent = isBaseNode(parentNode)
       ? await this.resources.loadByBaseNode(parentNode)
       : parentNode;
+
+    const parentType = await this.resourcesHost.getByName(parent.__typename);
+    const parentInterfaces = await this.resourcesHost.getInterfaces(parentType);
+    if (!parentInterfaces.includes(EnhancedResource.of(Commentable))) {
+      throw new InvalidIdForTypeException('Resource is not commentable');
+    }
     return parent as Commentable;
   }
 

--- a/src/components/comments/commentable.resolver.ts
+++ b/src/components/comments/commentable.resolver.ts
@@ -1,5 +1,12 @@
-import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { ListArg, LoggedInSession, Resource, Session } from '../../common';
+import { Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
+import {
+  ID,
+  IdArg,
+  ListArg,
+  LoggedInSession,
+  Resource,
+  Session,
+} from '~/common';
 import { Loader, LoaderOf } from '../../core';
 import { CommentThreadLoader } from './comment-thread.loader';
 import { CommentService } from './comment.service';
@@ -8,6 +15,13 @@ import { Commentable, CommentThreadList, CommentThreadListInput } from './dto';
 @Resolver(Commentable)
 export class CommentableResolver {
   constructor(private readonly service: CommentService) {}
+
+  @Query(() => Commentable, {
+    description: 'Load a commentable resource by ID',
+  })
+  async commentable(@IdArg({ name: 'resource' }) id: ID): Promise<Commentable> {
+    return await this.service.loadCommentable(id);
+  }
 
   @ResolveField(() => CommentThreadList, {
     description: 'List of comment threads belonging to the parent node.',

--- a/src/components/post/post.service.ts
+++ b/src/components/post/post.service.ts
@@ -1,10 +1,10 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import {
+  EnhancedResource,
   ID,
   InputException,
   NotFoundException,
   Resource,
-  ResourceShape,
   SecuredList,
   ServerException,
   Session,
@@ -112,7 +112,7 @@ export class PostService {
   }
 
   async securedList(
-    parentType: ResourceShape<any>,
+    parentType: EnhancedResource<any>,
     parent: Postable & Resource,
     input: PostListInput,
     session: Session

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -35,12 +35,12 @@ export class ResourcesHost {
 
   async getByName<K extends keyof ResourceMap>(
     name: K
-  ): Promise<ValueOf<Pick<ResourceMap, K>>>;
+  ): Promise<EnhancedResource<ValueOf<Pick<ResourceMap, K>>>>;
   async getByName(
     name: LiteralUnion<keyof ResourceMap, string>
-  ): Promise<ValueOf<ResourceMap>>;
-  async getByName(name: keyof ResourceMap) {
-    const map = await this.getMap();
+  ): Promise<EnhancedResource<ValueOf<ResourceMap>>>;
+  async getByName(name: keyof ResourceMap): Promise<EnhancedResource<any>> {
+    const map = await this.getEnhancedMap();
     const resource = map[name];
     if (!resource) {
       throw new ServerException(

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@nestjs/common';
+import { GraphQLSchemaHost } from '@nestjs/graphql';
+import { isObjectType } from 'graphql';
 import { mapValues } from 'lodash';
 import { ValueOf } from 'ts-essentials';
 import { LiteralUnion } from 'type-fest';
@@ -13,6 +15,8 @@ export type EnhancedResourceMap = {
 
 @Injectable()
 export class ResourcesHost {
+  constructor(private readonly gqlSchema: GraphQLSchemaHost) {}
+
   async getMap() {
     // Deferred import until now to prevent circular dependency
     const legacyPath = await import(
@@ -50,14 +54,46 @@ export class ResourcesHost {
     return resource;
   }
 
-  @CachedForArg()
   async getInterfaces(
     resource: EnhancedResource<any>
   ): Promise<ReadonlyArray<EnhancedResource<any>>> {
-    // Possible change in future to use GQL.
+    // Use interfaces from GQL schema if it's available.
+    // Otherwise, fallback to the interfaces from DTO class hierarchy.
+    // The former doesn't work with CLI.
+    // The latter doesn't work for IntersectionTypes.
+    // Hoping to resolve with https://github.com/nestjs/graphql/pull/2435
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      this.gqlSchema.schema;
+    } catch (e) {
+      return await this.getInterfacesFromClassType(resource);
+    }
+    return await this.getInterfacesFromGQLSchema(resource);
+  }
+
+  @CachedForArg()
+  private async getInterfacesFromClassType(
+    resource: EnhancedResource<any>
+  ): Promise<ReadonlyArray<EnhancedResource<any>>> {
     const map = await this.getEnhancedMap();
     const resSet = new Set<EnhancedResource<any>>(Object.values(map));
     return [...resource.interfaces].filter((i) => resSet.has(i));
+  }
+
+  @CachedForArg()
+  private async getInterfacesFromGQLSchema(
+    resource: EnhancedResource<any>
+  ): Promise<ReadonlyArray<EnhancedResource<any>>> {
+    const { schema } = this.gqlSchema;
+    const map = await this.getEnhancedMap();
+
+    const type = schema.getType(resource.name);
+    if (!type || !isObjectType(type)) {
+      return [];
+    }
+    return type
+      .getInterfaces()
+      .flatMap((i) => map[i.name as keyof ResourceMap] ?? []);
   }
 
   @CachedForArg()


### PR DESCRIPTION
- Add GQL query `commentable`, to load a `Commentable` resource
  This is better for UI instead of `commentThreads` query as the the list will always be automatically associated with the parent object; instead of having to manually sync changes to the cached queries for `commentThreads`.
- Throw a new client error (`InvalidIdForType`) when resource id given is not a `Commentable` resource.
   Previously, a server schema error was thrown, but this is a client problem.

Other changes:
- Migrate `CommentService` to use `Privileges`
- Update `ResourcesHost.getInterfaces` to use GQL schema when it's available (web server, not CLI/REPL)
- Change `ResourcesHost.getByName` to return an `EnhancedResource`