### PR TITLE
[EdgeDB] Tweak StepProgress context

### DIFF
--- a/dbschema/migrations/00069.edgeql
+++ b/dbschema/migrations/00069.edgeql
@@ -1,0 +1,17 @@
+CREATE MIGRATION m1uqme6noxofu7imqwvszj4ljpybefs7jgamutiv35ttbes5nwd3oq
+    ONTO m1dtvcrlfunyjcbw3b7ojqencgpo3cs77jzgkwdjvgkg2gxa7frz4q
+{
+  ALTER TYPE ProgressReport::ProductProgress::Step {
+      CREATE LINK projectContext: Project::Context {
+          SET REQUIRED USING (<Project::Context>{});
+      };
+      EXTENDING Project::ContextAware LAST;
+  };
+  ALTER TYPE ProgressReport::ProductProgress::Step {
+      ALTER LINK projectContext {
+          RESET OPTIONALITY;
+          DROP OWNED;
+          RESET TYPE;
+      };
+  };
+};

--- a/dbschema/product-progress.esdl
+++ b/dbschema/product-progress.esdl
@@ -1,5 +1,5 @@
 module ProgressReport::ProductProgress {
-  type Step extending Mixin::Timestamped {
+  type Step extending Mixin::Timestamped, Project::ContextAware {
     required report: default::ProgressReport;
     required product: default::Product;
     required variant: Variant;

--- a/src/components/product-progress/dto/product-progress.dto.ts
+++ b/src/components/product-progress/dto/product-progress.dto.ts
@@ -94,7 +94,9 @@ export type UnsecuredProductProgress = Merge<
 export class StepProgress {
   static readonly Props = keysOf<StepProgress>();
   static readonly SecuredProps = keysOf<SecuredProps<StepProgress>>();
-  static readonly Parent = 'dynamic'; // [Product, ProgressReport]
+  static readonly Parent = import('../../progress-report/dto').then(
+    (m) => m.ProgressReport, // technically ProgressReport & Product
+  );
   static readonly Variants = ProgressReportVariantProgress.Variants;
   static readonly ConfirmThisClassPassesSensitivityToPolicies = true;
 


### PR DESCRIPTION
`StepProgress` needs to be aware of `ProjectContext` for policy conditions.
It's not currently a `Resource` though. So I'm extending directly from `ContextAware`, instead of a `ProgressReport::Child`.

Switch `StepProgress.Parent` from `'dynamic'` to static `ProgressReport`.
This will keep it from being treated as "Embedded", which it is not.