### PR TITLE
File URLs

### DIFF
--- a/src/components/file/file-url.controller.ts
+++ b/src/components/file/file-url.controller.ts
@@ -1,0 +1,37 @@
+import {
+  Controller,
+  forwardRef,
+  Get,
+  Inject,
+  Param,
+  Query,
+  Response,
+} from '@nestjs/common';
+import { Response as IResponse } from 'express';
+import { ID, LoggedInSession, Session } from '~/common';
+import { FileService } from './file.service';
+
+@Controller(FileUrlController.path)
+export class FileUrlController {
+  static path = '/file';
+
+  constructor(
+    @Inject(forwardRef(() => FileService))
+    private readonly files: FileService
+  ) {}
+
+  @Get(':fileId/:fileName')
+  async download(
+    @Param('fileId') fileId: ID,
+    @Query('proxy') proxy: string | undefined,
+    @LoggedInSession() session: Session,
+    @Response() res: IResponse
+  ) {
+    const node = await this.files.getFileNode(fileId, session);
+
+    // TODO authorization using session
+
+    const url = await this.files.getDownloadUrl(node);
+    res.redirect(url);
+  }
+}

--- a/src/components/file/file-version.resolver.ts
+++ b/src/components/file/file-version.resolver.ts
@@ -21,6 +21,11 @@ export class FileVersionResolver {
 
   @ResolveField(() => URL, {
     description: 'A direct url to download the file version',
+    deprecationReason: stripIndent`
+      Use \`url\` instead.
+
+      Note while this url is anonymous, the new field, \`url\` is not.
+    `,
   })
   downloadUrl(@Parent() node: FileVersion): Promise<string> {
     return this.service.getDownloadUrl(node);

--- a/src/components/file/file-version.resolver.ts
+++ b/src/components/file/file-version.resolver.ts
@@ -1,4 +1,5 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
 import { URL } from 'url';
 import { FileVersion } from './dto';
 import { FileService } from './file.service';
@@ -6,6 +7,17 @@ import { FileService } from './file.service';
 @Resolver(FileVersion)
 export class FileVersionResolver {
   constructor(protected readonly service: FileService) {}
+
+  @ResolveField(() => URL, {
+    description: stripIndent`
+      A url to the file version.
+
+      This url could require authentication.
+    `,
+  })
+  async url(@Parent() node: FileVersion) {
+    return await this.service.getUrl(node);
+  }
 
   @ResolveField(() => URL, {
     description: 'A direct url to download the file version',

--- a/src/components/file/file.module.ts
+++ b/src/components/file/file.module.ts
@@ -3,6 +3,7 @@ import { AuthorizationModule } from '../authorization/authorization.module';
 import { DirectoryResolver } from './directory.resolver';
 import { FileNodeLoader } from './file-node.loader';
 import { FileNodeResolver } from './file-node.resolver';
+import { FileUrlController } from './file-url.controller';
 import { FileVersionResolver } from './file-version.resolver';
 import { FileRepository } from './file.repository';
 import { FileResolver } from './file.resolver';
@@ -24,7 +25,7 @@ import { LocalBucketController } from './local-bucket.controller';
     FileService,
     ...Object.values(handlers),
   ],
-  controllers: [LocalBucketController],
+  controllers: [FileUrlController, LocalBucketController],
   exports: [FileService],
 })
 export class FileModule {}

--- a/src/components/file/file.resolver.ts
+++ b/src/components/file/file.resolver.ts
@@ -76,6 +76,17 @@ export class FileResolver {
   }
 
   @ResolveField(() => URL, {
+    description: stripIndent`
+      A url to the file.
+
+      This url could require authentication.
+    `,
+  })
+  async url(@Parent() node: File) {
+    return await this.service.getUrl(node);
+  }
+
+  @ResolveField(() => URL, {
     description: 'A direct url to download the file',
   })
   downloadUrl(@Parent() node: File): Promise<string> {

--- a/src/components/file/file.resolver.ts
+++ b/src/components/file/file.resolver.ts
@@ -88,6 +88,11 @@ export class FileResolver {
 
   @ResolveField(() => URL, {
     description: 'A direct url to download the file',
+    deprecationReason: stripIndent`
+      Use \`url\` instead.
+
+      Note while this url is anonymous, the new field, \`url\` is not.
+    `,
   })
   downloadUrl(@Parent() node: File): Promise<string> {
     return this.service.getDownloadUrl(node);

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -125,7 +125,7 @@ export class FileService {
     const url = withAddedPath(
       this.config.hostUrl,
       FileUrl.path,
-      node.id,
+      isFile(node) ? node.latestVersionId : node.id,
       encodeURIComponent(node.name)
     );
     return url.toString();

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Connection } from 'cypher-query-builder';
 import { intersection } from 'lodash';
+import { withAddedPath } from '~/common/url.util';
 import {
   bufferFromStream,
   DuplicateException,
@@ -12,7 +13,7 @@ import {
   Session,
   UnauthorizedException,
 } from '../../common';
-import { ILogger, Logger } from '../../core';
+import { ConfigService, ILogger, Logger } from '../../core';
 import { FileBucket } from './bucket';
 import {
   CreateDefinedFileVersionInput,
@@ -33,6 +34,7 @@ import {
   RenameFileInput,
   RequestUploadOutput,
 } from './dto';
+import { FileUrlController as FileUrl } from './file-url.controller';
 import { FileRepository } from './file.repository';
 
 @Injectable()
@@ -41,6 +43,7 @@ export class FileService {
     private readonly bucket: FileBucket,
     private readonly repo: FileRepository,
     private readonly db: Connection,
+    private readonly config: ConfigService,
     @Logger('file:service') private readonly logger: ILogger
   ) {}
 
@@ -116,6 +119,16 @@ export class FileService {
     }
 
     return await bufferFromStream(data);
+  }
+
+  async getUrl(node: FileNode) {
+    const url = withAddedPath(
+      this.config.hostUrl,
+      FileUrl.path,
+      node.id,
+      encodeURIComponent(node.name)
+    );
+    return url.toString();
   }
 
   async getDownloadUrl(node: FileNode): Promise<string> {


### PR DESCRIPTION
# Problem / Context
In the beginning of v2 (circa 2018) it was decided that files would be sent and received directly to S3 via pre-signed urls. This prevented the API having to sent in the middle of this raw data transfer. This conceptually is a good thing, though I do question how much benefit it actually provides - especially considering the complexity. But none the less we have it now, so I'm game to keep it.

One of the challenges is that the pre-signed urls are short lived. This is the way we limit access to the file since the S3 bucket cannot discriminate on requester. If the link is shared with someone else, it's only valid for 15 mins (current configuration).

The v2 API had a specific endpoint to get a short-lived pre-signed url. With v3 GQL API, that moved into just a field on the `File` object. This made usage surprising because we can't just grab the URL field with the other file info and cache it like all our other API data. We had have another operation to grab the URL right when the user asked to download, and make sure we didn't use the cache for it.

This has also blocked us (kinda) from offering media files directly from our API - a notion I decided a while ago and haven't thought about much since. I think this thought came from the fact that we'd want these to be cacheable by the user's browser. However, our API would never give back the same URL for the image since they are generated on request. Thus a lot of work to essentially download a file for a maybe every user in a list of 25 users for example.

# Solution

An HTTP endpoint for serving files solves these problems.
Here's how it works:
1. GQL query asking for anything, now including a `url` field on a `File`
    ```gql
    query {
    	file(id: "4vSrsBdaLXx") {
			name
			createdAt
			mimeType
			url
		}
	}
    ```
2. The `url` value now just points back to our API at this new HTTP API.
	```
	http://localhost:3333/file/4vSrsBdaLXx/carson.webp
	```
3. That url is requested somehow
4. Upon receiving the request our API authorizes the requestor with their session
5. Now we finally generated the pre-signed url to the S3 object
6. We send that url back as a redirect response
7. Browser or HTTP client implicitly follows the redirect to grab the actual file from S3

### 🏆 Wins
- ⚡ Client/browser could stop after step 2 if it's already got that url cached
- 🔒 We still verify every user asking for the file
- ✨ Client doesn't have to have special logic to handle these file urls
- 😤 We still avoid being the middleman for serving the files

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3681183744) by [Unito](https://www.unito.io)
