### PR TITLE
Fix our edgedb date_range_get_upper()

### DIFF
--- a/dbschema/common.esdl
+++ b/dbschema/common.esdl
@@ -28,15 +28,5 @@ module default {
   
   # Get the inclusive upper bound of the given date range.
   function date_range_get_upper(period: range<cal::local_date>) -> cal::local_date
-    using ((
-      with
-        e := assert_exists(range_get_upper(period))
-        # https://github.com/edgedb/edgedb/issues/6786
-        # e - <cal::date_duration>"1 day"
-        select cal::to_local_date(
-          <int64>cal::date_get(e, 'year'),
-          <int64>cal::date_get(e, 'month'),
-          <int64>cal::date_get(e, 'day') - 1,
-        )
-    ));
+    using (<cal::local_date><str>assert_exists(range_get_upper(period)) - <cal::date_duration>"1 day");
 }

--- a/dbschema/migrations/00058.edgeql
+++ b/dbschema/migrations/00058.edgeql
@@ -1,0 +1,5 @@
+CREATE MIGRATION m1p2k7nnmg7o3qxxzywndo2r4zjwq2bfzi6lqakzhmzvyakc46o6uq
+    ONTO m157gy3t5mh6e3rdvucz3kyjnyvqcztjujwg6tidwsgiopximyrcja
+{
+  ALTER FUNCTION default::date_range_get_upper(period: range<cal::local_date>) USING ((<cal::local_date><std::str>std::assert_exists(std::range_get_upper(period)) - <cal::date_duration>'1 day'));
+};


### PR DESCRIPTION
The previous logic would not step back a month/year 2024-01-01 would yield 2024-01-00 which is obv invalid.

I discovered a better workaround by casting value to str first then back to local_date, which allows the duration math to work.