### PR TITLE
Change the way data classes enforce interface only

### DIFF
--- a/src/common/data-object.ts
+++ b/src/common/data-object.ts
@@ -1,3 +1,5 @@
+import { AbstractClassType } from './types';
+
 /**
  * A helper class to try to enforce proper usage of data objects.
  * Data classes should only enforce a shape, no instances, and therefore no
@@ -8,6 +10,15 @@
 export abstract class DataObject {
   // eslint-disable-next-line @typescript-eslint/no-useless-constructor,@typescript-eslint/no-empty-function,@seedcompany/no-unused-vars
   constructor(youShouldNotBeInstantiatingDataObjects: typeof inaccessible) {}
+
+  static defaultValue<T extends DataObject>(
+    type: AbstractClassType<T>,
+    partialExtra?: Partial<T>
+  ): T {
+    // @ts-expect-error ignore abstract modifier it's only to prevent instantiation.
+    // This is the only time we want to allow it.
+    return Object.assign(new type(inaccessible), partialExtra);
+  }
 }
 
 // Something that cannot be referenced, but still conforms to any (never does not).

--- a/src/common/data-object.ts
+++ b/src/common/data-object.ts
@@ -1,0 +1,14 @@
+/**
+ * A helper class to try to enforce proper usage of data objects.
+ * Data classes should only enforce a shape, no instances, and therefore no
+ * methods or getter/setters.
+ * This allows objects to be spread to change data while continuing to enforce
+ * immutability.
+ */
+export abstract class DataObject {
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor,@typescript-eslint/no-empty-function,@seedcompany/no-unused-vars
+  constructor(youShouldNotBeInstantiatingDataObjects: typeof inaccessible) {}
+}
+
+// Something that cannot be referenced, but still conforms to any (never does not).
+const inaccessible = Symbol('inaccessible');

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -3,6 +3,7 @@ export * from './buffer';
 export * from './temporal';
 export * from './calculated.decorator';
 export * from './context.type';
+export * from './data-object';
 export * from './date-filter.input';
 export { DbLabel } from './db-label.decorator';
 export * from './db-label.helpers';

--- a/src/common/pagination-list.ts
+++ b/src/common/pagination-list.ts
@@ -3,6 +3,7 @@ import { stripIndent } from 'common-tags';
 import { GraphQLScalarType } from 'graphql';
 import { lowerCase } from 'lodash';
 import { Class } from 'type-fest';
+import { DataObject } from './data-object';
 import { IPaginatedList } from './list.interface';
 import { AbstractClassType } from './types';
 
