### PR TITLE
EdgeDB CORD Schema Part 1

### DIFF
--- a/dbschema/ceremony.esdl
+++ b/dbschema/ceremony.esdl
@@ -1,5 +1,5 @@
 module Engagement {
-  abstract type Ceremony extending default::Resource {
+  abstract type Ceremony extending Resource {
     required planned: bool {
       default := false;
     };

--- a/dbschema/ceremony.esdl
+++ b/dbschema/ceremony.esdl
@@ -5,6 +5,14 @@ module Engagement {
     };
     estimatedDate: cal::local_date;
     actualDate: cal::local_date;
+
+    constraint exclusive on (.engagement);
+    trigger prohibitDelete after delete for each do (
+      assert(
+        not exists (__old__.engagement),
+        message := "Cannot delete ceremony while engagement still exists."
+      )
+    );
   }
   type DedicationCeremony extending Ceremony {}
   type CertificationCeremony extending Ceremony {}

--- a/dbschema/ceremony.esdl
+++ b/dbschema/ceremony.esdl
@@ -1,0 +1,11 @@
+module Engagement {
+  abstract type Ceremony extending default::Resource {
+    required planned: bool {
+      default := false;
+    };
+    estimatedDate: cal::local_date;
+    actualDate: cal::local_date;
+  }
+  type DedicationCeremony extending Ceremony {}
+  type CertificationCeremony extending Ceremony {}
+}

--- a/dbschema/common.esdl
+++ b/dbschema/common.esdl
@@ -1,3 +1,5 @@
 module default {
   global currentUserId: uuid;
+
+  scalar type ReportPeriod extending enum<Monthly, Quarterly>;
 }

--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -1,10 +1,5 @@
 module default {
-  abstract type Engagement extending Resource {
-    required project: Project {
-      readonly := true;
-      on target delete delete source;
-    }
-
+  abstract type Engagement extending Project::Resource {
     required status: Engagement::Status {
       default := Engagement::Status.InDevelopment;
     }
@@ -43,8 +38,6 @@ module default {
     property initialEndDate: cal::local_date {
       rewrite insert, update using (.endDate if .status = Engagement::Status.InDevelopment else .initialEndDate);
     };
-
-    property sensitivity := .project.sensitivity;
 
     description: json;
   }

--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -1,0 +1,117 @@
+module default {
+  abstract type Engagement extending Resource {
+    required project: Project {
+      readonly := true;
+      on target delete delete source;
+    }
+
+    required status: Engagement::Status {
+      default := Engagement::Status.InDevelopment;
+    }
+    statusModifiedAt: datetime {
+      rewrite update using (datetime_of_statement() if .status != __old__.status else .statusModifiedAt);
+    }
+    lastSuspendedAt: datetime {
+      rewrite update using (datetime_of_statement()
+        if .status != __old__.status
+            and .status = Engagement::Status.Suspended
+        else .lastSuspendedAt);
+    }
+    lastReactivatedAt: datetime {
+      rewrite update using (datetime_of_statement()
+        if .status != __old__.status
+          and .status = Engagement::Status.Active
+          and __old__.status = Engagement::Status.Suspended
+        else .lastReactivatedAt);
+    }
+
+    completedDate: cal::local_date {
+      annotation description := "Translation / Growth Plan complete date";
+    }
+    disbursementCompleteDate: cal::local_date;
+
+    startDateOverride: cal::local_date;
+    endDateOverride: cal::local_date;
+    property startDate := .startDateOverride ?? .project.mouStart;
+    property endDate := .endDateOverride ?? .project.mouEnd;
+    property initialEndDate: cal::local_date {
+      rewrite insert, update using (.endDate if .status = Engagement::Status.InDevelopment else .initialEndDate);
+    };
+
+    property sensitivity := .project.sensitivity;
+
+    description: json;
+  }
+
+  type LanguageEngagement extending Engagement {
+    overloaded required project: TranslationProject;
+
+    required language: Language {
+      readonly := true;
+    }
+    constraint exclusive on ((.project, .language));
+
+    property firstScripture := (
+      exists .language.firstScriptureEngagement
+    );
+
+    required lukePartnership: bool {
+      default := false;
+    };
+    required openToInvestorVisit: bool {
+      default := false;
+    };
+    paratextRegistryId: str;
+#     pnp: File;
+
+    sentPrintingDate: cal::local_date {
+      annotation deprecated := "Legacy data";
+    };
+    historicGoal: str {
+      annotation deprecated := "Legacy data";
+    }
+  }
+
+  type InternshipEngagement extending Engagement {
+    overloaded required project: InternshipProject;
+
+    required intern: User {
+      readonly := true;
+    }
+    constraint exclusive on ((.project, .intern));
+
+    mentor: User;
+#     position: Engagement::InternPosition;
+#     multi methodologies: ProductMethodology;
+#     countryOfOrigin: Location;
+#     growthPlan: File;
+  }
+}
+
+module Engagement {
+  scalar type Status extending enum<
+    InDevelopment,
+    DidNotDevelop,
+    Rejected,
+
+    Active,
+
+    DiscussingTermination,
+    DiscussingReactivation,
+    DiscussingChangeToPlan,
+    DiscussingSuspension,
+
+    FinalizingCompletion,
+    ActiveChangedPlan,
+    Suspended,
+
+    Terminated,
+    Completed,
+
+    # deprecated / legacy
+    Converted,
+    Unapproved,
+    Transferred,
+    NotRenewed,
+  >;
+}

--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -125,4 +125,16 @@ module Engagement {
     Transferred,
     NotRenewed,
   >;
+
+  abstract type Resource extending Project::Resource {
+    required engagement: default::Engagement {
+      readonly := true;
+      on target delete delete source;
+    };
+
+    # Not yet supported
+    # overloaded required project: default::Project {
+    #   default := .engagement.project;
+    # };
+  }
 }

--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -25,6 +25,12 @@ module default {
         else .lastReactivatedAt);
     }
 
+    required ceremony: Engagement::Ceremony {
+      readonly := true;
+      constraint exclusive;
+      on source delete delete target;
+    }
+
     completedDate: cal::local_date {
       annotation description := "Translation / Growth Plan complete date";
     }
@@ -50,6 +56,12 @@ module default {
       readonly := true;
     }
     constraint exclusive on ((.project, .language));
+
+    overloaded required ceremony: Engagement::DedicationCeremony {
+      default := (insert Engagement::DedicationCeremony {
+        createdAt := datetime_of_statement(),
+      });
+    };
 
     property firstScripture := (
       exists .language.firstScriptureEngagement
@@ -79,6 +91,12 @@ module default {
       readonly := true;
     }
     constraint exclusive on ((.project, .intern));
+
+    overloaded required ceremony: Engagement::CertificationCeremony {
+      default := (insert Engagement::CertificationCeremony {
+        createdAt := datetime_of_statement(),
+      });
+    };
 
     mentor: User;
 #     position: Engagement::InternPosition;

--- a/dbschema/language.esdl
+++ b/dbschema/language.esdl
@@ -1,0 +1,77 @@
+module default {
+  type Language extending Resource, Mixin::Pinnable, Mixin::Taggable {
+    required name: str;
+
+    required displayName: str {
+      default := .name;
+    }
+    displayNamePronunciation: str;
+
+    required sensitivity: Sensitivity {
+      annotation description := "The sensitivity of the language. This is a source / user settable.";
+      default := Sensitivity.High;
+    }
+
+    required ethnologue: Ethnologue::Language {
+      default := (insert Ethnologue::Language);
+      on source delete delete target;
+    }
+
+    required isDialect: bool {
+      default := false;
+    }
+
+    registryOfDialectsCode: str {
+      constraint exclusive;
+      constraint regexp(r'^[0-9]{5}$');
+    }
+
+    property population := .populationOverride ?? .ethnologue.population;
+    populationOverride: population;
+
+    required leastOfThese: bool {
+      default := false;
+    };
+    leastOfTheseReason: str;
+
+    required isSignLanguage: bool {
+      default := false;
+    };
+    signLanguageCode: str {
+      constraint regexp(r'^[A-Z]{2}\d{2}$');
+    };
+
+    sponsorEstimatedEndDate: cal::local_date;
+
+#     required hasExternalFirstScripture: bool {
+#       default := false;
+#     };
+#     single link firstScriptureEngagement := (
+#         select LanguageEngagement filter .language = __source__ and .firstScripture = true
+#     );
+#     firstScriptureEngagement: LanguageEngagement {
+#       constraint exclusive;
+#     }
+  }
+
+  scalar type population extending int32 {
+    constraint min_value(0);
+  }
+}
+
+module Ethnologue {
+  type Language {
+    code: code {
+      constraint exclusive;
+    };
+    provisionalCode: code {
+      constraint exclusive;
+    };
+    name: str;
+    population: default::population;
+  }
+
+  scalar type code extending str {
+    constraint regexp(r'^[a-z]{3}$');
+  };
+}

--- a/dbschema/language.esdl
+++ b/dbschema/language.esdl
@@ -43,15 +43,18 @@ module default {
 
     sponsorEstimatedEndDate: cal::local_date;
 
-#     required hasExternalFirstScripture: bool {
-#       default := false;
-#     };
-#     single link firstScriptureEngagement := (
-#         select LanguageEngagement filter .language = __source__ and .firstScripture = true
-#     );
-#     firstScriptureEngagement: LanguageEngagement {
-#       constraint exclusive;
-#     }
+    required hasExternalFirstScripture: bool {
+      default := false;
+    };
+    optional firstScriptureEngagement: LanguageEngagement;
+    # These two props above are mutually exclusive
+    constraint expression on (
+      (exists .firstScriptureEngagement and not .hasExternalFirstScripture)
+      or not exists .firstScriptureEngagement
+    );
+
+    multi link engagements := .<language[is LanguageEngagement];
+    multi link projects := .engagements.project;
   }
 
   scalar type population extending int32 {

--- a/dbschema/language.esdl
+++ b/dbschema/language.esdl
@@ -11,6 +11,7 @@ module default {
       annotation description := "The sensitivity of the language. This is a source / user settable.";
       default := Sensitivity.High;
     }
+    property effectiveSensitivity := max(.projects.sensitivity) ?? .sensitivity;
     trigger recalculateProjectSens after update for each do (
       update (
         select __new__.projects
@@ -66,6 +67,8 @@ module default {
       select LanguageEngagement filter __source__ = .language
     );
     multi link projects := .engagements.project;
+
+    property isMember := exists .projects.isMember;
   }
 
   scalar type population extending int32 {

--- a/dbschema/migrations/00002.edgeql
+++ b/dbschema/migrations/00002.edgeql
@@ -1,0 +1,368 @@
+CREATE MIGRATION m1m7pnl7vcffolzatfunjjqjdbdzezj6tl3u6zqp3zdtwmx54rtlpa
+    ONTO m1tuxy6kzs7grrv24yelgcujny4voaabiynfcyvlqelzxzrbs2gwxq
+{
+  CREATE MODULE Engagement IF NOT EXISTS;
+  CREATE MODULE Ethnologue IF NOT EXISTS;
+  CREATE MODULE Mixin IF NOT EXISTS;
+  CREATE MODULE Project IF NOT EXISTS;
+  CREATE MODULE User IF NOT EXISTS;
+  DROP ALIAS default::RootUser;
+  CREATE SCALAR TYPE Project::Status EXTENDING enum<InDevelopment, Active, Terminated, Completed, DidNotDevelop>;
+  CREATE SCALAR TYPE Project::Step EXTENDING enum<EarlyConversations, PendingConceptApproval, PrepForConsultantEndorsement, PendingConsultantEndorsement, PrepForFinancialEndorsement, PendingFinancialEndorsement, FinalizingProposal, PendingRegionalDirectorApproval, PendingZoneDirectorApproval, PendingFinanceConfirmation, OnHoldFinanceConfirmation, DidNotDevelop, Rejected, Active, ActiveChangedPlan, DiscussingChangeToPlan, PendingChangeToPlanApproval, PendingChangeToPlanConfirmation, DiscussingSuspension, PendingSuspensionApproval, Suspended, DiscussingReactivation, PendingReactivationApproval, DiscussingTermination, PendingTerminationApproval, FinalizingCompletion, Terminated, Completed>;
+  CREATE FUNCTION Project::statusFromStep(step: Project::Step) ->  Project::Status USING (WITH
+      dev :=
+          {Project::Step.EarlyConversations, Project::Step.PendingConceptApproval, Project::Step.PrepForConsultantEndorsement, Project::Step.PendingConsultantEndorsement, Project::Step.PrepForFinancialEndorsement, Project::Step.PendingFinancialEndorsement, Project::Step.FinalizingProposal, Project::Step.PendingRegionalDirectorApproval, Project::Step.PendingZoneDirectorApproval, Project::Step.PendingFinanceConfirmation, Project::Step.OnHoldFinanceConfirmation}
+      ,
+      active :=
+          {Project::Step.Active, Project::Step.ActiveChangedPlan, Project::Step.DiscussingChangeToPlan, Project::Step.PendingChangeToPlanApproval, Project::Step.PendingChangeToPlanConfirmation, Project::Step.DiscussingSuspension, Project::Step.PendingSuspensionApproval, Project::Step.Suspended, Project::Step.DiscussingReactivation, Project::Step.PendingReactivationApproval, Project::Step.DiscussingTermination, Project::Step.PendingTerminationApproval, Project::Step.FinalizingCompletion}
+  SELECT
+      (Project::Status.InDevelopment IF (step IN dev) ELSE (Project::Status.Active IF (step IN active) ELSE (Project::Status.DidNotDevelop IF (step = Project::Step.DidNotDevelop) ELSE (Project::Status.DidNotDevelop IF (step = Project::Step.Rejected) ELSE (Project::Status.Terminated IF (step = Project::Step.Terminated) ELSE (Project::Status.Completed IF (step = Project::Step.Completed) ELSE Project::Status.InDevelopment))))))
+  );
+  CREATE ABSTRACT TYPE Mixin::Taggable {
+      CREATE MULTI PROPERTY tags: std::str;
+  };
+  CREATE SCALAR TYPE default::ReportPeriod EXTENDING enum<Monthly, Quarterly>;
+  CREATE SCALAR TYPE default::Sensitivity EXTENDING enum<Low, Medium, High>;
+  CREATE ABSTRACT TYPE Mixin::Pinnable;
+  CREATE ABSTRACT TYPE default::Project EXTENDING default::Resource, Mixin::Pinnable, Mixin::Taggable {
+      CREATE REQUIRED PROPERTY step: Project::Step {
+          SET default := (Project::Step.EarlyConversations);
+      };
+      CREATE PROPERTY status := (Project::statusFromStep(.step));
+      CREATE PROPERTY departmentId: std::str;
+      CREATE PROPERTY estimatedSubmission: cal::local_date;
+      CREATE PROPERTY financialReportPeriod: default::ReportPeriod;
+      CREATE PROPERTY financialReportReceivedAt: std::datetime;
+      CREATE PROPERTY mouEnd: cal::local_date;
+      CREATE PROPERTY initialMouEnd: cal::local_date {
+          SET default := (.mouEnd);
+          CREATE REWRITE
+              UPDATE
+              USING ((.mouEnd IF (.status = Project::Status.InDevelopment) ELSE .initialMouEnd));
+      };
+      CREATE PROPERTY mouStart: cal::local_date;
+      CREATE REQUIRED PROPERTY name: std::str {
+          CREATE CONSTRAINT std::exclusive;
+      };
+      CREATE REQUIRED PROPERTY presetInventory: std::bool {
+          SET default := false;
+      };
+      CREATE REQUIRED PROPERTY sensitivity: default::Sensitivity {
+          SET default := (default::Sensitivity.High);
+          CREATE ANNOTATION std::description := 'The sensitivity of the project. This is user settable for internships and calculated for translation projects';
+      };
+      CREATE REQUIRED PROPERTY stepChangedAt: std::datetime {
+          SET default := (.createdAt);
+          CREATE REWRITE
+              UPDATE
+              USING ((std::datetime_of_statement() IF (.step != __old__.step) ELSE .stepChangedAt));
+      };
+      CREATE CONSTRAINT std::expression ON ((.mouEnd >= .mouStart));
+  };
+  CREATE TYPE default::InternshipProject EXTENDING default::Project;
+  CREATE SCALAR TYPE Ethnologue::code EXTENDING std::str {
+      CREATE CONSTRAINT std::regexp('^[a-z]{3}$');
+  };
+  CREATE SCALAR TYPE default::population EXTENDING std::int32 {
+      CREATE CONSTRAINT std::min_value(0);
+  };
+  CREATE TYPE Ethnologue::Language {
+      CREATE PROPERTY population: default::population;
+      CREATE PROPERTY code: Ethnologue::code {
+          CREATE CONSTRAINT std::exclusive;
+      };
+      CREATE PROPERTY name: std::str;
+      CREATE PROPERTY provisionalCode: Ethnologue::code {
+          CREATE CONSTRAINT std::exclusive;
+      };
+  };
+  CREATE TYPE default::TranslationProject EXTENDING default::Project;
+  CREATE TYPE default::Language EXTENDING default::Resource, Mixin::Pinnable, Mixin::Taggable {
+      CREATE REQUIRED PROPERTY sensitivity: default::Sensitivity {
+          SET default := (default::Sensitivity.High);
+          CREATE ANNOTATION std::description := 'The sensitivity of the language. This is a source / user settable.';
+      };
+      CREATE REQUIRED LINK ethnologue: Ethnologue::Language {
+          SET default := (INSERT
+              Ethnologue::Language
+          );
+          ON SOURCE DELETE DELETE TARGET;
+      };
+      CREATE PROPERTY populationOverride: default::population;
+      CREATE PROPERTY population := ((.populationOverride ?? .ethnologue.population));
+      CREATE REQUIRED PROPERTY hasExternalFirstScripture: std::bool {
+          SET default := false;
+      };
+      CREATE REQUIRED PROPERTY name: std::str;
+      CREATE REQUIRED PROPERTY displayName: std::str {
+          SET default := (.name);
+      };
+      CREATE PROPERTY displayNamePronunciation: std::str;
+      CREATE REQUIRED PROPERTY isDialect: std::bool {
+          SET default := false;
+      };
+      CREATE REQUIRED PROPERTY isSignLanguage: std::bool {
+          SET default := false;
+      };
+      CREATE REQUIRED PROPERTY leastOfThese: std::bool {
+          SET default := false;
+      };
+      CREATE PROPERTY leastOfTheseReason: std::str;
+      CREATE PROPERTY registryOfDialectsCode: std::str {
+          CREATE CONSTRAINT std::exclusive;
+          CREATE CONSTRAINT std::regexp('^[0-9]{5}$');
+      };
+      CREATE PROPERTY signLanguageCode: std::str {
+          CREATE CONSTRAINT std::regexp(r'^[A-Z]{2}\d{2}$');
+      };
+      CREATE PROPERTY sponsorEstimatedEndDate: cal::local_date;
+  };
+  CREATE SCALAR TYPE Engagement::Status EXTENDING enum<InDevelopment, DidNotDevelop, Rejected, Active, DiscussingTermination, DiscussingReactivation, DiscussingChangeToPlan, DiscussingSuspension, FinalizingCompletion, ActiveChangedPlan, Suspended, Terminated, Completed, Converted, Unapproved, Transferred, NotRenewed>;
+  CREATE ABSTRACT TYPE Project::Resource EXTENDING default::Resource {
+      CREATE REQUIRED LINK project: default::Project {
+          ON TARGET DELETE DELETE SOURCE;
+          SET readonly := true;
+      };
+      CREATE PROPERTY sensitivity := (.project.sensitivity);
+  };
+  CREATE ABSTRACT TYPE default::Engagement EXTENDING Project::Resource {
+      CREATE PROPERTY completedDate: cal::local_date {
+          CREATE ANNOTATION std::description := 'Translation / Growth Plan complete date';
+      };
+      CREATE PROPERTY description: std::json;
+      CREATE PROPERTY disbursementCompleteDate: cal::local_date;
+      CREATE PROPERTY endDateOverride: cal::local_date;
+      CREATE PROPERTY endDate := ((.endDateOverride ?? .project.mouEnd));
+      CREATE PROPERTY initialEndDate: cal::local_date;
+      CREATE PROPERTY lastReactivatedAt: std::datetime;
+      CREATE PROPERTY lastSuspendedAt: std::datetime;
+      CREATE PROPERTY startDateOverride: cal::local_date;
+      CREATE PROPERTY startDate := ((.startDateOverride ?? .project.mouStart));
+      CREATE REQUIRED PROPERTY status: Engagement::Status {
+          SET default := (Engagement::Status.InDevelopment);
+      };
+      CREATE PROPERTY statusModifiedAt: std::datetime {
+          CREATE REWRITE
+              UPDATE
+              USING ((std::datetime_of_statement() IF (.status != __old__.status) ELSE .statusModifiedAt));
+      };
+      ALTER PROPERTY initialEndDate {
+          CREATE REWRITE
+              INSERT
+              USING ((.endDate IF (.status = Engagement::Status.InDevelopment) ELSE .initialEndDate));
+          CREATE REWRITE
+              UPDATE
+              USING ((.endDate IF (.status = Engagement::Status.InDevelopment) ELSE .initialEndDate));
+      };
+      ALTER PROPERTY lastReactivatedAt {
+          CREATE REWRITE
+              UPDATE
+              USING ((std::datetime_of_statement() IF (((.status != __old__.status) AND (.status = Engagement::Status.Active)) AND (__old__.status = Engagement::Status.Suspended)) ELSE .lastReactivatedAt));
+      };
+      ALTER PROPERTY lastSuspendedAt {
+          CREATE REWRITE
+              UPDATE
+              USING ((std::datetime_of_statement() IF ((.status != __old__.status) AND (.status = Engagement::Status.Suspended)) ELSE .lastSuspendedAt));
+      };
+  };
+  CREATE TYPE default::LanguageEngagement EXTENDING default::Engagement {
+      CREATE REQUIRED LINK language: default::Language {
+          SET readonly := true;
+      };
+      ALTER LINK project {
+          SET OWNED;
+          SET REQUIRED;
+          SET TYPE default::TranslationProject USING (<default::TranslationProject>{});
+      };
+      CREATE CONSTRAINT std::exclusive ON ((.project, .language));
+      CREATE PROPERTY historicGoal: std::str {
+          CREATE ANNOTATION std::deprecated := 'Legacy data';
+      };
+      CREATE REQUIRED PROPERTY lukePartnership: std::bool {
+          SET default := false;
+      };
+      CREATE REQUIRED PROPERTY openToInvestorVisit: std::bool {
+          SET default := false;
+      };
+      CREATE PROPERTY paratextRegistryId: std::str;
+      CREATE PROPERTY sentPrintingDate: cal::local_date {
+          CREATE ANNOTATION std::deprecated := 'Legacy data';
+      };
+  };
+  ALTER TYPE default::TranslationProject {
+      CREATE MULTI LINK engagements := (.<project[IS default::LanguageEngagement]);
+      CREATE MULTI LINK languages := (.engagements.language);
+  };
+  ALTER TYPE default::LanguageEngagement {
+      CREATE TRIGGER recalculateProjectSensOnDelete
+          AFTER DELETE
+          FOR EACH DO (WITH
+              removedLang :=
+                  __old__.language
+          UPDATE
+              (SELECT
+                  __old__.project
+              FILTER
+                  (.sensitivity != (std::max(((.languages EXCEPT removedLang)).sensitivity) ?? default::Sensitivity.High))
+              )
+          SET {
+              sensitivity := (std::max(((.languages EXCEPT removedLang)).sensitivity) ?? default::Sensitivity.High)
+          });
+      CREATE TRIGGER recalculateProjectSensOnInsert
+          AFTER INSERT
+          FOR EACH DO (UPDATE
+              (SELECT
+                  __new__.project
+              FILTER
+                  (.sensitivity != (std::max(.languages.sensitivity) ?? default::Sensitivity.High))
+              )
+          SET {
+              sensitivity := (std::max(.languages.sensitivity) ?? default::Sensitivity.High)
+          });
+  };
+  CREATE ABSTRACT TYPE Engagement::Resource EXTENDING Project::Resource {
+      CREATE REQUIRED LINK engagement: default::Engagement {
+          ON TARGET DELETE DELETE SOURCE;
+          SET readonly := true;
+      };
+  };
+  CREATE ABSTRACT TYPE Engagement::Ceremony EXTENDING Engagement::Resource {
+      CREATE CONSTRAINT std::exclusive ON (.engagement);
+      CREATE PROPERTY actualDate: cal::local_date;
+      CREATE PROPERTY estimatedDate: cal::local_date;
+      CREATE REQUIRED PROPERTY planned: std::bool {
+          SET default := false;
+      };
+      CREATE TRIGGER prohibitDelete
+          AFTER DELETE
+          FOR EACH DO (std::assert(NOT (EXISTS (__old__.engagement)), message := 'Cannot delete ceremony while engagement still exists.'));
+  };
+  CREATE TYPE Engagement::CertificationCeremony EXTENDING Engagement::Ceremony;
+  CREATE TYPE Engagement::DedicationCeremony EXTENDING Engagement::Ceremony;
+  ALTER TYPE default::Engagement {
+      CREATE REQUIRED SINGLE LINK ceremony := (std::assert_exists(std::assert_single(.<engagement[IS Engagement::Ceremony])));
+  };
+  CREATE TYPE default::InternshipEngagement EXTENDING default::Engagement {
+      ALTER LINK project {
+          SET OWNED;
+          SET REQUIRED;
+          SET TYPE default::InternshipProject USING (<default::InternshipProject>{});
+      };
+      CREATE TRIGGER connectCertificationCeremony
+          AFTER INSERT
+          FOR EACH DO (INSERT
+              Engagement::CertificationCeremony
+              {
+                  createdAt := std::datetime_of_statement(),
+                  engagement := __new__,
+                  project := __new__.project
+              });
+  };
+  ALTER TYPE default::LanguageEngagement {
+      CREATE TRIGGER connectDedicationCeremony
+          AFTER INSERT
+          FOR EACH DO (INSERT
+              Engagement::DedicationCeremony
+              {
+                  createdAt := std::datetime_of_statement(),
+                  engagement := __new__,
+                  project := __new__.project
+              });
+  };
+  CREATE TYPE Project::Member EXTENDING Project::Resource {
+      CREATE MULTI PROPERTY roles: default::Role;
+  };
+  ALTER SCALAR TYPE default::UserStatus RENAME TO User::Status;
+  CREATE ABSTRACT TYPE Mixin::Owned;
+  ALTER TYPE default::User EXTENDING Mixin::Pinnable,
+  Mixin::Owned LAST;
+  ALTER TYPE Project::Member {
+      CREATE REQUIRED LINK user: default::User {
+          ON TARGET DELETE DELETE SOURCE;
+          SET readonly := true;
+          SET REQUIRED USING (<default::User>{});
+      };
+      CREATE CONSTRAINT std::exclusive ON ((.project, .user));
+  };
+  ALTER TYPE default::Project {
+      CREATE MULTI LINK members := (.<project[IS Project::Member]);
+      CREATE SINGLE LINK membership := (SELECT
+          .members FILTER
+              (.user.id = GLOBAL default::currentUserId)
+      LIMIT
+          1
+      );
+      CREATE PROPERTY isMember := (EXISTS (.membership));
+  };
+  ALTER TYPE Project::Resource {
+      CREATE PROPERTY isMember := (.project.isMember);
+  };
+  ALTER TYPE Mixin::Owned {
+      CREATE LINK owner: default::User {
+          SET default := (<default::User>GLOBAL default::currentUserId);
+      };
+      CREATE PROPERTY isOwner := ((.owner = <default::User>GLOBAL default::currentUserId));
+  };
+  ALTER TYPE default::User {
+      CREATE MULTI LINK pins: Mixin::Pinnable {
+          ON TARGET DELETE ALLOW;
+      };
+  };
+  ALTER TYPE Mixin::Pinnable {
+      CREATE PROPERTY pinned := ((__source__ IN (<default::User>GLOBAL default::currentUserId).pins));
+  };
+  ALTER TYPE default::Project {
+      CREATE PROPERTY engagementTotal := (std::count(.<project[IS default::Engagement]));
+  };
+  ALTER TYPE default::InternshipProject {
+      CREATE MULTI LINK engagements := (.<project[IS default::InternshipEngagement]);
+  };
+  ALTER TYPE default::Language {
+      CREATE OPTIONAL LINK firstScriptureEngagement: default::LanguageEngagement;
+      CREATE CONSTRAINT std::expression ON (((EXISTS (.firstScriptureEngagement) AND NOT (.hasExternalFirstScripture)) OR NOT (EXISTS (.firstScriptureEngagement))));
+      CREATE MULTI LINK engagements := (SELECT
+          default::LanguageEngagement
+      FILTER
+          (__source__ = .language)
+      );
+      CREATE MULTI LINK projects := (.engagements.project);
+      CREATE PROPERTY effectiveSensitivity := ((std::max(.projects.sensitivity) ?? .sensitivity));
+  };
+  ALTER TYPE default::TranslationProject {
+      CREATE TRIGGER confirmProjectSens
+          AFTER UPDATE
+          FOR EACH DO (std::assert((__new__.sensitivity = (std::max(__new__.languages.sensitivity) ?? default::Sensitivity.High)), message := 'TranslationProject sensitivity is automatically set to (and required to be) the highest sensitivity Language engaged'));
+  };
+  ALTER TYPE default::InternshipEngagement {
+      CREATE REQUIRED LINK intern: default::User {
+          SET readonly := true;
+          SET REQUIRED USING (<default::User>{});
+      };
+      CREATE CONSTRAINT std::exclusive ON ((.project, .intern));
+      CREATE LINK mentor: default::User;
+  };
+  ALTER TYPE default::Language {
+      CREATE PROPERTY isMember := (EXISTS (.projects.isMember));
+      CREATE TRIGGER recalculateProjectSens
+          AFTER UPDATE
+          FOR EACH DO (UPDATE
+              (SELECT
+                  __new__.projects
+              FILTER
+                  (.sensitivity != (std::max(.languages.sensitivity) ?? default::Sensitivity.High))
+              )
+          SET {
+              sensitivity := (std::max(.languages.sensitivity) ?? default::Sensitivity.High)
+          });
+  };
+  ALTER TYPE default::LanguageEngagement {
+      CREATE PROPERTY firstScripture := (EXISTS (.language.firstScriptureEngagement));
+  };
+  CREATE SCALAR TYPE default::Sens EXTENDING default::Sensitivity;
+  CREATE ALIAS default::RootUser := (
+      SELECT
+          default::User
+      FILTER
+          (.email = 'devops@tsco.org')
+  );
+};

--- a/dbschema/project-member.esdl
+++ b/dbschema/project-member.esdl
@@ -1,0 +1,11 @@
+module Project {
+  type Member extending Resource {
+    required user: default::User {
+      readonly := true;
+      on target delete delete source;
+    };
+    constraint exclusive on ((.project, .user));
+
+    multi roles: default::Role;
+  }
+}

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -1,0 +1,139 @@
+module default {
+  abstract type Project extending Resource, Mixin::Pinnable, Mixin::Taggable {
+    required name: str {
+      constraint exclusive;
+    };
+
+    required sensitivity: Sensitivity {
+      annotation description := "The sensitivity of the project. \
+        This is user settable for internships and calculated for translation projects";
+      default := Sensitivity.High;
+    };
+
+    departmentId: str;
+
+    required step: Project::Step {
+      default := Project::Step.EarlyConversations;
+    };
+    required stepChangedAt: datetime {
+      default := .createdAt;
+      rewrite update using (datetime_of_statement() if .step != __old__.step else .stepChangedAt);
+    }
+    property status := Project::statusFromStep(.step);
+
+    mouStart: cal::local_date;
+    mouEnd: cal::local_date;
+    constraint expression on (.mouEnd >= .mouStart);
+    initialMouEnd: cal::local_date {
+      default := .mouEnd;
+      rewrite update using (.mouEnd if .status = Project::Status.InDevelopment else .initialMouEnd);
+    }
+
+    estimatedSubmission: cal::local_date;
+
+    financialReportReceivedAt: datetime;
+    financialReportPeriod: ReportPeriod;
+
+    required presetInventory: bool {
+      default := false;
+    };
+
+    multi engagements: Engagement {
+      constraint exclusive;
+    }
+    property engagementTotal := count(.engagements);
+
+#       link primaryLocation: Location;
+#       link marketingLocation: Location;
+#       link fieldRegion: FieldRegion;
+#       link rootDirectory: Directory;
+  }
+
+  type TranslationProject extending Project {
+    overloaded multi engagements: LanguageEngagement;
+  }
+  type InternshipProject extending Project {
+    overloaded multi engagements: InternshipEngagement;
+  }
+}
+
+module Project {
+  scalar type Step extending enum<
+    EarlyConversations,
+    PendingConceptApproval,
+    PrepForConsultantEndorsement,
+    PendingConsultantEndorsement,
+    PrepForFinancialEndorsement,
+    PendingFinancialEndorsement,
+    FinalizingProposal,
+    PendingRegionalDirectorApproval,
+    PendingZoneDirectorApproval,
+    PendingFinanceConfirmation,
+    OnHoldFinanceConfirmation,
+    DidNotDevelop,
+    Rejected,
+    Active,
+    ActiveChangedPlan,
+    DiscussingChangeToPlan,
+    PendingChangeToPlanApproval,
+    PendingChangeToPlanConfirmation,
+    DiscussingSuspension,
+    PendingSuspensionApproval,
+    Suspended,
+    DiscussingReactivation,
+    PendingReactivationApproval,
+    DiscussingTermination,
+    PendingTerminationApproval,
+    FinalizingCompletion,
+    Terminated,
+    Completed,
+  >;
+
+  scalar type Status extending enum<
+    InDevelopment,
+    Active,
+    Terminated,
+    Completed,
+    DidNotDevelop,
+  >;
+
+  function statusFromStep(step: Step) -> Status
+    using (
+      with dev := {
+        Step.EarlyConversations,
+        Step.PendingConceptApproval,
+        Step.PrepForConsultantEndorsement,
+        Step.PendingConsultantEndorsement,
+        Step.PrepForFinancialEndorsement,
+        Step.PendingFinancialEndorsement,
+        Step.FinalizingProposal,
+        Step.PendingRegionalDirectorApproval,
+        Step.PendingZoneDirectorApproval,
+        Step.PendingFinanceConfirmation,
+        Step.OnHoldFinanceConfirmation,
+      },
+      active := {
+        Step.Active,
+        Step.ActiveChangedPlan,
+        Step.DiscussingChangeToPlan,
+        Step.PendingChangeToPlanApproval,
+        Step.PendingChangeToPlanConfirmation,
+        Step.DiscussingSuspension,
+        Step.PendingSuspensionApproval,
+        Step.Suspended,
+        Step.DiscussingReactivation,
+        Step.PendingReactivationApproval,
+        Step.DiscussingTermination,
+        Step.PendingTerminationApproval,
+        Step.FinalizingCompletion,
+      }
+    select
+      Status.InDevelopment if step in dev else
+      Status.Active        if step in active else
+      Status.DidNotDevelop if step = Step.DidNotDevelop else
+      Status.DidNotDevelop if step = Step.Rejected else
+      Status.Terminated    if step = Step.Terminated else
+      Status.Completed     if step = Step.Completed else
+      Status.InDevelopment
+    )
+}

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -58,6 +58,15 @@ module default {
 }
 
 module Project {
+  abstract type Resource extending default::Resource {
+    required project: default::Project {
+      readonly := true;
+      on target delete delete source;
+    };
+
+    property sensitivity := .project.sensitivity;
+  }
+
   scalar type Step extending enum<
     EarlyConversations,
     PendingConceptApproval,

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -38,10 +38,8 @@ module default {
       default := false;
     };
 
-    multi engagements: Engagement {
-      constraint exclusive;
-    }
-    property engagementTotal := count(.engagements);
+#     multi link engagements := .<project[is Engagement];
+    property engagementTotal := count(.<project[is Engagement]);
 
 #       link primaryLocation: Location;
 #       link marketingLocation: Location;
@@ -50,10 +48,12 @@ module default {
   }
 
   type TranslationProject extending Project {
-    overloaded multi engagements: LanguageEngagement;
+    multi link engagements := .<project[is LanguageEngagement];
+    multi link languages := .engagements.language;
   }
+
   type InternshipProject extending Project {
-    overloaded multi engagements: InternshipEngagement;
+    multi link engagements := .<project[is InternshipEngagement];
   }
 }
 

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -54,6 +54,14 @@ module default {
   type TranslationProject extending Project {
     multi link engagements := .<project[is LanguageEngagement];
     multi link languages := .engagements.language;
+
+    trigger confirmProjectSens after update for each do (
+      assert(
+        __new__.sensitivity = max(__new__.languages.sensitivity) ?? Sensitivity.High,
+        message := "TranslationProject sensitivity is automatically set to \
+          (and required to be) the highest sensitivity Language engaged"
+      )
+    );
   }
 
   type InternshipProject extending Project {

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -38,6 +38,10 @@ module default {
       default := false;
     };
 
+    multi link members := .<project[is Project::Member];
+    single link membership := (select .members filter .user.id = global currentUserId limit 1);
+    property isMember := exists .membership;
+
 #     multi link engagements := .<project[is Engagement];
     property engagementTotal := count(.<project[is Engagement]);
 
@@ -65,6 +69,7 @@ module Project {
     };
 
     property sensitivity := .project.sensitivity;
+    property isMember := .project.isMember;
   }
 
   scalar type Step extending enum<

--- a/dbschema/role.esdl
+++ b/dbschema/role.esdl
@@ -1,0 +1,26 @@
+module default {
+  scalar type Role extending enum<
+    Administrator,
+    BetaTester,
+    BibleTranslationLiaison,
+    Consultant,
+    ConsultantManager,
+    Controller,
+    ExperienceOperations,
+    FieldOperationsDirector,
+    FieldPartner,
+    FinancialAnalyst,
+    Fundraising,
+    Intern,
+    LeadFinancialAnalyst,
+    Leadership,
+    Liaison,
+    Marketing,
+    Mentor,
+    ProjectManager,
+    RegionalCommunicationsCoordinator,
+    RegionalDirector,
+    StaffMember,
+    Translator,
+  >;
+}

--- a/dbschema/sensitivity.esdl
+++ b/dbschema/sensitivity.esdl
@@ -1,0 +1,3 @@
+module default {
+  scalar type Sensitivity extending enum<Low, Medium, High>;
+}

--- a/dbschema/sensitivity.esdl
+++ b/dbschema/sensitivity.esdl
@@ -1,3 +1,6 @@
 module default {
   scalar type Sensitivity extending enum<Low, Medium, High>;
+
+  # This seems to work without consequences. To be safe though, probably shouldn't use this in schema yet.
+  scalar type Sens extending Sensitivity;
 }

--- a/dbschema/user.esdl
+++ b/dbschema/user.esdl
@@ -1,5 +1,5 @@
 module default {
-  type User extending Resource {
+  type User extending Resource, Mixin::Pinnable {
     email: str {
       constraint exclusive;
     };
@@ -19,6 +19,9 @@ module default {
     };
     multi roles: Role;
     title: str;
+    multi link pins: Mixin::Pinnable {
+      on target delete allow;
+    }
   }
 
   scalar type UserStatus extending enum<Active, Disabled>;

--- a/dbschema/user.esdl
+++ b/dbschema/user.esdl
@@ -1,5 +1,5 @@
 module default {
-  type User extending Resource, Mixin::Pinnable {
+  type User extending Resource, Mixin::Pinnable, Mixin::Owned {
     email: str {
       constraint exclusive;
     };

--- a/dbschema/user.esdl
+++ b/dbschema/user.esdl
@@ -14,8 +14,8 @@ module default {
     phone: str;
     timezone: str;
     about: str;
-    required status: UserStatus {
-      default := UserStatus.Active;
+    required status: User::Status {
+      default := User::Status.Active;
     };
     multi roles: Role;
     title: str;
@@ -24,35 +24,12 @@ module default {
     }
   }
 
-  scalar type UserStatus extending enum<Active, Disabled>;
-
-  scalar type Role extending enum<
-    Administrator,
-    BetaTester,
-    BibleTranslationLiaison,
-    Consultant,
-    ConsultantManager,
-    Controller,
-    ExperienceOperations,
-    FieldOperationsDirector,
-    FieldPartner,
-    FinancialAnalyst,
-    Fundraising,
-    Intern,
-    LeadFinancialAnalyst,
-    Leadership,
-    Liaison,
-    Marketing,
-    Mentor,
-    ProjectManager,
-    RegionalCommunicationsCoordinator,
-    RegionalDirector,
-    StaffMember,
-    Translator,
-  >;
-
   alias RootUser := (
       SELECT User
       FILTER .email = 'devops@tsco.org'
   );
+}
+
+module User {
+  scalar type Status extending enum<Active, Disabled>;
 }

--- a/dbschema/z.owned.esdl
+++ b/dbschema/z.owned.esdl
@@ -1,0 +1,8 @@
+module Mixin {
+  abstract type Owned {
+    link owner: default::User {
+      default := <default::User>(global default::currentUserId);
+    };
+    property isOwner := .owner = <default::User>(global default::currentUserId);
+  }
+}

--- a/dbschema/z.pinnable.esdl
+++ b/dbschema/z.pinnable.esdl
@@ -1,0 +1,5 @@
+module Mixin {
+  abstract type Pinnable {
+    property pinned := __source__ in (<default::User>global default::currentUserId).pins;
+  };
+};

--- a/dbschema/z.taggable.esdl
+++ b/dbschema/z.taggable.esdl
@@ -1,0 +1,5 @@
+module Mixin {
+  abstract type Taggable {
+    multi tags: str;
+  }
+}

--- a/src/core/edgedb/generate.ts
+++ b/src/core/edgedb/generate.ts
@@ -112,9 +112,18 @@ async function generateAll({
     client,
     root,
   });
-  addCustomScalarImports(
-    project.addSourceFileAtPath(generatedSchemaFile),
-    customScalars.values(),
+  const schemaFile = project.addSourceFileAtPath(generatedSchemaFile);
+  addCustomScalarImports(schemaFile, customScalars.values());
+
+  // Quick/naive fix for the type generated from
+  // Project::Resource extending default::Resource
+  schemaFile.replaceWithText(
+    schemaFile
+      .getFullText()
+      .replace(
+        'interface Resource extends Resource',
+        'interface Resource extends DefaultResource',
+      ) + '\ntype DefaultResource = Resource;\n',
   );
 
   await generateQueryFiles({ client, root });


### PR DESCRIPTION
Most parts of these objects are done:
- User
- Project
- Engagement
- Language
- Ceremony
- Project Member

Key points have been worked out:
- How sensitivity & (project) membership can be declared across schema objects for authorization system
- How sensitivity is calculated for translation projects (triggers written)
- Good direction on some conventions, like module organization.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5419271928) by [Unito](https://www.unito.io)
