### PR TITLE
Rethink Policy Props Logic

### DIFF
--- a/src/components/authorization/policies/by-role/financial-analyst-lead.policy.ts
+++ b/src/components/authorization/policies/by-role/financial-analyst-lead.policy.ts
@@ -8,8 +8,8 @@ import { member, Policy, Role, sensMediumOrLower } from '../util';
   r.Language.read.specifically((c) => [
     c.locations.whenAny(member, sensMediumOrLower).read,
   ]),
-  r.Organization.edit,
-  r.Partner.edit,
+  r.Organization.edit.andAllProps,
+  r.Partner.edit.andAllProps,
   r.Partnership.read.create.delete.specifically((p) => [
     p.many('mouStartOverride', 'mouEndOverride', 'mou', 'mouStatus').edit,
   ]),

--- a/src/components/authorization/policy/builder/allow-all.helper.ts
+++ b/src/components/authorization/policy/builder/allow-all.helper.ts
@@ -3,6 +3,7 @@ import { ResourceAction } from '../actions';
 import { ResourcesGranter } from '../granters';
 import { asNormalized } from './as-normalized.helper';
 import { action } from './perm-granter';
+import { andAllProps } from './resource-granter';
 
 /**
  * A helper to allow these actions for all resources
@@ -13,9 +14,9 @@ export const allowAll =
     Object.values(r).map((res) => allowActions(res, ...actions));
 
 /**
- * A helper to allow these actions for this resource.
+ * A helper to allow these actions for this resource & and all its props.
  */
 export const allowActions = (
   granter: ValueOf<ResourcesGranter>,
   ...actions: ResourceAction[]
-) => asNormalized(granter, (g) => g[action](...actions));
+) => asNormalized(granter, (g) => g[action](...actions)[andAllProps]);

--- a/src/components/authorization/policy/builder/perm-granter.ts
+++ b/src/components/authorization/policy/builder/perm-granter.ts
@@ -12,6 +12,11 @@ export type Permission = Condition<any> | boolean;
 export const action = Symbol('PermGranter.action');
 
 /**
+ * Add to the perms list.
+ */
+export const withPerms = Symbol('PermGranter.withPerms');
+
+/**
  * Extract permissions from granter.
  */
 export const extract = Symbol('PermGranter.extract');
@@ -42,13 +47,14 @@ export abstract class PermGranter<
    * Return grant with these actions added.
    */
   [action](...actions: TAction[]): this {
+    const perm = this.stagedCondition ?? true;
+    return this[withPerms](mapFromList(actions, (action) => [action, perm]));
+  }
+
+  [withPerms](...perms: Array<Permissions<TAction>>): this {
     const cloned = this.clone();
     cloned.trailingCondition = undefined;
-    const perm = cloned.stagedCondition ?? true;
-    cloned.perms = [
-      ...cloned.perms,
-      mapFromList(actions, (action) => [action, perm]),
-    ];
+    cloned.perms = [...cloned.perms, ...perms];
     return cloned;
   }
 

