### PR TITLE
[EdgeDB] Adjust enforcing project context during project insertion triggers

### DIFF
--- a/dbschema/migrations/00033.edgeql
+++ b/dbschema/migrations/00033.edgeql
@@ -1,0 +1,7 @@
+CREATE MIGRATION m1ijgeabkfengfe2lpxjtq7xxqjiulhehay7tuutdoa5g3scsenwvq
+    ONTO m1hb7zty3d4ekb5ftznc4tv4h5mgkxy6db42zbxylaw2rmrpveqsxq
+{
+  ALTER TYPE Project::Child {
+      ALTER TRIGGER enforceCorrectProjectContext USING (std::assert((__new__.projectContext = __new__.project.projectContext), message := "Given project context must match given project's context"));
+  };
+};

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -102,8 +102,8 @@ module Project {
     
     trigger enforceCorrectProjectContext after insert, update for each do (
       assert(
-        __new__.project in __new__.projectContext.projects,
-        message := "Given project must be in given project context"
+        __new__.projectContext = __new__.project.projectContext,
+        message := "Given project context must match given project's context"
       )
     );
   }


### PR DESCRIPTION
This is a bit better as it doesn't assume anything about the project context.
Only that the given project & projectContext combo match.

This fixes project insertion, which now has a budget inserted with a trigger.
And that budget / "project child" was trying to check that it was given
the right project/project-context combo.
But the project doesn't yet have itself within its context yet,
because that self-reference has to in a separate query after the insert.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5785203688) by [Unito](https://www.unito.io)
