### PR TITLE
[EdgeDB] Exception Handling/Formatting

### DIFF
--- a/src/common/exceptions/duplicate.exception.ts
+++ b/src/common/exceptions/duplicate.exception.ts
@@ -1,3 +1,10 @@
+import { ArgumentsHost } from '@nestjs/common';
+import {
+  GqlContextType as ContextKey,
+  GqlExecutionContext,
+} from '@nestjs/graphql';
+import { lowerCase, upperFirst } from 'lodash';
+import type { ExclusivityViolationError } from '~/core/edgedb';
 import { InputException } from './input.exception';
 
 /**
@@ -11,4 +18,47 @@ export class DuplicateException extends InputException {
       previous,
     );
   }
+
+  static fromDB(exception: ExclusivityViolationError, context?: ArgumentsHost) {
+    let property = exception.property;
+    const message = `${upperFirst(
+      lowerCase(property),
+    )} already exists and needs to be unique`;
+
+    // Attempt to add path prefix automatically to the property name, based
+    // on given GQL input.
+    if (context && context.getType<ContextKey>() === 'graphql') {
+      let gqlArgs = GqlExecutionContext.create(context as any).getArgs();
+
+      // unwind single `input` argument, based on our own conventions
+      if (Object.keys(gqlArgs).length === 1 && 'input' in gqlArgs) {
+        gqlArgs = gqlArgs.input;
+      }
+
+      const flattened = flattenObject(gqlArgs);
+      // Guess the correct path based on property name.
+      // This kinda assumes the property name will be unique amongst all the input.
+      const guessedPath = Object.keys(flattened).find(
+        (path) => property === path || path.endsWith('.' + property),
+      );
+      property = guessedPath ?? property;
+    }
+
+    const ex = new DuplicateException(property, message, exception);
+    ex.stack = exception.stack;
+    return ex;
+  }
 }
+
+const flattenObject = (obj: object, prefix = '') => {
+  const result: Record<string, any> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      const nestedObj = flattenObject(value, prefix + key + '.');
+      Object.assign(result, nestedObj);
+    } else {
+      result[prefix + key] = value;
+    }
+  }
+  return result;
+};

--- a/src/common/exceptions/exception.ts
+++ b/src/common/exceptions/exception.ts
@@ -29,8 +29,10 @@ export const hasPrevious = (e: Error): e is Error & { previous: Error } =>
 export function getPreviousList(ex: Error, includeSelf: boolean) {
   const previous: Error[] = includeSelf ? [ex] : [];
   let current = ex;
-  while (hasPrevious(current)) {
-    current = current.previous;
+  while (current.cause instanceof Error || hasPrevious(current)) {
+    current = hasPrevious(current)
+      ? current.previous
+      : (current.cause as Error);
     previous.push(current);
   }
   return previous;

--- a/src/components/authentication/authentication.edgedb.repository.ts
+++ b/src/components/authentication/authentication.edgedb.repository.ts
@@ -108,6 +108,9 @@ export class AuthenticationEdgeDBRepository
       ),
     }));
     const result = await this.db.run(query);
+    if (!result) {
+      return undefined;
+    }
     return {
       userId: result?.user?.id,
       roles: result?.user?.scopedRoles ?? [],

--- a/src/core/edgedb/edgedb.service.ts
+++ b/src/core/edgedb/edgedb.service.ts
@@ -85,6 +85,9 @@ export class EdgeDB {
         return await this.executor.current.query(query, args);
       }
     } catch (e) {
+      // Ignore this call in stack trace. This puts the actual query as the first.
+      e.stack = e.stack!.replace(/^\s+at EdgeDB\.run.+\n/m, '');
+
       if (ExclusivityViolationError.is(e)) {
         throw ExclusivityViolationError.cast(e);
       }

--- a/src/core/edgedb/error.util.ts
+++ b/src/core/edgedb/error.util.ts
@@ -1,5 +1,4 @@
-import { ConstraintViolationError } from 'edgedb';
+import { ExclusivityViolationError } from './exclusivity-violation.error';
 
 export const isExclusivityViolation = (e: unknown, property: string) =>
-  e instanceof ConstraintViolationError &&
-  e.message === `${property} violates exclusivity constraint`;
+  e instanceof ExclusivityViolationError && e.property === property;

--- a/src/core/edgedb/error.util.ts
+++ b/src/core/edgedb/error.util.ts
@@ -1,4 +1,0 @@
-import { ExclusivityViolationError } from './exclusivity-violation.error';
-
-export const isExclusivityViolation = (e: unknown, property: string) =>
-  e instanceof ExclusivityViolationError && e.property === property;

--- a/src/core/edgedb/exclusivity-violation.error.ts
+++ b/src/core/edgedb/exclusivity-violation.error.ts
@@ -1,0 +1,59 @@
+import { ConstraintViolationError } from 'edgedb';
+
+export class ExclusivityViolationError extends ConstraintViolationError {
+  constructor(
+    readonly objectFQN: string,
+    readonly property: string,
+    message?: string,
+    options?: {
+      cause?: unknown;
+    },
+  ) {
+    super(message, options);
+  }
+
+  static is(e: unknown): e is ConstraintViolationError {
+    return (
+      e instanceof ConstraintViolationError &&
+      (e as any)._message.endsWith(' violates exclusivity constraint')
+    );
+  }
+
+  static cast(e: ConstraintViolationError) {
+    if (e instanceof ExclusivityViolationError) {
+      return e;
+    }
+
+    // @ts-expect-error it's a private field
+    const message: string = e._message;
+    // @ts-expect-error it's a private field
+    const query: string = e._query;
+    // @ts-expect-error it's a private field
+    const attrs: Map<number, Uint8Array> = e._attrs;
+
+    const detail = new TextDecoder('utf8').decode(attrs.get(2 /* details */));
+    const matches = detail.match(
+      /^property '(.+)' of object type '(.+)' violates exclusivity constraint$/,
+    );
+    if (!matches) {
+      throw new Error(
+        `Could not parse exclusivity violation error; details: ${detail}`,
+      );
+    }
+    const property = matches[1];
+    const fqn = matches[2];
+    const ex = new ExclusivityViolationError(fqn, property, message, {
+      cause: e.cause,
+    });
+
+    ex.stack = e.stack!.replace(
+      /^ConstraintViolationError:/,
+      'ExclusivityViolationError:',
+    );
+    // @ts-expect-error it's a private field
+    ex._query = query;
+    // @ts-expect-error it's a private field
+    ex._attrs = attrs;
+    return ex;
+  }
+}

