### PR TITLE
Node 16 -> 18. Alpine -> Slim

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
 
     - name: Yarn cache
       uses: actions/cache@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base node stage that sets up common config for dev & prod
-FROM public.ecr.aws/docker/library/node:16-alpine as node
+FROM public.ecr.aws/docker/library/node:18-slim as node
 
 LABEL org.opencontainers.image.title="CORD API"
 LABEL org.opencontainers.image.vendor="Seed Company"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "packageManager": "yarn@3.4.0",
   "engines": {
-    "node": ">=16.11 || >= 18.9"
+    "node": ">= 18.9"
   },
   "scripts": {
     "prebuild": "rimraf dist",


### PR DESCRIPTION
Apparently alpine is meant for embedded devices, and though it is smaller, there's a performance trade off.
Switching to slim which uses the official glibc instead of the musl implementation.
https://snyk.io/blog/choosing-the-best-node-js-docker-image/

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4180775743) by [Unito](https://www.unito.io)
