### PR TITLE
Fix CommunityStory & Highlight not allowing sensitivity conditions in policies

### DIFF
--- a/src/components/authorization/policies/conditions/sensitivity.condition.ts
+++ b/src/components/authorization/policies/conditions/sensitivity.condition.ts
@@ -14,7 +14,11 @@ export type HasSensitivity =
   | { [EffectiveSensitivity]: Sensitivity };
 
 export class SensitivityCondition<
-  TResourceStatic extends ResourceShape<HasSensitivity>
+  TResourceStatic extends
+    | ResourceShape<HasSensitivity>
+    | (ResourceShape<any> & {
+        ConfirmThisClassPassesSensitivityToPolicies: true;
+      })
 > implements Condition<TResourceStatic>
 {
   constructor(private readonly access: Sensitivity) {}

--- a/src/components/progress-report/dto/community-stories.dto.ts
+++ b/src/components/progress-report/dto/community-stories.dto.ts
@@ -12,6 +12,7 @@ export class ProgressReportCommunityStory extends PromptVariantResponse<Communit
     (m) => m.ProgressReport
   );
   static Variants = ProgressReportHighlight.Variants;
+  static readonly ConfirmThisClassPassesSensitivityToPolicies = true;
 }
 
 export type CommunityStoryVariant = VariantOf<

--- a/src/components/progress-report/dto/hightlights.dto.ts
+++ b/src/components/progress-report/dto/hightlights.dto.ts
@@ -31,6 +31,7 @@ export class ProgressReportHighlight extends PromptVariantResponse<HighlightVari
     (m) => m.ProgressReport
   );
   static Variants = variants;
+  static readonly ConfirmThisClassPassesSensitivityToPolicies = true;
 }
 
 export type HighlightVariant = VariantOf<typeof ProgressReportHighlight>;


### PR DESCRIPTION
Here we add a static prop to DTOs to manually mark them as valid for `SensitivityCondition`.

In some cases we dynamically add sensitivity to objects that don't have those props, like `withEffectiveSensitivity`.
But the policies didn't know that the code calling the privileges service were passing this info (sensitivity) since it was dynamic.

With this flag we can communicate that.

There is no check between this flag and the actual caller passing this info, which isn't ideal. But this does allow us to keep using the sensitivity condition in policies only on resources that allow it. In practice the policies reference this manually more times than the service code. So favoring strictness for them vs the service code is a worthy trade.