### PR TITLE
Fix marketing access to Progress Report workflow by making status readable

### DIFF
--- a/src/components/authorization/policies/by-role/marketing.policy.ts
+++ b/src/components/authorization/policies/by-role/marketing.policy.ts
@@ -17,9 +17,7 @@ import {
     .read.whenAll(member, sensMediumOrLower)
     .read.specifically((p) => p.many('pmcEntityCode', 'pointOfContact').none)
     .children((c) => c.posts.edit),
-  // This is only here to allow the children connections below to work.
-  // I think the builder should be updated to be able to infer this automatically.
-  r.ProgressReport,
+  r.ProgressReport.specifically((p) => p.status.read), // allows access to workflow
   [
     r.ProgressReportCommunityStory,
     r.ProgressReportHighlight,


### PR DESCRIPTION


┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4149954291) by [Unito](https://www.unito.io)
