### PR TITLE
Migrate to new ECMA class fields

### DIFF
--- a/src/components/authentication/dto/register.dto.ts
+++ b/src/components/authentication/dto/register.dto.ts
@@ -6,7 +6,7 @@ import { CreatePerson } from '../../user/dto';
 @InputType()
 export abstract class RegisterInput extends CreatePerson {
   @Field()
-  readonly email: string;
+  declare readonly email: string;
 
   @Field()
   @MinLength(6)

--- a/src/components/budget/dto/budget-record.dto.ts
+++ b/src/components/budget/dto/budget-record.dto.ts
@@ -25,7 +25,7 @@ export class BudgetRecord extends IntersectionType(ChangesetAware, Resource) {
   static readonly Parent = import('./budget.dto').then((m) => m.Budget);
 
   @Field(() => Budget)
-  readonly parent: BaseNode;
+  declare readonly parent: BaseNode;
 
   readonly organization: Secured<ID>;
 
@@ -42,5 +42,5 @@ export class BudgetRecord extends IntersectionType(ChangesetAware, Resource) {
 
   // A list of non-global roles the requesting user has available for this object.
   // This is just a cache, to prevent extra db lookups within the same request.
-  readonly scope: ScopedRole[];
+  declare readonly scope: ScopedRole[];
 }

--- a/src/components/budget/dto/budget.dto.ts
+++ b/src/components/budget/dto/budget.dto.ts
@@ -29,7 +29,7 @@ export class Budget extends IntersectionType(ChangesetAware, Resource) {
   static readonly Parent = import('../../project/dto').then((m) => m.IProject);
 
   @Field(() => IProject)
-  readonly parent: BaseNode;
+  declare readonly parent: BaseNode;
 
   @Field()
   @DbLabel('BudgetStatus')
@@ -47,7 +47,7 @@ export class Budget extends IntersectionType(ChangesetAware, Resource) {
 
   // A list of non-global roles the requesting user has available for this object.
   // This is just a cache, to prevent extra db lookups within the same request.
-  readonly scope: ScopedRole[];
+  declare readonly scope: ScopedRole[];
 }
 
 @ObjectType({

--- a/src/components/changeset/dto/changeset.dto.ts
+++ b/src/components/changeset/dto/changeset.dto.ts
@@ -9,7 +9,7 @@ import { Resource, SecuredProps } from '../../../common';
 export class Changeset extends Resource {
   static readonly Props: string[] = keysOf<Changeset>();
   static readonly SecuredProps: string[] = keysOf<SecuredProps<Changeset>>();
-  __typename: string;
+  declare __typename: string;
 
   @Field({
     description: 'Whether this changeset is editable',

--- a/src/components/comments/dto/commentable.dto.ts
+++ b/src/components/comments/dto/commentable.dto.ts
@@ -14,5 +14,5 @@ export abstract class Commentable extends Resource {
     commentThreads: [CommentThread],
   };
 
-  __typename: string;
+  declare __typename: string;
 }

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -60,12 +60,12 @@ class Engagement extends ChangesetAwareResource {
   static readonly SecuredProps: string[] = keysOf<SecuredProps<Engagement>>();
   static readonly Parent = import('../../project/dto').then((m) => m.IProject);
 
-  readonly __typename: 'LanguageEngagement' | 'InternshipEngagement';
+  declare readonly __typename: 'LanguageEngagement' | 'InternshipEngagement';
 
   readonly project: ID;
 
   @Field(() => IProject)
-  readonly parent: BaseNode;
+  declare readonly parent: BaseNode;
 
   @Field(() => SecuredEngagementStatus, {
     middleware: [parentIdMiddleware],
@@ -129,7 +129,7 @@ class Engagement extends ChangesetAwareResource {
 
   // A list of non-global roles the requesting user has available for this object.
   // This is just a cache, to prevent extra db lookups within the same request.
-  readonly scope: ScopedRole[];
+  declare readonly scope: ScopedRole[];
 
   @Field()
   readonly description: SecuredRichTextNullable;
@@ -154,7 +154,7 @@ export class LanguageEngagement extends Engagement {
   );
 
   @Field(() => TranslationProject)
-  readonly parent: BaseNode;
+  declare readonly parent: BaseNode;
 
   readonly language: Secured<ID>;
 
@@ -192,7 +192,7 @@ export class InternshipEngagement extends Engagement {
   );
 
   @Field(() => InternshipProject)
-  readonly parent: BaseNode;
+  declare readonly parent: BaseNode;
 
   readonly countryOfOrigin: Secured<ID>;
 

--- a/src/components/file/dto/node.ts
+++ b/src/components/file/dto/node.ts
@@ -94,7 +94,7 @@ export class FileVersion extends BaseFile {
   static readonly Props = keysOf<FileVersion>();
   static readonly SecuredProps = keysOf<SecuredProps<FileVersion>>();
 
-  readonly type: FileNodeType.FileVersion;
+  declare readonly type: FileNodeType.FileVersion;
 }
 
 @ObjectType({
@@ -104,7 +104,7 @@ export class File extends BaseFile {
   static readonly Props = keysOf<File>();
   static readonly SecuredProps = keysOf<SecuredProps<File>>();
 
-  readonly type: FileNodeType.File;
+  declare readonly type: FileNodeType.File;
 
   readonly latestVersionId: ID;
 
@@ -121,7 +121,7 @@ export class Directory extends FileNode {
   static readonly Props = keysOf<Directory>();
   static readonly SecuredProps = keysOf<SecuredProps<Directory>>();
 
-  readonly type: FileNodeType.Directory;
+  declare readonly type: FileNodeType.Directory;
 
   @Field(() => Int, {
     description:

--- a/src/components/partner/dto/partner.dto.ts
+++ b/src/components/partner/dto/partner.dto.ts
@@ -78,7 +78,7 @@ export class Partner extends Interfaces {
 
   // A list of non-global roles the requesting user has available for this object.
   // This is just a cache, to prevent extra db lookups within the same request.
-  readonly scope: ScopedRole[];
+  declare readonly scope: ScopedRole[];
 }
 
 @ObjectType({

--- a/src/components/partnership/dto/partnership.dto.ts
+++ b/src/components/partnership/dto/partnership.dto.ts
@@ -53,7 +53,7 @@ export class Partnership extends IntersectionType(ChangesetAware, Resource) {
   readonly project: ID;
 
   @Field(() => IProject)
-  readonly parent: BaseNode;
+  declare readonly parent: BaseNode;
 
   @Field()
   readonly agreementStatus: SecuredPartnershipAgreementStatus;
@@ -98,5 +98,5 @@ export class Partnership extends IntersectionType(ChangesetAware, Resource) {
 
   // A list of non-global roles the requesting user has available for this object.
   // This is just a cache, to prevent extra db lookups within the same request.
-  readonly scope: ScopedRole[];
+  declare readonly scope: ScopedRole[];
 }

--- a/src/components/periodic-report/dto/periodic-report.dto.ts
+++ b/src/components/periodic-report/dto/periodic-report.dto.ts
@@ -62,7 +62,7 @@ class PeriodicReport extends Resource {
 
   // A list of non-global roles the requesting user has available for this object.
   // This is just a cache, to prevent extra db lookups within the same request.
-  readonly scope: ScopedRole[];
+  declare readonly scope: ScopedRole[];
 }
 
 export { PeriodicReport as IPeriodicReport };
@@ -75,7 +75,7 @@ export class FinancialReport extends PeriodicReport {
   static readonly SecuredProps = keysOf<SecuredProps<FinancialReport>>();
   static readonly Parent = 'dynamic';
 
-  readonly type: ReportType.Financial;
+  declare readonly type: ReportType.Financial;
 }
 
 @ObjectType({
@@ -86,7 +86,7 @@ export class NarrativeReport extends PeriodicReport {
   static readonly SecuredProps = keysOf<SecuredProps<NarrativeReport>>();
   static readonly Parent = 'dynamic';
 
-  readonly type: ReportType.Narrative;
+  declare readonly type: ReportType.Narrative;
 }
 
 @ObjectType({

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -106,9 +106,9 @@ export class ProductService {
     }
 
     const otherInput: CreateOtherProduct | undefined =
-      'title' in input ? input : undefined;
+      'title' in input && input.title !== undefined ? input : undefined;
     const derivativeInput: CreateDerivativeScriptureProduct | undefined =
-      'produces' in input ? input : undefined;
+      'produces' in input && input.produces !== undefined ? input : undefined;
     const scriptureInput: CreateDirectScriptureProduct | undefined =
       !otherInput && !derivativeInput ? input : undefined;
 
@@ -154,7 +154,7 @@ export class ProductService {
     }
 
     const type =
-      'title' in input
+      'title' in input && input.title !== undefined
         ? ProducibleType.OtherProduct
         : producibleType ?? ProducibleType.DirectScriptureProduct;
     const availableSteps = getAvailableSteps({
@@ -170,7 +170,7 @@ export class ProductService {
     });
 
     const id =
-      'title' in input
+      'title' in input && input.title !== undefined
         ? await this.repo.createOther({ ...input, progressTarget, steps })
         : await this.repo.create({
             ...input,

--- a/src/components/progress-report/dto/progress-report.entity.ts
+++ b/src/components/progress-report/dto/progress-report.entity.ts
@@ -36,10 +36,10 @@ export class ProgressReport extends IPeriodicReport {
   declare readonly type: ReportType.Progress;
 
   @Field(() => LanguageEngagement)
-  override readonly parent: BaseNode;
+  declare readonly parent: BaseNode;
 
   /** @deprecated */
-  readonly reportFile: DefinedFile;
+  declare readonly reportFile: DefinedFile;
 
   @Field(() => SecuredStatus, {
     middleware: [parentIdMiddleware],

--- a/src/components/project-change-request/dto/project-change-request.dto.ts
+++ b/src/components/project-change-request/dto/project-change-request.dto.ts
@@ -13,7 +13,7 @@ export abstract class ProjectChangeRequest extends Changeset {
   static readonly SecuredProps = keysOf<SecuredProps<ProjectChangeRequest>>();
   static readonly Parent = import('../../project/dto').then((m) => m.IProject);
 
-  __typename: 'ProjectChangeRequest';
+  declare __typename: 'ProjectChangeRequest';
 
   readonly project: ID;
 

--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -168,7 +168,7 @@ class Project extends Interfaces {
 
   // A list of non-global roles the requesting user has available for this object.
   // This is just a cache, to prevent extra db lookups within the same request.
-  readonly scope: ScopedRole[];
+  declare readonly scope: ScopedRole[];
 }
 
 // class name has to match schema name for interface resolvers to work.
@@ -182,7 +182,7 @@ export class TranslationProject extends Project {
   static readonly Props = keysOf<TranslationProject>();
   static readonly SecuredProps = keysOf<SecuredProps<TranslationProject>>();
 
-  readonly type: ProjectType.Translation;
+  declare readonly type: ProjectType.Translation;
 }
 
 @ObjectType({
@@ -192,7 +192,7 @@ export class InternshipProject extends Project {
   static readonly Props = keysOf<InternshipProject>();
   static readonly SecuredProps = keysOf<SecuredProps<InternshipProject>>();
 
-  readonly type: ProjectType.Internship;
+  declare readonly type: ProjectType.Internship;
 }
 
 export const projectRange = (project: UnsecuredDto<Project>) =>

--- a/src/components/prompts/prompt-variant-response.repository.ts
+++ b/src/components/prompts/prompt-variant-response.repository.ts
@@ -57,7 +57,7 @@ export const PromptVariantResponseRepository = <
     TResourceStatic,
     [Session]
   >(resource) {
-    readonly resource: EnhancedResource<TResourceStatic>;
+    declare readonly resource: EnhancedResource<TResourceStatic>;
 
     @Once()
     get edge() {

--- a/src/components/scripture/dto/scripture-reference.dto.ts
+++ b/src/components/scripture/dto/scripture-reference.dto.ts
@@ -47,10 +47,10 @@ export abstract class ScriptureReference extends ScriptureReferenceInput {
   @Field(() => Int, {
     description: `The chapter number.`,
   })
-  readonly chapter: number;
+  declare readonly chapter: number;
 
   @Field(() => Int, {
     description: `The verse number.`,
   })
-  readonly verse: number;
+  declare readonly verse: number;
 }

--- a/src/core/database/changes.ts
+++ b/src/core/database/changes.ts
@@ -103,6 +103,9 @@ export const getChanges =
   ): Partial<Omit<Changes, keyof Resource> & AndModifiedAt<TResource>> => {
     const res = EnhancedResource.of(resource);
     const actual = pickBy(omit(changes, Resource.Props), (change, prop) => {
+      if (change === undefined) {
+        return false;
+      }
       const key = isRelation(res, prop) ? prop.slice(0, -2) : prop;
       const existing = unwrapSecured(existingObject[key]);
       return !isSame(change, existing);

--- a/src/core/validation.pipe.ts
+++ b/src/core/validation.pipe.ts
@@ -26,7 +26,10 @@ export class ValidationException extends ClientException {
   constructor(errors: ValidationError[]) {
     super('Input validation failed');
     this.errors = flattenValidationErrors(errors);
-    Object.defineProperty(this, 'errorList', { value: errors });
+    Object.defineProperty(this, 'errorList', {
+      value: errors,
+      enumerable: false,
+    });
     const errorsAsString = flattenConstraints(errors)
       .map((e) => {
         const constraint = Object.values(e.constraints)[0];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "useDefineForClassFields": true,
     "jsx": "react-jsx",
     "lib": ["es2022"],
     "target": "es2021",


### PR DESCRIPTION
This opts in to the new (and future default) functionality.
This actually tells TS to emit properties at runtime.

This is opt-in because it's a breaking change for places we "override" a property.
We do this to narrow the parent type to a stricter one or just to declare a decorator.
With this new functionality, these spots would actually override the parents initial property.
Technically for us though it doesn't make a difference.
This TS says these are errors unless we give an initial value to these override spots.
Marking them as `declare` means no new runtime property will be emitted, and it's just the parent class's property that will be used. Which makes sense and would be what we want if it actually mattered (if these weren't just shapes).

Because these properties are non emitted to runtime, we probably could replace the `static Props` declarations in favor of this. But I'll leave that for a future PR.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4845311842) by [Unito](https://www.unito.io)
