### PR TITLE
Upgrade EdgeDB 4.4 -> 4.5

### DIFF
--- a/dbschema/migrations/00046.edgeql
+++ b/dbschema/migrations/00046.edgeql
@@ -1,0 +1,34 @@
+CREATE MIGRATION m1bh4xyugmqj3aeh2pujkbly6uq7lxdisxwdodawgw2flyvbxfnkkq
+    ONTO m1vzgo7d3slqdwhpmcigvmaxnh3cz7nhympvu7mb5g3beipzfve5tq
+{
+  ALTER TYPE default::Post {
+      DROP PROPERTY sensitivity;
+  };
+  ALTER TYPE Project::ContextAware {
+      DROP PROPERTY sensitivity;
+  };
+  ALTER TYPE default::InternshipEngagement {
+      ALTER LINK project {
+          SET REQUIRED;
+          SET TYPE default::InternshipProject USING (.project[IS default::InternshipProject]);
+      };
+  };
+  ALTER TYPE default::Project {
+      ALTER PROPERTY ownSensitivity {
+          SET REQUIRED USING (default::Sensitivity.High);
+          SET TYPE default::Sensitivity;
+      };
+  };
+  ALTER TYPE default::Language {
+      ALTER PROPERTY ownSensitivity {
+          SET REQUIRED USING (default::Sensitivity.High);
+          SET TYPE default::Sensitivity;
+      };
+  };
+  ALTER TYPE default::LanguageEngagement {
+      ALTER LINK project {
+          SET REQUIRED;
+          SET TYPE default::TranslationProject USING (.project[IS default::TranslationProject]);
+      };
+  };
+};

--- a/dbschema/migrations/00047.edgeql
+++ b/dbschema/migrations/00047.edgeql
@@ -1,0 +1,10 @@
+CREATE MIGRATION m1ah6i4a5c6enkrmypo7k3y6f3flr26mqlqtkw2t6437evoxqqzpna
+    ONTO m1bh4xyugmqj3aeh2pujkbly6uq7lxdisxwdodawgw2flyvbxfnkkq
+{
+  ALTER TYPE Project::ContextAware {
+      CREATE REQUIRED SINGLE PROPERTY sensitivity := ((std::max(.projectContext.projects.ownSensitivity) ?? (.ownSensitivity ?? default::Sensitivity.High)));
+  };
+  ALTER TYPE default::Post {
+      CREATE SINGLE PROPERTY sensitivity := (.container[IS Project::ContextAware].sensitivity);
+  };
+};

--- a/dbschema/migrations/00048.edgeql
+++ b/dbschema/migrations/00048.edgeql
@@ -1,0 +1,26 @@
+CREATE MIGRATION m1tn7o5vizqaygjvghqysxzw6ruf4xohudb2usgfg4z622ens24mba
+    ONTO m1ah6i4a5c6enkrmypo7k3y6f3flr26mqlqtkw2t6437evoxqqzpna
+{
+  ALTER TYPE default::Project {
+      ALTER PROPERTY departmentId {
+          CREATE REWRITE
+              UPDATE 
+              USING ((IF ((NOT (EXISTS (.departmentId)) AND (.status <= Project::Status.Active)) AND (.step >= Project::Step.PendingFinanceConfirmation)) THEN (WITH
+                  fa := 
+                      std::assert_exists(__subject__.primaryLocation.fundingAccount, message := 'Project must have a primary location')
+                  ,
+                  existing := 
+                      (SELECT
+                          (DETACHED default::Project).departmentId
+                      FILTER
+                          (default::Project.primaryLocation.fundingAccount = fa)
+                      )
+                  ,
+                  available := 
+                      (std::range_unpack(std::range(((fa.accountNumber * 10000) + 11), ((fa.accountNumber * 10000) + 9999))) EXCEPT existing)
+              SELECT
+                  std::min(available)
+              ) ELSE .departmentId));
+      };
+  };
+};

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -13,28 +13,27 @@ module default {
     departmentId: int32 {
       constraint exclusive;
       constraint expression on (__subject__ >= 10000 and __subject__ <= 99999);
-# Temporarily disabled. Upstream fix in progress.
-#       rewrite update using (
-#         if (
-#           not exists .departmentId and
-#           .status <= Project::Status.Active and
-#           .step >= Project::Step.PendingFinanceConfirmation
-#         ) then ((
-#           with
-#             fa := assert_exists(
-#               __subject__.primaryLocation.fundingAccount,
-#               message := "Project must have a primary location"
-#             ),
-#             existing := (
-#               select detached Project.departmentId filter Project.primaryLocation.fundingAccount = fa
-#             ),
-#             available := (
-#               range_unpack(range(fa.accountNumber * 10000 + 11, fa.accountNumber * 10000 + 9999))
-#               except existing
-#             )
-#           select min(available)
-#         )) else .departmentId
-#       );
+      rewrite update using (
+        if (
+          not exists .departmentId and
+          .status <= Project::Status.Active and
+          .step >= Project::Step.PendingFinanceConfirmation
+        ) then ((
+          with
+            fa := assert_exists(
+              __subject__.primaryLocation.fundingAccount,
+              message := "Project must have a primary location"
+            ),
+            existing := (
+              select detached Project.departmentId filter Project.primaryLocation.fundingAccount = fa
+            ),
+            available := (
+              range_unpack(range(fa.accountNumber * 10000 + 11, fa.accountNumber * 10000 + 9999))
+              except existing
+            )
+          select min(available)
+        )) else .departmentId
+      );
     };
     
     required step: Project::Step {

--- a/dbschema/seeds/007.language-engagements.edgeql
+++ b/dbschema/seeds/007.language-engagements.edgeql
@@ -36,7 +36,7 @@ with
     union (
       with
         language := assert_single((select Language filter .name = <str>engagement['language'])),
-        project := (select Project filter .name = <str>engagement['project']),
+        project := (select TranslationProject filter .name = <str>engagement['project']),
       select (
         (select LanguageEngagement filter .language = language and .project = project) ??
         (insert LanguageEngagement {

--- a/edgedb.toml
+++ b/edgedb.toml
@@ -1,2 +1,2 @@
 [edgedb]
-server-version = "4.0"
+server-version = "4.5"

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -65,7 +65,7 @@ export const resolveEngagementType = (val: Pick<AnyEngagement, '__typename'>) =>
  * This should be used for GraphQL but never for TypeScript types.
  */
 class Engagement extends ChangesetAwareResource {
-  static readonly DB = abstractType(e.Engagement);
+  static readonly DB: any = abstractType(e.Engagement);
   static readonly Props: string[] = keysOf<Engagement>();
   static readonly SecuredProps: string[] = keysOf<SecuredProps<Engagement>>();
   static readonly Parent = import('../../project/dto').then((m) => m.IProject);


### PR DESCRIPTION
This fixes:
- The rewrite with `departmentId`
- The overload on `Engagements` picking specific `Project` types.
- The overload on `Project/Language` setting `ownSensitivity` as required and defaulting to High.
- The `min_value/max_value` constraints. Though I didn't revert these because they aren't that much different than what we have right now.


To upgrade locally:
```
edgedb project upgrade
```
And idk if migrate is needed after
```
edgedb migrate
```
It could be that the migrate fails, as it did for me with my dev changes. So you'll need to blow away and start over.
```
edgedb project unlink -D --non-interactive
edgedb project init --non-interactive
yarn edgedb:seed
```

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5933818680) by [Unito](https://www.unito.io)
