### PR TITLE
[EdgeDB] Add current user alias

### DIFF
--- a/dbschema/common.esdl
+++ b/dbschema/common.esdl
@@ -1,5 +1,6 @@
 module default {
   global currentUserId: uuid;
+  alias currentUser := <User>(global currentUserId);
   
   scalar type ReportPeriod extending enum<Monthly, Quarterly>;
   

--- a/dbschema/file.esdl
+++ b/dbschema/file.esdl
@@ -23,11 +23,11 @@ module File {
     public: bool;
     
     required createdBy: default::User {
-      default := <default::User>(global default::currentUserId);
+      default := default::currentUser;
     };
     required modifiedBy: default::User {
-      default := <default::User>(global default::currentUserId);
-      rewrite update using (<default::User>(global default::currentUserId));
+      default := default::currentUser;
+      rewrite update using (default::currentUser);
       # TODO trigger change up the tree
       # TODO trigger re-eval on node delete?
     };

--- a/dbschema/migrations/00045.edgeql
+++ b/dbschema/migrations/00045.edgeql
@@ -1,0 +1,35 @@
+CREATE MIGRATION m1vzgo7d3slqdwhpmcigvmaxnh3cz7nhympvu7mb5g3beipzfve5tq
+    ONTO m1zpp5l5wqgcm7hmcunnzswx6oivv7eh5gtwq5ysfaxlk5vhkfjieq
+{
+  CREATE ALIAS default::currentUser := (
+      <default::User>GLOBAL default::currentUserId
+  );
+  ALTER TYPE File::Node {
+      ALTER LINK createdBy {
+          SET default := (default::currentUser);
+      };
+  };
+  ALTER TYPE File::Node {
+      ALTER LINK modifiedBy {
+          SET default := (default::currentUser);
+      };
+  };
+  ALTER TYPE Mixin::Owned {
+      ALTER LINK owner {
+          SET default := (default::currentUser);
+      };
+  };
+  ALTER TYPE File::Node {
+      ALTER LINK modifiedBy {
+          DROP REWRITE
+              UPDATE ;
+          };
+      };
+  ALTER TYPE File::Node {
+      ALTER LINK modifiedBy {
+          CREATE REWRITE
+              UPDATE 
+              USING (default::currentUser);
+      };
+  };
+};

--- a/dbschema/z.owned.esdl
+++ b/dbschema/z.owned.esdl
@@ -1,7 +1,7 @@
 module Mixin {
   abstract type Owned {
     link owner: default::User {
-      default := <default::User>(global default::currentUserId);
+      default := default::currentUser;
     };
     property isOwner := .owner = <default::User>(global default::currentUserId);
   }


### PR DESCRIPTION
There were a lot of places it couldn't be used in schema due to dependency cycles and other things.
But it's still useful in some places and it's very helpful in adhoc queries.

```edgeql
insert User {
  owner := <User>global currentUserId
}
```
```edgeql
insert User {
  owner := currentUser
}
```

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5922044431) by [Unito](https://www.unito.io)
