### PR TITLE
Update the vscode/launch.json file with newer settings for Jest extension debug option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,10 +11,23 @@
     },
     {
       "type": "node",
-      "name": "vscode-jest-tests",
+      "name": "vscode-jest-tests.v2",
       "request": "launch",
-      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-      "console": "integratedTerminal"
+      "args": [
+        "test",
+        "--",
+        "--runInBand",
+        "--watchAll=false",
+        "--testNamePattern",
+        "${jest.testNamePattern}",
+        "--runTestsByPath",
+        "${jest.testFile}"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "runtimeExecutable": "yarn"
     }
   ]
 }


### PR DESCRIPTION
This is a newer version of the config for one of the most popular Jest plugins for VSCode.  This modifies the entry originally placed here about 3 years ago.  😮 

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5429187741) by [Unito](https://www.unito.io)
