### PR TITLE
[EdgeDB] Posts & Embedded Schema

### DIFF
--- a/dbschema/language.esdl
+++ b/dbschema/language.esdl
@@ -1,5 +1,5 @@
 module default {
-  type Language extending Resource, Project::ContextAware, Mixin::Named, Mixin::Pinnable, Mixin::Taggable {
+  type Language extending Mixin::Postable, Resource, Project::ContextAware, Mixin::Named, Mixin::Pinnable, Mixin::Taggable {
     required displayName: str {
       default := .name;
     }

--- a/dbschema/migrations/00038.edgeql
+++ b/dbschema/migrations/00038.edgeql
@@ -1,0 +1,87 @@
+CREATE MIGRATION m1wdw2srbtq3ondtyuhcobwgcbdawourtp4vcapedti3kca2wh46dq
+    ONTO m1xzy4deu3w7kduilieoiydxysopymo7skj4sftggjen4vi3og6kaq
+{
+  CREATE MODULE Post IF NOT EXISTS;
+  CREATE ABSTRACT TYPE Mixin::Embedded {
+      CREATE REQUIRED SINGLE LINK container: default::Resource;
+  };
+  CREATE SCALAR TYPE Post::Shareability EXTENDING enum<Membership, Internal, AskToShareExternally, External>;
+  CREATE SCALAR TYPE Post::Type EXTENDING enum<Note, Story, Prayer>;
+  CREATE TYPE default::Post EXTENDING default::Resource, Mixin::Embedded, Mixin::Owned {
+      ALTER LINK container {
+          SET SINGLE;
+          ON TARGET DELETE DELETE SOURCE;
+          SET OWNED;
+          SET REQUIRED;
+      };
+      CREATE SINGLE PROPERTY isMember := (.container[IS Project::ContextAware].isMember);
+      CREATE SINGLE PROPERTY sensitivity := (.container[IS Project::ContextAware].sensitivity);
+      CREATE REQUIRED PROPERTY body: std::json;
+      CREATE REQUIRED PROPERTY shareability: Post::Shareability;
+      CREATE REQUIRED PROPERTY type: Post::Type;
+  };
+  CREATE ABSTRACT TYPE Mixin::Postable EXTENDING default::Resource {
+      CREATE LINK posts := (.<container[IS default::Post]);
+  };
+  ALTER TYPE default::Post {
+      CREATE TRIGGER enforcePostable
+          AFTER UPDATE, INSERT 
+          FOR EACH DO (std::assert((__new__.container IS Mixin::Postable), message := "A Post's container must be a Postable"));
+  };
+  ALTER TYPE Scripture::Verse {
+      ALTER PROPERTY chapter {
+          DROP CONSTRAINT std::min_value(1);
+      };
+  };
+  ALTER TYPE Scripture::Verse {
+      ALTER PROPERTY chapter {
+          CREATE CONSTRAINT std::min_value(1);
+      };
+  };
+  ALTER TYPE Scripture::Verse {
+      ALTER PROPERTY verse {
+          DROP CONSTRAINT std::min_value(1);
+      };
+  };
+  ALTER TYPE Scripture::Verse {
+      ALTER PROPERTY verse {
+          CREATE CONSTRAINT std::min_value(1);
+      };
+  };
+  ALTER TYPE Scripture::Verse {
+      ALTER PROPERTY verseId {
+          DROP CONSTRAINT std::min_value(0);
+      };
+  };
+  ALTER TYPE Scripture::Verse {
+      ALTER PROPERTY verseId {
+          CREATE CONSTRAINT std::min_value(0);
+      };
+  };
+  ALTER TYPE default::FundingAccount {
+      ALTER PROPERTY accountNumber {
+          DROP CONSTRAINT std::min_value(0);
+      };
+  };
+  ALTER TYPE default::FundingAccount {
+      ALTER PROPERTY accountNumber {
+          CREATE CONSTRAINT std::min_value(0);
+      };
+  };
+  ALTER TYPE default::Project {
+      ALTER PROPERTY departmentId {
+          DROP CONSTRAINT std::min_value(10000);
+      };
+  };
+  ALTER TYPE default::Project {
+      ALTER PROPERTY departmentId {
+          CREATE CONSTRAINT std::min_value(10000);
+      };
+  };
+  ALTER SCALAR TYPE default::population {
+      DROP CONSTRAINT std::min_value(0);
+  };
+  ALTER SCALAR TYPE default::population {
+      CREATE CONSTRAINT std::min_value(0);
+  };
+};

--- a/dbschema/migrations/00039.edgeql
+++ b/dbschema/migrations/00039.edgeql
@@ -1,0 +1,7 @@
+CREATE MIGRATION m1zqlgbrht5kontkpocymsg2f7wit5rsxkmgy6uy56myfyhncrvlvq
+    ONTO m1wdw2srbtq3ondtyuhcobwgcbdawourtp4vcapedti3kca2wh46dq
+{
+  ALTER TYPE default::Project EXTENDING Mixin::Postable BEFORE default::Resource;
+  ALTER TYPE default::Language EXTENDING Mixin::Postable BEFORE default::Resource;
+  ALTER TYPE default::Partner EXTENDING Mixin::Postable BEFORE default::Resource;
+};

--- a/dbschema/partner.esdl
+++ b/dbschema/partner.esdl
@@ -1,5 +1,5 @@
 module default {
-  type Partner extending Resource, Project::ContextAware, Mixin::Named, Mixin::Pinnable, Mixin::Taggable {
+  type Partner extending Mixin::Postable, Resource, Project::ContextAware, Mixin::Named, Mixin::Pinnable, Mixin::Taggable {
     overloaded name {
       constraint exclusive;
     }

--- a/dbschema/post.esdl
+++ b/dbschema/post.esdl
@@ -1,0 +1,33 @@
+module default {
+  type Post extending Resource, Mixin::Embedded, Mixin::Owned {
+    # https://github.com/edgedb/edgedb/issues/6695
+    # overloaded required single link container: Mixin::Postable
+    overloaded required single link container {
+      on target delete delete source;
+    };
+    trigger enforcePostable after insert, update for each do (
+      assert(
+        __new__.container is Mixin::Postable,
+        message := "A Post's container must be a Postable"
+      )
+    );
+    
+    required type: Post::Type;
+    required shareability: Post::Shareability;
+    required body: json;
+    
+    single property sensitivity := .container[is Project::ContextAware].sensitivity;
+    single property isMember := .container[is Project::ContextAware].isMember;
+  }
+}
+  
+module Mixin {
+  abstract type Postable extending default::Resource {
+    posts := .<container[is default::Post];
+  }
+}
+  
+module Post {
+  scalar type Type extending enum<Note, Story, Prayer>;
+  scalar type Shareability extending enum<Membership, Internal, AskToShareExternally, External>;
+}

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -1,5 +1,5 @@
 module default {
-  abstract type Project extending Resource, Project::ContextAware, Mixin::Named, Mixin::Pinnable, Mixin::Taggable {
+  abstract type Project extending Mixin::Postable, Resource, Project::ContextAware, Mixin::Named, Mixin::Pinnable, Mixin::Taggable {
     overloaded name {
       constraint exclusive;
     };

--- a/dbschema/z.embedded.esdl
+++ b/dbschema/z.embedded.esdl
@@ -1,0 +1,5 @@
+module Mixin {
+  abstract type Embedded {
+    required single link container: default::Resource;
+  }
+}


### PR DESCRIPTION
# Embedded Opener
I wanted a single thing we could use for "dynamic parents". This is now represented as an `Embedded` object which has a `container` link to another `Resource`.
```edgeql
abstract type Embedded {
  required single link container: default::Resource;
}
```
I wanted to avoid using word "parent" as the file tree schema will have "parents" but these aren't the same thing.
It's a small abstraction, but I'll show why this could be helpful further down.

# Post

I used Posts as a concrete type to prove out the embedded idea. The only hard thing here is the polymorphism of their "parent/container". Well and the RichText JSON scalar which I'll do in a separate PR.
This polymorphism made it hard for current app queries to answer authorization questions.
Is this post attached-to/contained-in a high sensitivity project? As discussed ad nauseam, determining sensitivity in the previous DB was very hard and unique for each object type.

Well based on the previous work done for `ProjectContext` here in EdgeDB land, `Post` can easily check for project context aware objects.
```edgeql
select Post {
  sensitivity := .container[is Project::ContextAware].sensitivity
}
```
This works across our different types as well. Projects, Languages, Partners, all compute this value differently, but Post doesn't need to worry about it.

Naturally I put this as a computed in the schema, so queries (and UI explorer) can just
```edgeql
select Post {*}
```
And see if a post has a sensitivity and what it is.

Currently the app code, as to pull the parent/container for each post and confirm permissions before allowing access to do something with the post.
So this change (along with the to be implemented access policies), should allow the app code to seamlessly query posts without having to do a bunch of work with the parent.

# Embedded Closer

As demonstrated above, the `ProjectContext` work is proving to make things much simpler when dealing with polymorphism. "If X is aware, grab its sensitivity".
But there's another case, what "if X isn't aware, but it has a container that could be".

This is what `Embedded` aims to answer. Though, I suspect it will be less useful than `ProjectContext`.

Perhaps we could have a list of Resources, and we wanted to get its own sensitivity or its container's sensitivity, if it exists.
`Embedded` gives us the single `container` property we can query.
```edgeql
select Resource {
  sensitivity := (
    [is Project::ContextAware].sensitivity ??
    [is Mixin::Embedded].container[is Project::ContextAware].sensitivity
  )
}
```
Kinda clunky, but it allows us to do it without enumerating every concrete type that could be embedded (i.e. Posts, Comments, Files, Media).

## Example Pic
![Screenshot 2024-01-12 at 8 58 08 AM](https://github.com/SeedCompany/cord-api-v3/assets/932566/9848cd69-0b15-46ce-a329-ca287497b4fe)

Here we see all different kinds of resources, all getting sensitivity in a unique way.
Now including Posts, which have no explicit schema references to project contexts.

## No Recursion

One caveat, is that this is only one level deep. We can't recurse yet, though this is on the roadmap for EdgeDB. So a Post can't be embedded into another Post.