### PR TITLE
Tweaked Marketing Policy for Team News and Community Stories

### DIFF
--- a/src/components/authorization/policies/by-role/marketing.policy.ts
+++ b/src/components/authorization/policies/by-role/marketing.policy.ts
@@ -25,7 +25,9 @@ import {
     r.ProgressReportHighlight,
     r.ProgressReportTeamNews,
   ].flatMap((it) => [
-    it.read.specifically((p) => [p.responses.when(variant('published')).edit]),
+    it.read.specifically((p) => [
+      p.responses.read.when(variant('published')).edit,
+    ]),
   ]),
   r.ProgressReportVarianceExplanation.read.specifically((p) => p.comments.none),
   r.ProgressReportWorkflowEvent.read.transitions('Publish').execute,


### PR DESCRIPTION
 Allow viewing of all variants for Team News and Community Stories.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/3999734250) by [Unito](https://www.unito.io)
