### PR TITLE
[EdgeDB] Build out scripture collection schema, for easier querying & inspection

### DIFF
--- a/dbschema/migrations/00037.edgeql
+++ b/dbschema/migrations/00037.edgeql
@@ -1,0 +1,67 @@
+CREATE MIGRATION m1xzy4deu3w7kduilieoiydxysopymo7skj4sftggjen4vi3og6kaq
+    ONTO m1ydhle3dwjru34saeiidf5dyepbesugdwttrvnsyxhezpme5bfqga
+{
+  CREATE MODULE Scripture IF NOT EXISTS;
+  CREATE TYPE Scripture::Collection {
+      CREATE REQUIRED PROPERTY label: std::str {
+          SET readonly := true;
+      };
+  };
+  CREATE TYPE Scripture::VerseRange {
+      CREATE REQUIRED PROPERTY label: std::str {
+          SET readonly := true;
+      };
+  };
+  ALTER TYPE Scripture::Collection {
+      CREATE MULTI LINK verses: Scripture::VerseRange {
+          ON SOURCE DELETE DELETE TARGET IF ORPHAN;
+          SET readonly := true;
+      };
+  };
+  CREATE TYPE Scripture::Verse {
+      CREATE REQUIRED PROPERTY verseId: std::int16 {
+          SET readonly := true;
+          CREATE CONSTRAINT std::max_value(31101);
+          CREATE CONSTRAINT std::min_value(0);
+      };
+      CREATE REQUIRED PROPERTY book: std::str {
+          SET readonly := true;
+      };
+      CREATE REQUIRED PROPERTY chapter: std::int16 {
+          SET readonly := true;
+          CREATE CONSTRAINT std::max_value(150);
+          CREATE CONSTRAINT std::min_value(1);
+      };
+      CREATE REQUIRED PROPERTY verse: std::int16 {
+          SET readonly := true;
+          CREATE CONSTRAINT std::max_value(176);
+          CREATE CONSTRAINT std::min_value(1);
+      };
+      CREATE PROPERTY label := (((((.book ++ ' ') ++ <std::str>.chapter) ++ ':') ++ <std::str>.verse));
+  };
+  ALTER TYPE Scripture::VerseRange {
+      CREATE REQUIRED LINK `end`: Scripture::Verse {
+          ON SOURCE DELETE DELETE TARGET IF ORPHAN;
+          SET readonly := true;
+      };
+      CREATE REQUIRED LINK `start`: Scripture::Verse {
+          ON SOURCE DELETE DELETE TARGET IF ORPHAN;
+          SET readonly := true;
+      };
+      CREATE PROPERTY ids := (std::range(<std::int32>.`start`.verseId, <std::int32>.`end`.verseId, inc_upper := true));
+  };
+  ALTER TYPE Scripture::Collection {
+      CREATE PROPERTY ids := (std::multirange(std::array_agg(.verses.ids)));
+  };
+  ALTER TYPE default::Producible {
+      CREATE LINK scripture: Scripture::Collection {
+          ON SOURCE DELETE DELETE TARGET IF ORPHAN;
+      };
+      CREATE TRIGGER denyEmptyScriptureCollection
+          AFTER UPDATE, INSERT 
+          FOR EACH DO (std::assert(EXISTS (__new__.scripture.verses), message := '`Producible.scripture` should have a `Scripture::Collection` with verses or be null/empty-set'));
+  };
+  ALTER TYPE default::Producible {
+      DROP PROPERTY scriptureReferences;
+  };
+};

--- a/dbschema/producible.esdl
+++ b/dbschema/producible.esdl
@@ -4,7 +4,20 @@ module default {
       delegated constraint exclusive;
     };
     
-    scriptureReferences: multirange<int32>;
+    scripture: Scripture::Collection {
+      on source delete delete target if orphan;
+      # https://github.com/edgedb/edgedb/issues/5827
+      # rewrite insert, update using (
+      #   if exists .scripture.verses then .scripture else <Scripture::Collection>{}
+      # );
+    }
+    # Enforce no empty collections for this type's use-case. Use null/empty-set instead.
+    trigger denyEmptyScriptureCollection after insert, update for each do (
+      assert(
+        exists __new__.scripture.verses,
+        message := "`Producible.scripture` should have a `Scripture::Collection` with verses or be null/empty-set"
+      )
+    );
   }
   
   type EthnoArt extending Producible;

--- a/dbschema/scripture.esdl
+++ b/dbschema/scripture.esdl
@@ -1,0 +1,54 @@
+module Scripture {
+  type Collection {
+    required label: str {
+      readonly := true;
+    }
+    # Want to allow optional for now for DerivativeScriptureProduct's scripture override use-case
+    multi verses: VerseRange {
+      readonly := true;
+      on source delete delete target if orphan;
+    }
+    ids := multirange(array_agg(.verses.ids));
+  }
+  
+  type VerseRange {
+    required label: str {
+      readonly := true;
+    }
+    required `start`: Verse {
+      readonly := true;
+      on source delete delete target if orphan;
+    }
+    required `end`: Verse {
+      readonly := true;
+      on source delete delete target if orphan;
+    }
+    ids := range(
+      <int32>.`start`.verseId,
+      <int32>.`end`.verseId,
+      inc_upper := true
+    );
+  }
+  
+  type Verse {
+    label := .book ++ " " ++ <str>.chapter ++ ":" ++ <str>.verse;
+    required book: str {
+      readonly := true;
+    }
+    required chapter: int16 {
+      readonly := true;
+      constraint min_value(1);
+      constraint max_value(150); # Psalms
+    }
+    required verse: int16 {
+      readonly := true;
+      constraint min_value(1);
+      constraint max_value(176); # Psalms 119
+    }
+    required verseId: int16 {
+      readonly := true;
+      constraint min_value(0);
+      constraint max_value(31101);
+    }
+  }
+}


### PR DESCRIPTION

There's a trade off here in simplicity of app code using this type vs information available.
I favored having information available, aka reading/select queries.
I'm exploring abstractions in app code currently to support this schema while reducing LoC.

- ✅ The `labels` here allow easy inspection on what the scripture is during adhoc exploration. They will be computed on write by the app.
- ✅ The `start/end.book/chapter/verse` fields allow the API to serve this data without having to compute from verse IDs. Good for reads.
- ✅ The `verseId` supports answering complex analytical questions. i.e. Does this engagement/product include _Matthew 1_?

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5822486982) by [Unito](https://www.unito.io)
