### PR TITLE
[EdgeDB] `PeriodicReport` schema

### DIFF
--- a/dbschema/common.esdl
+++ b/dbschema/common.esdl
@@ -23,4 +23,18 @@ module default {
   # This will be reflected to dynamically inject portable shapes in our EdgeQL queries.
   function hydrate(typeName: str, scopedValue: json) -> str
     using (typeName);
+  
+  # Get the inclusive upper bound of the given date range.
+  function date_range_get_upper(period: range<cal::local_date>) -> cal::local_date
+    using ((
+      with
+        e := assert_exists(range_get_upper(period))
+        # https://github.com/edgedb/edgedb/issues/6786
+        # e - <cal::date_duration>"1 day"
+        select cal::to_local_date(
+          <int64>cal::date_get(e, 'year'),
+          <int64>cal::date_get(e, 'month'),
+          <int64>cal::date_get(e, 'day') - 1,
+        )
+    ));
 }

--- a/dbschema/migrations/00054.edgeql
+++ b/dbschema/migrations/00054.edgeql
@@ -1,0 +1,40 @@
+CREATE MIGRATION m1mbjrsuqwwklgbswbvdbryp4p7gpgevkd7eq2qx6hfelhjvipkyhq
+    ONTO m1vp4elagp7wzixttjl3s6pk2q5ml2p4zq35vvdc3nouewe3qvcm3q
+{
+  CREATE FUNCTION default::date_range_get_upper(period: range<cal::local_date>) ->  cal::local_date USING (WITH
+      e := 
+          std::assert_exists(std::range_get_upper(period))
+  SELECT
+      cal::to_local_date(<std::int64>cal::date_get(e, 'year'), <std::int64>cal::date_get(e, 'month'), (<std::int64>cal::date_get(e, 'day') - 1))
+  );
+  CREATE ABSTRACT TYPE default::PeriodicReport EXTENDING default::Resource, Mixin::Embedded {
+      CREATE REQUIRED PROPERTY period: range<cal::local_date>;
+      CREATE PROPERTY `end` := (default::date_range_get_upper(.period));
+      CREATE LINK reportFile: default::File;
+      CREATE PROPERTY receivedDate: cal::local_date;
+      CREATE PROPERTY skippedReason: std::str;
+      CREATE PROPERTY `start` := (std::range_get_lower(.period));
+  };
+  CREATE TYPE default::FinancialReport EXTENDING default::PeriodicReport, Project::Child {
+      ALTER LINK container {
+          SET OWNED;
+          SET TYPE default::Project USING (<default::Project>{});
+      };
+  };
+  CREATE TYPE default::NarrativeReport EXTENDING default::PeriodicReport, Project::Child {
+      ALTER LINK container {
+          SET OWNED;
+          SET TYPE default::Project USING (<default::Project>{});
+      };
+  };
+  CREATE TYPE default::ProgressReport EXTENDING default::PeriodicReport, Engagement::Child {
+      ALTER LINK container {
+          SET OWNED;
+          SET TYPE default::LanguageEngagement USING (<default::LanguageEngagement>{});
+      };
+      ALTER LINK engagement {
+          SET OWNED;
+          SET TYPE default::LanguageEngagement USING (<default::LanguageEngagement>{});
+      };
+  };
+};

--- a/dbschema/periodic-report.esdl
+++ b/dbschema/periodic-report.esdl
@@ -11,14 +11,14 @@ module default {
   }
 
   type FinancialReport extending PeriodicReport, Project::Child {
-    overloaded required single link container: Project;
+    overloaded container: Project;
   }
 
   type NarrativeReport extending PeriodicReport, Project::Child {
-    overloaded required single link container: Project;
+    overloaded container: Project;
   }
 
   type ProgressReport extending PeriodicReport, Engagement::Child {
-    overloaded required single link container: Engagement;
+    overloaded container: Engagement;
   }
 }

--- a/dbschema/periodic-report.esdl
+++ b/dbschema/periodic-report.esdl
@@ -17,8 +17,4 @@ module default {
   type NarrativeReport extending PeriodicReport, Project::Child {
     overloaded container: Project;
   }
-
-  type ProgressReport extending PeriodicReport, Engagement::Child {
-    overloaded container: Engagement;
-  }
 }

