### PR TITLE
Allow file urls option to download file or not (disposition header)

### DIFF
--- a/src/components/file/file-url.controller.ts
+++ b/src/components/file/file-url.controller.ts
@@ -5,6 +5,7 @@ import {
   HttpStatus,
   Inject,
   Param,
+  Query,
   Request,
   Response,
 } from '@nestjs/common';
@@ -29,6 +30,7 @@ export class FileUrlController {
   @Get(':fileId/:fileName?')
   async download(
     @Param('fileId') fileId: ID,
+    @Query('download') download: '' | undefined,
     @Request() request: IRequest,
     @Response() res: unknown,
   ) {
@@ -41,7 +43,7 @@ export class FileUrlController {
 
     // TODO authorization using session
 
-    const url = await this.files.getDownloadUrl(node);
+    const url = await this.files.getDownloadUrl(node, download != null);
     const cacheControl = this.files.determineCacheHeader(node);
 
     const { httpAdapter } = this.httpAdapterHost;

--- a/src/components/file/file-url.resolver-util.ts
+++ b/src/components/file/file-url.resolver-util.ts
@@ -1,4 +1,4 @@
-import { ResolveField } from '@nestjs/graphql';
+import { Args, ResolveField } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { URL } from 'url';
 
@@ -9,4 +9,15 @@ export const Resolver = () =>
 
       This url could require authentication.
     `,
+  });
+
+export const DownloadArg = () =>
+  Args('download', {
+    description: stripIndent`
+      Whether the browser should download this file if opened directly
+
+      This sets the \`Content-Disposition\` header to \`attachment\` instead of \`inline\`.
+      https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
+    `,
+    defaultValue: false,
   });

--- a/src/components/file/file-url.resolver-util.ts
+++ b/src/components/file/file-url.resolver-util.ts
@@ -1,0 +1,12 @@
+import { ResolveField } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
+import { URL } from 'url';
+
+export const Resolver = () =>
+  ResolveField(() => URL, {
+    description: stripIndent`
+      A url to the file.
+
+      This url could require authentication.
+    `,
+  });

--- a/src/components/file/file-version.resolver.ts
+++ b/src/components/file/file-version.resolver.ts
@@ -10,8 +10,11 @@ export class FileVersionResolver {
   constructor(protected readonly service: FileService) {}
 
   @FileUrl.Resolver()
-  async url(@Parent() node: FileVersion) {
-    return await this.service.getUrl(node);
+  async url(
+    @Parent() node: FileVersion,
+    @FileUrl.DownloadArg() download: boolean,
+  ) {
+    return await this.service.getUrl(node, download);
   }
 
   @ResolveField(() => URL, {

--- a/src/components/file/file-version.resolver.ts
+++ b/src/components/file/file-version.resolver.ts
@@ -2,19 +2,14 @@ import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { URL } from 'url';
 import { FileVersion } from './dto';
+import * as FileUrl from './file-url.resolver-util';
 import { FileService } from './file.service';
 
 @Resolver(FileVersion)
 export class FileVersionResolver {
   constructor(protected readonly service: FileService) {}
 
-  @ResolveField(() => URL, {
-    description: stripIndent`
-      A url to the file version.
-
-      This url could require authentication.
-    `,
-  })
+  @FileUrl.Resolver()
   async url(@Parent() node: FileVersion) {
     return await this.service.getUrl(node);
   }

--- a/src/components/file/file.resolver.ts
+++ b/src/components/file/file.resolver.ts
@@ -77,8 +77,8 @@ export class FileResolver {
   }
 
   @FileUrl.Resolver()
-  async url(@Parent() node: File) {
-    return await this.service.getUrl(node);
+  async url(@Parent() node: File, @FileUrl.DownloadArg() download: boolean) {
+    return await this.service.getUrl(node, download);
   }
 
   @ResolveField(() => URL, {

--- a/src/components/file/file.resolver.ts
+++ b/src/components/file/file.resolver.ts
@@ -32,6 +32,7 @@ import {
   RequestUploadOutput,
 } from './dto';
 import { FileNodeLoader } from './file-node.loader';
+import * as FileUrl from './file-url.resolver-util';
 import { FileService } from './file.service';
 
 @Resolver(File)
@@ -75,13 +76,7 @@ export class FileResolver {
     return await this.service.listChildren(node, input, session);
   }
 
-  @ResolveField(() => URL, {
-    description: stripIndent`
-      A url to the file.
-
-      This url could require authentication.
-    `,
-  })
+  @FileUrl.Resolver()
   async url(@Parent() node: File) {
     return await this.service.getUrl(node);
   }

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -145,27 +145,28 @@ export class FileService {
     return data;
   }
 
-  async getUrl(node: FileNode) {
+  async getUrl(node: FileNode, download: boolean) {
     const url = withAddedPath(
       this.config.hostUrl,
       FileUrl.path,
       isFile(node) ? node.latestVersionId : node.id,
       encodeURIComponent(node.name),
     );
-    return url.toString();
+    return url.toString() + (download ? '?download' : '');
   }
 
-  async getDownloadUrl(node: FileNode): Promise<string> {
+  async getDownloadUrl(node: FileNode, download = true): Promise<string> {
     if (isDirectory(node)) {
       throw new InputException('View directories via GraphQL API');
     }
     const id = isFile(node) ? node.latestVersionId : node.id;
+    const disposition = download ? 'attachment' : 'inline';
     try {
       // before sending link, first check if object exists in s3
       await this.bucket.headObject(id);
       return await this.bucket.getSignedUrl(GetObject, {
         Key: id,
-        ResponseContentDisposition: `attachment; filename="${encodeURIComponent(
+        ResponseContentDisposition: `${disposition}; filename="${encodeURIComponent(
           node.name,
         )}"`,
         ResponseContentType: node.mimeType,

--- a/src/components/file/media-url.resolver.ts
+++ b/src/components/file/media-url.resolver.ts
@@ -12,9 +12,10 @@ export class MediaUrlResolver {
   @FileUrl.Resolver()
   async url(
     @Parent() media: Media,
+    @FileUrl.DownloadArg() download: boolean,
     @Loader(FileNodeLoader) files: LoaderOf<FileNodeLoader>,
   ) {
     const node = await files.load(media.file);
-    return await this.service.getUrl(node);
+    return await this.service.getUrl(node, download);
   }
 }

--- a/src/components/file/media-url.resolver.ts
+++ b/src/components/file/media-url.resolver.ts
@@ -1,8 +1,7 @@
-import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Parent, Resolver } from '@nestjs/graphql';
 import { Loader, LoaderOf } from '@seedcompany/data-loader';
-import { stripIndent } from 'common-tags';
-import { URL } from 'url';
 import { FileNodeLoader } from './file-node.loader';
+import * as FileUrl from './file-url.resolver-util';
 import { FileService } from './file.service';
 import { Media } from './media/media.dto';
 
@@ -10,13 +9,7 @@ import { Media } from './media/media.dto';
 export class MediaUrlResolver {
   constructor(protected readonly service: FileService) {}
 
-  @ResolveField(() => URL, {
-    description: stripIndent`
-      A url to the file version.
-
-      This url could require authentication.
-    `,
-  })
+  @FileUrl.Resolver()
   async url(
     @Parent() media: Media,
     @Loader(FileNodeLoader) files: LoaderOf<FileNodeLoader>,


### PR DESCRIPTION
I kinda wonder if this should be an enum instead of a boolean?
I also wonder what the default value should be? I did switch it from attachment to inline in this PR.

Shortcut to the change in our output: https://github.com/SeedCompany/cord-api-v3/pull/3058/files#diff-559f57a4094a5701bd377bab60ea5315133688bf78f2d6b93371891eab9bbb10R169

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5919092883) by [Unito](https://www.unito.io)
