### PR TITLE
[EdgeDB] RichText Scalar

### DIFF
--- a/dbschema/common.esdl
+++ b/dbschema/common.esdl
@@ -15,4 +15,6 @@ module default {
        )
     )
   );
+  
+  scalar type RichText extending json;
 }

--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -37,7 +37,7 @@ module default {
       rewrite insert, update using (.endDate if .status = Engagement::Status.InDevelopment else .initialEndDate);
     };
     
-    description: json;
+    description: RichText;
   }
   
   type LanguageEngagement extending Engagement {

--- a/dbschema/migrations/00043.edgeql
+++ b/dbschema/migrations/00043.edgeql
@@ -1,0 +1,15 @@
+CREATE MIGRATION m1wmrb3grzq5y55y5c447noyxdw26fcpatlu46n5f6ffh572opam6a
+    ONTO m1r3t2ku2jysgjliaq54y7saj4tuxecilnajoxgwa2blsb3p64svzq
+{
+  CREATE SCALAR TYPE default::RichText EXTENDING std::json;
+  ALTER TYPE default::Engagement {
+      ALTER PROPERTY description {
+          SET TYPE default::RichText;
+      };
+  };
+  ALTER TYPE default::Post {
+      ALTER PROPERTY body {
+          SET TYPE default::RichText;
+      };
+  };
+};

--- a/dbschema/post.esdl
+++ b/dbschema/post.esdl
@@ -14,7 +14,7 @@ module default {
     
     required type: Post::Type;
     required shareability: Post::Shareability;
-    required body: json;
+    required body: RichText;
     
     single property sensitivity := .container[is Project::ContextAware].sensitivity;
     single property isMember := .container[is Project::ContextAware].isMember;

--- a/src/core/edgedb/codecs/index.ts
+++ b/src/core/edgedb/codecs/index.ts
@@ -1,3 +1,4 @@
+import { RichTextCodec } from './rich-text.codec';
 import { LuxonCalendarDateCodec, LuxonDateTimeCodec } from './temporal.codec';
 import { ScalarCodecClass } from './type.util';
 import { OurUUIDCodec } from './uuid.codec';
@@ -9,4 +10,5 @@ export const codecs: readonly ScalarCodecClass[] = [
   OurUUIDCodec,
   LuxonDateTimeCodec,
   LuxonCalendarDateCodec,
+  RichTextCodec,
 ];

--- a/src/core/edgedb/codecs/rich-text.codec.ts
+++ b/src/core/edgedb/codecs/rich-text.codec.ts
@@ -1,0 +1,30 @@
+import { InvalidArgumentError } from 'edgedb';
+import { JSONCodec } from 'edgedb/dist/codecs/json.js';
+import { ReadBuffer, WriteBuffer } from 'edgedb/dist/primitives/buffer.js';
+import { RichTextDocument } from '~/common/rich-text.scalar';
+import { ScalarInfo } from './type.util';
+
+export class RichTextCodec extends JSONCodec {
+  static info: ScalarInfo = {
+    module: 'default',
+    type: 'RichText',
+    ts: RichTextDocument.name,
+    path: '~/common',
+  };
+  tsType = RichTextDocument.name;
+  importedType = true;
+
+  encode(buf: WriteBuffer, object: unknown) {
+    if (!(object instanceof RichTextDocument)) {
+      throw new InvalidArgumentError(
+        `a RichTextDocument was expected, got "${String(object)}"`,
+      );
+    }
+    super.encode(buf, object);
+  }
+
+  decode(buf: ReadBuffer): RichTextDocument {
+    const doc = super.decode(buf);
+    return RichTextDocument.from(doc);
+  }
+}


### PR DESCRIPTION
This declares a `RichText` scalar as a subtype of `json`.
We convert that to our `RichTextDocument` type & instance in app code (thanks to #3049)

I guess it's worth noting that there are some code paths, that don't account for this specific subtype, but uses the plain `json` logic.
For example, converting these documents to EdgeQL literals still does 
```ts
`to_json(${JSON.stringify(value)})`
```
This is actually fine, since our RichTextDocuments serialize to JSON as expected.
Just felt like it was worth calling out that not all code paths use this specific subtype logic.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5875143343) by [Unito](https://www.unito.io)
