### PR TITLE
Note in schema which operations have sensitive secrets

### DIFF
--- a/src/components/authentication/login.resolver.ts
+++ b/src/components/authentication/login.resolver.ts
@@ -6,6 +6,7 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
 import { AnonSession, GqlContextType, Session } from '../../common';
 import { Loader, LoaderOf } from '../../core';
 import { Powers as Power, Privileges } from '../authorization';
@@ -21,7 +22,10 @@ export class LoginResolver {
   ) {}
 
   @Mutation(() => LoginOutput, {
-    description: 'Login a user',
+    description: stripIndent`
+      Login a user
+      @sensitive-secrets
+    `,
   })
   async login(
     @Args('input') input: LoginInput,
@@ -34,7 +38,10 @@ export class LoginResolver {
   }
 
   @Mutation(() => LogoutOutput, {
-    description: 'Logout a user',
+    description: stripIndent`
+      Logout a user
+      @sensitive-secrets
+    `,
   })
   async logout(
     @AnonSession() session: Session,

--- a/src/components/authentication/password.resolver.ts
+++ b/src/components/authentication/password.resolver.ts
@@ -1,4 +1,5 @@
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
 import { AnonSession, LoggedInSession, Session } from '../../common';
 import { AuthenticationService } from './authentication.service';
 import {
@@ -15,7 +16,10 @@ export class PasswordResolver {
   constructor(private readonly authentication: AuthenticationService) {}
 
   @Mutation(() => ChangePasswordOutput, {
-    description: 'Change your password',
+    description: stripIndent`
+      Change your password
+      @sensitive-secrets
+    `,
   })
   async changePassword(
     @Args() { oldPassword, newPassword }: ChangePasswordArgs,
@@ -36,7 +40,10 @@ export class PasswordResolver {
   }
 
   @Mutation(() => ResetPasswordOutput, {
-    description: 'Reset Password',
+    description: stripIndent`
+      Reset Password
+      @sensitive-secrets
+    `,
   })
   async resetPassword(
     @Args('input') input: ResetPasswordInput,

--- a/src/components/authentication/register.resolver.ts
+++ b/src/components/authentication/register.resolver.ts
@@ -6,6 +6,7 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
 import { AnonSession, GqlContextType, Session } from '../../common';
 import { Loader, LoaderOf } from '../../core';
 import { Powers as Power, Privileges } from '../authorization';
@@ -21,7 +22,10 @@ export class RegisterResolver {
   ) {}
 
   @Mutation(() => RegisterOutput, {
-    description: 'Register a new user',
+    description: stripIndent`
+      Register a new user
+      @sensitive-secrets
+    `,
   })
   async register(
     @Args('input') input: RegisterInput,


### PR DESCRIPTION
I'd love to use a directive for this, but directives don't come through introspection.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5204470159) by [Unito](https://www.unito.io)
