### PR TITLE
EdgeDB Project Context Schema

### DIFF
--- a/dbschema/ceremony.esdl
+++ b/dbschema/ceremony.esdl
@@ -1,5 +1,5 @@
 module Engagement {
-  abstract type Ceremony extending Resource {
+  abstract type Ceremony extending Child {
     required planned: bool {
       default := false;
     };

--- a/dbschema/common.esdl
+++ b/dbschema/common.esdl
@@ -4,7 +4,6 @@ module default {
   scalar type ReportPeriod extending enum<Monthly, Quarterly>;
   
   # Helper function to workaround native support for sort ignoring accents
-  # Might need to sort this value next to the real value in order to index, kept up to date with a mutation rewrite.
   # https://stackoverflow.com/a/11007216
   # https://github.com/edgedb/edgedb/issues/386
   function str_sortable(value: str) -> str

--- a/dbschema/common.esdl
+++ b/dbschema/common.esdl
@@ -2,4 +2,18 @@ module default {
   global currentUserId: uuid;
   
   scalar type ReportPeriod extending enum<Monthly, Quarterly>;
+  
+  # Helper function to workaround native support for sort ignoring accents
+  # Might need to sort this value next to the real value in order to index, kept up to date with a mutation rewrite.
+  # https://stackoverflow.com/a/11007216
+  # https://github.com/edgedb/edgedb/issues/386
+  function str_sortable(value: str) -> str
+  using (
+    str_lower(
+      re_replace('Ñ', 'N',
+        str_trim(re_replace('[ [\\]|,\\-$]+', ' ', value, flags := 'g')),
+        flags := 'g'
+       )
+    )
+  );
 }

--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -99,6 +99,15 @@ module default {
       )
       set { ownSensitivity := max((.languages except removedLang).ownSensitivity) ?? Sensitivity.High }
     );
+    
+    trigger addProjectToContextOfLanguage after insert for each do (
+      update __new__.language.projectContext
+      set { projects += __new__.project }
+    );
+    trigger removeProjectFromContextOfLanguage after delete for each do (
+      update __old__.language.projectContext
+      set { projects -= __old__.project }
+    );
   }
   
   type InternshipEngagement extending Engagement {

--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -82,18 +82,20 @@ module default {
     
     trigger recalculateProjectSensOnInsert after insert for each do (
       update (
-        select __new__.project
-        # Filter out projects without change, so modifiedAt isn't bumped
-        filter .sensitivity != max(.languages.sensitivity) ?? Sensitivity.High
+        select TranslationProject
+        filter __new__ in .languages
+          # Filter out projects without change, so modifiedAt isn't bumped
+          and .sensitivity != max(.languages.sensitivity) ?? Sensitivity.High
       )
       set { sensitivity := max(.languages.sensitivity) ?? Sensitivity.High }
     );
     trigger recalculateProjectSensOnDelete after delete for each do (
       with removedLang := __old__.language
       update (
-        select __old__.project
-        # Filter out projects without change, so modifiedAt isn't bumped
-        filter .sensitivity != max((.languages except removedLang).sensitivity) ?? Sensitivity.High
+        select TranslationProject
+        filter __old__ in .languages
+          # Filter out projects without change, so modifiedAt isn't bumped
+          and .sensitivity != max((.languages except removedLang).sensitivity) ?? Sensitivity.High
       )
       set { sensitivity := max((.languages except removedLang).sensitivity) ?? Sensitivity.High }
     );

--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -77,6 +77,7 @@ module default {
         createdAt := datetime_of_statement(),
         engagement := __new__,
         project := __new__.project,
+        projectContext := __new__.projectContext,
       }
     );
     
@@ -129,6 +130,7 @@ module default {
         createdAt := datetime_of_statement(),
         engagement := __new__,
         project := __new__.project,
+        projectContext := __new__.projectContext,
       }
     );
   }

--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -85,9 +85,9 @@ module default {
         select TranslationProject
         filter __new__ in .languages
           # Filter out projects without change, so modifiedAt isn't bumped
-          and .sensitivity != max(.languages.sensitivity) ?? Sensitivity.High
+          and .sensitivity != max(.languages.ownSensitivity) ?? Sensitivity.High
       )
-      set { sensitivity := max(.languages.sensitivity) ?? Sensitivity.High }
+      set { sensitivity := max(.languages.ownSensitivity) ?? Sensitivity.High }
     );
     trigger recalculateProjectSensOnDelete after delete for each do (
       with removedLang := __old__.language
@@ -95,9 +95,9 @@ module default {
         select TranslationProject
         filter __old__ in .languages
           # Filter out projects without change, so modifiedAt isn't bumped
-          and .sensitivity != max((.languages except removedLang).sensitivity) ?? Sensitivity.High
+          and .sensitivity != max((.languages except removedLang).ownSensitivity) ?? Sensitivity.High
       )
-      set { sensitivity := max((.languages except removedLang).sensitivity) ?? Sensitivity.High }
+      set { sensitivity := max((.languages except removedLang).ownSensitivity) ?? Sensitivity.High }
     );
   }
   

--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -85,9 +85,9 @@ module default {
         select TranslationProject
         filter __new__ in .languages
           # Filter out projects without change, so modifiedAt isn't bumped
-          and .sensitivity != max(.languages.ownSensitivity) ?? Sensitivity.High
+          and .ownSensitivity != max(.languages.ownSensitivity) ?? Sensitivity.High
       )
