### PR TITLE
Refactor Fields into FieldSelection to be more flexible

### DIFF
--- a/src/common/field-selection.ts
+++ b/src/common/field-selection.ts
@@ -1,0 +1,125 @@
+import { GraphQLResolveInfo as ResolveInfo } from 'graphql';
+import {
+  parseResolveInfo,
+  ResolveTree,
+  simplifyParsedResolveInfoFragmentWithType,
+} from 'graphql-parse-resolve-info';
+import { LazyGetter } from 'lazy-get-decorator';
+import { difference } from 'lodash';
+import { LiteralUnion } from 'type-fest';
+import { ResourceMap } from '~/core';
+import { AbstractClassType } from './types';
+
+/**
+ * A helper to query the fields selected of a GraphQL operation.
+ *
+ * @example
+ * ```
+ * foo(
+ *   @Info(FieldSelection) fields: FieldSelection
+ * ) {
+ *   if (isOnlyGivenKeys(fields.forType('Language'), ['id']) {
+ *     // do shortcut or whatever
+ *   }
+ * }
+ * ```
+ */
+export class FieldSelection {
+  private constructor(
+    private readonly tree: ResolveTree,
+    private readonly resolveInfo: ResolveInfo,
+  ) {}
+
+  static parse(info: ResolveInfo) {
+    const tree = parseResolveInfo(info) as ResolveTree;
+    return new FieldSelection(tree, info);
+  }
+
+  static transform(info: ResolveInfo) {
+    return FieldSelection.parse(info);
+  }
+
+  /**
+   * This just smashes all the fields together into one big map.
+   * This is a quick and dirty way to get all the fields requested,
+   * regardless of associated type.
+   * Just because all these fields are requested, does not mean that they are
+   * actually returned.
+   * They could be for other types.
+   */
+  @LazyGetter() get forAllTypes(): FieldInfo<any> {
+    return Object.assign({}, ...Object.values(this.byRequestedTypes));
+  }
+
+  /**
+   * This returns all the requested fields for a given type.
+   * This actually figures out fields requested by interfaces,
+   * so it works more like you would expect.
+   *
+   * For example,
+   * ```
+   * {
+   *   Engagement: { id: {...} },
+   *   LanguageEngagement: { language: {...} },
+   * }
+   * ```
+   * ```ts
+   * Object.keys(forType('LanguageEngagement')) === ['id', 'language']
+   * ```
+   *
+   * This is great too if you know the resolved type to be returned in order
+   * to filter out requested but unrelated fields.
+   */
+  forType<T>(type: AbstractClassType<T>): FieldInfo<T>;
+  forType<K extends keyof ResourceMap>(
+    type: K,
+  ): FieldInfo<ResourceMap[K]['prototype']>;
+  forType(type: string | AbstractClassType<any>) {
+    const typeName = typeof type === 'string' ? type : type.constructor.name;
+    const typeObj = this.resolveInfo.schema.getType(typeName);
+    if (!typeObj) {
+      return {};
+    }
+    const { fields } = simplifyParsedResolveInfoFragmentWithType(
+      this.tree,
+      typeObj,
+    );
+    return fields;
+  }
+
+  /**
+   * Returns a map of fields requested in the operation by their requested type.
+   * This is fairly low-level, so you probably want to use `forType` instead.
+   *
+   * For example,
+   * ```
+   * {
+   *   Engagement: { id: {...} },
+   *   LanguageEngagement: { language: {...} },
+   * }
+   * ```
+   *
+   * So is `LanguageEngagement.id` requested? Yes, but that's not directly
+   * represented here.
+   */
+  get byRequestedTypes(): {
+    [Type in keyof ResourceMap]?: FieldInfo<ResourceMap[Type]['prototype']>;
+  } {
+    return this.tree.fieldsByTypeName;
+  }
+}
+
+export type FieldInfo<T> = {
+  [Field in LiteralUnion<
+    keyof T,
+    string // Allow other field names because they could be lazy resolvers not on our DTO.
+  >]?: ResolveTree;
+};
+
+/**
+ * A helper to confirm that only the given keys are present on the object.
+ */
+export const isOnlyGivenKeys = <T extends object>(
+  object: T,
+  keys: ReadonlyArray<LiteralUnion<keyof T, string>>,
+) => difference(Object.keys(object), keys).length === 0;

