### PR TITLE
[EdgeDB] Aliases for legacy IDs

### DIFF
--- a/dbschema/alias.esdl
+++ b/dbschema/alias.esdl
@@ -1,0 +1,10 @@
+module default {
+  type Alias {
+    required name: str {
+      constraint exclusive;
+    };
+    required target: Object {
+      on target delete delete source;
+    };
+  }
+}

--- a/dbschema/migrations/00051.edgeql
+++ b/dbschema/migrations/00051.edgeql
@@ -1,0 +1,12 @@
+CREATE MIGRATION m1tgd6yl63z2bp7ahtbi7sidb5gfl7mjs47ooqfbnuleffpap3auua
+    ONTO m1vlgekf4eyzweb6xmldmxwzohoh7xbrre6fbc7e2d3t7q7ry3qobq
+{
+  CREATE TYPE default::Alias {
+      CREATE REQUIRED LINK target: std::Object {
+          ON TARGET DELETE DELETE SOURCE;
+      };
+      CREATE REQUIRED PROPERTY name: std::str {
+          CREATE CONSTRAINT std::exclusive;
+      };
+  };
+};

--- a/src/common/id.arg.ts
+++ b/src/common/id.arg.ts
@@ -1,6 +1,6 @@
 import { PipeTransform, Type } from '@nestjs/common';
 import { Args, ArgsOptions, ID as IdType } from '@nestjs/graphql';
