### PR TITLE
Media 1.1 / Polls / Event Injection

### DIFF
--- a/src/common/create-and-inject.ts
+++ b/src/common/create-and-inject.ts
@@ -1,0 +1,18 @@
+import { ModuleRef } from '@nestjs/core';
+import { pickBy } from 'lodash';
+import { Class } from 'type-fest';
+
+/**
+ * A helper to create an instance of a class and inject dependencies.
+ */
+export async function createAndInject<T extends Class<any>>(
+  moduleRef: ModuleRef,
+  type: T,
+  ...input: ConstructorParameters<T>
+): Promise<InstanceType<T>> {
+  const injection = await moduleRef.resolve(type);
+  const injectionProps = pickBy(injection);
+  const object = new type(...input);
+  Object.assign(object, injectionProps);
+  return object;
+}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -26,6 +26,7 @@ export * from './pagination.input';
 export * from './pagination-list';
 export * from './parent-id.middleware';
 export * from './parent-types';
+export * from './poll';
 export * from './resource.dto';
 export * from './role.dto';
 export * from './secured-list';

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -3,6 +3,7 @@ export { Many, many, maybeMany, JsonSet, ArrayItem } from '@seedcompany/common';
 export * from './temporal';
 export * from './calculated.decorator';
 export * from './context.type';
+export * from './create-and-inject';
 export * from './data-object';
 export * from './date-filter.input';
 export { DbLabel } from './db-label.decorator';

--- a/src/common/poll.ts
+++ b/src/common/poll.ts
@@ -1,0 +1,124 @@
+import { setOf } from '@seedcompany/common';
+
+export class PollResults<T> {
+  constructor(protected readonly data: PollData<T>) {}
+
+  /** Returns true if there were any votes */
+  get anyVotes() {
+    return this.numberOfVotes > 0;
+  }
+
+  /** Returns true if there were no votes */
+  get noVotes() {
+    return this.numberOfVotes === 0;
+  }
+
+  get numberOfVotes() {
+    return [...this.data.votes.values()].reduce((total, cur) => total + cur, 0);
+  }
+
+  get vetoed() {
+    return this.data.vetoed;
+  }
+
+  /** Returns if there was a tie for the highest votes */
+  get tie() {
+    const [highest, second] = this.sorted;
+    return highest && second ? highest[1] === second[1] : false;
+  }
+
+  /** Returns the largest minority vote (could be majority too), if there was one */
+  get plurality() {
+    const [highest, second] = this.sorted;
+    if (!highest) {
+      return undefined;
+    }
+    return highest[1] > (second?.[1] ?? 0) ? highest[0] : undefined;
+  }
+
+  /** Returns the majority vote (>50%), if there was one */
+  get majority() {
+    const [first] = this.sorted;
+    if (!first) {
+      return undefined;
+    }
+    return first[1] > this.numberOfVotes / 2 ? first[0] : undefined;
+  }
+
+  /** Returns the unanimous vote, if there was one */
+  get unanimous() {
+    const all = this.sorted;
+    return all.length === 1 ? all[0][0] : undefined;
+  }
+
+  /** Returns all votes sorted by most voted first (ties are unaccounted for) */
+  get allVotes() {
+    return setOf(this.sorted.map(([vote]) => vote));
+  }
+
+  private get sorted() {
+    return [...this.data.votes].sort((a, b) => b[1] - a[1]);
+  }
+}
+
+/**
+ * @example
+ * const poll = new Poll();
+ *
+ * poll.noVotes; // true
+ * poll.vote(true);
+ * poll.unanimous; // true
+ * poll.anyVotes; // true
+ *
+ * poll.vote(false);
+ * poll.unanimous; // undefined
+ * poll.tie; // true
+ * poll.majority; // undefined
+ * poll.plurality; // undefined
+ *
+ * poll.vote(true);
+ * poll.majority; // true
+ * poll.plurality; // true
+ */
+export class Poll<T = boolean> extends PollResults<T> implements PollVoter<T> {
+  // Get a view of this poll, with results hidden.
+  readonly voter: PollVoter<T> = this;
+  // Get a readonly view of this poll's results.
+  readonly results: PollResults<T> = this;
+
+  constructor() {
+    super(new PollData<T>());
+  }
+
+  vote(vote: T) {
+    this.data.votes.set(vote, (this.data.votes.get(vote) ?? 0) + 1);
+  }
+
+  veto() {
+    this.data.vetoed = true;
+  }
+}
+
+/**
+ * The mutations available for a poll.
+ */
+export abstract class PollVoter<T> {
+  /** Cast a vote. */
+  abstract vote(vote: T): void;
+
+  /**
+   * Veto the poll all together.
+   * Multiple vetoes are allowed and are functionally the same.
+   * Consider using this instead of throwing an exception, for when you want to
+   * "cancel" the poll / override all other votes.
+   * Exceptions are for unexpected errors, where this veto would be a logical
+   * expectation, so throwing is not the best way to handle it.
+   * This could be enhanced in future to allow a reason for the veto.
+   */
+  abstract veto(): void;
+}
+
+class PollData<T> {
+  votes = new Map<T, number>();
+  vetoed = false;
+}

