### PR TITLE
Implicitly run GQL mutations in EdgeDB transactions

### DIFF
--- a/src/core/database/abstract-transactional-mutations.interceptor.ts
+++ b/src/core/database/abstract-transactional-mutations.interceptor.ts
@@ -1,0 +1,46 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { GqlContextType, GqlExecutionContext } from '@nestjs/graphql';
+import { GraphQLResolveInfo } from 'graphql';
+import { from, lastValueFrom } from 'rxjs';
+import { RollbackManager } from './rollback-manager';
+
+/**
+ * Run all mutations in a transaction.
+ * This allows automatic rollbacks on error.
+ */
+@Injectable()
+export abstract class TransactionalMutationsInterceptor
+  implements NestInterceptor
+{
+  constructor(private readonly rollbacks: RollbackManager) {}
+
+  async intercept(context: ExecutionContext, next: CallHandler) {
+    if (context.getType<GqlContextType>() !== 'graphql') {
+      return next.handle();
+    }
+
+    const ctx = GqlExecutionContext.create(context);
+    const info = ctx.getInfo<GraphQLResolveInfo>();
+    if (info.operation.operation !== 'mutation') {
+      return next.handle();
+    }
+
+    return from(
+      this.inTx(async () => {
+        try {
+          return await lastValueFrom(next.handle());
+        } catch (e) {
+          await this.rollbacks.runAndClear();
+          throw e;
+        }
+      }),
+    );
+  }
+
+  protected abstract inTx<R>(fn: () => Promise<R>): Promise<R>;
+}

--- a/src/core/database/database.module.ts
+++ b/src/core/database/database.module.ts
@@ -10,7 +10,7 @@ import { IndexerModule } from './indexer/indexer.module';
 import { MigrationModule } from './migration/migration.module';
 import { ParameterTransformer } from './parameter-transformer.service';
 import { RollbackManager } from './rollback-manager';
-import { TransactionalMutationsInterceptor } from './transactional-mutations.interceptor';
+import { Neo4jTransactionalMutationsInterceptor as TransactionalMutationsInterceptor } from './transactional-mutations.interceptor';
 
 @Module({
   imports: [IndexerModule, MigrationModule, ConfigModule, TracingModule],

--- a/src/core/database/transactional-mutations.interceptor.ts
+++ b/src/core/database/transactional-mutations.interceptor.ts
@@ -1,46 +1,12 @@
-import {
-  CallHandler,
-  ExecutionContext,
-  Injectable,
-  NestInterceptor,
-} from '@nestjs/common';
-import { GqlContextType, GqlExecutionContext } from '@nestjs/graphql';
+import { Inject, Injectable } from '@nestjs/common';
 import { Connection } from 'cypher-query-builder';
-import { GraphQLResolveInfo } from 'graphql';
-import { from, lastValueFrom } from 'rxjs';
-import { RollbackManager } from './rollback-manager';
+import { TransactionalMutationsInterceptor } from './abstract-transactional-mutations.interceptor';
 
-/**
- * Run all mutations in a neo4j transaction.
- * This allows automatic rollbacks on error.
- */
 @Injectable()
-export class TransactionalMutationsInterceptor implements NestInterceptor {
-  constructor(
-    private readonly db: Connection,
-    private readonly rollbacks: RollbackManager,
-  ) {}
+export class Neo4jTransactionalMutationsInterceptor extends TransactionalMutationsInterceptor {
+  @Inject(Connection) db: Connection;
 
-  async intercept(context: ExecutionContext, next: CallHandler) {
-    if (context.getType<GqlContextType>() !== 'graphql') {
-      return next.handle();
-    }
-
-    const ctx = GqlExecutionContext.create(context);
-    const info = ctx.getInfo<GraphQLResolveInfo>();
-    if (info.operation.operation !== 'mutation') {
-      return next.handle();
-    }
-
-    return from(
-      this.db.runInTransaction(async () => {
-        try {
-          return await lastValueFrom(next.handle());
-        } catch (e) {
-          await this.rollbacks.runAndClear();
-          throw e;
-        }
-      }),
-    );
+  protected async inTx<R>(fn: () => Promise<R>) {
+    return await this.db.runInTransaction(fn);
   }
 }

--- a/src/core/edgedb/edgedb-transactional-mutations.interceptor.ts
+++ b/src/core/edgedb/edgedb-transactional-mutations.interceptor.ts
@@ -1,0 +1,12 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { TransactionalMutationsInterceptor } from '../database/abstract-transactional-mutations.interceptor';
+import { TransactionContext } from './transaction.context';
+
+@Injectable()
+export class EdgeDBTransactionalMutationsInterceptor extends TransactionalMutationsInterceptor {
+  @Inject(TransactionContext) context: TransactionContext;
+
+  protected async inTx<R>(fn: () => Promise<R>) {
+    return await this.context.inTx(fn);
+  }
+}

--- a/src/core/edgedb/edgedb.module.ts
+++ b/src/core/edgedb/edgedb.module.ts
@@ -6,6 +6,7 @@ import { Class } from 'type-fest';
 import { EdgeDB } from './edgedb.service';
 import { Client } from './reexports';
 import { LuxonCalendarDateCodec, LuxonDateTimeCodec } from './temporal.codecs';
+import { TransactionContext } from './transaction.context';
 
 @Module({
   providers: [
@@ -23,6 +24,7 @@ import { LuxonCalendarDateCodec, LuxonDateTimeCodec } from './temporal.codecs';
       },
     },
     EdgeDB,
+    TransactionContext,
   ],
   exports: [EdgeDB, Client],
 })

--- a/src/core/edgedb/edgedb.module.ts
+++ b/src/core/edgedb/edgedb.module.ts
@@ -1,8 +1,10 @@
 import { Module, OnModuleDestroy } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { createClient } from 'edgedb';
 import { KNOWN_TYPENAMES } from 'edgedb/dist/codecs/consts.js';
 import { ScalarCodec } from 'edgedb/dist/codecs/ifaces.js';
 import { Class } from 'type-fest';
+import { EdgeDBTransactionalMutationsInterceptor } from './edgedb-transactional-mutations.interceptor';
 import { EdgeDB } from './edgedb.service';
 import { Client } from './reexports';
 import { LuxonCalendarDateCodec, LuxonDateTimeCodec } from './temporal.codecs';
@@ -25,6 +27,10 @@ import { TransactionContext } from './transaction.context';
     },
     EdgeDB,
     TransactionContext,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: EdgeDBTransactionalMutationsInterceptor,
+    },
   ],
   exports: [EdgeDB, Client],
 })

