### PR TITLE
Require filenames on defined file version upload (soft breaking)

### DIFF
--- a/src/components/file/dto/upload.dto.ts
+++ b/src/components/file/dto/upload.dto.ts
@@ -46,10 +46,9 @@ export abstract class CreateDefinedFileVersionInput {
   readonly uploadId: ID;
 
   @Field({
-    description: 'An optional name. Defaults to file name.',
-    nullable: true,
+    description: 'The file name',
   })
-  readonly name?: string;
+  readonly name: string;
 
   @Field({
     description:

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -421,14 +421,11 @@ export class FileService {
         field,
       );
     }
-    const name = input.name ?? (await this.getFile(file.value, session)).name;
     try {
       await this.createFileVersion(
         {
           parentId: file.value,
-          uploadId: input.uploadId,
-          name,
-          mimeType: input.mimeType,
+          ...input,
         },
         session,
       );

--- a/src/components/product/migrations/ReextractPlanningPnps.migration.ts
+++ b/src/components/product/migrations/ReextractPlanningPnps.migration.ts
@@ -36,6 +36,7 @@ export class ReextractPlanningPnpsMigration extends BaseMigration {
             id: engagement.id,
             pnp: {
               uploadId: row.pnpFileId,
+              name: row.pnpFileName,
             },
             methodology:
               row.methodologies.length > 1
@@ -72,8 +73,10 @@ export class ReextractPlanningPnpsMigration extends BaseMigration {
             node('', 'File'),
             relation('in', '', 'parent', ACTIVE),
             node('version', 'FileVersion'),
+            relation('out', '', 'name', ACTIVE),
+            node('name', 'Property'),
           ])
-          .return('version')
+          .return('version, name.value as name')
           .orderBy('version.createdAt', 'DESC')
           .raw('LIMIT 1'),
       )
@@ -93,9 +96,15 @@ export class ReextractPlanningPnpsMigration extends BaseMigration {
           .raw('WHERE size(methodologies) > 0')
           .return('methodologies'),
       )
-      .return<{ engId: ID; pnpFileId: ID; methodologies: Methodology[] }>([
+      .return<{
+        engId: ID;
+        pnpFileId: ID;
+        pnpFileName: string;
+        methodologies: Methodology[];
+      }>([
         'eng.id as engId',
         'version.id as pnpFileId',
+        'name as pnpFileName',
         'methodologies',
       ])
       .run();


### PR DESCRIPTION
This avoids an error where a name wasn't specified on the first defined file upload.
This was because we'd try to fetch the file which would be invalid,
because there weren't any versions.

In practice (in UI), the name is always given.
So while this is technically a breaking change,
it should be fine to roll out whenever.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4226989640) by [Unito](https://www.unito.io)
