### PR TITLE
Added hybrid financial reporting type

### DIFF
--- a/src/components/partnership/dto/financial-reporting-type.ts
+++ b/src/components/partnership/dto/financial-reporting-type.ts
@@ -3,6 +3,7 @@ import { registerEnumType } from '@nestjs/graphql';
 export enum FinancialReportingType {
   Funded = 'Funded',
   FieldEngaged = 'FieldEngaged',
+  Hybrid = 'Hybrid',
 }
 
 registerEnumType(FinancialReportingType, { name: 'FinancialReportingType' });


### PR DESCRIPTION
@bryanjnelson @CarsonF ,  The [ticket](https://seed-company-squad.monday.com/boards/3451697530/views/78801638/pulses/4488797704) in Monday says we should notify the DOMO team before merging this into production. The field currently being passed to Domo with the "Funded" or "Field Engaged" values is named FinRptType, so I believe the Hybrid value should do the same and no other changes are needed in the DOMO sets, but let me know if my thinking is wrong.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4804165841) by [Unito](https://www.unito.io)
