### PR TITLE
Make `ResourcesHost` sync

### DIFF
--- a/src/components/authorization/policy/executor/policy-dumper.ts
+++ b/src/components/authorization/policy/executor/policy-dumper.ts
@@ -46,7 +46,7 @@ export class PolicyDumper {
     const book = xlsx.utils.book_new();
 
     const chalk = new Chalk({ level: 0 });
-    const resources = await this.selectResources();
+    const resources = this.selectResources();
     for (const role of Role) {
       const dumped = resources.flatMap((res) =>
         this.dumpRes(role, res, { props: true }),
@@ -74,7 +74,7 @@ export class PolicyDumper {
     resourcesIn: Many<ResourceLike & string>,
   ) {
     const roles = search(rolesIn, [...Role], 'role');
-    const map = await this.resources.getEnhancedMap();
+    const map = this.resources.getEnhancedMap();
     const resources = searchResources(resourcesIn, map);
 
     const data = roles.flatMap((role) =>
@@ -140,10 +140,10 @@ export class PolicyDumper {
     console.log(table.toString());
   }
 
-  private async selectResources(...filtered: AnyResource[]) {
+  private selectResources(...filtered: AnyResource[]) {
     const selectedResources = filtered.length
       ? filtered
-      : Object.values<AnyResource>(await this.resources.getEnhancedMap());
+      : Object.values<AnyResource>(this.resources.getEnhancedMap());
     return sortBy(selectedResources, (r) => r.name);
   }
 

--- a/src/components/authorization/policy/granters.factory.ts
+++ b/src/components/authorization/policy/granters.factory.ts
@@ -39,7 +39,7 @@ export class GrantersFactory {
       ),
     );
 
-    const ResourceMap = await this.resourcesHost.getEnhancedMap();
+    const ResourceMap = this.resourcesHost.getEnhancedMap();
 
     const resGranter: ResourcesGranter = mapValues(
       ResourceMap,

--- a/src/components/comments/comment.service.ts
+++ b/src/components/comments/comment.service.ts
@@ -67,7 +67,7 @@ export class CommentService {
 
   async getPermissionsFromResource(resource: CommentableRef, session: Session) {
     const parent = await this.loadCommentable(resource);
-    const parentType = await this.resourcesHost.getByName(
+    const parentType = this.resourcesHost.getByName(
       // I'd like to type this prop as this but somehow blows everything up.
       parent.__typename as 'Commentable',
     );
@@ -93,7 +93,7 @@ export class CommentService {
       : parentNode;
 
     try {
-      await this.resourcesHost.verifyImplements(parent.__typename, Commentable);
+      this.resourcesHost.verifyImplements(parent.__typename, Commentable);
     } catch (e) {
       throw new NonCommentableType(e.message);
     }

--- a/src/components/file/media/events/can-update-event.ts
+++ b/src/components/file/media/events/can-update-event.ts
@@ -19,11 +19,11 @@ export class CanUpdateMediaUserMetadataEvent {
     @Optional() readonly allowUpdate: PollVoter<boolean>,
   ) {}
 
-  @Once() async getAttachedResource() {
+  @Once() getAttachedResource() {
     const attachedResName = this.resourceResolver.resolveTypeByBaseNode(
       this.media.attachedTo[0],
     );
-    const attachedResource = await this.resourceHost.getByName(attachedResName);
+    const attachedResource = this.resourceHost.getByName(attachedResName);
     return attachedResource;
   }
 }

--- a/src/components/post/post.service.ts
+++ b/src/components/post/post.service.ts
@@ -120,7 +120,7 @@ export class PostService {
 
   async getPermissionsFromPostable(resource: PostableRef, session: Session) {
     const parent = await this.loadPostable(resource);
-    const parentType = await this.resourcesHost.getByName(
+    const parentType = this.resourcesHost.getByName(
       parent.__typename as 'Postable',
     );
     return this.privileges.for(session, parentType, parent).forEdge('posts');
@@ -138,7 +138,7 @@ export class PostService {
       : parentNode;
 
     try {
-      await this.resourcesHost.verifyImplements(parent.__typename, Postable);
+      this.resourcesHost.verifyImplements(parent.__typename, Postable);
     } catch (e) {
       throw new NonPostableType(e.message);
     }

--- a/src/components/progress-report/media/handlers/update-media-metadata-check.handler.ts
+++ b/src/components/progress-report/media/handlers/update-media-metadata-check.handler.ts
@@ -12,7 +12,7 @@ export class ProgressReportUpdateMediaMetadataCheckHandler {
   ) {}
 
   async handle(event: CanUpdateMediaUserMetadataEvent) {
-    const attached = await event.getAttachedResource();
+    const attached = event.getAttachedResource();
     if (!attached.is(ReportMedia)) {
       return;
     }

--- a/src/components/search/search.service.ts
+++ b/src/components/search/search.service.ts
@@ -55,7 +55,7 @@ export class SearchService {
     // which is based on their first valid search label.
     const results = await this.repo.search({ ...input, type: types });
 
-    const ResourceMap = await this.resourceHost.getMap();
+    const ResourceMap = this.resourceHost.getMap();
 
     // Individually convert each result (id & type) to its search result
     // based on this.hydrators
@@ -94,9 +94,7 @@ export class SearchService {
               return null;
             }
 
-            const resource = await this.resourceHost.getByName(
-              hydrated.__typename,
-            );
+            const resource = this.resourceHost.getByName(hydrated.__typename);
             const perms = this.privileges.for(session, resource, hydrated).all;
             return matchedProps.some((key) =>
               // @ts-expect-error strict typing is hard for this dynamic use case.

--- a/src/core/edgedb/common.repository.ts
+++ b/src/core/edgedb/common.repository.ts
@@ -37,7 +37,7 @@ export class CommonRepository implements PublicOf<Neo4jCommonRepository> {
   ): Promise<readonly BaseNode[]> {
     const res = fqn
       ? typeof fqn === 'string'
-        ? await this.resources.getByEdgeDB(fqn)
+        ? this.resources.getByEdgeDB(fqn)
         : EnhancedResource.of(fqn)
       : undefined;
     const query = e.params({ ids: e.array(e.uuid) }, ({ ids }) =>
@@ -51,17 +51,14 @@ export class CommonRepository implements PublicOf<Neo4jCommonRepository> {
     );
     const nodes = await this.db.run(query, { ids });
 
-    return await Promise.all(
-      nodes.map(async (node): Promise<BaseNode> => {
-        const res = await this.resources.getByEdgeDB(node._typeFQN_);
-        return {
-          identity: node.id,
-          labels: [res.dbLabel],
-          properties: {
-            id: node.id,
-            createdAt: node.createdAt,
-          },
-        };
+    return nodes.map(
+      (node): BaseNode => ({
+        identity: node.id,
+        labels: [this.resources.getByEdgeDB(node._typeFQN_).dbLabel],
+        properties: {
+          id: node.id,
+          createdAt: node.createdAt,
+        },
       }),
     );
   }

--- a/src/core/edgedb/dto.repository.ts
+++ b/src/core/edgedb/dto.repository.ts
@@ -147,7 +147,7 @@ export const RepoFor = <
      * failed insert, after we finish migration.
      */
     async isUnique(value: string, fqn?: string) {
-      const res = fqn ? await this.resources.getByEdgeDB(fqn) : resource;
+      const res = fqn ? this.resources.getByEdgeDB(fqn) : resource;
       const query = e.select(e.Mixin.Named, (obj) => ({
         filter: e.op(
           e.op(obj.name, '=', value),

--- a/src/core/resources/resources.host.test.ts
+++ b/src/core/resources/resources.host.test.ts
@@ -11,21 +11,21 @@ describe('ResourcesHost', () => {
     await import('../../app.module');
 
     host = new ResourcesHost(new GraphQLSchemaHost());
-    all = await host.getEnhancedMap();
+    all = host.getEnhancedMap();
   });
 
   describe('By EdgeDB', () => {
-    it('FQN', async () => {
-      const res = await host.getByEdgeDB('default::User');
+    it('FQN', () => {
+      const res = host.getByEdgeDB('default::User');
       expect(res).toBeDefined();
       expect(res).toBe(all.User);
     });
-    it('Implicit default module', async () => {
-      const res = await host.getByEdgeDB('User');
+    it('Implicit default module', () => {
+      const res = host.getByEdgeDB('User');
       expect(res).toBe(all.User);
     });
-    it('GQL Name different from FQN', async () => {
-      const res = await host.getByEdgeDB('Ceremony');
+    it('GQL Name different from FQN', () => {
+      const res = host.getByEdgeDB('Ceremony');
       expect(res).toBe(all.Ceremony);
     });
   });

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -25,7 +25,7 @@ runRepl({
     const session = app
       .get(AuthenticationService)
       .lazySessionForRootAdminUser();
-    const Resources = await app.get(ResourcesHost).getEnhancedMap();
+    const Resources = app.get(ResourcesHost).getEnhancedMap();
 
     return {
       e,


### PR DESCRIPTION
Previously we needed to import the legacy resource map from another file. Now that's removed, so this no longer needs to be async.

Obviously, this has huge implications.

An argument could be made to keep this async
to allow for future functionality that needs to be async. However, I can't currently think of what this would be.

Making this sync allows for more places to use the current functionality.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5895368162) by [Unito](https://www.unito.io)
