### PR TITLE
Handle multiple file bucket sources & allow readonly

### DIFF
--- a/src/components/file/bucket/composite-bucket.ts
+++ b/src/components/file/bucket/composite-bucket.ts
@@ -1,0 +1,92 @@
+import { HeadObjectOutput } from '@aws-sdk/client-s3';
+import { Command } from '@aws-sdk/smithy-client';
+import { Type } from '@nestjs/common';
+import { FileBucket, GetObjectOutput, SignedOp } from './file-bucket';
+
+/**
+ * A bucket that is composed of multiple other sources.
+ *
+ * For read operations, the first source that has the file is used.
+ * If all fail, an error is thrown.
+ *
+ * For write operations, all writeable sources containing the file are used.
+ * If any fail, an error is thrown.
+ */
+export class CompositeBucket extends FileBucket {
+  constructor(private readonly sources: readonly FileBucket[]) {
+    super();
+  }
+
+  get isReadonly() {
+    return this.sources.every((src) => src.isReadonly);
+  }
+
+  async getSignedUrl<TCommandInput extends object>(
+    operation: Type<Command<TCommandInput, any, any>>,
+    input: SignedOp<TCommandInput>,
+  ): Promise<string> {
+    const [source] = await this.selectSource(input.Key);
+    return await source.getSignedUrl(operation, input);
+  }
+
+  async getObject(key: string): Promise<GetObjectOutput> {
+    const [source] = await this.selectSource(key);
+    return await source.getObject(key);
+  }
+
+  async headObject(key: string): Promise<HeadObjectOutput> {
+    const [_, output] = await this.selectSource(key);
+    return output;
+  }
+
+  async copyObject(oldKey: string, newKey: string): Promise<void> {
+    const [existing] = await this.selectSources(oldKey, this.writableSources);
+    await this.doAndThrowAllErrors(
+      existing.map(([bucket]) => bucket.copyObject(oldKey, newKey)),
+    );
+  }
+
+  async deleteObject(key: string): Promise<void> {
+    const [existing] = await this.selectSources(key, this.writableSources);
+    await this.doAndThrowAllErrors(
+      existing.map(([bucket]) => bucket.deleteObject(key)),
+    );
+  }
+
+  private get writableSources() {
+    return this.sources.flatMap((source) => (source.isReadonly ? [] : source));
+  }
+
+  private async doAndThrowAllErrors(actions: Array<Promise<void>>) {
+    const results = await Promise.allSettled(actions);
+    const errors = results.filter(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
+    );
+    if (errors.length > 0) {
+      throw new AggregateError(errors.map((error) => error.reason));
+    }
+  }
+
+  private async selectSource(key: string) {
+    const [success] = await this.selectSources(key);
+    return success[0];
+  }
+
+  private async selectSources(key: string, sources?: typeof this.sources) {
+    const results = await Promise.allSettled(
+      (sources ?? this.sources).map(
+        async (source) => [source, await source.headObject(key)] as const,
+      ),
+    );
+    const success = results.flatMap((result) =>
+      result.status === 'fulfilled' ? [result.value] : [],
+    );
+    const errors = results.flatMap((result) =>
+      result.status === 'rejected' ? result.reason : [],
+    );
+    if (success.length === 0) {
+      throw new AggregateError(errors);
+    }
+    return [success, errors] as const;
+  }
+}