@@ -22,6 +23,7 @@ export function PaginatedList<Type, ListItem = Type>(
 ) {
   @ObjectType({ isAbstract: true, implements: [IPaginatedList] })
   abstract class PaginatedListClass
+    extends DataObject
     implements PaginatedListType<ListItem>, IPaginatedList
   {
     @Field(() => [itemClass], {
@@ -40,10 +42,6 @@ export function PaginatedList<Type, ListItem = Type>(
       description: 'Whether the next page exists',
     })
     readonly hasMore: boolean;
-
-    protected constructor() {
-      // no instantiation, shape only
-    }
   }
 
   return PaginatedListClass;

--- a/src/common/pagination.input.ts
+++ b/src/common/pagination.input.ts
@@ -2,13 +2,14 @@ import { PipeTransform, Type } from '@nestjs/common';
 import { Args, ArgsOptions, Field, InputType, Int } from '@nestjs/graphql';
 import { Matches, Max, Min } from 'class-validator';
 import { stripIndent } from 'common-tags';
+import { DataObject } from './data-object';
 import { Order } from './order.enum';
 import { AbstractClassType } from './types';
 
 @InputType({
   isAbstract: true,
 })
-export abstract class PaginationInput {
+export abstract class PaginationInput extends DataObject {
   @Field(() => Int, {
     description: 'The number of items to return in a single page',
   })
@@ -24,16 +25,12 @@ export abstract class PaginationInput {
   })
   @Min(1)
   readonly page: number = 1;
-
-  protected constructor() {
-    // no instantiation, shape only
-  }
 }
 
 @InputType({
   isAbstract: true,
 })
-export abstract class CursorPaginationInput {
+export abstract class CursorPaginationInput extends DataObject {
   @Field(() => Int, {
     description: 'The number of items to return in a single page',
   })
@@ -56,10 +53,6 @@ export abstract class CursorPaginationInput {
     nullable: true,
   })
   readonly before?: string;
-
-  protected constructor() {
-    // no instantiation, shape only
-  }
 }
 
 export interface SortablePaginationInput<SortKey extends string = string>

--- a/src/common/pagination.input.ts
+++ b/src/common/pagination.input.ts
@@ -97,7 +97,7 @@ export const SortablePaginationInput = <SortKey extends string = string>({
  * A GQL argument for paginated list input
  */
 export const ListArg = <T extends PaginationInput>(
-  input: AbstractClassType<T> & { defaultVal: T },
+  input: AbstractClassType<T>,
   opts: Partial<ArgsOptions> = {},
   ...pipes: Array<Type<PipeTransform> | PipeTransform>
 ) =>
@@ -106,7 +106,7 @@ export const ListArg = <T extends PaginationInput>(
       name: 'input',
       type: () => input,
       nullable: true,
-      defaultValue: input.defaultVal,
+      defaultValue: DataObject.defaultValue(input),
       ...opts,
     },
     ...pipes

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -5,6 +5,7 @@ import { keys as keysOf } from 'ts-transformer-keys';
 import { inspect } from 'util';
 import { ScopedRole } from '../components/authorization';
 import { CalculatedSymbol } from './calculated.decorator';
+import { DataObject } from './data-object';
 import { DbLabel } from './db-label.decorator';
 import { getDbClassLabels, getDbPropertyLabels } from './db-label.helpers';
 import { ServerException } from './exceptions';
@@ -34,7 +35,7 @@ export const resolveByTypename =
   resolveType: resolveByTypename(Resource.name),
 })
 @DbLabel('BaseNode')
-export abstract class Resource {
+export abstract class Resource extends DataObject {
   static readonly Props: string[] = keysOf<Resource>();
   static readonly SecuredProps: string[] = [];
 
@@ -54,10 +55,6 @@ export abstract class Resource {
   // A list of non-global roles the requesting user has available for this object.
   // This is used by the authorization module to determine permissions.
   readonly scope?: ScopedRole[];
-
-  protected constructor() {
-    // no instantiation, shape only
-  }
 }
 
 export type ResourceShape<T> = AbstractClassType<T> & {

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -12,7 +12,7 @@ import { ServerException } from './exceptions';
 import { ID, IdField } from './id-field';
 import { DateTimeField } from './luxon.graphql';
 import { getParentTypes } from './parent-types';
-import { SecuredProps, UnsecuredDto } from './secured-property';
+import { MaybeSecured, SecuredProps } from './secured-property';
 import { AbstractClassType } from './types';
 import { has, mapFromList } from './util';
 import { cachedOnObject } from './weak-map-cache';
@@ -259,7 +259,7 @@ export const isResourceClass = <T>(
   has('Props', cls) && Array.isArray(cls.Props) && cls.Props.length > 0;
 
 export type MaybeUnsecuredInstance<TResourceStatic extends ResourceShape<any>> =
-  TResourceStatic['prototype'] | UnsecuredDto<TResourceStatic['prototype']>;
+  MaybeSecured<InstanceType<TResourceStatic>>;
 
 // Get the secured props of the resource
 // merged with all of the relations which are assumed to be secure.

--- a/src/common/secured-property.ts
+++ b/src/common/secured-property.ts
@@ -29,6 +29,8 @@ export type SecuredKeys<Dto extends Record<string, any>> = ConditionalKeys<
   Secured<any>
 >;
 
+export type MaybeSecured<Dto> = Dto | UnsecuredDto<Dto>;
+
 /**
  * Converts a DTO to unwrap its secured properties.
  * Non-secured properties are left as is.

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -13,10 +13,9 @@ export type MaybeAsync<T> = T | Promise<T>;
 /**
  * Used for generic GraphQL types
  */
-export type AbstractClassType<T> = {
+export type AbstractClassType<T> = (abstract new (...args: any[]) => T) & {
   prototype: T;
-  // eslint-disable-next-line @typescript-eslint/ban-types
-} & Function;
+};
 
 /**
  * Used for conditional generics

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -388,10 +388,7 @@ export class BudgetService {
     session: Session,
     changeset?: ID
   ): Promise<BudgetListOutput> {
-    const input = {
-      ...BudgetListInput.defaultVal,
-      ...partialInput,
-    };
+    const input = BudgetListInput.defaultValue(BudgetListInput, partialInput);
     const results = await this.budgetRepo.list(input, session);
     return await mapListResults(results, (id) =>
       this.readOne(id, session, viewOfChangeset(changeset))
@@ -403,10 +400,7 @@ export class BudgetService {
     session: Session,
     changeset?: ID
   ): Promise<BudgetListOutput> {
-    const input = {
-      ...BudgetListInput.defaultVal,
-      ...partialInput,
-    };
+    const input = BudgetListInput.defaultValue(BudgetListInput, partialInput);
     const results = await this.budgetRepo.listUnsecure(input);
     return await mapListResults(results, (id) =>
       this.readOne(id, session, viewOfChangeset(changeset))

--- a/src/components/budget/dto/list-budget.dto.ts
+++ b/src/components/budget/dto/list-budget.dto.ts
@@ -21,8 +21,6 @@ const defaultFilters = {};
 export class BudgetListInput extends SortablePaginationInput<keyof Budget>({
   defaultSort: 'status',
 }) {
-  static defaultVal = new BudgetListInput();
-
   @Type(() => BudgetFilters)
   @ValidateNested()
   readonly filter: BudgetFilters = defaultFilters;
@@ -47,8 +45,6 @@ export class BudgetRecordListInput extends SortablePaginationInput<
 >({
   defaultSort: 'fiscalYear',
 }) {
-  static defaultVal = new BudgetListInput();
-
   @Type(() => BudgetRecordFilters)
   @ValidateNested()
   readonly filter: BudgetRecordFilters;

--- a/src/components/ceremony/dto/list-ceremony.dto.ts
+++ b/src/components/ceremony/dto/list-ceremony.dto.ts
@@ -22,8 +22,6 @@ export class CeremonyListInput extends SortablePaginationInput<
 >({
   defaultSort: 'projectName',
 }) {
-  static defaultVal = new CeremonyListInput();
-
   @Field({ nullable: true })
   @Type(() => CeremonyFilters)
   @ValidateNested()

--- a/src/components/comments/dto/list-comment-thread.dto.ts
+++ b/src/components/comments/dto/list-comment-thread.dto.ts
@@ -9,9 +9,7 @@ export class CommentThreadListInput extends SortablePaginationInput<
 >({
   defaultSort: 'createdAt',
   defaultOrder: Order.DESC,
-}) {
-  static defaultVal = new CommentThreadListInput();
-}
+}) {}
 
 @ObjectType()
 export class CommentThreadList extends PaginatedList(CommentThread) {

--- a/src/components/comments/dto/list-comment.dto.ts
+++ b/src/components/comments/dto/list-comment.dto.ts
@@ -6,9 +6,7 @@ import { Comment } from './comment.dto';
 export class CommentListInput extends SortablePaginationInput<keyof Comment>({
   defaultSort: 'createdAt',
   defaultOrder: Order.DESC,
-}) {
-  static defaultVal = new CommentListInput();
-}
+}) {}
 
 @ObjectType()
 export abstract class CommentList extends PaginatedList(Comment) {}

--- a/src/components/engagement/dto/list-engagements.dto.ts
+++ b/src/components/engagement/dto/list-engagements.dto.ts
@@ -33,8 +33,6 @@ export class EngagementListInput extends SortablePaginationInput<
 >({
   defaultSort: 'createdAt',
 }) {
-  static defaultVal = new EngagementListInput();
-
   @Field({ nullable: true })
   @Type(() => EngagementFilters)
   @ValidateNested()

--- a/src/components/ethno-art/dto/list-ethno-art.dto.ts
+++ b/src/components/ethno-art/dto/list-ethno-art.dto.ts
@@ -13,8 +13,6 @@ const defaultFilters = {};
 export class EthnoArtListInput extends SortablePaginationInput<keyof EthnoArt>({
   defaultSort: 'name',
 }) {
-  static defaultVal = new EthnoArtListInput();
-
   @Type(() => EthnoArtFilters)
   @ValidateNested()
   readonly filter: EthnoArtFilters = defaultFilters;

--- a/src/components/field-region/dto/list-field-region.dto.ts
+++ b/src/components/field-region/dto/list-field-region.dto.ts
@@ -22,8 +22,6 @@ export class FieldRegionListInput extends SortablePaginationInput<
 >({
   defaultSort: 'name',
 }) {
-  static defaultVal = new FieldRegionListInput();
-
   @Type(() => FieldRegionFilters)
   @ValidateNested()
   readonly filter: FieldRegionFilters = defaultFilters;

--- a/src/components/field-zone/dto/list-field-zone.dto.ts
+++ b/src/components/field-zone/dto/list-field-zone.dto.ts
@@ -22,8 +22,6 @@ export class FieldZoneListInput extends SortablePaginationInput<
 >({
   defaultSort: 'name',
 }) {
-  static defaultVal = new FieldZoneListInput();
-
   @Type(() => FieldZoneFilters)
   @ValidateNested()
   readonly filter: FieldZoneFilters = defaultFilters;

--- a/src/components/file/dto/list.ts
+++ b/src/components/file/dto/list.ts
@@ -28,8 +28,6 @@ export class FileListInput extends SortablePaginationInput<
 >({
   defaultSort: 'name',
 }) {
-  static defaultVal = new FileListInput();
-
   @Field({ nullable: true })
   @Type(() => FileFilters)
   @ValidateNested()

--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -121,7 +121,7 @@ export class FileRepository extends CommonRepository {
   }
 
   async getChildrenById(parent: FileNode, input?: FileListInput) {
-    input ??= FileListInput.defaultVal;
+    input ??= FileListInput.defaultValue(FileListInput);
     const result = await this.db
       .query()
       .match([

--- a/src/components/film/dto/list-film.dto.ts
+++ b/src/components/film/dto/list-film.dto.ts
@@ -13,8 +13,6 @@ const defaultFilters = {};
 export class FilmListInput extends SortablePaginationInput<keyof Film>({
   defaultSort: 'name',
 }) {
-  static defaultVal = new FilmListInput();
-
   @Type(() => FilmFilters)
   @ValidateNested()
   readonly filter: FilmFilters = defaultFilters;

--- a/src/components/funding-account/dto/list-funding-account.dto.ts
+++ b/src/components/funding-account/dto/list-funding-account.dto.ts
@@ -7,9 +7,7 @@ export class FundingAccountListInput extends SortablePaginationInput<
   keyof FundingAccount
 >({
   defaultSort: 'name',
-}) {
-  static defaultVal = new FundingAccountListInput();
-}
+}) {}
 
 @ObjectType()
 export class FundingAccountListOutput extends PaginatedList(FundingAccount) {}

--- a/src/components/language/dto/list-language.dto.ts
+++ b/src/components/language/dto/list-language.dto.ts
@@ -55,8 +55,6 @@ const defaultFilters = {};
 export class LanguageListInput extends SortablePaginationInput<keyof Language>({
   defaultSort: 'name',
 }) {
-  static defaultVal = new LanguageListInput();
-
   @Field({ nullable: true })
   @Type(() => LanguageFilters)
   @ValidateNested()

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -230,10 +230,10 @@ export class LanguageService {
     input: ProjectListInput,
     session: Session
   ): Promise<SecuredProjectList> {
-    const { page, count } = {
-      ...ProjectListInput.defaultVal,
-      ...input,
-    };
+    const { page, count } = ProjectListInput.defaultValue(
+      ProjectListInput,
+      input
+    );
 
     const result: {
       items: Project[];

--- a/src/components/literacy-material/dto/list-literacy-material.dto.ts
+++ b/src/components/literacy-material/dto/list-literacy-material.dto.ts
@@ -15,8 +15,6 @@ export class LiteracyMaterialListInput extends SortablePaginationInput<
 >({
   defaultSort: 'name',
 }) {
-  static defaultVal = new LiteracyMaterialListInput();
-
   @Type(() => LiteracyMaterialFilters)
   @ValidateNested()
   readonly filter: LiteracyMaterialFilters = defaultFilters;

--- a/src/components/location/dto/list-locations.dto.ts
+++ b/src/components/location/dto/list-locations.dto.ts
@@ -20,8 +20,6 @@ const defaultFilters = {};
 export class LocationListInput extends SortablePaginationInput<keyof Location>({
   defaultSort: 'name',
 }) {
-  static defaultVal = new LocationListInput();
-
   @Type(() => LocationFilters)
   @ValidateNested()
   readonly filter: LocationFilters = defaultFilters;

--- a/src/components/organization/dto/list-organization.dto.ts
+++ b/src/components/organization/dto/list-organization.dto.ts
@@ -22,8 +22,6 @@ export class OrganizationListInput extends SortablePaginationInput<
 >({
   defaultSort: 'name',
 }) {
-  static defaultVal = new OrganizationListInput();
-
   @Type(() => OrganizationFilters)
   @ValidateNested()
   readonly filter: OrganizationFilters = defaultFilters;

--- a/src/components/partner/dto/list-partner.dto.ts
+++ b/src/components/partner/dto/list-partner.dto.ts
@@ -27,8 +27,6 @@ const defaultFilters = {};
 export class PartnerListInput extends SortablePaginationInput<keyof Partner>({
   defaultSort: 'createdAt',
 }) {
-  static defaultVal = new PartnerListInput();
-
   @Field({ nullable: true })
   @Type(() => PartnerFilters)
   @ValidateNested()

--- a/src/components/partnership/dto/list-partnership.dto.ts
+++ b/src/components/partnership/dto/list-partnership.dto.ts
@@ -22,8 +22,6 @@ export class PartnershipListInput extends SortablePaginationInput<
 >({
   defaultSort: 'createdAt',
 }) {
-  static defaultVal = new PartnershipListInput();
-
   @Type(() => PartnershipFilters)
   @ValidateNested()
   readonly filter: PartnershipFilters = defaultFilters;

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -298,11 +298,10 @@ export class PartnershipService {
     session: Session,
     changeset?: ID
   ): Promise<PartnershipListOutput> {
-    const input = {
-      ...PartnershipListInput.defaultVal,
-      ...partialInput,
-    };
-
+    const input = PartnershipListInput.defaultValue(
+      PartnershipListInput,
+      partialInput
+    );
     const results = await this.repo.list(input, session, changeset);
     return await mapListResults(results, (id) =>
       this.readOne(id, session, viewOfChangeset(changeset))

--- a/src/components/periodic-report/dto/list-periodic-reports.dto.ts
+++ b/src/components/periodic-report/dto/list-periodic-reports.dto.ts
@@ -26,8 +26,6 @@ export class PeriodicReportListInput extends SortablePaginationInput<
   readonly type?: ReportType;
 
   readonly parent?: ID;
-
-  static defaultVal = new PeriodicReportListInput();
 }
 
 @ObjectType()

--- a/src/components/pin/dto/pinned-list.dto.ts
+++ b/src/components/pin/dto/pinned-list.dto.ts
@@ -3,9 +3,7 @@ import { PaginatedList, PaginationInput } from '../../../common';
 import { Pinnable } from './pinnable.dto';
 
 @InputType()
-export class PinnedListInput extends PaginationInput {
-  static defaultVal = new PinnedListInput();
-}
+export class PinnedListInput extends PaginationInput {}
 
 @ObjectType()
 export class PinnedListOutput extends PaginatedList(Pinnable) {}

--- a/src/components/post/dto/list-posts.dto.ts
+++ b/src/components/post/dto/list-posts.dto.ts
@@ -22,8 +22,6 @@ export class PostListInput extends SortablePaginationInput<keyof Post>({
   defaultSort: 'createdAt',
   defaultOrder: Order.DESC,
 }) {
-  static defaultVal = new PostListInput();
-
   @Type(() => PostFilters)
   @ValidateNested()
   readonly filter: PostFilters = defaultFilters;

--- a/src/components/product/dto/completion-description.dto.ts
+++ b/src/components/product/dto/completion-description.dto.ts
@@ -4,8 +4,6 @@ import { ProductMethodology } from './product-methodology';
 
 @InputType()
 export class ProductCompletionDescriptionSuggestionsInput extends PaginationInput {
-  static defaultVal = new ProductCompletionDescriptionSuggestionsInput();
-
   @Field({
     nullable: true,
     description: 'A partial description to search for',

--- a/src/components/product/dto/list-product.dto.ts
+++ b/src/components/product/dto/list-product.dto.ts
@@ -44,8 +44,6 @@ const defaultFilters = {};
 export class ProductListInput extends SortablePaginationInput<keyof Product>({
   defaultSort: 'createdAt',
 }) {
-  static defaultVal = new ProductListInput();
-
   @Field({ nullable: true })
   @Type(() => ProductFilters)
   @ValidateNested()

--- a/src/components/project-change-request/dto/project-change-request-list.dto.ts
+++ b/src/components/project-change-request/dto/project-change-request-list.dto.ts
@@ -22,8 +22,6 @@ export class ProjectChangeRequestListInput extends SortablePaginationInput<
 >({
   defaultSort: 'createdAt',
 }) {
-  static defaultVal = new ProjectChangeRequestListInput();
-
   @Type(() => ProjectChangeRequestFilters)
   @ValidateNested()
   readonly filter: ProjectChangeRequestFilters = defaultFilters;

--- a/src/components/project/dto/list-projects.dto.ts
+++ b/src/components/project/dto/list-projects.dto.ts
@@ -99,8 +99,6 @@ const defaultFilters = {};
 export class ProjectListInput extends SortablePaginationInput<keyof IProject>({
   defaultSort: 'name',
 }) {
-  static defaultVal = new ProjectListInput();
-
   @Field({ nullable: true })
   @Type(() => ProjectFilters)
   @ValidateNested()

--- a/src/components/project/project-member/dto/list-project-members.dto.ts
+++ b/src/components/project/project-member/dto/list-project-members.dto.ts
@@ -29,8 +29,6 @@ export class ProjectMemberListInput extends SortablePaginationInput<
 >({
   defaultSort: 'createdAt',
 }) {
-  static defaultVal = new ProjectMemberListInput();
-
   @Field({ nullable: true })
   @Type(() => ProjectMemberFilters)
   @ValidateNested()

--- a/src/components/search/dto/search-results.dto.ts
+++ b/src/components/search/dto/search-results.dto.ts
@@ -101,7 +101,6 @@ export type SearchResult = SearchResultMap[keyof SearchableMap];
 
 export const SearchResult = createUnionType({
   name: 'SearchResult',
-  // @ts-expect-error ignore errors for abstract classes
   types: () => uniq(Object.values(searchable)),
   resolveType: (value: SearchResult) =>
     simpleSwitch(value.__typename, searchable),

--- a/src/components/search/dto/search.dto.ts
+++ b/src/components/search/dto/search.dto.ts
@@ -4,8 +4,6 @@ import { GqlSearchType, SearchResult, SearchType } from './search-results.dto';
 
 @InputType()
 export class SearchInput extends PaginationInput {
-  static defaultVal = new SearchInput();
-
   @Field({
     description: 'The search string to look for.',
   })

--- a/src/components/search/search.resolver.ts
+++ b/src/components/search/search.resolver.ts
@@ -1,5 +1,5 @@
-import { Args, Query, Resolver } from '@nestjs/graphql';
-import { AnonSession, Session } from '../../common';
+import { Query, Resolver } from '@nestjs/graphql';
+import { AnonSession, ListArg, Session } from '~/common';
 import { SearchInput, SearchOutput } from './dto';
 import { SearchService } from './search.service';
 
@@ -12,11 +12,7 @@ export class SearchResolver {
   })
   async search(
     @AnonSession() session: Session,
-    @Args({
-      name: 'input',
-      type: () => SearchInput,
-      defaultValue: SearchInput.defaultVal,
-    })
+    @ListArg(SearchInput, { nullable: false })
     input: SearchInput
   ): Promise<SearchOutput> {
     return await this.service.search(input, session);

--- a/src/components/song/dto/list-story.dto.ts
+++ b/src/components/song/dto/list-story.dto.ts
@@ -13,8 +13,6 @@ const defaultFilters = {};
 export class SongListInput extends SortablePaginationInput<keyof Song>({
   defaultSort: 'name',
 }) {
-  static defaultVal = new SongListInput();
-
   @Type(() => SongFilters)
   @ValidateNested()
   readonly filter: SongFilters = defaultFilters;

--- a/src/components/story/dto/list-story.dto.ts
+++ b/src/components/story/dto/list-story.dto.ts
@@ -13,8 +13,6 @@ const defaultFilters = {};
 export class StoryListInput extends SortablePaginationInput<keyof Story>({
   defaultSort: 'name',
 }) {
-  static defaultVal = new StoryListInput();
-
   @Type(() => StoryFilters)
   @ValidateNested()
   readonly filter: StoryFilters = defaultFilters;

--- a/src/components/user/dto/list-users.dto.ts
+++ b/src/components/user/dto/list-users.dto.ts
@@ -19,8 +19,6 @@ const defaultFilters = {};
 export class UserListInput extends SortablePaginationInput<keyof User>({
   defaultSort: 'id', // TODO How to sort on name?
 }) {
-  static defaultVal = new UserListInput();
-
   @Field({ nullable: true })
   @Type(() => UserFilters)
   @ValidateNested()

--- a/src/components/user/education/dto/list-education.dto.ts
+++ b/src/components/user/education/dto/list-education.dto.ts
@@ -22,8 +22,6 @@ export class EducationListInput extends SortablePaginationInput<
 >({
   defaultSort: 'institution',
 }) {
-  static defaultVal = new EducationListInput();
-
   @Type(() => EducationFilters)
   @ValidateNested()
   readonly filter: EducationFilters = defaultFilters;

--- a/src/components/user/unavailability/dto/list-unavailabilities.dto.ts
+++ b/src/components/user/unavailability/dto/list-unavailabilities.dto.ts
@@ -24,8 +24,6 @@ export class UnavailabilityListInput extends SortablePaginationInput<
   defaultSort: 'start',
   defaultOrder: Order.DESC,
 }) {
-  static defaultVal = new UnavailabilityListInput();
-
   @Type(() => UnavailabilityFilters)
   @ValidateNested()
   readonly filter: UnavailabilityFilters = defaultFilters;

--- a/src/core/exception.filter.ts
+++ b/src/core/exception.filter.ts
@@ -200,7 +200,9 @@ export class ExceptionFilter implements GqlExceptionFilter {
 
   private errorToCodes(ex: Error) {
     return compact(
-      getParentTypes(ex.constructor).flatMap((e) => this.errorToCode(e, ex))
+      getParentTypes(ex.constructor as AbstractClassType<Error>).flatMap((e) =>
+        this.errorToCode(e as AbstractClassType<Error>, ex)
+      )
     );
   }
 

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -17,6 +17,7 @@ import {
   maybeMany,
   Session,
 } from '~/common';
+import * as common from '~/common';
 import { bootstrapLogger, ConfigService, ResourcesHost } from '~/core';
 import { AppModule } from './app.module';
 import { AuthenticationService } from './components/authentication';
@@ -48,6 +49,7 @@ async function bootstrap() {
     mapFromList,
     many,
     maybeMany,
+    common,
     // eslint-disable-next-line @typescript-eslint/naming-convention
     __: lodash, // single underscore is "last execution result"
     lodash,


### PR DESCRIPTION
# Backstory
We only want data classes to be used by shapes only. No instances, or methods or getters/setters. All of those things should be done by actors/services. This also allows spreading to work which helps adjusting data while maintaining immutability.

There were two ways enforced this.
1. abstract classes. This was an easy one liner, but it had to be done to every class.
    ```ts
    abstract class User {}
    ```
3. protected constructors. This allowed a base class to declare a protected constructor and subclasses could just be normal while still enforcing no instantiation.
    ```ts
    class Resource {
      protected constructor() {}
    }
    class User extends Resource {}
    class Project extends Resource {}
    ```

Unfortunately both of these things made it hard to reference a static class type and convert to an instance type and vise versa. That's because TS uses the constructor signature to determine this, and when it's not public or abstract it's not instantiatable and doesn't work.
But I found a work around online:
https://github.com/SeedCompany/cord-api-v3/blob/39d2d98484dc350400bded4fcf1ffc9d7c2b160e/src/common/types.ts#L16-L19

This mostly works but it uses the `Function` type which is an object that has a `prototype: any` property. This makes it hard for TS to follow through on types in complex situations.

# A better way

Here's the new type definition:
https://github.com/SeedCompany/cord-api-v3/blob/e19f7cd29d2bfbadd0eb2739f455eda7c11adf25/src/common/types.ts#L16-L18

The reference to `Function` has been dropped which is the driving goal of this PR.

Since 2 years ago, TS has added the ability to use abstract constructors like this, so that's one hurdle unblocked.

That still leaves us needing to have all constructors public. 
Well it dawned on me that visibility isn't the only way to enforce a signature. 
https://github.com/SeedCompany/cord-api-v3/blob/280b07992a14892c106845c58ff369f7cab72d5e/src/common/data-object.ts#L8-L14

By having a constructor that requires an arg whose type can never be used, this also limits the ability to new-up the object as the signature can never be properly fulfilled.

This also lets us use the `InstanceType` which is more intuitive than `prototype`.
```diff
- TResourceStatic['prototype']
+ InstanceType<TResourceStatic>
```
But I left existing usage alone for now.

# Default values

This then gave errors in the way we were previously doing default values for some objects.
We'd do
```ts
class Foo {
  static defaultVal = new Foo();
  protected constructor() {}

  limit = 1;
}
```
With the constructor protected, we could only new-up inside of the class, hence the `defaultVal` static prop. Really what we were trying to get is `{ limit: 1 }` without having to redeclare all default property values. This was copy pasted everywhere even when it was not needed.

No we just have a function `DataObject.defaultValue(Foo)` which accepts the static class and will extract the default value shape from it.