### PR TITLE
Fix big ChangesOf regression involving DefinedFiles

### DIFF
--- a/src/components/engagement/dto/update-engagement.dto.ts
+++ b/src/components/engagement/dto/update-engagement.dto.ts
@@ -25,16 +25,16 @@ export abstract class UpdateEngagement {
   readonly id: ID;
 
   @DateField({ nullable: true })
-  readonly completeDate?: CalendarDate;
+  readonly completeDate?: CalendarDate | null;
 
   @DateField({ nullable: true })
-  readonly disbursementCompleteDate?: CalendarDate;
+  readonly disbursementCompleteDate?: CalendarDate | null;
 
   @DateField({ nullable: true })
-  readonly startDateOverride?: CalendarDate;
+  readonly startDateOverride?: CalendarDate | null;
 
   @DateField({ nullable: true })
-  readonly endDateOverride?: CalendarDate;
+  readonly endDateOverride?: CalendarDate | null;
 
   readonly initialEndDate?: CalendarDate | null;
 
@@ -87,7 +87,7 @@ export abstract class UpdateInternshipEngagement extends UpdateEngagement {
   readonly countryOfOriginId?: ID | null;
 
   @Field(() => InternshipPosition, { nullable: true })
-  readonly position?: InternshipPosition;
+  readonly position?: InternshipPosition | null;
 
   @Field(() => [ProductMethodology], { nullable: true })
   readonly methodologies?: readonly ProductMethodology[];

--- a/src/components/file/resolve-defined-file.ts
+++ b/src/components/file/resolve-defined-file.ts
@@ -12,7 +12,7 @@ import { FileNodeLoader } from './file-node.loader';
 
 export async function resolveDefinedFile(
   loader: LoaderOf<FileNodeLoader>,
-  input: Secured<FileId | LinkTo<'File'>>,
+  input: Secured<FileId | LinkTo<'File'> | null>,
 ): Promise<SecuredFile> {
   return await mapSecuredValue(input, async (file) => {
     const fileId = isIdLike(file) ? file : file.id;

--- a/src/components/project/dto/update-project.dto.ts
+++ b/src/components/project/dto/update-project.dto.ts
@@ -80,7 +80,7 @@ export abstract class UpdateProject {
   readonly financialReportReceivedAt?: DateTime;
 
   @Field(() => ReportPeriod, { nullable: true })
-  readonly financialReportPeriod?: ReportPeriod;
+  readonly financialReportPeriod?: ReportPeriod | null;
 
   @Field({ nullable: true })
   readonly presetInventory?: boolean;

--- a/src/core/database/changes.ts
+++ b/src/core/database/changes.ts
@@ -67,7 +67,7 @@ type ChangeOf<Val> = Val extends SetChangeType<any, infer Override>
   ? Override
   :
       | RawChangeOf<UnwrapSecured<Val> & {}>
-      | (UnwrapSecured<Val> extends null ? null : unknown);
+      | (null extends UnwrapSecured<Val> ? null : never);
 
 type RawChangeOf<Val> = Val extends FileId | LinkTo<'File'>
   ? CreateDefinedFileVersionInput

--- a/src/core/database/changes.ts
+++ b/src/core/database/changes.ts
@@ -1,7 +1,7 @@
 import { entries } from '@seedcompany/common';
 import { difference, omit, pickBy } from 'lodash';
 import { DateTime } from 'luxon';
-import { ConditionalKeys } from 'type-fest';
+import { ConditionalKeys, IsAny } from 'type-fest';
 import { LinkTo } from '~/core';
 import {
   EnhancedResource,
@@ -13,7 +13,7 @@ import {
   unwrapSecured,
   UnwrapSecured,
 } from '../../common';
-import { CreateDefinedFileVersionInput, FileId } from '../../components/file';
+import { CreateDefinedFileVersionInput } from '../../components/file';
 import { Variable } from './query';
 import { NativeDbValue } from './results';
 
@@ -57,11 +57,13 @@ type ChangeKey<Key extends keyof T & string, T> = T[Key] extends SetChangeType<
   ? Override extends string
     ? Override
     : never
-  : UnwrapSecured<T[Key]> extends FileId | LinkTo<'File'>
-  ? Key
-  : NonNullable<UnwrapSecured<T[Key]>> extends ID | LinkTo<any>
-  ? `${Key}Id` // our convention for single relationships
-  : Key;
+  : UnwrapSecured<T[Key]> & {} extends infer Value
+  ? IsFileField<Value> extends true
+    ? Key // our file input fields don't add id suffix, because they are objects.
+    : Value extends ID | LinkTo<any>
+    ? `${Key}Id` // our convention for single relationships
+    : Key
+  : never;
 
 type ChangeOf<Val> = Val extends SetChangeType<any, infer Override>
   ? Override
@@ -69,11 +71,21 @@ type ChangeOf<Val> = Val extends SetChangeType<any, infer Override>
       | RawChangeOf<UnwrapSecured<Val> & {}>
       | (null extends UnwrapSecured<Val> ? null : never);
 
-type RawChangeOf<Val> = Val extends FileId | LinkTo<'File'>
+type RawChangeOf<Val> = IsFileField<Val> extends true
   ? CreateDefinedFileVersionInput
   : Val extends LinkTo<any>
   ? ID
   : Val;
+
+type IsFileField<Val> = Val extends LinkTo<'File'>
+  ? true
+  : Val extends ID<infer IDType>
+  ? IsAny<IDType> extends true
+    ? false // ID == ID<any> != ID<'File'>
+    : IDType extends 'File'
+    ? true
+    : false
+  : false;
 
 /**
  * Only props of T that can be written directly to DB


### PR DESCRIPTION
`FileId` used to have a unique brand that TS could discriminate on.
I removed this in https://github.com/SeedCompany/cord-api-v3/commit/a50ae3c19a37034570b1e4212d801f0f74cb6790 to be forward compatible with the `LinkTo<File>` approach.
So that removal broke this code.
Fixed this by not considering `ID<any>` to be a File ID (`ID<File>`) (for this change mapping).

Unfortunately that break mentioned above was immediately hidden by my next commit https://github.com/SeedCompany/cord-api-v3/commit/2b9f01e034d60e8ec501bbe61d07e0fb0a9ef8eb which was also bugged.
I mixed up the "do nothing" union type with the intersection one.
For reference
```
X | unknown == unknown
X | never   == X
X & unknown == X
X & never   == never
```
So fixed that too.

Fixed some more places where nulls are expected.

┆Issue is synchronized with this [Monday item](https://seed-company-squad.monday.com/boards/3451697530/pulses/6172675544) by [Unito](https://www.unito.io)