--- a/src/components/authorization/policy/builder/perm-granter.ts
+++ b/src/components/authorization/policy/builder/perm-granter.ts
@@ -30,20 +30,6 @@ export abstract class PermGranter<
   ) {}
 
   /**
-   * The requester can do nothing with this prop or object.
-   *
-   * This is not a DENY action. It can be overridden by another entry
-   * in the same or even different policy.
-   *
-   * This does provide logical value when you want to:
-   * - Exclude a certain prop from object level actions.
-   * - Exclude an implementation from actions defined for an interface.
-   */
-  get none() {
-    return this;
-  }
-
-  /**
    * Return grant with these actions added.
    */
   [action](...actions: TAction[]): this {

--- a/src/components/authorization/policy/builder/prop-granter.ts
+++ b/src/components/authorization/policy/builder/prop-granter.ts
@@ -6,7 +6,7 @@ import {
 import { PropAction } from '../actions';
 import { Condition } from '../conditions';
 import { createLazyRecord } from '../lazy-record';
-import { action, extract, PermGranter } from './perm-granter';
+import { action, extract, PermGranter, withPerms } from './perm-granter';
 
 export class PropGranter<
   TResourceStatic extends ResourceShape<any>
@@ -17,6 +17,15 @@ export class PropGranter<
     stagedCondition?: Condition<TResourceStatic>
   ) {
     super(stagedCondition);
+  }
+
+  /**
+   * The requester can do nothing with the given prop(s).
+   *
+   * It can be overridden by another entry in a different policy.
+   */
+  get none() {
+    return this[withPerms]({ read: false, edit: false });
   }
 
   /**

--- a/src/components/authorization/policy/builder/resource-granter.ts
+++ b/src/components/authorization/policy/builder/resource-granter.ts
@@ -32,8 +32,8 @@ export class ResourceGranter<
   /**
    * Grant specific actions to individual props of this object.
    *
-   * Any props not explicitly defined will fall back to granted actions defined
-   * on this object.
+   * Any props not explicitly defined (from any policy) will fall back to granted
+   * actions defined on this object (from any policy).
    *
    * Conditions previously given will apply automatically to these props,
    * unless the prop defines its own condition.

--- a/src/components/authorization/policy/builder/resource-granter.ts
+++ b/src/components/authorization/policy/builder/resource-granter.ts
@@ -38,6 +38,19 @@ export class ResourceGranter<
   }
 
   /**
+   * The requester can do nothing with this resource.
+   *
+   * This is not a DENY action.
+   * It can be overridden by another entry in the same or even different policy.
+   *
+   * This does provide logical value when you want to exclude an implementation
+   * from actions defined for an interface.
+   */
+  get none() {
+    return this;
+  }
+
+  /**
    * Grant specific actions to individual props of this object.
    *
    * Any props not explicitly defined (from any policy) will fall back to granted

--- a/src/components/authorization/policy/executor/policy-executor.ts
+++ b/src/components/authorization/policy/executor/policy-executor.ts
@@ -114,9 +114,11 @@ export class PolicyExecutor {
     permissions: ReadonlyArray<Permission | undefined>
   ): Permission | undefined {
     return this.policyFactory.mergePermission(permissions, any, [
-      // 'deny', // Deny actions should not cross into other policies, ignoring.
       'allow',
       'conditional',
+      // Allow "deny" to apply as long as there's no "allow" or conditions
+      // from other policies.
+      'deny',
     ]);
   }
 

--- a/src/components/authorization/policy/executor/policy-executor.ts
+++ b/src/components/authorization/policy/executor/policy-executor.ts
@@ -54,16 +54,15 @@ export class PolicyExecutor {
     }
 
     if (prop) {
-      return (
-        this.resolvePermission(
-          policies.map((policy) => {
-            return (
-              policy.grants.get(resource)?.propLevel[prop]?.[action] ??
-              policy.grants.get(resource)?.objectLevel[action]
-            );
-          })
-        ) ?? false
+      const resolved = this.resolvePermission(
+        policies.map((policy) => {
+          return policy.grants.get(resource)?.propLevel[prop]?.[action];
+        })
       );
+      if (resolved != null) {
+        return resolved;
+      }
+      // fall through to resource level
     }
 
     return (

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -22,7 +22,7 @@ import { bootstrapLogger, ConfigService, ResourcesHost } from '~/core';
 import { AppModule } from './app.module';
 import { AuthenticationService } from './components/authentication';
 import 'source-map-support/register';
-import { Role } from './components/authorization';
+import { Role, rolesForScope } from './components/authorization';
 
 /**
  * This does the same thing as {@link import('@nestjs/core').repl}
@@ -54,9 +54,9 @@ async function bootstrap() {
     __: lodash, // single underscore is "last execution result"
     lodash,
     session,
-    sessionFor: (role: Role): Session => ({
+    sessionFor: (...roles: Role[]): Session => ({
       ...session,
-      roles: [`global:${role}`],
+      roles: roles.map(rolesForScope('global')),
     }),
     Resources,
   });


### PR DESCRIPTION
# Problem Scenario
Currently we have this edge case scenario:
```ts
// Policy A
r.Organization.read
// Policy B
r.Organization.specifically(p => p.address.none)
```
If policy `A` is executed first then the user has `read` permission for `address`.
If policy `B` is executed first then the user has **no** permission for `address`.
So that's no good, we obviously what these to be deterministic.

This brings up what do we mean by the policy `A` line.
Currently it means the user can `read` `Organizations` _and_ all of its properties (since they aren't specified).
But perhaps in this case we wanted to defer to other policies so that policy `B`'s line applies.

# Logical Changes
So this PR changes a few things, in attempt to address these problems.
1. We now exhaustive check all props first, before falling back to resource level.
    - Before we'd check and use in this order:
      - Policy A `Organization.address.read`
      - Policy A `Organization.read`
      - Policy B `Organization.address.read`
      - Policy B `Organization.read`
    - Now the order is:
      - Policy A `Organization.address.read`
      - Policy B `Organization.address.read`
      - Policy A `Organization.read`
      - Policy B `Organization.read`
1. Add `ResourceGranter.andAllProps`
    - The first point has big implications. It means another policy with a conditional permission on a property takes precedence over the current policy's resource level permission.
    - This could not be desired, so now there's an additional flag (`andAllProps`) to explicitly communicate that the current policy's resource level permissions apply to all the properties as well and no other policies should "get in the way".
    - Other property level permissions are still considered. (See Example 4)
3. `PropGranter.none` is actually a _DENY_ action
    - This _deny_ as precedence over other actions only within the current policy, but not outside of the current policy.

# Examples

Let's run through some examples for clarity.

## Example 1
```ts
// Policy A
r.Organization.read
// Policy B
r.Organization.read.specifically(p => p.address.when(member).read)
```
Assuming both apply, the user will only have `read` permission if a member for `address`.

## Example 2
```ts
// Policy A
r.Organization.read
// Policy B
r.Organization.specifically(p => p.address.none)
```
Assuming both apply, the user will not have any permissions for `address`.

## Example 3
```ts
// Policy A
r.Organization.read.andAllProps
// Policy B
r.Organization.specifically(p => p.address.none)
```
Assuming both apply, the user will have `read` permissions for `address`.

## Example 4
```ts
// Policy A
r.Organization.read.andAllProps
// Policy B
r.Organization.specifically(p => p.address.edit)
```
Assuming both apply, the user will have `read` & `edit` permissions for `address`.

## Example 5
```ts
r.Organization.specifically(p => [
  p.address.none,
  p.address.read,
  // or any other form, etc
  p.address.read.none,
])
```
The user will not have any permissions for `address`.

# Conclusion

Policies are deterministic now for these edge cases.
For the most part, things should behave more intuitively. 

It's unclear where `.andAllProps` should apply to existing policies. I've already applied them to Administrator and Leadership  where we are expecting unfettered/read access to everything.

Hopefully this all makes sense and is the right direction.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3509457875) by [Unito](https://www.unito.io)
