### PR TITLE
Fix reading partially saved variance explanation

### DIFF
--- a/src/components/progress-report/variance-explanation/variance-explanation.repository.ts
+++ b/src/components/progress-report/variance-explanation/variance-explanation.repository.ts
@@ -1,18 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import {
-  inArray,
-  isNull,
-  node,
-  not,
-  Query,
-  relation,
-} from 'cypher-query-builder';
+import { inArray, node, Query, relation } from 'cypher-query-builder';
 import { ID, Session, UnsecuredDto } from '~/common';
 import { DtoRepository } from '~/core';
 import { DbChanges } from '~/core/database/changes';
 import {
   ACTIVE,
-  exp,
   ExpressionInput,
   matchProps,
   merge,
@@ -45,7 +37,7 @@ export class ProgressReportVarianceExplanationRepository extends DtoRepository(
   }
 
   protected hydrate() {
-    const placeholder: UnsecuredDto<VarianceExplanation> & ExpressionInput = {
+    const defaults: UnsecuredDto<VarianceExplanation> & ExpressionInput = {
       report: 'report.id' as ID,
       reasons: [],
       comments: null,
@@ -56,19 +48,10 @@ export class ProgressReportVarianceExplanationRepository extends DtoRepository(
         .subQuery((sub) =>
           sub
             .with(ctx)
-            .with(ctx)
-            .where({ node: not(isNull()) })
-            .apply(matchProps())
+            .apply(matchProps({ optional: true, excludeBaseProps: true }))
             .return<{ dto: UnsecuredDto<VarianceExplanation> }>(
-              merge('props', {
-                report: 'report.id',
-              }).as('dto')
+              merge(defaults, 'props').as('dto')
             )
-            .union()
-            .with(ctx)
-            .with(ctx)
-            .where({ node: isNull() })
-            .return(exp(placeholder).as('dto'))
         )
         .return('dto');
   }


### PR DESCRIPTION
Turns out it's easier to just carry the null `node` through and allow optional properties, then just default the missing props with a merge.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3838399505) by [Unito](https://www.unito.io)
