### PR TITLE
Create DB indexes for auth tokens

### DIFF
--- a/src/components/authentication/authentication.repository.ts
+++ b/src/components/authentication/authentication.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { ID, ServerException, Session } from '../../common';
-import { DatabaseService } from '../../core';
+import { DatabaseService, OnIndex } from '../../core';
 import {
   ACTIVE,
   matchUserGloballyScopedRoles,
@@ -324,5 +324,14 @@ export class AuthenticationRepository {
       .raw('WHERE NOT token.value = $token', { token: session.token })
       .setValues({ 'oldRel.active': false })
       .run();
+  }
+
+  @OnIndex()
+  private createIndexes() {
+    return [
+      `CREATE INDEX AuthToken_value IF NOT EXISTS FOR (n:Token) ON (n.value)`,
+      `CREATE INDEX AuthEmailToken_token IF NOT EXISTS FOR (n:EmailToken) ON (n.token)`,
+      `CREATE INDEX AuthEmailToken_email IF NOT EXISTS FOR (n:EmailToken) ON (n.value)`,
+    ];
   }
 }


### PR DESCRIPTION
SMH that this has taken soon long to be noticed / fixed.

Here's the profiled query (from prod db) that runs to resume the user's session, which happens on EVERY HTTP request.
```diff
- 2,801,240 total db hits in 9,643 ms
+ 1 total db hits in 44 ms
```

(The top left of this graph is the starting point. The other steps below the first 2 are insignificant performance wise).
Before: 
![Screen Shot 2022-12-01 at 8 59 39 AM](https://user-images.githubusercontent.com/932566/205086019-0b0bffe8-4e38-4fca-a794-6d411e43b263.png)

After:
![Screen Shot 2022-12-01 at 9 03 19 AM](https://user-images.githubusercontent.com/932566/205086762-3049a716-0968-4d55-bd7c-194902d7f3ef.png)