--- a/src/core/edgedb/edgedb.module.ts
+++ b/src/core/edgedb/edgedb.module.ts
@@ -1,6 +1,6 @@
 import { Module, OnModuleDestroy } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
-import { createClient } from 'edgedb';
+import { createClient, Duration } from 'edgedb';
 import { KNOWN_TYPENAMES } from 'edgedb/dist/codecs/consts.js';
 import { ScalarCodec } from 'edgedb/dist/codecs/ifaces.js';
 import { Class } from 'type-fest';
@@ -15,7 +15,15 @@ import { TransactionContext } from './transaction.context';
     {
       provide: Client,
       useFactory: () => {
-        const client = createClient();
+        const client = createClient().withConfig({
+          // Bump from 1 min, as needed by test suite.
+          // It's probably because we open & do more with in the transaction
+          // than is expected by the library.
+          // I'm not worried about this, and it's possible this can be removed
+          // after migration if app overall is faster without Neo4j.
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          session_idle_transaction_timeout: Duration.from({ minutes: 5 }),
+        });
 
         registerCustomScalarCodecs(client, [
           LuxonDateTimeCodec,

--- a/src/core/edgedb/transaction.context.ts
+++ b/src/core/edgedb/transaction.context.ts
@@ -1,0 +1,28 @@
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { AsyncLocalStorage } from 'async_hooks';
+import { Executor } from 'edgedb';
+import { Client } from './reexports';
+
+@Injectable()
+export class TransactionContext
+  extends AsyncLocalStorage<Executor>
+  implements OnModuleDestroy
+{
+  constructor(private readonly client: Client) {
+    super();
+  }
+
+  async inTx<R>(fn: () => Promise<R>): Promise<R> {
+    return await this.client.transaction(async (tx) => {
+      return await this.run(tx, fn);
+    });
+  }
+
+  get current() {
+    return this.getStore() ?? this.client;
+  }
+
+  onModuleDestroy() {
+    this.disable();
+  }
+}


### PR DESCRIPTION
This is the same thing as what we do for Neo4j.
It's worth noting that both of these interceptors are live right now, which could have unintended consequences with retry/rollback logic between the two DBs. This is only a temporary migration concern, so I'm not going to give it much thought until I need to.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5500377488) by [Unito](https://www.unito.io)