--- a/src/common/fields.pipe.ts
+++ b/src/common/fields.pipe.ts
@@ -1,18 +1,7 @@
-import { ArgumentMetadata, PipeTransform } from '@nestjs/common';
-import {
-  getNamedType,
-  GraphQLInterfaceType,
-  GraphQLResolveInfo,
-  isAbstractType,
-  isCompositeType,
-  isInterfaceType,
-} from 'graphql';
-import { parseResolveInfo, ResolveTree } from 'graphql-parse-resolve-info';
-import { difference, pick } from 'lodash';
+import { PipeTransform } from '@nestjs/common';
 import type { ChangesetAware } from '../components/changeset/dto';
+import { FieldSelection, isOnlyGivenKeys } from './field-selection';
 import type { Resource } from './resource.dto';
-
-export type FieldInfo<T> = Partial<Record<keyof T, ResolveTree>>;
 
 /**
  * Returns the fields requested by the operation (requester).
@@ -21,41 +10,7 @@ export type FieldInfo<T> = Partial<Record<keyof T, ResolveTree>>;
  * @Info(Fields) fields: FieldInfo<Foo>
  * ```
  */
-export class Fields<T>
-  implements PipeTransform<GraphQLResolveInfo, FieldInfo<T>>
-{
-  transform(info: GraphQLResolveInfo, _metadata: ArgumentMetadata) {
-    const { fieldsByTypeName } = parseResolveInfo(info) as ResolveTree;
-
-    // Below is our own implementation of simplifyParsedResolveInfoFragmentWithType
-    // Ours includes all fields from all possible output types
-    const strippedType = getNamedType(info.returnType);
-    if (!isCompositeType(strippedType)) {
-      return {};
-    }
-    const parents = isInterfaceType(strippedType)
-      ? getInterfacesDeep(strippedType).map((t) => t.name)
-      : [];
-    const children = isAbstractType(strippedType)
-      ? info.schema.getPossibleTypes(strippedType).map((t) => t.name)
-      : [];
-    const allTypes = [strippedType.name, ...parents, ...children];
-
-    const fieldsByFilteredTypes = pick(fieldsByTypeName, allTypes);
-    const merged = Object.assign({}, ...Object.values(fieldsByFilteredTypes));
-
-    return merged;
-  }
-}
-
-// Not sure if this is entirely necessary, I think each interface has a
-// flat list of parents. But just to be safe...
-const getInterfacesDeep = (
-  type: GraphQLInterfaceType,
-): GraphQLInterfaceType[] => [
-  type,
-  ...type.getInterfaces().flatMap(getInterfacesDeep),
-];
+export const Fields = FieldSelection;
 
 /**
  * Converts the field info to a boolean if the only fields asked for are in this list.
@@ -66,9 +21,8 @@ const getInterfacesDeep = (
  */
 export const IsOnly = <T>(
   fields: Array<keyof T & string>,
-): PipeTransform<FieldInfo<T>, boolean> => ({
-  transform: (requested) =>
-    difference(Object.keys(requested), fields).length === 0,
+): PipeTransform<FieldSelection, boolean> => ({
+  transform: (selection) => isOnlyGivenKeys(selection.forAllTypes, fields),
 });
 
 /**

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -13,6 +13,7 @@ export * from './disabled.decorator';
 export * from './mutation-placeholder.output';
 export * from './exceptions';
 export * from './expose-enum-order.helper';
+export * from './field-selection';
 export * from './fields.pipe';
 export * from './filter-field';
 export * from './firstLettersOfWords';


### PR DESCRIPTION
This was a journey and hopefully this PR description and the new code better describes the actual use cases and when to use the available functionality.

## Bug fix: Excluding fields from types that are actually relevant
Previously with `Fields` I was limiting the types to filter out any irrelevant types. I do not know why I was doing this, because GQL already enforces that irrelevant types are not spread into a field selection. It turns out I was limiting the types too much, and breaking some use cases.
Like this one
```gql
query {
  periodicReport(id: "") {
    parent {
      id
      ...on Engagement {
        project { id }
      }
    }
  }
}
```
If the report was a `ProgressReport`, the `parent` was [declared](https://github.com/SeedCompany/cord-api-v3/blob/d7583b355396a7e1268df946654e6ca06ff1d62e/src/components/progress-report/dto/progress-report.entity.ts#L38-L39) as a `LanguageEngagement`.
So the [previous logic took that field type](https://github.com/SeedCompany/cord-api-v3/blob/0b0896eb9827efa148f4caf648162f690f538094~1/src/common/fields.pipe.ts#L32), and [mistakenly didn't consider  the interfaces](https://github.com/SeedCompany/cord-api-v3/blob/0b0896eb9827efa148f4caf648162f690f538094~1/src/common/fields.pipe.ts#L36-L38) of `LanguageEngagement` because `LanguageEngagement` was NOT an interface.
Thus the request for `project` was ignored and the [ID shortcut was used](https://github.com/SeedCompany/cord-api-v3/blob/0b0896eb9827efa148f4caf648162f690f538094~1/src/components/progress-report/resolvers/progress-report-parent.resolver.ts#L15-L17).
Which then broke the resolver for project who was expecting an `Engagement` but only had the ID shortcut.

So I went about fixing that mistake so that interfaces of concrete object types were included. And then I thought about unions as well. 
And then I asked myself, "what am I actually excluding here?"
I found out that Apollo Server already enforces that fragments cannot be spread into places where there is no correlation.
```gql
query {
  periodicReport(id: "") {
    ...on User {} # GQL Validation Error
  }
}
```

So in reality, we should've been considering all the fields from all the types, as they could've been applicable.

The logical change, and bug fix, in this PR is to stop filtering out fields for types because they could be relevant. Like how the `Engagement` type is used in the example above.

## New Features

The next question I asked myself is "why does `simplifyParsedResolveInfoFragmentWithType` from `graphql-parse-resolve-info` (the underlying library providing this functionality) exist?"
Which was the previous "filter" logic I had adapted and now just removed.

Well, I found it out it is because if we did have better information, we could want to limit the selected fields more.
Take this example:
```gql
query {
  engagement(id: "") {
    id
    ...on LanguageEngagement {
      language {
        canRead
      }
    }
    ...on InternshipEngagement {
      mentor {
        canRead
      }
    }
  }
}
```
Here we are asking for `language` or `mentor` based on the type of Engagement returned. Since the query returns the interface `Engagement`, GQL knows it could be either concrete type.
Say, for example, we determined the type of the engagement for the given ID was actually a `LanguageEngagement`.
It would be appropriate in that case to ignore the `mentor` field selection as we know Apollo Server will do the same.

With this new `FieldSelection` class I added functionality for that.
```ts
engagement(
  @Info(FieldSelection) fields: FieldSelection,
  ...
) {
  ...
  const info = fields.forType('LanguageEngagement');
  // info only has keys for `id` and `language`.
}
```
It's a bit contrived I know. Say `language` wasn't selected, and we knew we had a `LanguageEngagement` and we could ignore the `mentor` field.
```ts
if (isOnlyGivenKeys(fields.forType('LanguageEngagement'), ['id']) {
  return { id };
}
```
Since only the id was requested, and we have it, and we know we can ignore `mentor` then we do not need to go to the DB.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4374349478) by [Unito](https://www.unito.io)
