### PR TITLE
EdgeDB.withOptions / Connect App Session to `currentUserId` global

### DIFF
--- a/src/components/authentication/session.interceptor.ts
+++ b/src/components/authentication/session.interceptor.ts
@@ -11,6 +11,7 @@ import {
   GqlContextType as GqlRequestType,
 } from '@nestjs/graphql';
 import { csv } from '@seedcompany/common';
+import { isUUID } from 'class-validator';
 import { Request } from 'express';
 import { GraphQLResolveInfo } from 'graphql';
 import { from, lastValueFrom } from 'rxjs';
@@ -47,7 +48,10 @@ export class SessionInterceptor implements NestInterceptor {
     } else if (type === 'http') {
       session = await this.handleHttp(executionContext);
     }
-    const currentUserId = session?.userId;
+    // TODO temporarily check if UUID before applying global.
+    // Once migration is complete this can be removed.
+    const currentUserId =
+      session?.userId && isUUID(session.userId) ? session.userId : undefined;
     return from(
       this.edgeDB.withOptions(
         (options) => options.withGlobals({ currentUserId }),

--- a/src/core/edgedb/edgedb.module.ts
+++ b/src/core/edgedb/edgedb.module.ts
@@ -7,6 +7,7 @@ import { Class } from 'type-fest';
 import { EdgeDBTransactionalMutationsInterceptor } from './edgedb-transactional-mutations.interceptor';
 import { EdgeDB } from './edgedb.service';
 import { Options } from './options';
+import { OptionsContext } from './options.context';
 import { Client } from './reexports';
 import { LuxonCalendarDateCodec, LuxonDateTimeCodec } from './temporal.codecs';
 import { TransactionContext } from './transaction.context';
@@ -25,13 +26,14 @@ import { TransactionContext } from './transaction.context';
         session_idle_transaction_timeout: Duration.from({ minutes: 5 }),
       }),
     },
+    OptionsContext,
     {
       provide: Client,
-      inject: ['DEFAULT_OPTIONS'],
-      useFactory: (options: Options) => {
+      inject: [OptionsContext],
+      useFactory: (options: OptionsContext) => {
         const client = createClient();
 
-        Object.assign(client, { options });
+        Object.assign(client, { options: options.current });
 
         registerCustomScalarCodecs(client, [
           LuxonDateTimeCodec,

--- a/src/core/edgedb/edgedb.service.ts
+++ b/src/core/edgedb/edgedb.service.ts
@@ -3,11 +3,27 @@ import { Injectable } from '@nestjs/common';
 import { $, Executor } from 'edgedb';
 import { TypedEdgeQL } from './edgeql';
 import { InlineQueryCardinalityMap } from './generated-client/inline-queries';
+import { OptionsContext, OptionsFn } from './options.context';
 import { TransactionContext } from './transaction.context';
 
 @Injectable()
 export class EdgeDB {
-  constructor(private readonly executor: TransactionContext) {}
+  constructor(
+    private readonly executor: TransactionContext,
+    private readonly optionsContext: OptionsContext,
+  ) {}
+
+  /**
+   * Apply options to the scope of the given function.
+   * @example
+   * await EdgeDB.withOptions((options) => options.withGlobals({ ... }), async () => {
+   *   // Queries have the options applied
+   *   await EdgeDB.run(...);
+   * });
+   */
+  async withOptions<R>(applyOptions: OptionsFn, runWith: () => Promise<R>) {
+    return await this.optionsContext.withOptions(applyOptions, runWith);
+  }
 
   /** Run a query from an edgeql string */
   run<R>(query: TypedEdgeQL<null, R>): Promise<R>;

--- a/src/core/edgedb/options.context.ts
+++ b/src/core/edgedb/options.context.ts
@@ -1,0 +1,41 @@
+import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
+import { AsyncLocalStorage } from 'async_hooks';
+import { Options } from './options';
+
+export type OptionsFn = (options: Options) => Options;
+
+@Injectable()
+export class OptionsContext
+  extends AsyncLocalStorage<Options>
+  implements OptionsContext, OnModuleDestroy
+{
+  constructor(@Inject('DEFAULT_OPTIONS') readonly root: Options) {
+    super();
+  }
+
+  async withOptions<R>(applyOptions: OptionsFn, runWith: () => Promise<R>) {
+    const options = applyOptions(this.current);
+    return await this.run(options, runWith);
+  }
+
+  get current() {
+    return lazyRef(() => this.getStore() ?? this.root);
+  }
+
+  onModuleDestroy() {
+    this.disable();
+  }
+}
+
+/**
+ * Returns "an object" that calls the given function every time
+ * it's referenced to get the actual object.
+ */
+const lazyRef = <T extends object>(getter: () => T): T => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return new Proxy({} as T, {
+    get(target: T, p: string, receiver: unknown) {
+      return Reflect.get(getter(), p, receiver);
+    },
+  });
+};

--- a/src/core/edgedb/options.ts
+++ b/src/core/edgedb/options.ts
@@ -1,0 +1,33 @@
+import {
+  Options as EdgeDBOptions,
+  RetryOptions,
+  Session,
+  SimpleRetryOptions,
+  SimpleTransactionOptions,
+  TransactionOptions,
+} from 'edgedb/dist/options.js';
+
+// Flatten Session modifiers, just as Client does.
+export class Options extends EdgeDBOptions {
+  static defaults() {
+    return new Options(EdgeDBOptions.defaults());
+  }
+  withTransactionOptions(opt: TransactionOptions | SimpleTransactionOptions) {
+    return new Options(super.withTransactionOptions(opt));
+  }
+  withRetryOptions(opt: RetryOptions | SimpleRetryOptions) {
+    return new Options(super.withRetryOptions(opt));
+  }
+  withSession(opt: Session) {
+    return new Options(super.withSession(opt));
+  }
+  withModuleAliases(aliases: { [name: string]: string }) {
+    return this.withSession(this.session.withModuleAliases(aliases));
+  }
+  withConfig(config: { [name: string]: any }) {
+    return this.withSession(this.session.withConfig(config));
+  }
+  withGlobals(globals: { [name: string]: any }) {
+    return this.withSession(this.session.withGlobals(globals));
+  }
+}


### PR DESCRIPTION
This exposes EdgeDB's `with*` options modifiers with an ALS. Essentially now we can do:
```ts
constructor(private readonly edgeDB: EdgeDB) {}

foo() {
  await this.edgeDB.withOptions(
    options => options.withGlobals({ foo: 'bar' }).withModuleAliases({ p: 'Project' }),
    async () => {
      // This block will have the above options applied
      await this.edgeDB.run(query);
    }
  );
}
```
`withOptions` can be called multiple times to further configure the queries.

This is also independent of the current connection/transaction.
This allows a transaction to be started without a global and then later have a global applied.
This separation isn't really intended by the library, but it works with a Proxy referencing the current options stored in the ALS.
This is what we need to apply the `currentUserId` global from the `SessionInterceptor`.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5501248704) by [Unito](https://www.unito.io)
