### PR TITLE
Improve DX with webserver and REPL when neo4j connection is not available

### DIFF
--- a/src/components/admin/admin.service.ts
+++ b/src/components/admin/admin.service.ts
@@ -24,7 +24,7 @@ export class AdminService implements OnApplicationBootstrap {
     const finishing = this.repo.finishing(() => this.setupRootObjects());
     // Wait for root object setup when running tests, else just let it run in
     // background and allow webserver to start.
-    if (this.config.jest || this.config.isRepl) {
+    if (this.config.jest) {
       await finishing;
     } else {
       finishing.catch((exception) => {

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -145,9 +145,7 @@ export const makeConfig = (env: EnvironmentService) =>
     frontendUrl = env.string('FRONTEND_URL').optional('http://localhost:3001');
 
     neo4j = (() => {
-      const driverConfig: Neo4JDriverConfig = {
-        maxTransactionRetryTime: 30_000,
-      };
+      const driverConfig: Neo4JDriverConfig = {};
       let url = env.string('NEO4J_URL').optional('bolt://localhost');
       const parsed = new URL(url);
       const username = env

--- a/src/core/database/cypher.factory.ts
+++ b/src/core/database/cypher.factory.ts
@@ -91,10 +91,12 @@ export const CypherFactory: FactoryProvider<Connection> = {
           routingTable,
         });
       } else if (
-        level === LogLevel.ERROR &&
-        message.includes(
-          'experienced a fatal error {"code":"ServiceUnavailable","name":"Neo4jError"}',
-        )
+        (level === LogLevel.WARNING &&
+          message.includes('Failed to connect to server')) ||
+        (level === LogLevel.ERROR &&
+          message.includes(
+            'experienced a fatal error {"code":"ServiceUnavailable","name":"Neo4jError"}',
+          ))
       ) {
         // Change connection failure messages to debug.
         // Connection failures are thrown so they will get logged

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -127,18 +127,12 @@ export class DatabaseService {
     const session = this.db.driver.session();
     try {
       const generalInfo = await session.executeRead((tx) =>
-        tx
-          .run(
-            `
+        tx.run(`
           call dbms.components()
           yield versions, edition
           unwind versions as version
           return version, edition
-        `,
-          )
-          .catch((e) => {
-            throw createBetterError(e);
-          }),
+        `),
       );
       const info = generalInfo.records[0];
       if (!info) {
@@ -160,6 +154,8 @@ export class DatabaseService {
             r.get(version[0] >= 5 ? 'statusMessage' : 'error') || undefined,
         })),
       };
+    } catch (e) {
+      throw createBetterError(e);
     } finally {
       await session.close();
     }

--- a/src/core/database/errors.ts
+++ b/src/core/database/errors.ts
@@ -52,7 +52,7 @@ export class ServiceUnavailableError extends Neo4jError {
       )
       // Strip excessive documentation.
       .replace(
-        'Please ensure that your database is listening on the correct host and port and that you have compatible encryption settings both on Neo4j server and driver. Note that the default encryption setting has changed in Neo4j 4.0. ',
+        ' Please ensure that your database is listening on the correct host and port and that you have compatible encryption settings both on Neo4j server and driver. Note that the default encryption setting has changed in Neo4j 4.0.',
         '',
       );
     const ex = new this(message);

--- a/src/core/database/indexer/indexer.module.ts
+++ b/src/core/database/indexer/indexer.module.ts
@@ -48,7 +48,7 @@ export class IndexerModule implements OnModuleInit {
     );
     // Wait for indexing to finish when running tests, else just let it run in
     // background and allow webserver to start.
-    if (this.config.jest || this.config.isRepl) {
+    if (this.config.jest) {
       await finishing;
     } else {
       finishing.catch((exception) => {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -4,14 +4,7 @@ import * as fs from 'fs';
 // eslint-disable-next-line no-restricted-imports
 import * as lodash from 'lodash';
 import { DateTime, Duration, Interval } from 'luxon';
-import {
-  CalendarDate,
-  DateInterval,
-  many,
-  maybeMany,
-  Role,
-  Session,
-} from '~/common';
+import { CalendarDate, DateInterval, many, maybeMany } from '~/common';
 import * as common from '~/common';
 import './polyfills';
 
@@ -22,15 +15,15 @@ runRepl({
     return { logger };
   },
   extraContext: async (app) => {
-    const { ConfigService, ResourcesHost } = await import('~/core');
+    const { ResourcesHost } = await import('~/core');
     const { AuthenticationService } = await import(
       './components/authentication'
     );
     const { Pnp } = await import('./components/pnp');
 
-    const session = await app
+    const session = app
       .get(AuthenticationService)
-      .sessionForUser(app.get(ConfigService).rootAdmin.id);
+      .lazySessionForRootAdminUser();
     const Resources = await app.get(ResourcesHost).getEnhancedMap();
 
     return {
@@ -46,10 +39,7 @@ runRepl({
       __: lodash, // single underscore is "last execution result"
       lodash,
       session,
-      sessionFor: (role: Role): Session => ({
-        ...session,
-        roles: [`global:${role}`],
-      }),
+      sessionFor: session.withRoles,
       Resources,
       loadPnp: (filepath: string) => Pnp.fromBuffer(fs.readFileSync(filepath)),
     };


### PR DESCRIPTION
Many of these improvements are just restoring functionality that regressed with recent neo4j upgrades.

I changed REPL to not wait for neo4j indexes or admin setup. This is almost never needed.

I changed the root admin session to be lazily loaded, so REPL can start without it.
This will load the root user ID when the DB connection becomes available.
If trying to access `session.userId` before DB connection is established / ID is loaded an error is thrown.
`await session` will wait for the ID to be populated, but FYI you could be waiting for forever.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5493631409) by [Unito](https://www.unito.io)
