### PR TITLE
[EdgeDB] Unhack the `Post.container` type overload

### DIFF
--- a/dbschema/migrations/00044.edgeql
+++ b/dbschema/migrations/00044.edgeql
@@ -1,0 +1,10 @@
+CREATE MIGRATION m1zpp5l5wqgcm7hmcunnzswx6oivv7eh5gtwq5ysfaxlk5vhkfjieq
+    ONTO m1wmrb3grzq5y55y5c447noyxdw26fcpatlu46n5f6ffh572opam6a
+{
+  ALTER TYPE default::Post {
+      ALTER LINK container {
+          SET TYPE Mixin::Postable USING (.container[IS Mixin::Postable]);
+      };
+      DROP TRIGGER enforcePostable;
+  };
+};

--- a/dbschema/post.esdl
+++ b/dbschema/post.esdl
@@ -1,16 +1,8 @@
 module default {
   type Post extending Resource, Mixin::Embedded, Mixin::Owned {
-    # https://github.com/edgedb/edgedb/issues/6695
-    # overloaded required single link container: Mixin::Postable
-    overloaded required single link container {
+    overloaded required single link container: Mixin::Postable {
       on target delete delete source;
     };
-    trigger enforcePostable after insert, update for each do (
-      assert(
-        __new__.container is Mixin::Postable,
-        message := "A Post's container must be a Postable"
-      )
-    );
     
     required type: Post::Type;
     required shareability: Post::Shareability;


### PR DESCRIPTION
This bug was actually from the `Project.departmentId` rewrite bug. That rewrite is temporarily commented out until that bug is fixed. Fix has been identified, and they have a PR up for it currently, so I expect it to be in our hands in a couple of weeks.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5895347110) by [Unito](https://www.unito.io)