--- a/src/components/file/media/events/can-update-event.ts
+++ b/src/components/file/media/events/can-update-event.ts
@@ -1,3 +1,4 @@
+import { Injectable, Optional, Scope } from '@nestjs/common';
 import { PollVoter } from '~/common';
 import { AnyMedia, MediaUserMetadata } from '../media.dto';
 
@@ -5,10 +6,11 @@ import { AnyMedia, MediaUserMetadata } from '../media.dto';
  * An attempt to update the media metadata.
  * Vote with `allowUpdate` to control whether the update is allowed.
  */
+@Injectable({ scope: Scope.TRANSIENT })
 export class CanUpdateMediaUserMetadataEvent {
   constructor(
-    readonly media: AnyMedia,
-    readonly input: MediaUserMetadata,
-    readonly allowUpdate: PollVoter<boolean>,
+    @Optional() readonly media: AnyMedia,
+    @Optional() readonly input: MediaUserMetadata,
+    @Optional() readonly allowUpdate: PollVoter<boolean>,
   ) {}
 }

--- a/src/components/file/media/events/can-update-event.ts
+++ b/src/components/file/media/events/can-update-event.ts
@@ -1,5 +1,7 @@
-import { Injectable, Optional, Scope } from '@nestjs/common';
+import { Inject, Injectable, Optional, Scope } from '@nestjs/common';
+import { CachedByArg as Once } from '@seedcompany/common';
 import { PollVoter } from '~/common';
+import { ResourceResolver, ResourcesHost } from '~/core';
 import { AnyMedia, MediaUserMetadata } from '../media.dto';
 
 /**
@@ -8,9 +10,20 @@ import { AnyMedia, MediaUserMetadata } from '../media.dto';
  */
 @Injectable({ scope: Scope.TRANSIENT })
 export class CanUpdateMediaUserMetadataEvent {
+  @Inject() private readonly resourceHost: ResourcesHost;
+  @Inject() private readonly resourceResolver: ResourceResolver;
+
   constructor(
     @Optional() readonly media: AnyMedia,
     @Optional() readonly input: MediaUserMetadata,
     @Optional() readonly allowUpdate: PollVoter<boolean>,
   ) {}
+
+  @Once() async getAttachedResource() {
+    const attachedResName = this.resourceResolver.resolveTypeByBaseNode(
+      this.media.attachedTo[0],
+    );
+    const attachedResource = await this.resourceHost.getByName(attachedResName);
+    return attachedResource;
+  }
 }

--- a/src/components/file/media/events/can-update-event.ts
+++ b/src/components/file/media/events/can-update-event.ts
@@ -1,0 +1,14 @@
+import { PollVoter } from '~/common';
+import { AnyMedia, MediaUserMetadata } from '../media.dto';
+
+/**
+ * An attempt to update the media metadata.
+ * Vote with `allowUpdate` to control whether the update is allowed.
+ */
+export class CanUpdateMediaUserMetadataEvent {
+  constructor(
+    readonly media: AnyMedia,
+    readonly input: MediaUserMetadata,
+    readonly allowUpdate: PollVoter<boolean>,
+  ) {}
+}

--- a/src/components/file/media/media.dto.ts
+++ b/src/components/file/media/media.dto.ts
@@ -21,6 +21,7 @@ import {
   simpleSwitch,
 } from '~/common';
 import { BaseNode } from '~/core/database/results';
+import { RegisterResource } from '~/core/resources';
 import { FileVersion } from '../dto';
 
 export type AnyMedia = Image | Video | Audio;
