### PR TITLE
EdgeQL Hydration

### DIFF
--- a/dbschema/common.esdl
+++ b/dbschema/common.esdl
@@ -18,4 +18,9 @@ module default {
   );
   
   scalar type RichText extending json;
+  
+  # A fake function to produce valid EdgeQL syntax.
+  # This will be reflected to dynamically inject portable shapes in our EdgeQL queries.
+  function hydrate(typeName: str, scopedValue: json) -> str
+    using (typeName);
 }

--- a/dbschema/migrations/00052.edgeql
+++ b/dbschema/migrations/00052.edgeql
@@ -1,0 +1,5 @@
+CREATE MIGRATION m1rqfvf4ah2ev4ncoxa6l7x5u6h6tssd6r7cbneshimgxzbtdzdppq
+    ONTO m1tgd6yl63z2bp7ahtbi7sidb5gfl7mjs47ooqfbnuleffpap3auua
+{
+  CREATE FUNCTION default::hydrate(typeName: std::str, scopedValue: std::json) ->  std::str USING (typeName);
+};

--- a/src/core/edgedb/generator/find-hydration-shapes.ts
+++ b/src/core/edgedb/generator/find-hydration-shapes.ts
@@ -1,0 +1,145 @@
+import { cleanSplit, mapEntries } from '@seedcompany/common';
+import { adapter } from 'edgedb';
+import { $ as $$ } from 'execa';
+import { readFile } from 'fs/promises';
+import { Directory, Node, SyntaxKind } from 'ts-morph';
+import { hydratorsNeeded, injectHydrators } from './inject-hydrators';
+import { GeneratorParams, toFqn } from './util';
+
+interface Hydrator {
+  fqn: string;
+  type: string;
+  query: string;
+  fields: string;
+  source: string;
+  dependencies: Set<string>;
+}
+export type HydratorMap = ReadonlyMap<string, Hydrator>;
+
+export async function findHydrationShapes({ root }: GeneratorParams) {
+  const queries = await Promise.all([
+    findInQueryFiles(root),
+    findInInlineQueries(root),
+  ]);
+
+  const unsorted = mapEntries(queries.flat(), ({ query, source }, { SKIP }) => {
+    const matches = query.match(RE_SELECT_NAME_AND_FIELDS);
+    if (!matches) {
+      return SKIP;
+    }
+    const [_, type] = matches;
+    const fqn = toFqn(type);
+    const dependencies = hydratorsNeeded(query);
+    const hydrator: Hydrator = {
+      fqn,
+      type,
+      query,
+      source,
+      dependencies,
+      fields: '',
+    };
+    return [fqn, hydrator];
+  }).asMap;
+
+  const hydrators = topoSort(unsorted);
+
+  for (const hydrator of hydrators.values()) {
+    hydrator.query = injectHydrators(hydrator.query, hydrators);
+    hydrator.fields = hydrator.query.match(RE_SELECT_NAME_AND_FIELDS)![2];
+  }
+
+  return hydrators;
+}
+
+function topoSort(map: HydratorMap): HydratorMap {
+  const sorted = new Map<string, Hydrator>();
+  const visiting = new Set<string>();
+
+  const visit = (hydrator: Hydrator) => {
+    if (visiting.has(hydrator.fqn)) {
+      const last = Array.from(visiting).at(-1)!;
+      throw new Error(
+        `Circular dependency involving ${hydrator.type} and ${last}`,
+      );
+    }
+    visiting.add(hydrator.fqn);
+    for (const dep of hydrator.dependencies) {
+      const depHydrator = map.get(dep);
+      if (!depHydrator) {
+        throw new Error(`Hydrator ${dep} referenced but not defined`);
+      }
+      visit(depHydrator);
+    }
+    sorted.set(hydrator.fqn, hydrator);
+    visiting.delete(hydrator.fqn);
+  };
+
+  for (const type of map.values()) {
+    visit(type);
+  }
+
+  return sorted;
+}
+
+async function findInQueryFiles(root: Directory) {
+  const grepForShortList = await $$({
+    reject: false,
+    cwd: root.getPath(),
+  })`find src -type f -name hydrate*.edgeql`;
+  const shortList = grepForShortList.stdout
+    ? grepForShortList.stdout.split('\n')
+    : [];
+  const all = await Promise.all(
+    shortList.map(async (path) => {
+      const contents = await readFile(path, 'utf8');
+      return { contents, source: './' + path };
+    }),
+  );
+  return all.flatMap(({ contents, source }) =>
+    cleanSplit(contents, ';').map((query) => ({ query, source })),
+  );
+}
+
+async function findInInlineQueries(root: Directory) {
+  const grepForShortList = await $$({
+    reject: false,
+    cwd: root.getPath(),
+  })`grep -lRE ${` hydrate\\w+ = edgeql`} src --exclude-dir=src/core/edgedb`;
+  const shortList = grepForShortList.stdout
+    ? root.addSourceFilesAtPaths(grepForShortList.stdout.split('\n'))
+    : [];
+  return (
+    shortList.flatMap((file) =>
+      file.getDescendantsOfKind(SyntaxKind.CallExpression).flatMap((call) => {
+        if (call.getExpression().getText() !== 'edgeql') {
+          return [];
+        }
+        const args = call.getArguments();
+
+        if (
+          args.length > 1 ||
+          (!Node.isStringLiteral(args[0]) &&
+            !Node.isNoSubstitutionTemplateLiteral(args[0]))
+        ) {
+          return [];
+        }
+        // Too hard to find parent types that have name
+        if (!(call as any).getParent()?.getName()?.includes('hydrate')) {
+          return [];
+        }
+
+        const path = adapter.path.posix.relative(
+          root.getPath(),
+          call.getSourceFile().getFilePath(),
+        );
+        const lineNumber = call.getStartLineNumber();
+        const source = `./${path}:${lineNumber}`;
+
+        const query = args[0].getText().slice(1, -1);
+        return { query, source };
+      }),
+    ) ?? []
+  );
+}
+
+const RE_SELECT_NAME_AND_FIELDS = /select ([\w:]+) \{((?:.|\n)+)}/i;

