### PR TITLE
[EdgeDB] Tweak Resource Types

### DIFF
--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -249,9 +249,7 @@ export class EnhancedResource<T extends ResourceShape<any>> {
     return type as any;
   }
 
-  get dbFQN(): ResourceShape<any> extends T
-    ? string
-    : DBType<T>['__element__']['__name__'] {
+  get dbFQN(): ResourceShape<any> extends T ? string : DBName<DBType<T>> {
     return this.db.__element__.__name__ as any;
   }
 
@@ -306,6 +304,8 @@ export type DBType<TResourceStatic extends ResourceShape<any>> =
       ? T
       : never
     : never;
+
+export type DBName<T extends $.TypeSet> = T['__element__']['__name__'];
 
 export type MaybeUnsecuredInstance<TResourceStatic extends ResourceShape<any>> =
   MaybeSecured<InstanceType<TResourceStatic>>;

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -5,7 +5,7 @@ import { DateTime } from 'luxon';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { inspect } from 'util';
 import type { ResourceDBMap, ResourceMap } from '~/core';
-import { $ } from '~/core/edgedb/reexports';
+import { $, e } from '~/core/edgedb/reexports';
 import { ScopedRole } from '../components/authorization';
 import { CalculatedSymbol } from './calculated.decorator';
 import { DataObject } from './data-object';
@@ -297,7 +297,9 @@ export type ResourceName<TResourceStatic extends ResourceShape<any>> =
         string;
 
 export type DBType<TResourceStatic extends ResourceShape<any>> =
-  ResourceName<TResourceStatic> extends keyof ResourceDBMap
+  ResourceShape<any> extends TResourceStatic
+    ? typeof e.Resource // short-circuit non-specific types
+    : ResourceName<TResourceStatic> extends keyof ResourceDBMap
     ? ResourceDBMap[ResourceName<TResourceStatic>] extends infer T extends $.$expr_PathNode
       ? T
       : never

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -249,7 +249,9 @@ export class EnhancedResource<T extends ResourceShape<any>> {
     return type as any;
   }
 
-  get dbFQN(): DBType<T>['__element__']['__name__'] {
+  get dbFQN(): ResourceShape<any> extends T
+    ? string
+    : DBType<T>['__element__']['__name__'] {
     return this.db.__element__.__name__ as any;
   }
 

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -90,7 +90,7 @@ export class ResourcesHost {
       map as Record<string, EnhancedResource<any>>,
       (_, r, { SKIP }) => {
         try {
-          return r.dbFQN as string;
+          return r.dbFQN;
         } catch (e) {
           return SKIP;
         }

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -3,14 +3,15 @@ import { GraphQLSchemaHost } from '@nestjs/graphql';
 import { CachedByArg, mapKeys } from '@seedcompany/common';
 import { isObjectType } from 'graphql';
 import { mapValues } from 'lodash';
-import { LiteralUnion, ValueOf } from 'type-fest';
+import { ConditionalKeys, LiteralUnion, ValueOf } from 'type-fest';
 import {
+  DBName,
   EnhancedResource,
   InvalidIdForTypeException,
   ResourceShape,
   ServerException,
 } from '~/common';
-import { ResourceMap } from './map';
+import { ResourceDBMap, ResourceMap } from './map';
 import { __privateDontUseThis } from './resource-map-holder';
 
 export type EnhancedResourceMap = {
@@ -23,6 +24,10 @@ export type ResourceLike =
   | ResourceShape<any>
   | EnhancedResource<any>
   | LooseResourceName;
+
+type ResourceNameFromDBName<K extends DBName<ValueOf<ResourceDBMap>>> =
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  ConditionalKeys<ResourceDBMap, { __element__: { __name__: K } }>;
 
 @Injectable()
 export class ResourcesHost {
@@ -65,7 +70,14 @@ export class ResourcesHost {
     return this.getByName(name as any);
   }
 
-  getByEdgeDB(name: string): EnhancedResource<ValueOf<ResourceMap>> {
+  getByEdgeDB<K extends keyof ResourceMap>(
+    name: K,
+  ): EnhancedResource<ValueOf<Pick<ResourceMap, K>>>;
+  getByEdgeDB<K extends DBName<ValueOf<ResourceDBMap>>>(
+    name: K,
+  ): EnhancedResource<ValueOf<Pick<ResourceMap, ResourceNameFromDBName<K>>>>;
+  getByEdgeDB(name: string): EnhancedResource<any>;
+  getByEdgeDB(name: string) {
     const fqnMap = this.edgeDBFQNMap();
     const resByFQN = fqnMap.get(
       name.includes('::') ? name : `default::${name}`,

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -61,9 +61,7 @@ export class ResourcesHost {
     return resource;
   }
 
-  getByDynamicName(
-    name: LooseResourceName,
-  ): EnhancedResource<ValueOf<ResourceMap>> {
+  getByDynamicName(name: LooseResourceName): EnhancedResource<any> {
     return this.getByName(name as any);
   }
 


### PR DESCRIPTION
The current goal is to have strict output from strict input, but allow / have useable loose output from loose/dynamic input.

```ts
EnhancedResource.of(User).dbFQN => "default::User"
EnhancedResource.of(<any>).dbFQN => string
EnhancedResource.of(User).db => e.User
EnhancedResource.of(<any>).db => e.Resource

ResourcesHost.getByDynamicName("User") => EnhancedResource<any>
ResourcesHost.getByDynamicName("User").db => e.Resource
ResourcesHost.getByDynamicName("asdf").db => e.Resource & RuntimeError


ResourcesHost.getByEdgeDB("User") => EnhancedResource<User>
ResourcesHost.getByEdgeDB("default::User") => EnhancedResource<User>
ResourcesHost.getByEdgeDB("asdf") => EnhancedResource<any> & RuntimeError
```

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/6030761933) by [Unito](https://www.unito.io)
