### PR TITLE
Fix schema check not including what's already in base ref

### DIFF
--- a/.github/workflows/api-schema.yml
+++ b/.github/workflows/api-schema.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request[matrix.ref].ref }}
+          ref: ${{ matrix.ref == 'base' && github.event.pull_request[matrix.ref].ref || '' }}
 
       - name: Node Setup & Yarn Install
         uses: ./.github/actions/setup


### PR DESCRIPTION
Only specify ref for base case and use default ref for head case. The default ref for pull requests actually creates a merge commit with the base ref.
This is what we want here as the "diff" should be based on new changes going into base, and excluding commits already in base.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3630679418) by [Unito](https://www.unito.io)
