### PR TITLE
[EdgeDB] Abstract Common & DTO Repositories

### DIFF
--- a/src/components/project/project-member/project-member.repository.ts
+++ b/src/components/project/project-member/project-member.repository.ts
@@ -117,7 +117,9 @@ export class ProjectMemberRepository extends DtoRepository<
           node('user', 'User'),
         ])
         .subQuery('user', (sub) =>
-          sub.with('user as node').apply(this.users.hydrate(session.userId)),
+          sub
+            .with('user as node')
+            .apply(this.users.hydrateAsNeo4j(session.userId)),
         )
         .return<{ dto: UnsecuredDto<ProjectMember> }>(
           merge('props', { user: 'dto' }).as('dto'),

--- a/src/components/user/user.edgedb.repository.ts
+++ b/src/components/user/user.edgedb.repository.ts
@@ -12,14 +12,7 @@ import type { UserRepository } from './user.repository';
 @Injectable()
 export class UserEdgeDBRepository
   extends RepoFor(User).withDefaults()
-  implements
-    Omit<
-      PublicOf<UserRepository>,
-      // hydrate is public (not default) and specific to Neo4j,
-      // but it will only be called by other neo4j repositories,
-      // so it doesn't have to match here
-      'hydrate'
-    >
+  implements PublicOf<UserRepository>
 {
   async doesEmailAddressExist(email: string) {
     const query = e.select(e.User, () => ({
@@ -42,5 +35,9 @@ export class UserEdgeDBRepository
   }
   removeOrganizationFromUser(args: RemoveOrganizationFromUser): Promise<void> {
     throw new NotImplementedException().with(args);
+  }
+
+  hydrateAsNeo4j(_session: unknown): any {
+    throw new NotImplementedException();
   }
 }

--- a/src/components/user/user.edgedb.repository.ts
+++ b/src/components/user/user.edgedb.repository.ts
@@ -1,90 +1,46 @@
 import { Injectable } from '@nestjs/common';
-import { ID, NotFoundException, Session } from '~/common';
-import { e, EdgeDB } from '~/core/edgedb';
-import { CreatePerson, User, UserListInput } from './dto';
-import { UserRepository } from './user.repository';
-
-const hydrate = e.shape(e.User, (user) => ({
-  ...user['*'],
-  // Other links if needed
-}));
+import { NotImplementedException, PublicOf } from '~/common';
+import { e, RepoFor, ScopeOf } from '~/core/edgedb';
+import {
+  AssignOrganizationToUser,
+  RemoveOrganizationFromUser,
+  User,
+  UserListInput,
+} from './dto';
+import type { UserRepository } from './user.repository';
 
 @Injectable()
-export class UserEdgedbRepository extends UserRepository {
-  constructor(private readonly edgedb: EdgeDB) {
-    super();
-  }
-
-  async readOne(id: ID, _session: Session | ID) {
-    const query = e.select(e.User, (user) => ({
-      ...hydrate(user),
-      filter_single: { id },
-    }));
-    const user = await this.edgedb.run(query);
-    if (!user) {
-      throw new NotFoundException('Could not find user');
-    }
-    return user;
-  }
-
-  async readMany(ids: readonly ID[], _session: Session | ID) {
-    const query = e.params({ ids: e.array(e.uuid) }, ({ ids }) =>
-      e.select(e.User, (user) => ({
-        ...hydrate(user),
-        filter: e.op(user.id, 'in', e.array_unpack(ids)),
-      })),
-    );
-    const users = await this.edgedb.run(query, { ids });
-    return users;
-  }
-
+export class UserEdgeDBRepository
+  extends RepoFor(User).withDefaults()
+  implements
+    Omit<
+      PublicOf<UserRepository>,
+      // hydrate is public (not default) and specific to Neo4j,
+      // but it will only be called by other neo4j repositories,
+      // so it doesn't have to match here
+      'hydrate'
+    >
+{
   async doesEmailAddressExist(email: string) {
     const query = e.select(e.User, () => ({
       filter_single: { email },
     }));
-    const result = await this.edgedb.run(query);
+    const result = await this.db.run(query);
     return !!result;
   }
 
-  async list(input: UserListInput, _session: Session) {
-    const sortKey = input.sort as keyof (typeof e.User)['*'];
-    const all = e.select(e.User, (user) => ({
-      filter: e.all(
-        input.filter.pinned != null
-          ? e.op(user.pinned, '=', input.filter.pinned)
-          : true,
-        // More filters here when needed...
-      ),
-      order_by: {
-        expression: user[sortKey],
-        direction: input.order,
-      },
-    }));
-    const thisPage = e.select(all, () => ({
-      offset: (input.page - 1) * input.count,
-      limit: input.count + 1,
-    }));
-    const query = e.select({
-      items: e.select(thisPage, (user) => ({
-        ...hydrate(user),
-        limit: input.count,
-      })),
-      total: e.count(all),
-      hasMore: e.op(e.count(thisPage), '>', input.count),
-    });
-    return await this.edgedb.run(query);
+  protected listFilters(user: ScopeOf<typeof e.User>, input: UserListInput) {
+    return [
+      input.filter.pinned != null &&
+        e.op(user.pinned, '=', input.filter.pinned),
+      // More filters here when needed...
+    ];
   }
 
-  async create(input: CreatePerson) {
-    const query = e.insert(e.User, { ...input });
-    const result = await this.edgedb.run(query);
-    return result.id;
+  assignOrganizationToUser(args: AssignOrganizationToUser): Promise<void> {
+    throw new NotImplementedException().with(args);
   }
-
-  async delete(id: ID, _session: Session, _object: User): Promise<void> {
-    const query = e.delete(e.User, () => ({
-      filter_single: { id },
-    }));
-    await this.edgedb.run(query);
+  removeOrganizationFromUser(args: RemoveOrganizationFromUser): Promise<void> {
+    throw new NotImplementedException().with(args);
   }
 }

--- a/src/components/user/user.module.ts
+++ b/src/components/user/user.module.ts
@@ -12,7 +12,7 @@ import { EducationModule } from './education/education.module';
 import { KnownLanguageRepository } from './known-language.repository';
 import { KnownLanguageResolver } from './known-language.resolver';
 import { UnavailabilityModule } from './unavailability/unavailability.module';
-import { UserEdgedbRepository } from './user.edgedb.repository';
+import { UserEdgeDBRepository } from './user.edgedb.repository';
 import { UserLoader } from './user.loader';
 import { UserRepository } from './user.repository';
 import { UserResolver } from './user.resolver';
@@ -36,7 +36,7 @@ import { UserService } from './user.service';
     AssignableRolesResolver,
     UserLoader,
     UserService,
-    splitDb(UserRepository, UserEdgedbRepository),
+    splitDb(UserRepository, UserEdgeDBRepository as any),
     KnownLanguageRepository,
   ],
   exports: [UserService, UserRepository, EducationModule, UnavailabilityModule],

--- a/src/components/user/user.module.ts
+++ b/src/components/user/user.module.ts
@@ -36,7 +36,7 @@ import { UserService } from './user.service';
     AssignableRolesResolver,
     UserLoader,
     UserService,
-    splitDb(UserRepository, UserEdgeDBRepository as any),
+    splitDb(UserRepository, UserEdgeDBRepository),
     KnownLanguageRepository,
   ],
   exports: [UserService, UserRepository, EducationModule, UnavailabilityModule],

--- a/src/components/user/user.repository.ts
+++ b/src/components/user/user.repository.ts
@@ -84,10 +84,13 @@ export class UserRepository extends DtoRepository<typeof User, [Session | ID]>(
     if (!result) {
       throw new ServerException('Failed to create user');
     }
-    return result.id;
+    return result;
   }
 
-  async update(existing: User, changes: ChangesOf<User, UpdateUser>) {
+  async update(
+    existing: User,
+    changes: ChangesOf<User, UpdateUser>,
+  ): Promise<unknown> {
     const { roles, email, ...simpleChanges } = changes;
 
     await this.updateProperties(existing, simpleChanges);
@@ -97,6 +100,8 @@ export class UserRepository extends DtoRepository<typeof User, [Session | ID]>(
     if (roles) {
       await this.updateRoles(existing, roles);
     }
+
+    return undefined;
   }
 
   hydrate(requestingUserId: Session | ID) {

--- a/src/components/user/user.repository.ts
+++ b/src/components/user/user.repository.ts
@@ -104,7 +104,7 @@ export class UserRepository extends DtoRepository<typeof User, [Session | ID]>(
     return undefined;
   }
 
-  hydrate(requestingUserId: Session | ID) {
+  protected hydrate(requestingUserId: Session | ID) {
     return (query: Query) =>
       query
         .subQuery('node', (sub) =>
@@ -346,5 +346,9 @@ export class UserRepository extends DtoRepository<typeof User, [Session | ID]>(
         .return('oldRel');
       await removePrimary.first();
     }
+  }
+
+  hydrateAsNeo4j(session: Session | ID) {
+    return this.hydrate(session);
   }
 }

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -79,7 +79,7 @@ export class UserService {
       this.verifyRolesAreAssignable(session, input.roles);
     }
 
-    const id = await this.userRepo.create(input);
+    const { id } = await this.userRepo.create(input);
     return id;
   }
 

--- a/src/core/database/dto.repository.ts
+++ b/src/core/database/dto.repository.ts
@@ -18,7 +18,7 @@ import { DbTypeOf } from './db-type';
 import { OnIndex } from './indexer';
 import { matchProps } from './query';
 
-export const privileges = Symbol('DtoRepository.privileges');
+export const privileges = Symbol.for('DtoRepository.privileges');
 
 /**
  * A repository for a simple DTO. This provides a few methods out of the box.

--- a/src/core/edgedb/common.repository.ts
+++ b/src/core/edgedb/common.repository.ts
@@ -1,0 +1,76 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { EnhancedResource, ID, isIdLike, PublicOf } from '~/common';
+import type { CommonRepository as Neo4jCommonRepository } from '~/core/database';
+import { ResourceLike, ResourcesHost } from '~/core/resources/resources.host';
+import type { BaseNode } from '../database/results';
+import { EdgeDB } from './edgedb.service';
+import { e } from './reexports';
+
+/**
+ * This provides a few methods out of the box.
+ */
+@Injectable()
+export class CommonRepository implements PublicOf<Neo4jCommonRepository> {
+  @Inject(EdgeDB)
+  protected readonly db: EdgeDB;
+  @Inject(ResourcesHost)
+  protected readonly resources: ResourcesHost;
+
+  /**
+   * Here for compatibility with the Neo4j version.
+   * @deprecated this should be replaced with a different output shape,
+   * after we finish migration.
+   */
+  async getBaseNode(id: ID, fqn?: ResourceLike): Promise<BaseNode | undefined> {
+    const res = await this.getBaseNodes([id], fqn);
+    return res[0];
+  }
+
+  /**
+   * Here for compatibility with the Neo4j version.
+   * @deprecated this should be replaced with a different output shape,
+   * after we finish migration.
+   */
+  async getBaseNodes(
+    ids: readonly ID[],
+    fqn?: ResourceLike,
+  ): Promise<readonly BaseNode[]> {
+    const res = fqn
+      ? typeof fqn === 'string'
+        ? await this.resources.getByEdgeDB(fqn)
+        : EnhancedResource.of(fqn)
+      : undefined;
+    const query = e.params({ ids: e.array(e.uuid) }, ({ ids }) =>
+      e.select((res?.db ?? e.Object) as typeof e.Object, (obj) => ({
+        id: true,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        _typeFQN_: obj.__type__.name,
+        createdAt: obj.is(e.Mixin.Timestamped).createdAt,
+        filter: e.op(obj.id, 'in', e.array_unpack(ids)),
+      })),
+    );
+    const nodes = await this.db.run(query, { ids });
+
+    return await Promise.all(
+      nodes.map(async (node): Promise<BaseNode> => {
+        const res = await this.resources.getByEdgeDB(node._typeFQN_);
+        return {
+          identity: node.id,
+          labels: [res.dbLabel],
+          properties: {
+            id: node.id,
+            createdAt: node.createdAt,
+          },
+        };
+      }),
+    );
+  }
+
+  async deleteNode(objectOrId: { id: ID } | ID, _changeset?: ID) {
+    const id = isIdLike(objectOrId) ? objectOrId : objectOrId.id;
+    const query = e.delete(e.Object, () => ({
+      filter_single: { id },
+    }));
+    await this.db.run(query);
+  }
+}

--- a/src/core/edgedb/dto.repository.ts
+++ b/src/core/edgedb/dto.repository.ts
@@ -1,0 +1,255 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  isNotFalsy,
+  many,
+  Many,
+  mapKeys,
+  Nil,
+  setOf,
+} from '@seedcompany/common';
+import { LazyGetter as Once } from 'lazy-get-decorator';
+import { lowerCase } from 'lodash';
+import { AbstractClass } from 'type-fest';
+import {
+  EnhancedResource,
+  ID,
+  NotFoundException,
+  PaginatedListType,
+  PaginationInput,
+  ResourceShape,
+  SortablePaginationInput,
+} from '~/common';
+import { ResourceLike } from '~/core';
+import { Privileges } from '../../components/authorization';
+import { getChanges } from '../database/changes';
+import { privileges } from '../database/dto.repository';
+import { CommonRepository } from './common.repository';
+import { InsertShape } from './generated-client/insert';
+import { $expr_PathNode, $linkPropify } from './generated-client/path';
+import {
+  $expr_Select,
+  objectTypeToSelectShape,
+  SelectFilterExpression,
+  SelectModifiers,
+} from './generated-client/select';
+import { UpdateShape } from './generated-client/update';
+import { $, e } from './reexports';
+
+/**
+ * A repository for a simple DTO. This provides a few methods out of the box.
+ */
+export const RepoFor = <
+  TResourceStatic extends ResourceShape<any>,
+  DBType extends (TResourceStatic['DB'] & {})['__element__'],
+  HydratedShape extends objectTypeToSelectShape<DBType> = (TResourceStatic['DB'] & {})['*'],
+>(
+  resourceIn: TResourceStatic,
+  options: {
+    hydrate?: ShapeFn<$.TypeSet<DBType>, HydratedShape>;
+  } = {},
+) => {
+  type Dto = $.computeObjectShape<DBType['__pointers__'], HydratedShape>;
+
+  const resource = EnhancedResource.of(resourceIn);
+
+  const hydrate = e.shape(
+    resource.db,
+    (options.hydrate ?? ((obj: any) => obj['*'])) as any,
+  ) as (scope: unknown) => HydratedShape;
+
+  @Injectable()
+  abstract class Repository extends CommonRepository {
+    static customize<Customized extends Repository>(
+      customizer: (cls: typeof Repository) => AbstractClass<Customized>,
+    ): AbstractClass<
+      Customized & Omit<DefaultDtoRepository, keyof Customized>
+    > {
+      const customizedClass = customizer(Repository);
+      const customMethodNames = setOf(
+        Object.getOwnPropertyNames(customizedClass.prototype),
+      );
+      const nonDeclaredDefaults = mapKeys(
+        Object.getOwnPropertyDescriptors(DefaultDtoRepository.prototype),
+        (name, _, { SKIP }) =>
+          typeof name === 'string' && customMethodNames.has(name) ? SKIP : name,
+      ).asRecord;
+      Object.defineProperties(customizedClass.prototype, nonDeclaredDefaults);
+
+      return customizedClass as any;
+    }
+    static withDefaults() {
+      return DefaultDtoRepository;
+    }
+
+    @Inject(Privileges)
+    protected readonly [privileges]: Privileges;
+    protected readonly resource = resource;
+    protected readonly hydrate = hydrate;
+
+    @Once()
+    get privileges() {
+      return this[privileges].forResource(resource);
+    }
+
+    getActualChanges = getChanges(resource.type);
+
+    // region List Helpers
+
+    protected listFilters(
+      _scope: ScopeOf<$.TypeSet<DBType>>,
+      _input: any,
+    ): Many<SelectFilterExpression | false | Nil> {
+      return [];
+    }
+
+    protected orderBy<Scope extends $expr_PathNode>(
+      scope: ScopeOf<$.TypeSet<DBType>>,
+      input: SortablePaginationInput,
+    ) {
+      // TODO Validate this is a valid sort key
+      const sortKey = input.sort as keyof Scope['*'];
+      return {
+        expression: scope[sortKey],
+        direction: input.order,
+      } as const;
+    }
+
+    protected async paginate(
+      listOfAllQuery: $expr_Select<
+        $.TypeSet<$.ObjectType<DBType['__name__']>, $.Cardinality.Many>
+      >,
+      input: PaginationInput,
+    ) {
+      const thisPage = e.select(listOfAllQuery as any, () => ({
+        offset: (input.page - 1) * input.count,
+        limit: input.count + 1,
+      }));
+      const items = e.select(thisPage, (obj) => ({
+        ...this.hydrate(obj),
+        limit: input.count,
+      }));
+      const query = e.select({
+        items,
+        total: e.count(listOfAllQuery),
+        hasMore: e.op(e.count(thisPage), '>', input.count),
+      });
+
+      const result = await this.db.run(query);
+      return result as PaginatedListType<Dto>;
+    }
+
+    // endregion
+
+    /**
+     * Here for compatibility with the Neo4j version.
+     * @deprecated this should be replaced with just error handling from a
+     * failed insert, after we finish migration.
+     */
+    async isUnique(value: string, fqn?: string) {
+      const res = fqn ? await this.resources.getByEdgeDB(fqn) : resource;
+      const query = e.select(e.Mixin.Named, (obj) => ({
+        filter: e.op(
+          e.op(obj.name, '=', value),
+          'and',
+          e.op(obj.__type__.name, '=', res.dbFQN as string),
+        ),
+        limit: 1,
+      }));
+
+      const found = await this.db.run(query);
+      return found.length === 0;
+    }
+
+    async getBaseNodes(ids: readonly ID[], fqn?: ResourceLike) {
+      return await super.getBaseNodes(ids, fqn ?? resource);
+    }
+  }
+
+  class DefaultDtoRepository extends Repository {
+    async readOne(id: ID) {
+      const rows = await this.readMany([id]);
+      if (!rows[0]) {
+        throw new NotFoundException(
+          `Could not find ${lowerCase(this.resource.name)}`,
+        );
+      }
+      return rows[0];
+    }
+
+    async readMany(ids: readonly ID[]): Promise<readonly Dto[]> {
+      const query = e.params({ ids: e.array(e.uuid) }, ({ ids }) =>
+        e.select(this.resource.db, (obj: any) => ({
+          ...(this.hydrate(obj) as any),
+          filter: e.op(obj.id, 'in', e.array_unpack(ids)),
+        })),
+      );
+      const rows = await this.db.run(query, { ids });
+      return rows as readonly Dto[];
+    }
+
+    async list(input: PaginationInput) {
+      const all = e.select(this.resource.db, (obj: any) => {
+        const filters = many(this.listFilters(obj, input)).filter(isNotFalsy);
+        const filter =
+          filters.length === 0
+            ? null
+            : filters.length === 1
+            ? filters[0]
+            : e.all(e.set(...filters));
+        return {
+          ...(filter ? { filter } : {}),
+          ...(input instanceof SortablePaginationInput
+            ? { order_by: this.orderBy(obj, input as SortablePaginationInput) }
+            : {}),
+        };
+      });
+      return await this.paginate(all as any, input);
+    }
+
+    async create(input: Omit<InsertShape<DBType>, `@${string}`>): Promise<Dto> {
+      const query = e.select(
+        e.insert(this.resource.db, input as any),
+        this.hydrate as any,
+      );
+      return (await this.db.run(query)) as Dto;
+    }
+
+    async update(
+      existing: Pick<Dto, 'id'>,
+      input: UpdateShape<TResourceStatic['DB'] & {}>,
+    ): Promise<Dto> {
+      const query = e.select(
+        e.update(this.resource.db, () => ({
+          filter_single: { id: existing.id } as any,
+          set: input,
+        })),
+        this.hydrate as any,
+      );
+      return (await this.db.run(query)) as Dto;
+    }
+
+    async delete(id: ID): Promise<void> {
+      const query = e.delete(this.resource.db, () => ({
+        filter_single: { id } as any,
+      }));
+      await this.db.run(query);
+    }
+  }
+
+  return Repository;
+};
+
+type ShapeFn<
+  Expr extends $.ObjectTypeExpression,
+  Shape extends objectTypeToSelectShape<Expr['__element__']> &
+    SelectModifiers<Expr['__element__']>,
+> = (scope: ScopeOf<Expr>) => Readonly<Shape>;
+
+export type ScopeOf<Expr extends $.ObjectTypeExpression> = $.$scopify<
+  Expr['__element__']
+> &
+  $linkPropify<{
+    [k in keyof Expr]: k extends '__cardinality__'
+      ? $.Cardinality.One
+      : Expr[k];
+  }>;

--- a/src/core/edgedb/index.ts
+++ b/src/core/edgedb/index.ts
@@ -3,3 +3,4 @@ export { edgeql, EdgeQLArgsOf, EdgeQLReturnOf } from './edgeql';
 export * from './edgedb.service';
 export * from './withScope';
 export * from './exclusivity-violation.error';
+export * from './common.repository';

--- a/src/core/edgedb/index.ts
+++ b/src/core/edgedb/index.ts
@@ -4,3 +4,4 @@ export * from './edgedb.service';
 export * from './withScope';
 export * from './exclusivity-violation.error';
 export * from './common.repository';
+export * from './dto.repository';

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -16,6 +16,7 @@ runRepl({
   },
   extraContext: async (app) => {
     const { ResourcesHost } = await import('~/core');
+    const { e } = await import('~/core/edgedb');
     const { AuthenticationService } = await import(
       './components/authentication'
     );
@@ -27,6 +28,7 @@ runRepl({
     const Resources = await app.get(ResourcesHost).getEnhancedMap();
 
     return {
+      e,
       DateTime,
       Duration,
       Interval,


### PR DESCRIPTION
This eases the migration to EdgeDB repositories by providing some of the common functions that were declared on the neo4j side.
Additionally it provides all of these common methods out of the box: `readOne, readMany, list, create, update, delete`.

Usage:
```ts
class MyRepo extends RepoFor(Foo).withDefaults() {}
```
If one of the default methods signature doesn't match what you want you can customize it.
```ts
class MyRepo extends RepoFor(Foo).customize(cls => {
  return class extends cls {
    async create(color: string) {
      ...
    }
  }
}) {}
```
Obviously more additional methods can be added on as well, like the User Repo already does.

By default the _hydrated_ object is `*` aka `select User {*}`. This can be customized with a `hydrate` option, and then later accessed via class prop. It has to be like this for TS generics to work.
```ts
class UserRepo extends RepoFor(User, {
  hydrate: (user) => ({
    ...user['*'],
    educationIds: user.education.id,
    // etc
  })
}).withDefaults() {

  listActive() {
    const query = e.select(e.User, user => ({
      ...this.hydrate(user),
      filter: e.op(user.status, '=', e.User.Status.Active),
    });
    return this.db.run(query);
  }

}
```

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5688686531) by [Unito](https://www.unito.io)
