### PR TITLE
HOST_URL usage tweaks

### DIFF
--- a/src/common/url.util.ts
+++ b/src/common/url.util.ts
@@ -1,0 +1,10 @@
+import { posix } from 'path';
+
+export const withAddedPath = (
+  url: URL | string,
+  ...pathSegments: string[]
+): URL => {
+  const next = new URL(url);
+  next.pathname = posix.join(next.pathname, ...pathSegments);
+  return next;
+};

--- a/src/components/file/bucket/local-bucket.ts
+++ b/src/components/file/bucket/local-bucket.ts
@@ -5,7 +5,7 @@ import { InputException } from '../../../common';
 import { BucketOptions, FileBucket } from './file-bucket';
 
 export interface LocalBucketOptions extends BucketOptions {
-  baseUrl: string;
+  baseUrl: URL;
 }
 
 export type FakeAwsFile = Required<Pick<GetObjectOutput, 'ContentType'>> &
@@ -15,7 +15,7 @@ export type FakeAwsFile = Required<Pick<GetObjectOutput, 'ContentType'>> &
  * Common functionality for "local" (non-s3) buckets
  */
 export abstract class LocalBucket extends FileBucket {
-  private readonly baseUrl: string;
+  private readonly baseUrl: URL;
 
   constructor(options: LocalBucketOptions) {
     super(options);

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -34,7 +34,6 @@ export class ConfigService implements EmailOptionsFactory {
   hostUrl = this.env
     .string('host_url')
     .optional(`http://localhost:${this.publicPort}`);
-  globalPrefix = '';
 
   @Lazy() get graphQL() {
     return {
@@ -194,7 +193,7 @@ export class ConfigService implements EmailOptionsFactory {
       this.env.string('FILES_LOCAL_DIR').optional() ??
       (this.jest ? undefined : '.files');
     // Routes to LocalBucketController
-    const baseUrl = join(this.hostUrl, this.globalPrefix, 'file');
+    const baseUrl = join(this.hostUrl, 'file');
     return {
       bucket,
       localDirectory,

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -11,9 +11,9 @@ import LRUCache from 'lru-cache';
 import { Duration, DurationLike } from 'luxon';
 import { nanoid } from 'nanoid';
 import { Config as Neo4JDriverConfig } from 'neo4j-driver';
-import { join } from 'path';
 import { PoolConfig } from 'pg';
 import { Merge } from 'type-fest';
+import { withAddedPath } from '~/common/url.util';
 import { ID, ServerException } from '../../common';
 import { FrontendUrlWrapper } from '../email/templates/frontend-url';
 import { LogLevel } from '../logger';
@@ -193,7 +193,7 @@ export class ConfigService implements EmailOptionsFactory {
       this.env.string('FILES_LOCAL_DIR').optional() ??
       (this.jest ? undefined : '.files');
     // Routes to LocalBucketController
-    const baseUrl = join(this.hostUrl, 'file');
+    const baseUrl = withAddedPath(this.hostUrl, 'file');
     return {
       bucket,
       localDirectory,

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -31,8 +31,8 @@ export class ConfigService implements EmailOptionsFactory {
   port = this.env.number('port').optional(3000);
   // The port where the app is being hosted. i.e. a docker bound port
   publicPort = this.env.number('public_port').optional(this.port);
-  hostUrl = this.env
-    .string('host_url')
+  readonly hostUrl = this.env
+    .url('host_url')
     .optional(`http://localhost:${this.publicPort}`);
 
   @Lazy() get graphQL() {

--- a/src/core/config/environment.service.ts
+++ b/src/core/config/environment.service.ts
@@ -63,6 +63,15 @@ export class EnvironmentService implements Iterable<[string, string]> {
     return this.wrap(key, (raw: string) => raw);
   }
 
+  url(key: string): ConfigValue<
+    Readonly<URL> &
+      // Work around the linter not liking implicit toString concat
+      string,
+    URL | string
+  > {
+    return this.wrap(key, (raw) => Object.freeze(new URL(raw)) as any);
+  }
+
   boolean(key: string) {
     return this.wrap(key, (raw: string | boolean) =>
       typeof raw === 'boolean' ? raw : raw.toLowerCase() === 'true'

--- a/src/core/tracing/tracing.module.ts
+++ b/src/core/tracing/tracing.module.ts
@@ -48,7 +48,7 @@ export class TracingModule implements OnModuleInit, NestModule {
     }
 
     XRay.SegmentUtils.setServiceData({
-      name: this.config.hostUrl,
+      name: this.config.hostUrl.toString(),
       version: (await this.version.version).toString(),
       runtime: process.release?.name ?? 'unknown',
       // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ async function bootstrap() {
   app.enableCors(config.cors);
   app.use(cookieParser());
 
-  app.setGlobalPrefix(new URL(config.hostUrl).pathname.slice(1));
+  app.setGlobalPrefix(config.hostUrl.pathname.slice(1));
 
   config.applyTimeouts(app.getHttpServer(), config.httpTimeouts);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,15 +22,13 @@ async function bootstrap() {
   app.enableCors(config.cors);
   app.use(cookieParser());
 
-  app.setGlobalPrefix(config.globalPrefix);
+  app.setGlobalPrefix(new URL(config.hostUrl).pathname.slice(1));
 
   config.applyTimeouts(app.getHttpServer(), config.httpTimeouts);
 
   app.enableShutdownHooks();
   await app.listen(config.port, () => {
-    app
-      .get(Logger)
-      .log(`Listening at ${config.hostUrl}/${config.globalPrefix}`);
+    app.get(Logger).log(`Listening at ${config.hostUrl}`);
   });
 }
 bootstrap().catch((err) => {


### PR DESCRIPTION
- Replace hardcoded empty `ConfigService.globalPrefix` with pathname of the `HOST_URL` env var
- Convert `ConfigService.hostUrl` to be a URL object
- Fix path joining for `baseUrl`.
   Previously, the  scheme's double slash was being messed up.
   Also I suspect it didn't work on windows.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3680083367) by [Unito](https://www.unito.io)
