### PR TITLE
Fix Apollo Server v4 error handling

### DIFF
--- a/src/core/config/config.module.ts
+++ b/src/core/config/config.module.ts
@@ -11,9 +11,13 @@ import { VersionService } from './version.service';
       useFactory: (env: EnvironmentService) =>
         Object.assign(new ConfigService(), new (makeConfig(env))()),
     },
+    {
+      provide: 'CONFIG',
+      useExisting: ConfigService,
+    },
     EnvironmentService,
     VersionService,
   ],
-  exports: [ConfigService, VersionService],
+  exports: [ConfigService, 'CONFIG', VersionService],
 })
 export class ConfigModule {}

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -40,7 +40,8 @@ import { WaitResolver } from './wait.resolver';
   providers: [
     AwsS3Factory,
     ExceptionNormalizer,
-    { provide: APP_FILTER, useClass: ExceptionFilter },
+    ExceptionFilter,
+    { provide: APP_FILTER, useExisting: ExceptionFilter },
     { provide: APP_PIPE, useClass: ValidationPipe },
     { provide: APP_INTERCEPTOR, useClass: TimeoutInterceptor },
     WaitResolver,

--- a/src/core/exception/exception.normalizer.ts
+++ b/src/core/exception/exception.normalizer.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 // eslint-disable-next-line no-restricted-imports
 import * as Nest from '@nestjs/common';
 import { compact, uniq } from 'lodash';
@@ -10,8 +10,8 @@ import {
   JsonSet,
   simpleSwitch,
 } from '~/common';
-import { ConfigService } from '~/core';
-import * as Neo from '../database';
+import type { ConfigService } from '~/core';
+import * as Neo from '../database/errors';
 import { isSrcFrame } from './is-src-frame';
 import { normalizeFramePath } from './normalize-frame-path';
 
@@ -25,7 +25,7 @@ export interface ExceptionJson {
 
 @Injectable()
 export class ExceptionNormalizer {
-  constructor(private readonly config?: ConfigService) {}
+  constructor(@Inject('CONFIG') private readonly config?: ConfigService) {}
 
   normalize(ex: Error): ExceptionJson {
     const {


### PR DESCRIPTION
- [Fix ExceptionNormalizer dependency on ~/core](https://github.com/SeedCompany/cord-api-v3/commit/eb49b602744ef931253b8655dc9e5c05e456d84f) 
  Part of this is allowing `ConfigService` to be accessed by a string instead of the class ref
- [Unify ApolloServer error handling with our global exception filter](https://github.com/SeedCompany/cord-api-v3/commit/926e813e1241e96800b73f796a731416558e4a05) 
	Previously, some paths were not running through our exception filter.
	This may have been from the Apollo Server v4 upgrade.
	I noticed this with error through from a field resolver.
	
	All error -> output is handled in a unified spot.
	Now we check codes instead of regex matching messages, win.
- [Remove error logging from GraphqlLoggingPlugin](https://github.com/SeedCompany/cord-api-v3/commit/d8eff902c567f1f216ca31959d38d8667f85b68c) 
	This code path stopped working with Apollo Server v4.
	Their errors now have `extensions`, so it was hitting the early return.
	
	These errors are now handled in our normal code path with previous commit,
	so there's no need to restore this logic.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5034007362) by [Unito](https://www.unito.io)
