### PR TITLE
Add GQL queries for LanguageEngagements

### DIFF
--- a/src/components/engagement/dto/list-engagements.dto.ts
+++ b/src/components/engagement/dto/list-engagements.dto.ts
@@ -42,6 +42,14 @@ export class EngagementListOutput extends PaginatedList<
   itemsDescription: PaginatedList.itemDescriptionFor('engagements'),
 }) {}
 
+@ObjectType()
+export class LanguageEngagementListOutput extends PaginatedList(
+  LanguageEngagement,
+  {
+    itemsDescription: PaginatedList.itemDescriptionFor('language engagements'),
+  },
+) {}
+
 @ObjectType({
   description: SecuredList.descriptionFor('engagements'),
 })


### PR DESCRIPTION
It's annoying to have to add fragments to narrow type when you all you want is language engagements.
It's problematic with codegen expecting certain types that only exist on the concrete.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/6050522434) by [Unito](https://www.unito.io)