-import { ValidateIdPipe } from './validators';
+import { ValidateIdPipe } from './validators/short-id.validator';
 
 export const IdArg = (
   opts: Partial<ArgsOptions> = {},

--- a/src/common/validators/index.ts
+++ b/src/common/validators/index.ts
@@ -1,4 +1,4 @@
 export * from './email.validator';
 export * from './iana-timezone.validator';
 export * from './iso-3166-1-alpha-3.validator';
-export * from './short-id.validator';
+export { IsId } from './short-id.validator';

--- a/src/common/validators/short-id.validator.ts
+++ b/src/common/validators/short-id.validator.ts
@@ -1,28 +1,54 @@
-import { ArgumentMetadata, PipeTransform } from '@nestjs/common';
-import { ValidationOptions } from 'class-validator';
+import { ArgumentMetadata, Injectable, PipeTransform } from '@nestjs/common';
+import {
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
 import { ValidationException } from '~/core/validation';
 import { isValidId } from '../generate-id';
+import { ID } from '../id-field';
 import { ValidateBy } from './validateBy';
 
 export const IsId = (validationOptions?: ValidationOptions) =>
-  ValidateBy(
-    {
-      name: 'IsId',
-      validator: {
-        validate: isValidId,
-        defaultMessage: () =>
-          validationOptions?.each
-            ? 'Each value in $property must be a valid ID'
-            : 'Invalid ID',
-      },
-    },
-    validationOptions,
-  );
+  ValidateBy(ValidIdConstraint, {
+    message: validationOptions?.each
+      ? 'Each value in $property must be a valid ID'
+      : 'Invalid ID',
+    ...validationOptions,
+  });
 
+@Injectable()
+export class IdResolver {
+  async resolve(value: ID): Promise<ID> {
+    return value;
+  }
+}
+
+@Injectable()
+@ValidatorConstraint({ name: 'IsId', async: true })
+export class ValidIdConstraint implements ValidatorConstraintInterface {
+  constructor(private readonly resolver: IdResolver) {}
+
+  async validate(value: unknown, args: ValidationArguments) {
+    if (isValidId(value)) {
+      (args.object as any)[args.property] = await this.resolver.resolve(value);
+      return true;
+    }
+    return false;
+  }
+}
+
+@Injectable()
 export class ValidateIdPipe implements PipeTransform {
+  constructor(private readonly resolver: IdResolver) {}
+
   transform(id: unknown, metadata: ArgumentMetadata) {
-    if (id == null || isValidId(id)) {
-      return id;
+    if (id == null) {
+      return null;
+    }
+    if (isValidId(id)) {
+      return this.resolver.resolve(id);
     }
     throw new ValidationException([
       {

--- a/src/components/changeset/changeset.arg.ts
+++ b/src/components/changeset/changeset.arg.ts
@@ -7,14 +7,10 @@ import {
 import { Args, ArgsOptions, ID as IDType } from '@nestjs/graphql';
 import { Resolver } from '@nestjs/graphql/dist/enums/resolver.enum.js';
 import { RESOLVER_TYPE_METADATA as TypeKey } from '@nestjs/graphql/dist/graphql.constants.js';
-import {
-  ID,
-  InputException,
-  ServerException,
-  ValidateIdPipe,
-} from '../../common';
-import { createAugmentedMetadataPipe } from '../../common/augmented-metadata.pipe';
-import { ResourceLoader } from '../../core';
+import { ID, InputException, ServerException } from '~/common';
+import { createAugmentedMetadataPipe } from '~/common/augmented-metadata.pipe';
+import { ValidateIdPipe } from '~/common/validators/short-id.validator';
+import { ResourceLoader } from '~/core/resources';
 
 const pipeMetadata = createAugmentedMetadataPipe<{
   mutation: boolean;

--- a/src/core/edgedb/alias-id-resolver.ts
+++ b/src/core/edgedb/alias-id-resolver.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common';
+import { isUUID } from 'class-validator';
+import DataLoader from 'dataloader';
+import LRU from 'lru-cache';
+import { ID, NotFoundException } from '~/common';
+import { IdResolver } from '~/common/validators/short-id.validator';
+import { ILogger, Logger } from '~/core/logger';
+import { EdgeDB } from './edgedb.service';
+import { e } from './reexports';
+
+@Injectable()
+export class AliasIdResolver implements IdResolver {
+  private readonly loader: DataLoader<ID, ID>;
+
+  constructor(
+    private readonly db: EdgeDB,
+    @Logger('alias-resolver') private readonly logger: ILogger,
+  ) {
+    this.loader = new DataLoader((x) => this.loadMany(x), {
+      // Since this loader exists for the lifetime of the process
+      // and there's no cache invalidation, we'll just use an LRU cache
+      cacheMap: new LRU({
+        max: 10_000,
+      }),
+    });
+  }
+
+  async resolve(value: ID): Promise<ID> {
+    try {
+      return await this.loader.load(value);
+    } catch (e) {
+      if (e instanceof NotFoundException) {
+        this.loader.clear(value); // maybe it'll be there next request
+        return value; // assume valid or defer error
+      }
+      throw e;
+    }
+  }
+
+  async loadMany(ids: readonly ID[]): Promise<ReadonlyArray<ID | Error>> {
+    const aliases = ids.filter((id) => {
+      if (isUUID(id)) {
+        return false;
+      }
+      return true;
+    });
+    if (aliases.length === 0) {
+      return ids;
+    }
+
+    this.logger.info('Resolving aliases', { ids: aliases });
+    const foundList = await this.db.run(this.query, { aliasList: aliases });
+    return ids.map((id) => {
+      const found = foundList.find((f) => f.name === id);
+      return found
+        ? found.targetId
+        : !aliases.includes(id)
+        ? id
+        : new NotFoundException();
+    });
+  }
+
+  private readonly query = e.params(
+    { aliasList: e.array(e.str) },
+    ({ aliasList }) =>
+      e.select(e.Alias, (alias) => ({
+        filter: e.op(alias.name, 'in', e.array_unpack(aliasList)),
+        name: true,
+        targetId: alias.target.id,
+      })),
+  );
+}

--- a/src/core/edgedb/edgedb.module.ts
+++ b/src/core/edgedb/edgedb.module.ts
@@ -1,7 +1,10 @@
 import { Module, OnModuleDestroy } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { createClient, Duration } from 'edgedb';
+import { IdResolver } from '~/common/validators/short-id.validator';
 import type { ConfigService } from '~/core';
+import { splitDb } from '../database/split-db.provider';
+import { AliasIdResolver } from './alias-id-resolver';
 import { codecs, registerCustomScalarCodecs } from './codecs';
 import { EdgeDBTransactionalMutationsInterceptor } from './edgedb-transactional-mutations.interceptor';
 import { EdgeDB } from './edgedb.service';
@@ -49,8 +52,9 @@ import { TransactionContext } from './transaction.context';
       provide: APP_INTERCEPTOR,
       useClass: EdgeDBTransactionalMutationsInterceptor,
     },
+    splitDb(IdResolver, AliasIdResolver),
   ],
-  exports: [EdgeDB, Client],
+  exports: [EdgeDB, Client, IdResolver],
 })
 export class EdgeDBModule implements OnModuleDestroy {
   constructor(private readonly client: Client) {}

--- a/src/core/validation/validation.module.ts
+++ b/src/core/validation/validation.module.ts
@@ -2,7 +2,6 @@ import { Module } from '@nestjs/common';
 import { APP_PIPE } from '@nestjs/core';
 import { Validator } from 'class-validator';
 import {
-  IdResolver,
   ValidateIdPipe,
   ValidIdConstraint,
 } from '~/common/validators/short-id.validator';
@@ -15,8 +14,7 @@ import { ValidationPipe } from './validation.pipe';
     { provide: APP_PIPE, useExisting: ValidationPipe },
     ValidIdConstraint,
     ValidateIdPipe,
-    IdResolver,
   ],
-  exports: [ValidationPipe, ValidateIdPipe, IdResolver],
+  exports: [ValidationPipe, ValidateIdPipe],
 })
 export class ValidationModule {}

--- a/src/core/validation/validation.module.ts
+++ b/src/core/validation/validation.module.ts
@@ -1,6 +1,11 @@
 import { Module } from '@nestjs/common';
 import { APP_PIPE } from '@nestjs/core';
 import { Validator } from 'class-validator';
+import {
+  IdResolver,
+  ValidateIdPipe,
+  ValidIdConstraint,
+} from '~/common/validators/short-id.validator';
 import { ValidationPipe } from './validation.pipe';
 
 @Module({
@@ -8,7 +13,10 @@ import { ValidationPipe } from './validation.pipe';
     Validator,
     ValidationPipe,
     { provide: APP_PIPE, useExisting: ValidationPipe },
+    ValidIdConstraint,
+    ValidateIdPipe,
+    IdResolver,
   ],
-  exports: [ValidationPipe],
+  exports: [ValidationPipe, ValidateIdPipe, IdResolver],
 })
 export class ValidationModule {}


### PR DESCRIPTION
This will allow the API/UI to accept our current IDs even after the migration.
My main motivation for this is to not break all references to our URLs that include IDs.

This works with an `Alias` type/table that maps a string to some object.
It assumes all IDs now (after migration) are some form of a UUID.
Therefore, any string that's not a UUID would make a DB call to convert to the target's UUID.
These aliases still have to be globally unique, as our current IDs are.

This currently works transparently for all input fields/args that are of type `ID`, or rather use the [`IdArg`](https://github.com/SeedCompany/cord-api-v3/blob/bfaae760e62d40d4aada19f4b3f8635bacb6f483/src/common/id.arg.ts#L5-L5) or [`IsId`](https://github.com/SeedCompany/cord-api-v3/blob/bfaae760e62d40d4aada19f4b3f8635bacb6f483/src/common/validators/short-id.validator.ts#L13-L13)/[`IdField`](https://github.com/SeedCompany/cord-api-v3/blob/bfaae760e62d40d4aada19f4b3f8635bacb6f483/src/common/id-field.ts#L7-L7) decorators.

Example with an alias called "root":
![Screenshot 2024-01-29 at 4 06 37 PM](https://github.com/SeedCompany/cord-api-v3/assets/932566/246a93d3-87aa-4c3a-b86b-015c7f315e5e)

This doesn't account for using those aliases or legacy IDs in the output results. So any places accepting CORD data, would still have a breaking change.

---

I could see this becoming a user-facing feature in the future hence the generic name `Alias` instead of "legacy ID".
i.e.
```
cordfield.com/projects/adunu-cluster
```

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/5954870901) by [Unito](https://www.unito.io)
