### PR TITLE
Validation Injectability

### DIFF
--- a/src/common/validators/short-id.validator.ts
+++ b/src/common/validators/short-id.validator.ts
@@ -1,6 +1,6 @@
 import { ArgumentMetadata, PipeTransform } from '@nestjs/common';
 import { ValidationOptions } from 'class-validator';
-import { ValidationException } from '../../core/validation.pipe';
+import { ValidationException } from '~/core/validation';
 import { isValidId } from '../generate-id';
 import { ValidateBy } from './validateBy';
 

--- a/src/common/validators/validateBy.ts
+++ b/src/common/validators/validateBy.ts
@@ -1,16 +1,25 @@
-import { FnLike } from '@seedcompany/common';
+import { Type } from '@nestjs/common';
 import {
   registerDecorator,
   ValidationOptions,
   ValidatorConstraintInterface,
 } from 'class-validator';
+import { MergeExclusive } from 'type-fest';
 
-export interface ValidateByOptions {
-  name: string;
-  constraints?: any[];
-  validator: ValidatorConstraintInterface | FnLike;
-  async?: boolean;
-}
+export type ValidateByOptions =
+  | MergeExclusive<
+      {
+        validator: ValidatorConstraintInterface;
+        name: string;
+        async?: boolean;
+        constraints?: any[];
+      },
+      {
+        validator: Type<ValidatorConstraintInterface>;
+        constraints?: any[];
+      }
+    >
+  | Type<ValidatorConstraintInterface>;
 
 export const ValidateBy =
   (
@@ -19,13 +28,11 @@ export const ValidateBy =
   ): PropertyDecorator =>
   (object: Record<string, any>, propertyName: string | symbol) => {
     registerDecorator({
-      name: options.name,
       target: object.constructor,
       propertyName: propertyName as string,
       options: validationOptions,
-      constraints: options.constraints,
-      validator: options.validator,
-      async: options.async,
+      ...options,
+      validator: typeof options === 'function' ? options : options.validator,
     });
   };
 

--- a/src/components/changeset/changeset.module.ts
+++ b/src/components/changeset/changeset.module.ts
@@ -4,6 +4,7 @@ import { ChangesetAwareResolver } from './changeset-aware.resolver';
 import { ValidateChangesetEditablePipe } from './changeset.arg';
 import { ChangesetRepository } from './changeset.repository';
 import { ChangesetResolver } from './changeset.resolver';
