### PR TITLE
Add variants to `ProductProgress`

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -45,3 +45,4 @@ export {
   SecuredRichTextNullable,
 } from './rich-text.scalar';
 export * from './weak-map-cache';
+export * from './variant.dto';

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -24,6 +24,7 @@ export * from './pagination-list';
 export * from './parent-id.middleware';
 export * from './parent-types';
 export * from './resource.dto';
+export * from './role.dto';
 export * from './secured-list';
 export * from './secured-property';
 export * from './secured-date';

--- a/src/common/role.dto.ts
+++ b/src/common/role.dto.ts
@@ -1,0 +1,49 @@
+import { ObjectType, registerEnumType } from '@nestjs/graphql';
+import { SecuredEnumList } from '~/common/secured-property';
+import type { ResourcesGranter } from '../components/authorization';
+
+export enum Role {
+  Administrator = 'Administrator',
+  BetaTester = 'BetaTester',
+  BibleTranslationLiaison = 'BibleTranslationLiaison',
+  Consultant = 'Consultant',
+  ConsultantManager = 'ConsultantManager',
+  Controller = 'Controller',
+  ExperienceOperations = 'ExperienceOperations',
+  FieldOperationsDirector = 'FieldOperationsDirector',
+  FieldPartner = 'FieldPartner',
+  FinancialAnalyst = 'FinancialAnalyst',
+  Fundraising = 'Fundraising',
+  Intern = 'Intern',
+  LeadFinancialAnalyst = 'LeadFinancialAnalyst',
+  Leadership = 'Leadership',
+  Liaison = 'Liaison',
+  Marketing = 'Marketing',
+  Mentor = 'Mentor',
+  ProjectManager = 'ProjectManager',
+  RegionalCommunicationsCoordinator = 'RegionalCommunicationsCoordinator',
+  RegionalDirector = 'RegionalDirector',
+  StaffMember = 'StaffMember',
+  Translator = 'Translator',
+}
+
+registerEnumType(Role, { name: 'Role' });
+
+@ObjectType({
+  description: SecuredEnumList.descriptionFor('roles'),
+})
+export abstract class SecuredRoles extends SecuredEnumList<Role, Role>(Role) {}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Role {
+  /**
+   * A helper to grant roles to be assignable in a more readable way.
+   * This should be used within a Policy.
+   */
+  export const assignable = (
+    resources: ResourcesGranter,
+    roles: readonly Role[]
+  ) => resources.AssignableRoles.grant(roles);
+
+  Object.defineProperty(Role, 'assignable', { enumerable: false });
+}

--- a/src/common/variant.dto.ts
+++ b/src/common/variant.dto.ts
@@ -1,7 +1,10 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
-import { entries, IdField, InputException, ResourceShape } from '~/common';
-import { Role } from '../../authorization';
+import { ResourceShape } from '~/common/resource.dto';
+import { InputException } from './exceptions';
+import { IdField } from './id-field';
+import { Role } from './role.dto';
+import { entries } from './util';
 
 @ObjectType()
 export class Variant<Key extends string = string> {

--- a/src/components/authorization/dto/role.dto.ts
+++ b/src/components/authorization/dto/role.dto.ts
@@ -1,38 +1,6 @@
-import { ObjectType, registerEnumType } from '@nestjs/graphql';
-import { SecuredEnumList } from '~/common';
-import { ResourcesGranter } from '../policy';
+import { Role } from '~/common';
 
-export enum Role {
-  Administrator = 'Administrator',
-  BetaTester = 'BetaTester',
-  BibleTranslationLiaison = 'BibleTranslationLiaison',
-  Consultant = 'Consultant',
-  ConsultantManager = 'ConsultantManager',
-  Controller = 'Controller',
-  ExperienceOperations = 'ExperienceOperations',
-  FieldOperationsDirector = 'FieldOperationsDirector',
-  FieldPartner = 'FieldPartner',
-  FinancialAnalyst = 'FinancialAnalyst',
-  Fundraising = 'Fundraising',
-  Intern = 'Intern',
-  LeadFinancialAnalyst = 'LeadFinancialAnalyst',
-  Leadership = 'Leadership',
-  Liaison = 'Liaison',
-  Marketing = 'Marketing',
-  Mentor = 'Mentor',
-  ProjectManager = 'ProjectManager',
-  RegionalCommunicationsCoordinator = 'RegionalCommunicationsCoordinator',
-  RegionalDirector = 'RegionalDirector',
-  StaffMember = 'StaffMember',
-  Translator = 'Translator',
-}
-
-registerEnumType(Role, { name: 'Role' });
-
-@ObjectType({
-  description: SecuredEnumList.descriptionFor('roles'),
-})
-export abstract class SecuredRoles extends SecuredEnumList<Role, Role>(Role) {}
+export * from '~/common/role.dto';
 
 export type ProjectScope = 'project';
 export type GlobalScope = 'global';
@@ -55,17 +23,3 @@ export const withoutScope = (role: ScopedRole): Role => splitScope(role)[1];
 
 export const splitScope = (role: ScopedRole) =>
   role.split(':') as [AuthScope, Role];
-
-// eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace Role {
-  /**
-   * A helper to grant roles to be assignable in a more readable way.
-   * This should be used within a Policy.
-   */
-  export const assignable = (
-    resources: ResourcesGranter,
-    roles: readonly Role[]
-  ) => resources.AssignableRoles.grant(roles);
-
-  Object.defineProperty(Role, 'assignable', { enumerable: false });
-}

