### PR TITLE
Tweak File Bucket Setup 

### DIFF
--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Connection } from 'cypher-query-builder';
 import { intersection } from 'lodash';
 import {
@@ -34,12 +34,11 @@ import {
   RequestUploadOutput,
 } from './dto';
 import { FileRepository } from './file.repository';
-import { FilesBucketToken } from './files-bucket.factory';
 
 @Injectable()
 export class FileService {
   constructor(
-    @Inject(FilesBucketToken) private readonly bucket: FileBucket,
+    private readonly bucket: FileBucket,
     private readonly repo: FileRepository,
     private readonly db: Connection,
     @Logger('file:service') private readonly logger: ILogger

--- a/src/components/file/files-bucket.factory.ts
+++ b/src/components/file/files-bucket.factory.ts
@@ -1,15 +1,20 @@
 import { S3 } from '@aws-sdk/client-s3';
 import { FactoryProvider } from '@nestjs/common';
+import { withAddedPath } from '~/common/url.util';
 import { ConfigService } from '../../core';
 import { FileBucket, FilesystemBucket, MemoryBucket, S3Bucket } from './bucket';
+import { LocalBucketController } from './local-bucket.controller';
 
 export const FilesBucketFactory: FactoryProvider = {
   provide: FileBucket,
   useFactory: (s3: S3, config: ConfigService) => {
-    const { bucket, localDirectory, baseUrl, signedUrlExpires } = config.files;
+    const { bucket, localDirectory, signedUrlExpires } = config.files;
     if (bucket) {
       return new S3Bucket({ s3, bucket, signedUrlExpires });
     }
+
+    const baseUrl = withAddedPath(config.hostUrl, LocalBucketController.path);
+
     if (localDirectory) {
       return new FilesystemBucket({
         rootDirectory: localDirectory,

--- a/src/components/file/files-bucket.factory.ts
+++ b/src/components/file/files-bucket.factory.ts
@@ -1,12 +1,10 @@
 import { S3 } from '@aws-sdk/client-s3';
 import { FactoryProvider } from '@nestjs/common';
 import { ConfigService } from '../../core';
-import { FilesystemBucket, MemoryBucket, S3Bucket } from './bucket';
-
-export const FilesBucketToken = Symbol('FilesBucket');
+import { FileBucket, FilesystemBucket, MemoryBucket, S3Bucket } from './bucket';
 
 export const FilesBucketFactory: FactoryProvider = {
-  provide: FilesBucketToken,
+  provide: FileBucket,
   useFactory: (s3: S3, config: ConfigService) => {
     const { bucket, localDirectory, baseUrl, signedUrlExpires } = config.files;
     if (bucket) {

--- a/src/components/file/local-bucket.controller.ts
+++ b/src/components/file/local-bucket.controller.ts
@@ -2,7 +2,6 @@ import {
   Controller,
   Get,
   Headers,
-  Inject,
   Put,
   Query,
   Request,
@@ -12,12 +11,11 @@ import { Request as IRequest, Response as IResponse } from 'express';
 import rawBody from 'raw-body';
 import { InputException, ServerException } from '../../common';
 import { FileBucket, LocalBucket } from './bucket';
-import { FilesBucketToken } from './files-bucket.factory';
 
 @Controller('/file')
 export class LocalBucketController {
   private readonly bucket: LocalBucket | undefined;
-  constructor(@Inject(FilesBucketToken) bucket: FileBucket) {
+  constructor(bucket: FileBucket) {
     this.bucket = bucket instanceof LocalBucket ? bucket : undefined;
   }
 

--- a/src/components/file/local-bucket.controller.ts
+++ b/src/components/file/local-bucket.controller.ts
@@ -14,7 +14,7 @@ import { FileBucket, LocalBucket } from './bucket';
 
 @Controller(LocalBucketController.path)
 export class LocalBucketController {
-  static path = '/file';
+  static path = '/local-bucket';
 
   private readonly bucket: LocalBucket | undefined;
   constructor(bucket: FileBucket) {

--- a/src/components/file/local-bucket.controller.ts
+++ b/src/components/file/local-bucket.controller.ts
@@ -12,8 +12,10 @@ import rawBody from 'raw-body';
 import { InputException, ServerException } from '../../common';
 import { FileBucket, LocalBucket } from './bucket';
 
-@Controller('/file')
+@Controller(LocalBucketController.path)
 export class LocalBucketController {
+  static path = '/file';
+
   private readonly bucket: LocalBucket | undefined;
   constructor(bucket: FileBucket) {
     this.bucket = bucket instanceof LocalBucket ? bucket : undefined;

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -13,7 +13,6 @@ import { nanoid } from 'nanoid';
 import { Config as Neo4JDriverConfig } from 'neo4j-driver';
 import { PoolConfig } from 'pg';
 import { Merge } from 'type-fest';
-import { withAddedPath } from '~/common/url.util';
 import { ID, ServerException } from '../../common';
 import { FrontendUrlWrapper } from '../email/templates/frontend-url';
 import { LogLevel } from '../logger';
@@ -192,12 +191,9 @@ export class ConfigService implements EmailOptionsFactory {
     const localDirectory =
       this.env.string('FILES_LOCAL_DIR').optional() ??
       (this.jest ? undefined : '.files');
-    // Routes to LocalBucketController
-    const baseUrl = withAddedPath(this.hostUrl, 'file');
     return {
       bucket,
       localDirectory,
-      baseUrl,
       signedUrlExpires: Duration.fromObject({ minutes: 15 }),
     };
   }

--- a/test/file.e2e-spec.ts
+++ b/test/file.e2e-spec.ts
@@ -13,8 +13,7 @@ import {
   FileNodeType,
   RequestUploadOutput,
 } from '../src/components/file';
-import { LocalBucket } from '../src/components/file/bucket';
-import { FilesBucketToken } from '../src/components/file/files-bucket.factory';
+import { FileBucket, LocalBucket } from '../src/components/file/bucket';
 import { User } from '../src/components/user';
 import { DatabaseService } from '../src/core';
 import {
@@ -122,7 +121,7 @@ describe('File e2e', () => {
 
   beforeAll(async () => {
     app = await createTestApp();
-    bucket = app.get(FilesBucketToken);
+    bucket = app.get(FileBucket);
     await createSession(app);
     me = await registerUser(app, {
       roles: [Role.ProjectManager],

--- a/test/utility/create-file.ts
+++ b/test/utility/create-file.ts
@@ -6,8 +6,7 @@ import {
   FileListInput,
   RequestUploadOutput,
 } from '../../src/components/file';
-import { LocalBucket } from '../../src/components/file/bucket';
-import { FilesBucketToken } from '../../src/components/file/files-bucket.factory';
+import { FileBucket, LocalBucket } from '../../src/components/file/bucket';
 import { mimeTypes } from '../../src/components/file/mimeTypes';
 import { TestApp } from './create-app';
 import { RawFile, RawFileNode, RawFileNodeChildren } from './fragments';
@@ -53,7 +52,7 @@ export const uploadFileContents = async (
     size: ContentLength,
   } = completeInput;
 
-  const bucket = app.get(FilesBucketToken);
+  const bucket = app.get(FileBucket);
   assert(bucket instanceof LocalBucket);
   await bucket.upload(url, {
     Body,


### PR DESCRIPTION
- Drop the `FilesBucketToken` indirection and assume singleton.
   It just hasn't been useful.
   We can create another token if/when we need another instance.
   It was creating a circular dependency with ⬇️ 
- Move `baseUrl` for `LocalBucket` to be determined in factory instead of `ConfigService`.
   There's nothing directly configurable about it.
   Defined a static class prop for the path prefix as well to DRY registration and usage.
- Changed path prefix from `/file` -> `/local-bucket`
   This is more explicit that it's a specific path for the dev feature.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3680102236) by [Unito](https://www.unito.io)
