### PR TITLE
Fix email lower case transform overruling explicit null input

### DIFF
--- a/src/common/email-field.ts
+++ b/src/common/email-field.ts
@@ -1,0 +1,12 @@
+import { applyDecorators } from '@nestjs/common';
+import { Field, FieldOptions } from '@nestjs/graphql';
+import { toLower } from 'lodash';
+import { Transform } from './transform.decorator';
+import { IsEmail } from './validators';
+
+export const EmailField = (options: FieldOptions = {}) =>
+  applyDecorators(
+    Field(() => String, options),
+    Transform(({ value }) => toLower(value)),
+    IsEmail(),
+  );

--- a/src/common/email-field.ts
+++ b/src/common/email-field.ts
@@ -1,12 +1,11 @@
 import { applyDecorators } from '@nestjs/common';
 import { Field, FieldOptions } from '@nestjs/graphql';
-import { toLower } from 'lodash';
 import { Transform } from './transform.decorator';
 import { IsEmail } from './validators';
 
 export const EmailField = (options: FieldOptions = {}) =>
   applyDecorators(
     Field(() => String, options),
-    Transform(({ value }) => toLower(value)),
+    Transform(({ value }) => value?.toLowerCase()),
     IsEmail(),
   );

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -38,6 +38,7 @@ export { Session, LoggedInSession, AnonSession } from './session';
 export * from './types';
 export * from './validators';
 export * from './name-field';
+export * from './email-field';
 export * from './id-field';
 export * from './url.field';
 export * from './object-view';

--- a/src/components/authentication/dto/login.dto.ts
+++ b/src/components/authentication/dto/login.dto.ts
@@ -1,13 +1,9 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
-import { Transform } from 'class-transformer';
-import { toLower } from 'lodash';
-import { ID, IsEmail } from '../../../common';
+import { EmailField, ID } from '~/common';
 
 @InputType()
 export abstract class LoginInput {
-  @Field()
-  @IsEmail()
-  @Transform(({ value }) => toLower(value))
+  @EmailField()
   email: string;
 
   @Field()

--- a/src/components/authentication/dto/passwords.dto.ts
+++ b/src/components/authentication/dto/passwords.dto.ts
@@ -1,8 +1,6 @@
 import { ArgsType, Field, InputType, ObjectType } from '@nestjs/graphql';
-import { Transform } from 'class-transformer';
 import { MinLength } from 'class-validator';
-import { toLower } from 'lodash';
-import { IsEmail, MutationPlaceholderOutput } from '../../../common';
+import { EmailField, MutationPlaceholderOutput } from '~/common';
 
 @InputType()
 export abstract class ResetPasswordInput {
@@ -31,9 +29,7 @@ export abstract class ChangePasswordOutput extends MutationPlaceholderOutput {}
 
 @ArgsType()
 export abstract class ForgotPasswordArgs {
-  @Field()
-  @IsEmail()
-  @Transform(({ value }) => toLower(value))
+  @EmailField()
   readonly email: string;
 }
 

--- a/src/components/user/dto/check-email.dto.ts
+++ b/src/components/user/dto/check-email.dto.ts
@@ -1,12 +1,8 @@
-import { ArgsType, Field } from '@nestjs/graphql';
-import { Transform } from 'class-transformer';
-import { toLower } from 'lodash';
-import { IsEmail } from '../../../common';
+import { ArgsType } from '@nestjs/graphql';
+import { EmailField } from '~/common';
 
 @ArgsType()
 export abstract class CheckEmailArgs {
-  @Field()
-  @IsEmail()
-  @Transform(({ value }) => toLower(value))
+  @EmailField()
   readonly email: string;
 }

--- a/src/components/user/dto/create-person.dto.ts
+++ b/src/components/user/dto/create-person.dto.ts
@@ -1,17 +1,15 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Transform, Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { toLower, uniq } from 'lodash';
-import { IsEmail, IsIanaTimezone, NameField } from '../../../common';
+import { uniq } from 'lodash';
+import { EmailField, IsIanaTimezone, NameField } from '~/common';
 import { Role } from '../../authorization';
 import { UserStatus } from './user-status.enum';
 import { User } from './user.dto';
 
 @InputType()
 export abstract class CreatePerson {
-  @Field(() => String, { nullable: true })
-  @IsEmail()
-  @Transform(({ value }) => toLower(value))
+  @EmailField({ nullable: true })
   readonly email?: string | null;
 
   @NameField()

--- a/src/components/user/dto/update-user.dto.ts
+++ b/src/components/user/dto/update-user.dto.ts
@@ -1,14 +1,8 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Transform, Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { toLower, uniq } from 'lodash';
-import {
-  ID,
-  IdField,
-  IsEmail,
-  IsIanaTimezone,
-  NameField,
-} from '../../../common';
+import { uniq } from 'lodash';
+import { EmailField, ID, IdField, IsIanaTimezone, NameField } from '~/common';
 import { Role } from '../../authorization';
 import { UserStatus } from './user-status.enum';
 import { User } from './user.dto';
@@ -18,9 +12,7 @@ export abstract class UpdateUser {
   @IdField()
   readonly id: ID;
 
-  @Field(() => String, { nullable: true })
-  @IsEmail()
-  @Transform(({ value }) => toLower(value))
+  @EmailField({ nullable: true })
   readonly email?: string | null;
 
   @NameField({ nullable: true })


### PR DESCRIPTION
`null` -> `""` with lodash function, which was then an invalid email.

Fixes https://seed-company-squad.monday.com/boards/3451697530/pulses/4579760959

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4861471586) by [Unito](https://www.unito.io)
