### PR TITLE
Sync S3 signing expiration with http cache

### DIFF
--- a/src/components/file/bucket/filesystem-bucket.ts
+++ b/src/components/file/bucket/filesystem-bucket.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'fs';
-import { dirname, join, resolve } from 'path';
+import { dirname, join } from 'path';
 import { Readable } from 'stream';
 import { NotFoundException } from '../../../common';
 import { FakeAwsFile, LocalBucket, LocalBucketOptions } from './local-bucket';
@@ -11,12 +11,9 @@ export interface FilesystemBucketOptions extends LocalBucketOptions {
 /**
  * A bucket that uses the local filesystem
  */
-export class FilesystemBucket extends LocalBucket {
-  private readonly rootDir: string;
-
-  constructor(options: FilesystemBucketOptions) {
-    super(options);
-    this.rootDir = resolve(options.rootDirectory);
+export class FilesystemBucket extends LocalBucket<FilesystemBucketOptions> {
+  private get rootDir() {
+    return this.options.rootDirectory;
   }
 
   protected async saveFile(key: string, file: FakeAwsFile) {

--- a/src/components/file/bucket/local-bucket.ts
+++ b/src/components/file/bucket/local-bucket.ts
@@ -1,15 +1,16 @@
 import {
-  GetObjectCommandInput,
-  PutObjectCommandInput,
+  GetObjectCommand as GetObject,
+  PutObjectCommand as PutObject,
 } from '@aws-sdk/client-s3';
+import { Command } from '@aws-sdk/smithy-client';
+import { Type } from '@nestjs/common';
 import { pickBy } from 'lodash';
-import { DateTime } from 'luxon';
+import { DateTime, Duration } from 'luxon';
 import { assert } from 'ts-essentials';
-import { Except } from 'type-fest';
 import { InputException } from '~/common';
-import { BucketOptions, FileBucket, GetObjectOutput } from './file-bucket';
+import { FileBucket, GetObjectOutput, SignedOp } from './file-bucket';
 
-export interface LocalBucketOptions extends BucketOptions {
+export interface LocalBucketOptions {
   baseUrl: URL;
 }
 
@@ -26,17 +27,14 @@ export abstract class LocalBucket extends FileBucket {
   private readonly baseUrl: URL;
 
   constructor(options: LocalBucketOptions) {
-    super(options);
+    super();
     this.baseUrl = options.baseUrl;
   }
 
   async download(signed: string): Promise<GetObjectOutput> {
-    const parsed: GetObjectCommandInput = this.validateSignedUrl(
-      'getObject',
-      signed,
-    );
+    const parsed = this.validateSignedUrl(GetObject, signed);
     return {
-      ...(await this.getObject(parsed.Key!)),
+      ...(await this.getObject(parsed.Key)),
       ...pickBy(
         {
           ContentType: parsed.ResponseContentType,
@@ -52,8 +50,8 @@ export abstract class LocalBucket extends FileBucket {
   }
 
   async upload(signed: string, file: FakeAwsFile) {
-    const parsed = this.validateSignedUrl('putObject', signed);
-    await this.saveFile(parsed.Key!, {
+    const parsed = this.validateSignedUrl(PutObject, signed);
+    await this.saveFile(parsed.Key, {
       ContentLength: file.Body.byteLength,
       LastModified: new Date(),
       ...file,
@@ -64,19 +62,19 @@ export abstract class LocalBucket extends FileBucket {
 
   protected abstract saveFile(key: string, file: FakeAwsFile): Promise<void>;
 
-  protected async getSignedUrl(
-    operation: string,
-    key: string,
-    options?: Except<
-      GetObjectCommandInput | PutObjectCommandInput,
-      'Bucket' | 'Key'
-    >,
+  async getSignedUrl<TCommandInput extends object>(
+    operation: Type<Command<TCommandInput, any, any>>,
+    input: SignedOp<TCommandInput>,
   ) {
     const signed = JSON.stringify({
-      operation,
-      Key: key,
-      expires: DateTime.local().plus(this.signedUrlExpires).toMillis(),
-      ...options,
+      operation: operation.constructor.name,
+      ...input,
+      signing: {
+        ...input.signing,
+        expiresIn: DateTime.local()
+          .plus(Duration.from(input.signing.expiresIn))
+          .toMillis(),
+      },
     });
     const url = new URL(this.baseUrl);
     url.searchParams.set('signed', signed);
@@ -86,10 +84,10 @@ export abstract class LocalBucket extends FileBucket {
   /**
    * parses & validates the signed url or just the json query param
    */
-  protected validateSignedUrl(
-    operation: string,
+  protected validateSignedUrl<TCommandInput extends object>(
+    operation: Type<Command<TCommandInput, any, any>>,
     url: string,
-  ): GetObjectCommandInput | PutObjectCommandInput {
+  ): SignedOp<TCommandInput> & { Key: string } {
     let raw;
     try {
       raw = new URL(url).searchParams.get('signed');
@@ -99,14 +97,17 @@ export abstract class LocalBucket extends FileBucket {
     assert(typeof raw === 'string');
     let parsed;
     try {
-      parsed = JSON.parse(raw);
-      assert(parsed.operation === operation);
+      parsed = JSON.parse(raw) as SignedOp<TCommandInput> & {
+        operation: string;
+        Key: string;
+      };
+      assert(parsed.operation === operation.constructor.name);
       assert(typeof parsed.Key === 'string');
-      assert(typeof parsed.expires === 'number');
+      assert(typeof parsed.signing.expiresIn === 'number');
     } catch (e) {
       throw new InputException(e);
     }
-    if (DateTime.local() > DateTime.fromMillis(parsed.expires)) {
+    if (DateTime.local() > DateTime.fromMillis(parsed.signing.expiresIn)) {
       throw new InputException('url expired');
     }
     return parsed;

--- a/src/components/file/bucket/local-bucket.ts
+++ b/src/components/file/bucket/local-bucket.ts
@@ -23,12 +23,11 @@ export type FakeAwsFile = Required<Pick<GetObjectOutput, 'ContentType'>> &
 /**
  * Common functionality for "local" (non-s3) buckets
  */
-export abstract class LocalBucket extends FileBucket {
-  private readonly baseUrl: URL;
-
-  constructor(options: LocalBucketOptions) {
+export abstract class LocalBucket<
+  Options extends LocalBucketOptions = LocalBucketOptions,
+> extends FileBucket {
+  constructor(protected options: Options) {
     super();
-    this.baseUrl = options.baseUrl;
   }
 
   async download(signed: string): Promise<GetObjectOutput> {
@@ -76,7 +75,7 @@ export abstract class LocalBucket extends FileBucket {
           .toMillis(),
       },
     });
-    const url = new URL(this.baseUrl);
+    const url = new URL(this.options.baseUrl);
     url.searchParams.set('signed', signed);
     return url.toString();
   }

--- a/src/components/file/files-bucket.factory.ts
+++ b/src/components/file/files-bucket.factory.ts
@@ -8,9 +8,9 @@ import { LocalBucketController } from './local-bucket.controller';
 export const FilesBucketFactory: FactoryProvider = {
   provide: FileBucket,
   useFactory: (s3: S3, config: ConfigService) => {
-    const { bucket, localDirectory, signedUrlExpires } = config.files;
+    const { bucket, localDirectory } = config.files;
     if (bucket) {
-      return new S3Bucket({ s3, bucket, signedUrlExpires });
+      return new S3Bucket(s3, bucket);
     }
 
     const baseUrl = withAddedPath(config.hostUrl, LocalBucketController.path);
@@ -19,10 +19,9 @@ export const FilesBucketFactory: FactoryProvider = {
       return new FilesystemBucket({
         rootDirectory: localDirectory,
         baseUrl,
-        signedUrlExpires,
       });
     }
-    return new MemoryBucket({ baseUrl, signedUrlExpires });
+    return new MemoryBucket({ baseUrl });
   },
   inject: [S3, ConfigService],
 };

--- a/src/components/file/files-bucket.factory.ts
+++ b/src/components/file/files-bucket.factory.ts
@@ -1,5 +1,6 @@
 import { S3 } from '@aws-sdk/client-s3';
 import { FactoryProvider } from '@nestjs/common';
+import { resolve } from 'path';
 import { withAddedPath } from '~/common/url.util';
 import { ConfigService } from '../../core';
 import { FileBucket, FilesystemBucket, MemoryBucket, S3Bucket } from './bucket';
@@ -17,7 +18,7 @@ export const FilesBucketFactory: FactoryProvider = {
 
     if (localDirectory) {
       return new FilesystemBucket({
-        rootDirectory: localDirectory,
+        rootDirectory: resolve(localDirectory),
         baseUrl,
       });
     }

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -18,6 +18,8 @@ import { FrontendUrlWrapper } from '../email/templates/frontend-url';
 import { LogLevel } from '../logger';
 import { EnvironmentService } from './environment.service';
 
+const dur = Duration.from;
+
 type HttpTimeoutOptions = typeof ConfigService.prototype.httpTimeouts;
 
 /**
@@ -194,7 +196,11 @@ export class ConfigService implements EmailOptionsFactory {
     return {
       bucket,
       localDirectory,
-      signedUrlExpires: Duration.fromObject({ minutes: 15 }),
+      cacheTtl: {
+        file: { private: dur('1h'), public: dur('1d') },
+        version: { private: dur('1h'), public: dur('1 month') },
+      },
+      putTtl: dur('10m'),
     };
   }
 

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -198,7 +198,7 @@ export class ConfigService implements EmailOptionsFactory {
       localDirectory,
       cacheTtl: {
         file: { private: dur('1h'), public: dur('1d') },
-        version: { private: dur('1h'), public: dur('1 month') },
+        version: { private: dur('1h'), public: dur('6d') },
       },
       putTtl: dur('10m'),
     };


### PR DESCRIPTION
This fixes a fresh cache url pointing to an invalid s3 url.

This moves the signing expiration from the Bucket layer to the FileService layer. This makes more sense as it's a business decision vs the actual persistence logic.

I also took the opportunity to refactor to use aws-sdk v3 command classes.
Doing it this way with generics is more elegant, as we don't need to explicitly reference actions and their input options in bucket abstraction.

---

In the future, maybe we can set the S3 files to be public if they are in cord, and skip url signing for them. That would allow us to increase our caching duration. Another option would be to put a CDN in front, I think that would allow the CDN to serve the fresh cached file directly instead of redirecting to a stale pre-signed url.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4263443216) by [Unito](https://www.unito.io)
