### PR TITLE
Refactor ffprobe to use signed url instead of piped s3 object stream

### DIFF
--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -154,7 +154,7 @@ export class FileRepository extends CommonRepository {
     return result!;
   }
 
-  private hydrate() {
+  hydrate() {
     return (query: Query) =>
       query
         .subQuery((sub) =>
@@ -463,13 +463,13 @@ export class FileRepository extends CommonRepository {
         }),
       )
       .apply(this.defaultPublicFromParent(input.public))
-      .return<{ id: ID }>('node.id as id');
+      .apply(this.hydrate());
 
     const result = await createFile.first();
     if (!result) {
       throw new ServerException('Failed to create file version');
     }
-    return result;
+    return result.dto as FileVersion;
   }
 
   async rename(fileNode: FileNode, newName: string): Promise<void> {

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -154,7 +154,9 @@ export class FileService {
       await this.bucket.headObject(id);
       return await this.bucket.getSignedUrl(GetObject, {
         Key: id,
-        ResponseContentDisposition: `attachment; filename="${node.name}"`,
+        ResponseContentDisposition: `attachment; filename="${encodeURIComponent(
+          node.name,
+        )}"`,
         ResponseContentType: node.mimeType,
         ResponseCacheControl: this.determineCacheHeader(node),
         signing: {

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -14,7 +14,6 @@ import {
   DurationIn,
   generateId,
   ID,
-  IdOf,
   InputException,
   NotFoundException,
   ServerException,
@@ -318,7 +317,7 @@ export class FileService {
     const mimeType =
       mimeTypeOverride ?? upload?.ContentType ?? 'application/octet-stream';
 
-    await this.repo.createFileVersion(
+    const fv = await this.repo.createFileVersion(
       fileId,
       {
         id: uploadId,
@@ -357,16 +356,7 @@ export class FileService {
       }
     }
 
-    await this.mediaService.detectAndSave(
-      this.asDownloadable(
-        {
-          file: uploadId as IdOf<FileVersion>,
-          mimeType,
-          ...media,
-        },
-        uploadId,
-      ),
-    );
+    await this.mediaService.detectAndSave(fv, media);
 
     // Change the file's name to match the latest version name
     await this.rename({ id: fileId, name }, session);

--- a/src/components/file/media/media.module.ts
+++ b/src/components/file/media/media.module.ts
@@ -1,4 +1,5 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
+import { FileModule } from '../file.module';
 import { DetectExistingMediaMigration } from './detect-existing-media.migration';
 import { DimensionsResolver } from './dimensions.resolver';
 import { MediaByFileVersionLoader } from './media-by-file-version.loader';
@@ -9,6 +10,7 @@ import { MediaResolver } from './media.resolver';
 import { MediaService } from './media.service';
 
 @Module({
+  imports: [forwardRef(() => FileModule)],
   providers: [
     DimensionsResolver,
     MediaByFileVersionLoader,

--- a/src/components/file/media/media.service.ts
+++ b/src/components/file/media/media.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { Except, RequireAtLeastOne } from 'type-fest';
-import { NotFoundException, ServerException } from '~/common';
-import { Downloadable } from '../dto';
+import { RequireAtLeastOne } from 'type-fest';
+import { IdOf, NotFoundException, ServerException } from '~/common';
+import { FileVersion } from '../dto';
 import { MediaDetector } from './media-detector.service';
-import { AnyMedia, Media, MediaUserMetadata } from './media.dto';
+import { AnyMedia, MediaUserMetadata } from './media.dto';
 import { MediaRepository } from './media.repository';
 
 @Injectable()
@@ -13,12 +13,17 @@ export class MediaService {
     private readonly repo: MediaRepository,
   ) {}
 
-  async detectAndSave(input: Downloadable<Except<Media, 'id' | '__typename'>>) {
-    const media = await this.detector.detect(input);
+  async detectAndSave(file: FileVersion, metadata?: MediaUserMetadata) {
+    const media = await this.detector.detect(file);
     if (!media) {
       return null;
     }
-    return await this.repo.create({ ...input, ...media });
+    return await this.repo.create({
+      file: file.id as IdOf<FileVersion>,
+      mimeType: file.mimeType,
+      ...media,
+      ...metadata,
+    });
   }
 
   async updateUserMetadata(


### PR DESCRIPTION
I think this ends up being better in every way.

NodeJS doesn't have to worry about piping streams, and the hangs that were occurring there.

Additionally, even when the previous process worked, we got a detected duration of 0. This is some difference with ffprobe.
Input streams would give this, but files/urls are detected correctly.

I upgraded the migration as well to re-detect any existing media that has a duration of 0.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5095334479) by [Unito](https://www.unito.io)
