### PR TITLE
[EdgeDB] Fix generated query builder with Jest & ESM

### DIFF
--- a/src/core/edgedb/index.ts
+++ b/src/core/edgedb/index.ts
@@ -1,4 +1,4 @@
 export * from './reexports';
 export { edgeql, EdgeQLArgsOf, EdgeQLReturnOf } from './edgeql';
 export * from './edgedb.service';
-export { default as e } from './generated-client/index.mjs';
+export { default as e } from './generated-client';


### PR DESCRIPTION
Switch generated query builder's target `mts` -> `ts` to fix usage with jest

Originally switched to support ESM.
Jest struggles with the imports though, and I could not find a configuration that worked.
The generated files produced with the `ts` target are fine for our use, aside from the import/export from `'edgedb/*'`; these need the file extension to work with ESM.
Example:
```diff
- import { Cardinality } from "edgedb/dist/reflection/index";
+ import { Cardinality } from "edgedb/dist/reflection/index.js";
```

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5503511966) by [Unito](https://www.unito.io)
