### PR TITLE
removed organization property

### DIFF
--- a/src/components/authorization/policies/by-role/financial-analyst.policy.ts
+++ b/src/components/authorization/policies/by-role/financial-analyst.policy.ts
@@ -35,9 +35,7 @@ import {
     r.Organization.read.create.whenAny(member, sensMediumOrLower).edit,
     r.Partner.read.create
       .specifically((p) => [
-        p
-          .many('organization', 'pointOfContact')
-          .whenAny(member, sensMediumOrLower).read,
+        p.many('pointOfContact').whenAny(member, sensMediumOrLower).read,
       ])
       .children((c) => c.posts.edit),
     r.Partnership.read


### PR DESCRIPTION
@CarsonF - We think that this change will solve the issue of an FA not being able to view a Partner that is not attached to a project yet.  This is problematic currently when an FA creates a new Partner and then can't see it.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4285173590) by [Unito](https://www.unito.io)
