### PR TITLE
Unify jest config into single TS file

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,4 @@
+// @ts-check
 const baseConfig = require('@seedcompany/eslint-plugin').configs.base;
 
 const oldRestrictedImports = [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,6 @@
       "name": "vscode-jest-tests",
       "request": "launch",
       "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-      "args": ["--config", "${workspaceFolder}/test/jest-e2e.json"],
       "console": "integratedTerminal"
     }
   ]

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,53 @@
+import type { Config } from '@jest/types';
+import { debuggerIsAttached } from 'debugger-is-attached';
+import { Duration } from 'luxon';
+
+// eslint-disable-next-line import/no-default-export
+export default async (): Promise<Config.InitialOptions> => {
+  const debugging = await debuggerIsAttached();
+
+  const base = {
+    preset: 'ts-jest/presets/default-esm',
+    testEnvironment: 'node',
+    setupFiles: ['./test/jest.d.ts'],
+    setupFilesAfterEnv: ['./src/polyfills.ts'],
+  } satisfies Config.InitialProjectOptions;
+
+  const e2e = {
+    ...base,
+    displayName: 'E2E',
+    roots: ['test'],
+    testRegex: '\\.e2e-spec\\.tsx?$',
+    setupFiles: [
+      ...base.setupFiles,
+      // Set longer timeout.
+      // Cannot be done at project level config.
+      // Don't want to override cli arg or timeout set below for debugging either.
+      ...(debugging ? [] : ['./test/jest-setup.ts']),
+    ],
+    slowTestThreshold: 60_000,
+  } satisfies Config.InitialProjectOptions;
+
+  return {
+    ...base,
+    projects: [
+      {
+        ...base,
+        displayName: 'Unit',
+        roots: ['src'],
+      },
+      e2e,
+      {
+        ...e2e,
+        displayName: 'Security',
+        roots: ['test/security'],
+        testRegex: '\\.security\\.ts$',
+      },
+    ],
+    // WebStorm doesn't need this as it adds the cli flag automatically.
+    // I'm guessing VSCode needs it.
+    ...(debugging
+      ? { testTimeout: Duration.fromObject({ hours: 2 }).toMillis() }
+      : {}),
+  };
+};

--- a/package.json
+++ b/package.json
@@ -22,12 +22,10 @@
     "repl": "yarn start --entryFile repl",
     "gen-id": "ts-node -Te \"let g = require('./src/common/generate-id').generateId; for (let i = 0, l = process.argv[1] || 1; i < l; i++) { g().then(console.log) }\"",
     "lint": "eslint --ext .ts,.tsx --fix --max-warnings 0 .",
