### PR TITLE
Cypher Query Summary / Stats

### DIFF
--- a/src/common/temporal/duration.ts
+++ b/src/common/temporal/duration.ts
@@ -1,5 +1,6 @@
 import { Duration, DurationLike, DurationLikeObject } from 'luxon';
 import { Writable } from 'type-fest';
+import { inspect } from 'util';
 
 /**
  * A duration represented as an:
@@ -72,4 +73,10 @@ const normalizedUnit = (unit: string): keyof DurationLikeObject => {
 // @ts-expect-error Adding here, which will be called by pg client
 Duration.prototype.toPostgres = function (this: Duration) {
   return this.toISO();
+};
+
+// @ts-expect-error Yes, it doesn't have to be defined, we are adding it.
+Duration.prototype[inspect.custom] = function (this: Duration) {
+  const str = this.toHuman({ unitDisplay: 'short' });
+  return `[Duration] ${str}`;
 };

--- a/src/core/database/query-augmentation/index.ts
+++ b/src/core/database/query-augmentation/index.ts
@@ -10,3 +10,4 @@ import './log-it';
 import './map';
 import './pattern-formatting';
 import './subquery';
+import './summary';

--- a/src/core/database/query-augmentation/summary.ts
+++ b/src/core/database/query-augmentation/summary.ts
@@ -1,0 +1,67 @@
+import { Connection, Query } from 'cypher-query-builder';
+import { ResultSummary } from 'neo4j-driver';
+import { Stats } from 'neo4j-driver-core';
+
+declare module 'cypher-query-builder/dist/typings/connection' {
+  interface Connection {
+    /**
+     * Execute query and return summary.
+     */
+    executeAndReturnSummary(query: Query): Promise<ResultSummary>;
+  }
+}
+
+declare module 'cypher-query-builder/dist/typings/query' {
+  interface Query {
+    /**
+     * Execute query and return summary.
+     */
+    executeAndReturnSummary(): Promise<ResultSummary>;
+    /**
+     * Execute query and return stats.
+     */
+    executeAndReturnStats(): Promise<Stats>;
+  }
+}
+
+// Same body as `connection.run` other than the `summary()` call
+Connection.prototype.executeAndReturnSummary =
+  async function executeAndReturnSummary(this: Connection, query: Query) {
+    if (!this.open) {
+      throw new Error('Cannot run query; connection is not open.');
+    }
+
+    if (query.getClauses().length === 0) {
+      throw new Error('Cannot run query: no clauses attached to the query.');
+    }
+
+    const session = this.session();
+    if (!session) {
+      throw new Error('Cannot run query: connection is not open.');
+    }
+
+    const queryObj = query.buildQueryObject();
+
+    try {
+      return await session.run(queryObj.query, queryObj.params).summary();
+    } finally {
+      await session.close();
+    }
+  };
+
+// Same body as `Query.run` just a different connection call.
+Query.prototype.executeAndReturnSummary =
+  async function executeAndReturnSummary(this: Query) {
+    if (!this.connection) {
+      throw new Error('Cannot run query; no connection object available.');
+    }
+
+    return await this.connection.executeAndReturnSummary(this);
+  };
+
+Query.prototype.executeAndReturnStats = async function executeAndReturnStats(
+  this: Query
+) {
+  const summary = await this.executeAndReturnSummary();
+  return summary.updateStatistics.updates();
+};

--- a/src/core/logger/formatters.ts
+++ b/src/core/logger/formatters.ts
@@ -191,7 +191,7 @@ export const printForCli = () =>
 const printObj = (obj: Record<string, any>) =>
   Object.keys(obj).length > 0
     ? ` ${prettyPrint(obj, {
-        depth: 2, // 2 default
+        depth: 3, // 2 default
         colors: colorsEnabled,
       })}`
     : '';


### PR DESCRIPTION
# `executeAndLogStats`
```ts
db.query()
...
.executeAndLogStats()
```

```
[database:results:stats] X.update +15ms { nodesCreated: 1, propertiesSet: 4, labelsAdded: 1 }
```
stats are also returned for programmatic usage. Also `executeAndReturnStats` to use without logging.

# Duration custom debug output
```ts
Duration.fromObject({ minutes: 10 });
```
```
[Duration] 10 min
```

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3880051083) by [Unito](https://www.unito.io)
