### PR TITLE
Drop deprecated short-lived downloadUrl field

### DIFF
--- a/src/components/file/file-version.resolver.ts
+++ b/src/components/file/file-version.resolver.ts
@@ -1,6 +1,4 @@
-import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { stripIndent } from 'common-tags';
-import { URL } from 'url';
+import { Parent, Resolver } from '@nestjs/graphql';
 import { FileVersion } from './dto';
 import * as FileUrl from './file-url.resolver-util';
 import { FileService } from './file.service';
@@ -15,17 +13,5 @@ export class FileVersionResolver {
     @FileUrl.DownloadArg() download: boolean,
   ) {
     return await this.service.getUrl(node, download);
-  }
-
-  @ResolveField(() => URL, {
-    description: 'A direct url to download the file version',
-    deprecationReason: stripIndent`
-      Use \`url\` instead.
-
-      Note while this url is anonymous, the new field, \`url\` is not.
-    `,
-  })
-  downloadUrl(@Parent() node: FileVersion): Promise<string> {
-    return this.service.getDownloadUrl(node);
   }
 }

--- a/src/components/file/file.resolver.ts
+++ b/src/components/file/file.resolver.ts
@@ -7,7 +7,6 @@ import {
   Resolver,
 } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
-import { URL } from 'url';
 import {
   AnonSession,
   ID,
@@ -80,18 +79,6 @@ export class FileResolver {
   @FileUrl.Resolver()
   async url(@Parent() node: File, @FileUrl.DownloadArg() download: boolean) {
     return await this.service.getUrl(node, download);
-  }
-
-  @ResolveField(() => URL, {
-    description: 'A direct url to download the file',
-    deprecationReason: stripIndent`
-      Use \`url\` instead.
-
-      Note while this url is anonymous, the new field, \`url\` is not.
-    `,
-  })
-  downloadUrl(@Parent() node: File): Promise<string> {
-    return this.service.getDownloadUrl(node);
   }
 
   @Mutation(() => DeleteFileNodeOutput, {


### PR DESCRIPTION
No longer used now: seedcompany/cord-field#1511

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5923277137) by [Unito](https://www.unito.io)
