### PR TITLE
Only enable impersonation if logged in

### DIFF
--- a/src/components/authentication/authentication.service.ts
+++ b/src/components/authentication/authentication.service.ts
@@ -117,15 +117,16 @@ export class AuthenticationService {
       );
     }
 
-    impersonatee = impersonatee
-      ? {
-          id: impersonatee?.id,
-          roles: [
-            ...(impersonatee.roles ?? []),
-            ...(result.impersonateeRoles ?? []),
-          ],
-        }
-      : undefined;
+    impersonatee =
+      impersonatee && result.userId
+        ? {
+            id: impersonatee?.id,
+            roles: [
+              ...(impersonatee.roles ?? []),
+              ...(result.impersonateeRoles ?? []),
+            ],
+          }
+        : undefined;
 
     const requesterSession: Session = {
       token,


### PR DESCRIPTION
Situation is: caller calls session query with impersonation while not logged in.

Previously we threw an error that the impersonation was unauthorized.
This prevented the caller from ever establishing a session to login with.

Now we will just ignore their impersonation input if they are not logged in.
This allows a session to be established and login to be preformed.
After that point any operations will continue to error out if they are not authorized.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5203896421) by [Unito](https://www.unito.io)