--- a/src/components/file/bucket/file-bucket.ts
+++ b/src/components/file/bucket/file-bucket.ts
@@ -20,6 +20,10 @@ export type SignedOp<T extends object> = Omit<T, 'Bucket'> & {
  * Base interface for a bucket of files
  */
 export abstract class FileBucket {
+  get isReadonly() {
+    return false;
+  }
+
   abstract getSignedUrl<TCommandInput extends object>(
     operation: Type<Command<TCommandInput, any, any>>,
     input: SignedOp<TCommandInput>,

--- a/src/components/file/bucket/file-bucket.ts
+++ b/src/components/file/bucket/file-bucket.ts
@@ -13,6 +13,7 @@ import { DurationIn } from '~/common';
 export type GetObjectOutput = Merge<AwsGetObjectOutput, { Body: Readable }>;
 
 export type SignedOp<T extends object> = Omit<T, 'Bucket'> & {
+  Key: string;
   signing: Merge<RequestPresigningArguments, { expiresIn: DurationIn }>;
 };
 

--- a/src/components/file/bucket/index.ts
+++ b/src/components/file/bucket/index.ts
@@ -1,4 +1,5 @@
 export * from './file-bucket';
+export * from './composite-bucket';
 export * from './local-bucket';
 export * from './memory-bucket';
 export * from './filesystem-bucket';

--- a/src/components/file/bucket/parse-uri.test.ts
+++ b/src/components/file/bucket/parse-uri.test.ts
@@ -1,0 +1,35 @@
+import { parseUri } from './parse-uri';
+
+test.each<[uri: string, output: [type: string, path: string, ro: boolean]]>([
+  // absolute
+  ['/var/log', ['', '/var/log', false]],
+  ['files:///var/log', ['files', '/var/log', false]],
+  ['FILES:///var/log:ro', ['files', '/var/log', true]],
+  ['files:///var/log:readonly', ['files', '/var/log', true]],
+  ['/var/log:ro', ['', '/var/log', true]],
+
+  // relative
+  ['.', ['', '.', false]],
+  ['./asdf', ['', './asdf', false]],
+  ['files://./asdf:ro', ['files', './asdf', true]],
+  ['files://asdf:RO', ['files', 'asdf', true]],
+  ['./asdf:ro', ['', './asdf', true]],
+  ['./asdf:readOnly', ['', './asdf', true]],
+
+  // windose
+  ['C:\\\\asdf\\\\sdf', ['', 'C:\\\\asdf\\\\sdf', false]],
+  ['C:\\\\asdf\\\\sdf:ro', ['', 'C:\\\\asdf\\\\sdf', true]],
+  ['C:\\\\asdf\\\\sdf:readonly', ['', 'C:\\\\asdf\\\\sdf', true]],
+  ['files://C:\\\\asdf\\\\sdf:readonly', ['files', 'C:\\\\asdf\\\\sdf', true]],
+
+  // s3
+  ['s3://foo', ['s3', 'foo', false]],
+  ['s3://foo/path', ['s3', 'foo/path', false]],
+  ['S3://foo/path:ro', ['s3', 'foo/path', true]],
+  ['s3://foo/path:readonly', ['s3', 'foo/path', true]],
+  ['s3://foo:readonly', ['s3', 'foo', true]],
+  ['s3://my.bucket.com', ['s3', 'my.bucket.com', false]],
+])('%s', (uri, output) => {
+  const parsed = parseUri(uri);
+  expect([parsed.type, parsed.path, parsed.readonly]).toEqual(output);
+});

--- a/src/components/file/bucket/parse-uri.ts
+++ b/src/components/file/bucket/parse-uri.ts
@@ -1,0 +1,24 @@
+export interface ParsedBucketUri {
+  /**
+   * The type or scheme. Case-insensitive and converted to lowercase.
+   * Optional, so if omitted, it will be an empty string.
+   */
+  type: string;
+  path: string;
+  readonly: boolean;
+}
+
+export const parseUri = (uri: string): ParsedBucketUri => {
+  const typeMatch = /^(?:(\w+)?:\/\/)?(.+)$/.exec(uri);
+  if (!typeMatch) {
+    // Shouldn't ever happen
+    throw new Error('Failed to parse Bucket URI');
+  }
+  const [, type, remainingSrc] = typeMatch;
+  const roMatch = /(:ro|:readonly)$/i.exec(remainingSrc);
+  const readonly = !!roMatch;
+  const path = roMatch
+    ? remainingSrc.slice(0, -roMatch[0].length)
+    : remainingSrc;
+  return { type: type?.toLowerCase() ?? '', path, readonly };
+};

--- a/src/components/file/bucket/readonly-bucket.ts
+++ b/src/components/file/bucket/readonly-bucket.ts
@@ -1,0 +1,40 @@
+import { Command } from '@aws-sdk/smithy-client';
+import { Type } from '@nestjs/common';
+import { FileBucket, SignedOp } from './file-bucket';
+
+export class ReadonlyBucket extends FileBucket {
+  constructor(private readonly source: FileBucket) {
+    super();
+  }
+
+  get isReadonly() {
+    return true;
+  }
+
+  async getSignedUrl<TCommandInput extends object>(
+    operation: Type<Command<TCommandInput, any, any>>,
+    input: SignedOp<TCommandInput>,
+  ) {
+    return await this.source.getSignedUrl(operation, input);
+  }
+
+  async getObject(key: string) {
+    return await this.source.getObject(key);
+  }
+
+  async headObject(key: string) {
+    return await this.source.headObject(key);
+  }
+
+  async copyObject(_oldKey: string, _newKey: string) {
+    throw new Error('File bucket is readonly and cannot copy objects');
+  }
+
+  async deleteObject(_key: string) {
+    throw new Error('File bucket is readonly and cannot delete objects');
+  }
+
+  async moveObject(_oldKey: string, _newKey: string): Promise<void> {
+    throw new Error('File bucket is readonly and cannot move objects');
+  }
+}

--- a/src/components/file/files-bucket.factory.ts
+++ b/src/components/file/files-bucket.factory.ts
@@ -3,27 +3,58 @@ import { FactoryProvider } from '@nestjs/common';
 import { resolve } from 'path';
 import { withAddedPath } from '~/common/url.util';
 import { ConfigService } from '../../core';
-import { FileBucket, FilesystemBucket, MemoryBucket, S3Bucket } from './bucket';
+import {
+  CompositeBucket,
+  FileBucket,
+  FilesystemBucket,
+  MemoryBucket,
+  S3Bucket,
+} from './bucket';
+import { ParsedBucketUri } from './bucket/parse-uri';
+import { ReadonlyBucket } from './bucket/readonly-bucket';
 import { LocalBucketController } from './local-bucket.controller';
+
+type FileFactory = (uri: ParsedBucketUri) => FileBucket;
 
 export const FilesBucketFactory: FactoryProvider = {
   provide: FileBucket,
   useFactory: (s3: S3, config: ConfigService) => {
-    const { bucket, localDirectory } = config.files;
-    if (bucket) {
-      const [bucketName, ...prefix] = bucket.split('/');
-      return new S3Bucket(s3, bucketName, prefix.join('/'));
-    }
+    const { sources } = config.files;
 
     const baseUrl = withAddedPath(config.hostUrl, LocalBucketController.path);
 
-    if (localDirectory) {
-      return new FilesystemBucket({
-        rootDirectory: resolve(localDirectory),
+    const files: FileFactory = ({ path }) =>
+      new FilesystemBucket({
+        rootDirectory: resolve(path),
         baseUrl,
       });
+    const factories = {
+      s3: ({ path }) => {
+        const [bucket, ...prefix] = path.split('/');
+        return new S3Bucket(s3, bucket, prefix.join('/'));
+      },
+      '': files,
+      file: files,
+      files: files,
+      filesystem: files,
+      memory: () => new MemoryBucket({ baseUrl }),
+    } satisfies Record<string, FileFactory>;
+
+    const built = sources.flatMap((uri) => {
+      const type = uri.type as keyof typeof factories;
+      if (!(type in factories)) {
+        return [];
+      }
+      const bucket = factories[type](uri);
+      return uri.readonly ? new ReadonlyBucket(bucket) : bucket;
+    });
+    if (built.length === 1) {
+      return built[0];
     }
-    return new MemoryBucket({ baseUrl });
+    if (built.length === 0) {
+      return factories.memory();
+    }
+    return new CompositeBucket(built);
   },
   inject: [S3, ConfigService],
 };

--- a/src/components/file/files-bucket.factory.ts
+++ b/src/components/file/files-bucket.factory.ts
@@ -11,7 +11,8 @@ export const FilesBucketFactory: FactoryProvider = {
   useFactory: (s3: S3, config: ConfigService) => {
     const { bucket, localDirectory } = config.files;
     if (bucket) {
-      return new S3Bucket(s3, bucket);
+      const [bucketName, ...prefix] = bucket.split('/');
+      return new S3Bucket(s3, bucketName, prefix.join('/'));
     }
 
     const baseUrl = withAddedPath(config.hostUrl, LocalBucketController.path);


### PR DESCRIPTION
This allows more flexibility when a database is moved around while still allowing the files to backed by the original bucket.
```env
FILES_SOURCE=s3://prod-support, s3://prod:readonly
FILES_SOURCE=./files, s3://a-bucket:ro
FILES_SOURCE=memory://, file://./test/fixtures
```

Updated S3 to support paths as well if a unified bucket is desired.
```env
FILES_SOURCE=s3://cord/prod-support, s3://cord/prod:readonly
```

FYI not having any writable sources right now just throws a server error. It's allowed, but probably not handled well.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4265290932) by [Unito](https://www.unito.io)