@@ -68,6 +69,7 @@ export class MediaUserMetadata extends DataObject {
 @InterfaceType({
   resolveType: resolveMedia,
 })
+@RegisterResource()
 export class Media extends MediaUserMetadata {
   static readonly Props: string[] = keysOf<Media>();
   static readonly SecuredProps: string[] = keysOf<SecuredProps<Media>>();
@@ -140,4 +142,10 @@ export class Audio extends TemporalMedia {
   static readonly SecuredProps = keysOf<SecuredProps<Audio>>();
 
   declare __typename: 'Audio';
+}
+
+declare module '~/core/resources/map' {
+  interface ResourceMap {
+    Media: typeof Media;
+  }
 }

--- a/src/components/file/media/media.dto.ts
+++ b/src/components/file/media/media.dto.ts
@@ -20,6 +20,7 @@ import {
   ServerException,
   simpleSwitch,
 } from '~/common';
+import { BaseNode } from '~/core/database/results';
 import { FileVersion } from '../dto';
 
 export type AnyMedia = Image | Video | Audio;
@@ -77,6 +78,9 @@ export class Media extends MediaUserMetadata {
   readonly id: ID;
 
   readonly file: IdOf<FileVersion>;
+
+  /** The resource that holds the root file node that this media is attached to */
+  readonly attachedTo: [resource: BaseNode, relation: string];
 
   @Field(() => String)
   readonly mimeType: string;

--- a/src/components/file/media/media.loader.ts
+++ b/src/components/file/media/media.loader.ts
@@ -1,10 +1,10 @@
 import { DataLoaderStrategy } from '@seedcompany/data-loader';
 import { ID } from '~/common';
 import { LoaderFactory } from '~/core/resources';
-import { AnyMedia } from './media.dto';
+import { AnyMedia, Media } from './media.dto';
 import { MediaRepository } from './media.repository';
 
-@LoaderFactory()
+@LoaderFactory(() => Media)
 export class MediaLoader implements DataLoaderStrategy<AnyMedia, ID> {
   constructor(private readonly repo: MediaRepository) {}
 

--- a/src/components/file/media/media.module.ts
+++ b/src/components/file/media/media.module.ts
@@ -2,6 +2,7 @@ import { forwardRef, Module } from '@nestjs/common';
 import { FileModule } from '../file.module';
 import { DetectExistingMediaMigration } from './detect-existing-media.migration';
 import { DimensionsResolver } from './dimensions.resolver';
+import { CanUpdateMediaUserMetadataEvent } from './events/can-update-event';
 import { MediaByFileVersionLoader } from './media-by-file-version.loader';
 import { MediaDetector } from './media-detector.service';
 import { MediaLoader } from './media.loader';
@@ -20,6 +21,7 @@ import { MediaService } from './media.service';
     MediaResolver,
     MediaService,
     DetectExistingMediaMigration,
+    CanUpdateMediaUserMetadataEvent,
   ],
   exports: [MediaService],
 })

--- a/src/components/file/media/media.repository.ts
+++ b/src/components/file/media/media.repository.ts
@@ -154,10 +154,24 @@ export class MediaRepository extends CommonRepository {
       .apply(this.hydrate());
 
     const result = await query.first();
-    if (!result) {
-      throw new ServerException('Failed to save media info');
+    if (result) {
+      return result.dto;
     }
-    return result.dto;
+    if (input.file) {
+      const exists = await this.getBaseNode(input.file, 'FileVersion');
+      if (!exists) {
+        throw new NotFoundException(
+          'Media could not be saved to nonexistent file',
+        );
+      }
+    }
+    if (input.id) {
+      const exists = await this.getBaseNode(input.id, 'Media');
+      if (!exists) {
+        throw new NotFoundException('Media could not be found');
+      }
+    }
+    throw new ServerException('Failed to save media info');
   }
 }
 

--- a/src/components/file/media/media.service.ts
+++ b/src/components/file/media/media.service.ts
@@ -1,7 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import { RequireAtLeastOne } from 'type-fest';
-import { IdOf, NotFoundException, ServerException } from '~/common';
+import {
+  IdOf,
+  NotFoundException,
+  Poll,
+  ServerException,
+  UnauthorizedException,
+} from '~/common';
+import { IEventBus } from '~/core';
 import { FileVersion } from '../dto';
+import { CanUpdateMediaUserMetadataEvent } from './events/can-update-event';
 import { MediaDetector } from './media-detector.service';
 import { AnyMedia, MediaUserMetadata } from './media.dto';
 import { MediaRepository } from './media.repository';
@@ -11,6 +19,7 @@ export class MediaService {
   constructor(
     private readonly detector: MediaDetector,
     private readonly repo: MediaRepository,
+    private readonly eventBus: IEventBus,
   ) {}
 
   async detectAndSave(file: FileVersion, metadata?: MediaUserMetadata) {
@@ -29,6 +38,16 @@ export class MediaService {
   async updateUserMetadata(
     input: RequireAtLeastOne<Pick<AnyMedia, 'id' | 'file'>> & MediaUserMetadata,
   ) {
+    const media = await this.repo.readOne(input);
+    const poll = new Poll();
+    const event = new CanUpdateMediaUserMetadataEvent(media, input, poll);
+    await this.eventBus.publish(event);
+    if (!(poll.plurality && !poll.vetoed)) {
+      throw new UnauthorizedException(
+        'You do not have permission to update this media metadata',
+      );
+    }
+
     try {
       return await this.repo.save(input);
     } catch (e) {


### PR DESCRIPTION
Part of work for #2883, pulled out as this logic can stand on its own.

The biggest goal of this PR is to allow authorization to the `updateMediaMetadata` mutation to be configurable.
This is a generic mutation, but its objects are nested within other objects whose access is more fine tuned. We've basically ignored this concept so far in the application and assumed good actors...so here's the first step into fixing that.

I tried a few things here, that I'm not completely sure about. Just trying to see how it played out. Happy to receive feedback about it.

# Polls
The first is [polls](https://github.com/SeedCompany/cord-api-v3/blob/bf2dc3d86341fa53a4410cbb630e8181ceee3782/src/common/poll.ts). We needed event handlers to be communicate values back to the event source. 
My starting point was that multiple handlers could weigh in to this event. They should be able to do so without conflicting with, or being aware of, other handlers. Though we have [event handler prioritization](https://github.com/SeedCompany/cord-api-v3/blob/bf2dc3d86341fa53a4410cbb630e8181ceee3782/src/components/project/handlers/step-changed-notification.handler.ts#L13-L13), it's kinda a bad thing to rely on, since it needs to make some loose assumptions about handlers.

It made sense to make this it's own thing separate from events, so multiple events could use it.
It's generic so votes don't have to be only boolean, but can be enum values or anything.

The goal of `Polls` is to provide a standard way for the application to weigh in on X decision.
 
```ts
const whichColor = new Poll<Color>();
whichColor.vote('red');
whichColor.vote('green');
whichColor.vote('blue');
whichColor.vote('red');

whichColor.plurality // 'red'
whichColor.majority // undefined
whichColor.vote('red');
whichColor.majority // 'red' (3/5)
```

Admittedly this is possibly over engineered.
I take solace in the fact that this is well encapsulated, can be dropped in as single liners anywhere, and is flexible in result aggregation.

```ts
const allowUpdate = new Poll();
const event = new MyEvent(
  // Only allow event handlers to vote, not read results.
  allowUpdate.voter
);
// true if plurality voted true and no one vetoed.
const isAllowed = allowUpdate.plurality && !allowUpdate.vetoed;

// in handlers
event.allowUpdate.vote(true);
```

Again though it could simply be
```ts
const event = new MyEvent();
event.allowUpdate++;
const isAllowed = event.allowUpdate > 0;
```
However this does expose the current value, so handlers could base logic off it which is bad, since handlers run non deterministically.
The current value could be made private and an increment/decrement methods exposed. But that is more work for each event, which is what I was trying to avoid.
This also only works with boolean values, voting with anything else would have to be done differently.
This also doesn't capture ties.

Part of me also thinks that even just being in a situation where multiple places are voting on functionality sounds like spaghetti. In several places we have multiple event handlers for an event, but they only act on certain properties of the event. Leading to still a 1-1 situation for individual events, just decoupled.

It's probably too early to know if this is a good direction or not, since we don't have other use cases. 

This PR's concrete use case:
https://github.com/SeedCompany/cord-api-v3/blob/ea7f2b664adfb26179c73c01e447d21553b12ddc/src/components/file/media/media.service.ts#L38-L49
https://github.com/SeedCompany/cord-api-v3/blob/ea7f2b664adfb26179c73c01e447d21553b12ddc/src/components/file/media/events/can-update-event.ts#L4-L14
Vote happens in other PR:
https://github.com/SeedCompany/cord-api-v3/blob/d1a5870ffc691a0503e5493d0b1cc48f0b9af906/src/components/progress-report/media/handlers/update-media-metadata-check.handler.ts#L23-L27

# Partial Injection
This may be unique to events, since they are some of the only places we actually create instances ourselves.
And that's because each time they have different properties, obviously.
But what would it look like if they could also inject services as well? Is this even a good idea?
[Here](https://github.com/SeedCompany/cord-api-v3/commit/56990e898f3198e83ae01e9cf9fc6c09395cb610) I setup the event to be injectable, and added a thin helper to do that creation merging.
[Here](https://github.com/SeedCompany/cord-api-v3/commit/9c65a1b646e8daf907f70942a60ae56897d863b5) I injected service to discover more information about the event properties.
This could be in the service, and then passed into the event. That's how we do it everywhere else. This was an attempt to do it differently to see what we think.
A possible advantage of this is the logic could be skipped if no event handlers need it, though that's probably not likely.