-      set { sensitivity := max(.languages.ownSensitivity) ?? Sensitivity.High }
+      set { ownSensitivity := max(.languages.ownSensitivity) ?? Sensitivity.High }
     );
     trigger recalculateProjectSensOnDelete after delete for each do (
       with removedLang := __old__.language
@@ -95,9 +95,9 @@ module default {
         select TranslationProject
         filter __old__ in .languages
           # Filter out projects without change, so modifiedAt isn't bumped
-          and .sensitivity != max((.languages except removedLang).ownSensitivity) ?? Sensitivity.High
+          and .ownSensitivity != max((.languages except removedLang).ownSensitivity) ?? Sensitivity.High
       )
-      set { sensitivity := max((.languages except removedLang).ownSensitivity) ?? Sensitivity.High }
+      set { ownSensitivity := max((.languages except removedLang).ownSensitivity) ?? Sensitivity.High }
     );
   }
   

--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -1,5 +1,5 @@
 module default {
-  abstract type Engagement extending Project::Resource {
+  abstract type Engagement extending Project::Child {
     required status: Engagement::Status {
       default := Engagement::Status.InDevelopment;
     }
@@ -163,7 +163,11 @@ module Engagement {
     NotRenewed,
   >;
   
-  abstract type Resource extending Project::Resource {
+  abstract type Child extending Project::Child {
+    annotation description := "\
+      A type that is a child of an engagement. \
+      It will always have a reference to a single engagement & project that it is under.";
+    
     required engagement: default::Engagement {
       readonly := true;
       on target delete delete source;

--- a/dbschema/language.esdl
+++ b/dbschema/language.esdl
@@ -1,6 +1,7 @@
 module default {
   type Language extending Resource, Mixin::Pinnable, Mixin::Taggable {
     required name: str;
+    index on (str_sortable(.name));
     
     required displayName: str {
       default := .name;
@@ -11,6 +12,8 @@ module default {
       annotation description := "The sensitivity of the language. This is a source / user settable.";
       default := Sensitivity.High;
     }
+    index on (.sensitivity);
+    
     property effectiveSensitivity := max(.projects.sensitivity) ?? .sensitivity;
     trigger recalculateProjectSens after update for each do (
       update (
@@ -69,6 +72,8 @@ module default {
     multi link projects := .engagements.project;
     
     property isMember := exists .projects.isMember;
+    
+    index on ((.name, .sensitivity, .leastOfThese, .isSignLanguage, .isDialect));
   }
   
   scalar type population extending int32 {

--- a/dbschema/language.esdl
+++ b/dbschema/language.esdl
@@ -17,9 +17,10 @@ module default {
     property effectiveSensitivity := max(.projects.sensitivity) ?? .sensitivity;
     trigger recalculateProjectSens after update for each do (
       update (
-        select __new__.projects
-        # Filter out projects without change, so modifiedAt isn't bumped
-        filter .sensitivity != max(.languages.sensitivity) ?? Sensitivity.High
+        select TranslationProject
+        filter __new__ in .languages
+          # Filter out projects without change, so modifiedAt isn't bumped
+          and .sensitivity != max(.languages.sensitivity) ?? Sensitivity.High
       )
       set { sensitivity := max(.languages.sensitivity) ?? Sensitivity.High }
     );

--- a/dbschema/language.esdl
+++ b/dbschema/language.esdl
@@ -14,15 +14,15 @@ module default {
     }
 #     index on (.ownSensitivity);
     
-#     property sensitivity := max(.projects.sensitivity) ?? .ownSensitivity;
+#     property sensitivity := max(.projects.ownSensitivity) ?? .ownSensitivity;
     trigger recalculateProjectSens after update for each do (
       update (
         select TranslationProject
         filter __new__ in .languages
           # Filter out projects without change, so modifiedAt isn't bumped
-          and .sensitivity != max(.languages.ownSensitivity) ?? Sensitivity.High
+          and .ownSensitivity != max(.languages.ownSensitivity) ?? Sensitivity.High
       )
-      set { sensitivity := max(.languages.ownSensitivity) ?? Sensitivity.High }
+      set { ownSensitivity := max(.languages.ownSensitivity) ?? Sensitivity.High }
     );
     
     required ethnologue: Ethnologue::Language {

--- a/dbschema/language.esdl
+++ b/dbschema/language.esdl
@@ -14,7 +14,6 @@ module default {
     }
 #     index on (.ownSensitivity);
     
-#     property sensitivity := max(.projects.ownSensitivity) ?? .ownSensitivity;
     trigger recalculateProjectSens after update for each do (
       update (
         select TranslationProject
@@ -31,10 +30,11 @@ module default {
     trigger connectEthnologue after insert for each do (
       insert Ethnologue::Language {
         language := __new__,
+        ownSensitivity := __new__.ownSensitivity,
         projectContext := __new__.projectContext
       }
     );
-    trigger matchEthnologueToOwnSens after insert, update for each do (
+    trigger matchEthnologueToOwnSens after update for each do (
       update __new__.ethnologue
       filter .ownSensitivity != __new__.ownSensitivity
       set { ownSensitivity := __new__.ownSensitivity }

--- a/dbschema/language.esdl
+++ b/dbschema/language.esdl
@@ -12,9 +12,9 @@ module default {
       annotation description := "The sensitivity of the language. This is a source / user settable.";
       default := Sensitivity.High;
     }
-    index on (.sensitivity);
+#     index on (.sensitivity);
     
-    property effectiveSensitivity := max(.projects.sensitivity) ?? .sensitivity;
+#     property effectiveSensitivity := max(.projects.sensitivity) ?? .sensitivity;
     trigger recalculateProjectSens after update for each do (
       update (
         select TranslationProject

--- a/dbschema/language.esdl
+++ b/dbschema/language.esdl
@@ -1,5 +1,5 @@
 module default {
-  type Language extending Resource, Mixin::Pinnable, Mixin::Taggable, Project::HasContext {
+  type Language extending Resource, Project::ContextAware, Mixin::Pinnable, Mixin::Taggable {
     required name: str;
     index on (str_sortable(.name));
     
@@ -12,7 +12,6 @@ module default {
       annotation description := "The sensitivity of the language. This is a source / user settable.";
       default := Sensitivity.High;
     }
-#     index on (.ownSensitivity);
     
     trigger recalculateProjectSens after update for each do (
       update (
@@ -81,6 +80,10 @@ module default {
       select LanguageEngagement filter __source__ = .language
     );
     
+    overloaded link projectContext: Project::Context {
+      default := (insert Project::Context);
+    }
+    
     index on ((.name, .ownSensitivity, .leastOfThese, .isSignLanguage, .isDialect));
   }
   
@@ -90,7 +93,7 @@ module default {
 }
  
 module Ethnologue {
-  type Language extending Project::HasContext {
+  type Language extending Project::ContextAware {
     required language: default::Language {
       on target delete delete source;
       constraint exclusive;

--- a/dbschema/language.esdl
+++ b/dbschema/language.esdl
@@ -25,10 +25,14 @@ module default {
       set { ownSensitivity := max(.languages.ownSensitivity) ?? Sensitivity.High }
     );
     
-    required ethnologue: Ethnologue::Language {
-      default := (insert Ethnologue::Language);
-      on source delete delete target;
-    }
+    required single link ethnologue := assert_exists(assert_single(
+      .<language[is Ethnologue::Language]
+    ));
+    trigger connectEthnologue after insert for each do (
+      insert Ethnologue::Language {
+        language := __new__
+      }
+    );
     
     required isDialect: bool {
       default := false;
@@ -84,6 +88,11 @@ module default {
  
 module Ethnologue {
   type Language {
+    required language: default::Language {
+      on target delete delete source;
+      constraint exclusive;
+    };
+    
     code: code {
       constraint exclusive;
     };

--- a/dbschema/language.esdl
+++ b/dbschema/language.esdl
@@ -8,21 +8,21 @@ module default {
     }
     displayNamePronunciation: str;
     
-    required sensitivity: Sensitivity {
+    required ownSensitivity: Sensitivity {
       annotation description := "The sensitivity of the language. This is a source / user settable.";
       default := Sensitivity.High;
     }
-#     index on (.sensitivity);
+#     index on (.ownSensitivity);
     
-#     property effectiveSensitivity := max(.projects.sensitivity) ?? .sensitivity;
+#     property sensitivity := max(.projects.sensitivity) ?? .ownSensitivity;
     trigger recalculateProjectSens after update for each do (
       update (
         select TranslationProject
         filter __new__ in .languages
           # Filter out projects without change, so modifiedAt isn't bumped
-          and .sensitivity != max(.languages.sensitivity) ?? Sensitivity.High
+          and .sensitivity != max(.languages.ownSensitivity) ?? Sensitivity.High
       )
-      set { sensitivity := max(.languages.sensitivity) ?? Sensitivity.High }
+      set { sensitivity := max(.languages.ownSensitivity) ?? Sensitivity.High }
     );
     
     required ethnologue: Ethnologue::Language {
@@ -74,7 +74,7 @@ module default {
     
     property isMember := exists .projects.isMember;
     
-    index on ((.name, .sensitivity, .leastOfThese, .isSignLanguage, .isDialect));
+    index on ((.name, .ownSensitivity, .leastOfThese, .isSignLanguage, .isDialect));
   }
   
   scalar type population extending int32 {

--- a/dbschema/migrations/00005.edgeql
+++ b/dbschema/migrations/00005.edgeql
@@ -1,0 +1,42 @@
+CREATE MIGRATION m1mhq7b2c53yr7fxf7x5sgjogvrkg4hjj2nhpdivxja66sjpc5amza
+    ONTO m1unudoy7u4j3s2waa5jadkb43qedra7r6eab3ndzk22fhf4p5bfwq
+{
+  CREATE FUNCTION default::str_sortable(value: std::str) ->  std::str USING (std::str_lower(std::re_replace('Ñ', 'N', std::str_trim(std::re_replace(r'[ [\]|,\-$]+', ' ', value, flags := 'g')), flags := 'g')));
+  ALTER TYPE default::Language {
+      CREATE INDEX ON (default::str_sortable(.name));
+      CREATE INDEX ON (.sensitivity);
+      CREATE INDEX ON ((.name, .sensitivity, .leastOfThese, .isSignLanguage, .isDialect));
+      ALTER TRIGGER recalculateProjectSens USING (UPDATE
+          (SELECT
+              default::TranslationProject
+          FILTER
+              ((__new__ IN .languages) AND (.sensitivity != (std::max(.languages.sensitivity) ?? default::Sensitivity.High)))
+          )
+      SET {
+          sensitivity := (std::max(.languages.sensitivity) ?? default::Sensitivity.High)
+      });
+  };
+  ALTER TYPE default::LanguageEngagement {
+      ALTER TRIGGER recalculateProjectSensOnDelete USING (WITH
+          removedLang := 
+              __old__.language
+      UPDATE
+          (SELECT
+              default::TranslationProject
+          FILTER
+              ((__old__ IN .languages) AND (.sensitivity != (std::max(((.languages EXCEPT removedLang)).sensitivity) ?? default::Sensitivity.High)))
+          )
+      SET {
+          sensitivity := (std::max(((.languages EXCEPT removedLang)).sensitivity) ?? default::Sensitivity.High)
+      });
+      ALTER TRIGGER recalculateProjectSensOnInsert USING (UPDATE
+          (SELECT
+              default::TranslationProject
+          FILTER
+              ((__new__ IN .languages) AND (.sensitivity != (std::max(.languages.sensitivity) ?? default::Sensitivity.High)))
+          )
+      SET {
+          sensitivity := (std::max(.languages.sensitivity) ?? default::Sensitivity.High)
+      });
+  };
+};

--- a/dbschema/migrations/00006.edgeql
+++ b/dbschema/migrations/00006.edgeql
@@ -1,0 +1,16 @@
+CREATE MIGRATION m1hjnudahjdbrqvoi7ikqsalk5uv4gyfk5rbzcnonq2qoauw4ee2ea
+    ONTO m1mhq7b2c53yr7fxf7x5sgjogvrkg4hjj2nhpdivxja66sjpc5amza
+{
+  ALTER TYPE default::InternshipEngagement {
+      ALTER LINK project {
+          RESET OPTIONALITY;
+          RESET TYPE;
+      };
+  };
+  ALTER TYPE default::LanguageEngagement {
+      ALTER LINK project {
+          RESET OPTIONALITY;
+          RESET TYPE;
+      };
+  };
+};

--- a/dbschema/migrations/00007.edgeql
+++ b/dbschema/migrations/00007.edgeql
@@ -1,0 +1,11 @@
+CREATE MIGRATION m17wcugznjhc34awd734qo7mxst3vzwhc54xjrqawsjtlcuhbafdga
+    ONTO m1hjnudahjdbrqvoi7ikqsalk5uv4gyfk5rbzcnonq2qoauw4ee2ea
+{
+  ALTER TYPE Project::Resource {
+      DROP PROPERTY sensitivity;
+  };
+  ALTER TYPE default::Language {
+      DROP INDEX ON (.sensitivity);
+      DROP PROPERTY effectiveSensitivity;
+  };
+};

--- a/dbschema/migrations/00008.edgeql
+++ b/dbschema/migrations/00008.edgeql
@@ -1,0 +1,9 @@
+CREATE MIGRATION m1rtq3fw45vdkon7lgrpisvdak2g663tcv7bekfed2bfxgkj23lu4q
+    ONTO m17wcugznjhc34awd734qo7mxst3vzwhc54xjrqawsjtlcuhbafdga
+{
+  ALTER TYPE default::Language {
+      ALTER PROPERTY sensitivity {
+          RENAME TO ownSensitivity;
+      };
+  };
+};

--- a/dbschema/migrations/00009.edgeql
+++ b/dbschema/migrations/00009.edgeql
@@ -1,0 +1,9 @@
+CREATE MIGRATION m1kgkikeo6qaen7zzrnuhvhfiqak32ap254imd6or7naaatelnf24q
+    ONTO m1rtq3fw45vdkon7lgrpisvdak2g663tcv7bekfed2bfxgkj23lu4q
+{
+  ALTER TYPE default::Project {
+      ALTER PROPERTY sensitivity {
+          RENAME TO ownSensitivity;
+      };
+  };
+};

--- a/dbschema/migrations/00010.edgeql
+++ b/dbschema/migrations/00010.edgeql
@@ -1,0 +1,46 @@
+CREATE MIGRATION m1bl5usbsd57f2obaikame74dp7p3oitsmulfitpvducp2k4oetwea
+    ONTO m1kgkikeo6qaen7zzrnuhvhfiqak32ap254imd6or7naaatelnf24q
+{
+  ALTER TYPE Project::Resource {
+      DROP PROPERTY isMember;
+  };
+  CREATE TYPE Project::Context;
+  CREATE ABSTRACT TYPE Project::HasContext {
+      CREATE REQUIRED LINK projectContext: Project::Context {
+          SET default := (INSERT
+              Project::Context
+          );
+      };
+      CREATE PROPERTY ownSensitivity: default::Sensitivity;
+  };
+  ALTER TYPE default::Language {
+      DROP PROPERTY isMember;
+  };
+  ALTER TYPE default::Project {
+      DROP PROPERTY isMember;
+      EXTENDING Project::HasContext LAST;
+  };
+  ALTER TYPE Project::Context {
+      CREATE MULTI LINK projects: default::Project {
+          ON TARGET DELETE ALLOW;
+      };
+  };
+  ALTER TYPE Project::HasContext {
+      CREATE REQUIRED SINGLE PROPERTY isMember := (EXISTS (.projectContext.projects.membership));
+  };
+  ALTER TYPE default::Project {
+      ALTER PROPERTY ownSensitivity {
+          RESET OPTIONALITY;
+          RESET TYPE;
+      };
+  };
+  ALTER TYPE Project::Resource {
+      CREATE PROPERTY isMember := (.project.isMember);
+  };
+  ALTER TYPE Project::HasContext {
+      CREATE REQUIRED SINGLE PROPERTY sensitivity := ((std::max(.projectContext.projects.ownSensitivity) ?? (.ownSensitivity ?? default::Sensitivity.High)));
+  };
+  ALTER TYPE default::Language {
+      CREATE PROPERTY isMember := (EXISTS (.projects.isMember));
+  };
+};

--- a/dbschema/migrations/00011.edgeql
+++ b/dbschema/migrations/00011.edgeql
@@ -1,0 +1,31 @@
+CREATE MIGRATION m1je52dmicyhild43tygqtxydgf4mp5nymhqyibrzv2a2yg5kbf4yq
+    ONTO m1bl5usbsd57f2obaikame74dp7p3oitsmulfitpvducp2k4oetwea
+{
+  ALTER TYPE Ethnologue::Language {
+      CREATE REQUIRED LINK language: default::Language {
+          ON TARGET DELETE DELETE SOURCE;
+          SET REQUIRED USING (SELECT
+              default::Language FILTER
+                  (.ethnologue = __source__)
+          LIMIT
+              1
+          );
+          CREATE CONSTRAINT std::exclusive;
+      };
+  };
+  ALTER TYPE default::Language {
+      ALTER LINK ethnologue {
+          RESET default;
+          USING (std::assert_exists(std::assert_single(.<language[IS Ethnologue::Language])));
+          RESET ON SOURCE DELETE;
+          SET SINGLE;
+      };
+      CREATE TRIGGER connectEthnologue
+          AFTER INSERT 
+          FOR EACH DO (INSERT
+              Ethnologue::Language
+              {
+                  language := __new__
+              });
+  };
+};

--- a/dbschema/migrations/00012.edgeql
+++ b/dbschema/migrations/00012.edgeql
@@ -1,0 +1,51 @@
+CREATE MIGRATION m1moj5gskfzn7ieyayntlanzckxil5nhwjxmnp6zjfuhb64rcfzscq
+    ONTO m1je52dmicyhild43tygqtxydgf4mp5nymhqyibrzv2a2yg5kbf4yq
+{
+  ALTER TYPE Ethnologue::Language EXTENDING Project::HasContext LAST;
+  ALTER TYPE default::Language {
+      DROP PROPERTY isMember;
+  };
+  ALTER TYPE default::Language {
+      DROP LINK projects;
+      EXTENDING Project::HasContext LAST;
+  };
+  ALTER TYPE default::Language {
+      ALTER TRIGGER connectEthnologue USING (INSERT
+          Ethnologue::Language
+          {
+              language := __new__,
+              projectContext := __new__.projectContext
+          });
+      ALTER PROPERTY ownSensitivity {
+          RESET OPTIONALITY;
+          RESET TYPE;
+      };
+  };
+  ALTER TYPE default::Language {
+      CREATE TRIGGER matchEthnologueToOwnSens
+          AFTER UPDATE, INSERT 
+          FOR EACH DO (UPDATE
+              __new__.ethnologue
+          FILTER
+              (.ownSensitivity != __new__.ownSensitivity)
+          SET {
+              ownSensitivity := __new__.ownSensitivity
+          });
+  };
+  ALTER TYPE default::LanguageEngagement {
+      CREATE TRIGGER addProjectToContextOfLanguage
+          AFTER INSERT 
+          FOR EACH DO (UPDATE
+              __new__.language.projectContext
+          SET {
+              projects += __new__.project
+          });
+      CREATE TRIGGER removeProjectFromContextOfLanguage
+          AFTER DELETE 
+          FOR EACH DO (UPDATE
+              __old__.language.projectContext
+          SET {
+              projects -= __old__.project
+          });
+  };
+};

--- a/dbschema/migrations/00013.edgeql
+++ b/dbschema/migrations/00013.edgeql
@@ -1,0 +1,15 @@
+CREATE MIGRATION m1v3l6r54gp2kccouwc6nv7jpogxfsfyclk5l7yqds4pj4qyunyqra
+    ONTO m1moj5gskfzn7ieyayntlanzckxil5nhwjxmnp6zjfuhb64rcfzscq
+{
+  ALTER TYPE default::Language {
+      DROP TRIGGER connectEthnologue;
+      DROP TRIGGER recalculateProjectSens;
+  };
+  ALTER TYPE default::LanguageEngagement {
+      DROP TRIGGER recalculateProjectSensOnDelete;
+      DROP TRIGGER recalculateProjectSensOnInsert;
+  };
+  ALTER TYPE default::TranslationProject {
+      DROP TRIGGER confirmProjectSens;
+  };
+};

--- a/dbschema/migrations/00014.edgeql
+++ b/dbschema/migrations/00014.edgeql
@@ -1,0 +1,57 @@
+CREATE MIGRATION m1f57erjzmisxbtd2xgj7zo33kgljsjaaohar22n5r27x7q6gzobea
+    ONTO m1v3l6r54gp2kccouwc6nv7jpogxfsfyclk5l7yqds4pj4qyunyqra
+{
+  ALTER TYPE default::Language {
+      CREATE TRIGGER connectEthnologue
+          AFTER INSERT 
+          FOR EACH DO (INSERT
+              Ethnologue::Language
+              {
+                  language := __new__,
+                  projectContext := __new__.projectContext
+              });
+      CREATE TRIGGER recalculateProjectSens
+          AFTER UPDATE 
+          FOR EACH DO (UPDATE
+              (SELECT
+                  default::TranslationProject
+              FILTER
+                  ((__new__ IN .languages) AND (.ownSensitivity != (std::max(.languages.ownSensitivity) ?? default::Sensitivity.High)))
+              )
+          SET {
+              ownSensitivity := (std::max(.languages.ownSensitivity) ?? default::Sensitivity.High)
+          });
+  };
+  ALTER TYPE default::LanguageEngagement {
+      CREATE TRIGGER recalculateProjectSensOnDelete
+          AFTER DELETE 
+          FOR EACH DO (WITH
+              removedLang := 
+                  __old__.language
+          UPDATE
+              (SELECT
+                  default::TranslationProject
+              FILTER
+                  ((__old__ IN .languages) AND (.ownSensitivity != (std::max(((.languages EXCEPT removedLang)).ownSensitivity) ?? default::Sensitivity.High)))
+              )
+          SET {
+              ownSensitivity := (std::max(((.languages EXCEPT removedLang)).ownSensitivity) ?? default::Sensitivity.High)
+          });
+      CREATE TRIGGER recalculateProjectSensOnInsert
+          AFTER INSERT 
+          FOR EACH DO (UPDATE
+              (SELECT
+                  default::TranslationProject
+              FILTER
+                  ((__new__ IN .languages) AND (.ownSensitivity != (std::max(.languages.ownSensitivity) ?? default::Sensitivity.High)))
+              )
+          SET {
+              ownSensitivity := (std::max(.languages.ownSensitivity) ?? default::Sensitivity.High)
+          });
+  };
+  ALTER TYPE default::TranslationProject {
+      CREATE TRIGGER confirmProjectSens
+          AFTER UPDATE 
+          FOR EACH DO (std::assert((__new__.ownSensitivity = (std::max(__new__.languages.ownSensitivity) ?? default::Sensitivity.High)), message := 'TranslationProject sensitivity is automatically set to (and required to be) the highest sensitivity Language engaged'));
+  };
+};

--- a/dbschema/migrations/00015.edgeql
+++ b/dbschema/migrations/00015.edgeql
@@ -1,0 +1,27 @@
+CREATE MIGRATION m1dppmmlph6slcbs3kbiwtpegecjb5isy335ff4zlglui4zghlkmua
+    ONTO m1f57erjzmisxbtd2xgj7zo33kgljsjaaohar22n5r27x7q6gzobea
+{
+  ALTER TYPE default::Language {
+      ALTER TRIGGER connectEthnologue USING (INSERT
+          Ethnologue::Language
+          {
+              language := __new__,
+              ownSensitivity := __new__.ownSensitivity,
+              projectContext := __new__.projectContext
+          });
+  };
+  ALTER TYPE default::Language {
+      DROP TRIGGER matchEthnologueToOwnSens;
+  };
+  ALTER TYPE default::Language {
+      CREATE TRIGGER matchEthnologueToOwnSens
+          AFTER UPDATE 
+          FOR EACH DO (UPDATE
+              __new__.ethnologue
+          FILTER
+              (.ownSensitivity != __new__.ownSensitivity)
+          SET {
+              ownSensitivity := __new__.ownSensitivity
+          });
+  };
+};

--- a/dbschema/migrations/00016.edgeql
+++ b/dbschema/migrations/00016.edgeql
@@ -1,0 +1,10 @@
+CREATE MIGRATION m1qxegbs7vzamuvsv7cs6r4nntxkwayrdhdlkx3223iyq3hsidd3ga
+    ONTO m1dppmmlph6slcbs3kbiwtpegecjb5isy335ff4zlglui4zghlkmua
+{
+  ALTER TYPE default::InternshipEngagement {
+      DROP TRIGGER connectCertificationCeremony;
+  };
+  ALTER TYPE default::LanguageEngagement {
+      DROP TRIGGER connectDedicationCeremony;
+  };
+};

--- a/dbschema/migrations/00017.edgeql
+++ b/dbschema/migrations/00017.edgeql
@@ -1,0 +1,52 @@
+CREATE MIGRATION m1yqrqv3p2ejs6crcj32nafkikyoj67b2gfwhola6nyjhndffjzmfq
+    ONTO m1qxegbs7vzamuvsv7cs6r4nntxkwayrdhdlkx3223iyq3hsidd3ga
+{
+  ALTER TYPE Project::HasContext {
+      ALTER LINK projectContext {
+          RESET default;
+      };
+      ALTER PROPERTY ownSensitivity {
+          CREATE ANNOTATION std::description := "A writable source of a sensitivity. This doesn't necessarily mean it be the same as .sensitivity, which is what is used for authorization.";
+      };
+  };
+  ALTER TYPE Project::Resource {
+      CREATE LINK projectContext: Project::Context {
+          SET REQUIRED USING (<Project::Context>{});
+      };
+  };
+  ALTER TYPE Project::Resource {
+      DROP PROPERTY isMember;
+      EXTENDING Project::HasContext LAST;
+      ALTER LINK projectContext {
+          RESET OPTIONALITY;
+          DROP OWNED;
+          RESET TYPE;
+      };
+  };
+  ALTER TYPE Project::Resource {
+      CREATE TRIGGER enforceCorrectProjectContext
+          AFTER UPDATE, INSERT 
+          FOR EACH DO (std::assert((__new__.project IN __new__.projectContext.projects), message := 'Given project must be in given project context'));
+  };
+  ALTER TYPE Project::Context {
+      CREATE ANNOTATION std::description := 'A type that holds a reference to a list of projects. This allows multiple objects to hold a reference to the same list. For example, Language & Ethnologue::Language share the same context / project list.';
+  };
+  ALTER TYPE default::Project {
+      ALTER LINK projectContext {
+          SET default := (INSERT
+              Project::Context
+          );
+          SET OWNED;
+          SET TYPE Project::Context;
+      };
+  };
+  ALTER TYPE default::Language {
+      ALTER LINK projectContext {
+          SET default := (INSERT
+              Project::Context
+          );
+          SET OWNED;
+          SET TYPE Project::Context;
+      };
+  };
+};

--- a/dbschema/migrations/00018.edgeql
+++ b/dbschema/migrations/00018.edgeql
@@ -1,0 +1,32 @@
+CREATE MIGRATION m1v6vmh2owlqk4hmin44txizh64lrl6xjo4rlay4gyfk3sjskyqe2q
+    ONTO m1yqrqv3p2ejs6crcj32nafkikyoj67b2gfwhola6nyjhndffjzmfq
+{
+  CREATE ABSTRACT TYPE Project::ContextAware {
+      CREATE REQUIRED LINK projectContext: Project::Context;
+      CREATE OPTIONAL PROPERTY ownSensitivity: default::Sensitivity {
+          CREATE ANNOTATION std::description := "A writable source of a sensitivity. This doesn't necessarily mean it be the same as .sensitivity, which is what is used for authorization.";
+      };
+      CREATE ANNOTATION std::description := 'A type that has a project context, which allows it to be\n      aware of the sensitivity & current user membership for the associated context.';
+  };
+  ALTER TYPE Project::Resource {
+      DROP EXTENDING Project::HasContext;
+      EXTENDING Project::ContextAware LAST;
+  };
+  ALTER TYPE default::Project {
+      DROP EXTENDING Project::HasContext;
+      EXTENDING Project::ContextAware BEFORE Mixin::Pinnable;
+  };
+  ALTER TYPE Project::ContextAware {
+      CREATE REQUIRED SINGLE PROPERTY isMember := (EXISTS (.projectContext.projects.membership));
+      CREATE REQUIRED SINGLE PROPERTY sensitivity := ((std::max(.projectContext.projects.ownSensitivity) ?? (.ownSensitivity ?? default::Sensitivity.High)));
+  };
+  ALTER TYPE Ethnologue::Language {
+      DROP EXTENDING Project::HasContext;
+      EXTENDING Project::ContextAware LAST;
+  };
+  ALTER TYPE default::Language {
+      DROP EXTENDING Project::HasContext;
+      EXTENDING Project::ContextAware BEFORE Mixin::Pinnable;
+  };
+  DROP TYPE Project::HasContext;
+};

--- a/dbschema/migrations/00019.edgeql
+++ b/dbschema/migrations/00019.edgeql
@@ -1,0 +1,28 @@
+CREATE MIGRATION m16iocvtxxrlcx2ireyxh66ma6ti5tpi3hr7jga2lnfjvoi2nez3ha
+    ONTO m1v6vmh2owlqk4hmin44txizh64lrl6xjo4rlay4gyfk3sjskyqe2q
+{
+  ALTER TYPE default::InternshipEngagement {
+      CREATE TRIGGER connectCertificationCeremony
+          AFTER INSERT 
+          FOR EACH DO (INSERT
+              Engagement::CertificationCeremony
+              {
+                  createdAt := std::datetime_of_statement(),
+                  engagement := __new__,
+                  project := __new__.project,
+                  projectContext := __new__.projectContext
+              });
+  };
+  ALTER TYPE default::LanguageEngagement {
+      CREATE TRIGGER connectDedicationCeremony
+          AFTER INSERT 
+          FOR EACH DO (INSERT
+              Engagement::DedicationCeremony
+              {
+                  createdAt := std::datetime_of_statement(),
+                  engagement := __new__,
+                  project := __new__.project,
+                  projectContext := __new__.projectContext
+              });
+  };
+};

--- a/dbschema/migrations/00020.edgeql
+++ b/dbschema/migrations/00020.edgeql
@@ -1,0 +1,27 @@
+CREATE MIGRATION m15a6v6vq6uagxsmifldt2bj5d2et34zxi7vzln7fuu6ehdolxl7dq
+    ONTO m16iocvtxxrlcx2ireyxh66ma6ti5tpi3hr7jga2lnfjvoi2nez3ha
+{
+  CREATE ABSTRACT TYPE Project::Child EXTENDING default::Resource, Project::ContextAware {
+      CREATE REQUIRED LINK project: default::Project {
+          ON TARGET DELETE DELETE SOURCE;
+          SET readonly := true;
+      };
+      CREATE TRIGGER enforceCorrectProjectContext
+          AFTER UPDATE, INSERT 
+          FOR EACH DO (std::assert((__new__.project IN __new__.projectContext.projects), message := 'Given project must be in given project context'));
+      CREATE ANNOTATION std::description := 'A type that is a child of a project. It will always have a reference to a single project that it is under.';
+  };
+  ALTER TYPE Engagement::Resource {
+      DROP EXTENDING Project::Resource;
+      EXTENDING Project::Child LAST;
+  };
+  ALTER TYPE Project::Member {
+      DROP EXTENDING Project::Resource;
+      EXTENDING Project::Child LAST;
+  };
+  ALTER TYPE default::Engagement {
+      DROP EXTENDING Project::Resource;
+      EXTENDING Project::Child LAST;
+  };
+  DROP TYPE Project::Resource;
+};

--- a/dbschema/migrations/00021.edgeql
+++ b/dbschema/migrations/00021.edgeql
@@ -1,0 +1,19 @@
+CREATE MIGRATION m1c5l3sqykj5an6vd6jjfgzpiax2hg5mpnu5gl2jrovvrb6q2oglia
+    ONTO m15a6v6vq6uagxsmifldt2bj5d2et34zxi7vzln7fuu6ehdolxl7dq
+{
+  CREATE ABSTRACT TYPE Engagement::Child EXTENDING Project::Child {
+      CREATE REQUIRED LINK engagement: default::Engagement {
+          ON TARGET DELETE DELETE SOURCE;
+          SET readonly := true;
+      };
+      CREATE TRIGGER enforceEngagementProject
+          AFTER UPDATE, INSERT 
+          FOR EACH DO (std::assert((__new__.engagement.project = __new__.project), message := 'Given engagement must be for the same project as the given project.'));
+      CREATE ANNOTATION std::description := 'A type that is a child of an engagement. It will always have a reference to a single engagement & project that it is under.';
+  };
+  ALTER TYPE Engagement::Ceremony {
+      DROP EXTENDING Engagement::Resource;
+      EXTENDING Engagement::Child LAST;
+  };
+  DROP TYPE Engagement::Resource;
+};

--- a/dbschema/project-member.esdl
+++ b/dbschema/project-member.esdl
@@ -1,5 +1,5 @@
 module Project {
-  type Member extending Resource {
+  type Member extending Child {
     required user: default::User {
       readonly := true;
       on target delete delete source;

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -4,7 +4,7 @@ module default {
       constraint exclusive;
     };
     
-    required sensitivity: Sensitivity {
+    required ownSensitivity: Sensitivity {
       annotation description := "The sensitivity of the project. \
         This is user settable for internships and calculated for translation projects";
       default := Sensitivity.High;
@@ -57,7 +57,7 @@ module default {
     
     trigger confirmProjectSens after update for each do (
       assert(
-        __new__.sensitivity = max(__new__.languages.ownSensitivity) ?? Sensitivity.High,
+        __new__.ownSensitivity = max(__new__.languages.ownSensitivity) ?? Sensitivity.High,
         message := "TranslationProject sensitivity is automatically set to \
           (and required to be) the highest sensitivity Language engaged"
       )
@@ -76,7 +76,7 @@ module Project {
       on target delete delete source;
     };
     
-#     property sensitivity := .project.sensitivity;
+#     property sensitivity := .project.ownSensitivity;
     property isMember := .project.isMember;
   }
   

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -73,7 +73,11 @@ module default {
 }
  
 module Project {
-  abstract type Resource extending default::Resource, ContextAware {
+  abstract type Child extending default::Resource, ContextAware {
+    annotation description := "\
+      A type that is a child of a project. \
+      It will always have a reference to a single project that it is under.";
+    
     required project: default::Project {
       readonly := true;
       on target delete delete source;

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -76,7 +76,7 @@ module Project {
       on target delete delete source;
     };
     
-    property sensitivity := .project.sensitivity;
+#     property sensitivity := .project.sensitivity;
     property isMember := .project.isMember;
   }
   

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -57,7 +57,7 @@ module default {
     
     trigger confirmProjectSens after update for each do (
       assert(
-        __new__.sensitivity = max(__new__.languages.sensitivity) ?? Sensitivity.High,
+        __new__.sensitivity = max(__new__.languages.ownSensitivity) ?? Sensitivity.High,
         message := "TranslationProject sensitivity is automatically set to \
           (and required to be) the highest sensitivity Language engaged"
       )

--- a/edgedb.toml
+++ b/edgedb.toml
@@ -1,2 +1,2 @@
 [edgedb]
-server-version = "3.0"
+server-version = "4.0"


### PR DESCRIPTION
# Why
This builds upon #2922. It established the pattern for how a project's sensitivity and current user's membership is shared for all types under a project, engagement, products, partnerships, etc.

However, we still have the use case of Languages, Partners, etc. These also use their related project's sensitivity and membership to determine authorization. It's just that they need aggregate multiple projects instead of a single one.

I had `isMember` and `effectiveSensitivity` defined on `Language`, and this is useful when we are looking at a language directly.
```
select Language {*}
filter .effectiveSensitivity <= Sens.Medium
```
This would indeed work for language queries and access policies. So I thought I had the problem solved, though admittedly a bit clumsy for these handful of types that were "project aware but outside projects". Since they would need to declare their own `sensitivity` and `isMember` fields themselves.

I started working on `File` schema, and wanted something that also works for `Posts/Comments` which are embedded into other resources. Now if I wanted to say "this directory can only be read if it's parent's sensitivity is medium or lower" it was impossible.
Every type that had a computed sensitivity property would need to be enumerated.
Something like
```
select Object {
  sensitivity := (
    [is Project].sensitivity ??
    [is Language].sensitivity ??
    [is Partner].sensitivity ??
    [is Organization].sensitivity
  )
}
```
This is not good.
We needed a way to refer to a single `sensitivity` field.

To do this we needed a unified _**stored**_ field that all project based queries could point back to.

# Project Context (What)

This adds a `Project::Context` type which holds a list of projects.
All project (context) aware objects will now have a reference to one of these:
- For Project `English 1`, its project context list would just be itself:
   `{ English 1 }`
- For Language `English`, its project context list would be all projects engaged with it:
   `{ English 1, English 2, English 3 }`
- For Partner `Seed Co`, its project context list would be all projects its partnered with:
   `{ English 1, Spanish 1 }`

Now `Language`, `Project`, `Engagement` all extend from `Project::ContextAware`. This abstract type is now able to provide a _single_ computed field for `sensitivity` that all 3 of these concrete types can use.
Looking back at our query above, it can now be
```
select Object {
  [is Project::ContextAware].sensitivity
}
```

## Draw backs

I've prioritized reading back these values, as that is the main need. For app queries, access policies, and adhoc reads from DB UI.
In order to make this happen though, this project context list is (unfortunately) denormalized from the actual relations that declare these connections.
So it's up to the _write process_ to declare how these different relations should affect project contexts.
For languages (and partners in future), this is done with triggers (which you can see I've added [here](https://github.com/SeedCompany/cord-api-v3/pull/2931/files#diff-5d11b98de213d001e2229978d3f171f85951a44d37a1fe2dba45d0dc1b91fd18R104-R111)). So queries do not need to worry about it.
You can also see that `Ethnologue::Language` now actually supports these as well. It shares the project context from the related `default::Language` so it gets those changes automatically.

`Projects` is the main hiccup. Currently edgedb cannot "link to self" with a single insert operation. Since a project's context is a list of itself, this is a problem. So for now, when creating projects, the project needs to be created first, and the separately, secondly updated to add itself to its context. But this will be done once in app code, and will just have to be something to remember if doing adhoc project creation.
This is by far the biggest rough edge, and I'll keep an eye out for a better (schema declared) workaround.

# `ownSensitivity`

With sensitivity being the single computed field on all of these types, we needed a different stored field to be the source.
I called this `ownSensitivity`, aka a Language's own sensitivity. Where as the "effective sensitivity" for authorization is now pulled from `sensitivity`.
This, I think, is more clear too. `ownSensitivity` is always writable, and `sensitivity` is always computed.
`Project::ContextAware` declares this field as optional, but `Project` & `Language` overload to make it required.

# `Project::Child`

I renamed `Project::Resource` -> `Project::Child` to hopefully be a bit more clear.
Also `Engagement::Resource` -> `Engagement::Child`.
Still not 100% sold, but could be better...maybe.

# EdgeDB 4.0

Also bumped to v4 lol

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5471944036) by [Unito](https://www.unito.io)