--- a/src/core/edgedb/generator/inject-hydrators.ts
+++ b/src/core/edgedb/generator/inject-hydrators.ts
@@ -1,0 +1,51 @@
+import { HydratorMap } from './find-hydration-shapes';
+import { toFqn } from './util';
+
+export const injectHydrators = (query: string, map: HydratorMap) => {
+  return query
+    .replaceAll(RE_SELECT, (_, type: string) => {
+      const hydration = map.get(toFqn(type));
+      if (!hydration) {
+        return _;
+      }
+      return `select ${type} {${hydration.fields}}`;
+    })
+    .replaceAll(RE_HYDRATE_CALL, (fakeFn) => {
+      const matches = fakeFn.match(RE_HYDRATE_EXTRACT);
+      if (!matches) {
+        return fakeFn;
+      }
+      const [, key, variable] = matches;
+      const hydration = map.get(toFqn(key));
+      if (!hydration) {
+        return fakeFn;
+      }
+      const injected = `(select ${variable} {${hydration.fields.replaceAll(
+        RegExp('(?<!\\sDETACHED\\s)' + hydration.type, 'gi'),
+        variable,
+      )}})`;
+      return injected;
+    });
+};
+
+export const hydratorsNeeded = (query: string) => {
+  const needed = new Set<string>();
+  query
+    .replaceAll(RE_SELECT, (_, type: string) => {
+      needed.add(toFqn(type));
+      return _;
+    })
+    .replaceAll(RE_HYDRATE_CALL, (fakeFn) => {
+      const matches = fakeFn.match(RE_HYDRATE_EXTRACT);
+      if (!matches) {
+        return fakeFn;
+      }
+      needed.add(toFqn(matches[1]));
+      return fakeFn;
+    });
+  return needed;
+};
+
+const RE_SELECT = /select\s+([\w:]+)\s*\{}/gi;
+const RE_HYDRATE_CALL = /hydrate\(.+\)/g;
+const RE_HYDRATE_EXTRACT = /hydrate\(['"]([\w:]+)['"],\s*<json>(.+)\)/;

--- a/src/core/edgedb/generator/util.ts
+++ b/src/core/edgedb/generator/util.ts
@@ -1,11 +1,14 @@
 import { Client } from 'edgedb';
 import { Directory, SourceFile } from 'ts-morph';
 import { ScalarInfo } from '../codecs';
+import { HydratorMap } from './find-hydration-shapes';
 
 export interface GeneratorParams {
   client: Client;
   root: Directory;
   edgedbDir: Directory;
+  hydrators: HydratorMap;
+  errors: Error[];
 }
 
 export function addCustomScalarImports(
@@ -23,3 +26,6 @@ export function addCustomScalarImports(
     })),
   );
 }
