### PR TITLE
Expose impersonator user via session when applicable

### DIFF
--- a/src/components/authentication/session.resolver.ts
+++ b/src/components/authentication/session.resolver.ts
@@ -97,6 +97,21 @@ export class SessionResolver {
     return output.user ? await users.load(output.user) : null;
   }
 
+  @ResolveField(() => User, {
+    nullable: true,
+    description:
+      'The impersonator if the user is logged in and impersonating someone else',
+  })
+  async impersonator(
+    @Parent() { session }: SessionOutput,
+    @Loader(UserLoader) users: LoaderOf<UserLoader>
+  ): Promise<User | null> {
+    if (session.anonymous || !session.impersonator) {
+      return null;
+    }
+    return await users.load(session.impersonator.userId);
+  }
+
   @ResolveField(() => [Power], { nullable: true })
   async powers(@Parent() output: SessionOutput): Promise<Power[]> {
     return [...this.privileges.forUser(output.session).powers];


### PR DESCRIPTION
This allows the UI to correctly know the logged in user, even while impersonating.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3992616000) by [Unito](https://www.unito.io)
