### PR TITLE
Supercede PR Media `uploadableVariants` -> `availableVariants`

### DIFF
--- a/src/components/progress-report/media/dto/media-list.dto.ts
+++ b/src/components/progress-report/media/dto/media-list.dto.ts
@@ -1,4 +1,4 @@
-import { InputType, ObjectType } from '@nestjs/graphql';
+import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import {
   PaginatedList,
   SortablePaginationInput,
@@ -27,4 +27,15 @@ export class ProgressReportMediaList extends PaginatedList(
   ProgressReportMedia,
 ) {
   readonly report: ProgressReport;
+}
+
+@ObjectType()
+export class AvailableProgressReportMediaVariant {
+  @Field(() => Variant)
+  readonly variant: Variant<MediaVariant>;
+
+  @Field({
+    description: 'Whether the user can upload/create media for this variant',
+  })
+  readonly canCreate: boolean;
 }

--- a/src/components/progress-report/media/resolvers/list.resolver.ts
+++ b/src/components/progress-report/media/resolvers/list.resolver.ts
@@ -2,6 +2,7 @@ import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { AnonSession, Session, Variant } from '~/common';
 import { Privileges, withVariant } from '../../../authorization';
 import {
+  AvailableProgressReportMediaVariant as AvailableVariant,
   ProgressReportMedia as ReportMedia,
   ProgressReportMediaList as ReportMediaList,
 } from '../dto';
@@ -12,6 +13,7 @@ export class ProgressReportMediaListResolver {
 
   @ResolveField(() => [Variant], {
     description: 'The variants the requester has access to upload',
+    deprecationReason: 'Use `availableVariants` instead',
   })
   uploadableVariants(
     @Parent() { report }: ReportMediaList,
@@ -21,6 +23,27 @@ export class ProgressReportMediaListResolver {
     const privileges = this.privileges.for(session, ReportMedia);
     return ReportMedia.Variants.filter((variant) =>
       privileges.forContext(withVariant(context, variant)).can('create'),
+    );
+  }
+
+  @ResolveField(() => [AvailableVariant], {
+    description: 'The variants available to the requester',
+  })
+  availableVariants(
+    @Parent() { report }: ReportMediaList,
+    @AnonSession() session: Session,
+  ): readonly AvailableVariant[] {
+    const context = report as any; // the report is fine for condition context
+    const privileges = this.privileges.for(session, ReportMedia);
+    return ReportMedia.Variants.filter((variant) =>
+      privileges.forContext(withVariant(context, variant)).can('read'),
+    ).map(
+      (variant): AvailableVariant => ({
+        variant,
+        canCreate: privileges
+          .forContext(withVariant(context, variant))
+          .can('create'),
+      }),
     );
   }
 }


### PR DESCRIPTION
This list includes variants that are read only.
This list can be used in the UI to provide a unified list, matching existing variants or providing placeholders.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5234603840) by [Unito](https://www.unito.io)
