### PR TITLE
Fix progress summary query

### DIFF
--- a/src/components/progress-summary/progress-summary.repository.ts
+++ b/src/components/progress-summary/progress-summary.repository.ts
@@ -44,11 +44,12 @@ export class ProgressSummaryRepository extends CommonRepository {
         relation('out', '', 'summary', ACTIVE),
         node('ps', 'ProgressSummary'),
       ])
-      .subQuery('ps', (sub) =>
-        sub.return(
-          'collect(apoc.map.fromValues([ps.period, apoc.convert.toMap(ps)])) as collected',
-        ),
-      )
+      .with([
+        'report',
+        'totalVerses',
+        'totalVerseEquivalents',
+        'collect(apoc.map.fromValues([ps.period, apoc.convert.toMap(ps)])) as collected',
+      ])
       .return<{ dto: FetchedSummaries }>(
         merge(
           listConcat('collected', {


### PR DESCRIPTION
It appears that collecting inside the subquery was not changing the cardinality of the overall result.

Moving out of subquery fixes this.

Regression from f6f06f67a8391e82aec3e33e2a0b1546f5ea80cf

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4828835696) by [Unito](https://www.unito.io)
