### PR TITLE
Unify media saving queries / Fix duplicate media nodes

### DIFF
--- a/src/components/file/media/media.service.ts
+++ b/src/components/file/media/media.service.ts
@@ -18,7 +18,7 @@ export class MediaService {
     if (!media) {
       return null;
     }
-    return await this.repo.create({
+    return await this.repo.save({
       file: file.id as IdOf<FileVersion>,
       mimeType: file.mimeType,
       ...media,
@@ -30,7 +30,7 @@ export class MediaService {
     input: RequireAtLeastOne<Pick<AnyMedia, 'id' | 'file'>> & MediaUserMetadata,
   ) {
     try {
-      return await this.repo.update(input);
+      return await this.repo.save(input);
     } catch (e) {
       if (e instanceof ServerException) {
         const exists = await this.repo.getBaseNode(


### PR DESCRIPTION
I was mistakenly creating multiple media nodes with each migration attempt.
This fixes that by merging, so a media node is only created when needed.

I could've done other ways too, but this seems better as now it's idempotent.

Also dropping duplicate media nodes as well.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5111740158) by [Unito](https://www.unito.io)
