### PR TITLE
Recalc total verse equivalents saved as NaN

### DIFF
--- a/src/components/product/migrations/fix-nan-total-verse-equivalents.migration.ts
+++ b/src/components/product/migrations/fix-nan-total-verse-equivalents.migration.ts
@@ -1,0 +1,52 @@
+import { node, relation } from 'cypher-query-builder';
+import { ID } from '~/common';
+import { BaseMigration, Migration } from '~/core/database';
+import { ACTIVE } from '~/core/database/query';
+import { getTotalVerseEquivalents } from '../../scripture/verse-equivalents';
+import { ProductService } from '../product.service';
+
+@Migration('2023-10-27T09:47:07')
+export class FixNaNTotalVerseEquivalentsMigration extends BaseMigration {
+  constructor(private readonly productService: ProductService) {
+    super();
+  }
+
+  async up() {
+    const session = this.fakeAdminSession;
+    const ids = await this.db
+      .query()
+      .match([
+        node('product', 'Product'),
+        relation('out', '', 'totalVerseEquivalents', ACTIVE),
+        node('tve', 'Property'),
+      ])
+      .raw('WHERE tve.hadNaN = true or isNaN(tve.value)')
+      .return<{ id: ID }>('product.id as id')
+      .map('id')
+      .run();
+
+    const products = await this.productService.readManyUnsecured(
+      ids,
+      this.fakeAdminSession,
+    );
+
+    for (const p of products) {
+      const correctTotalVerseEquivalent = getTotalVerseEquivalents(
+        ...p.scriptureReferences,
+      );
+
+      if (p.__typename === 'DirectScriptureProduct') {
+        await this.productService.updateDirect(
+          { id: p.id, totalVerseEquivalents: correctTotalVerseEquivalent },
+          session,
+        );
+      }
+      if (p.__typename === 'DerivativeScriptureProduct') {
+        await this.productService.updateDerivative(
+          { id: p.id, totalVerseEquivalents: correctTotalVerseEquivalent },
+          session,
+        );
+      }
+    }
+  }
+}

--- a/src/components/product/product.module.ts
+++ b/src/components/product/product.module.ts
@@ -4,6 +4,7 @@ import { FileModule } from '../file/file.module';
 import { ScriptureModule } from '../scripture';
 import { StoryModule } from '../story/story.module';
 import * as handlers from './handlers';
+import { FixNaNTotalVerseEquivalentsMigration } from './migrations/fix-nan-total-verse-equivalents.migration';
 import { ProducibleResolver } from './producible.resolver';
 import { ProductExtractor } from './product-extractor.service';
 import { ProductLoader } from './product.loader';
@@ -25,6 +26,7 @@ import { ProductService } from './product.service';
     ProductService,
     ProductRepository,
     ProductExtractor,
+    FixNaNTotalVerseEquivalentsMigration,
     ...Object.values(handlers),
   ],
   exports: [ProductService],


### PR DESCRIPTION
@CarsonF could you help me with the cypher query?  I'm getting back an empty array, so not sure how to pull ScriptureRange for both the scriptureReferences (Direct Scripture Products) and the scriptureReferencesOverride (Derivative Scripture Products) as a collection.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5394965702) by [Unito](https://www.unito.io)
