### PR TITLE
Move invalid ID validation into updateRelationList method

### DIFF
--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -144,41 +144,20 @@ export class PartnerService {
     }
 
     if (fieldRegions) {
-      const { totalCount } = await this.repo.updateRelationList({
-        id: partner.id,
-        relation: 'fieldRegions',
-        newList: fieldRegions,
-      });
-
-      if (totalCount !== fieldRegions.length) {
-        await this.validateIds(
-          fieldRegions,
-          'FieldRegion',
-          'fieldRegionId',
-          'Field region not found',
-        );
+      try {
+        await this.repo.updateRelationList({
+          id: partner.id,
+          relation: 'fieldRegions',
+          newList: fieldRegions,
+        });
+      } catch (e) {
+        throw e instanceof InputException
+          ? e.withField('partner.fieldRegions')
+          : e;
       }
     }
 
     return await this.readOne(input.id, session);
-  }
-
-  protected async validateIds(
-    ids: readonly ID[],
-    label: string,
-    resourceField: string,
-    errMsg: string,
-  ): Promise<void> {
-    const validNodes = await this.repo.getBaseNodes(ids, label);
-    const validIds = new Set(
-      validNodes.map((validId) => validId.properties.id),
-    );
-
-    for (const id of ids) {
-      if (!validIds.has(id)) {
-        throw new NotFoundException(errMsg, `partner.${resourceField}[${id}]`);
-      }
-    }
   }
 
   async delete(id: ID, session: Session): Promise<void> {


### PR DESCRIPTION
We'll always want to do this, so do it once here.

Using a custom exception class as well, so the consumer can get a list of invalid IDs back programmatically.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5270307212) by [Unito](https://www.unito.io)
