### PR TITLE
[EdgeDB] Fix getBaseNode not using the right type name in some cases

### DIFF
--- a/src/core/resources/resources.host.test.ts
+++ b/src/core/resources/resources.host.test.ts
@@ -1,0 +1,32 @@
+import { GraphQLSchemaHost } from '@nestjs/graphql';
+import { EnhancedResourceMap } from '~/core';
+import { ResourcesHost } from './resources.host';
+
+describe('ResourcesHost', () => {
+  let host: ResourcesHost;
+  let all: EnhancedResourceMap;
+
+  beforeAll(async () => {
+    // Load all files to ensure all resources are registered
+    await import('../../app.module');
+
+    host = new ResourcesHost(new GraphQLSchemaHost());
+    all = await host.getEnhancedMap();
+  });
+
+  describe('By EdgeDB', () => {
+    it('FQN', async () => {
+      const res = await host.getByEdgeDB('default::User');
+      expect(res).toBeDefined();
+      expect(res).toBe(all.User);
+    });
+    it('Implicit default module', async () => {
+      const res = await host.getByEdgeDB('User');
+      expect(res).toBe(all.User);
+    });
+    it('GQL Name different from FQN', async () => {
+      const res = await host.getByEdgeDB('Ceremony');
+      expect(res).toBe(all.Ceremony);
+    });
+  });
+});

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -68,17 +68,23 @@ export class ResourcesHost {
   }
 
   async getByEdgeDB(
-    fqn: string,
+    name: string,
   ): Promise<EnhancedResource<ValueOf<ResourceMap>>> {
-    fqn = fqn.includes('::') ? fqn : `default::${fqn}`;
-    const map = await this.edgeDBFQNMap();
-    const resource = map.get(fqn);
-    if (!resource) {
-      throw new ServerException(
-        `Unable to determine resource from ResourceMap for EdgeDB FQN: ${fqn}`,
-      );
+    const fqnMap = await this.edgeDBFQNMap();
+    const resByFQN = fqnMap.get(
+      name.includes('::') ? name : `default::${name}`,
+    );
+    if (resByFQN) {
+      return resByFQN;
     }
-    return resource;
+    const nameMap = await this.getEnhancedMap();
+    const resByName = nameMap[name as keyof ResourceMap];
+    if (resByName) {
+      return resByName as any;
+    }
+    throw new ServerException(
+      `Unable to determine resource from ResourceMap for EdgeDB FQN: ${name}`,
+    );
   }
 
   @CachedByArg()


### PR DESCRIPTION
Basically this handles
'Ceremony' -> 'Engagement::Ceremony' (after trying 'default::Ceremony')
Not a code path we are currently hitting, but possible in future.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5884380174) by [Unito](https://www.unito.io)
