### PR TITLE
Use native ffprobe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 # Base node stage that sets up common config for dev & prod
 FROM public.ecr.aws/docker/library/node:18-slim as node
 
-# Add wget in for healthchecks
+# Install these native packages
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates wget curl \
+    && apt-get install -y --no-install-recommends \
+      ca-certificates wget curl \
+      # Install ffprobe from here, as the npm version is manually published and as of comment segfaults with urls
+      ffmpeg \
     && apt-get clean -q -y \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
If `ffprobe` is in `PATH`, then use that as It's more likely that it's to update since it uses
(1st party?) native package manager releases.

The npm one is only manually updated/published.
It'll be good for fallback/dev, but native will be better.

The npm linux version segfaults with urls, so this fixes that.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5110763105) by [Unito](https://www.unito.io)
