### PR TITLE
Fix `Postable.posts` resolution error

### DIFF
--- a/src/components/post/dto/postable.dto.ts
+++ b/src/components/post/dto/postable.dto.ts
@@ -19,8 +19,6 @@ export abstract class Postable {
   } satisfies ResourceRelationsShape;
   static readonly Parent = 'dynamic';
 
-  readonly __typename: string;
-
   @IdField({
     description: "The object's ID",
   })

--- a/src/components/post/post.service.ts
+++ b/src/components/post/post.service.ts
@@ -18,7 +18,8 @@ import { CreatePost, Post, Postable, UpdatePost } from './dto';
 import { PostListInput, SecuredPostList } from './dto/list-posts.dto';
 import { PostRepository } from './post.repository';
 
-type PostableRef = ID | BaseNode | Postable;
+type ConcretePostable = Postable & { __typename: string };
+type PostableRef = ID | BaseNode | ConcretePostable;
 
 @Injectable()
 export class PostService {
@@ -93,7 +94,7 @@ export class PostService {
   }
 
   async securedList(
-    parent: Postable & Resource,
+    parent: ConcretePostable & Resource,
     input: PostListInput,
     session: Session,
   ): Promise<SecuredPostList> {
@@ -125,7 +126,7 @@ export class PostService {
     return this.privileges.for(session, parentType, parent).forEdge('posts');
   }
 
-  private async loadPostable(resource: PostableRef): Promise<Postable> {
+  private async loadPostable(resource: PostableRef): Promise<ConcretePostable> {
     const parentNode = isIdLike(resource)
       ? await this.repo.getBaseNode(resource, Resource)
       : resource;
@@ -133,7 +134,7 @@ export class PostService {
       throw new NotFoundException('Resource does not exist', 'resourceId');
     }
     const parent = isBaseNode(parentNode)
-      ? ((await this.resources.loadByBaseNode(parentNode)) as Postable)
+      ? ((await this.resources.loadByBaseNode(parentNode)) as ConcretePostable)
       : parentNode;
 
     try {

--- a/src/components/post/postable.resolver.ts
+++ b/src/components/post/postable.resolver.ts
@@ -1,4 +1,5 @@
-import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Info, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { GraphQLResolveInfo } from 'graphql';
 import { ListArg, LoggedInSession, Resource, Session } from '~/common';
 import { Loader, LoaderOf } from '~/core';
 import { Postable } from './dto';
@@ -14,13 +15,17 @@ export class PostableResolver {
     description: 'List of posts belonging to the parent node.',
   })
   async posts(
+    @Info() info: GraphQLResolveInfo,
     @Parent() parent: Postable & Resource,
     @ListArg(PostListInput) input: PostListInput,
     @LoggedInSession() session: Session,
     @Loader(PostLoader) posts: LoaderOf<PostLoader>,
   ): Promise<SecuredPostList> {
     const list = await this.service.securedList(
-      parent,
+      {
+        ...parent,
+        __typename: info.parentType.name,
+      },
       {
         ...input,
         filter: {

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -81,6 +81,11 @@ export class ResourcesHost {
   }
 
   async enhance(ref: ResourceLike) {
+    // Safety check, since this very dynamic code, it's very possible the types are lying.
+    // @eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (ref == null) {
+      throw new ServerException('Resource reference is actually null');
+    }
     return typeof ref === 'string'
       ? await this.getByDynamicName(ref)
       : EnhancedResource.of(ref);


### PR DESCRIPTION
- [Give a better error message when ResourceHost encounters null input](https://github.com/SeedCompany/cord-api-v3/commit/11caf17d7daeec8a460c5d12ec72c00b470236d0)

- [Change how Postable asks for __typename](https://github.com/SeedCompany/cord-api-v3/commit/c95fa372005ba6bf9c3fb51889eda2d3b28ba5fd) 
	Stop requiring implementations to declare the `__typename` field.
	This apparently was tricky for TS as it was missed in the _Project_ shapes.
	This string can also be gotten from GraphQL or `ResourceLoader`,
	so it's not always necessary to specify manually.
	
	Instead, we'll change types to only ask for `__typename`
	when the `PostableRef` is an actual `Postable` object.

- [Fix regression](https://github.com/SeedCompany/cord-api-v3/commit/6220c2894664d090425468f361c17b14038824d6) from d6790f0 where `Postable.posts` errored out because typename was missing
  Previous commit helps reveal this mistake.