### PR TITLE
Change timezone data caching strategy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ RUN echo GIT_BRANCH=$GIT_BRANCH >> .env
 # This stage can run everything
 FROM node as dev
 
+# Grab latest timezone data
+RUN mkdir -p .cache && curl -o .cache/timezones https://raw.githubusercontent.com/moment/moment-timezone/master/data/meta/latest.json
+
 # Install dependencies (in separate docker layer from app code)
 COPY .yarn .yarn
 COPY patches patches

--- a/src/components/timezone/timezone.service.ts
+++ b/src/components/timezone/timezone.service.ts
@@ -1,4 +1,5 @@
 import { Resolver } from '@nestjs/graphql';
+import { mkdir, readFile, writeFile } from 'fs/promises';
 import got from 'got';
 import { mapValues } from 'lodash';
 import { IanaCountry, TimeZone } from './timezone.dto';
@@ -22,32 +23,41 @@ interface ZoneJson {
   comments: string;
 }
 
+interface ParsedTimeZones {
+  zones: Record<string, TimeZone>;
+  countries: Record<string, IanaCountry>;
+}
+
 @Resolver()
 export class TimeZoneService {
-  private readonly httpCache = new Map();
-
-  async timezones(): Promise<Record<string, TimeZone>> {
+  async timezones() {
     const d = await this.getData();
     return d.zones;
   }
 
-  async countries(): Promise<Record<string, IanaCountry>> {
+  async countries() {
     const d = await this.getData();
     return d.countries;
   }
 
   private async getData() {
-    const data = await got
-      .get(
-        'https://raw.githubusercontent.com/moment/moment-timezone/master/data/meta/latest.json',
-        {
-          cache: this.httpCache,
-        },
-      )
-      .json<TzJson>();
+    if (!this.#fetchingData) {
+      this.#fetchingData = this.loadAndParse();
+    }
+    try {
+      return await this.#fetchingData;
+    } catch (e) {
+      this.#fetchingData = undefined;
+      return { zones: {}, countries: {} };
+    }
+  }
+  #fetchingData: Promise<ParsedTimeZones> | undefined;
+
+  private async loadAndParse(): Promise<ParsedTimeZones> {
+    const data = JSON.parse(await this.loadFromFsOrDownload()) as TzJson;
 
     // Convert lists of codes to lists of their objects
-    // This creates circular references but GQL should handle it
+    // This creates circular references, but GQL should handle it
     const countries = mapValues(data.countries, (c) => {
       const o = c as unknown as IanaCountry;
       o.code = c.abbr;
@@ -63,5 +73,18 @@ export class TimeZoneService {
     });
 
     return { zones, countries };
+  }
+
+  private async loadFromFsOrDownload() {
+    try {
+      return await readFile('.cache/timezones', 'utf-8');
+    } catch (e) {
+      const sourceUrl =
+        'https://raw.githubusercontent.com/moment/moment-timezone/master/data/meta/latest.json';
+      const text = await got.get(sourceUrl).text();
+      await mkdir('.cache', { recursive: true });
+      await writeFile('.cache/timezones', text, 'utf-8');
+      return text;
+    }
   }
 }


### PR DESCRIPTION
Fixes #664

Previously, we only cached the data for 5 minutes. This data actually only changes around once a month.

Instead, we will grab it at build and save it to the image. This way it will be automatically fresh as of build time, and we won't rely on GitHub in production.

For dev mode, we will just grab it anytime it doesn't exist on disk.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4807021557) by [Unito](https://www.unito.io)
