### PR TITLE
Fix cypher variable clobbering named parameter

### DIFF
--- a/src/core/database/query-augmentation/condition-variables.ts
+++ b/src/core/database/query-augmentation/condition-variables.ts
@@ -23,12 +23,12 @@ const Parameter = new ParameterBag().addParam('')
 const Pattern = Object.getPrototypeOf(NodePattern) as Class<TSPattern>;
 
 export class Variable extends Parameter {
-  constructor(variable: string) {
-    super(variable, variable);
+  constructor(variable: string, name = variable) {
+    super(name, variable);
   }
 
   toString() {
-    return `${this.name}`;
+    return `${this.value}`;
   }
 }
 
@@ -42,26 +42,12 @@ ParameterBag.prototype.addParam = function addParam(
   value: any | Variable,
   name?: string
 ) {
-  if (value instanceof Variable) {
-    this.parameterMap[value.name] = value;
-    return value;
-  }
   const actualName = this.getName(name);
-  const param = new Parameter(actualName, value);
+  const param =
+    value instanceof Variable
+      ? new Variable(value.value, actualName)
+      : new Parameter(actualName, value);
   this.parameterMap[actualName] = param;
-  return param;
-};
-
-ParameterBag.prototype.addExistingParam = function addExistingParam(
-  this: TSParameterBag,
-  param: TSParameter
-) {
-  if (param instanceof Variable) {
-    this.parameterMap[param.name] = param;
-    return param;
-  }
-  param.name = this.getName(param.name);
-  this.parameterMap[param.name] = param;
   return param;
 };
 

--- a/src/core/database/query-augmentation/condition-variables.ts
+++ b/src/core/database/query-augmentation/condition-variables.ts
@@ -10,7 +10,7 @@ import type {
 } from 'cypher-query-builder/dist/typings/parameter-bag';
 import type { ParameterContainer as TSParameterContainer } from 'cypher-query-builder/dist/typings/parameter-container';
 import { Class } from 'type-fest';
-import { many, Many, mapFromList } from '../../../common';
+import { mapFromList } from '../../../common';
 
 // This class is not exported so grab it a hacky way
 const ParameterContainer = Object.getPrototypeOf(
@@ -23,7 +23,7 @@ const Parameter = new ParameterBag().addParam('')
 const Pattern = Object.getPrototypeOf(NodePattern) as Class<TSPattern>;
 
 export class Variable extends Parameter {
-  constructor(variable: string, public refs: readonly string[]) {
+  constructor(variable: string) {
     super(variable, variable);
   }
 
@@ -34,11 +34,8 @@ export class Variable extends Parameter {
 
 /**
  * @param expression The expression to inline in the query
- * @param refs References used in the expression.
- *             Can be used to import them into sub-queries.
  */
-export const variable = (expression: string, refs?: Many<string>) =>
-  new Variable(expression, refs ? many(refs) : []);
+export const variable = (expression: string) => new Variable(expression);
 
 ParameterBag.prototype.addParam = function addParam(
   this: TSParameterBag,


### PR DESCRIPTION
# Bug
If a query has a variable with the same name as a parameter, the parameter is not bound.
```ts
.query()
// add bound parameter $variant
.raw('', { variant: "foo" })
// Convert bound parameter to whatever cypher calls a local variable in the query.
.with('$variant as variant')
// Use var to do logic
.matchNode('n', { variant: variable('variant') }) // MATCH (n { variant: variant })
```
Without this PR, the query would not have the `$variant` parameter bound and sent.

# Fix

Change `Variable` to print `value` instead of `name`.
The `name` is the bound parameter name, prefixed with `$`.
It is actually mutable to keep it unique in the context of the whole query.
This should be allowed & ignored, as variables are stripped out instead of
being turned into bound parameters.
The `value` is always the raw untouched cypher expression which is what we want.

With this change, we don't need to work around CQB's naming logic,
which simplifies the implementation as well.