### PR TITLE
[EdgeDB] Automatically handle not found ID errors from user input

### DIFF
--- a/src/common/exceptions/duplicate.exception.ts
+++ b/src/common/exceptions/duplicate.exception.ts
@@ -1,8 +1,4 @@
 import { ArgumentsHost } from '@nestjs/common';
-import {
-  GqlContextType as ContextKey,
-  GqlExecutionContext,
-} from '@nestjs/graphql';
 import { lowerCase, upperFirst } from 'lodash';
 import type { ExclusivityViolationError } from '~/core/edgedb';
 import { InputException } from './input.exception';
@@ -27,38 +23,14 @@ export class DuplicateException extends InputException {
 
     // Attempt to add path prefix automatically to the property name, based
     // on given GQL input.
-    if (context && context.getType<ContextKey>() === 'graphql') {
-      let gqlArgs = GqlExecutionContext.create(context as any).getArgs();
-
-      // unwind single `input` argument, based on our own conventions
-      if (Object.keys(gqlArgs).length === 1 && 'input' in gqlArgs) {
-        gqlArgs = gqlArgs.input;
-      }
-
-      const flattened = flattenObject(gqlArgs);
-      // Guess the correct path based on property name.
-      // This kinda assumes the property name will be unique amongst all the input.
-      const guessedPath = Object.keys(flattened).find(
-        (path) => property === path || path.endsWith('.' + property),
-      );
-      property = guessedPath ?? property;
-    }
+    // This kinda assumes the property name will be unique amongst all the input.
+    const guessedPath = Object.keys(
+      InputException.getFlattenInput(context),
+    ).find((path) => property === path || path.endsWith('.' + property));
+    property = guessedPath ?? property;
 
     const ex = new DuplicateException(property, message, exception);
     ex.stack = exception.stack;
     return ex;
   }
 }
-
-const flattenObject = (obj: object, prefix = '') => {
-  const result: Record<string, any> = {};
-  for (const [key, value] of Object.entries(obj)) {
-    if (value && typeof value === 'object' && !Array.isArray(value)) {
-      const nestedObj = flattenObject(value, prefix + key + '.');
-      Object.assign(result, nestedObj);
-    } else {
-      result[prefix + key] = value;
-    }
-  }
-  return result;
-};

--- a/src/core/exception/exception.normalizer.ts
+++ b/src/core/exception/exception.normalizer.ts
@@ -127,7 +127,10 @@ export class ExceptionNormalizer {
     }
 
     const gqlContext =
-      context && context.getType<ContextKey>() === 'graphql'
+      context &&
+      context.getType<ContextKey>() === 'graphql' &&
+      // schema input validation errors don't create an execution context correctly
+      !(ex instanceof GraphQLError)
         ? GqlExecutionContext.create(context as any)
         : undefined;
 


### PR DESCRIPTION
Now user input IDs can be passed straight into EdgeDB queries without validating, and still have a proper error returned when not found. No more pre validation or manual conversion needed.
![Screenshot 2024-01-19 at 4 42 23 PM](https://github.com/SeedCompany/cord-api-v3/assets/932566/970671f6-d1ae-42c5-879b-091b22e1ecf1)

This does require that the query be composed in a way that gives info enough back in the error for us to do the conversion.
Object casts work great for this.
```edgeql
<User><uuid>"..."
```
https://github.com/SeedCompany/cord-api-v3/blob/3cb6a335e0fa27ee21a50d844763b67b7dfba75a/src/components/field-zone/field-zone.edgedb.repository.ts#L20-L20
A manual assertion won't give enough info, so that will still be returned as a server error, which it could rightly be.
```edgeql
assert_exists((select User filter .id = <uuid>"..."))
```
This gives a generic assertion failed error so it won't be properly converted.
Much more verbose, so just use object casts lol.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5895484751) by [Unito](https://www.unito.io)
