### PR TITLE
[EdgeDB] Default Repo create/update handle link IDs

### DIFF
--- a/src/components/field-region/field-region.edgedb.repository.ts
+++ b/src/components/field-region/field-region.edgedb.repository.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { PublicOf } from '../../common';
-import { ChangesOf } from '../../core/database/changes';
-import { e, RepoFor } from '../../core/edgedb';
-import { CreateFieldRegion, FieldRegion, UpdateFieldRegion } from './dto';
+import { PublicOf } from '~/common';
+import { RepoFor } from '~/core/edgedb';
+import { FieldRegion } from './dto';
 import { FieldRegionRepository } from './field-region.repository';
 
 @Injectable()
@@ -13,40 +12,5 @@ export class FieldRegionEdgeDBRepository
       director: true,
       fieldZone: true,
     }),
-  }).customize((cls) => {
-    return class extends cls {
-      async create(input: CreateFieldRegion) {
-        const created = e.insert(e.FieldRegion, {
-          name: input.name,
-          director: e.cast(e.User, e.cast(e.uuid, input.directorId)),
-          fieldZone: e.cast(e.FieldZone, e.cast(e.uuid, input.fieldZoneId)),
-        });
-        const query = e.select(created, this.hydrate);
-        return await this.db.run(query);
-      }
-
-      async update(
-        { id }: Pick<FieldRegion, 'id'>,
-        changes: ChangesOf<FieldRegion, UpdateFieldRegion>,
-      ) {
-        const region = e.cast(e.FieldRegion, e.cast(e.uuid, id));
-        const updated = e.update(region, () => ({
-          set: {
-            ...(changes.name && { name: changes.name }),
-            ...(changes.directorId && {
-              director: e.cast(e.User, e.cast(e.uuid, changes.directorId)),
-            }),
-            ...(changes.fieldZoneId && {
-              fieldZone: e.cast(
-                e.FieldZone,
-                e.cast(e.uuid, changes.fieldZoneId),
-              ),
-            }),
-          },
-        }));
-        const query = e.select(updated, this.hydrate);
-        return await this.db.run(query);
-      }
-    };
-  })
+  }).withDefaults()
   implements PublicOf<FieldRegionRepository> {}

--- a/src/components/field-zone/field-zone.edgedb.repository.ts
+++ b/src/components/field-zone/field-zone.edgedb.repository.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PublicOf } from '~/common';
-import { ChangesOf } from '~/core/database/changes';
-import { e, RepoFor } from '~/core/edgedb';
-import { CreateFieldZone, FieldZone, UpdateFieldZone } from './dto';
+import { RepoFor } from '~/core/edgedb';
+import { FieldZone } from './dto';
 import { FieldZoneRepository } from './field-zone.repository';
 
 @Injectable()
@@ -12,33 +11,5 @@ export class FieldZoneEdgeDBRepository
       ...zone['*'],
       director: true,
     }),
-  }).customize((cls) => {
-    return class extends cls {
-      async create(input: CreateFieldZone) {
-        const created = e.insert(e.FieldZone, {
-          name: input.name,
-          director: e.cast(e.User, e.cast(e.uuid, input.directorId)),
-        });
-        const query = e.select(created, this.hydrate);
-        return await this.db.run(query);
-      }
-
-      async update(
-        { id }: Pick<FieldZone, 'id'>,
-        changes: ChangesOf<FieldZone, UpdateFieldZone>,
-      ) {
-        const zone = e.cast(e.FieldZone, e.cast(e.uuid, id));
-        const updated = e.update(zone, () => ({
-          set: {
-            ...(changes.name && { name: changes.name }),
-            ...(changes.directorId && {
-              director: e.cast(e.User, e.cast(e.uuid, changes.directorId)),
-            }),
-          },
-        }));
-        const query = e.select(updated, this.hydrate);
-        return await this.db.run(query);
-      }
-    };
-  })
+  }).withDefaults()
   implements PublicOf<FieldZoneRepository> {}

