### PR TITLE
Fix `VariantResponse.modifiedAt` on first save

### DIFF
--- a/src/components/prompts/prompt-variant-response.service.ts
+++ b/src/components/prompts/prompt-variant-response.service.ts
@@ -237,13 +237,19 @@ export const PromptVariantResponseListService = <
         await this.repo.submitResponse(input, session);
       }
 
+      const responses = mapFromList(response.responses, (response) => [
+        response.variant,
+        response,
+      ]);
       const updated: UnsecuredDto<PromptVariantResponse<TVariant>> = {
         ...response,
-        responses: response.responses.map((response) => ({
-          ...response,
-          ...(response.variant === variant.key
+        responses: this.resource.Variants.map(({ key }) => ({
+          ...responses[key],
+          ...(variant.key === key
             ? {
+                variant: key,
                 response: input.response,
+                creator: responses[key]?.creator ?? session.userId,
                 modifiedAt: DateTime.now(),
               }
             : {}),


### PR DESCRIPTION
If the variant response didn't exist before,
then it wasn't in the array so our new modifiedAt was missed. Now we loop through all variants,
and create the new variant response when needed.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3929395445) by [Unito](https://www.unito.io)
