### PR TITLE
[EdgeDB] Create `Producible`, `Film`, `EthnoArt`, and `Story` schemas

### DIFF
--- a/dbschema/migrations/00028.edgeql
+++ b/dbschema/migrations/00028.edgeql
@@ -1,0 +1,14 @@
+CREATE MIGRATION m1rob2znvgmu7myqon4wzkdxur6765udhhucohw6apoxhtrbbnxova
+    ONTO m1aqhugpxmkst3yhkmyd5avjuqvbxk7ekgroiipkkhz3ockszv2rka
+{
+  CREATE ABSTRACT TYPE default::Producible EXTENDING default::Resource, Mixin::Named {
+      ALTER PROPERTY name {
+          SET OWNED;
+          CREATE DELEGATED CONSTRAINT std::exclusive;
+      };
+      CREATE PROPERTY scriptureReferences: multirange<std::int32>;
+  };
+  CREATE TYPE default::EthnoArt EXTENDING default::Producible;
+  CREATE TYPE default::Film EXTENDING default::Producible;
+  CREATE TYPE default::Story EXTENDING default::Producible;
+};

--- a/dbschema/producible.esdl
+++ b/dbschema/producible.esdl
@@ -1,0 +1,13 @@
+module default {
+  abstract type Producible extending Resource, Mixin::Named {
+    overloaded name {
+      delegated constraint exclusive;
+    };
+    
+    scriptureReferences: multirange<int32>;
+  }
+  
+  type EthnoArt extending Producible;
+  type Film extending Producible;
+  type Story extending Producible;
+}


### PR DESCRIPTION
@CarsonF - I'm not necessarily sold on the splitting out of all of these into their own `esdl` files now that I see the end result.  A case could be made to place them all in the `producible.esdl`.  Or perhaps even include them in the `Producible` module even?  Thoughts appreciated.

[Monday Task](https://seed-company-squad.monday.com/boards/3451697530/pulses/5452828634)

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5553618688) by [Unito](https://www.unito.io)
