### PR TITLE
Fix NaN from missing difficulty of book

### DIFF
--- a/src/components/scripture/book-difficulty-factor.test.ts
+++ b/src/components/scripture/book-difficulty-factor.test.ts
@@ -1,0 +1,6 @@
+import { Book } from '@seedcompany/scripture';
+import { difficultyOfBook } from './book-difficulty-factor';
+
+test.each([...Book])(`difficultyOfBook is defined: %s`, (book) => {
+  expect(difficultyOfBook(book)).toBeDefined();
+});

--- a/src/components/scripture/book-difficulty-factor.ts
+++ b/src/components/scripture/book-difficulty-factor.ts
@@ -2,9 +2,10 @@ import { Book } from '@seedcompany/scripture';
 import { BookDifficulty } from './dto';
 
 export const difficultyFactorOfBook = (book: Book): number =>
-  factorMap[difficultyOfBook(book)];
+  factorMap[difficultyOfBook(book)] ?? 0;
 
-export const difficultyOfBook = (book: Book) => difficultyMap[book.name];
+export const difficultyOfBook = (book: Book): BookDifficulty =>
+  difficultyMap[book.name];
 
 const factorMap: Record<BookDifficulty, number> = {
   Easy: 0.8,
@@ -13,7 +14,7 @@ const factorMap: Record<BookDifficulty, number> = {
   Hardest: 1.5625,
 };
 
-const difficultyMap: Record<string, `${BookDifficulty}`> = {
+const difficultyMap: Record<string, BookDifficulty> = {
   Genesis: 'Normal',
   Exodus: 'Normal',
   Leviticus: 'Hard',
@@ -32,7 +33,7 @@ const difficultyMap: Record<string, `${BookDifficulty}`> = {
   Nehemiah: 'Normal',
   Esther: 'Easy',
   Job: 'Hardest',
-  Psalm: 'Hard',
+  Psalms: 'Hard',
   Proverbs: 'Hard',
   Ecclesiastes: 'Hard',
   'Song of Solomon': 'Hard',


### PR DESCRIPTION
@atGit2021 did all the hard work of narrowing the `NaN` down to this function returning `undefined`.
```ts
undefined * x == NaN
```

I fixed the Psalms name from [the name change](https://github.com/SeedCompany/libs/commit/3bf0f68fdb98b3f3d47aa4bb7422f6fbdcb4d362), added tests to ensure our book map is exhaustive, and am returning `0` as factor when book cannot be found as a last chance safety check.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5353627293) by [Unito](https://www.unito.io)