+import { ObjectViewPipe } from './dto';
 import { EnforceChangesetEditablePipe } from './enforce-changeset-editable.pipe';
 
 @Module({
@@ -11,6 +12,7 @@ import { EnforceChangesetEditablePipe } from './enforce-changeset-editable.pipe'
     ChangesetAwareResolver,
     ChangesetResolver,
     ChangesetRepository,
+    ObjectViewPipe,
     { provide: APP_PIPE, useClass: EnforceChangesetEditablePipe },
     ValidateChangesetEditablePipe,
   ],

--- a/src/components/changeset/dto/changeset.args.ts
+++ b/src/components/changeset/dto/changeset.args.ts
@@ -1,4 +1,4 @@
-import { PipeTransform } from '@nestjs/common';
+import { Injectable, PipeTransform } from '@nestjs/common';
 import { Args, ArgsType } from '@nestjs/graphql';
 import { ID, IdField, ObjectView } from '~/common';
 import { ValidationPipe } from '~/core/validation';
@@ -20,9 +20,12 @@ export type IdsAndView = ChangesetIds & { view: ObjectView };
 export const IdsAndViewArg = () =>
   Args({ type: () => ChangesetIds }, ObjectViewPipe);
 
-class ObjectViewPipe implements PipeTransform {
+@Injectable()
+export class ObjectViewPipe implements PipeTransform {
+  constructor(private readonly validator: ValidationPipe) {}
+
   async transform({ id, changeset }: ChangesetIds) {
-    await new ValidationPipe().transform(
+    await this.validator.transform(
       { id, changeset },
       {
         metatype: ChangesetIds,

--- a/src/components/changeset/dto/changeset.args.ts
+++ b/src/components/changeset/dto/changeset.args.ts
@@ -24,14 +24,11 @@ export const IdsAndViewArg = () =>
 export class ObjectViewPipe implements PipeTransform {
   constructor(private readonly validator: ValidationPipe) {}
 
-  async transform({ id, changeset }: ChangesetIds) {
-    await this.validator.transform(
-      { id, changeset },
-      {
-        metatype: ChangesetIds,
-        type: 'body',
-      },
-    );
+  async transform(input: ChangesetIds) {
+    const { id, changeset } = await this.validator.transform(input, {
+      metatype: ChangesetIds,
+      type: 'body',
+    });
     const view: ObjectView = changeset ? { changeset } : { active: true };
     return { id, changeset, view };
   }

--- a/src/components/changeset/dto/changeset.args.ts
+++ b/src/components/changeset/dto/changeset.args.ts
@@ -1,7 +1,7 @@
 import { PipeTransform } from '@nestjs/common';
 import { Args, ArgsType } from '@nestjs/graphql';
-import { ID, IdField, ObjectView } from '../../../common';
-import { ValidationPipe } from '../../../core/validation.pipe';
+import { ID, IdField, ObjectView } from '~/common';
+import { ValidationPipe } from '~/core/validation';
 
 /**
  * A helper for id & changeset arguments.

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -1,5 +1,5 @@
 import { Global, Module } from '@nestjs/common';
-import { APP_FILTER, APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
+import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
 import { DataLoaderModule } from '@seedcompany/data-loader';
 import { EmailModule } from '@seedcompany/nestjs-email';
 import { ConsoleModule } from 'nestjs-console';
@@ -19,7 +19,7 @@ import { ResourceModule } from './resources/resource.module';
 import { ScalarProviders } from './scalars.resolver';
 import { TimeoutInterceptor } from './timeout.interceptor';
 import { TracingModule } from './tracing';
-import { ValidationPipe } from './validation.pipe';
+import { ValidationModule } from './validation/validation.module';
 import { WaitResolver } from './wait.resolver';
 
 @Global()
@@ -36,13 +36,13 @@ import { WaitResolver } from './wait.resolver';
     EventsModule,
     TracingModule,
     ResourceModule,
+    ValidationModule,
   ],
   providers: [
     AwsS3Factory,
     ExceptionNormalizer,
     ExceptionFilter,
     { provide: APP_FILTER, useExisting: ExceptionFilter },
-    { provide: APP_PIPE, useClass: ValidationPipe },
     { provide: APP_INTERCEPTOR, useClass: TimeoutInterceptor },
     WaitResolver,
     ...ScalarProviders,
@@ -60,6 +60,7 @@ import { WaitResolver } from './wait.resolver';
     EventsModule,
     ResourceModule,
     TracingModule,
+    ValidationModule,
   ],
 })
 export class CoreModule {}

--- a/src/core/exception/exception.filter.ts
+++ b/src/core/exception/exception.filter.ts
@@ -4,7 +4,7 @@ import { GqlContextType, GqlExceptionFilter } from '@nestjs/graphql';
 import { mapValues } from '@seedcompany/common';
 import { ConfigService } from '../config/config.service';
 import { ILogger, Logger, LogLevel } from '../logger';
-import { ValidationException } from '../validation.pipe';
+import { ValidationException } from '../validation';
 import { ExceptionJson, ExceptionNormalizer } from './exception.normalizer';
 import { isFromHackAttempt } from './is-from-hack-attempt';
 

--- a/src/core/validation/index.ts
+++ b/src/core/validation/index.ts
@@ -1,0 +1,2 @@
+export * from './validation.exception';
+export * from './validation.pipe';

--- a/src/core/validation/validation.exception.ts
+++ b/src/core/validation/validation.exception.ts
@@ -1,24 +1,9 @@
-import {
-  ValidationPipe as BaseValidationPipe,
-  Injectable,
-  ValidationError,
-} from '@nestjs/common';
+import { ValidationError } from '@nestjs/common';
 import { entries } from '@seedcompany/common';
 import { SetRequired } from 'type-fest';
 import { fileURLToPath } from 'url';
-import { ClientException } from '../common/exceptions';
-import { jestSkipFileInExceptionSource } from './exception';
-
-@Injectable()
-export class ValidationPipe extends BaseValidationPipe {
-  constructor() {
-    super({
-      transform: true,
-      skipMissingProperties: true,
-      exceptionFactory: (es) => new ValidationException(es),
-    });
-  }
-}
+import { ClientException } from '~/common/exceptions';
+import { jestSkipFileInExceptionSource } from '../exception';
 
 export class ValidationException extends ClientException {
   readonly errors: Record<string, Record<string, string>>;

--- a/src/core/validation/validation.module.ts
+++ b/src/core/validation/validation.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { APP_PIPE } from '@nestjs/core';
+import { Validator } from 'class-validator';
 import { ValidationPipe } from './validation.pipe';
 
 @Module({
   providers: [
+    Validator,
     ValidationPipe,
     { provide: APP_PIPE, useExisting: ValidationPipe },
   ],

--- a/src/core/validation/validation.module.ts
+++ b/src/core/validation/validation.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { APP_PIPE } from '@nestjs/core';
+import { ValidationPipe } from './validation.pipe';
+
+@Module({
+  providers: [
+    ValidationPipe,
+    { provide: APP_PIPE, useExisting: ValidationPipe },
+  ],
+  exports: [ValidationPipe],
+})
+export class ValidationModule {}

--- a/src/core/validation/validation.pipe.ts
+++ b/src/core/validation/validation.pipe.ts
@@ -1,0 +1,16 @@
+import {
+  ValidationPipe as BaseValidationPipe,
+  Injectable,
+} from '@nestjs/common';
+import { ValidationException } from './validation.exception';
+
+@Injectable()
+export class ValidationPipe extends BaseValidationPipe {
+  constructor() {
+    super({
+      transform: true,
+      skipMissingProperties: true,
+      exceptionFactory: (es) => new ValidationException(es),
+    });
+  }
+}

--- a/src/core/validation/validation.pipe.ts
+++ b/src/core/validation/validation.pipe.ts
@@ -2,15 +2,34 @@ import {
   ValidationPipe as BaseValidationPipe,
   Injectable,
 } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import { useContainer, ValidatorOptions } from 'class-validator';
 import { ValidationException } from './validation.exception';
 
 @Injectable()
 export class ValidationPipe extends BaseValidationPipe {
-  constructor() {
+  constructor(private readonly moduleRef: ModuleRef) {
     super({
       transform: true,
       skipMissingProperties: true,
       exceptionFactory: (es) => new ValidationException(es),
     });
+  }
+  private readonly containerForLib = {
+    get: (type: any) => {
+      if (type.name === 'CustomConstraint') {
+        // Prototype-less constraints. Null to fall back to default, which just calls constructor once.
+        return null;
+      }
+      return this.moduleRef.get(type);
+    },
+  };
+
+  protected async validate(
+    object: object,
+    validatorOptions?: ValidatorOptions,
+  ) {
+    useContainer(this.containerForLib, { fallback: true });
+    return await super.validate(object, validatorOptions);
   }
 }


### PR DESCRIPTION
This allows validators to be injectable. Prepping for future work.

Example:
```ts
@Injectable()
@ValidatorConstraint({ name: 'Foo', async: true })
export class FooConstraint implements ValidatorConstraintInterface {
  constructor(
    // inject anything...
  ) {}

  async validate(value: unknown, args: ValidationArguments) {
    ...
  }
}

const IsFoo = createValidationDecorator(FooConstraint);
// or
const IsFoo = () => ValidateBy(FooConstraint);
```
Obviously the constraint class provided in a module as well.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5954156315) by [Unito](https://www.unito.io)
