### PR TITLE
Separate DB Type from Unsecured Type / Refactor Product Scripture Parsing

### DIFF
--- a/src/components/ethno-art/ethno-art.repository.ts
+++ b/src/components/ethno-art/ethno-art.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Query } from 'cypher-query-builder';
-import { ID, Session, UnsecuredDto } from '../../common';
-import { DatabaseService, DtoRepository } from '../../core';
+import { ID, Session } from '../../common';
+import { DatabaseService, DbTypeOf, DtoRepository } from '../../core';
 import {
   createNode,
   matchProps,
@@ -48,7 +48,7 @@ export class EthnoArtRepository extends DtoRepository(EthnoArt) {
       query
         .apply(matchProps())
         .subQuery('node', this.scriptureRefs.list())
-        .return<{ dto: UnsecuredDto<EthnoArt> }>(
+        .return<{ dto: DbTypeOf<EthnoArt> }>(
           merge('props', {
             scriptureReferences: 'scriptureReferences',
           }).as('dto'),

--- a/src/components/ethno-art/ethno-art.service.ts
+++ b/src/components/ethno-art/ethno-art.service.ts
@@ -7,9 +7,8 @@ import {
   ServerException,
   Session,
   UnauthorizedException,
-  UnsecuredDto,
 } from '../../common';
-import { HandleIdLookup, ILogger, Logger } from '../../core';
+import { DbTypeOf, HandleIdLookup, ILogger, Logger } from '../../core';
 import { ifDiff } from '../../core/database/changes';
 import { mapListResults } from '../../core/database/results';
 import { AuthorizationService } from '../authorization/authorization.service';
@@ -80,7 +79,7 @@ export class EthnoArtService {
   }
 
   private async secure(
-    dto: UnsecuredDto<EthnoArt>,
+    dto: DbTypeOf<EthnoArt>,
     session: Session,
   ): Promise<EthnoArt> {
     const securedProps = await this.authorizationService.secureProperties(

--- a/src/components/film/film.repository.ts
+++ b/src/components/film/film.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { node, Query } from 'cypher-query-builder';
-import { ID, Session, UnsecuredDto } from '../../common';
-import { DatabaseService, DtoRepository } from '../../core';
+import { ID, Session } from '../../common';
+import { DatabaseService, DbTypeOf, DtoRepository } from '../../core';
 import {
   createNode,
   matchProps,
@@ -52,7 +52,7 @@ export class FilmRepository extends DtoRepository(Film) {
       query
         .apply(matchProps())
         .subQuery('node', this.scriptureRefs.list())
-        .return<{ dto: UnsecuredDto<Film> }>(
+        .return<{ dto: DbTypeOf<Film> }>(
           merge('props', {
             scriptureReferences: 'scriptureReferences',
           }).as('dto'),

--- a/src/components/film/film.service.ts
+++ b/src/components/film/film.service.ts
@@ -8,9 +8,8 @@ import {
   ServerException,
   Session,
   UnauthorizedException,
-  UnsecuredDto,
 } from '../../common';
-import { HandleIdLookup, ILogger, Logger } from '../../core';
+import { DbTypeOf, HandleIdLookup, ILogger, Logger } from '../../core';
 import { ifDiff } from '../../core/database/changes';
 import { mapListResults } from '../../core/database/results';
 import { AuthorizationService } from '../authorization/authorization.service';
@@ -85,10 +84,7 @@ export class FilmService {
     return await Promise.all(films.map((dto) => this.secure(dto, session)));
   }
 
-  private async secure(
-    dto: UnsecuredDto<Film>,
-    session: Session,
-  ): Promise<Film> {
+  private async secure(dto: DbTypeOf<Film>, session: Session): Promise<Film> {
     const securedProps = await this.authorizationService.secureProperties(
       Film,
       {

--- a/src/components/product/dto/producible.dto.ts
+++ b/src/components/product/dto/producible.dto.ts
@@ -6,12 +6,12 @@ import {
 } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { SetDbType } from '~/core/database';
 import { RegisterResource } from '~/core/resources';
 import {
   Resource,
   SecuredProperty,
   SecuredProps,
-  SetUnsecuredType,
   UnsecuredDto,
 } from '../../../common';
 import { SetChangeType } from '../../../core/database/changes';
@@ -37,7 +37,7 @@ export abstract class Producible extends Resource {
 
   @Field(() => SecuredScriptureRanges)
   readonly scriptureReferences: SecuredScriptureRanges &
-    SetUnsecuredType<DbScriptureReferences> &
+    SetDbType<DbScriptureReferences> &
     SetChangeType<'scriptureReferences', readonly ScriptureRangeInput[]>;
 }
 

--- a/src/components/product/dto/product.dto.ts
+++ b/src/components/product/dto/product.dto.ts
@@ -3,6 +3,7 @@ import { stripIndent } from 'common-tags';
 import { startCase } from 'lodash';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { MergeExclusive } from 'type-fest';
+import { SetDbType } from '~/core';
 import { RegisterResource } from '~/core/resources';
 import {
   DbLabel,
@@ -16,7 +17,6 @@ import {
   Sensitivity,
   SensitivityField,
   ServerException,
-  SetUnsecuredType,
   UnsecuredDto,
 } from '../../../common';
 import { SetChangeType } from '../../../core/database/changes';
@@ -184,7 +184,7 @@ export class DerivativeScriptureProduct extends Product {
     `,
   })
   readonly scriptureReferencesOverride: SecuredScriptureRangesOverride &
-    SetUnsecuredType<DbScriptureReferences | null> &
+    SetDbType<DbScriptureReferences | null> &
     SetChangeType<
       'scriptureReferencesOverride',
       readonly ScriptureRangeInput[] | null

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -16,9 +16,13 @@ import {
   Range,
   ServerException,
   Session,
-  UnsecuredDto,
 } from '../../common';
-import { CommonRepository, DatabaseService, OnIndex } from '../../core';
+import {
+  CommonRepository,
+  DatabaseService,
+  DbTypeOf,
+  OnIndex,
+} from '../../core';
 import { DbChanges, getChanges } from '../../core/database/changes';
 import {
   ACTIVE,
@@ -51,7 +55,7 @@ import {
   DirectScriptureProduct,
   ProductMethodology as Methodology,
   OtherProduct,
-  ProducibleRef,
+  Producible,
   ProducibleType,
   Product,
   ProductCompletionDescriptionSuggestionsInput,
@@ -62,14 +66,14 @@ import {
 
 export type HydratedProductRow = Merge<
   Omit<
-    UnsecuredDto<
+    DbTypeOf<
       DirectScriptureProduct & DerivativeScriptureProduct & OtherProduct
     >,
     'scriptureReferencesOverride'
   >,
   {
     isOverriding: boolean;
-    produces: Merge<ProducibleRef, { __typename: string[] }> | null;
+    produces: Merge<DbTypeOf<Producible>, { __typename: string[] }> | null;
     unspecifiedScripture: UnspecifiedScripturePortion | null;
   }
 >;

--- a/src/components/prompts/prompt-variant-response.repository.ts
+++ b/src/components/prompts/prompt-variant-response.repository.ts
@@ -14,6 +14,7 @@ import {
   VariantOf,
 } from '~/common';
 import { DtoRepository } from '~/core';
+import { DbTypeOf } from '~/core/database/db-type';
 import { privileges } from '~/core/database/dto.repository';
 import {
   ACTIVE,
@@ -120,7 +121,7 @@ export const PromptVariantResponseRepository = <
               )
               .return('collect(response) as responses'),
           )
-          .return<{ dto: UnsecuredDto<InstanceType<TResourceStatic>> }>(
+          .return<{ dto: DbTypeOf<InstanceType<TResourceStatic>> }>(
             merge('node', {
               parent: 'parent',
               prompt: 'prompt.value',

--- a/src/components/story/story.repository.ts
+++ b/src/components/story/story.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Query } from 'cypher-query-builder';
-import { ID, Session, UnsecuredDto } from '../../common';
+import { DbTypeOf } from '~/core/database/db-type';
+import { ID, Session } from '../../common';
 import { DatabaseService, DtoRepository } from '../../core';
 import {
   createNode,
@@ -50,7 +51,7 @@ export class StoryRepository extends DtoRepository(Story) {
       query
         .apply(matchProps())
         .subQuery('node', this.scriptureRefs.list())
-        .return<{ dto: UnsecuredDto<Story> }>(
+        .return<{ dto: DbTypeOf<Story> }>(
           merge('props', {
             scriptureReferences: 'scriptureReferences',
           }).as('dto'),

--- a/src/components/story/story.service.ts
+++ b/src/components/story/story.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { DbTypeOf } from '~/core/database/db-type';
 import {
   DuplicateException,
   ID,
@@ -7,7 +8,6 @@ import {
   ServerException,
   Session,
   UnauthorizedException,
-  UnsecuredDto,
 } from '../../common';
 import { HandleIdLookup, ILogger, Logger } from '../../core';
 import { ifDiff } from '../../core/database/changes';
@@ -82,10 +82,7 @@ export class StoryService {
     return await Promise.all(stories.map((dto) => this.secure(dto, session)));
   }
 
-  private async secure(
-    dto: UnsecuredDto<Story>,
-    session: Session,
-  ): Promise<Story> {
+  private async secure(dto: DbTypeOf<Story>, session: Session): Promise<Story> {
     const securedProps = await this.authorizationService.secureProperties(
       Story,
       {

--- a/src/core/database/db-type.ts
+++ b/src/core/database/db-type.ts
@@ -1,0 +1,26 @@
+import { UnwrapSecured } from '~/common';
+
+/**
+ * Specify this on a property to override the key & value type for DbTypeOf on
+ * the object.
+ *
+ * @example
+ * class Foo {
+ *   color: string & SetDbType<'hexColor', number>
+ * }
+ * const changes: DbTypeOf<Foo> = {
+ *   hexColor: 0xFFFFFF,
+ * };
+ */
+export interface SetDbType<Value> {
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- shush we are hiding this. It's only for TS types.
+  __db_type__?: Value;
+}
+
+export type DbTypeOf<Dto> = {
+  [K in keyof Dto as Exclude<K, 'canDelete'>]: DbValueOf<Dto[K]>;
+};
+
+type DbValueOf<Val> = Val extends SetDbType<infer Override>
+  ? Override
+  : UnwrapSecured<Val>;

--- a/src/core/database/dto.repository.ts
+++ b/src/core/database/dto.repository.ts
@@ -15,6 +15,7 @@ import {
 import { Privileges } from '../../components/authorization';
 import { DbChanges, getChanges } from './changes';
 import { CommonRepository } from './common.repository';
+import { DbTypeOf } from './db-type';
 import { OnIndex } from './indexer';
 import { matchProps } from './query';
 
@@ -137,7 +138,7 @@ export const DtoRepository = <
       return (query: Query) =>
         query
           .apply(matchProps())
-          .return<{ dto: UnsecuredDto<TResource> }>('props as dto');
+          .return<{ dto: DbTypeOf<TResource> }>('props as dto');
     }
 
     @OnIndex()

--- a/src/core/database/index.ts
+++ b/src/core/database/index.ts
@@ -6,3 +6,4 @@ export * from './common.repository';
 export { DtoRepository } from './dto.repository';
 export * from './indexer';
 export * from './migration';
+export * from './db-type';


### PR DESCRIPTION
Now we have
```
DB Type -> Unsecured Type -> Type
```
This let's us handle DB results separately from the securing/authorization logic.

As we now do with the product's scripture references.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/4995334605) by [Unito](https://www.unito.io)
