### PR TITLE
Refactor some dynamic resources code

### DIFF
--- a/src/components/comments/comment.service.ts
+++ b/src/components/comments/comment.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import {
-  EnhancedResource,
   ID,
   InvalidIdForTypeException,
   isIdLike,
@@ -93,12 +92,10 @@ export class CommentService {
       ? await this.resources.loadByBaseNode(parentNode)
       : parentNode;
 
-    const parentType = await this.resourcesHost.getByDynamicName(
-      parent.__typename,
-    );
-    const parentInterfaces = await this.resourcesHost.getInterfaces(parentType);
-    if (!parentInterfaces.includes(EnhancedResource.of(Commentable))) {
-      throw new NonCommentableType('Resource does not implement Commentable');
+    try {
+      await this.resourcesHost.verifyImplements(parent.__typename, Commentable);
+    } catch (e) {
+      throw new NonCommentableType(e.message);
     }
     return parent as Commentable;
   }

--- a/src/components/comments/comment.service.ts
+++ b/src/components/comments/comment.service.ts
@@ -93,7 +93,9 @@ export class CommentService {
       ? await this.resources.loadByBaseNode(parentNode)
       : parentNode;
 
-    const parentType = await this.resourcesHost.getByName(parent.__typename);
+    const parentType = await this.resourcesHost.getByDynamicName(
+      parent.__typename,
+    );
     const parentInterfaces = await this.resourcesHost.getInterfaces(parentType);
     if (!parentInterfaces.includes(EnhancedResource.of(Commentable))) {
       throw new NonCommentableType('Resource does not implement Commentable');

--- a/src/components/language/dto/language.dto.ts
+++ b/src/components/language/dto/language.dto.ts
@@ -26,7 +26,7 @@ import {
 import { SetChangeType } from '../../../core/database/changes';
 import { Location } from '../../location/dto';
 import { Pinnable } from '../../pin/dto';
-import { Post, Postable } from '../../post/dto';
+import { Postable } from '../../post/dto';
 import { UpdateEthnologueLanguage } from './update-language.dto';
 
 const Interfaces: Type<Resource & Pinnable & Postable> = IntersectionType(
@@ -87,7 +87,7 @@ export class Language extends Interfaces {
   static readonly Relations = {
     ethnologue: EthnologueLanguage,
     locations: [Location], // a child list but not creating deleting...does it still count?
-    posts: [Post],
+    ...Postable.Relations,
   };
 
   @NameField({

--- a/src/components/partner/dto/partner.dto.ts
+++ b/src/components/partner/dto/partner.dto.ts
@@ -19,7 +19,7 @@ import {
 import { ScopedRole } from '../../authorization';
 import { FinancialReportingType } from '../../partnership/dto/financial-reporting-type';
 import { Pinnable } from '../../pin/dto';
-import { Post, Postable } from '../../post/dto';
+import { Postable } from '../../post/dto';
 import { IProject } from '../../project/dto';
 import { SecuredPartnerTypes } from './partner-type.enum';
 
@@ -43,7 +43,7 @@ export class Partner extends Interfaces {
   static readonly SecuredProps = keysOf<SecuredProps<Partner>>();
   static readonly Relations = {
     projects: [IProject],
-    posts: [Post],
+    ...Postable.Relations,
   };
 
   readonly organization: Secured<ID>;

--- a/src/components/post/dto/postable.dto.ts
+++ b/src/components/post/dto/postable.dto.ts
@@ -1,15 +1,32 @@
 import { InterfaceType } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
-import { ID, IdField } from '../../../common';
+import { keys as keysOf } from 'ts-transformer-keys';
+import { ID, IdField, SecuredProps } from '~/common';
+import { RegisterResource } from '~/core/resources';
+import { Post } from './post.dto';
 
+@RegisterResource()
 @InterfaceType({
   description: stripIndent`
     An object that can be used to enable Post discussions on a Node.
   `,
 })
 export abstract class Postable {
+  static readonly Props: string[] = keysOf<Postable>();
+  static readonly SecuredProps: string[] = keysOf<SecuredProps<Postable>>();
+  static readonly Relations = {
+    posts: [Post],
+  };
+  static readonly Parent = 'dynamic';
+
   @IdField({
     description: "The object's ID",
   })
   readonly id: ID;
+}
+
+declare module '~/core/resources/map' {
+  interface ResourceMap {
+    Postable: typeof Postable;
+  }
 }

--- a/src/components/post/postable.resolver.ts
+++ b/src/components/post/postable.resolver.ts
@@ -24,7 +24,9 @@ export class PostableResolver {
     @LoggedInSession() session: Session,
     @Loader(PostLoader) posts: LoaderOf<PostLoader>,
   ): Promise<SecuredPostList> {
-    const parentType = await this.resourcesHost.getByName(info.parentType.name);
+    const parentType = await this.resourcesHost.getByName(
+      info.parentType.name as 'Postable',
+    );
     const list = await this.service.securedList(
       parentType,
       parent,

--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -37,8 +37,7 @@ import { Location } from '../../location/dto';
 import { Partnership } from '../../partnership/dto';
 import { SecuredReportPeriod } from '../../periodic-report/dto';
 import { Pinnable } from '../../pin/dto';
-import { Post } from '../../post/dto';
-import { Postable } from '../../post/dto/postable.dto';
+import { Postable } from '../../post/dto';
 import { ProjectChangeRequest } from '../../project-change-request/dto';
 import { ProjectMember } from '../project-member/dto';
 import { ProjectStatus } from './status.enum';
@@ -81,7 +80,7 @@ class Project extends Interfaces {
     engagement: [Engagement], // why singular
     // edge case because it's writable for internships but not secured
     sensitivity: Sensitivity,
-    posts: [Post], // from Postable interface
+    ...Postable.Relations,
     changeRequests: [ProjectChangeRequest],
     ...Commentable.Relations,
   };

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -3,8 +3,7 @@ import { GraphQLSchemaHost } from '@nestjs/graphql';
 import { CachedByArg } from '@seedcompany/common';
 import { isObjectType } from 'graphql';
 import { mapValues } from 'lodash';
-import { ValueOf } from 'ts-essentials';
-import { LiteralUnion } from 'type-fest';
+import { LiteralUnion, ValueOf } from 'type-fest';
 import { EnhancedResource, ServerException } from '~/common';
 import type { LegacyResourceMap } from '../../components/authorization/model/resource-map';
 import { ResourceMap } from './map';
@@ -40,11 +39,7 @@ export class ResourcesHost {
 
   async getByName<K extends keyof ResourceMap>(
     name: K,
-  ): Promise<EnhancedResource<ValueOf<Pick<ResourceMap, K>>>>;
-  async getByName(
-    name: LiteralUnion<keyof ResourceMap, string>,
-  ): Promise<EnhancedResource<ValueOf<ResourceMap>>>;
-  async getByName(name: keyof ResourceMap): Promise<EnhancedResource<any>> {
+  ): Promise<EnhancedResource<ValueOf<Pick<ResourceMap, K>>>> {
     const map = await this.getEnhancedMap();
     const resource = map[name];
     if (!resource) {
@@ -53,6 +48,12 @@ export class ResourcesHost {
       );
     }
     return resource;
+  }
+
+  async getByDynamicName(
+    name: LiteralUnion<keyof ResourceMap, string>,
+  ): Promise<EnhancedResource<ValueOf<ResourceMap>>> {
+    return await this.getByName(name as any);
   }
 
   async getInterfaces(


### PR DESCRIPTION
```ts
getByName('Foo')
```
was not erroring out even though we explicitly know "Foo" is not in the `ResourceMap`.
Splitting the out the `getByDynamicName` method fixes this.

---

Refactored some of the logic in comments service for use in other modules.

---

Sorry @brentkulwicki with some of these stricter types, I couldn't get away without fixing some of the Postable stuff we just talked about.