### PR TITLE
Some small tweaks extracted from large AP work

### DIFF
--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -241,6 +241,9 @@ export class EnhancedResource<T extends ResourceShape<any>> {
     return new Set(props);
   }
 
+  get hasDB() {
+    return !!EnhancedResource.dbTypes.get(this.type);
+  }
   get db(): DBType<T> {
     const type = EnhancedResource.dbTypes.get(this.type);
     if (!type) {

--- a/src/core/edgedb/edgedb.service.ts
+++ b/src/core/edgedb/edgedb.service.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/unified-signatures */
 import { Injectable } from '@nestjs/common';
 import { $, Executor } from 'edgedb';
+import { QueryArgs } from 'edgedb/dist/ifaces';
 import { retry, RetryOptions } from '~/common/retry';
 import { TypedEdgeQL } from './edgeql';
 import { ExclusivityViolationError } from './exclusivity-violation.error';
@@ -57,6 +58,9 @@ export class EdgeDB {
     },
     args: Args,
   ): Promise<R>;
+
+  /** Run raw EdgeQL without types */
+  run(query: string, args?: QueryArgs): Promise<unknown>;
 
   async run(query: any, args?: any) {
     try {

--- a/src/core/resources/resource-name.types.ts
+++ b/src/core/resources/resource-name.types.ts
@@ -32,7 +32,7 @@ export type ResourceName<
   T,
   IncludeSubclasses extends boolean = false,
 > = IsAny<T> extends true
-  ? string // short-circuit and prevent many seemly random circular definitions
+  ? AllResourceNames // short-circuit and prevent many seemly random circular definitions
   : T extends AllResourceDBNames
   ? ResourceNameFromStatic<
       ResourceMap[ResourceNameFromDBName<T>],

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -71,7 +71,11 @@ export class ResourcesHost {
 
   getByEdgeDB<Name extends ResourceNameLike | AllResourceDBNames>(
     name: Name,
-  ): EnhancedResource<ResourceStaticFromName<ResourceName<Name>>> {
+  ): EnhancedResource<
+    string extends Name
+      ? ResourceShape<any>
+      : ResourceStaticFromName<ResourceName<Name>>
+  > {
     const fqnMap = this.edgeDBFQNMap();
     const resByFQN = fqnMap.get(
       name.includes('::') ? name : `default::${name}`,


### PR DESCRIPTION
- [Allow running raw EdgeQL query strings without return types](https://github.com/SeedCompany/cord-api-v3/commit/2cf492f84bb1463b63e42ec0764b6fe1cae327f5)
  There's no reason to make this a type error. It's just the return type that is unknown.
  REPL uses this signature.
- [Change `ResourceName<any>` to `AllResourceNames` instead of `string`](https://github.com/SeedCompany/cord-api-v3/commit/ff2e71be6279ae2bda1df815362e9a727ab82e31)
  No reason to use _any_ string, which we know it's a union of all of our literal strings.
  ```ts
  const resource = ResourcesHost.getByDynamicName('...');
  resource.name === 'User' | 'Project' | ...
  resource.name === 'asdf' // TS error
  ```
- [Expose resources keyed by DB FQNs](https://github.com/SeedCompany/cord-api-v3/commit/110d32c1b545fabba8162181c2a429103720c7ac)
  Exposing the raw map for usages which would rather check nullability instead of having an error thrown. Also doesn't provide the extra checks that `getByEdgeDB`.
  ```ts
  ResourcesHost.getByEdgeDB('asdf') // error thrown
  ResourcesHost.byEdgeFQN.get('asdf') // null
  ResourcesHost.getByEdgeDB('User') // User
  ResourcesHost.byEdgeFQN.get('User') // null
  ResourcesHost.byEdgeFQN.get('default::User') // User
  ```