### PR TITLE
[EdgeDB] nanoid scalar to generate types as ID

### DIFF
--- a/dbschema/common.esdl
+++ b/dbschema/common.esdl
@@ -17,6 +17,8 @@ module default {
     )
   );
   
+  scalar type nanoid extending str;
+  
   scalar type RichText extending json;
   
   # A fake function to produce valid EdgeQL syntax.

--- a/dbschema/migrations/00057.edgeql
+++ b/dbschema/migrations/00057.edgeql
@@ -1,0 +1,10 @@
+CREATE MIGRATION m157gy3t5mh6e3rdvucz3kyjnyvqcztjujwg6tidwsgiopximyrcja
+    ONTO m1fxvebe36c36flhjxywklrqqquert6b7dj5j4biwl6gxaqpddz5ra
+{
+  CREATE SCALAR TYPE default::nanoid EXTENDING std::str;
+  ALTER TYPE Prompt::PromptVariantResponse {
+      ALTER PROPERTY promptId {
+          SET TYPE default::nanoid;
+      };
+  };
+};

--- a/dbschema/prompt-variant-response.esdl
+++ b/dbschema/prompt-variant-response.esdl
@@ -2,7 +2,7 @@ module Prompt {
   abstract type PromptVariantResponse extending Mixin::Embedded, Mixin::Timestamped, Mixin::Owned {
     annotation description := "An instance of a prompt and the responses per variant.";
 
-    promptId: str;
+    promptId: default::nanoid;
     responses := .<pvr[is VariantResponse];
   }
 

--- a/src/core/edgedb/codecs/index.ts
+++ b/src/core/edgedb/codecs/index.ts
@@ -1,3 +1,4 @@
+import { NanoIDCodec } from './nanoid.codec';
 import { RichTextCodec } from './rich-text.codec';
 import { LuxonCalendarDateCodec, LuxonDateTimeCodec } from './temporal.codec';
 import { ScalarCodecClass } from './type.util';
@@ -8,6 +9,7 @@ export type { ScalarInfo } from './type.util';
 
 export const codecs: readonly ScalarCodecClass[] = [
   OurUUIDCodec,
+  NanoIDCodec,
   LuxonDateTimeCodec,
   LuxonCalendarDateCodec,
   RichTextCodec,

--- a/src/core/edgedb/codecs/nanoid.codec.ts
+++ b/src/core/edgedb/codecs/nanoid.codec.ts
@@ -1,0 +1,13 @@
+import { StrCodec } from 'edgedb/dist/codecs/text.js';
+import { ScalarInfo } from './type.util';
+
+export class NanoIDCodec extends StrCodec {
+  static info: ScalarInfo = {
+    module: 'default',
+    type: 'nanoid',
+    ts: 'ID',
+    path: '~/common',
+  };
+  tsType = 'ID';
+  importedType = true;
+}

--- a/src/core/edgedb/generator/query-builder.ts
+++ b/src/core/edgedb/generator/query-builder.ts
@@ -1,6 +1,7 @@
 import { generateQueryBuilder as runQueryBuilderGenerator } from '@edgedb/generate/dist/edgeql-js.js';
 import { groupBy } from '@seedcompany/common';
 import { Directory } from 'ts-morph';
+import { codecs } from '../codecs';
 import { customScalars } from './scalars';
 import { addCustomScalarImports, GeneratorParams } from './util';
 
@@ -42,7 +43,10 @@ function addJsExtensionDeepPathsOfEdgedbLibrary(qbDir: Directory) {
 }
 
 function fixCustomScalarsImports(qbDir: Directory) {
-  for (const scalars of groupBy(customScalars.values(), (s) => s.module)) {
+  for (const scalars of groupBy(
+    codecs.map((c) => c.info),
+    (s) => s.module,
+  )) {
     const moduleFile = qbDir.addSourceFileAtPath(
       `modules/${scalars[0]!.module}.ts`,
     );


### PR DESCRIPTION
This correctly generates types like
```ts
class PromptVariantResponse {
  promptId: ID;
  ...
}
```
This is more accurate than `string`.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/6148790225) by [Unito](https://www.unito.io)
