### PR TITLE
Move budget record non-finalized check to policies

### DIFF
--- a/src/components/authorization/policies/by-role/project-manager.policy.ts
+++ b/src/components/authorization/policies/by-role/project-manager.policy.ts
@@ -32,7 +32,7 @@ const stepsUntilFinancialEndorsement = takeWhile(
     ]),
 
     r.Budget.read.when(member).edit,
-    r.BudgetRecord.read.when(member).edit,
+    r.BudgetRecord.read.whenAll(member, field('status', 'Pending')).edit,
     r.Ceremony.read.when(member).edit,
     r.Education.read.create,
     inherit(

--- a/src/components/budget/budget-record.repository.ts
+++ b/src/components/budget/budget-record.repository.ts
@@ -163,6 +163,8 @@ export class BudgetRecordRepository extends DtoRepository<
             node('node'),
             relation('in', '', 'record'),
             node('budget', labelForView('Budget', view)),
+            relation('out', '', 'status', ACTIVE),
+            node('status'),
           ])
           .match([
             node('node'),
@@ -176,6 +178,7 @@ export class BudgetRecordRepository extends DtoRepository<
               parent: 'budget',
               organization: 'organization.id',
               changeset: 'changeset.id',
+              status: 'status.value',
             }).as(outputVar),
           ),
       );

--- a/src/components/budget/budget.repository.ts
+++ b/src/components/budget/budget.repository.ts
@@ -108,24 +108,6 @@ export class BudgetRepository extends DtoRepository<
       .run();
   }
 
-  async getStatusByRecord(recordId: ID) {
-    const result = await this.db
-      .query()
-      .match([
-        node('budgetRecord', 'BudgetRecord', { id: recordId }),
-        relation('in', '', 'record', ACTIVE),
-        node('budget', 'Budget'),
-        relation('out', '', 'status', ACTIVE),
-        node('status', 'Property'),
-      ])
-      .return<{ status: Status }>('status.value as status')
-      .first();
-    if (!result) {
-      throw new NotFoundException('Budget could not be found');
-    }
-    return result.status;
-  }
-
   async list({ filter, ...input }: BudgetListInput, session: Session) {
     const result = await this.db
       .query()

--- a/src/components/budget/dto/budget-record.dto.ts
+++ b/src/components/budget/dto/budget-record.dto.ts
@@ -16,6 +16,7 @@ import {
   SensitivityField,
 } from '../../../common';
 import { ChangesetAware } from '../../changeset/dto';
+import { BudgetStatus } from './budget-status.enum';
 import { Budget } from './budget.dto';
 
 @Calculated()
@@ -45,6 +46,8 @@ export class BudgetRecord extends IntersectionType(ChangesetAware, Resource) {
     description: "Based on the project's sensitivity",
   })
   readonly sensitivity: Sensitivity;
+
+  readonly status: BudgetStatus;
 }
 
 declare module '~/core/resources/map' {

--- a/src/components/budget/dto/budget-record.dto.ts
+++ b/src/components/budget/dto/budget-record.dto.ts
@@ -15,7 +15,6 @@ import {
   Sensitivity,
   SensitivityField,
 } from '../../../common';
-import { ScopedRole } from '../../authorization';
 import { ChangesetAware } from '../../changeset/dto';
 import { Budget } from './budget.dto';
 
@@ -46,10 +45,6 @@ export class BudgetRecord extends IntersectionType(ChangesetAware, Resource) {
     description: "Based on the project's sensitivity",
   })
   readonly sensitivity: Sensitivity;
-
-  // A list of non-global roles the requesting user has available for this object.
-  // This is just a cache, to prevent extra db lookups within the same request.
-  declare readonly scope: ScopedRole[];
 }
 
 declare module '~/core/resources/map' {

--- a/src/components/budget/dto/budget.dto.ts
+++ b/src/components/budget/dto/budget.dto.ts
@@ -14,7 +14,6 @@ import {
   Sensitivity,
   SensitivityField,
 } from '../../../common';
-import { ScopedRole } from '../../authorization';
 import { ChangesetAware } from '../../changeset/dto';
 import { DefinedFile } from '../../file/dto';
 import { IProject } from '../../project/dto';
@@ -50,10 +49,6 @@ export class Budget extends IntersectionType(ChangesetAware, Resource) {
     description: "Based on the project's sensitivity",
   })
   readonly sensitivity: Sensitivity;
-
-  // A list of non-global roles the requesting user has available for this object.
-  // This is just a cache, to prevent extra db lookups within the same request.
-  declare readonly scope: ScopedRole[];
 }
 
 @ObjectType({

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -577,12 +577,7 @@ export class ProjectService {
     return {
       value: budgetToReturn,
       canRead: perms.can('read'),
-      canEdit:
-        (perms.can('edit') &&
-          budgetToReturn?.status === BudgetStatus.Pending) ||
-        this.budgetService.canEditFinalized(
-          session.roles.concat(project.scope),
-        ),
+      canEdit: perms.can('edit'),
     };
   }
 


### PR DESCRIPTION
This fixes the `budget.record.canEdit` flag to correctly emit `false` if the budget is finalized & you/FPM cannot edit finalized budgets.
It's also much cleaner.