### PR TITLE
Explanation of progress migration to update saved reasons

### DIFF
--- a/src/components/progress-report/migrations/UpdateExplanationReasons.migration.ts
+++ b/src/components/progress-report/migrations/UpdateExplanationReasons.migration.ts
@@ -1,0 +1,37 @@
+import { node, relation } from 'cypher-query-builder';
+import { BaseMigration, Migration } from '~/core';
+import { ACTIVE } from '~/core/database/query';
+
+@Migration('2023-03-10T17:00:00')
+export class UpdateExplanationReasonsMigration extends BaseMigration {
+  private async findAndReplaceReason(oldReason: string, newReason: string) {
+    await this.db
+      .query()
+      .match([
+        node('', 'ProgressReportVarianceExplanation'),
+        relation('out', '', 'reasons', ACTIVE),
+        node('reasons', 'Property'),
+      ])
+      .raw(
+        `WHERE size(apoc.coll.intersection(reasons.value, $oldReasons)) > 0`,
+        {
+          oldReasons: [oldReason],
+        },
+      )
+      .setValues({ 'reasons.value': [newReason] })
+      .return('reasons.value as value')
+      .run();
+  }
+
+  async up() {
+    const oldReason1 = 'Partner organization issues: leadership/infrastructure';
+    const newReason1 = 'Partner organization issues currently being addressed.';
+    await this.findAndReplaceReason(oldReason1, newReason1);
+
+    const oldReason2 =
+      'Delayed activities/activities did not occur/slow start of project';
+    const newReason2 =
+      'Delayed activities; activities did not occur; slow start of project';
+    await this.findAndReplaceReason(oldReason2, newReason2);
+  }
+}

--- a/src/components/progress-report/progress-report.module.ts
+++ b/src/components/progress-report/progress-report.module.ts
@@ -7,6 +7,7 @@ import { ProgressReportHighlightsRepository } from './highlights/progress-report
 import { ProgressReportHighlightsResolver } from './highlights/progress-report-highlights.resolver';
 import { ProgressReportHighlightsService } from './highlights/progress-report-highlights.service';
 import { AddProgressReportStatusMigration } from './migrations/AddStatus.migration';
+import { UpdateExplanationReasonsMigration } from './migrations/UpdateExplanationReasons.migration';
 import { ProgressReportExtraForPeriodicInterfaceRepository } from './progress-report-extra-for-periodic-interface.repository';
 import { ProgressReportRepository } from './progress-report.repository';
 import { ProgressReportService } from './progress-report.service';
@@ -40,6 +41,7 @@ import { ProgressReportWorkflowModule } from './workflow/progress-report-workflo
     ProgressReportRepository,
     ProgressReportExtraForPeriodicInterfaceRepository,
     AddProgressReportStatusMigration,
+    UpdateExplanationReasonsMigration,
   ],
   exports: [ProgressReportExtraForPeriodicInterfaceRepository],
 })

--- a/src/components/progress-report/variance-explanation/reason-options.ts
+++ b/src/components/progress-report/variance-explanation/reason-options.ts
@@ -16,12 +16,12 @@ export class ProgressReportVarianceExplanationReasonOptions extends DataObject {
 
   @Field(() => [String])
   readonly behind: ReadonlySet<string> = new JsonSet([
-    'Delayed activities/activities did not occur/slow start of project',
+    'Delayed activities; activities did not occur; slow start of project',
     'Team is being trained at start of project; they expect to catch up by end of project',
     'Delayed hiring and/or replacement of personnel',
     'Economic/political/civil instability or unrest',
     'Late or delayed partner reporting',
-    'Partner organization issues: leadership/infrastructure',
+    'Partner organization issues currently being addressed.',
     'Health issues with team members or their families',
     'Team member passed away',
     'Security breach/teams in hiding',


### PR DESCRIPTION
In this PR the following were done:
- Created a migration to update the saved reason values in the database
- Changed the values in the reasons list so the API can send to the UI the appropriate list

This should close #2754 

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4125434166) by [Unito](https://www.unito.io)