--- a/src/core/edgedb/index.ts
+++ b/src/core/edgedb/index.ts
@@ -2,5 +2,4 @@ export * from './reexports';
 export { edgeql, EdgeQLArgsOf, EdgeQLReturnOf } from './edgeql';
 export * from './edgedb.service';
 export * from './withScope';
-export * from './error.util';
 export * from './exclusivity-violation.error';

--- a/src/core/edgedb/index.ts
+++ b/src/core/edgedb/index.ts
@@ -3,3 +3,4 @@ export { edgeql, EdgeQLArgsOf, EdgeQLReturnOf } from './edgeql';
 export * from './edgedb.service';
 export * from './withScope';
 export * from './error.util';
+export * from './exclusivity-violation.error';

--- a/src/core/exception/exception.filter.ts
+++ b/src/core/exception/exception.filter.ts
@@ -62,6 +62,10 @@ export class ExceptionFilter implements GqlExceptionFilter {
       ? HttpStatus.FORBIDDEN
       : codes.has('Client')
       ? HttpStatus.BAD_REQUEST
+      : codes.has('Transient')
+      ? HttpStatus.SERVICE_UNAVAILABLE
+      : codes.has('NotImplemented')
+      ? HttpStatus.NOT_IMPLEMENTED
       : HttpStatus.INTERNAL_SERVER_ERROR;
 
     const out = {

--- a/src/core/exception/exception.filter.ts
+++ b/src/core/exception/exception.filter.ts
@@ -32,7 +32,7 @@ export class ExceptionFilter implements GqlExceptionFilter {
 
     let normalized: ExceptionJson;
     try {
-      normalized = this.normalizer.normalize(exception);
+      normalized = this.normalizer.normalize(exception, args);
     } catch (e) {
       throw exception;
     }

--- a/src/core/exception/exception.normalizer.ts
+++ b/src/core/exception/exception.normalizer.ts
@@ -98,6 +98,22 @@ export class ExceptionNormalizer {
       };
     }
 
+    // Again, dig deep here to find connection errors.
+    // These would be the root problem that we'd want to expose.
+    const edgeError = exs.find(
+      (e): e is Edge.EdgeDBError => e instanceof Edge.EdgeDBError,
+    );
+    if (
+      edgeError &&
+      (edgeError instanceof Edge.AvailabilityError ||
+        edgeError instanceof Edge.ClientConnectionError)
+    ) {
+      return {
+        codes: this.errorToCodes(ex),
+        message: 'Failed to connect to CORD database',
+      };
+    }
+
     if (ex instanceof ExclusivityViolationError) {
       ex = DuplicateException.fromDB(ex, context);
     } else if (ex instanceof Edge.EdgeDBError) {

--- a/src/core/logger/formatters.ts
+++ b/src/core/logger/formatters.ts
@@ -10,7 +10,7 @@ import * as stacktrace from 'stack-trace';
 import { MESSAGE } from 'triple-beam';
 import { fileURLToPath } from 'url';
 import { config, format, LogEntry } from 'winston';
-import { Exception } from '../../common/exceptions';
+import { hasPrevious } from '~/common';
 import { maskSecrets as maskSecretsOfObj } from '../../common/mask-secrets';
 import { getNameFromEntry } from './logger.interface';
 
@@ -77,9 +77,7 @@ export const exceptionInfo = () =>
     delete info.stack;
 
     const flatten = (ex: Error): Error[] =>
-      ex instanceof Exception && ex.previous
-        ? [ex, ...flatten(ex.previous)]
-        : [ex];
+      hasPrevious(ex) ? [ex, ...flatten(ex.previous)] : [ex];
 
     info.exceptions = flatten(info.exception).map((ex): ParsedError => {
       const { name: _, message, stack: __, ...other } = ex;


### PR DESCRIPTION
This removes the boilerplate of wrapping db errors 1) to convert to generic failures to nicer error messages, 2) convert exclusivity violations to duplicate input errors.

Transactions will now also retry retryable errors, even when they are wrapped in other ones. Not as useful now, but doesn't hurt anything and matches what we do with Neo4j.

Fixed auth not throwing `NoSession`, when it should be.

Have a custom `ExclusivityViolationError` error class now with can be used to programmatically check the object FQN & property name that failed. As stated above, this is converted to a `DuplicateException` on the way out.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5688525797) by [Unito](https://www.unito.io)
