### PR TITLE
Typed IDs v2

### DIFF
--- a/src/common/id-field.test.ts
+++ b/src/common/id-field.test.ts
@@ -1,0 +1,37 @@
+/* eslint-disable @seedcompany/no-unused-vars */
+import { test } from '@jest/globals';
+import type { User } from '../components/user';
+import { ID } from './id-field';
+
+test('only types here', () => undefined);
+
+const NameFromSelf: ID<'User'> = '' as ID<'User'>;
+const NameFromDB: ID<'User'> = '' as ID<'default::User'>;
+const NameFromInstance: ID<'User'> = '' as ID<User>;
+const NameFromStatic: ID<'User'> = '' as ID<typeof User>;
+
+const NameToSelf: ID<'User'> = '' as ID<'User'>;
+const NameToDB: ID<'default::User'> = '' as ID<'User'>;
+const NameToInstance: ID<User> = '' as ID<'User'>;
+const NameToStatic: ID<typeof User> = '' as ID<'User'>;
+
+const NameFromAny: ID<'User'> = '' as ID;
+const NameToAny: ID = '' as ID<'User'>;
+
+const AnyStringWorks: ID<'asdf'> = '' as ID;
+const AnyObjectWorks: ID<Date> = '' as ID;
+
+// @ts-expect-error this should be blocked
+const UserIncompatibleDifferent: ID<'User'> = '' as ID<'Location'>;
+// @ts-expect-error this should be blocked
+const UserIncompatibleDifferent2: ID<'Location'> = '' as ID<'User'>;
+
+const SubclassesAreCompatible: ID<'Engagement'> =
+  '' as ID<'LanguageEngagement'>;
+// @ts-expect-error this should be blocked
+const InterfaceIsNotDirectlyCompatibleWithConcrete: ID<'LanguageEngagement'> =
+  '' as ID<'Engagement'>;
+const ButCanBeTypeCastAsInterfaceOverlapsConcrete =
+  '' as ID<'Engagement'> as ID<'LanguageEngagement'>;
+// @ts-expect-error this should be blocked
+const IndependentTypesCannotBeTypeCast = '' as ID<'Engagement'> as ID<'User'>;

--- a/src/common/id-field.ts
+++ b/src/common/id-field.ts
@@ -1,7 +1,12 @@
 import { applyDecorators } from '@nestjs/common';
 import { Field, FieldOptions, ID as IDType } from '@nestjs/graphql';
 import { ValidationOptions } from 'class-validator';