-    "test": "node --experimental-vm-modules $(yarn bin jest)",
-    "test:watch": "yarn test --watch",
-    "test:cov": "yarn test --coverage",
-    "test:debug": "node --experimental-vm-modules --inspect-brk $(yarn bin jest)",
-    "test:e2e": "yarn test --config ./test/jest-e2e.json",
-    "test:security": "yarn test --config ./test/jest-security.json",
+    "test": "yarn test:base --selectProjects Unit",
+    "test:e2e": "yarn test:base --selectProjects E2E",
+    "test:security": "yarn test:base --selectProjects Security",
+    "test:base": "node --experimental-vm-modules --inspect $(yarn bin jest)",
     "type-check": "tsc -p tsconfig.check.json"
   },
   "dependencies": {
@@ -116,6 +114,7 @@
     "@types/triple-beam": "^1.3.2",
     "@types/validator": "^13.7.17",
     "@typescript-eslint/parser": "^5.62.0",
+    "debugger-is-attached": "^1.2.0",
     "eslint": "^8.45.0",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-typescript-sort-keys": "^2.3.0",
@@ -149,15 +148,5 @@
     "typescript": {
       "unplugged": true
     }
-  },
-  "jest": {
-    "preset": "ts-jest/presets/default-esm",
-    "roots": [
-      "<rootDir>/src"
-    ],
-    "setupFiles": [
-      "./src/polyfills.ts"
-    ],
-    "testEnvironment": "node"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nestjs/platform-express": "^10.1.0",
     "@patarapolw/prettyprint": "^1.0.3",
     "@seedcompany/common": ">=0.10 <1",
-    "@seedcompany/data-loader": "^0.5.2",
+    "@seedcompany/data-loader": "^0.5.4",
     "@seedcompany/nestjs-email": "^3.3.1",
     "argon2": "^0.30.3",
     "aws-xray-sdk-core": "^3.5.1",

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -64,7 +64,8 @@ export class EngagementService {
   constructor(
     private readonly repo: EngagementRepository,
     private readonly ceremonyService: CeremonyService,
-    private readonly products: ProductService,
+    @Inject(forwardRef(() => ProductService))
+    private readonly products: ProductService & {},
     private readonly config: ConfigService,
     private readonly files: FileService,
     private readonly engagementRules: EngagementRules,

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { compact } from 'lodash';
 import {
   CalendarDate,
@@ -45,8 +45,10 @@ export class LanguageService {
   constructor(
     private readonly ethnologueLanguageService: EthnologueLanguageService,
     private readonly locationService: LocationService,
-    private readonly projectService: ProjectService,
-    private readonly engagementService: EngagementService,
+    @Inject(forwardRef(() => ProjectService))
+    private readonly projectService: ProjectService & {},
+    @Inject(forwardRef(() => EngagementService))
+    private readonly engagementService: EngagementService & {},
     private readonly authorizationService: AuthorizationService,
     private readonly repo: LanguageRepository,
     @Logger('language:service') private readonly logger: ILogger,

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,9 +1,0 @@
-{
-  "preset": "ts-jest/presets/default-esm",
-  "testTimeout": 100000,
-  "rootDir": "..",
-  "roots": ["<rootDir>/test"],
-  "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
-  "setupFiles": ["./src/polyfills.ts", "./src/app.module.ts", "./test/jest.d.ts"]
-}

--- a/test/jest-security.json
+++ b/test/jest-security.json
@@ -1,5 +1,0 @@
-{
-  "extends": "./jest-e2e.json",
-  "roots": ["<rootDir>/test/security"],
-  "testRegex": ".security.ts$"
-}

--- a/test/jest-setup.ts
+++ b/test/jest-setup.ts
@@ -1,0 +1,3 @@
+import { jest } from '@jest/globals';
+
+jest.setTimeout(120_000); // 2 minutes

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*.spec.ts", "tools", ".eslintrc.cjs", "jest.config.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*.spec.ts", "**/*.test.ts", "tools", ".eslintrc.cjs", "jest.config.ts"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "tools"]
+  "exclude": ["node_modules", "test", "dist", "**/*.spec.ts", "tools", ".eslintrc.cjs", "jest.config.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -56,6 +56,6 @@
     "sourceMap": true,
     "incremental": true,
   },
-  "include": ["src", "test"],
+  "include": ["src", "test", ".eslintrc.cjs", "jest.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,9 +2537,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@seedcompany/data-loader@npm:^0.5.2":
-  version: 0.5.2
-  resolution: "@seedcompany/data-loader@npm:0.5.2"
+"@seedcompany/data-loader@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "@seedcompany/data-loader@npm:0.5.4"
   dependencies:
     "@nestjs/common": ^9 || ^10
     "@nestjs/core": ^9 || ^10
@@ -2550,10 +2550,7 @@ __metadata:
     "@nestjs/core": ^10
     "@nestjs/graphql": ">=7"
     reflect-metadata: ^0.1.12
-  peerDependenciesMeta:
-    "@nestjs/graphql":
-      optional: true
-  checksum: ef1cf1f1d869bb80487c5a755750823ee052d61e77d5bdf2200490ccecee76d1b62590d6e961472a995a6f287feb7f7c582cee71534fb1eab5f6f1edce69a2dc
+  checksum: be8904c8d2b95c160689b35e3b392d63efb13134b1ae2bd5a44d77021cccc0afd26f39ffe89e63c417fd9c64539433e801c07877fdb66d7cb0bd2f8763ca5136
   languageName: node
   linkType: hard
 
@@ -5111,7 +5108,7 @@ __metadata:
     "@nestjs/testing": ^10.1.0
     "@patarapolw/prettyprint": ^1.0.3
     "@seedcompany/common": ">=0.10 <1"
-    "@seedcompany/data-loader": ^0.5.2
+    "@seedcompany/data-loader": ^0.5.4
     "@seedcompany/eslint-plugin": ^3.4.1
     "@seedcompany/nestjs-email": ^3.3.1
     "@tsconfig/strictest": ^2.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -5140,6 +5140,7 @@ __metadata:
     common-tags: ^1.8.2
     cookie-parser: ^1.4.6
     cypher-query-builder: "patch:cypher-query-builder@6.0.4#./patches/cypher-query-builder.patch"
+    debugger-is-attached: ^1.2.0
     dotenv: ^16.3.1
     dotenv-expand: ^10.0.0
     eslint: ^8.45.0
@@ -5363,6 +5364,13 @@ __metadata:
   dependencies:
     ms: ^2.1.1
   checksum: b3d8c5940799914d30314b7c3304a43305fd0715581a919dacb8b3176d024a782062368405b47491516d2091d6462d4d11f2f4974a405048094f8bfebfa3071c
+  languageName: node
+  linkType: hard
+
+"debugger-is-attached@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "debugger-is-attached@npm:1.2.0"
+  checksum: 76d29cf440bd93e5363e5f3fb5f06e5663b7ce54d8dfbdb269f495389f59613b8e2da5511b5823be4858f994c79c267b160a1d4ba0169dab9793f0747ad60190
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Tests now do not need to call out a specific config file 🎉 
  This is much better for IDE integration, as now the IDE can invoke jest for any type of test without breaking on not using the right config flag.
- Config is TS instead of JSON 🎉 
- Yarn scripts are changed to filter to certain files to maintain previous functionality.
- Dropped aliases with easy flags.
```diff
- yarn test:watch
+ yarn test --watch

- yarn test:cov
+ yarn test --coverage

- yarn test:debug
+ yarn test
```

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4909977957) by [Unito](https://www.unito.io)