+
+export const toFqn = (type: string) =>
+  type.includes(':') ? type : `default::${type}`;


### PR DESCRIPTION
# Problem
One of the big reasons why I pushed for the query builder in the past few weeks, is it has the ability to have "shared/portable shapes" ([doc](https://www.edgedb.com/docs/clients/js/select#portable-shapes)). This is what powers the `hydrate` function in the edgedb repos.
It allows us to define the shape we expect back for the type once, instead of in every query.

Unfortunately, EdgeQL does not natively support this concept yet. ([Proposal](https://github.com/edgedb/edgedb/issues/5736))

Also unfortunately, the TS query builder seems to push TS to its limits and TS slows down & eventually gives up (errors out). This was made evident in my work on the file module.

So we need a solution, which is this.

# Solution

Doing our own hydration concept. This is basically magical string injection, but hear me out.

A big goal I had with this is that our input would still be valid EdgeQL. In case their LSP hits before an actual solution from them on this front, I didn't want our queries to appear "broken" by them.

So here it is:

## Declaring hydration shapes
First hydration shapes will be declared one of two ways:
- An edgeql file with `hydrate` in the name. 
- In a TS file, an `edgeql()` call assigned to a variable with `hydrate` in the name.

```edgeql
# src/components/user/queries/hydrate-user.edgeql
select User {
  id,
  email
};
```
```ts
// src/components/user/user.edgedb.repository.ts
const hydrate = edgeql(`
  select User {
    id,
    email
  }
`);
```
Note that the filename or variable name doesn't really matter as long as it includes "hydrate".
We key off of the actual type selected.

## Using hydration shapes

There are two ways to access these hydrators.

### Empty select `{}`

The easiest is an explicit empty select `{}`.
```edgeql
select User {}
filter .id = <uuid>$id
```
Here we see that we have the type `User` and we want to hydrate it.

### Fake hydrate function

In other cases, we have a reference in the query that we want to hydrate.
```edgeql
select User {
  education := hydrate('User::Education', <json>.education)
}
filter .id = <uuid>$id
```
So what this says is hydrate `.education` with the type `User::Education` .
Since we don't know the type of `.education` statically, we have to declare it here.

Again I wanted to always have valid EdgeQL syntax, so I declared this fake `hydrate` function in our schema. The DB functions are fairly limited right now in the types that they can accept.
That's why we have the `<json>` cast boilerplate - it is actually ignored in our generated queries.

### Recursion

Hydrators can also be used in other hydrators, so long as they don't cycle.

# Complete example
```edgeql
# hydrate-user.edgeql
select User {
  id,
  email,
  education := hydrate('User::Education', <json>.education)
};

select User::Education {
  degree,
  major,
  institution
}
```
```edgeql
# user-by-email.edgeql
select User {}
filter .email = <str>$email
```
This query gets generated to 
```edgeql
select User {
  id,
  email,
  education := (select .education {
    degree,
    major,
    institution
  })
}
filter .email = <str>$email
```

# Caveats

I haven't figured out a way to interchange these edgeql hydrators with the query builder hydrate functions. So if we need/want to use both, they have to be declared in two spots.
It could be possible to mitigate this with more work.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5939136043) by [Unito](https://www.unito.io)
