### PR TITLE
Add the root node and resource attached to root node to hydrated FileNode

### DIFF
--- a/src/components/file/dto/node.ts
+++ b/src/components/file/dto/node.ts
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon';
 import { Readable } from 'stream';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { MergeExclusive, Opaque } from 'type-fest';
+import { BaseNode } from '~/core/database/results';
 import { RegisterResource } from '~/core/resources';
 import {
   DateTimeField,
@@ -69,6 +70,12 @@ abstract class FileNode extends Resource {
   readonly public: boolean;
 
   readonly createdById: ID;
+
+  /** The root FileNode. This could be self */
+  readonly root: BaseNode;
+
+  /** The resource the root FileNode is attached to */
+  readonly rootAttachedTo: [resource: BaseNode, relationName: string];
 }
 
 // class name has to match schema name for interface resolvers to work.

--- a/src/components/file/events/after-file-upload.event.ts
+++ b/src/components/file/events/after-file-upload.event.ts
@@ -1,0 +1,9 @@
+import { File } from '../dto';
+
+/**
+ * Emitted as the last step of the file upload process.
+ * Feel free to throw to abort mutation.
+ */
+export class AfterFileUploadEvent {
+  constructor(readonly file: File) {}
+}

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -227,6 +227,12 @@ export class FileService {
     return await this.getDirectory(id, session);
   }
 
+  async createRootDirectory(
+    ...args: Parameters<FileRepository['createRootDirectory']>
+  ) {
+    return await this.repo.createRootDirectory(...args);
+  }
+
   async requestUpload(): Promise<RequestUploadOutput> {
     const id = await generateId();
     const url = await this.bucket.getSignedUrl(PutObject, {

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -8,7 +8,6 @@ import { Connection } from 'cypher-query-builder';
 import { intersection } from 'lodash';
 import { Duration } from 'luxon';
 import { Readable } from 'stream';
-import { withAddedPath } from '~/common/url.util';
 import {
   DuplicateException,
   DurationIn,
@@ -19,8 +18,9 @@ import {
   ServerException,
   Session,
   UnauthorizedException,
-} from '../../common';
-import { ConfigService, ILogger, Logger } from '../../core';
+} from '~/common';
+import { withAddedPath } from '~/common/url.util';
+import { ConfigService, IEventBus, ILogger, Logger } from '~/core';
 import { FileBucket } from './bucket';
 import {
   CreateDefinedFileVersionInput,
@@ -41,6 +41,7 @@ import {
   RenameFileInput,
   RequestUploadOutput,
 } from './dto';
+import { AfterFileUploadEvent } from './events/after-file-upload.event';
 import { FileUrlController as FileUrl } from './file-url.controller';
 import { FileRepository } from './file.repository';
 import { MediaService } from './media/media.service';
@@ -53,6 +54,7 @@ export class FileService {
     private readonly db: Connection,
     private readonly config: ConfigService,
     private readonly mediaService: MediaService,
+    private readonly eventBus: IEventBus,
     @Logger('file:service') private readonly logger: ILogger,
   ) {}
 
@@ -361,7 +363,11 @@ export class FileService {
     // Change the file's name to match the latest version name
     await this.rename({ id: fileId, name }, session);
 
-    return await this.getFile(fileId, session);
+    const file = await this.getFile(fileId, session);
+
+    await this.eventBus.publish(new AfterFileUploadEvent(file));
+
+    return file;
   }
 
   private async validateParentNode(

--- a/test/utility/create-directory.ts
+++ b/test/utility/create-directory.ts
@@ -14,14 +14,14 @@ export async function createRootDirectory(app: TestApp, name?: string) {
     .get(AuthenticationService)
     .resumeSession(app.graphql.authToken);
   const session = loggedInSession(rawSession);
-  const actual = await app
-    .get(FileService)
-    .createDirectory(undefined, name, session);
-
-  expect(actual).toBeTruthy();
-  expect(actual.name).toBe(name);
-
-  return actual;
+  const id = await app.get(FileService).createRootDirectory({
+    // An attachment point is required, so just use the current user.
+    resource: { __typename: 'User', id: session.userId },
+    relation: 'dir',
+    name,
+    session,
+  });
+  return await app.get(FileService).getDirectory(id, session);
 }
 
 export async function createDirectory(


### PR DESCRIPTION
Part of work for #2883, pulled out as this logic can stand on its own.

- `FileNode`'s now return the `root` `FileNode` from the DB
- `FileNode`'s now return the _resource_ and _relation_ the _root_ `FileNode` is attached to.

This allows other parts of the application to start doing more complex logic with these files.
For example, authorization has mostly been stubbed. This is the first step in knowing where the file "lives" under, in order to facilitate more fine grain checks.

This change requires `FileNode`'s to not be orphaned. This affects how project's root directories were created. So that has been refactored, and now is one less DB call too.

I also added an event for `AfterFileUpload`, which doesn't relate at all other than being in the file service. It will allow other parts of the app to hook into file uploads for verification.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5125562810) by [Unito](https://www.unito.io)
