### PR TITLE
Impersonate roles/users via new HTTP headers

### DIFF
--- a/src/common/role.dto.ts
+++ b/src/common/role.dto.ts
@@ -44,6 +44,8 @@ export namespace Role {
     resources: ResourcesGranter,
     roles: readonly Role[]
   ) => resources.AssignableRoles.grant(roles);
-
   Object.defineProperty(Role, 'assignable', { enumerable: false });
+
+  export const all = new Set(Object.keys(Role)) as ReadonlySet<Role>;
+  Object.defineProperty(Role, 'all', { enumerable: false });
 }

--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -11,9 +11,16 @@ export interface Session {
   readonly token: string;
   readonly issuedAt: DateTime;
   readonly userId: ID;
-  readonly roles: ScopedRole[];
+  readonly roles: readonly ScopedRole[];
   readonly anonymous: boolean;
 
+  /**
+   * The "real", requesting user's session, when they are impersonating.
+   */
+  readonly impersonator?: Session;
+  /**
+   * The user and/or role the requesting user is impersonating.
+   */
   readonly impersonatee?: {
     id?: ID;
     roles: readonly ScopedRole[];

--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -13,6 +13,11 @@ export interface Session {
   readonly userId: ID;
   readonly roles: ScopedRole[];
   readonly anonymous: boolean;
+
+  readonly impersonatee?: {
+    id?: ID;
+    roles: readonly ScopedRole[];
+  };
 }
 
 export function loggedInSession(session: Session): Session {

--- a/src/components/authentication/authentication.repository.ts
+++ b/src/components/authentication/authentication.repository.ts
@@ -46,23 +46,6 @@ export class AuthenticationRepository {
     }
   }
 
-  async getUserFromSession(session: Session) {
-    const result = await this.db
-      .query()
-      .raw('', { token: session.token })
-      .match([
-        node('token', 'Token', {
-          ...ACTIVE,
-          value: variable('$token'),
-        }),
-        relation('in', '', 'token', ACTIVE),
-        node('user', 'User'),
-      ])
-      .return<{ id: ID }>('user.id as id')
-      .first();
-    return result?.id;
-  }
-
   async savePasswordHashOnUser(userId: ID, passwordHash: string) {
     await this.db
       .query()

--- a/src/components/authentication/authentication.service.ts
+++ b/src/components/authentication/authentication.service.ts
@@ -93,7 +93,10 @@ export class AuthenticationService {
     await this.repo.deleteSessionToken(token);
   }
 
-  async resumeSession(token: string): Promise<Session> {
+  async resumeSession(
+    token: string,
+    impersonatee?: Session['impersonatee']
+  ): Promise<Session> {
     this.logger.debug('Decoding token', { token });
 
     const { iat } = this.decodeJWT(token);
@@ -114,6 +117,7 @@ export class AuthenticationService {
       userId: result.userId ?? ('anonuserid' as ID),
       anonymous: !result.userId,
       roles: result.roles,
+      impersonatee,
     };
     this.logger.debug('Resumed session', session);
     return session;

--- a/src/components/authentication/authentication.service.ts
+++ b/src/components/authentication/authentication.service.ts
@@ -121,14 +121,24 @@ export class AuthenticationService {
         }
       : undefined;
 
-    const session: Session = {
+    const requesterSession: Session = {
       token,
       issuedAt: DateTime.fromMillis(iat),
       userId: result.userId ?? ('anonuserid' as ID),
       anonymous: !result.userId,
       roles: result.roles,
-      impersonatee,
     };
+
+    const session: Session = impersonatee
+      ? {
+          ...requesterSession,
+          userId: impersonatee?.id ?? requesterSession.userId,
+          roles: impersonatee.roles,
+          impersonator: requesterSession,
+          impersonatee,
+        }
+      : requesterSession;
+
     this.logger.debug('Resumed session', session);
     return session;
   }

--- a/src/components/authentication/authentication.service.ts
+++ b/src/components/authentication/authentication.service.ts
@@ -101,7 +101,7 @@ export class AuthenticationService {
 
     const { iat } = this.decodeJWT(token);
 
-    const result = await this.repo.resumeSession(token);
+    const result = await this.repo.resumeSession(token, impersonatee?.id);
 
     if (!result) {
       this.logger.debug('Failed to find active token in database', { token });
@@ -110,6 +110,16 @@ export class AuthenticationService {
         'NoSession'
       );
     }
+
+    impersonatee = impersonatee
+      ? {
+          id: impersonatee?.id,
+          roles: [
+            ...(impersonatee.roles ?? []),
+            ...(result.impersonateeRoles ?? []),
+          ],
+        }
+      : undefined;
 
     const session: Session = {
       token,

--- a/src/components/authentication/session.interceptor.ts
+++ b/src/components/authentication/session.interceptor.ts
@@ -81,9 +81,7 @@ export class SessionInterceptor implements NestInterceptor {
     return req?.cookies?.[this.config.sessionCookie.name] || null;
   }
 
-  private getImpersonateeFromContext(
-    context: GqlContextType
-  ): Session['impersonatee'] {
+  getImpersonateeFromContext(context: GqlContextType): Session['impersonatee'] {
     const user = context.request?.headers?.['x-cord-impersonate-user'] as
       | ID
       | undefined;

--- a/src/components/authentication/session.resolver.ts
+++ b/src/components/authentication/session.resolver.ts
@@ -15,7 +15,6 @@ import {
 import { ConfigService, ILogger, Loader, LoaderOf, Logger } from '../../core';
 import { Powers as Power, Privileges } from '../authorization';
 import { User, UserLoader } from '../user';
-import { AuthenticationRepository } from './authentication.repository';
 import { AuthenticationService } from './authentication.service';
 import { SessionOutput } from './dto';
 import { SessionInterceptor } from './session.interceptor';
@@ -24,7 +23,6 @@ import { SessionInterceptor } from './session.interceptor';
 export class SessionResolver {
   constructor(
     private readonly authentication: AuthenticationService,
-    private readonly repo: AuthenticationRepository,
     private readonly privileges: Privileges,
     private readonly config: ConfigService,
     private readonly sessionInt: SessionInterceptor,
@@ -65,9 +63,7 @@ export class SessionResolver {
     }
     context.session = session; // Set for data loaders invoked later in operation
 
-    const userFromSession = session.anonymous
-      ? undefined
-      : await this.repo.getUserFromSession(session);
+    const userFromSession = session.anonymous ? undefined : session.userId;
 
     if (browser) {
       const { name, expires, ...options } = this.config.sessionCookie;

--- a/src/components/authentication/session.resolver.ts
+++ b/src/components/authentication/session.resolver.ts
@@ -46,11 +46,12 @@ export class SessionResolver {
     browser?: boolean
   ): Promise<SessionOutput> {
     const existingToken = this.sessionInt.getTokenFromContext(context);
+    const impersonatee = this.sessionInt.getImpersonateeFromContext(context);
 
     let token = existingToken || (await this.authentication.createToken());
     let session;
     try {
-      session = await this.authentication.resumeSession(token);
+      session = await this.authentication.resumeSession(token, impersonatee);
     } catch (exception) {
       if (!(exception instanceof UnauthenticatedException)) {
         throw exception;
@@ -60,7 +61,7 @@ export class SessionResolver {
         { exception }
       );
       token = await this.authentication.createToken();
-      session = await this.authentication.resumeSession(token);
+      session = await this.authentication.resumeSession(token, impersonatee);
     }
     context.session = session; // Set for data loaders invoked later in operation
 

--- a/src/components/authorization/policy/executor/policy-dumper.ts
+++ b/src/components/authorization/policy/executor/policy-dumper.ts
@@ -37,7 +37,7 @@ export class PolicyDumper {
   async write(filename?: string) {
     const book = xlsx.utils.book_new();
 
-    for (const role of Object.keys(Role) as Role[]) {
+    for (const role of [...Role.all]) {
       const data = await this.dumpFor(role);
       const sheet = xlsx.utils.json_to_sheet(data);
       xlsx.utils.book_append_sheet(book, sheet, startCase(role).slice(0, 31));

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -184,9 +184,7 @@ export class UserService {
   getAssignableRoles(session: Session) {
     const privileges = this.privileges.for(session, AssignableRoles);
     const assignableRoles = new Set(
-      (Object.keys(Role) as Role[]).filter((role: Role) =>
-        privileges.can('edit', role)
-      )
+      [...Role.all].filter((role) => privileges.can('edit', role))
     );
     return assignableRoles;
   }


### PR DESCRIPTION
Closes #2682

Use this header so impersonate a specific user
```http
X-CORD-Impersonate-User: w2mBuPVnkbw
```

Use this header to Impersonate one or more roles
```http
X-CORD-Impersonate-Role: StaffMember, Controller
```
If used with user header the user's roles are added to the ones given here.

In both cases, these are only allowed if the requesting user has permission to "assign" all of the impersonatee's & given roles.
I believe `AssignableRoles` already communicates the restrictions we want here, so I used that.
It's probably worth renaming `assignable` to something else, like maybe `admin`.

<!--
┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3653719227) by [Unito](https://www.unito.io)
-->