### PR TITLE
Add command to print Privileges (Policies) to CLI for queried roles/resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "yaml": "^2.3.1"
   },
   "devDependencies": {
+    "@leeoniya/ufuzzy": "^1.0.8",
     "@nestjs/cli": "^10.1.10",
     "@nestjs/schematics": "^10.0.1",
     "@nestjs/testing": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "@types/triple-beam": "^1.3.2",
     "@types/validator": "^13.7.17",
     "@typescript-eslint/parser": "^5.62.0",
+    "cli-table3": "^0.6.3",
     "debugger-is-attached": "^1.2.0",
     "eslint": "^8.45.0",
     "eslint-plugin-no-only-tests": "^3.1.0",

--- a/src/common/search-camel-case.ts
+++ b/src/common/search-camel-case.ts
@@ -1,0 +1,79 @@
+import Fuzzy from '@leeoniya/ufuzzy';
+import { startCase } from 'lodash';
+
+/**
+ * Think of this like your IDE symbol lookup with camel case/humps.
+ * https://www.jetbrains.com/help/rider/Navigation_and_Search__CamelHumps.html
+ * https://learn.microsoft.com/en-us/visualstudio/ide/visual-studio-search?view=vs-2022#search-files-and-code
+ *
+ * @example
+ * // For resources
+ * langEng -> LanguageEngagement
+ * proj -> Project
+ * VarExp -> ProgressReportVarianceExplanation
+ *
+ * // For Roles
+ * admin -> Administrator
+ * BTL -> BibleTranslationLiaison
+ * rcc -> RegionalCommunicationsCoordinator
+ */
+export function searchCamelCase<T extends string>(
+  items: Iterable<T>,
+  needle: string,
+) {
+  const itemArr = [...items];
+  const collator = new Intl.Collator('en');
+  const fuzzy = new Fuzzy({
+    sort: (info, haystack) => {
+      const {
+        idx,
+        chars,
+        terms,
+        interLft2,
+        interLft1,
+        start,
+        intraIns,
+        interIns,
+      } = info;
+
+      return idx
+        .map((v, i) => i)
+        .sort(
+          (ia, ib) =>
+            // most contiguous chars matched
+            chars[ib] - chars[ia] ||
+            // least char intra-fuzz (most contiguous)
+            intraIns[ia] - intraIns[ib] ||
+            // earliest start of match
+            start[ia] - start[ib] ||
+            // shortest match first
+            haystack[idx[ia]].length - haystack[idx[ib]].length ||
+            // most prefix bounds, boosted by full term matches
+            terms[ib] +
+              interLft2[ib] +
+              0.5 * interLft1[ib] -
+              (terms[ia] + interLft2[ia] + 0.5 * interLft1[ia]) ||
+            // the highest density of match (the least term inter-fuzz)
+            interIns[ia] - interIns[ib] ||
+            // alphabetic
+            collator.compare(haystack[idx[ia]], haystack[idx[ib]]),
+        );
+    },
+  });
+  const [indexes, _, order] = fuzzy.search(
+    itemArr.map((v) => startCase(v)),
+    startCase(needle).replace(/([A-Z])(?=[A-Z])/g, '$1 '),
+  );
+
+  // If no matches try again as with the search as the first letters of each camel hump word.
+  if (indexes?.length === 0 && needle === needle.toLowerCase()) {
+    return searchCamelCase(itemArr, needle.toUpperCase());
+  }
+
+  if (!indexes || indexes.length === 0 || !order || order.length === 0) {
+    return [];
+  }
+
+  const results = order.map((idx) => itemArr[indexes[idx]]);
+  return results;
+}

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -58,3 +58,15 @@ export function has<K extends string | number | symbol, T>(
 
 export const csv = (str: string): readonly string[] =>
   compact(str.split(',').map((s) => s.trim()));
+
+/**
+ * This is logically very simple.
+ * The usefulness is to allow this logic within an expression.
+ */
+export const firstOr = <T>(items: readonly T[], makeError: () => Error): T => {
+  const first = items.at(0);
+  if (first) {
+    return first;
+  }
+  throw makeError();
+};

--- a/src/components/authorization/policy/conditions/aggregate.condition.ts
+++ b/src/components/authorization/policy/conditions/aggregate.condition.ts
@@ -58,12 +58,11 @@ export abstract class AggregateConditions<
 
   [inspect.custom](_depth: number, _options: InspectOptionsStylized) {
     const name = this instanceof AndConditions ? ' AND ' : ' OR ';
-    return this.conditions
-      .map((c) => {
-        const l = inspect(c);
-        return c instanceof AggregateConditions ? `(${l})` : l;
-      })
-      .join(name);
+    const asStrings = this.conditions.map((c) => {
+      const l = inspect(c);
+      return c instanceof AggregateConditions ? `(${l})` : l;
+    });
+    return [...new Set(asStrings)].join(name);
   }
 }
 

--- a/src/components/authorization/policy/executor/policy-dumper.ts
+++ b/src/components/authorization/policy/executor/policy-dumper.ts
@@ -4,6 +4,7 @@ import Chalk, { Chalk as ChalkInstance } from 'chalk';
 import Table from 'cli-table3';
 import { sortBy, startCase } from 'lodash';
 import { DateTime } from 'luxon';
+import { Command, Console } from 'nestjs-console';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { inspect } from 'util';
 import xlsx from 'xlsx';
@@ -20,6 +21,7 @@ import { CalculatedCondition, PolicyExecutor } from './policy-executor';
 
 type AnyResource = EnhancedResource<any>;
 
+@Console()
 @Injectable()
 export class PolicyDumper {
   constructor(
@@ -49,6 +51,9 @@ export class PolicyDumper {
     xlsx.writeFile(book, filename ?? 'permissions.xlsx');
   }
 
+  @Command({
+    command: 'policy:dump <role> <resource>',
+  })
   async dump(role: Role, resource: ResourceLike) {
     const res = await this.resources.enhance(resource);
     const data = this.dumpRes(role, res);

--- a/src/components/authorization/policy/executor/policy-dumper.ts
+++ b/src/components/authorization/policy/executor/policy-dumper.ts
@@ -1,14 +1,16 @@
 import { Injectable } from '@nestjs/common';
-import { Nil } from '@seedcompany/common';
+import { cleanJoin, many, Many, Nil } from '@seedcompany/common';
 import Chalk, { Chalk as ChalkInstance } from 'chalk';
 import Table from 'cli-table3';
 import { sortBy, startCase } from 'lodash';
 import { DateTime } from 'luxon';
 import { Command, Console } from 'nestjs-console';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { LiteralUnion } from 'type-fest';
 import { inspect } from 'util';
 import xlsx from 'xlsx';
 import {
+  csv,
   EnhancedResource,
   firstOr,
   ID,
@@ -43,7 +45,9 @@ export class PolicyDumper {
     const chalk = new Chalk.Instance({ level: 0 });
     const resources = await this.selectResources();
     for (const role of Role.all) {
-      const dumped = resources.flatMap((res) => this.dumpRes(role, res));
+      const dumped = resources.flatMap((res) =>
+        this.dumpRes(role, res, { props: true }),
+      );
       const data = dumped.map((row) => ({
         Resource: startCase(row.resource.name),
         'Property/Relationship': startCase(row.edge),
@@ -62,38 +66,58 @@ export class PolicyDumper {
   @Command({
     command: 'policy:dump <role> <resource>',
   })
-  async dump(role: Role, resource: ResourceLike) {
-    role = firstOr(searchCamelCase(Role.all, role), notFound('role', role));
-    resource =
-      typeof resource === 'string'
-        ? firstOr(
-            searchCamelCase(await this.resources.getNames(), resource),
-            notFound('resource', resource),
-          )
-        : resource;
+  async dump(
+    rolesIn: Many<LiteralUnion<Role, string>>,
+    resourcesIn: Many<ResourceLike & string>,
+  ) {
+    const roles = search(rolesIn, [...Role.all], 'role').sort((a, b) =>
+      a.localeCompare(b),
+    );
+    const resBank = await this.resources.getNames();
+    const resources = await Promise.all(
+      search(resourcesIn, resBank, 'resource')
+        .sort((a, b) => a.localeCompare(b))
+        .map((res) => this.resources.enhance(res)),
+    );
 
-    const res = await this.resources.enhance(resource);
-    const data = this.dumpRes(role, res);
+    const data = roles.flatMap((role) =>
+      resources.flatMap((res) =>
+        this.dumpRes(role, res, {
+          props: roles.length === 1 && resources.length === 1,
+        }),
+      ),
+    );
 
     const table = new Table({
       style: { compact: true },
     });
     const chalk = new Chalk.Instance();
 
+    const showRoleCol = roles.length > 1;
+    const showResCol = resources.length > 1 || !showRoleCol;
+
     // Table title
     table.push([
       {
-        content: chalk.magentaBright`Permissions for ${chalk.italic(
-          startCase(role),
-        )} for ${chalk.italic(startCase(res.name))}`,
-        colSpan: Object.keys(data[0]).slice(1).length,
+        content: chalk.magentaBright(
+          cleanJoin(' ', [
+            'Permissions',
+            roles.length === 1 && `for ${chalk.italic(startCase(roles[0]))}`,
+            resources.length === 1 &&
+              `for ${chalk.italic(startCase(resources[0].name))}`,
+          ]),
+        ),
+        colSpan: 4 + (showRoleCol ? 1 : 0) + (showResCol ? 1 : 0),
         hAlign: 'center',
       },
     ]);
 
     // Table header row
     table.push([
-      undefined,
+      ...(showRoleCol ? [chalk.magentaBright('Role')] : []),
+      ...(showResCol
+        ? [resources.length === 1 ? undefined : chalk.magentaBright('Resource')]
+        : []),
       ...['Read', 'Edit', 'Create', 'Delete'].map((k) =>
         chalk.magentaBright(k),
       ),
@@ -102,7 +126,14 @@ export class PolicyDumper {
     // Table data rows
     table.push(
       ...data.map((row) => [
-        chalk.cyan(row.edge ? '.' + row.edge : row.resource.name),
+        ...(showRoleCol ? [chalk.cyan(startCase(row.role))] : []),
+        ...(showResCol
+          ? [
+              chalk.cyan(
+                row.edge ? ' .' + row.edge : startCase(row.resource.name),
+              ),
+            ]
+          : []),
         ...[row.read, row.edit, row.create, row.delete].map((perm) =>
           this.humanizePerm(perm, chalk),
         ),
@@ -136,7 +167,11 @@ export class PolicyDumper {
     return chalk.yellow(inspect(perm));
   }
 
-  private dumpRes(role: Role, resource: AnyResource): DumpedRow[] {
+  private dumpRes(
+    role: Role,
+    resource: AnyResource,
+    options: { props: boolean },
+  ): DumpedRow[] {
     const session: Session = {
       token: 'system',
       issuedAt: DateTime.now(),
@@ -154,6 +189,7 @@ export class PolicyDumper {
       });
     return [
       {
+        role,
         resource,
         edge: undefined,
         ...mapFromList(keysOf<Record<ResourceAction, boolean>>(), (action) => [
@@ -161,14 +197,16 @@ export class PolicyDumper {
           resolve(action),
         ]),
       },
-      ...(
-        [
-          [resource.securedPropsPlusExtra, keysOf<Record<PropAction, ''>>()],
-          [resource.childSingleKeys, keysOf<Record<ChildSingleAction, ''>>()],
-          [resource.childListKeys, keysOf<Record<ChildListAction, ''>>()],
-        ] as const
+      ...(options.props
+        ? ([
+            [resource.securedPropsPlusExtra, keysOf<Record<PropAction, ''>>()],
+            [resource.childSingleKeys, keysOf<Record<ChildSingleAction, ''>>()],
+            [resource.childListKeys, keysOf<Record<ChildListAction, ''>>()],
+          ] as const)
+        : []
       ).flatMap(([set, actions]) =>
         [...set].map((prop) => ({
+          role,
           resource,
           edge: prop,
           ...mapFromList(actions, (action) => [action, resolve(action, prop)]),
@@ -179,6 +217,7 @@ export class PolicyDumper {
 }
 
 interface DumpedRow {
+  role: Role;
   resource: AnyResource;
   edge?: string;
   read: Permission;
@@ -187,5 +226,21 @@ interface DumpedRow {
   delete?: Permission;
 }
 
-const notFound = (thing: string, input: string) => () =>
-  new Error(`Could not find ${thing} from "${input}"`);
+const search = <T extends string>(
+  input: Many<string>,
+  bank: T[],
+  thing: string,
+) => {
+  const values = many(input);
+  if (values.some((v) => v === '*' || v === '_')) {
+    return bank;
+  }
+  return values
+    .flatMap(csv)
+    .map((r) =>
+      firstOr(
+        searchCamelCase(bank, r),
+        () => new Error(`Could not find ${thing} from "${r}"`),
+      ),
+    );
+};

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -37,6 +37,11 @@ export class ResourcesHost {
     return map;
   }
 
+  async getNames() {
+    const map = await this.getMap();
+    return Object.keys(map) as Array<keyof ResourceMap>;
+  }
+
   async getEnhancedMap(): Promise<EnhancedResourceMap> {
     const map = await this.getMap();
     return mapValues(map, EnhancedResource.of) as any;

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -19,7 +19,7 @@ export type EnhancedResourceMap = {
 
 type LooseResourceName = LiteralUnion<keyof ResourceMap, string>;
 
-type ResourceRef =
+export type ResourceLike =
   | ResourceShape<any>
   | EnhancedResource<any>
   | LooseResourceName;
@@ -61,7 +61,7 @@ export class ResourcesHost {
     return await this.getByName(name as any);
   }
 
-  async verifyImplements(resource: ResourceRef, theInterface: ResourceRef) {
+  async verifyImplements(resource: ResourceLike, theInterface: ResourceLike) {
     const iface = await this.enhance(theInterface);
     if (!(await this.doesImplement(resource, iface))) {
       throw new InvalidIdForTypeException(
@@ -70,12 +70,12 @@ export class ResourcesHost {
     }
   }
 
-  async doesImplement(resource: ResourceRef, theInterface: ResourceRef) {
+  async doesImplement(resource: ResourceLike, theInterface: ResourceLike) {
     const interfaces = await this.getInterfaces(await this.enhance(resource));
     return interfaces.includes(await this.enhance(theInterface));
   }
 
-  private async enhance(ref: ResourceRef) {
+  async enhance(ref: ResourceLike) {
     return typeof ref === 'string'
       ? await this.getByDynamicName(ref)
       : EnhancedResource.of(ref);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2130,6 +2130,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@leeoniya/ufuzzy@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "@leeoniya/ufuzzy@npm:1.0.8"
+  checksum: 899a9269fa72c773c4806ff6ca7277a9ed69a8e3e7f0e8db9d3f4c9aa9c23d1d5c1df1e5cbea47d720af85ae6aa2ad88822443cd18ef94631876b96d23f4d7e2
+  languageName: node
+  linkType: hard
+
 "@lukeed/csprng@npm:^1.0.0":
   version: 1.1.0
   resolution: "@lukeed/csprng@npm:1.1.0"
@@ -5107,6 +5114,7 @@ __metadata:
     "@aws-sdk/s3-request-presigner": ^3.370.0
     "@faker-js/faker": ^8.0.2
     "@golevelup/nestjs-discovery": ^4.0.0
+    "@leeoniya/ufuzzy": ^1.0.8
     "@nestjs/apollo": ^12.0.7
     "@nestjs/cli": ^10.1.10
     "@nestjs/common": ^10.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -4736,7 +4736,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-table3@npm:0.6.3":
+"cli-table3@npm:0.6.3, cli-table3@npm:^0.6.3":
   version: 0.6.3
   resolution: "cli-table3@npm:0.6.3"
   dependencies:
@@ -5143,6 +5143,7 @@ __metadata:
     aws-xray-sdk-core: ^3.5.1
     class-transformer: ^0.5.1
     class-validator: ^0.14.0
+    cli-table3: ^0.6.3
     commander: ^11.0.0
     common-tags: ^1.8.2
     cookie-parser: ^1.4.6


### PR DESCRIPTION
## Run with
With REPL
```ts
await $(PolicyDumper).dump('<role>', '<resource>')
```
With CLI
```bash
yarn console policy:dump <role> <resource>
```

## The role/resource input actually searches similar to how your IDE does it.
- `langEng` -> `LanguageEngagement`
- `VarExp` -> `ProgressReportVarianceExplanation`
- `rcc` -> `RegionalCommunicationsCoordinator`

![Screenshot 2023-08-04 at 10 31 15 AM](https://github.com/SeedCompany/cord-api-v3/assets/932566/202c13f6-36f8-411b-929f-53c6f8d95809)

## Multiple roles or resources can be given as well separated by comma
![Screenshot 2023-08-04 at 10 33 01 AM](https://github.com/SeedCompany/cord-api-v3/assets/932566/bbdaee33-5d37-49f7-b8bf-6ed5e609bf45)
![Screenshot 2023-08-04 at 10 33 32 AM](https://github.com/SeedCompany/cord-api-v3/assets/932566/c21c47a5-a36c-4099-9d3c-e15e2a7e21b7)
![Screenshot 2023-08-04 at 10 33 56 AM](https://github.com/SeedCompany/cord-api-v3/assets/932566/45acf11c-41f1-40d7-88a9-d29ac26760b3)

## `*` or `_` can be used to select everything
![Screenshot 2023-08-04 at 10 35 30 AM](https://github.com/SeedCompany/cord-api-v3/assets/932566/58050a66-7425-4280-b4bf-f1ade596705f)
![Screenshot 2023-08-04 at 10 35 58 AM](https://github.com/SeedCompany/cord-api-v3/assets/932566/1ae5d72d-f150-4b75-b2e0-3af060f61690)

## Properties can be selected too
![Screenshot 2023-08-04 at 10 38 03 AM](https://github.com/SeedCompany/cord-api-v3/assets/932566/27cb6589-fef6-4849-802a-17d4c3a6b441)
![Screenshot 2023-08-04 at 10 38 46 AM](https://github.com/SeedCompany/cord-api-v3/assets/932566/e5a28239-fa68-449d-b57a-47697e602250)
![Screenshot 2023-08-04 at 10 39 15 AM](https://github.com/SeedCompany/cord-api-v3/assets/932566/200196d6-34e9-4d88-be63-cdce84e4087c)


![Screenshot 2023-08-04 at 2 40 59 PM](https://github.com/SeedCompany/cord-api-v3/assets/932566/7bae7b84-b4dd-4cb6-a856-1931be14aa66)
![Screenshot 2023-08-04 at 2 42 12 PM](https://github.com/SeedCompany/cord-api-v3/assets/932566/70092d00-e310-4090-8ce6-18468d0b7379)


┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4933361952) by [Unito](https://www.unito.io)
