### PR TITLE
[EdgeDB] Associate DB types with our TS resources

### DIFF
--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -247,6 +247,10 @@ export class EnhancedResource<T extends ResourceShape<any>> {
     return type;
   }
 
+  get dbFQN(): (T['DB'] & {})['__element__']['__name__'] {
+    return this.db.__element__.__name__;
+  }
+
   @Once()
   get dbLabels() {
     return getDbClassLabels(this.type);

--- a/src/components/budget/dto/budget-record.dto.ts
+++ b/src/components/budget/dto/budget-record.dto.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { BaseNode } from '~/core/database/results';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   ID,
@@ -22,6 +23,7 @@ import { Budget } from './budget.dto';
   implements: [Resource, ChangesetAware],
 })
 export class BudgetRecord extends IntersectionType(ChangesetAware, Resource) {
+  static readonly DB = e.Budget.Record;
   static readonly Props = keysOf<BudgetRecord>();
   static readonly SecuredProps = keysOf<SecuredProps<BudgetRecord>>();
   static readonly Parent = import('./budget.dto').then((m) => m.Budget);

--- a/src/components/budget/dto/budget.dto.ts
+++ b/src/components/budget/dto/budget.dto.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { BaseNode } from '~/core/database/results';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   DbLabel,
@@ -24,6 +25,7 @@ import { BudgetStatus } from './budget-status.enum';
   implements: [Resource, ChangesetAware],
 })
 export class Budget extends IntersectionType(ChangesetAware, Resource) {
+  static readonly DB = e.Budget;
   static readonly Props = keysOf<Budget>();
   static readonly SecuredProps = keysOf<SecuredProps<Budget>>();
   static readonly Relations = {

--- a/src/components/ceremony/dto/ceremony.dto.ts
+++ b/src/components/ceremony/dto/ceremony.dto.ts
@@ -1,5 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   Calculated,
@@ -19,6 +20,7 @@ import { CeremonyType } from './ceremony-type.enum';
   implements: [Resource],
 })
 export class Ceremony extends Resource {
+  static readonly DB = e.Engagement.Ceremony;
   static readonly Props = keysOf<Ceremony>();
   static readonly SecuredProps = keysOf<SecuredProps<Ceremony>>();
   static readonly Parent = import('../../engagement/dto').then(

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { MergeExclusive } from 'type-fest';
 import { BaseNode } from '~/core/database/results';
+import { abstractType, e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   Calculated,
@@ -64,6 +65,7 @@ export const resolveEngagementType = (val: Pick<AnyEngagement, '__typename'>) =>
  * This should be used for GraphQL but never for TypeScript types.
  */
 class Engagement extends ChangesetAwareResource {
+  static readonly DB = abstractType(e.Engagement);
   static readonly Props: string[] = keysOf<Engagement>();
   static readonly SecuredProps: string[] = keysOf<SecuredProps<Engagement>>();
   static readonly Parent = import('../../project/dto').then((m) => m.IProject);
@@ -152,6 +154,7 @@ export { Engagement as IEngagement, AnyEngagement as Engagement };
   implements: [Engagement],
 })
 export class LanguageEngagement extends Engagement {
+  static readonly DB = e.LanguageEngagement;
   static readonly Props = keysOf<LanguageEngagement>();
   static readonly SecuredProps = keysOf<SecuredProps<LanguageEngagement>>();
   static readonly Relations = {
@@ -197,6 +200,7 @@ export class LanguageEngagement extends Engagement {
   implements: [Engagement],
 })
 export class InternshipEngagement extends Engagement {
+  static readonly DB = e.InternshipEngagement;
   static readonly Props = keysOf<InternshipEngagement>();
   static readonly SecuredProps = keysOf<SecuredProps<InternshipEngagement>>();
   static readonly Parent = import('../../project/dto').then(

--- a/src/components/ethno-art/dto/ethno-art.dto.ts
+++ b/src/components/ethno-art/dto/ethno-art.dto.ts
@@ -1,5 +1,6 @@
 import { ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   DbUnique,
@@ -21,6 +22,7 @@ declare module '../../product/dto/producible.dto' {
   implements: [Producible, Resource],
 })
 export class EthnoArt extends Producible {
+  static readonly DB = e.EthnoArt;
   static readonly Props = keysOf<EthnoArt>();
   static readonly SecuredProps = keysOf<SecuredProps<EthnoArt>>();
 

--- a/src/components/field-region/dto/field-region.dto.ts
+++ b/src/components/field-region/dto/field-region.dto.ts
@@ -1,5 +1,6 @@
 import { ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   DbUnique,
@@ -18,6 +19,7 @@ import {
   implements: [Resource],
 })
 export class FieldRegion extends Resource {
+  static readonly DB = e.FieldRegion;
   static readonly Props = keysOf<FieldRegion>();
   static readonly SecuredProps = keysOf<SecuredProps<FieldRegion>>();
 

--- a/src/components/field-zone/dto/field-zone.dto.ts
+++ b/src/components/field-zone/dto/field-zone.dto.ts
@@ -1,5 +1,6 @@
 import { ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   DbUnique,
@@ -17,6 +18,7 @@ import {
   implements: [Resource],
 })
 export class FieldZone extends Resource {
+  static readonly DB = e.FieldZone;
   static readonly Props = keysOf<FieldZone>();
   static readonly SecuredProps = keysOf<SecuredProps<FieldZone>>();
 

--- a/src/components/file/dto/node.ts
+++ b/src/components/file/dto/node.ts
@@ -6,6 +6,7 @@ import { Readable } from 'stream';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { MergeExclusive, Opaque } from 'type-fest';
 import { BaseNode } from '~/core/database/results';
+import { abstractType, e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   DateTimeField,
@@ -50,6 +51,7 @@ export const resolveFileNode = (val: AnyFileNode) => {
  * This should be used for GraphQL but never for TypeScript types.
  */
 abstract class FileNode extends Resource {
+  static readonly DB = abstractType(e.File.Node);
   static readonly Props: string[] = keysOf<FileNode>();
   static readonly SecuredProps: string[] = keysOf<SecuredProps<FileNode>>();
 
@@ -104,6 +106,7 @@ abstract class BaseFile extends FileNode {
   implements: [FileNode, Resource],
 })
 export class FileVersion extends BaseFile {
+  static readonly DB = e.File.Version;
   static readonly Props = keysOf<FileVersion>();
   static readonly SecuredProps = keysOf<SecuredProps<FileVersion>>();
 
@@ -115,6 +118,7 @@ export class FileVersion extends BaseFile {
   implements: [FileNode, Resource],
 })
 export class File extends BaseFile {
+  static readonly DB = e.File;
   static readonly Props = keysOf<File>();
   static readonly SecuredProps = keysOf<SecuredProps<File>>();
 
@@ -133,6 +137,7 @@ export class File extends BaseFile {
   implements: [FileNode, Resource],
 })
 export class Directory extends FileNode {
+  static readonly DB = e.Directory;
   static readonly Props = keysOf<Directory>();
   static readonly SecuredProps = keysOf<SecuredProps<Directory>>();
 

--- a/src/components/film/dto/film.dto.ts
+++ b/src/components/film/dto/film.dto.ts
@@ -1,5 +1,6 @@
 import { ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   DbUnique,
@@ -21,6 +22,7 @@ declare module '../../product/dto/producible.dto' {
   implements: [Producible, Resource],
 })
 export class Film extends Producible {
+  static readonly DB = e.Film;
   static readonly Props = keysOf<Film>();
   static readonly SecuredProps = keysOf<SecuredProps<Film>>();
 

--- a/src/components/funding-account/dto/funding-account.dto.ts
+++ b/src/components/funding-account/dto/funding-account.dto.ts
@@ -1,5 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   DbLabel,
@@ -17,6 +18,7 @@ import {
   implements: [Resource],
 })
 export class FundingAccount extends Resource {
+  static readonly DB = e.FundingAccount;
   static readonly Props = keysOf<FundingAccount>();
   static readonly SecuredProps = keysOf<SecuredProps<FundingAccount>>();
 

--- a/src/components/language/dto/language.dto.ts
+++ b/src/components/language/dto/language.dto.ts
@@ -3,6 +3,7 @@ import { Field, ObjectType } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { GraphQLString } from 'graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   Calculated,
@@ -47,6 +48,7 @@ export abstract class SecuredTags extends SecuredPropertyList<string>(
 @RegisterResource()
 @ObjectType()
 export class EthnologueLanguage {
+  static readonly DB = e.Ethnologue.Language;
   static readonly Props = keysOf<EthnologueLanguage>();
   static readonly SecuredProps = keysOf<SecuredProps<EthnologueLanguage>>();
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -87,6 +89,7 @@ export class EthnologueLanguage {
   implements: [Resource, Pinnable, Postable],
 })
 export class Language extends Interfaces {
+  static readonly DB = e.Language;
   static readonly Props = keysOf<Language>();
   static readonly SecuredProps = keysOf<SecuredProps<Language>>();
   static readonly Relations = {

--- a/src/components/location/dto/location.dto.ts
+++ b/src/components/location/dto/location.dto.ts
@@ -1,5 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   DbLabel,
@@ -28,6 +29,7 @@ export abstract class SecuredLocationType extends SecuredEnum(LocationType) {}
   implements: [Resource],
 })
 export class Location extends Resource {
+  static readonly DB = e.Location;
   static readonly Props = keysOf<Location>();
   static readonly SecuredProps = keysOf<SecuredProps<Location>>();
 

--- a/src/components/organization/dto/organization.dto.ts
+++ b/src/components/organization/dto/organization.dto.ts
@@ -1,5 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   DbUnique,
@@ -22,6 +23,7 @@ import { SecuredOrganizationTypes } from './organization-type.dto';
   implements: Resource,
 })
 export class Organization extends Resource {
+  static readonly DB = e.Organization;
   static readonly Props = keysOf<Organization>();
   static readonly SecuredProps = keysOf<SecuredProps<Organization>>();
   static readonly Relations = {

--- a/src/components/partner/dto/partner.dto.ts
+++ b/src/components/partner/dto/partner.dto.ts
@@ -2,6 +2,7 @@ import { Type } from '@nestjs/common';
 import { Field, ObjectType } from '@nestjs/graphql';
 import { DateTime } from 'luxon';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   DateTimeField,
@@ -46,6 +47,7 @@ export abstract class SecuredFinancialReportingTypes extends SecuredEnumList(
   implements: [Resource, Pinnable, Postable],
 })
 export class Partner extends Interfaces {
+  static readonly DB = e.Partner;
   static readonly Props = keysOf<Partner>();
   static readonly SecuredProps = keysOf<SecuredProps<Partner>>();
   static readonly Relations = () =>

--- a/src/components/product/dto/producible.dto.ts
+++ b/src/components/product/dto/producible.dto.ts
@@ -2,6 +2,7 @@ import { Field, InterfaceType, ObjectType } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { SetDbType } from '~/core/database';
+import { abstractType, e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   EnumType,
@@ -29,6 +30,7 @@ import {
   implements: [Resource],
 })
 export abstract class Producible extends Resource {
+  static readonly DB = abstractType(e.Producible);
   static readonly Props: string[] = keysOf<Producible>();
   static readonly SecuredProps: string[] = keysOf<SecuredProps<Producible>>();
 

--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -4,6 +4,7 @@ import { stripIndent } from 'common-tags';
 import { DateTime } from 'luxon';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { MergeExclusive } from 'type-fest';
+import { abstractType, e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   DateInterval,
@@ -75,6 +76,7 @@ export const resolveProjectType = (val: Pick<AnyProject, 'type'>) =>
   implements: [Resource, Pinnable, Postable, ChangesetAware, Commentable],
 })
 class Project extends Interfaces {
+  static readonly DB = abstractType(e.Project);
   static readonly Props: string[] = keysOf<Project>();
   static readonly SecuredProps: string[] = keysOf<SecuredProps<Project>>();
   static readonly Relations = () =>
@@ -187,6 +189,7 @@ export { Project as IProject, AnyProject as Project };
   implements: [Project],
 })
 export class TranslationProject extends Project {
+  static readonly DB = e.TranslationProject;
   static readonly Props = keysOf<TranslationProject>();
   static readonly SecuredProps = keysOf<SecuredProps<TranslationProject>>();
 
@@ -198,6 +201,7 @@ export class TranslationProject extends Project {
   implements: [Project],
 })
 export class InternshipProject extends Project {
+  static readonly DB = e.InternshipProject;
   static readonly Props = keysOf<InternshipProject>();
   static readonly SecuredProps = keysOf<SecuredProps<InternshipProject>>();
 

--- a/src/components/project/project-member/dto/project-member.dto.ts
+++ b/src/components/project/project-member/dto/project-member.dto.ts
@@ -1,6 +1,7 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { DateTime } from 'luxon';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   DateTimeField,
@@ -19,6 +20,7 @@ import { SecuredUser, User } from '../../../user/dto';
   implements: [Resource],
 })
 export class ProjectMember extends Resource {
+  static readonly DB = e.Project.Member;
   static readonly Props = keysOf<ProjectMember>();
   static readonly SecuredProps = keysOf<SecuredProps<ProjectMember>>();
   static readonly Parent = import('../../dto').then((m) => m.IProject);

--- a/src/components/user/dto/user.dto.ts
+++ b/src/components/user/dto/user.dto.ts
@@ -1,6 +1,7 @@
 import { Type } from '@nestjs/common';
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   DbUnique,
@@ -40,6 +41,7 @@ export abstract class SecuredUserStatus extends SecuredEnum(UserStatus) {}
   implements: [Resource, Pinnable],
 })
 export class User extends PinnableResource {
+  static readonly DB = e.User;
   static readonly Props = keysOf<User>();
   static readonly SecuredProps = keysOf<SecuredProps<User>>();
   static readonly Relations = () =>

--- a/src/components/user/education/dto/education.dto.ts
+++ b/src/components/user/education/dto/education.dto.ts
@@ -10,6 +10,7 @@ import {
   SecuredProps,
   SecuredString,
 } from '~/common';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 
 export type Degree = EnumType<typeof Degree>;
@@ -35,6 +36,7 @@ export abstract class SecuredDegree extends SecuredEnum(Degree) {}
   implements: [Resource],
 })
 export class Education extends Resource {
+  static readonly DB = e.User.Education;
   static readonly Props = keysOf<Education>();
   static readonly SecuredProps = keysOf<SecuredProps<Education>>();
   static readonly Parent = import('../../dto').then((m) => m.User);

--- a/src/components/user/unavailability/dto/unavailability.dto.ts
+++ b/src/components/user/unavailability/dto/unavailability.dto.ts
@@ -1,5 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
+import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   Resource,
@@ -13,6 +14,7 @@ import {
   implements: [Resource],
 })
 export class Unavailability extends Resource {
+  static readonly DB = e.User.Unavailability;
   static readonly Props = keysOf<Unavailability>();
   static readonly SecuredProps = keysOf<SecuredProps<Unavailability>>();
   static readonly Parent = import('../../dto').then((m) => m.User);

--- a/src/core/edgedb/abstract.type-util.ts
+++ b/src/core/edgedb/abstract.type-util.ts
@@ -1,0 +1,24 @@
+import { LiteralUnion } from 'type-fest';
+import type * as $ from './generated-client/reflection';
+
+/**
+ * Loosen the object type to allow for extension
+ */
+export const abstractType = <T extends $.ObjectType>(
+  obj: $.$expr_PathNode<$.TypeSet<T, $.Cardinality.Many>>,
+): $.$expr_PathNode<
+  $.TypeSet<
+    $.ObjectType<
+      // Keeping the type hint but allowing any string for name
+      // since subtypes will have different names
+      LiteralUnion<T['__name__'], string>,
+      // No Change
+      T['__pointers__'],
+      // No Change
+      T['__shape__']
+      // Using default instead, to be compatible with subtypes
+      // T['__exclusives__']
+    >,
+    $.Cardinality.Many
+  >
+> => obj as any;

--- a/src/core/edgedb/index.ts
+++ b/src/core/edgedb/index.ts
@@ -1,6 +1,5 @@
 export * from './reexports';
 export { edgeql, EdgeQLArgsOf, EdgeQLReturnOf } from './edgeql';
 export * from './edgedb.service';
-export { default as e, $infer } from './generated-client';
 export * from './withScope';
 export * from './error.util';

--- a/src/core/edgedb/reexports.ts
+++ b/src/core/edgedb/reexports.ts
@@ -1,3 +1,7 @@
 // Only use this if you need the extra methods.
 // Otherwise, for querying, use EdgeDb from below.
 export { Client } from 'edgedb/dist/baseClient.js';
+
+export { default as e, $infer } from './generated-client';
+export * as $ from './generated-client/reflection';
+export * from './abstract.type-util';


### PR DESCRIPTION
This will ease migration at the least. Currently we pass around resource names or objects, and we need to be able to do EdgeDB things with those now.

For example, these are all the same:
```ts
e.select(	e.Budget											);
e.select(	Budget.DB											);
e.select(	EnhancedResource.of(Budget).db						);
e.select(	(await $(ResourcesHost).getByName('Budget')).db		);
```
Also:
```ts
EnhancedResource.of(Project).dbFQN; // => "default::Project"
EnhancedResource.of(Ceremony).dbFQN; // => "Engagement::Ceremony"
```

This is just a first step. And since I touched all the DTOs for the EdgeDB schema we have so far, I wanted to get it in. More will come later that uses this.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5601073410) by [Unito](https://www.unito.io)