--- a/src/core/edgedb/query-util/easy-insert.ts
+++ b/src/core/edgedb/query-util/easy-insert.ts
@@ -1,0 +1,103 @@
+import { Cardinality } from 'edgedb/dist/reflection';
+import {
+  ConditionalPick,
+  MergeExclusive,
+  RequireExactlyOne,
+  StringKeyOf,
+} from 'type-fest';
+import { ID } from '~/common';
+import { AllResourceDBNames } from '~/core';
+import {
+  pointerToAssignmentExpression,
+  setToAssignmentExpression,
+} from '../generated-client/casting';
+import { pointerIsOptional } from '../generated-client/insert';
+import { $ } from '../reexports';
+
+export type EasyInsertShape<El extends $.ObjectType> = $.typeutil.flatten<
+  RawInsertShape<El>
+>;
+
+type RawInsertShape<El extends $.ObjectType> =
+  // short-circuit infinitely deep
+  $.ObjectType extends El
+    ? never
+    : $.typeutil.stripNever<
+        $.stripNonInsertables<$.stripBacklinks<El['__pointers__']>>
+      > extends infer Shape
+    ? Shape extends $.ObjectTypePointers
+      ? $.typeutil.addQuestionMarks<
+          InsertPointerValues<ConditionalPick<Shape, $.PropertyDesc>>
+        > &
+          AddIdSuffixOptionForInsert<
+            $.typeutil.addQuestionMarks<
+              InsertPointerValues<ConditionalPick<Shape, $.LinkDesc>>
+            >
+          >
+      : never
+    : never;
+
+export type EasyUpdateShape<Root extends $.ObjectTypeSet> =
+  $.typeutil.stripNever<
+    $.stripNonUpdateables<$.stripBacklinks<Root['__element__']['__pointers__']>>
+  > extends infer Shape
+    ? Shape extends $.ObjectTypePointers
+      ? UpdatePointerValues<ConditionalPick<Shape, $.PropertyDesc>> &
+          AddIdSuffixOptionForUpdate<
+            UpdatePointerValues<ConditionalPick<Shape, $.LinkDesc>>
+          >
+      : never
+    : never;
+
+type InsertPointerValues<Shape extends $.ObjectTypePointers> = {
+  [k in keyof Shape]:
+    | pointerToAssignmentExpression<Shape[k]>
+    | AddIDsForLinks<Shape[k]>
+    | AddNullability<Shape[k]>
+    | (Shape[k]['hasDefault'] extends true ? undefined : never);
+};
+
+type UpdatePointerValues<Shape extends $.ObjectTypePointers> = {
+  [k in keyof Shape]?:
+    | pointerToAssignmentExpression<Shape[k]>
+    | AddModifyMultiSet<Shape[k]>
+    | AddIDsForLinks<Shape[k]>
+    | AddNullability<Shape[k]>;
+};
+
+type AddIdSuffixOptionForInsert<Links extends Record<string, any>> = {
+  [K in StringKeyOf<Links>]: MergeExclusive<
+    $.typeutil.addQuestionMarks<Record<`${K}Id`, Links[K]>>,
+    $.typeutil.addQuestionMarks<Record<K, Links[K]>>
+  >;
+}[StringKeyOf<Links>];
+
+type AddIdSuffixOptionForUpdate<Links extends Record<string, any>> = {
+  // cannot figure out how to get exclusive keys here to work.
+  [K in StringKeyOf<Links>]: Partial<Record<K | `${K}Id`, Links[K]>>;
+}[StringKeyOf<Links>];
+
+type AddModifyMultiSet<Pointer extends $.LinkDesc | $.PropertyDesc> =
+  Pointer['cardinality'] extends Cardinality.Many | Cardinality.AtLeastOne
+    ? RequireExactlyOne<
+        Record<'+=' | '-=', pointerToAssignmentExpression<Pointer, true>>
+      >
+    : never;
+
+type AddNullability<Pointer extends $.LinkDesc | $.PropertyDesc> =
+  pointerIsOptional<Pointer> extends true ? undefined | null : never;
+
+type AddIDsForLinks<Pointer extends $.LinkDesc | $.PropertyDesc> =
+  Pointer extends $.LinkDesc<infer TargetType, infer Cardinality>
+    ? AsIDs<
+        TargetType['__name__'] extends AllResourceDBNames
+          ? ID<TargetType['__name__']>
+          : ID,
+        Cardinality
+      >
+    : never;
+
+type AsIDs<IDType, Card extends $.Cardinality> = setToAssignmentExpression<
+  $.TypeSet<$.ScalarType<string, IDType>, Card>,
+  false
+>;

--- a/src/core/edgedb/query-util/map-to-set-block.ts
+++ b/src/core/edgedb/query-util/map-to-set-block.ts
@@ -1,0 +1,47 @@
+import { many, mapEntries } from '@seedcompany/common';
+import { ID, ServerException } from '~/common';
+import { $, e } from '../reexports';
+
+export const mapToSetBlock = (
+  type: $.$expr_PathNode,
+  changes: Record<string, any>,
+) => {
+  const el = type.__element__;
+  const pointers = el.__pointers__;
+
+  return mapEntries(changes, ([key, value], { SKIP }) => {
+    // If some kind of EdgeQL expression, use as-is
+    if (
+      typeof value === 'object' &&
+      ('toEdgeQL' in value || '+=' in value || '-=' in value)
+    ) {
+      return [key, value];
+    }
+
+    // strip our xId suffix
+    const pointerKey =
+      !(key in pointers) && key.endsWith('Id') && key.slice(0, -2) in pointers
+        ? (key.slice(0, -2) as keyof typeof pointers)
+        : (key as keyof typeof pointers);
+
+    const pointer = pointers[pointerKey];
+    if (!pointer || pointer.readonly || pointer.computed) {
+      throw new ServerException(`Cannot update ${el.__name__}.${pointerKey}`);
+    }
+    if (value === undefined) {
+      return SKIP;
+    }
+
+    const eqlValue =
+      value === null
+        ? null
+        : pointer.__kind__ === 'property'
+        ? value
+        : e.cast(
+            pointer.target,
+            e.set(...many(value).map((v) => e.uuid(v as ID))),
+          );
+
+    return [pointerKey, eqlValue];
+  }).asRecord;
+};


### PR DESCRIPTION
The queries built will now automatically cast IDs for links to their object refs.
The methods will also accept props with an `Id` suffix and strip it off.

This should help make a lot of our queries involving links easier, as demonstrated by FieldZone & FieldRegion repos.

```diff
  create({
    name: input.name,
-   director: e.cast(e.User, e.cast(e.uuid, input.directorId)),
+   directorId: input.directorId,
  })
```
This is only a shortcut: EdgeQL expressions can still be given, and IDs can be given to `director` (no `Id` suffix).

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/6155607311) by [Unito](https://www.unito.io)
