### PR TITLE
Fix/Remove trailing spaces on logged cypher queries

### DIFF
--- a/src/core/database/highlight-cypher.util.ts
+++ b/src/core/database/highlight-cypher.util.ts
@@ -9,7 +9,15 @@ export function highlight(query: string) {
     padding: 0,
     theme,
   });
-  pretty = pretty.split('\n').slice(0, -1).join('\n');
+  pretty = pretty
+    .split('\n')
+    .slice(0, -1)
+    // strip off trailing spaces meant for a "code block background."
+    // we don't set a background color, and this makes copy/pasting into
+    // neo4j editor painful.
+    // eslint-disable-next-line no-control-regex
+    .map((line) => line.replace(/( )+\u001B\[39m$/, ''))
+    .join('\n');
   return pretty;
 }
 


### PR DESCRIPTION
The library added them so the highlight makes a "block/square", which looks good when a background color is used.
However, we don't use a background color, and these spaces are copied. So pasting into Neo4j UI makes it hard to read/manipulate. 
Strip them off.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5005637349) by [Unito](https://www.unito.io)