--- a/dbschema/periodic-report.esdl
+++ b/dbschema/periodic-report.esdl
@@ -1,7 +1,20 @@
 module default {
   abstract type PeriodicReport extending Resource, Mixin::Embedded {
-    required `start`: cal::local_date;
-    required `end`: cal::local_date;
+    required period: range<cal::local_date>;
+    `start` := range_get_lower(.period);
+
+    # Adjust for `range_get_upper` giving next day: subtract 1 from day manually
+    # due to `cal::to_local_date` arithmetic error.
+    # See: https://github.com/edgedb/edgedb/issues/6786
+    `end` := (
+      with
+        e := range_get_upper(.period)
+        select cal::to_local_date(
+          <int64>cal::date_get(e, 'year'),
+          <int64>cal::date_get(e, 'month'),
+          <int64>cal::date_get(e, 'day') - 1,
+        )
+    );
 
     receivedDate: cal::local_date;
 

--- a/dbschema/periodic-report.esdl
+++ b/dbschema/periodic-report.esdl
@@ -2,31 +2,18 @@ module default {
   abstract type PeriodicReport extending Resource, Mixin::Embedded {
     required period: range<cal::local_date>;
     `start` := range_get_lower(.period);
-
-    # Adjust for `range_get_upper` giving next day: subtract 1 from day manually
-    # due to `cal::to_local_date` arithmetic error.
-    # See: https://github.com/edgedb/edgedb/issues/6786
-    `end` := (
-      with
-        e := range_get_upper(.period)
-        select cal::to_local_date(
-          <int64>cal::date_get(e, 'year'),
-          <int64>cal::date_get(e, 'month'),
-          <int64>cal::date_get(e, 'day') - 1,
-        )
-    );
-
-    receivedDate: cal::local_date;
-
+    `end` := date_range_get_upper(.period);
+    
     skippedReason: str;
-
+    
     reportFile: File;
+    receivedDate: cal::local_date;
   }
-
+  
   type FinancialReport extending PeriodicReport, Project::Child {
     overloaded container: Project;
   }
-
+  
   type NarrativeReport extending PeriodicReport, Project::Child {
     overloaded container: Project;
   }

--- a/dbschema/periodic-report.esdl
+++ b/dbschema/periodic-report.esdl
@@ -1,0 +1,18 @@
+module default {
+  abstract type PeriodicReport extending Engagement::Child {
+    # https://github.com/edgedb/edgedb/issues/6766
+    # overloaded engagement: LanguageEngagement;
+
+    required `start`: cal::local_date;
+    required `end`: cal::local_date;
+
+    receivedDate: cal::local_date;
+
+    skippedReason: str;
+
+    reportFile: File;
+  }
+
+  type FinancialReport extending PeriodicReport {}
+  type NarrativeReport extending PeriodicReport {}
+}

--- a/dbschema/periodic-report.esdl
+++ b/dbschema/periodic-report.esdl
@@ -1,8 +1,5 @@
 module default {
-  abstract type PeriodicReport extending Engagement::Child {
-    # https://github.com/edgedb/edgedb/issues/6766
-    # overloaded engagement: LanguageEngagement;
-
+  abstract type PeriodicReport extending Mixin::Embedded {
     required `start`: cal::local_date;
     required `end`: cal::local_date;
 
@@ -13,6 +10,15 @@ module default {
     reportFile: File;
   }
 
-  type FinancialReport extending PeriodicReport {}
-  type NarrativeReport extending PeriodicReport {}
+  type FinancialReport extending PeriodicReport, Project::Child {
+    overloaded required single link container: Project;
+  }
+
+  type NarrativeReport extending PeriodicReport, Project::Child {
+    overloaded required single link container: Project;
+  }
+
+  type ProgressReport extending PeriodicReport, Engagement::Child {
+    overloaded required single link container: Engagement;
+  }
 }

--- a/dbschema/periodic-report.esdl
+++ b/dbschema/periodic-report.esdl
@@ -1,5 +1,5 @@
 module default {
-  abstract type PeriodicReport extending Mixin::Embedded {
+  abstract type PeriodicReport extending Resource, Mixin::Embedded {
     required `start`: cal::local_date;
     required `end`: cal::local_date;
 

--- a/dbschema/progress-report.esdl
+++ b/dbschema/progress-report.esdl
@@ -1,5 +1,6 @@
 module default {
   type ProgressReport extending PeriodicReport, Engagement::Child {
-    overloaded container: Engagement;
+    overloaded container: LanguageEngagement;
+    overloaded engagement: LanguageEngagement;
   }
 }

--- a/dbschema/progress-report.esdl
+++ b/dbschema/progress-report.esdl
@@ -1,0 +1,5 @@
+module default {
+  type ProgressReport extending PeriodicReport, Engagement::Child {
+    overloaded container: Engagement;
+  }
+}


### PR DESCRIPTION
<!--- replace the text in brackets with Monday link for your task -->
## [Monday task](https://seed-company-squad.monday.com/boards/3451697530/views/78801638/pulses/5774743985)

## Description
<!--- Describe the changes in this pull request -->
In this PR we are adding the EdgeDB schema for the `PeriodicReport`. This work is to be able to move forward with the EdgeDB migration and unblock future work that requires `PeriodicReport` or children types.

In this work we started using the `range` type from EdgeDB for the period a `PeriodicReport` is in and the `start` and `end` are computed fields from the `period` field.


## Checklist
- [x] Change the task url above to the actual Monday task
- [x] Add/update tests if needed or N/A
- [x] Add reviewers to this PR
