### PR TITLE
Add updateProperties query helper

### DIFF
--- a/src/core/database/query/deactivate-property.ts
+++ b/src/core/database/query/deactivate-property.ts
@@ -70,7 +70,7 @@ export const deactivateProperty =
         ])
         .apply((q) =>
           key instanceof Variable
-            ? q.raw(`WHERE type(oldToProp) = ${key.name}`)
+            ? q.raw(`WHERE type(oldToProp) = ${key.toString()}`)
             : q
         )
         .setValues({

--- a/src/core/database/query/deactivate-property.ts
+++ b/src/core/database/query/deactivate-property.ts
@@ -50,10 +50,16 @@ export const deactivateProperty =
     numDeactivatedVar = 'numPropsDeactivated',
     importVars = [],
   }: DeactivatePropertyOptions<TResourceStatic, TObject, Key>) =>
-  <R>(query: Query<R>) =>
-    query.comment`
-      deactivateProperty(${nodeName}.${key})
-    `.subQuery([nodeName, ...many(importVars)], (sub) =>
+  <R>(query: Query<R>) => {
+    const imports = [
+      nodeName,
+      key instanceof Variable ? key : '',
+      ...many(importVars),
+    ];
+
+    const docKey = key instanceof Variable ? `[${key.toString()}]` : `.${key}`;
+    const docSignature = `deactivateProperty(${nodeName}${docKey})`;
+    return query.comment(docSignature).subQuery(imports, (sub) =>
       sub
         .match([
           node(nodeName),
@@ -81,3 +87,4 @@ export const deactivateProperty =
         .apply(prefixNodeLabelsWithDeleted('oldPropVar'))
         .return(`count(oldPropVar) as ${numDeactivatedVar}`)
     );
+  };

--- a/src/core/database/query/deactivate-property.ts
+++ b/src/core/database/query/deactivate-property.ts
@@ -1,12 +1,13 @@
 import { node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { MergeExclusive } from 'type-fest';
-import { ACTIVE, Variable } from '.';
 import {
+  EnhancedResource,
   ID,
   MaybeUnsecuredInstance,
   ResourceShape,
-} from '../../../common';
+} from '~/common';
+import { ACTIVE, Variable } from '.';
 import { DbChanges } from '../changes';
 import { prefixNodeLabelsWithDeleted } from './deletes';
 
@@ -18,7 +19,7 @@ export type DeactivatePropertyOptions<
   Key extends keyof DbChanges<TObject> & string
 > = MergeExclusive<
   {
-    resource: TResourceStatic;
+    resource: TResourceStatic | EnhancedResource<TResourceStatic>;
     key: Key;
   },
   {

--- a/src/core/database/query/deactivate-property.ts
+++ b/src/core/database/query/deactivate-property.ts
@@ -1,4 +1,5 @@
 import { node, Query, relation } from 'cypher-query-builder';
+import { Parameter } from 'cypher-query-builder/dist/typings/parameter-bag';
 import { DateTime } from 'luxon';
 import { MergeExclusive } from 'type-fest';
 import {
@@ -7,7 +8,7 @@ import {
   MaybeUnsecuredInstance,
   ResourceShape,
 } from '~/common';
-import { ACTIVE, Variable } from '.';
+import { ACTIVE, Variable, variable as varRef } from '.';
 import { DbChanges } from '../changes';
 import { prefixNodeLabelsWithDeleted } from './deletes';
 
@@ -29,6 +30,7 @@ export type DeactivatePropertyOptions<
   changeset?: ID;
   nodeName?: string;
   numDeactivatedVar?: string;
+  now?: Parameter;
 };
 
 /**
@@ -46,6 +48,7 @@ export const deactivateProperty =
     changeset,
     nodeName = 'node',
     numDeactivatedVar = 'numPropsDeactivated',
+    now,
   }: DeactivatePropertyOptions<TResourceStatic, TObject, Key>) =>
   <R>(query: Query<R>) => {
     const imports = [nodeName, key instanceof Variable ? key : ''];
@@ -74,7 +77,7 @@ export const deactivateProperty =
         )
         .setValues({
           [`${changeset ? 'oldChange' : 'oldToProp'}.active`]: false,
-          'oldPropVar.deletedAt': DateTime.local(),
+          'oldPropVar.deletedAt': now ? varRef(now.toString()) : DateTime.now(),
         })
         .with('oldPropVar')
         .apply(prefixNodeLabelsWithDeleted('oldPropVar'))

--- a/src/core/database/query/deactivate-property.ts
+++ b/src/core/database/query/deactivate-property.ts
@@ -4,8 +4,6 @@ import { MergeExclusive } from 'type-fest';
 import { ACTIVE, Variable } from '.';
 import {
   ID,
-  many,
-  Many,
   MaybeUnsecuredInstance,
   ResourceShape,
 } from '../../../common';
@@ -30,7 +28,6 @@ export type DeactivatePropertyOptions<
   changeset?: ID;
   nodeName?: string;
   numDeactivatedVar?: string;
-  importVars?: Many<string>;
 };
 
 /**
@@ -48,14 +45,9 @@ export const deactivateProperty =
     changeset,
     nodeName = 'node',
     numDeactivatedVar = 'numPropsDeactivated',
-    importVars = [],
   }: DeactivatePropertyOptions<TResourceStatic, TObject, Key>) =>
   <R>(query: Query<R>) => {
-    const imports = [
-      nodeName,
-      key instanceof Variable ? key : '',
-      ...many(importVars),
-    ];
+    const imports = [nodeName, key instanceof Variable ? key : ''];
 
     const docKey = key instanceof Variable ? `[${key.toString()}]` : `.${key}`;
     const docSignature = `deactivateProperty(${nodeName}${docKey})`;

--- a/src/core/database/query/index.ts
+++ b/src/core/database/query/index.ts
@@ -11,6 +11,7 @@ export * from './deletes';
 export * from './match-project-based-props';
 export * from './match-changeset-and-changed-props';
 export * from './update-property';
+export * from './update-properties';
 export { QueryFragment } from '../query-augmentation/apply';
 export * from '../query-augmentation/condition-variables';
 export * from './where-path';

--- a/src/core/database/query/update-properties.ts
+++ b/src/core/database/query/update-properties.ts
@@ -1,0 +1,62 @@
+import { Query } from 'cypher-query-builder';
+import { pickBy } from 'lodash';
+import { DateTime } from 'luxon';
+import {
+  EnhancedResource,
+  ID,
+  MaybeUnsecuredInstance,
+  ResourceShape,
+} from '~/common';
+import { updateProperty, variable } from '.';
+import { DbChanges } from '../changes';
+
+export interface UpdatePropertiesOptions<
+  TResourceStatic extends ResourceShape<any>,
+  TObject extends Partial<MaybeUnsecuredInstance<TResourceStatic>> & {
+    id: ID;
+  }
+> {
+  resource: TResourceStatic | EnhancedResource<TResourceStatic>;
+  changes: DbChanges<TObject>;
+  changeset?: ID;
+  nodeName?: string;
+  numUpdatedVar?: string;
+}
+
+export const updateProperties =
+  <
+    TResourceStatic extends ResourceShape<any>,
+    TObject extends Partial<MaybeUnsecuredInstance<TResourceStatic>> & {
+      id: ID;
+    }
+  >({
+    resource,
+    changes,
+    changeset,
+    nodeName = 'node',
+    numUpdatedVar = 'numPropsUpdated',
+  }: UpdatePropertiesOptions<TResourceStatic, TObject>) =>
+  <R>(query: Query<R>) => {
+    resource = EnhancedResource.of(resource);
+
+    const propEntries = Object.entries(
+      pickBy(changes, (value) => value !== undefined)
+    ).map(([key, value]) => ({ key, value }));
+
+    return query
+      .comment(`updateProperties(${resource.dbLabel})`)
+      .subQuery(nodeName, (sub) =>
+        sub
+          .unwind(propEntries, 'prop')
+          .apply(
+            updateProperty({
+              key: variable('prop.key'),
+              variable: 'prop.value',
+              changeset,
+              nodeName,
+              now: query.params.addParam(DateTime.local(), 'now'),
+            })
+          )
+          .return(`count(prop) as ${numUpdatedVar}`)
+      );
+  };

--- a/src/core/database/query/update-property.ts
+++ b/src/core/database/query/update-property.ts
@@ -1,5 +1,6 @@
 import { Query } from 'cypher-query-builder';
-import { ID, MaybeUnsecuredInstance, ResourceShape } from '../../../common';
+import { DateTime } from 'luxon';
+import { ID, MaybeUnsecuredInstance, ResourceShape } from '~/common';
 import { DbChanges } from '../changes';
 import { createProperty, CreatePropertyOptions } from './create-property';
 import {
@@ -30,7 +31,12 @@ export const updateProperty =
   >(
     options: UpdatePropertyOptions<TResourceStatic, TObject, Key>
   ) =>
-  <R>(query: Query<R>) =>
-    query
-      .apply(deactivateProperty<TResourceStatic, TObject, Key>(options))
-      .apply(createProperty<TResourceStatic, TObject, Key>(options));
+  <R>(query: Query<R>) => {
+    const resolved = {
+      ...options,
+      now: options.now ?? query.params.addParam(DateTime.now(), 'now'),
+    };
+    return query
+      .apply(deactivateProperty<TResourceStatic, TObject, Key>(resolved))
+      .apply(createProperty<TResourceStatic, TObject, Key>(resolved));
+  };


### PR DESCRIPTION
# TLDR
A function to update multiple properties dynamically in a single query.
```ts
.apply(
  updateProperties({
    resource: User,
    changes: {
      firstName: 'Carson',
      lastName: 'Full',
    },
  })
)
```
Having this in a query fragment allows all the DB flexibility, via just an ID match with our `DatabaseService.updateProperties`.
For example, the node could match in a different way or _merged/created_ first.


# `createProperty` dynamic keys

Previously we were not able to achieve above snippet because while properties could be created in the query builder, the generated query referenced these properties explicitly.

```ts
createProperty({
  resource: User,
  key: 'firstName', // dynamic...kinda
  value: 'Carson',
})
```
```cql
CREATE (node)-[:firstName { active: true }]->(:Property { value: 'Carson' })
```
Again, the property key had to be known ahead of time, it couldn't be determined based on database data.

Now we use APOC to allow this.
```ts
createProperty({
  resource: User,
  key: variable('propertyToUpdate'),
  value: 'Carson',
})
```
```cql
CREATE (newPropNode:Property { value: 'Carson' })
CALL apoc.create.relationship(node, propertyToUpdate, { active: true }, newPropNode)
```

# `updateProperties`

Circling back to this
```ts
updateProperties({
  resource: User,
  changes: {
    firstName: 'Carson',
    lastName: 'Full',
  },
})
```
compiles to
```cql
UNWIND [
  { key: 'firstName', value: 'Carson' },
  { key: 'lastName', value: 'Full' }
] as prop
CREATE (newPropNode:Property { value: prop.value })
CALL apoc.create.relationship(node, prop.key, { active: true }, newPropNode)
```
This is a simplified snippet, look to src for other details.

# "Now" in these functions

I updated the logic so that all of the `createdAt/deletedAt` properties from a single call to `updateProperties/updateProperty` will use the same instant. Previously, they were within a few milliseconds, but not exactly the same. This could help with correlating changes.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3643047632) by [Unito](https://www.unito.io)
