### PR TITLE
Generate typed inline queries using new `edgeql()` wrapper

### DIFF
--- a/src/core/edgedb/edgedb.module.ts
+++ b/src/core/edgedb/edgedb.module.ts
@@ -3,7 +3,8 @@ import { createClient } from 'edgedb';
 import { KNOWN_TYPENAMES } from 'edgedb/dist/codecs/consts.js';
 import { ScalarCodec } from 'edgedb/dist/codecs/ifaces.js';
 import { Class } from 'type-fest';
-import { Client, EdgeDB } from './reexports';
+import { EdgeDB } from './edgedb.service';
+import { Client } from './reexports';
 import { LuxonCalendarDateCodec, LuxonDateTimeCodec } from './temporal.codecs';
 
 @Module({
@@ -21,10 +22,7 @@ import { LuxonCalendarDateCodec, LuxonDateTimeCodec } from './temporal.codecs';
         return client;
       },
     },
-    {
-      provide: EdgeDB,
-      useExisting: Client,
-    },
+    EdgeDB,
   ],
   exports: [EdgeDB, Client],
 })

--- a/src/core/edgedb/edgedb.service.ts
+++ b/src/core/edgedb/edgedb.service.ts
@@ -1,0 +1,68 @@
+/* eslint-disable @typescript-eslint/unified-signatures */
+import { Injectable } from '@nestjs/common';
+import { $, Executor } from 'edgedb';
+import { TypedEdgeQL } from './edgeql';
+import { InlineQueryCardinalityMap } from './generated-client/inline-queries';
+import { Client } from './reexports';
+
+@Injectable()
+export class EdgeDB {
+  constructor(private readonly client: Client) {}
+
+  /** Run a query from an edgeql string */
+  run<R>(query: TypedEdgeQL<null, R>): Promise<R>;
+  /** Run a query from an edgeql string */
+  run<Args extends Record<string, any>, R>(
+    query: TypedEdgeQL<Args, R>,
+    args: Args,
+  ): Promise<R>;
+
+  /** Run a query from a edgeql file */
+  run<Args, R>(
+    query: (client: Executor, args: Args) => Promise<R>,
+    args: Args,
+  ): Promise<R>;
+  /** Run a query from a edgeql file */
+  run<R>(query: (client: Executor) => Promise<R>): Promise<R>;
+
+  /** Run a query from the query builder */
+  run<R>(query: { run: (client: Executor) => Promise<R> }): Promise<R>;
+
+  async run(query: any, args?: any) {
+    if (query instanceof TypedEdgeQL) {
+      const cardinality = InlineQueryCardinalityMap.get(query.query);
+      if (!cardinality) {
+        throw new Error(`Query was not found from inline query generation`);
+      }
+      const exeMethod = cardinalityToExecutorMethod[cardinality];
+
+      // eslint-disable-next-line @typescript-eslint/return-await
+      return await this.client[exeMethod](query.query, args);
+    }
+
+    if (query.run) {
+      // eslint-disable-next-line @typescript-eslint/return-await
+      return await query.run(this.client);
+    }
+
+    if (typeof query === 'function') {
+      // eslint-disable-next-line @typescript-eslint/return-await
+      return await query(this.client, args);
+    }
+
+    // For REPL, as this is untyped and assumes many/empty cardinality
+    if (typeof query === 'string') {
+      return await this.client.query(query, args);
+    }
+
+    throw new Error('Could not figure out how to run given query');
+  }
+}
+
+const cardinalityToExecutorMethod = {
+  One: 'queryRequiredSingle',
+  AtMostOne: 'querySingle',
+  Many: 'query',
+  AtLeastOne: 'query',
+  Empty: 'query',
+} satisfies Record<`${$.Cardinality}`, keyof Executor>;

--- a/src/core/edgedb/edgeql.ts
+++ b/src/core/edgedb/edgeql.ts
@@ -1,0 +1,25 @@
+import { stripIndent } from 'common-tags';
+import { InlineQueryMap as QueryMap } from './generated-client/inline-queries';
+
+export const edgeql = <const Query extends string>(
+  query: Query,
+): Query extends keyof QueryMap ? QueryMap[Query] : unknown => {
+  return new TypedEdgeQL(stripIndent(query)) as any;
+};
+
+export type EdgeQLArgsOf<T extends TypedEdgeQL<any, any>> =
+  T extends TypedEdgeQL<infer Args, any> ? Args : never;
+
+export type EdgeQLReturnOf<T extends TypedEdgeQL<any, any>> =
+  T extends TypedEdgeQL<any, infer Return> ? Return : never;
+
+// Internal symbol to mark a query as typed
+const edgeqlTS = Symbol('edgeqlTS');
+
+export class TypedEdgeQL<Args, Return> {
+  constructor(readonly query: string) {}
+  [edgeqlTS]?: {
+    args: Args;
+    return: Return;
+  };
+}

