### PR TITLE
Progress report workflow notes

### DIFF
--- a/src/components/progress-report/workflow/dto/execute-progress-report-transition.input.ts
+++ b/src/components/progress-report/workflow/dto/execute-progress-report-transition.input.ts
@@ -1,20 +1,20 @@
-import { ArgsType, Field } from '@nestjs/graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { ID, IdField, RichTextDocument, RichTextField } from '~/common';
 import { ProgressReportStatus } from '../../dto';
 
-@ArgsType()
+@InputType()
 export abstract class ExecuteProgressReportTransitionInput {
   @IdField({
-    name: 'reportId',
+    name: 'report',
   })
-  readonly reportId: ID;
+  readonly report: ID;
 
   @IdField({
-    name: 'transitionId',
+    name: 'transition',
     description: 'Execute this transition',
     nullable: true,
   })
-  readonly transitionId?: ID;
+  readonly transition?: ID;
 
   @Field(() => ProgressReportStatus, {
     description: 'Bypass the workflow, and go straight to this status.',

--- a/src/components/progress-report/workflow/dto/execute-progress-report-transition.input.ts
+++ b/src/components/progress-report/workflow/dto/execute-progress-report-transition.input.ts
@@ -10,7 +10,7 @@ export abstract class ExecuteProgressReportTransitionInput {
   readonly reportId: ID;
 
   @IdField({
-    name: 'transition',
+    name: 'transitionId',
     description: 'Execute this transition',
     nullable: true,
   })

--- a/src/components/progress-report/workflow/dto/execute-progress-report-transition.input.ts
+++ b/src/components/progress-report/workflow/dto/execute-progress-report-transition.input.ts
@@ -1,0 +1,24 @@
+import { ArgsType, Field } from '@nestjs/graphql';
+import { ID, IdField } from '~/common';
+import { ProgressReportStatus } from '../../dto';
+
+@ArgsType()
+export abstract class ExecuteProgressReportTransitionInput {
+  @IdField({
+    name: 'id',
+  })
+  readonly reportId: ID;
+
+  @IdField({
+    name: 'transition',
+    description: 'Execute this transition',
+    nullable: true,
+  })
+  readonly transitionId?: ID;
+
+  @Field(() => ProgressReportStatus, {
+    description: 'Bypass the workflow, and go straight to this status.',
+    nullable: true,
+  })
+  readonly status?: ProgressReportStatus;
+}

--- a/src/components/progress-report/workflow/dto/execute-progress-report-transition.input.ts
+++ b/src/components/progress-report/workflow/dto/execute-progress-report-transition.input.ts
@@ -1,5 +1,5 @@
 import { ArgsType, Field } from '@nestjs/graphql';
-import { ID, IdField } from '~/common';
+import { ID, IdField, RichTextDocument, RichTextField } from '~/common';
 import { ProgressReportStatus } from '../../dto';
 
 @ArgsType()
@@ -21,4 +21,9 @@ export abstract class ExecuteProgressReportTransitionInput {
     nullable: true,
   })
   readonly status?: ProgressReportStatus;
+
+  @RichTextField({
+    nullable: true,
+  })
+  readonly notes?: RichTextDocument;
 }

--- a/src/components/progress-report/workflow/dto/execute-progress-report-transition.input.ts
+++ b/src/components/progress-report/workflow/dto/execute-progress-report-transition.input.ts
@@ -5,7 +5,7 @@ import { ProgressReportStatus } from '../../dto';
 @ArgsType()
 export abstract class ExecuteProgressReportTransitionInput {
   @IdField({
-    name: 'id',
+    name: 'reportId',
   })
   readonly reportId: ID;
 

--- a/src/components/progress-report/workflow/dto/workflow-event.dto.ts
+++ b/src/components/progress-report/workflow/dto/workflow-event.dto.ts
@@ -8,6 +8,7 @@ import {
   IdOf,
   Secured,
   SecuredProps,
+  SecuredRichTextNullable,
   SetUnsecuredType,
 } from '~/common';
 import { RegisterResource } from '~/core';
@@ -40,6 +41,9 @@ export abstract class ProgressReportWorkflowEvent {
 
   @Field(() => ProgressReportStatus)
   readonly status: ProgressReportStatus;
+
+  @Field()
+  readonly notes: SecuredRichTextNullable;
 }
 
 declare module '~/core/resources/map' {

--- a/src/components/progress-report/workflow/progress-report-workflow.repository.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.repository.ts
@@ -1,6 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { inArray, node, Query, relation } from 'cypher-query-builder';
-import { ID, NotFoundException, Order, Session, UnsecuredDto } from '~/common';
+import {
+  ID,
+  NotFoundException,
+  Order,
+  RichTextDocument,
+  Session,
+  UnsecuredDto,
+} from '~/common';
 import { DtoRepository } from '~/core';
 import {
   ACTIVE,
@@ -75,13 +82,19 @@ export class ProgressReportWorkflowRepository extends DtoRepository(
   async recordTransition(
     report: ID,
     { id: transition, to: status }: InternalTransition,
-    session: Session
+    session: Session,
+    notes?: RichTextDocument
   ) {
-    await this.recordEvent(report, { status, transition }, session);
+    await this.recordEvent(report, { status, transition, notes }, session);
   }
 
-  async recordBypass(report: ID, status: Status, session: Session) {
-    await this.recordEvent(report, { status }, session);
+  async recordBypass(
+    report: ID,
+    status: Status,
+    session: Session,
+    notes?: RichTextDocument
+  ) {
+    await this.recordEvent(report, { status, notes }, session);
   }
 
   private async recordEvent(

--- a/src/components/progress-report/workflow/progress-report-workflow.service.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.service.ts
@@ -69,6 +69,7 @@ export class ProgressReportWorkflowService {
       reportId,
       transitionId,
       status: overrideStatus,
+      notes,
     }: ExecuteProgressReportTransitionInput,
     session: Session
   ) {
@@ -82,7 +83,7 @@ export class ProgressReportWorkflowService {
       }
 
       await Promise.all([
-        this.repo.recordBypass(reportId, overrideStatus, session),
+        this.repo.recordBypass(reportId, overrideStatus, session, notes),
         this.repo.changeStatus(reportId, overrideStatus),
       ]);
       return;
@@ -95,7 +96,7 @@ export class ProgressReportWorkflowService {
     }
 
     await Promise.all([
-      this.repo.recordTransition(reportId, transition, session),
+      this.repo.recordTransition(reportId, transition, session, notes),
       this.repo.changeStatus(reportId, transition.to),
     ]);
 

--- a/src/components/progress-report/workflow/progress-report-workflow.service.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.service.ts
@@ -66,8 +66,8 @@ export class ProgressReportWorkflowService {
 
   async executeTransition(
     {
-      reportId,
-      transitionId,
+      report: reportId,
+      transition: transitionId,
       status: overrideStatus,
       notes,
     }: ExecuteProgressReportTransitionInput,

--- a/src/components/progress-report/workflow/progress-report-workflow.service.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.service.ts
@@ -9,6 +9,7 @@ import {
 import { ResourceLoader } from '~/core';
 import { Privileges } from '../../authorization';
 import { ProgressReport, ProgressReportStatus as Status } from '../dto';
+import { ExecuteProgressReportTransitionInput } from './dto/execute-progress-report-transition.input';
 import { ProgressReportWorkflowEvent as WorkflowEvent } from './dto/workflow-event.dto';
 import { ProgressReportWorkflowRepository } from './progress-report-workflow.repository';
 import { Transitions } from './transitions';
@@ -64,9 +65,11 @@ export class ProgressReportWorkflowService {
   }
 
   async executeTransition(
-    reportId: ID,
-    transitionId: ID | undefined,
-    overrideStatus: Status | undefined,
+    {
+      reportId,
+      transitionId,
+      status: overrideStatus,
+    }: ExecuteProgressReportTransitionInput,
     session: Session
   ) {
     const currentStatus = await this.repo.currentStatus(reportId);

--- a/src/components/progress-report/workflow/resolvers/progress-report-execute-transition.resolver.ts
+++ b/src/components/progress-report/workflow/resolvers/progress-report-execute-transition.resolver.ts
@@ -1,7 +1,8 @@
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
-import { ID, IdArg, LoggedInSession, Session } from '~/common';
+import { LoggedInSession, Session } from '~/common';
 import { ResourceLoader } from '~/core';
-import { ProgressReport, ProgressReportStatus } from '../../dto';
+import { ProgressReport } from '../../dto';
+import { ExecuteProgressReportTransitionInput } from '../dto/execute-progress-report-transition.input';
 import { ProgressReportWorkflowService } from '../progress-report-workflow.service';
 
 @Resolver()
@@ -13,28 +14,10 @@ export class ProgressReportExecuteTransitionResolver {
 
   @Mutation(() => ProgressReport)
   async transitionProgressReport(
-    @IdArg() reportId: ID,
-    @IdArg({
-      name: 'transition',
-      nullable: true,
-      description: 'Execute this transition',
-    })
-    transitionId: ID | undefined,
-    @Args({
-      name: 'status',
-      type: () => ProgressReportStatus,
-      nullable: true,
-      description: 'Bypass the workflow, and go straight to this status.',
-    })
-    status: ProgressReportStatus | undefined,
+    @Args() input: ExecuteProgressReportTransitionInput,
     @LoggedInSession() session: Session
   ): Promise<ProgressReport> {
-    await this.workflow.executeTransition(
-      reportId,
-      transitionId,
-      status,
-      session
-    );
-    return await this.resources.load(ProgressReport, reportId);
+    await this.workflow.executeTransition(input, session);
+    return await this.resources.load(ProgressReport, input.reportId);
   }
 }

--- a/src/components/progress-report/workflow/resolvers/progress-report-execute-transition.resolver.ts
+++ b/src/components/progress-report/workflow/resolvers/progress-report-execute-transition.resolver.ts
@@ -14,10 +14,10 @@ export class ProgressReportExecuteTransitionResolver {
 
   @Mutation(() => ProgressReport)
   async transitionProgressReport(
-    @Args() input: ExecuteProgressReportTransitionInput,
+    @Args({ name: 'input' }) input: ExecuteProgressReportTransitionInput,
     @LoggedInSession() session: Session
   ): Promise<ProgressReport> {
     await this.workflow.executeTransition(input, session);
-    return await this.resources.load(ProgressReport, input.reportId);
+    return await this.resources.load(ProgressReport, input.report);
   }
 }


### PR DESCRIPTION
For the additional notes step on the UI, we needed to allow the API to be aware of the notes object and be able to store them in the DB.

Acceptance criteria:

- [x] the `notes` should be Nullable/optional
- [x] the `notes` should be stored in the DB upon a transition execution

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3536019095) by [Unito](https://www.unito.io)
