### PR TITLE
Fix policies incorrectly defaulting to object level action when a property is specifically called out

### DIFF
--- a/src/components/authorization/policies/by-role/financial-analyst.policy.ts
+++ b/src/components/authorization/policies/by-role/financial-analyst.policy.ts
@@ -20,7 +20,7 @@ import {
       r.Engagement.read
         .when(member)
         .create.delete.specifically((p) => [
-          p.many('disbursementCompleteDate', 'status').when(member).edit,
+          p.many('disbursementCompleteDate', 'status').edit,
         ]),
       r.LanguageEngagement.specifically((p) => [p.paratextRegistryId.none]),
     ),

--- a/src/components/authorization/policies/by-role/financial-analyst.policy.ts
+++ b/src/components/authorization/policies/by-role/financial-analyst.policy.ts
@@ -59,7 +59,7 @@ import {
             'financialReportPeriod',
             'financialReportReceivedAt',
           )
-          .when(member).edit,
+          .read.when(member).edit,
       ])
       .children((c) => c.posts.edit),
     r.ProjectMember.read.when(member).edit.create.delete,

--- a/src/components/authorization/policies/by-role/project-manager.policy.ts
+++ b/src/components/authorization/policies/by-role/project-manager.policy.ts
@@ -84,7 +84,7 @@ import {
       .edit.specifically((p) => [
         p
           .many('rootDirectory', 'otherLocations', 'primaryLocation')
-          .whenAny(member, sensMediumOrLower).read,
+          .edit.whenAny(member, sensMediumOrLower).read,
       ])
       .children((c) => c.posts.read.create),
     r.ProjectMember.read.when(member).edit.create.delete,

--- a/src/components/authorization/policies/by-role/regional-director.policy.ts
+++ b/src/components/authorization/policies/by-role/regional-director.policy.ts
@@ -6,7 +6,7 @@ import { member, Policy, Role, sensMediumOrLower } from '../util';
 
   r.Partnership.read,
   r.Project.when(member).edit.specifically(
-    (p) => p.rootDirectory.when(sensMediumOrLower).read,
+    (p) => p.rootDirectory.edit.when(sensMediumOrLower).read,
   ),
 ])
 export class RegionalDirectorPolicy {}

--- a/src/components/authorization/policy/executor/policy-executor.ts
+++ b/src/components/authorization/policy/executor/policy-executor.ts
@@ -54,7 +54,7 @@ export class PolicyExecutor {
       const condition = isChildRelation
         ? grants.childRelations[prop]?.[action]
         : prop
-        ? grants.propLevel[prop]?.[action] ?? grants.objectLevel[action]
+        ? (grants.propLevel[prop] ?? grants.objectLevel)[action]
         : grants.objectLevel[action];
 
       if (condition == null) {


### PR DESCRIPTION
Here's an example of something being ignored.
https://github.com/SeedCompany/cord-api-v3/blob/ad02252edfda9eb300e3c15282aceabac3fb661e/src/components/authorization/policies/by-role/consultant-manager.policy.ts#L20-L20
It was falling back to organization object level _read_ instead of using the absence of actions explicitly called out on the `address` property.