### PR TITLE
Allow secured objects to be used as context for Privileges

### DIFF
--- a/src/components/authorization/policies/conditions/sensitivity.condition.ts
+++ b/src/components/authorization/policies/conditions/sensitivity.condition.ts
@@ -8,10 +8,7 @@ const sensitivityRank = { High: 3, Medium: 2, Low: 1 };
 const CQL_VAR = 'sens';
 
 export class SensitivityCondition<
-  TResourceStatic extends ResourceShape<any> & {
-    // Enforcing at TS level that resource needs a sensitivity prop to use this condition.
-    prototype: { sensitivity: Sensitivity };
-  }
+  TResourceStatic extends ResourceShape<{ sensitivity: Sensitivity }>
 > implements Condition<TResourceStatic>
 {
   constructor(private readonly access: Sensitivity) {}

--- a/src/components/authorization/policy/object.type.ts
+++ b/src/components/authorization/policy/object.type.ts
@@ -1,12 +1,12 @@
-import { ResourceShape, UnsecuredDto } from '~/common';
+import { MaybeUnsecuredInstance, ResourceShape } from '~/common';
 
 /**
  * An instance of a resource for use in executing policy conditions.
  * It's a bit unclear what this needs to be, so this could change in the future.
  * I at least know it needs to be unsecured, since that would happen after this process.
  *
- * This type mostly exists to be a DRY to reference this uncertainty since it's
- * pass around a lot of places in this module.
+ * This type mostly exists to be a DRY way to reference this uncertainty since it's
+ * passed around a lot of places in this module.
  */
 export type ResourceObjectContext<TResourceStatic extends ResourceShape<any>> =
-  UnsecuredDto<TResourceStatic['prototype']>;
+  MaybeUnsecuredInstance<TResourceStatic>;

--- a/src/components/progress-report/workflow/progress-report-workflow.granter.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.granter.ts
@@ -1,5 +1,5 @@
 import { Query } from 'cypher-query-builder';
-import { ID, keys, Many } from '~/common';
+import { ID, isIdLike, keys, Many } from '~/common';
 import { Granter, ResourceGranter } from '../../authorization';
 import { action } from '../../authorization/policy/builder/perm-granter';
 import { PropsGranterFn } from '../../authorization/policy/builder/resource-granter';
@@ -99,7 +99,9 @@ class TransitionCondition implements Condition<typeof Event> {
     if (!transitionId) {
       return false;
     }
-    return this.allowedTransitionIds.has(transitionId);
+    return this.allowedTransitionIds.has(
+      isIdLike(transitionId) ? transitionId : transitionId.id
+    );
   }
 
   asCypherCondition(query: Query) {


### PR DESCRIPTION
This limitation was artificial and in practice irrelevant.
Our current usage of context is mainly `sensitivity`, `scope`, which are not secured.
If we needed other secured properties in the future, we could create an internal property to house this value to pass around and use internally.
Odds are even the secured properties that could be needed, like `Project.step`, will still be readable in every place that matters.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3489703307) by [Unito](https://www.unito.io)
┆Link To Item: https://seed-company-squad.monday.com/boards/3451697530/pulses/3489703307
