### PR TITLE
Improve logging of Neo4j connection errors

### DIFF
--- a/src/core/database/errors.ts
+++ b/src/core/database/errors.ts
@@ -49,7 +49,18 @@ export class ServiceUnavailableError extends Neo4jError {
     if (e instanceof ServiceUnavailableError) {
       return e;
     }
-    const ex = new this(e.message);
+    const message = e.message
+      // Strip useless empty routing table.
+      .replace(
+        / No routing servers available. Known routing table:.+$/,
+        ' No routing servers available.',
+      )
+      // Strip excessive documentation.
+      .replace(
+        'Please ensure that your database is listening on the correct host and port and that you have compatible encryption settings both on Neo4j server and driver. Note that the default encryption setting has changed in Neo4j 4.0. ',
+        '',
+      );
+    const ex = new this(message);
     replaceStack(ex, e);
     return ex;
   }

--- a/src/core/database/errors.ts
+++ b/src/core/database/errors.ts
@@ -50,7 +50,7 @@ export class ServiceUnavailableError extends Neo4jError {
       return e;
     }
     const ex = new this(e.message);
-    ex.stack = e.stack;
+    replaceStack(ex, e);
     return ex;
   }
 }
@@ -71,7 +71,7 @@ export class SessionExpiredError extends Neo4jError {
       return e;
     }
     const ex = new this(e.message);
-    ex.stack = e.stack;
+    replaceStack(ex, e);
     return ex;
   }
 }
@@ -92,7 +92,7 @@ export class ConnectionTimeoutError extends Neo4jError {
       return e;
     }
     const ex = new this(e.message);
-    ex.stack = e.stack;
+    replaceStack(ex, e);
     return ex;
   }
 }
@@ -113,7 +113,7 @@ export class ConstraintError extends Neo4jError {
       return e;
     }
     const ex = new this(e.message);
-    ex.stack = e.stack;
+    replaceStack(ex, e);
     return ex;
   }
 }
@@ -152,7 +152,7 @@ export class UniquenessError extends ConstraintError {
       info.value,
       e.message,
     );
-    ex.stack = e.stack;
+    replaceStack(ex, e);
     return ex;
   }
 }
@@ -195,6 +195,19 @@ const cast = (e: Neo4jError): Neo4jError => {
   // Hide worthless code
   if (e.code === 'N/A') {
     noEnumerate(e, 'code');
+  }
+
+  return e;
+};
+
+const replaceStack = (e: Error, original: Error) => {
+  e.stack = `${e.name}: ${e.message}`;
+
+  const originalStack = original.stack;
+  const stackStart = originalStack?.indexOf('    at') ?? -1;
+  const originalTrace = stackStart >= 0 ? originalStack!.slice(stackStart) : '';
+  if (originalTrace) {
+    e.stack += `\n${originalTrace}`;
   }
 
   return e;

--- a/src/core/graphql/gql-context.host.ts
+++ b/src/core/graphql/gql-context.host.ts
@@ -15,7 +15,7 @@ import {
 import { GraphQLRequestContext as RequestContext } from 'apollo-server-types';
 import { AsyncLocalStorage } from 'async_hooks';
 import { Request, Response } from 'express';
-import { GqlContextType as ContextType, GqlContextType } from '../../common';
+import { GqlContextType as ContextType } from '~/common';
 import { AsyncLocalStorageNoContextException } from '../async-local-storage-no-context.exception';
 
 /**
@@ -25,7 +25,7 @@ export abstract class GqlContextHost {
   /**
    * The current GraphQL context
    */
-  readonly context: GqlContextType;
+  readonly context: ContextType;
 }
 
 /**
@@ -43,7 +43,7 @@ export class GqlContextHostImpl
     ApolloPlugin<ContextType>
 {
   als = new AsyncLocalStorage<{
-    ctx?: GqlContextType;
+    ctx?: ContextType;
     execution?: ExecutionContext;
   }>();
 

--- a/src/core/logger/formatters.ts
+++ b/src/core/logger/formatters.ts
@@ -208,7 +208,9 @@ export const printForJson = () =>
         type,
         message,
         ...other,
-        stack,
+        // Only include stack if it includes trace.
+        // Otherwise, the type and message have already been given.
+        stack: stack.includes('    at ') ? stack : undefined,
       })),
       ...metadata,
     };


### PR DESCRIPTION
Connection errors are not related to the db queries making them, so I removed the stack trace from them.
I also stripped out the "routing table" verbiage as it is empty & useless for these connection errors.

### Previous
```yaml
logger: nest
message: Failed to connect to CORD database
exceptions:
  - type: ServiceUnavailableError
    message: "Could not perform discovery. No routing servers available. Known
      routing table: RoutingTable[database=default database, expirationTime=0,
      currentTime=1681238029665, routers=[], readers=[], writers=[]]"
    stack: >-
      Neo4jError: Could not perform discovery. No routing servers available.
      Known routing table: RoutingTable[database=default database,
      expirationTime=0, currentTime=1681238029665, routers=[], readers=[],
      writers=[]]

      : 
          at AuthenticationRepository.saveSessionToken (/opt/cord-api/src/components/authentication/authentication.repository.ts:27:8)
          at AuthenticationService.createToken (/opt/cord-api/src/components/authentication/authentication.service.ts:44:21)
          at SessionResolver.session (/opt/cord-api/src/components/authentication/session.resolver.ts:49:61)
          at /opt/cord-api/node_modules/@nestjs/core/helpers/external-context-creator.js:67:33
          at processTicksAndRejections (node:internal/process/task_queues:95:5)
```
### Now
```yaml
logger: nest
message: Failed to connect to CORD database
exceptions:
- type: ServiceUnavailableError
  message: Could not perform discovery. No routing servers available.
```

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4296745217) by [Unito](https://www.unito.io)