-import { Opaque } from 'type-fest';
+import { IsAny, IsNever, Tagged } from 'type-fest';
+import type {
+  AllResourceDBNames,
+  ResourceName,
+  ResourceNameLike,
+} from '~/core';
 import { IsId } from './validators';
 
 export const IdField = ({
@@ -13,11 +18,26 @@ export const IdField = ({
     IsId(validation),
   );
 
-export type ID = Opaque<string, 'ID'>;
-
 export const isIdLike = (value: unknown): value is ID =>
   typeof value === 'string';
 
-declare const ref: unique symbol;
-/** An ID for a specific thing */
-export type IdOf<T> = ID & { readonly [ref]: T };
+export type ID<Kind extends IDKindLike = any> = Tagged<string, 'ID'> &
+  IDTo<IDTag<Kind>>;
+
+/** @deprecated Use {@link ID} */
+export type IdOf<Kind extends IDKindLike> = ID<Kind>;
+
+declare const IDTo: unique symbol;
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type IDTo<T> = { readonly [IDTo]: T };
+
+// Normalize resource name if possible, otherwise use input directly
+type IDTag<Kind> = IsAny<Kind> extends true
+  ? any // continue to allow ID<any> to be assignable to any ID
+  : ResourceName<Kind, true> extends infer Normalized
+  ? IsNever<Normalized> extends false
+    ? Normalized
+    : Kind
+  : never;
+
+type IDKindLike = ResourceNameLike | AllResourceDBNames | object;

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -4,7 +4,7 @@ import { LazyGetter as Once } from 'lazy-get-decorator';
 import { DateTime } from 'luxon';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { inspect } from 'util';
-import type { ResourceDBMap, ResourceMap } from '~/core';
+import type { ResourceDBMap, ResourceName } from '~/core';
 import { $, e } from '~/core/edgedb/reexports';
 import { ScopedRole } from '../components/authorization';
 import { CalculatedSymbol } from './calculated.decorator';
@@ -284,23 +284,11 @@ export const isResourceClass = <T>(
 ): cls is ResourceShape<T> =>
   'Props' in cls && Array.isArray(cls.Props) && cls.Props.length > 0;
 
-export type ResourceName<TResourceStatic extends ResourceShape<any>> =
-  ResourceShape<any> extends TResourceStatic
-    ? string // short-circuit non-specific types
-    : {
-        [Name in keyof ResourceMap]: ResourceMap[Name] extends TResourceStatic // Only self or subclasses
-          ? TResourceStatic extends ResourceMap[Name] // Exclude subclasses
-            ? Name
-            : never
-          : never;
-      }[keyof ResourceMap] &
-        string;
-
 export type DBType<TResourceStatic extends ResourceShape<any>> =
   ResourceShape<any> extends TResourceStatic
     ? typeof e.Resource // short-circuit non-specific types
-    : ResourceName<TResourceStatic> extends keyof ResourceDBMap
-    ? ResourceDBMap[ResourceName<TResourceStatic>] extends infer T extends $.$expr_PathNode
+    : ResourceName<TResourceStatic> extends `${infer Name extends keyof ResourceDBMap}`
+    ? ResourceDBMap[Name] extends infer T extends $.$expr_PathNode
       ? T
       : never
     : never;

--- a/src/core/resources/index.ts
+++ b/src/core/resources/index.ts
@@ -2,5 +2,6 @@ export * from './resource-resolver.service';
 export { LoaderFactory } from './loader.registry';
 export * from './resource.loader';
 export * from './resources.host';
+export * from './resource-name.types';
 export * from './resource.decorator';
 export * from './map';

--- a/src/core/resources/resource-name.types.ts
+++ b/src/core/resources/resource-name.types.ts
@@ -1,0 +1,86 @@
+import { ConditionalKeys, IsAny, LiteralUnion, ValueOf } from 'type-fest';
+import { DBName, ResourceShape } from '~/common';
+import { ResourceDBMap, ResourceMap } from './map';
+
+export type AllResourceNames = keyof ResourceMap;
+export type AllResourceDBNames = DBName<ValueOf<ResourceDBMap>>;
+export type ResourceNameLike = LiteralUnion<AllResourceNames, string>;
+
+//region ResourceName
+/**
+ * Given some sort of identifier for a resource type,
+ * return our resource name if known, otherwise never.
+ *
+ * @example User
+ * "User"           -> "User"
+ * "default::User"  -> "User"
+ * typeof User      -> "User"
+ * User             -> "User"
+ *
+ * @example Including subclasses
+ *
+ * ResourceName<"Engagement", true>
+ *   -> "Engagement" | "LanguageEngagement" | "InternshipEngagement"
+ *
+ * @example Edge Cases
+ * any                  -> string
+ * ResourceShape<any>   -> string
+ * "foo"                -> never
+ * Foo                  -> never
+ */
+export type ResourceName<
+  T,
+  IncludeSubclasses extends boolean = false,
+> = IsAny<T> extends true
+  ? string // short-circuit and prevent many seemly random circular definitions
+  : T extends AllResourceDBNames
+  ? ResourceNameFromStatic<
+      ResourceMap[ResourceNameFromDBName<T>],
+      IncludeSubclasses
+    >
+  : T extends AllResourceNames
+  ? ResourceNameFromStatic<ResourceMap[T], IncludeSubclasses>
+  : T extends ResourceShape<any>
+  ? ResourceNameFromStatic<T, IncludeSubclasses>
+  : ResourceNameFromInstance<T> extends string
+  ? ResourceNameFromInstance<T, IncludeSubclasses> & string
+  : never;
+
+type ResourceNameFromInstance<
+  TResource,
+  IncludeSubclasses extends boolean = false,
+> = {
+  [Name in keyof ResourceMap]: ResourceMap[Name]['prototype'] extends TResource // Only self or subclasses
+    ? IncludeSubclasses extends true
+      ? Name
+      : TResource extends ResourceMap[Name]['prototype'] // Exclude subclasses
+      ? Name
+      : never
+    : never;
+}[keyof ResourceMap];
+
+type ResourceNameFromStatic<
+  TResourceStatic extends ResourceShape<any>,
+  IncludeSubclasses extends boolean = false,
+> = ResourceShape<any> extends TResourceStatic
+  ? string // short-circuit non-specific types
+  : {
+      [Name in keyof ResourceMap]: ResourceMap[Name] extends TResourceStatic // Only self or subclasses
+        ? IncludeSubclasses extends true
+          ? Name
+          : TResourceStatic extends ResourceMap[Name] // Exclude subclasses
+          ? Name
+          : never
+        : never;
+    }[keyof ResourceMap];
+
+type ResourceNameFromDBName<Name extends AllResourceDBNames> =
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  ConditionalKeys<ResourceDBMap, { __element__: { __name__: Name } }>;
+//endregion
+
+export type ResourceStaticFromName<Name> = string extends Name
+  ? ResourceShape<any>
+  : Name extends keyof ResourceMap
+  ? ValueOf<Pick<ResourceMap, Name>>
+  : never;

--- a/src/core/resources/resource.loader.ts
+++ b/src/core/resources/resource.loader.ts
@@ -18,7 +18,7 @@ type SomeResourceType = ValueOf<ResourceMap>;
  */
 export interface PolymorphicLinkTo<Key extends keyof ResourceMap> {
   __typename: Key;
-  id: ID;
+  id: ID<Key>;
 }
 
 /**
@@ -30,7 +30,7 @@ export type LinkToUnknown = PolymorphicLinkTo<keyof ResourceMap>;
  * A reference to a resource with a static / known type.
  */
 export interface LinkTo<Key extends keyof ResourceMap> {
-  id: ID;
+  id: ID<Key>;
   // Here for DX, and maybe type checking.
   // Won't be used at runtime.
   __typename?: Key;

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -3,31 +3,30 @@ import { GraphQLSchemaHost } from '@nestjs/graphql';
 import { CachedByArg, mapKeys } from '@seedcompany/common';
 import { isObjectType } from 'graphql';
 import { mapValues } from 'lodash';
-import { ConditionalKeys, LiteralUnion, ValueOf } from 'type-fest';
+import { ValueOf } from 'type-fest';
 import {
-  DBName,
   EnhancedResource,
   InvalidIdForTypeException,
   ResourceShape,
   ServerException,
 } from '~/common';
-import { ResourceDBMap, ResourceMap } from './map';
+import { ResourceMap } from './map';
 import { __privateDontUseThis } from './resource-map-holder';
+import {
+  AllResourceDBNames,
+  ResourceName,
+  ResourceNameLike,
+  ResourceStaticFromName,
+} from './resource-name.types';
 
 export type EnhancedResourceMap = {
   [K in keyof ResourceMap]: EnhancedResource<ResourceMap[K]>;
 };
 
-type LooseResourceName = LiteralUnion<keyof ResourceMap, string>;
-
 export type ResourceLike =
   | ResourceShape<any>
   | EnhancedResource<any>
-  | LooseResourceName;
-
-type ResourceNameFromDBName<K extends DBName<ValueOf<ResourceDBMap>>> =
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  ConditionalKeys<ResourceDBMap, { __element__: { __name__: K } }>;
+  | ResourceNameLike;
 
 @Injectable()
 export class ResourcesHost {
@@ -66,18 +65,13 @@ export class ResourcesHost {
     return resource;
   }
 
-  getByDynamicName(name: LooseResourceName): EnhancedResource<any> {
+  getByDynamicName(name: ResourceNameLike): EnhancedResource<any> {
     return this.getByName(name as any);
   }
 
-  getByEdgeDB<K extends keyof ResourceMap>(
-    name: K,
-  ): EnhancedResource<ValueOf<Pick<ResourceMap, K>>>;
-  getByEdgeDB<K extends DBName<ValueOf<ResourceDBMap>>>(
-    name: K,
-  ): EnhancedResource<ValueOf<Pick<ResourceMap, ResourceNameFromDBName<K>>>>;
-  getByEdgeDB(name: string): EnhancedResource<any>;
-  getByEdgeDB(name: string) {
+  getByEdgeDB<Name extends ResourceNameLike | AllResourceDBNames>(
+    name: Name,
+  ): EnhancedResource<ResourceStaticFromName<ResourceName<Name>>> {
     const fqnMap = this.edgeDBFQNMap();
     const resByFQN = fqnMap.get(
       name.includes('::') ? name : `default::${name}`,


### PR DESCRIPTION
`IdOf` seems to be working well, and helps with DX. This standardizes it and improves the functionality.

- Type generic can now be given to `ID`
- Deprecated `IdOf` for `ID`
- Types/Kinds can be:
  - Resource names: `ID<'User'>`. These are easy to use without needing imports.
  - EdgeDB FQNs: `ID<'default::User'>`. These will allow DB QB types to be compatible.
  - Class "instances": `ID<User>`. These are a little nicer than strings, if already imported. And needed because that's what `IdOf` used.
  - Static class references: `ID<typeof User>`. Here for completeness, but idk the use case.
- These are normalized, so they are compatible with each other
  ```ts
  ID<'User'> == ID<'default::User'> == ID<User> == ID<typeof User>
  ```
- Concrete types are compatible with interface types 😎 
  ```ts
  const existing: ID<LanguageEngagement>;
  const id: ID<Engagement> = existing;
  ```

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/6131937445) by [Unito](https://www.unito.io)
