### PR TITLE
Limit graphql middleware to graphql routes

### DIFF
--- a/src/core/graphql/graphql.module.ts
+++ b/src/core/graphql/graphql.module.ts
@@ -36,6 +36,8 @@ export class GraphqlModule implements NestModule {
 
   configure(consumer: MiddlewareConsumer) {
     const uploadMiddleware = createUploadMiddleware();
-    consumer.apply(this.middleware.use, uploadMiddleware).forRoutes('*');
+    consumer
+      .apply(this.middleware.use, uploadMiddleware)
+      .forRoutes('/graphql', '/graphql/*');
   }
 }


### PR DESCRIPTION
graphql-upload was being invoked on many hack attempt routes, which are spamming logs with invalid input errors.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5289496451) by [Unito](https://www.unito.io)
