### PR TITLE
Fix local file urls when using multiple file sources

### DIFF
--- a/src/components/file/bucket/local-bucket.ts
+++ b/src/components/file/bucket/local-bucket.ts
@@ -87,7 +87,7 @@ export abstract class LocalBucket<
     input: SignedOp<TCommandInput>,
   ) {
     const signed = JSON.stringify({
-      operation: operation.constructor.name,
+      operation: operation.name.replace(/Command$/, ''),
       ...input,
       signing: {
         ...input.signing,
@@ -119,7 +119,10 @@ export abstract class LocalBucket<
       const parsed = this.parseSignedUrl(u) as SignedOp<TCommandInput> & {
         operation: string;
       };
-      assert(parsed.operation === operation.constructor.name);
+      assert(
+        parsed.operation === operation.name ||
+          `${parsed.operation}Command` === operation.name,
+      );
       return parsed;
     } catch (e) {
       throw new InvalidSignedUrlException(e);

--- a/src/components/file/bucket/local-bucket.ts
+++ b/src/components/file/bucket/local-bucket.ts
@@ -10,10 +10,10 @@ import { DateTime, Duration } from 'luxon';
 import { URL } from 'node:url';
 import { Readable } from 'stream';
 import { assert } from 'ts-essentials';
-import { InputException } from '~/common';
 import {
   FileBucket,
   GetObjectOutput,
+  InvalidSignedUrlException,
   PutObjectInput,
   SignedOp,
 } from './file-bucket';
@@ -108,27 +108,37 @@ export abstract class LocalBucket<
     operation: Type<Command<TCommandInput, any, any>>,
     url: string,
   ): SignedOp<TCommandInput> & { Key: string } {
-    let raw;
+    let u: URL;
     try {
-      raw = new URL(url).searchParams.get('signed');
+      u = new URL(url);
     } catch (e) {
-      raw = url;
+      u = new URL('http://localhost');
+      u.searchParams.set('signed', url);
     }
-    assert(typeof raw === 'string');
-    let parsed;
     try {
-      parsed = JSON.parse(raw) as SignedOp<TCommandInput> & {
+      const parsed = this.parseSignedUrl(u) as SignedOp<TCommandInput> & {
         operation: string;
-        Key: string;
       };
       assert(parsed.operation === operation.constructor.name);
+      return parsed;
+    } catch (e) {
+      throw new InvalidSignedUrlException(e);
+    }
+  }
+
+  parseSignedUrl(url: URL) {
+    const raw = url.searchParams.get('signed');
+    let parsed;
+    try {
+      parsed = JSON.parse(raw || '') as SignedOp<{ operation: string }>;
+      assert(typeof parsed.operation === 'string');
       assert(typeof parsed.Key === 'string');
       assert(typeof parsed.signing.expiresIn === 'number');
     } catch (e) {
-      throw new InputException(e);
+      throw new InvalidSignedUrlException(e);
     }
     if (DateTime.local() > DateTime.fromMillis(parsed.signing.expiresIn)) {
-      throw new InputException('url expired');
+      throw new InvalidSignedUrlException('URL expired');
     }
     return parsed;
   }

--- a/src/components/file/bucket/readonly-bucket.ts
+++ b/src/components/file/bucket/readonly-bucket.ts
@@ -18,6 +18,10 @@ export class ReadonlyBucket extends FileBucket {
     return await this.source.getSignedUrl(operation, input);
   }
 
+  async parseSignedUrl(url: URL) {
+    return await this.source.parseSignedUrl(url);
+  }
+
   async getObject(key: string) {
     return await this.source.getObject(key);
   }


### PR DESCRIPTION
This was a known issue, because the `LocalBucketController` was not referencing the `FileBucket` interface but rather checking if the instance was a `LocalBucket`. This wasn't really a problem until I introduced the `CompositeBucket` and `ReadonlyBucket`. With these wrappers in mix, the `instanceof` check fails.

This is resolved by exposing the validation & parsing of signed urls from the `FileBucket` interface.
This allows the wrappers to forward the calls on dynamically.

With both that and the `putObject` methods in the interface, the controller can use those; replacing the `LocalBucket.upload()/download()` calls.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5196462075) by [Unito](https://www.unito.io)
