### PR TITLE
Treat `ProgressReport.status` as calculated

### DIFF
--- a/src/components/progress-report/dto/progress-report.entity.ts
+++ b/src/components/progress-report/dto/progress-report.entity.ts
@@ -1,6 +1,11 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
-import { parentIdMiddleware, SecuredProperty, SecuredProps } from '~/common';
+import {
+  Calculated,
+  parentIdMiddleware,
+  SecuredProperty,
+  SecuredProps,
+} from '~/common';
 import { RegisterResource } from '~/core';
 import { BaseNode } from '~/core/database/results';
 import { LanguageEngagement } from '../../engagement/dto';
@@ -39,6 +44,7 @@ export class ProgressReport extends IPeriodicReport {
   @Field(() => SecuredStatus, {
     middleware: [parentIdMiddleware],
   })
+  @Calculated()
   readonly status: SecuredStatus;
 }
 

--- a/src/components/progress-report/workflow/resolvers/progress-report-transitions.resolver.ts
+++ b/src/components/progress-report/workflow/resolvers/progress-report-transitions.resolver.ts
@@ -16,7 +16,7 @@ export class ProgressReportTransitionsResolver {
     @Parent() status: SecuredProgressReportStatus & ParentIdMiddlewareAdditions,
     @AnonSession() session: Session
   ): Promise<ProgressReportWorkflowTransition[]> {
-    if (!status.canRead || !status.canEdit || !status.value) {
+    if (!status.canRead || !status.value) {
       return [];
     }
     return this.workflow.getAvailableTransitions(session, status.value);


### PR DESCRIPTION
- Removed check for editing status in transitions progress report transitions resolver
- Marked status field as calculated

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3994140486) by [Unito](https://www.unito.io)
