### PR TITLE
Project sorting status, step, engagement count

### DIFF
--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -4,12 +4,14 @@ import { stripIndent } from 'common-tags';
 import { DateTime } from 'luxon';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { MergeExclusive } from 'type-fest';
+import { sortingForEnumIndex } from '~/core/database/query';
 import { abstractType, e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
 import {
   DateInterval,
   DateTimeField,
   DbLabel,
+  DbSort,
   DbUnique,
   ID,
   IntersectionType,
@@ -44,7 +46,7 @@ import { Postable } from '../../post/dto';
 import { ProjectChangeRequest } from '../../project-change-request/dto';
 import { ProjectMember } from '../project-member/dto';
 import { ProjectStatus } from './project-status.enum';
-import { SecuredProjectStep } from './project-step.enum';
+import { ProjectStep, SecuredProjectStep } from './project-step.enum';
 import { ProjectType } from './project-type.enum';
 
 type AnyProject = MergeExclusive<TranslationProject, InternshipProject>;
@@ -114,10 +116,12 @@ class Project extends Interfaces {
     middleware: [parentIdMiddleware],
   })
   @DbLabel('ProjectStep')
+  @DbSort(sortingForEnumIndex(ProjectStep))
   readonly step: SecuredProjectStep;
 
   @Field(() => ProjectStatus)
   @DbLabel('ProjectStatus')
+  @DbSort(sortingForEnumIndex(ProjectStatus))
   readonly status: ProjectStatus;
 
   readonly primaryLocation: Secured<ID | null>;

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -286,6 +286,14 @@ export class ProjectRepository extends CommonRepository {
             query
               .apply(matchProjectSens('node'))
               .return<{ sortValue: string }>('sensitivity as sortValue'),
+          engagements: (query) =>
+            query
+              .match([
+                node('node'),
+                relation('out', '', 'engagement'),
+                node('engagement', 'LanguageEngagement'),
+              ])
+              .return<{ sortValue: number }>('count(engagement) as sortValue'),
         }),
       )
       .apply(paginate(input, this.hydrate(session.userId)))

--- a/src/core/database/query/cypher-functions.ts
+++ b/src/core/database/query/cypher-functions.ts
@@ -69,6 +69,7 @@ export const apoc = {
   },
   coll: {
     flatten: fn1('apoc.coll.flatten'),
+    indexOf: fn('apoc.coll.indexOf'),
   },
   convert: {
     /** Converts Neo4j node to object/map of the node's properties */

--- a/src/core/database/query/lists.ts
+++ b/src/core/database/query/lists.ts
@@ -3,13 +3,14 @@ import { identity } from 'rxjs';
 import {
   getDbSortTransformer,
   ID,
+  MadeEnum,
   Order,
   PaginatedListType,
   PaginationInput,
   Resource,
   ResourceShape,
 } from '~/common';
-import { collect } from './cypher-functions';
+import { apoc, collect } from './cypher-functions';
 import { ACTIVE } from './matching';
 
 /**
@@ -97,7 +98,7 @@ export const sorting =
     return query.comment`sorting(${sort})`
       .subQuery('*', matcher)
       .with('*')
-      .orderBy(sortTransformer('sortValue'), order);
+      .orderBy(`${sortTransformer('sortValue')}`, order);
   };
 
 const matchPropSort = (prop: string) => (query: Query) =>
@@ -111,6 +112,14 @@ const matchPropSort = (prop: string) => (query: Query) =>
 
 const matchBasePropSort = (prop: string) => (query: Query) =>
   query.return(`node.${prop} as sortValue`);
+
+export const sortingForEnumIndex =
+  <T extends string>(theEnum: MadeEnum<T>) =>
+  (variable: string) =>
+    apoc.coll.indexOf(
+      [...theEnum.values].map((v) => `"${v}"`),
+      variable,
+    );
 
 export const whereNotDeletedInChangeset = (changeset?: ID) => (query: Query) =>
   changeset


### PR DESCRIPTION
[ticket](https://seed-company-squad.monday.com/boards/3451697530/views/78801638/pulses/5675458057?filter=XQAAAALKAAAAAAAAAABBqQqHk62Wwa8yt9cbbXI48HpL2ei1XixEiNVOhiWmf4IrTn4lrcVxz0d8EzlqDpxL1dc7i9JjI1nNW0HEFgqaXhsDsHWTHjMEE6-qlUKWgWTaunFWUdBXUlo9GrL7-Dxs3yXtVsCpk7bU6tq4ASH03XfQsurYW6oz6SfWXIHjSrPNZIVE3__87GiYdcf5oUuHV6IpVDC18IDUOyTd3hSlyn4xwV6TGJGJ____cnOAAA)

This adds sorting on projects entity for status (by status type rather than alphabetically) and engagements (by engagement count)

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5825418833) by [Unito](https://www.unito.io)