--- a/src/core/edgedb/generate.ts
+++ b/src/core/edgedb/generate.ts
@@ -115,16 +115,14 @@ async function generateAll({
   const schemaFile = project.addSourceFileAtPath(generatedSchemaFile);
   addCustomScalarImports(schemaFile, customScalars.values());
 
-  // Quick/naive fix for the type generated from
+  // Fix the type generated from
   // Project::Resource extending default::Resource
-  schemaFile.replaceWithText(
-    schemaFile
-      .getFullText()
-      .replace(
-        'interface Resource extends Resource',
-        'interface Resource extends DefaultResource',
-      ) + '\ntype DefaultResource = Resource;\n',
-  );
+  schemaFile.addTypeAlias({ name: 'DefaultResource', type: 'Resource' });
+  schemaFile
+    .getModule('Project')!
+    .getInterface('Resource')!
+    .removeExtends(0)
+    .addExtends('DefaultResource');
 
   await generateQueryFiles({ client, root });
   fixCustomScalarImportsInGeneratedEdgeqlFiles(project);

--- a/src/core/edgedb/index.ts
+++ b/src/core/edgedb/index.ts
@@ -1,2 +1,3 @@
 export * from './reexports';
+export { edgeql, EdgeQLArgsOf, EdgeQLReturnOf } from './edgeql';
 export { default as e } from './generated-client/index.mjs';

--- a/src/core/edgedb/index.ts
+++ b/src/core/edgedb/index.ts
@@ -1,3 +1,4 @@
 export * from './reexports';
 export { edgeql, EdgeQLArgsOf, EdgeQLReturnOf } from './edgeql';
+export * from './edgedb.service';
 export { default as e } from './generated-client/index.mjs';

--- a/src/core/edgedb/reexports.ts
+++ b/src/core/edgedb/reexports.ts
@@ -1,12 +1,3 @@
-import { Transaction } from 'edgedb/dist/transaction.js';
-
 // Only use this if you need the extra methods.
 // Otherwise, for querying, use EdgeDb from below.
 export { Client } from 'edgedb/dist/baseClient.js';
-
-// Using this as it's a runtime symbol for the Executor TS shape
-// which makes it perfect for injection.
-// @ts-expect-error private constructor; doesn't matter that's not how we are using it.
-// We could just export the Transaction as an aliased named, but this also
-// allows REPL to reference it with the correct name.
-export abstract class EdgeDB extends Transaction {}


### PR DESCRIPTION
I know the edgedb team pushes for the query builder, and they want it to be as close to EdgeQL syntax as possible. It's certainly closer than what we have with our cypher query builder, but it's not quite there.
This is why I went through the effort of supporting `*.edgeql` query files which could be used in app code.

However, I fear that the query builder will still be favored over these files because small queries can be contained in a block of code rather than a whole exclusive file. This is a bit concerning, because the QB does have rumors of being hard on TS and the aforementioned cypher QB headache.

This is why I'm introducing support for typed query strings inline in TS files...

# `edgeql()`
```ts
import { edgeql, EdgeDB } from '~/core/edgedb';

class Repository {
  constructor(private db: EdgeDB) {}

  listUsers() {
    const query = edgeql(`
      select User {*}
    `);

    const users = await this.db.run(query);

    users[0].realFirstName // fully typed.
  }
}
```

This does require running `yarn edgedb:gen` after every query change, just like the query files do.
So that's still a pro for the QB.
I'd like to support watching for changes in a future iteration.

# `EdgeDB` service

I've adjusted the `EdgeDB` service to support a unified signature for running all types of queries.

```ts
import { users as usersFromQueryFile } from './users.edgeql';

const inline = edgeql(`
  select User {*}
`);

const qb = e.select(e.Project.Member, (pm) => pm['*']);

const a = await this.db.run(usersFromQueryFile);
const b = await this.db.run(inline);
const c = await this.db.run(qb);
```

The previously exported Executor methods are no longer exposed. Will keep it that way until need arises, as this should be sufficient for app usage. The `Client` service is still available as well for special cases.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5441919616) by [Unito](https://www.unito.io)
