### PR TITLE
Move Language/Project name to `Mixin::Named`

### DIFF
--- a/dbschema/language.esdl
+++ b/dbschema/language.esdl
@@ -1,8 +1,5 @@
 module default {
-  type Language extending Resource, Project::ContextAware, Mixin::Pinnable, Mixin::Taggable {
-    required name: str;
-    index on (str_sortable(.name));
-    
+  type Language extending Resource, Project::ContextAware, Mixin::Named, Mixin::Pinnable, Mixin::Taggable {
     required displayName: str {
       default := .name;
     }

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -1,6 +1,6 @@
 module default {
-  abstract type Project extending Resource, Project::ContextAware, Mixin::Pinnable, Mixin::Taggable {
-    required name: str {
+  abstract type Project extending Resource, Project::ContextAware, Mixin::Named, Mixin::Pinnable, Mixin::Taggable {
+    overloaded name {
       constraint exclusive;
     };
     

--- a/dbschema/z.named.esdl
+++ b/dbschema/z.named.esdl
@@ -1,0 +1,24 @@
+module Mixin {
+  abstract type Named {
+    required name: str {
+      rewrite insert, update using (default::str_clean(.name));
+    };
+    
+    index on (default::str_sortable(.name));
+    
+    index fts::index on (
+      fts::with_options(
+        .name,
+        language := fts::Language.eng,
+      )
+    );
+  } 
+}
+ 
+module default {
+  function str_clean(string: str) -> optional str
+    using(
+      with trimmed := str_trim(string, " \t\r\n")
+      select if len(trimmed) > 0 then trimmed else <str>{}
+    );
+}


### PR DESCRIPTION
This makes it easy to grab a name from a polymorphic query.
I'm hoping we can rework user to also use this. Producibles & Files can also use this.
```
select Resource {
  id,
  [is Mixin::Named].name
}
```
I think this will come in handy for Search as well.

Also added some constraints for a trimmed string, so "Foo " becomes "Foo" and "   " becomes null & constraint error.
It's as a function so we could choose to apply it to more places.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5488033422) by [Unito](https://www.unito.io)
