### PR TITLE
Fix `delete Object` usage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # Represent TS generated files as generated
 *.generated.tsx linguist-generated
 *.generated.ts linguist-generated
+dbschema/migrations/*.edgeql linguist-generated

--- a/dbschema/ceremony.esdl
+++ b/dbschema/ceremony.esdl
@@ -7,12 +7,6 @@ module Engagement {
     actualDate: cal::local_date;
     
     constraint exclusive on (.engagement);
-    trigger prohibitDelete after delete for each do (
-      assert(
-        not exists (__old__.engagement),
-        message := "Cannot delete ceremony while engagement still exists."
-      )
-    );
   }
   type DedicationCeremony extending Ceremony {}
   type CertificationCeremony extending Ceremony {}

--- a/dbschema/language.esdl
+++ b/dbschema/language.esdl
@@ -82,6 +82,7 @@ module default {
     );
     overloaded link projectContext: Project::Context {
       default := (insert Project::Context);
+      on source delete delete target;
     }
     
     index on ((.name, .ownSensitivity, .leastOfThese, .isSignLanguage, .isDialect));

--- a/dbschema/migrations/00071.edgeql
+++ b/dbschema/migrations/00071.edgeql
@@ -1,0 +1,39 @@
+CREATE MIGRATION m1gb5s7btpy76oedup56hbchk5exrtz6x74bs6hhzfkzkc5htinl4q
+    ONTO m1dxwenx3me4w6ho2egcvovzzyqpcbibk4y2iro7ybed3i3v5utcyq
+{
+  ALTER TYPE Engagement::Ceremony {
+      DROP TRIGGER prohibitDelete;
+  };
+  ALTER TYPE Scripture::Collection {
+      ALTER LINK verses {
+          ON TARGET DELETE DEFERRED RESTRICT;
+      };
+  };
+  ALTER TYPE default::Project {
+      ALTER LINK projectContext {
+          ON SOURCE DELETE DELETE TARGET;
+      };
+      DROP TRIGGER enforceContext;
+  };
+  ALTER TYPE default::Language {
+      ALTER LINK projectContext {
+          ON SOURCE DELETE DELETE TARGET;
+      };
+  };
+  ALTER TYPE default::Organization {
+      ALTER LINK projectContext {
+          SET default := (INSERT
+              Project::Context
+          );
+          ON SOURCE DELETE DELETE TARGET;
+          SET OWNED;
+          SET TYPE Project::Context;
+      };
+  };
+  ALTER TYPE default::Partner {
+      ALTER LINK organization {
+          ON SOURCE DELETE DELETE TARGET;
+          ON TARGET DELETE DELETE SOURCE;
+      };
+  };
+};

--- a/dbschema/organization.esdl
+++ b/dbschema/organization.esdl
@@ -8,6 +8,11 @@ module default {
     #address: str; #TODO - this needs figured out - needed on here and Partner?
     multi types: Organization::Type;
     multi reach: Organization::Reach;
+
+    overloaded link projectContext: Project::Context {
+      default := (insert Project::Context);
+      on source delete delete target;
+    }
   }
 }
   

--- a/dbschema/partner.esdl
+++ b/dbschema/partner.esdl
@@ -25,6 +25,8 @@ module default {
     required organization: Organization {
       readonly := true;
       constraint exclusive;
+      on source delete delete target;
+      on target delete delete source;
     };
     multi languagesOfConsulting: Language;
     multi fieldRegions: FieldRegion;

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -97,14 +97,6 @@ module default {
         # projects := {__subject__},
       });
     }
-    # Setting the new project as its own context should be the immediate next thing that happens
-    # So enforce that that happens (as best we can), and assert that the context is ever only itself.
-    trigger enforceContext after update for each do (
-      assert(
-        __new__ in __new__.projectContext.projects and count(__new__.projectContext.projects) = 1,
-        message := "A Project's own context should be itself (no more or less)"
-      )
-    );
     
     trigger createBudgetOnInsert after insert for each do (
       insert default::Budget {

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -96,6 +96,7 @@ module default {
         # https://github.com/edgedb/edgedb/issues/3960
         # projects := {__subject__},
       });
+      on source delete delete target;
     }
     
     trigger createBudgetOnInsert after insert for each do (

--- a/dbschema/scripture.esdl
+++ b/dbschema/scripture.esdl
@@ -7,6 +7,7 @@ module Scripture {
     multi verses: VerseRange {
       readonly := true;
       on source delete delete target;
+      on target delete deferred restrict;
     }
     ids := multirange(array_agg(.verses.ids));
   }


### PR DESCRIPTION
- Doing `delete Object` would fail on the two trigger assertions.
  - These were to prevent mistakes, but these actions should
only happen in one spot in the schema or app code.
    So I'm fine dropping them to make deletes more ergonomic.
  - FWIW both of these should work from my perspective
with `delete Object` so maybe they are bugs.
- Deleting `Partner` or `Organization` deletes the other.
- Deleting `Language`/`Project`/`Org` deletes their `ProjectContext`
- Deleting `Scripture::VerseRanges` are allowed if their `Scripture::Collection` is being deleted too
- Marking migration files as generated so GitHub doesn't render them by default (or count them in diff stats)