--- a/src/components/authorization/index.ts
+++ b/src/components/authorization/index.ts
@@ -1,2 +1,10 @@
 export * from './dto';
 export * from './policy';
+export {
+  HasScope,
+  HasSensitivity,
+  withEffectiveSensitivity,
+  withMembershipRoles,
+  withScope,
+  withVariant,
+} from './policies/conditions';

--- a/src/components/authorization/index.ts
+++ b/src/components/authorization/index.ts
@@ -1,8 +1,10 @@
 export * from './dto';
 export * from './policy';
 export {
+  HasCreator,
   HasScope,
   HasSensitivity,
+  HasVariant,
   withEffectiveSensitivity,
   withMembershipRoles,
   withScope,

--- a/src/components/authorization/model/resource-map.ts
+++ b/src/components/authorization/model/resource-map.ts
@@ -30,7 +30,6 @@ import {
   IPeriodicReport as PeriodicReport,
 } from '../../periodic-report/dto';
 import { Post } from '../../post/dto';
-import { StepProgress } from '../../product-progress/dto';
 import {
   DerivativeScriptureProduct,
   DirectScriptureProduct,
@@ -96,7 +95,6 @@ export const LegacyResourceMap = {
   FinancialReport,
   NarrativeReport,
   ProjectChangeRequest,
-  StepProgress,
   Song,
   Story,
   Unavailability,

--- a/src/components/authorization/policies/conditions/owner.condition.ts
+++ b/src/components/authorization/policies/conditions/owner.condition.ts
@@ -11,7 +11,7 @@ import {
 
 const CQL_VAR = 'requestingUser';
 
-interface HasCreator {
+export interface HasCreator {
   creator: ID | Secured<ID>;
 }
 

--- a/src/components/authorization/policies/conditions/variant.condition.ts
+++ b/src/components/authorization/policies/conditions/variant.condition.ts
@@ -1,7 +1,6 @@
 import { Query } from 'cypher-query-builder';
 import { inspect, InspectOptionsStylized } from 'util';
-import { Many, ResourceShape } from '~/common';
-import type { VariantOf } from '../../../prompts/dto/variant.dto';
+import { Many, ResourceShape, VariantOf } from '~/common';
 import {
   AsCypherParams,
   Condition,

--- a/src/components/authorization/policies/conditions/variant.condition.ts
+++ b/src/components/authorization/policies/conditions/variant.condition.ts
@@ -1,6 +1,6 @@
 import { Query } from 'cypher-query-builder';
 import { inspect, InspectOptionsStylized } from 'util';
-import { Many, ResourceShape, VariantOf } from '~/common';
+import { Many, ResourceShape, Variant, VariantOf } from '~/common';
 import {
   AsCypherParams,
   Condition,
@@ -41,9 +41,12 @@ class VariantCondition<TResourceStatic extends ResourceShape<any>>
   }
 }
 
-export const withVariant = <T extends object>(obj: T, variant: string) =>
+export const withVariant = <T extends object>(
+  obj: T,
+  variant: string | Variant
+) =>
   Object.defineProperty(obj, VariantForCondition, {
-    value: variant,
+    value: typeof variant === 'string' ? variant : variant.key,
     enumerable: false,
     writable: true,
   }) as T & HasVariant;

--- a/src/components/authorization/policies/conditions/variant.condition.ts
+++ b/src/components/authorization/policies/conditions/variant.condition.ts
@@ -7,6 +7,12 @@ import {
   IsAllowedParams,
 } from '../../policy/conditions';
 
+const VariantForCondition = Symbol('Variant');
+
+export interface HasVariant {
+  [VariantForCondition]: string;
+}
+
 class VariantCondition<TResourceStatic extends ResourceShape<any>>
   implements Condition<TResourceStatic>
 {
@@ -35,14 +41,12 @@ class VariantCondition<TResourceStatic extends ResourceShape<any>>
   }
 }
 
-export const withVariant = <T extends object>(obj: T, variant: string): T =>
+export const withVariant = <T extends object>(obj: T, variant: string) =>
   Object.defineProperty(obj, VariantForCondition, {
     value: variant,
     enumerable: false,
     writable: true,
-  });
-
-const VariantForCondition = Symbol('Variant');
+  }) as T & HasVariant;
 
 /**
  * The following actions if the object is one of the given variants.

--- a/src/components/product-progress/dto/index.ts
+++ b/src/components/product-progress/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './product-progress.dto';
 export * from './product-progress.input';
 export * from './progress-format.enum';
+export * from './variant-progress.dto';

--- a/src/components/product-progress/dto/product-progress.dto.ts
+++ b/src/components/product-progress/dto/product-progress.dto.ts
@@ -3,14 +3,41 @@ import { stripIndent } from 'common-tags';
 import { DateTime } from 'luxon';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { Merge } from 'type-fest';
-import { RegisterResource } from '~/core';
 import {
   ID,
   SecuredFloatNullable,
   SecuredProps,
+  SetUnsecuredType,
   UnsecuredDto,
-} from '../../../common';
-import { ProductStep } from '../../product';
+  Variant,
+} from '~/common';
+import { RegisterResource } from '~/core';
+import { Product, ProductStep } from '../../product';
+import { ProgressReport } from '../../progress-report/dto';
+import {
+  ProgressReportVariantProgress,
+  ProgressVariant,
+} from './variant-progress.dto';
+
+export interface ProgressVariantByProductInput {
+  product: Product;
+  variant: Variant<ProgressVariant>;
+}
+
+export interface ProgressVariantByProductOutput
+  extends Pick<ProgressReportVariantProgress, 'variant' | 'details'> {
+  product: Product;
+}
+
+export interface ProgressVariantByReportInput {
+  report: ProgressReport;
+  variant: Variant<ProgressVariant>;
+}
+
+export interface ProgressVariantByReportOutput
+  extends Pick<ProgressReportVariantProgress, 'variant' | 'details'> {
+  report: ProgressReport;
+}
 
 @ObjectType({
   description: 'The progress of a product for a given report',
@@ -28,6 +55,10 @@ export class ProductProgress {
   readonly productId: ID;
 
   readonly reportId: ID;
+
+  @Field(() => Variant)
+  readonly variant: Variant<ProgressVariant> &
+    SetUnsecuredType<ProgressVariant>;
 
   @Field(() => [StepProgress], {
     description: stripIndent`
@@ -63,6 +94,7 @@ export class StepProgress {
   static readonly Props = keysOf<StepProgress>();
   static readonly SecuredProps = keysOf<SecuredProps<StepProgress>>();
   static readonly Parent = 'dynamic'; // [Product, ProgressReport]
+  static readonly Variants = ProgressReportVariantProgress.Variants;
 
   // Both of these only exist if progress has been reported (or explicitly set to null).
   // I have these here to show that they can exist in the DB, but they are private to the API.

--- a/src/components/product-progress/dto/product-progress.dto.ts
+++ b/src/components/product-progress/dto/product-progress.dto.ts
@@ -3,6 +3,7 @@ import { stripIndent } from 'common-tags';
 import { DateTime } from 'luxon';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { Merge } from 'type-fest';
+import { RegisterResource } from '~/core';
 import {
   ID,
   SecuredFloatNullable,
@@ -54,6 +55,7 @@ export type UnsecuredProductProgress = Merge<
   }
 >;
 
+@RegisterResource()
 @ObjectType({
   description: `The progress of a product's step for a given report`,
 })
@@ -79,4 +81,10 @@ export class StepProgress {
     `,
   })
   readonly completed: SecuredFloatNullable;
+}
+
+declare module '~/core/resources/map' {
+  interface ResourceMap {
+    StepProgress: typeof StepProgress;
+  }
 }

--- a/src/components/product-progress/dto/product-progress.input.ts
+++ b/src/components/product-progress/dto/product-progress.input.ts
@@ -2,11 +2,12 @@ import { Field, Float, InputType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { Max, Min, ValidateNested } from 'class-validator';
 import { stripIndent } from 'common-tags';
-import { ID, IdField } from '../../../common';
+import { ID, IdField } from '~/common';
 import { ProductStep } from '../../product';
+import { VariantProgressArg } from './variant-progress.dto';
 
 @InputType()
-export abstract class ProductProgressInput {
+export abstract class ProductProgressInput extends VariantProgressArg {
   @IdField({
     description: 'Which product are you reporting on?',
   })

--- a/src/components/product-progress/dto/variant-progress.dto.ts
+++ b/src/components/product-progress/dto/variant-progress.dto.ts
@@ -1,0 +1,64 @@
+import { ArgsType, Field, InputType, ObjectType } from '@nestjs/graphql';
+import { keys as keysOf } from 'ts-transformer-keys';
+import {
+  Role,
+  SecuredProps,
+  SetUnsecuredType,
+  Variant,
+  VariantInputField,
+  VariantOf,
+} from '~/common';
+import { RegisterResource } from '~/core';
+import {
+  ProductProgress,
+  UnsecuredProductProgress,
+} from './product-progress.dto';
+
+export type ProgressVariant = VariantOf<typeof ProgressReportVariantProgress>;
+
+@RegisterResource()
+@ObjectType()
+export class ProgressReportVariantProgress {
+  static readonly Props = keysOf<ProgressReportVariantProgress>();
+  static readonly SecuredProps =
+    keysOf<SecuredProps<ProgressReportVariantProgress>>();
+  static readonly Parent = import(
+    '../../progress-report/dto/progress-report.entity'
+  ).then((m) => m.ProgressReport);
+
+  static readonly Variants = Variant.createList({
+    partner: {
+      label: 'Field Partner',
+      responsibleRole: Role.FieldPartner,
+    },
+    official: {
+      label: 'Field Operations',
+      responsibleRole: Role.ProjectManager,
+    },
+  });
+  static readonly FallbackVariant =
+    ProgressReportVariantProgress.Variants.byKey('official');
+
+  @Field(() => Variant)
+  readonly variant: Variant<ProgressVariant> &
+    SetUnsecuredType<ProgressVariant>;
+
+  readonly details: readonly ProductProgress[] &
+    SetUnsecuredType<readonly UnsecuredProductProgress[]>;
+}
+
+declare module '~/core/resources/map' {
+  interface ResourceMap {
+    ProgressReportVariantProgress: typeof ProgressReportVariantProgress;
+  }
+}
+
+@ArgsType()
+@InputType({ isAbstract: true })
+export class VariantProgressArg {
+  @VariantInputField(ProgressReportVariantProgress, {
+    defaultValue: ProgressReportVariantProgress.FallbackVariant,
+  })
+  // @ts-expect-error Ensure property is defined so @Transform runs to apply default value
+  readonly variant: Variant<ProgressVariant> = null;
+}

--- a/src/components/product-progress/handlers/extract-pnp-progress.handler.ts
+++ b/src/components/product-progress/handlers/extract-pnp-progress.handler.ts
@@ -2,6 +2,7 @@ import { EventsHandler, ILogger, Logger } from '../../../core';
 import { ReportType } from '../../periodic-report/dto';
 import { PeriodicReportUploadedEvent } from '../../periodic-report/events';
 import { ProducibleType, ProductService } from '../../product';
+import { ProgressReportVariantProgress as Progress } from '../dto';
 import { ProductProgressService } from '../product-progress.service';
 import { StepProgressExtractor } from '../step-progress-extractor.service';
 
@@ -78,6 +79,8 @@ export class ExtractPnpProgressHandler {
           {
             ...input,
             reportId: event.report.id,
+            // TODO this seems fine for now as only this variant will upload PnPs.
+            variant: Progress.FallbackVariant,
           },
           event.session
         );

--- a/src/components/product-progress/migrations/AddVariantToProgress.migration.ts
+++ b/src/components/product-progress/migrations/AddVariantToProgress.migration.ts
@@ -1,0 +1,17 @@
+import { isNull } from 'cypher-query-builder';
+import { BaseMigration, Migration } from '~/core';
+import { ProgressReportVariantProgress as Progress } from '../dto';
+
+@Migration('2022-11-18T18:53:48.113')
+export class AddVariantToProgressMigration extends BaseMigration {
+  async up() {
+    await this.db
+      .query()
+      .matchNode('node', 'ProductProgress')
+      .where({ 'node.variant': isNull() })
+      .setValues({
+        'node.variant': Progress.FallbackVariant.key,
+      })
+      .run();
+  }
+}

--- a/src/components/product-progress/product-progress-by-product.loader.ts
+++ b/src/components/product-progress/product-progress-by-product.loader.ts
@@ -1,18 +1,15 @@
-import { ID } from '../../common';
+import { LoaderFactory, LoaderOptionsOf, OrderedNestDataLoader } from '~/core';
 import {
-  LoaderFactory,
-  LoaderOptionsOf,
-  OrderedNestDataLoader,
-} from '../../core';
-import { Product } from '../product';
-import { ProductProgress } from './dto';
+  ProgressVariantByProductInput,
+  ProgressVariantByProductOutput,
+} from './dto';
 import { ProductProgressService } from './product-progress.service';
 
 @LoaderFactory()
 export class ProductProgressByProductLoader extends OrderedNestDataLoader<
-  { product: Product; progress: readonly ProductProgress[] },
-  Product,
-  ID
+  ProgressVariantByProductOutput,
+  ProgressVariantByProductInput,
+  string
 > {
   constructor(private readonly service: ProductProgressService) {
     super();
@@ -21,12 +18,15 @@ export class ProductProgressByProductLoader extends OrderedNestDataLoader<
   getOptions(): LoaderOptionsOf<ProductProgressByProductLoader> {
     return {
       ...super.getOptions(),
-      propertyKey: (result) => result.product,
-      cacheKeyFn: (report) => report.id,
+      propertyKey: (result) => ({
+        product: result.product,
+        variant: result.variant,
+      }),
+      cacheKeyFn: (args) => `${args.product.id}:${args.variant.key}`,
     };
   }
 
-  async loadMany(products: readonly Product[]) {
+  async loadMany(products: readonly ProgressVariantByProductInput[]) {
     return await this.service.readAllForManyProducts(products, this.session);
   }
 }

--- a/src/components/product-progress/product-progress-by-report.loader.ts
+++ b/src/components/product-progress/product-progress-by-report.loader.ts
@@ -1,18 +1,15 @@
-import { ID } from '../../common';
+import { LoaderFactory, LoaderOptionsOf, OrderedNestDataLoader } from '~/core';
 import {
-  LoaderFactory,
-  LoaderOptionsOf,
-  OrderedNestDataLoader,
-} from '../../core';
-import type { ProgressReport } from '../progress-report/dto';
-import { ProductProgress } from './dto';
+  ProgressVariantByReportInput,
+  ProgressVariantByReportOutput,
+} from './dto';
 import { ProductProgressService } from './product-progress.service';
 
 @LoaderFactory()
 export class ProductProgressByReportLoader extends OrderedNestDataLoader<
-  { report: ProgressReport; progress: readonly ProductProgress[] },
-  ProgressReport,
-  ID
+  ProgressVariantByReportOutput,
+  ProgressVariantByReportInput,
+  string
 > {
   constructor(private readonly service: ProductProgressService) {
     super();
@@ -21,12 +18,15 @@ export class ProductProgressByReportLoader extends OrderedNestDataLoader<
   getOptions(): LoaderOptionsOf<ProductProgressByReportLoader> {
     return {
       ...super.getOptions(),
-      propertyKey: (result) => result.report,
-      cacheKeyFn: (report) => report.id,
+      propertyKey: (result) => ({
+        report: result.report,
+        variant: result.variant,
+      }),
+      cacheKeyFn: (args) => `${args.report.id}:${args.variant.key}`,
     };
   }
 
-  async loadMany(reports: readonly ProgressReport[]) {
+  async loadMany(reports: readonly ProgressVariantByReportInput[]) {
     return await this.service.readAllForManyReports(reports, this.session);
   }
 }

--- a/src/components/product-progress/product-progress.module.ts
+++ b/src/components/product-progress/product-progress.module.ts
@@ -3,6 +3,7 @@ import { AuthorizationModule } from '../authorization/authorization.module';
 import { PeriodicReportModule } from '../periodic-report/periodic-report.module';
 import { ProductModule } from '../product/product.module';
 import * as handlers from './handlers';
+import { AddVariantToProgressMigration } from './migrations/AddVariantToProgress.migration';
 import { ProductConnectionResolver } from './product-connection.resolver';
 import { ProductProgressByProductLoader } from './product-progress-by-product.loader';
 import { ProductProgressByReportLoader } from './product-progress-by-report.loader';
@@ -26,6 +27,7 @@ import { StepProgressResolver } from './step-progress.resolver';
     ProductProgressRepository,
     StepProgressExtractor,
     ...Object.values(handlers),
+    AddVariantToProgressMigration,
   ],
   exports: [ProductProgressService],
 })

--- a/src/components/product-progress/product-progress.service.ts
+++ b/src/components/product-progress/product-progress.service.ts
@@ -6,21 +6,31 @@ import {
   mapFromList,
   Session,
   UnauthorizedException,
-} from '../../common';
+  Variant,
+} from '~/common';
 import {
   HasScope,
   HasSensitivity,
   Privileges,
   UserResourcePrivileges,
+  withVariant,
 } from '../authorization';
 import { Product } from '../product';
 import type { ProgressReport } from '../progress-report/dto';
 import {
   ProductProgress,
   ProductProgressInput,
+  ProgressVariantByProductInput,
+  ProgressVariantByProductOutput,
+  ProgressVariantByReportInput,
+  ProgressVariantByReportOutput,
   StepProgress,
   UnsecuredProductProgress,
 } from './dto';
+import {
+  ProgressReportVariantProgress as Progress,
+  ProgressVariant,
+} from './dto/variant-progress.dto';
 import { ProductProgressRepository } from './product-progress.repository';
 import { StepNotPlannedException } from './step-not-planned.exception';
 
@@ -32,47 +42,53 @@ export class ProductProgressService {
   ) {}
 
   async readAllForManyReports(
-    reports: readonly ProgressReport[],
+    reports: readonly ProgressVariantByReportInput[],
     session: Session
-  ) {
+  ): Promise<readonly ProgressVariantByReportOutput[]> {
     if (reports.length === 0) {
       return [];
     }
-    const reportMap = mapFromList(reports, (r) => [r.id, r]);
-    const progressForManyReports =
-      await this.repo.readAllProgressReportsForManyReports(
-        reports.map((report) => report.id)
-      );
-    return progressForManyReports.map(({ reportId, progressList }) => {
-      const report = reportMap[reportId];
-      const progress = progressList.map((progress) =>
-        this.secure(progress, this.privilegesFor(session, report))
-      );
-      return { report, progress };
+    const reportMap = mapFromList(reports, (r) => [r.report.id, r.report]);
+    const rows = await this.repo.readAllProgressReportsForManyReports(reports);
+    return rows.map((row): ProgressVariantByReportOutput => {
+      const report = reportMap[row.reportId];
+      return {
+        report,
+        variant: Progress.Variants.byKey(row.variant),
+        details: row.progressList.map((progress) =>
+          this.secure(progress, this.privilegesFor(session, report))
+        ),
+      };
     });
   }
 
-  async readAllForManyProducts(products: readonly Product[], session: Session) {
+  async readAllForManyProducts(
+    products: readonly ProgressVariantByProductInput[],
+    session: Session
+  ): Promise<readonly ProgressVariantByProductOutput[]> {
     if (products.length === 0) {
       return [];
     }
-    const productMap = mapFromList(products, (r) => [r.id, r]);
-    const progressForManyProducts =
-      await this.repo.readAllProgressReportsForManyProducts(
-        products.map((product) => product.id)
-      );
-    return progressForManyProducts.map(({ productId, progressList }) => {
-      const product = productMap[productId];
-      const progress = progressList.map((progress) =>
-        this.secure(progress, this.privilegesFor(session, product))
-      );
-      return { product, progress };
+    const productMap = mapFromList(products, (p) => [p.product.id, p.product]);
+    const rows = await this.repo.readAllProgressReportsForManyProducts(
+      products
+    );
+    return rows.map((row): ProgressVariantByProductOutput => {
+      const product = productMap[row.productId];
+      return {
+        product,
+        variant: Progress.Variants.byKey(row.variant),
+        details: row.progressList.map((progress) =>
+          this.secure(progress, this.privilegesFor(session, product))
+        ),
+      };
     });
   }
 
   async readOne(
     report: ID | ProgressReport,
     product: ID | Product,
+    variant: Variant<ProgressVariant>,
     session: Session
   ): Promise<ProductProgress> {
     const productId = isIdLike(product) ? product : product.id;
@@ -83,27 +99,30 @@ export class ProductProgressService {
       ? report
       : await this.repo.getScope(productId, session);
 
-    const progress = await this.repo.readOne(productId, reportId);
+    const progress = await this.repo.readOne(productId, reportId, variant);
     return this.secure(progress, this.privilegesFor(session, context));
   }
 
   async readOneForCurrentReport(
-    product: Product,
+    input: ProgressVariantByProductInput,
     session: Session
   ): Promise<ProductProgress | undefined> {
-    const progress = await this.repo.readOneForCurrentReport(product.id);
+    const progress = await this.repo.readOneForCurrentReport(input);
     if (!progress) {
       return undefined;
     }
-    return this.secure(progress, this.privilegesFor(session, product));
+    return this.secure(progress, this.privilegesFor(session, input.product));
   }
 
   async update(input: ProductProgressInput, session: Session) {
     const scope = await this.repo.getScope(input.productId, session);
-    const privileges = this.privilegesFor(session, scope);
+    const privileges = this.privilegesFor(
+      session,
+      withVariant(scope, input.variant)
+    );
     if (!privileges.can('edit', 'completed')) {
       throw new UnauthorizedException(
-        `You do not have permission to update this product's progress`
+        `You do not have the permission to update the "${input.variant.label}" variant of this goal's progress`
       );
     }
 
@@ -136,9 +155,13 @@ export class ProductProgressService {
     progress: UnsecuredProductProgress,
     privileges: UserResourcePrivileges<typeof StepProgress>
   ): ProductProgress {
+    const vp = privileges.forContext(
+      withVariant(privileges.context!, progress.variant)
+    );
     return {
       ...progress,
-      steps: progress.steps.map((step) => privileges.secure(step)),
+      variant: Progress.Variants.byKey(progress.variant),
+      steps: progress.steps.map((step) => vp.secure(step)),
     };
   }
 

--- a/src/components/product-progress/progress-report-connection.resolver.ts
+++ b/src/components/product-progress/progress-report-connection.resolver.ts
@@ -1,7 +1,7 @@
-import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { Loader, LoaderOf } from '../../core';
 import { ProgressReport } from '../progress-report/dto';
-import { ProductProgress } from './dto';
+import { ProductProgress, VariantProgressArg } from './dto';
 import { ProductProgressByReportLoader } from './product-progress-by-report.loader';
 
 @Resolver(() => ProgressReport)
@@ -11,9 +11,10 @@ export class ProgressReportConnectionResolver {
   })
   async progress(
     @Parent() report: ProgressReport,
+    @Args() { variant }: VariantProgressArg,
     @Loader(ProductProgressByReportLoader)
     loader: LoaderOf<ProductProgressByReportLoader>
   ): Promise<readonly ProductProgress[]> {
-    return (await loader.load(report)).progress;
+    return (await loader.load({ report, variant })).details;
   }
 }

--- a/src/components/product-progress/progress-report-connection.resolver.ts
+++ b/src/components/product-progress/progress-report-connection.resolver.ts
@@ -39,6 +39,9 @@ export class ProgressReportConnectionResolver {
         }
         throw entry;
       }
+      if (entry.details.length === 0) {
+        return [];
+      }
       return [entry.details];
     });
   }

--- a/src/components/product-progress/progress-report-connection.resolver.ts
+++ b/src/components/product-progress/progress-report-connection.resolver.ts
@@ -1,7 +1,12 @@
 import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { Loader, LoaderOf } from '../../core';
+import { ClientException } from '~/common';
+import { Loader, LoaderOf } from '~/core';
 import { ProgressReport } from '../progress-report/dto';
-import { ProductProgress, VariantProgressArg } from './dto';
+import {
+  ProductProgress,
+  ProgressReportVariantProgress as Progress,
+  VariantProgressArg,
+} from './dto';
 import { ProductProgressByReportLoader } from './product-progress-by-report.loader';
 
 @Resolver(() => ProgressReport)
@@ -16,5 +21,25 @@ export class ProgressReportConnectionResolver {
     loader: LoaderOf<ProductProgressByReportLoader>
   ): Promise<readonly ProductProgress[]> {
     return (await loader.load({ report, variant })).details;
+  }
+
+  @ResolveField(() => [[ProductProgress]])
+  async progressForAllVariants(
+    @Parent() report: ProgressReport,
+    @Loader(ProductProgressByReportLoader)
+    loader: LoaderOf<ProductProgressByReportLoader>
+  ): Promise<ReadonlyArray<readonly ProductProgress[]>> {
+    const detailsOrErrors = await loader.loadMany(
+      Progress.Variants.map((variant) => ({ report, variant }))
+    );
+    return detailsOrErrors.flatMap((entry) => {
+      if (entry instanceof Error) {
+        if (entry instanceof ClientException) {
+          return [];
+        }
+        throw entry;
+      }
+      return [entry.details];
+    });
   }
 }

--- a/src/components/progress-report/dto/community-stories.dto.ts
+++ b/src/components/progress-report/dto/community-stories.dto.ts
@@ -1,8 +1,7 @@
 import { keys as keysOf } from 'ts-transformer-keys';
-import { SecuredProps } from '~/common';
+import { SecuredProps, VariantOf } from '~/common';
 import { RegisterResource } from '~/core';
 import { PromptVariantResponse } from '../../prompts/dto';
-import { VariantOf } from '../../prompts/dto/variant.dto';
 import { ProgressReportHighlight } from './hightlights.dto';
 
 @RegisterResource()

--- a/src/components/progress-report/dto/hightlights.dto.ts
+++ b/src/components/progress-report/dto/hightlights.dto.ts
@@ -1,9 +1,8 @@
 import { keys as keysOf } from 'ts-transformer-keys';
-import { SecuredProps } from '~/common';
+import { SecuredProps, Variant, VariantOf } from '~/common';
 import { RegisterResource } from '~/core';
 import { Role } from '../../authorization';
 import { PromptVariantResponse } from '../../prompts/dto';
-import { Variant, VariantOf } from '../../prompts/dto/variant.dto';
 
 const variants = Variant.createList({
   draft: {

--- a/src/components/prompts/dto/prompt-list.dto.ts
+++ b/src/components/prompts/dto/prompt-list.dto.ts
@@ -1,6 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql';
+import { Variant } from '~/common';
 import { Prompt } from './prompt.dto';
-import { Variant } from './variant.dto';
 
 @ObjectType()
 export abstract class PromptList {

--- a/src/components/prompts/dto/prompt-response.dto.ts
+++ b/src/components/prompts/dto/prompt-response.dto.ts
@@ -15,12 +15,12 @@ import {
   SecuredRichTextNullable,
   SetUnsecuredType,
   UnsecuredDto,
+  Variant,
 } from '~/common';
 import { ResourceRef } from '~/core';
 import { BaseNode } from '~/core/database/results';
 import { User } from '../../user';
 import { Prompt, SecuredPrompt } from './prompt.dto';
-import { Variant } from './variant.dto';
 
 @ObjectType()
 export class PromptResponse extends Resource {

--- a/src/components/prompts/prompt-variant-response.repository.ts
+++ b/src/components/prompts/prompt-variant-response.repository.ts
@@ -10,6 +10,8 @@ import {
   ResourceShape,
   Session,
   UnsecuredDto,
+  VariantList,
+  VariantOf,
 } from '~/common';
 import { DtoRepository } from '~/core';
 import { privileges } from '~/core/database/dto.repository';
@@ -34,7 +36,6 @@ import {
   UpdatePromptVariantResponse,
   VariantResponse,
 } from './dto';
-import { VariantList, VariantOf } from './dto/variant.dto';
 
 export const PromptVariantResponseRepository = <
   Parent extends ResourceShape<any>,

--- a/src/components/prompts/prompt-variant-response.service.ts
+++ b/src/components/prompts/prompt-variant-response.service.ts
@@ -12,6 +12,8 @@ import {
   Session,
   UnauthorizedException,
   UnsecuredDto,
+  VariantList,
+  VariantOf,
 } from '~/common';
 import { ResourceLoader } from '~/core';
 import { mapListResults } from '~/core/database/results';
@@ -25,7 +27,6 @@ import {
   PromptVariantResponseList,
   UpdatePromptVariantResponse,
 } from './dto';
-import { VariantList, VariantOf } from './dto/variant.dto';
 import { PromptVariantResponseRepository } from './prompt-variant-response.repository';
 
 export const PromptVariantResponseListService = <


### PR DESCRIPTION
This is a pretty rough short-term addition. Adds essentially a unique `StepProgress` for each progress variant.

We are assuming `ProgressReport.pnpFile` is only one variant. We are assuming summaries are only available for this variant as well.

I think I've maintained API compatibility, which was a soft goal since this is in production right now.