### PR TITLE
Allow nulls on InternshipEngagement mentor & countryOfOrigin

### DIFF
--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -208,11 +208,11 @@ export class InternshipEngagement extends Engagement {
   @Field(() => InternshipProject)
   declare readonly parent: BaseNode;
 
-  readonly countryOfOrigin: Secured<ID>;
+  readonly countryOfOrigin: Secured<ID | null>;
 
   readonly intern: Secured<ID>;
 
-  readonly mentor: Secured<ID>;
+  readonly mentor: Secured<ID | null>;
 
   @Field()
   @DbLabel('InternPosition')

--- a/src/components/engagement/dto/update-engagement.dto.ts
+++ b/src/components/engagement/dto/update-engagement.dto.ts
@@ -81,10 +81,10 @@ export abstract class UpdateLanguageEngagement extends UpdateEngagement {
 @InputType()
 export abstract class UpdateInternshipEngagement extends UpdateEngagement {
   @IdField({ nullable: true })
-  readonly mentorId?: ID;
+  readonly mentorId?: ID | null;
 
   @IdField({ nullable: true })
-  readonly countryOfOriginId?: ID;
+  readonly countryOfOriginId?: ID | null;
 
   @Field(() => InternshipPosition, { nullable: true })
   readonly position?: InternshipPosition;

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -358,12 +358,17 @@ export class EngagementService {
     );
 
     try {
-      if (mentorId) {
-        await this.repo.updateMentor(input.id, mentorId);
+      if (mentorId !== undefined) {
+        await this.repo.updateRelation('mentor', 'User', input.id, mentorId);
       }
 
-      if (countryOfOriginId) {
-        await this.repo.updateCountryOfOrigin(input.id, countryOfOriginId);
+      if (countryOfOriginId !== undefined) {
+        await this.repo.updateRelation(
+          'countryOfOrigin',
+          'User',
+          input.id,
+          countryOfOriginId,
+        );
       }
 
       await this.repo.updateInternshipProperties(

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -365,7 +365,7 @@ export class EngagementService {
       if (countryOfOriginId !== undefined) {
         await this.repo.updateRelation(
           'countryOfOrigin',
-          'User',
+          'Location',
           input.id,
           countryOfOriginId,
         );


### PR DESCRIPTION
In order to allow certain fields to be nullable within EdgeDB the DTO & Service that handle those fields needed to be modified. Follow this [PR](https://github.com/SeedCompany/cord-api-v3/pull/2909) as a guide the following fields were altered to allow nulls:

InternshipEngagment.countryOfOrigin
InternshipEngagment.mentor

This is the related [Monday Ticket](https://seed-company-squad.monday.com/boards/3451697530/pulses/4909441234)

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5601657093) by [Unito](https://www.unito.io)
