### PR TITLE
Don't require `BaseNode` label when marking relationships as inactive when deleting nodes

### DIFF
--- a/src/core/database/query/deletes.ts
+++ b/src/core/database/query/deletes.ts
@@ -17,11 +17,7 @@ export const deleteBaseNode = (nodeVar: string) => (query: Query) =>
       node('propertyNode', 'Property'),
     ])
     // Mark any parent base node relationships (pointing to the base node) as active = false.
-    .optionalMatch([
-      node(nodeVar),
-      relation('in', 'baseNodeRel'),
-      node('', 'BaseNode'),
-    ])
+    .optionalMatch([node(nodeVar), relation('in', 'baseNodeRel'), node()])
     .setValues({
       [`${nodeVar}.deletedAt`]: DateTime.local(),
       'baseNodeRel.active': false,


### PR DESCRIPTION
Don't require nodes with relationships pointing to the node being deleted to have `BaseNode` label.

`VariantGroup` doesn't have these so that was causing a bug. But also, this requirement never really made sense. It just never came up until now.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5237005640) by [Unito](https://www.unito.io)
