### PR TITLE
Make update Neo4j properties/relations implementation details of repos

### DIFF
--- a/src/components/authorization/policy/executor/user-resource-privileges.ts
+++ b/src/components/authorization/policy/executor/user-resource-privileges.ts
@@ -13,7 +13,7 @@ import {
   UnauthorizedException,
   UnsecuredDto,
 } from '~/common';
-import { ChangesOf, isRelation } from '~/core/database/changes';
+import { AnyChangesOf, isRelation } from '~/core/database/changes';
 import {
   AnyAction,
   ChildListAction,
@@ -169,7 +169,7 @@ export class UserResourcePrivileges<
    * Verifies the current user can make the changes specified to the given object.
    */
   verifyChanges(
-    changes: ChangesOf<TResourceStatic['prototype']>,
+    changes: AnyChangesOf<TResourceStatic['prototype']>,
     {
       pathPrefix: pathPrefixProp,
     }: {

--- a/src/components/budget/budget-record.repository.ts
+++ b/src/components/budget/budget-record.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
+import { ChangesOf } from '~/core/database/changes';
 import {
   ID,
   labelForView,
@@ -21,7 +22,13 @@ import {
   paginate,
   sorting,
 } from '../../core/database/query';
-import { BudgetRecord, BudgetRecordListInput, CreateBudgetRecord } from './dto';
+import {
+  Budget,
+  BudgetRecord,
+  BudgetRecordListInput,
+  CreateBudgetRecord,
+  UpdateBudgetRecord,
+} from './dto';
 
 interface BudgetRecordHydrateArgs {
   recordVar?: string;
@@ -64,6 +71,14 @@ export class BudgetRecordRepository extends DtoRepository<
       throw new ServerException('Failed to create a budget record');
     }
     return result.id;
+  }
+
+  async update(
+    existing: BudgetRecord,
+    changes: ChangesOf<Budget, UpdateBudgetRecord>,
+    changeset?: ID,
+  ) {
+    return await this.updateProperties(existing, changes, changeset);
   }
 
   async doesRecordExist(input: CreateBudgetRecord) {

--- a/src/components/budget/budget.repository.ts
+++ b/src/components/budget/budget.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { inArray, node, Query, relation } from 'cypher-query-builder';
 import { pickBy } from 'lodash';
+import { ChangesOf } from '~/core/database/changes';
 import {
   ID,
   labelForView,
@@ -34,6 +35,7 @@ import {
   BudgetRecord,
   CreateBudget,
   BudgetStatus as Status,
+  UpdateBudget,
 } from './dto';
 
 @Injectable()
@@ -86,6 +88,16 @@ export class BudgetRepository extends DtoRepository<
     }
 
     return result.id;
+  }
+
+  async update(
+    existing: Budget,
+    simpleChanges: Omit<
+      ChangesOf<Budget, UpdateBudget>,
+      'universalTemplateFile'
+    >,
+  ) {
+    return await this.updateProperties(existing, simpleChanges);
   }
 
   async readMany(ids: readonly ID[], session: Session, view?: ObjectView) {

--- a/src/components/budget/budget.repository.ts
+++ b/src/components/budget/budget.repository.ts
@@ -12,7 +12,7 @@ import {
   UnsecuredDto,
   viewOfChangeset,
 } from '../../common';
-import { DatabaseService, DtoRepository } from '../../core';
+import { DtoRepository } from '../../core';
 import {
   ACTIVE,
   createNode,
@@ -43,11 +43,8 @@ export class BudgetRepository extends DtoRepository<
   typeof Budget,
   [session: Session, view?: ObjectView]
 >(Budget) {
-  constructor(
-    db: DatabaseService,
-    private readonly records: BudgetRecordRepository,
-  ) {
-    super(db);
+  constructor(private readonly records: BudgetRecordRepository) {
+    super();
   }
 
   async doesProjectExist(projectId: ID, session: Session) {

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -228,7 +228,7 @@ export class BudgetService {
       universalTemplateFile,
       session,
     );
-    return await this.budgetRepo.updateProperties(budget, simpleChanges);
+    return await this.budgetRepo.update(budget, simpleChanges);
   }
 
   async updateRecord(
@@ -249,7 +249,7 @@ export class BudgetService {
     this.privileges.for(session, BudgetRecord, br).verifyChanges(changes);
 
     try {
-      const result = await this.budgetRecordsRepo.updateProperties(
+      const result = await this.budgetRecordsRepo.update(
         br,
         changes,
         changeset,

--- a/src/components/ceremony/ceremony.repository.ts
+++ b/src/components/ceremony/ceremony.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
+import { ChangesOf } from '~/core/database/changes';
 import { ID, Session, UnsecuredDto } from '../../common';
 import { DtoRepository } from '../../core';
 import {
@@ -12,7 +13,12 @@ import {
   requestingUser,
   sorting,
 } from '../../core/database/query';
-import { Ceremony, CeremonyListInput, CreateCeremony } from './dto';
+import {
+  Ceremony,
+  CeremonyListInput,
+  CreateCeremony,
+  UpdateCeremony,
+} from './dto';
 
 @Injectable()
 export class CeremonyRepository extends DtoRepository<
@@ -33,6 +39,13 @@ export class CeremonyRepository extends DtoRepository<
       .apply(await createNode(Ceremony, { initialProps }))
       .return<{ id: ID }>('node.id as id')
       .first();
+  }
+
+  async update(
+    existing: Ceremony,
+    changes: ChangesOf<Ceremony, UpdateCeremony>,
+  ) {
+    return await this.updateProperties(existing, changes);
   }
 
   protected hydrate(session: Session) {

--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -77,7 +77,7 @@ export class CeremonyService {
     const object = await this.readOne(input.id, session);
     const changes = this.ceremonyRepo.getActualChanges(object, input);
     this.privileges.for(session, Ceremony, object).verifyChanges(changes);
-    return await this.ceremonyRepo.updateProperties(object, changes);
+    return await this.ceremonyRepo.update(object, changes);
   }
 
   async delete(id: ID, session: Session): Promise<void> {

--- a/src/components/comments/comment-thread.repository.ts
+++ b/src/components/comments/comment-thread.repository.ts
@@ -1,7 +1,7 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
 import { ID, Session, UnsecuredDto } from '../../common';
-import { DatabaseService, DtoRepository } from '../../core';
+import { DtoRepository } from '../../core';
 import {
   ACTIVE,
   createNode,
@@ -19,9 +19,8 @@ export class CommentThreadRepository extends DtoRepository(CommentThread) {
   constructor(
     @Inject(forwardRef(() => CommentRepository))
     private readonly comments: CommentRepository & {},
-    db: DatabaseService,
   ) {
-    super(db);
+    super();
   }
 
   async create(parent: ID, session: Session) {

--- a/src/components/comments/comment.repository.ts
+++ b/src/components/comments/comment.repository.ts
@@ -1,6 +1,7 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
+import { ChangesOf } from '~/core/database/changes';
 import { ID, Session, UnsecuredDto } from '../../common';
 import { DatabaseService, DtoRepository } from '../../core';
 import {
@@ -15,7 +16,12 @@ import {
   variable,
 } from '../../core/database/query';
 import { CommentThreadRepository } from './comment-thread.repository';
-import { Comment, CommentListInput, CreateCommentInput } from './dto';
+import {
+  Comment,
+  CommentListInput,
+  CreateCommentInput,
+  UpdateCommentInput,
+} from './dto';
 
 @Injectable()
 export class CommentRepository extends DtoRepository(Comment) {
@@ -54,6 +60,13 @@ export class CommentRepository extends DtoRepository(Comment) {
         'thread.id as threadId',
       ])
       .first();
+  }
+
+  async update(
+    existing: UnsecuredDto<Comment>,
+    changes: ChangesOf<Comment, UpdateCommentInput>,
+  ) {
+    await this.updateProperties(existing, changes);
   }
 
   override hydrate() {

--- a/src/components/comments/comment.repository.ts
+++ b/src/components/comments/comment.repository.ts
@@ -3,7 +3,7 @@ import { node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { ChangesOf } from '~/core/database/changes';
 import { ID, Session, UnsecuredDto } from '../../common';
-import { DatabaseService, DtoRepository } from '../../core';
+import { DtoRepository } from '../../core';
 import {
   ACTIVE,
   createNode,
@@ -28,9 +28,8 @@ export class CommentRepository extends DtoRepository(Comment) {
   constructor(
     @Inject(forwardRef(() => CommentThreadRepository))
     readonly threads: CommentThreadRepository & {},
-    db: DatabaseService,
   ) {
-    super(db);
+    super();
   }
 
   async create(input: CreateCommentInput, session: Session) {

--- a/src/components/comments/comment.service.ts
+++ b/src/components/comments/comment.service.ts
@@ -136,7 +136,7 @@ export class CommentService {
 
     const changes = this.repo.getActualChanges(object, input);
     this.privileges.for(session, Comment, object).verifyChanges(changes);
-    await this.repo.updateProperties(object, changes);
+    await this.repo.update(object, changes);
 
     return await this.readOne(input.id, session);
   }

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -16,7 +16,7 @@ import {
   UnsecuredDto,
   viewOfChangeset,
 } from '../../common';
-import { CommonRepository, DatabaseService, OnIndex } from '../../core';
+import { CommonRepository, OnIndex } from '../../core';
 import { ChangesOf, getChanges } from '../../core/database/changes';
 import {
   ACTIVE,
@@ -56,8 +56,8 @@ export type LanguageOrEngagementId = MergeExclusive<
 
 @Injectable()
 export class EngagementRepository extends CommonRepository {
-  constructor(db: DatabaseService, private readonly privileges: Privileges) {
-    super(db);
+  constructor(private readonly privileges: Privileges) {
+    super();
   }
 
   async readOne(id: ID, session: Session, view?: ObjectView) {

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -286,28 +286,14 @@ export class EngagementService {
       .for(session, LanguageEngagement, object)
       .verifyChanges(changes);
 
-    const { pnp, ...simpleChanges } = changes;
-
     await this.files.updateDefinedFile(
       object.pnp,
       'engagement.pnp',
-      pnp,
+      changes.pnp,
       session,
     );
 
-    try {
-      await this.repo.updateLanguageProperties(
-        object,
-        simpleChanges,
-        changeset,
-      );
-    } catch (exception) {
-      this.logger.error('Error updating language engagement', { exception });
-      throw new ServerException(
-        'Could not update LanguageEngagement',
-        exception,
-      );
-    }
+    await this.repo.updateLanguage(object, changes, changeset);
 
     const updated = (await this.repo.readOne(
       input.id,
@@ -347,44 +333,14 @@ export class EngagementService {
       .for(session, InternshipEngagement, object)
       .verifyChanges(changes, { pathPrefix: 'engagement' });
 
-    const { mentorId, countryOfOriginId, growthPlan, ...simpleChanges } =
-      changes;
-
     await this.files.updateDefinedFile(
       object.growthPlan,
       'engagement.growthPlan',
-      growthPlan,
+      changes.growthPlan,
       session,
     );
 
-    try {
-      if (mentorId !== undefined) {
-        await this.repo.updateRelation('mentor', 'User', input.id, mentorId);
-      }
-
-      if (countryOfOriginId !== undefined) {
-        await this.repo.updateRelation(
-          'countryOfOrigin',
-          'Location',
-          input.id,
-          countryOfOriginId,
-        );
-      }
-
-      await this.repo.updateInternshipProperties(
-        object,
-        simpleChanges,
-        changeset,
-      );
-    } catch (exception) {
-      this.logger.warning('Failed to update InternshipEngagement', {
-        exception,
-      });
-      throw new ServerException(
-        'Could not update InternshipEngagement',
-        exception,
-      );
-    }
+    await this.repo.updateInternship(object, changes, changeset);
 
     const updated = (await this.repo.readOne(
       input.id,

--- a/src/components/engagement/handlers/set-initial-end-date.handler.ts
+++ b/src/components/engagement/handlers/set-initial-end-date.handler.ts
@@ -84,13 +84,13 @@ export class SetInitialEndDate implements IEventHandler<SubscribedEvent> {
       initialEndDate: initialEndDate || null,
     };
     if (engagement.__typename === 'LanguageEngagement') {
-      await this.engagementRepo.updateLanguageProperties(
+      await this.engagementRepo.updateLanguage(
         engagement as UnsecuredDto<LanguageEngagement>,
         updateInput,
         changeset,
       );
     } else {
-      await this.engagementRepo.updateInternshipProperties(
+      await this.engagementRepo.updateInternship(
         engagement as UnsecuredDto<InternshipEngagement>,
         updateInput,
         changeset,

--- a/src/components/ethno-art/ethno-art.repository.ts
+++ b/src/components/ethno-art/ethno-art.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Query } from 'cypher-query-builder';
 import { ChangesOf } from '~/core/database/changes';
 import { ID, Session } from '../../common';
-import { DatabaseService, DbTypeOf, DtoRepository } from '../../core';
+import { DbTypeOf, DtoRepository } from '../../core';
 import {
   createNode,
   matchProps,
@@ -20,11 +20,8 @@ import {
 
 @Injectable()
 export class EthnoArtRepository extends DtoRepository(EthnoArt) {
-  constructor(
-    private readonly scriptureRefs: ScriptureReferenceRepository,
-    db: DatabaseService,
-  ) {
-    super(db);
+  constructor(private readonly scriptureRefs: ScriptureReferenceRepository) {
+    super();
   }
   async create(input: CreateEthnoArt, _session: Session) {
     const initialProps = {

--- a/src/components/ethno-art/ethno-art.repository.ts
+++ b/src/components/ethno-art/ethno-art.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Query } from 'cypher-query-builder';
+import { ChangesOf } from '~/core/database/changes';
 import { ID, Session } from '../../common';
 import { DatabaseService, DbTypeOf, DtoRepository } from '../../core';
 import {
@@ -10,7 +11,12 @@ import {
   sorting,
 } from '../../core/database/query';
 import { ScriptureReferenceRepository } from '../scripture';
-import { CreateEthnoArt, EthnoArt, EthnoArtListInput } from './dto';
+import {
+  CreateEthnoArt,
+  EthnoArt,
+  EthnoArtListInput,
+  UpdateEthnoArt,
+} from './dto';
 
 @Injectable()
 export class EthnoArtRepository extends DtoRepository(EthnoArt) {
@@ -20,7 +26,6 @@ export class EthnoArtRepository extends DtoRepository(EthnoArt) {
   ) {
     super(db);
   }
-
   async create(input: CreateEthnoArt, _session: Session) {
     const initialProps = {
       name: input.name,
@@ -31,6 +36,16 @@ export class EthnoArtRepository extends DtoRepository(EthnoArt) {
       .apply(await createNode(EthnoArt, { initialProps }))
       .return<{ id: ID }>('node.id as id')
       .first();
+  }
+
+  async update(
+    existing: EthnoArt,
+    simpleChanges: Omit<
+      ChangesOf<EthnoArt, UpdateEthnoArt>,
+      'scriptureReferences'
+    >,
+  ) {
+    await this.updateProperties(existing, simpleChanges);
   }
 
   async list(input: EthnoArtListInput, _session: Session) {

--- a/src/components/ethno-art/ethno-art.service.ts
+++ b/src/components/ethno-art/ethno-art.service.ts
@@ -106,7 +106,7 @@ export class EthnoArtService {
 
     await this.scriptureRefs.update(input.id, scriptureReferences);
 
-    await this.repo.updateProperties(ethnoArt, simpleChanges);
+    await this.repo.update(ethnoArt, simpleChanges);
 
     return await this.readOne(input.id, session);
   }

--- a/src/components/field-region/field-region.repository.ts
+++ b/src/components/field-region/field-region.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
+import { ChangesOf } from '~/core/database/changes';
 import { ID, Session, UnsecuredDto } from '../../common';
 import { DtoRepository } from '../../core';
 import {
@@ -13,7 +14,12 @@ import {
   requestingUser,
   sorting,
 } from '../../core/database/query';
-import { CreateFieldRegion, FieldRegion, FieldRegionListInput } from './dto';
+import {
+  CreateFieldRegion,
+  FieldRegion,
+  FieldRegionListInput,
+  UpdateFieldRegion,
+} from './dto';
 
 @Injectable()
 export class FieldRegionRepository extends DtoRepository(FieldRegion) {
@@ -37,6 +43,19 @@ export class FieldRegionRepository extends DtoRepository(FieldRegion) {
       .return<{ id: ID }>('node.id as id');
 
     return await query.first();
+  }
+
+  async update(
+    existing: FieldRegion,
+    changes: ChangesOf<FieldRegion, UpdateFieldRegion>,
+  ) {
+    const { directorId, ...simpleChanges } = changes;
+
+    if (directorId) {
+      // TODO update director - lol this was never implemented
+    }
+
+    await this.updateProperties(existing, simpleChanges);
   }
 
   protected hydrate() {

--- a/src/components/field-region/field-region.service.ts
+++ b/src/components/field-region/field-region.service.ts
@@ -90,9 +90,8 @@ export class FieldRegionService {
     this.privileges
       .for(session, FieldRegion, fieldRegion)
       .verifyChanges(changes);
-    // update director
 
-    await this.repo.updateProperties(fieldRegion, changes);
+    await this.repo.update(fieldRegion, changes);
 
     return await this.readOne(input.id, session);
   }

--- a/src/components/field-zone/field-zone.repository.ts
+++ b/src/components/field-zone/field-zone.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
+import { ChangesOf } from '~/core/database/changes';
 import { ID, Session, UnsecuredDto } from '../../common';
 import { DtoRepository } from '../../core';
 import {
@@ -14,7 +15,12 @@ import {
   requestingUser,
   sorting,
 } from '../../core/database/query';
-import { CreateFieldZone, FieldZone, FieldZoneListInput } from './dto';
+import {
+  CreateFieldZone,
+  FieldZone,
+  FieldZoneListInput,
+  UpdateFieldZone,
+} from './dto';
 
 @Injectable()
 export class FieldZoneRepository extends DtoRepository(FieldZone) {
@@ -55,7 +61,20 @@ export class FieldZoneRepository extends DtoRepository(FieldZone) {
         );
   }
 
-  async updateDirector(directorId: ID, id: ID) {
+  async update(
+    existing: FieldZone,
+    changes: ChangesOf<FieldZone, UpdateFieldZone>,
+  ) {
+    const { directorId, ...simpleChanges } = changes;
+
+    if (directorId) {
+      await this.updateDirector(directorId, existing.id);
+    }
+
+    await this.updateProperties(existing, simpleChanges);
+  }
+
+  private async updateDirector(directorId: ID, id: ID) {
     const createdAt = DateTime.local();
     const query = this.db
       .query()

--- a/src/components/field-zone/field-zone.service.ts
+++ b/src/components/field-zone/field-zone.service.ts
@@ -83,14 +83,7 @@ export class FieldZoneService {
     const changes = this.repo.getActualChanges(fieldZone, input);
     this.privileges.for(session, FieldZone, fieldZone).verifyChanges(changes);
 
-    const { directorId, ...simpleChanges } = changes;
-
-    // update director
-    if (directorId) {
-      await this.repo.updateDirector(directorId, input.id);
-    }
-
-    await this.repo.updateProperties(fieldZone, simpleChanges);
+    await this.repo.update(fieldZone, changes);
 
     return await this.readOne(input.id, session);
   }

--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -22,7 +22,6 @@ import {
 } from '../../common';
 import {
   CommonRepository,
-  DatabaseService,
   ILogger,
   Logger,
   OnIndex,
@@ -54,11 +53,8 @@ import {
 
 @Injectable()
 export class FileRepository extends CommonRepository {
-  constructor(
-    db: DatabaseService,
-    @Logger('file:repository') private readonly logger: ILogger,
-  ) {
-    super(db);
+  constructor(@Logger('file:repository') private readonly logger: ILogger) {
+    super();
   }
 
   @OnIndex()

--- a/src/components/film/film.repository.ts
+++ b/src/components/film/film.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { node, Query } from 'cypher-query-builder';
+import { ChangesOf } from '~/core/database/changes';
 import { ID, Session } from '../../common';
 import { DatabaseService, DbTypeOf, DtoRepository } from '../../core';
 import {
@@ -12,7 +13,7 @@ import {
   sorting,
 } from '../../core/database/query';
 import { ScriptureReferenceRepository } from '../scripture';
-import { CreateFilm, Film, FilmListInput } from './dto';
+import { CreateFilm, Film, FilmListInput, UpdateFilm } from './dto';
 
 @Injectable()
 export class FilmRepository extends DtoRepository(Film) {
@@ -23,7 +24,7 @@ export class FilmRepository extends DtoRepository(Film) {
     super(db);
   }
 
-  async createFilm(input: CreateFilm, session: Session) {
+  async create(input: CreateFilm, session: Session) {
     const initialProps = {
       name: input.name,
       canDelete: true,
@@ -34,6 +35,13 @@ export class FilmRepository extends DtoRepository(Film) {
       .apply(await createNode(Film, { initialProps }))
       .return<{ id: ID }>('node.id as id')
       .first();
+  }
+
+  async update(
+    existing: Film,
+    simpleChanges: Omit<ChangesOf<Film, UpdateFilm>, 'scriptureReferences'>,
+  ) {
+    await this.updateProperties(existing, simpleChanges);
   }
 
   async list({ filter, ...input }: FilmListInput, session: Session) {

--- a/src/components/film/film.repository.ts
+++ b/src/components/film/film.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { node, Query } from 'cypher-query-builder';
 import { ChangesOf } from '~/core/database/changes';
 import { ID, Session } from '../../common';
-import { DatabaseService, DbTypeOf, DtoRepository } from '../../core';
+import { DbTypeOf, DtoRepository } from '../../core';
 import {
   createNode,
   matchProps,
@@ -17,11 +17,8 @@ import { CreateFilm, Film, FilmListInput, UpdateFilm } from './dto';
 
 @Injectable()
 export class FilmRepository extends DtoRepository(Film) {
-  constructor(
-    private readonly scriptureRefs: ScriptureReferenceRepository,
-    db: DatabaseService,
-  ) {
-    super(db);
+  constructor(private readonly scriptureRefs: ScriptureReferenceRepository) {
+    super();
   }
 
   async create(input: CreateFilm, session: Session) {

--- a/src/components/film/film.service.ts
+++ b/src/components/film/film.service.ts
@@ -44,7 +44,7 @@ export class FilmService {
     }
 
     try {
-      const result = await this.repo.createFilm(input, session);
+      const result = await this.repo.create(input, session);
 
       if (!result) {
         throw new ServerException('failed to create a film');
@@ -106,7 +106,7 @@ export class FilmService {
 
     await this.scriptureRefs.update(input.id, scriptureReferences);
 
-    await this.repo.updateProperties(film, simpleChanges);
+    await this.repo.update(film, simpleChanges);
 
     return await this.readOne(input.id, session);
   }

--- a/src/components/funding-account/funding-account.repository.ts
+++ b/src/components/funding-account/funding-account.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { node } from 'cypher-query-builder';
+import { ChangesOf } from '~/core/database/changes';
 import { ID, Session } from '../../common';
 import { DtoRepository } from '../../core';
 import {
@@ -13,6 +14,7 @@ import {
   CreateFundingAccount,
   FundingAccount,
   FundingAccountListInput,
+  UpdateFundingAccount,
 } from './dto';
 
 @Injectable()
@@ -30,6 +32,13 @@ export class FundingAccountRepository extends DtoRepository(FundingAccount) {
       .return<{ id: ID }>('node.id as id');
 
     return await query.first();
+  }
+
+  async update(
+    existing: FundingAccount,
+    changes: ChangesOf<FundingAccount, UpdateFundingAccount>,
+  ) {
+    return await this.updateProperties(existing, changes);
   }
 
   async list(input: FundingAccountListInput, session: Session) {

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -101,7 +101,7 @@ export class FundingAccountService {
     this.privileges
       .for(session, FundingAccount, fundingAccount)
       .verifyChanges(changes);
-    return await this.repo.updateProperties(fundingAccount, changes);
+    return await this.repo.update(fundingAccount, changes);
   }
 
   async delete(id: ID, session: Session): Promise<void> {

--- a/src/components/language/ethnologue-language/ethnologue-language.repository.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.repository.ts
@@ -1,8 +1,13 @@
 import { Injectable } from '@nestjs/common';
+import { ChangesOf } from '~/core/database/changes';
 import { ID, Session } from '../../../common';
 import { DtoRepository } from '../../../core';
 import { createNode, matchRequestingUser } from '../../../core/database/query';
-import { CreateEthnologueLanguage, EthnologueLanguage } from '../dto';
+import {
+  CreateEthnologueLanguage,
+  EthnologueLanguage,
+  UpdateEthnologueLanguage,
+} from '../dto';
 
 @Injectable()
 export class EthnologueLanguageRepository extends DtoRepository(
@@ -23,5 +28,12 @@ export class EthnologueLanguageRepository extends DtoRepository(
       .return<{ id: ID }>('node.id as id');
 
     return await query.first();
+  }
+
+  async update(
+    existing: EthnologueLanguage,
+    changes: ChangesOf<EthnologueLanguage, UpdateEthnologueLanguage>,
+  ) {
+    await this.updateProperties(existing, changes);
   }
 }

--- a/src/components/language/ethnologue-language/ethnologue-language.service.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.service.ts
@@ -75,7 +75,7 @@ export class EthnologueLanguageService {
       .verifyChanges(changes);
 
     try {
-      await this.repo.updateProperties(ethnologueLanguage, changes);
+      await this.repo.update(ethnologueLanguage, changes);
     } catch (exception) {
       this.logger.error('update failed', { exception });
       throw new ServerException(

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -7,6 +7,7 @@ import {
   Query,
   relation,
 } from 'cypher-query-builder';
+import { ChangesOf } from '~/core/database/changes';
 import {
   ID,
   labelForView,
@@ -37,7 +38,12 @@ import {
   variable,
 } from '../../core/database/query';
 import { ProjectStatus } from '../project';
-import { CreateLanguage, Language, LanguageListInput } from './dto';
+import {
+  CreateLanguage,
+  Language,
+  LanguageListInput,
+  UpdateLanguage,
+} from './dto';
 
 @Injectable()
 export class LanguageRepository extends DtoRepository<
@@ -75,6 +81,14 @@ export class LanguageRepository extends DtoRepository<
       .return<{ id: ID }>('node.id as id');
 
     return await createLanguage.first();
+  }
+
+  async update(
+    existing: Language,
+    simpleChanges: Omit<ChangesOf<Language, UpdateLanguage>, 'ethnologue'>,
+    changeset?: ID,
+  ) {
+    await this.updateProperties(existing, simpleChanges, changeset);
   }
 
   async readMany(ids: readonly ID[], session: Session, view?: ObjectView) {

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -149,7 +149,7 @@ export class LanguageService {
       );
     }
 
-    await this.repo.updateProperties(object, simpleChanges, view?.changeset);
+    await this.repo.update(object, simpleChanges, view?.changeset);
 
     return await this.readOne(input.id, session, view);
   }

--- a/src/components/location/dto/update-location.dto.ts
+++ b/src/components/location/dto/update-location.dto.ts
@@ -16,7 +16,7 @@ export abstract class UpdateLocation {
   readonly name?: string;
 
   @Field(() => LocationType, { nullable: true })
-  readonly type: LocationType;
+  readonly type?: LocationType;
 
   @Field(() => String, {
     nullable: true,

--- a/src/components/location/location.repository.ts
+++ b/src/components/location/location.repository.ts
@@ -20,7 +20,12 @@ import {
   sorting,
 } from '../../core/database/query';
 import { FileId } from '../file';
-import { CreateLocation, Location, LocationListInput } from './dto';
+import {
+  CreateLocation,
+  Location,
+  LocationListInput,
+  UpdateLocation,
+} from './dto';
 
 @Injectable()
 export class LocationRepository extends DtoRepository(Location) {
@@ -62,6 +67,36 @@ export class LocationRepository extends DtoRepository(Location) {
     }
 
     return { id: result.id, mapImageId };
+  }
+
+  async update(changes: UpdateLocation) {
+    const {
+      id,
+      fundingAccountId,
+      defaultFieldRegionId,
+      mapImage,
+      ...simpleChanges
+    } = changes;
+
+    await this.updateProperties({ id }, simpleChanges);
+
+    if (fundingAccountId !== undefined) {
+      await this.updateRelation(
+        'fundingAccount',
+        'FundingAccount',
+        id,
+        fundingAccountId,
+      );
+    }
+
+    if (defaultFieldRegionId !== undefined) {
+      await this.updateRelation(
+        'defaultFieldRegion',
+        'FieldRegion',
+        id,
+        defaultFieldRegionId,
+      );
+    }
   }
 
   protected hydrate() {

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -94,39 +94,7 @@ export class LocationService {
     const changes = this.repo.getActualChanges(location, input);
     this.privileges.for(session, Location, location).verifyChanges(changes);
 
-    const {
-      fundingAccountId,
-      defaultFieldRegionId,
-      mapImage,
-      ...simpleChanges
-    } = changes;
-
-    await this.repo.updateProperties(location, simpleChanges);
-
-    if (fundingAccountId !== undefined) {
-      await this.repo.updateRelation(
-        'fundingAccount',
-        'FundingAccount',
-        input.id,
-        fundingAccountId,
-      );
-    }
-
-    if (defaultFieldRegionId !== undefined) {
-      await this.repo.updateRelation(
-        'defaultFieldRegion',
-        'FieldRegion',
-        input.id,
-        defaultFieldRegionId,
-      );
-    }
-
-    await this.files.updateDefinedFile(
-      location.mapImage,
-      'location.mapImage',
-      mapImage,
-      session,
-    );
+    await this.repo.update({ id: input.id, ...changes });
 
     return await this.readOne(input.id, session);
   }

--- a/src/components/organization/organization.repository.ts
+++ b/src/components/organization/organization.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
+import { ChangesOf } from '~/core/database/changes';
 import { ID, Session, UnsecuredDto } from '../../common';
 import { DtoRepository } from '../../core';
 import {
@@ -16,7 +17,12 @@ import {
   requestingUser,
   sorting,
 } from '../../core/database/query';
-import { CreateOrganization, Organization, OrganizationListInput } from './dto';
+import {
+  CreateOrganization,
+  Organization,
+  OrganizationListInput,
+  UpdateOrganization,
+} from './dto';
 
 @Injectable()
 export class OrganizationRepository extends DtoRepository<
@@ -40,6 +46,13 @@ export class OrganizationRepository extends DtoRepository<
       .return<{ id: ID }>('node.id as id');
 
     return await query.first();
+  }
+
+  async update(
+    existing: Organization,
+    changes: ChangesOf<Organization, UpdateOrganization>,
+  ) {
+    return await this.updateProperties(existing, changes);
   }
 
   protected hydrate(session: Session) {

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -103,7 +103,7 @@ export class OrganizationService {
       .for(session, Organization, organization)
       .verifyChanges(changes);
 
-    return await this.repo.updateProperties(organization, changes);
+    return await this.repo.update(organization, changes);
   }
 
   async delete(id: ID, session: Session): Promise<void> {

--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -129,78 +129,12 @@ export class PartnerService {
 
     const changes = this.repo.getActualChanges(partner, input);
     this.privileges.for(session, Partner, partner).verifyChanges(changes);
-    const {
-      pointOfContactId,
-      languageOfWiderCommunicationId,
-      fieldRegions,
-      countries,
-      languagesOfConsulting,
-      ...simpleChanges
-    } = changes;
 
-    await this.repo.updateProperties(partner, simpleChanges);
-
-    if (pointOfContactId !== undefined) {
-      await this.repo.updateRelation(
-        'pointOfContact',
-        'User',
-        input.id,
-        pointOfContactId,
-      );
+    if (changes.countries) {
+      await this.verifyCountries(changes.countries);
     }
 
-    if (languageOfWiderCommunicationId) {
-      await this.repo.updateRelation(
-        'languageOfWiderCommunication',
-        'Language',
-        partner.id,
-        languageOfWiderCommunicationId,
-      );
-    }
-
-    if (countries) {
-      await this.verifyCountries(countries);
-
-      try {
-        await this.repo.updateRelationList({
-          id: partner.id,
-          relation: 'countries',
-          newList: countries,
-        });
-      } catch (e) {
-        throw e instanceof InputException
-          ? e.withField('partner.countries')
-          : e;
-      }
-    }
-
-    if (fieldRegions) {
-      try {
-        await this.repo.updateRelationList({
-          id: partner.id,
-          relation: 'fieldRegions',
-          newList: fieldRegions,
-        });
-      } catch (e) {
-        throw e instanceof InputException
-          ? e.withField('partner.fieldRegions')
-          : e;
-      }
-    }
-
-    if (languagesOfConsulting) {
-      try {
-        await this.repo.updateRelationList({
-          id: partner.id,
-          relation: 'languagesOfConsulting',
-          newList: languagesOfConsulting,
-        });
-      } catch (e) {
-        throw e instanceof InputException
-          ? e.withField('partner.languagesOfConsulting')
-          : e;
-      }
-    }
+    await this.repo.update(partner, changes);
 
     return await this.readOne(input.id, session);
   }

--- a/src/components/partnership/partnership.repository.ts
+++ b/src/components/partnership/partnership.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Node, node, Query, relation } from 'cypher-query-builder';
 import { pickBy } from 'lodash';
 import { DateTime } from 'luxon';
+import { ChangesOf } from '~/core/database/changes';
 import {
   generateId,
   ID,
@@ -35,6 +36,7 @@ import {
   Partnership,
   PartnershipAgreementStatus,
   PartnershipListInput,
+  UpdatePartnership,
 } from './dto';
 
 @Injectable()
@@ -81,6 +83,17 @@ export class PartnershipRepository extends DtoRepository<
       throw new ServerException('Failed to create partnership');
     }
     return { id: result.id, mouId, agreementId };
+  }
+
+  async update(
+    existing: Partnership,
+    simpleChanges: Omit<
+      ChangesOf<Partnership, UpdatePartnership>,
+      'mou' | 'agreement'
+    >,
+    changeset?: ID,
+  ) {
+    await this.updateProperties(existing, simpleChanges, changeset);
   }
 
   async readMany(ids: readonly ID[], session: Session, view?: ObjectView) {

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -213,7 +213,7 @@ export class PartnershipService {
       await this.repo.removePrimaryFromOtherPartnerships(input.id);
     }
 
-    await this.repo.updateProperties(object, simpleChanges, view?.changeset);
+    await this.repo.update(object, simpleChanges, view?.changeset);
     await this.files.updateDefinedFile(
       object.mou,
       'partnership.mou',

--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -18,7 +18,7 @@ import {
   Session,
   UnsecuredDto,
 } from '../../common';
-import { DatabaseService, DtoRepository } from '../../core';
+import { DtoRepository } from '../../core';
 import {
   ACTIVE,
   createNode,
@@ -53,9 +53,8 @@ export class PeriodicReportRepository extends DtoRepository<
 >(IPeriodicReport) {
   constructor(
     private readonly progressRepo: ProgressReportExtraForPeriodicInterfaceRepository,
-    db: DatabaseService,
   ) {
-    super(db);
+    super();
   }
 
   async merge(input: MergePeriodicReports) {

--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -9,6 +9,7 @@ import {
   Query,
   relation,
 } from 'cypher-query-builder';
+import { ChangesOf } from '~/core/database/changes';
 import {
   CalendarDate,
   generateId,
@@ -41,6 +42,7 @@ import {
   PeriodicReportListInput,
   ReportType,
   resolveReportType,
+  UpdatePeriodicReportInput,
 } from './dto';
 
 @Injectable()
@@ -160,6 +162,17 @@ export class PeriodicReportRepository extends DtoRepository<
         'report.id as id, interval',
       );
     return await query.run();
+  }
+
+  async update<T extends PeriodicReport | UnsecuredDto<PeriodicReport>>(
+    existing: T,
+    simpleChanges: Omit<
+      ChangesOf<PeriodicReport, UpdatePeriodicReportInput>,
+      'reportFile'
+    > &
+      Partial<Pick<PeriodicReport, 'start' | 'end'>>,
+  ) {
+    return await this.updateProperties(existing, simpleChanges);
   }
 
   async list(input: PeriodicReportListInput, session: Session) {

--- a/src/components/periodic-report/periodic-report.service.ts
+++ b/src/components/periodic-report/periodic-report.service.ts
@@ -69,7 +69,7 @@ export class PeriodicReportService {
 
     const { reportFile, ...simpleChanges } = changes;
 
-    const updated = await this.repo.updateProperties(current, simpleChanges);
+    const updated = await this.repo.update(current, simpleChanges);
 
     if (reportFile) {
       const file = await this.files.updateDefinedFile(
@@ -232,7 +232,7 @@ export class PeriodicReportService {
         // no change
         return;
       }
-      await this.repo.updateProperties(report, {
+      await this.repo.update(report, {
         start: at,
         end: at,
       });

--- a/src/components/post/post.repository.ts
+++ b/src/components/post/post.repository.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { inArray, node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
-import { ID, Session } from '~/common';
+import { ID, Session, UnsecuredDto } from '~/common';
 import { DbTypeOf, DtoRepository } from '~/core/database';
+import { ChangesOf } from '~/core/database/changes';
 import {
   ACTIVE,
   createNode,
@@ -13,7 +14,7 @@ import {
   paginate,
   sorting,
 } from '~/core/database/query';
-import { CreatePost, Post } from './dto';
+import { CreatePost, Post, UpdatePost } from './dto';
 import { PostListInput } from './dto/list-posts.dto';
 import { PostShareability } from './dto/shareability.dto';
 
@@ -40,6 +41,13 @@ export class PostRepository extends DtoRepository<typeof Post, [Session] | []>(
       )
       .apply(this.hydrate())
       .first();
+  }
+
+  async update(
+    existing: UnsecuredDto<Post>,
+    changes: ChangesOf<Post, UpdatePost>,
+  ) {
+    return await this.updateProperties(existing, changes);
   }
 
   async readMany(ids: readonly ID[], session: Session) {

--- a/src/components/post/post.service.ts
+++ b/src/components/post/post.service.ts
@@ -68,7 +68,7 @@ export class PostService {
 
     const changes = this.repo.getActualChanges(object, input);
     this.privileges.for(session, Post, object).verifyChanges(changes);
-    const updated = await this.repo.updateProperties(object, changes);
+    const updated = await this.repo.update(object, changes);
 
     return this.secure(updated, session);
   }

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -17,12 +17,7 @@ import {
   ServerException,
   Session,
 } from '../../common';
-import {
-  CommonRepository,
-  DatabaseService,
-  DbTypeOf,
-  OnIndex,
-} from '../../core';
+import { CommonRepository, DbTypeOf, OnIndex } from '../../core';
 import { DbChanges, getChanges } from '../../core/database/changes';
 import {
   ACTIVE,
@@ -80,11 +75,8 @@ export type HydratedProductRow = Merge<
 
 @Injectable()
 export class ProductRepository extends CommonRepository {
-  constructor(
-    private readonly scriptureRefs: ScriptureReferenceRepository,
-    db: DatabaseService,
-  ) {
-    super(db);
+  constructor(private readonly scriptureRefs: ScriptureReferenceRepository) {
+    super();
   }
 
   async readMany(ids: readonly ID[], session: Session) {

--- a/src/components/project/project-member/project-member.repository.ts
+++ b/src/components/project/project-member/project-member.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Node, node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
+import { ChangesOf } from '~/core/database/changes';
 import { ID, Session, UnsecuredDto } from '../../../common';
 import { DatabaseService, DtoRepository } from '../../../core';
 import {
@@ -18,6 +19,7 @@ import {
   CreateProjectMember,
   ProjectMember,
   ProjectMemberListInput,
+  UpdateProjectMember,
 } from './dto';
 
 @Injectable()
@@ -91,6 +93,13 @@ export class ProjectMemberRepository extends DtoRepository<
       ])
       .return<{ id: ID }>('projectMember.id as id')
       .first();
+  }
+
+  async update(
+    existing: ProjectMember,
+    changes: ChangesOf<ProjectMember, UpdateProjectMember>,
+  ) {
+    await this.updateProperties(existing, changes);
   }
 
   protected hydrate(session: Session) {

--- a/src/components/project/project-member/project-member.repository.ts
+++ b/src/components/project/project-member/project-member.repository.ts
@@ -3,7 +3,7 @@ import { Node, node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { ChangesOf } from '~/core/database/changes';
 import { ID, Session, UnsecuredDto } from '../../../common';
-import { DatabaseService, DtoRepository } from '../../../core';
+import { DtoRepository } from '../../../core';
 import {
   ACTIVE,
   matchPropsAndProjectSensAndScopedRoles,
@@ -27,8 +27,8 @@ export class ProjectMemberRepository extends DtoRepository<
   typeof ProjectMember,
   [session: Session]
 >(ProjectMember) {
-  constructor(private readonly users: UserRepository, db: DatabaseService) {
-    super(db);
+  constructor(private readonly users: UserRepository) {
+    super();
   }
 
   async verifyRelationshipEligibility(projectId: ID, userId: ID) {

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -187,7 +187,7 @@ export class ProjectMemberService {
 
     const changes = this.repo.getActualChanges(object, input);
     this.privileges.for(session, ProjectMember, object).verifyChanges(changes);
-    await this.repo.updateProperties(object, changes);
+    await this.repo.update(object, changes);
     return await this.readOne(input.id, session);
   }
 

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -9,12 +9,7 @@ import {
   Session,
   UnsecuredDto,
 } from '../../common';
-import {
-  CommonRepository,
-  ConfigService,
-  DatabaseService,
-  OnIndex,
-} from '../../core';
+import { CommonRepository, ConfigService, OnIndex } from '../../core';
 import { ChangesOf, getChanges } from '../../core/database/changes';
 import {
   ACTIVE,
@@ -46,11 +41,10 @@ import { projectListFilter } from './list-filter.query';
 @Injectable()
 export class ProjectRepository extends CommonRepository {
   constructor(
-    db: DatabaseService,
     private readonly config: ConfigService,
     private readonly privileges: Privileges,
   ) {
-    super(db);
+    super();
   }
 
   async getRoles(session: Session) {

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -15,7 +15,7 @@ import {
   DatabaseService,
   OnIndex,
 } from '../../core';
-import { DbChanges, getChanges } from '../../core/database/changes';
+import { ChangesOf, getChanges } from '../../core/database/changes';
 import {
   ACTIVE,
   createNode,
@@ -211,35 +211,71 @@ export class ProjectRepository extends CommonRepository {
     return result.id;
   }
 
-  async updateProperties(
-    currentProject: UnsecuredDto<Project>,
-    simpleChanges: DbChanges<TranslationProject | InternshipProject>,
+  async update(
+    existing: UnsecuredDto<Project>,
+    changes: ChangesOf<Project, UpdateProject>,
     changeset?: ID,
   ) {
-    return await this.db.updateProperties({
+    const {
+      primaryLocationId,
+      marketingLocationId,
+      fieldRegionId,
+      ...simpleChanges
+    } = changes;
+
+    let result = await this.db.updateProperties({
       type:
-        currentProject.type === ProjectType.Translation
+        existing.type === ProjectType.Translation
           ? TranslationProject
           : InternshipProject,
-      object: currentProject,
+      object: existing,
       changes: simpleChanges,
       changeset,
     });
-  }
 
-  async updateRelation(
-    relationName: string,
-    otherLabel: string,
-    id: ID,
-    otherId: ID | null,
-  ) {
-    await super.updateRelation(
-      relationName,
-      otherLabel,
-      id,
-      otherId,
-      'Project',
-    );
+    if (primaryLocationId !== undefined) {
+      await this.updateRelation(
+        'primaryLocation',
+        'Location',
+        existing.id,
+        primaryLocationId,
+        'Project',
+      );
+      result = {
+        ...result,
+        primaryLocation: primaryLocationId,
+      };
+    }
+
+    if (fieldRegionId !== undefined) {
+      await this.updateRelation(
+        'fieldRegion',
+        'FieldRegion',
+        existing.id,
+        fieldRegionId,
+        'Project',
+      );
+      result = {
+        ...result,
+        fieldRegion: fieldRegionId,
+      };
+    }
+
+    if (marketingLocationId !== undefined) {
+      await this.updateRelation(
+        'marketingLocation',
+        'Location',
+        existing.id,
+        marketingLocationId,
+        'Project',
+      );
+      result = {
+        ...result,
+        marketingLocation: marketingLocationId,
+      };
+    }
+
+    return result;
   }
 
   async list(input: ProjectListInput, session: Session) {
@@ -261,28 +297,6 @@ export class ProjectRepository extends CommonRepository {
       .apply(paginate(input, this.hydrate(session.userId)))
       .first();
     return result!; // result from paginate() will always have 1 row.
-  }
-
-  async getMembershipRoles(projectId: ID | Project, session: Session) {
-    const query = this.db
-      .query()
-      .match([
-        node('node', 'Project', { id: projectId }),
-        relation('out', '', 'member', ACTIVE),
-        node('projectMember', 'ProjectMember'),
-        relation('out', '', 'user', ACTIVE),
-        node('user', 'User', { id: session.userId }),
-      ])
-      .match([
-        node('projectMember'),
-        relation('out', 'r', 'roles', ACTIVE),
-        node('roles', 'Property'),
-      ])
-      .return('collect(roles.value) as memberRoles')
-      .asResult<{
-        memberRoles: Role[][];
-      }>();
-    return await query.first();
   }
 
   @OnIndex()

--- a/src/components/story/story.repository.ts
+++ b/src/components/story/story.repository.ts
@@ -3,7 +3,7 @@ import { Query } from 'cypher-query-builder';
 import { ChangesOf } from '~/core/database/changes';
 import { DbTypeOf } from '~/core/database/db-type';
 import { ID, Session } from '../../common';
-import { DatabaseService, DtoRepository } from '../../core';
+import { DtoRepository } from '../../core';
 import {
   createNode,
   matchProps,
@@ -17,11 +17,8 @@ import { CreateStory, Story, StoryListInput, UpdateStory } from './dto';
 
 @Injectable()
 export class StoryRepository extends DtoRepository(Story) {
-  constructor(
-    private readonly scriptureRefs: ScriptureReferenceRepository,
-    db: DatabaseService,
-  ) {
-    super(db);
+  constructor(private readonly scriptureRefs: ScriptureReferenceRepository) {
+    super();
   }
 
   async create(input: CreateStory, session: Session) {

--- a/src/components/story/story.repository.ts
+++ b/src/components/story/story.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Query } from 'cypher-query-builder';
+import { ChangesOf } from '~/core/database/changes';
 import { DbTypeOf } from '~/core/database/db-type';
 import { ID, Session } from '../../common';
 import { DatabaseService, DtoRepository } from '../../core';
@@ -12,7 +13,7 @@ import {
   sorting,
 } from '../../core/database/query';
 import { ScriptureReferenceRepository } from '../scripture';
-import { CreateStory, Story, StoryListInput } from './dto';
+import { CreateStory, Story, StoryListInput, UpdateStory } from './dto';
 
 @Injectable()
 export class StoryRepository extends DtoRepository(Story) {
@@ -34,6 +35,13 @@ export class StoryRepository extends DtoRepository(Story) {
       .apply(await createNode(Story, { initialProps }))
       .return<{ id: ID }>('node.id as id')
       .first();
+  }
+
+  async update(
+    existing: Story,
+    simpleChanges: Omit<ChangesOf<Story, UpdateStory>, 'scriptureReferences'>,
+  ) {
+    await this.updateProperties(existing, simpleChanges);
   }
 
   async list({ filter, ...input }: StoryListInput, _session: Session) {

--- a/src/components/story/story.service.ts
+++ b/src/components/story/story.service.ts
@@ -102,7 +102,7 @@ export class StoryService {
     const { scriptureReferences, ...simpleChanges } = changes;
 
     await this.scriptureRefs.update(input.id, scriptureReferences);
-    await this.repo.updateProperties(story, simpleChanges);
+    await this.repo.update(story, simpleChanges);
 
     return await this.readOne(input.id, session);
   }

--- a/src/components/user/education/education.repository.ts
+++ b/src/components/user/education/education.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
+import { ChangesOf } from '~/core/database/changes';
 import { ID, Session } from '../../../common';
 import { DtoRepository } from '../../../core';
 import {
@@ -10,7 +11,12 @@ import {
   paginate,
   sorting,
 } from '../../../core/database/query';
-import { CreateEducation, Education, EducationListInput } from './dto';
+import {
+  CreateEducation,
+  Education,
+  EducationListInput,
+  UpdateEducation,
+} from './dto';
 
 @Injectable()
 export class EducationRepository extends DtoRepository(Education) {
@@ -45,6 +51,13 @@ export class EducationRepository extends DtoRepository(Education) {
       ])
       .return<{ id: ID }>('user.id as id')
       .first();
+  }
+
+  async update(
+    existing: Education,
+    changes: ChangesOf<Education, UpdateEducation>,
+  ) {
+    await this.updateProperties(existing, changes);
   }
 
   async list({ filter, ...input }: EducationListInput, _session: Session) {

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -84,7 +84,7 @@ export class EducationService {
       this.privileges.for(session, Education, ed).verifyChanges(changes);
     }
 
-    await this.repo.updateProperties(ed, changes);
+    await this.repo.update(ed, changes);
     return await this.readOne(input.id, session);
   }
 

--- a/src/components/user/unavailability/unavailability.repository.ts
+++ b/src/components/user/unavailability/unavailability.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
+import { ChangesOf } from '~/core/database/changes';
 import { ID, ServerException, Session } from '../../../common';
 import { DtoRepository } from '../../../core';
 import {
@@ -14,6 +15,7 @@ import {
   CreateUnavailability,
   Unavailability,
   UnavailabilityListInput,
+  UpdateUnavailability,
 } from './dto';
 
 @Injectable()
@@ -39,6 +41,13 @@ export class UnavailabilityRepository extends DtoRepository(Unavailability) {
       throw new ServerException('Could not create unavailability');
     }
     return result.id;
+  }
+
+  async update(
+    existing: Unavailability,
+    changes: ChangesOf<Unavailability, UpdateUnavailability>,
+  ) {
+    return await this.updateProperties(existing, changes);
   }
 
   async getUserIdByUnavailability(id: ID) {

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -97,7 +97,7 @@ export class UnavailabilityService {
         .for(session, Unavailability, unavailability)
         .verifyChanges(changes);
     }
-    return await this.repo.updateProperties(unavailability, changes);
+    return await this.repo.update(unavailability, changes);
   }
 
   async delete(id: ID, session: Session): Promise<void> {

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -109,23 +109,11 @@ export class UserService {
 
     this.privileges.for(session, User, user).verifyChanges(changes);
 
-    const { roles, email, ...simpleChanges } = changes;
-
-    if (roles) {
-      this.verifyRolesAreAssignable(session, roles);
+    if (changes.roles) {
+      this.verifyRolesAreAssignable(session, changes.roles);
     }
 
-    await this.userRepo.updateProperties(user, simpleChanges);
-
-    // Update email
-    if (email !== undefined) {
-      await this.userRepo.updateEmail(user, email);
-    }
-
-    // Update roles
-    if (roles) {
-      await this.userRepo.updateRoles(user, roles);
-    }
+    await this.userRepo.update(user, changes);
 
     return await this.readOne(input.id, session);
   }

--- a/src/core/database/common.repository.ts
+++ b/src/core/database/common.repository.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Optional } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { setOf } from '@seedcompany/common';
 import { inArray, node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
@@ -26,9 +26,6 @@ import { BaseNode } from './results';
 export class CommonRepository {
   @Inject(DatabaseService)
   protected db: DatabaseService;
-
-  // eslint-disable-next-line @typescript-eslint/no-empty-function,@typescript-eslint/no-useless-constructor
-  constructor(@Optional() _old?: unknown) {}
 
   async isUnique(value: string, label: string) {
     const exists = await this.db

--- a/src/core/database/common.repository.ts
+++ b/src/core/database/common.repository.ts
@@ -65,7 +65,7 @@ export class CommonRepository {
       .run();
   }
 
-  async updateRelation(
+  protected async updateRelation(
     relationName: string,
     otherLabel: string,
     id: ID,
@@ -103,7 +103,7 @@ export class CommonRepository {
       .run();
   }
 
-  async updateRelationList({
+  protected async updateRelationList({
     id,
     label,
     relation,

--- a/src/core/database/common.repository.ts
+++ b/src/core/database/common.repository.ts
@@ -27,15 +27,6 @@ export class CommonRepository {
   @Inject(DatabaseService)
   protected db: DatabaseService;
 
-  async isUnique(value: string, label: string) {
-    const exists = await this.db
-      .query()
-      .matchNode('node', label, { value })
-      .return('node')
-      .first();
-    return !exists;
-  }
-
   async getBaseNode(
     id: ID,
     label?: string | ResourceShape<any> | EnhancedResource<any>,

--- a/src/core/database/dto.repository.ts
+++ b/src/core/database/dto.repository.ts
@@ -99,7 +99,7 @@ export const DtoRepository = <
         .run();
     }
 
-    async updateProperties<
+    protected async updateProperties<
       TObject extends Partial<TResource | UnsecuredDto<TResource>> & {
         id: ID;
       },
@@ -112,7 +112,7 @@ export const DtoRepository = <
       });
     }
 
-    async updateRelation(
+    protected async updateRelation(
       relationName: string,
       otherLabel: string,
       id: ID,
@@ -127,7 +127,7 @@ export const DtoRepository = <
       );
     }
 
-    async updateRelationList(
+    protected async updateRelationList(
       options: Parameters<CommonRepository['updateRelationList']>[0],
     ) {
       return await super.updateRelationList({

--- a/src/core/database/dto.repository.ts
+++ b/src/core/database/dto.repository.ts
@@ -56,7 +56,12 @@ export const DtoRepository = <
         }
         label = defaultLabel;
       }
-      return await super.isUnique(value, label);
+      const exists = await this.db
+        .query()
+        .matchNode('node', label, { value })
+        .return('node')
+        .first();
+      return !exists;
     }
     @Once() private get uniqueLabel() {
       const labels = resource.Props.flatMap(


### PR DESCRIPTION
This reduces the surface area the repos & hides neo4j concepts. This will allow EdgeDB implementations to fulfill the repo shape while ignoring neo4j helpers.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5603542150) by [Unito](https://www.unito.io)
