### PR TITLE
Fix omitting `customize` `omit` acting like omitting all default methods

### DIFF
--- a/src/core/edgedb/dto.repository.ts
+++ b/src/core/edgedb/dto.repository.ts
@@ -73,7 +73,7 @@ export const RepoFor = <
   abstract class Repository extends CommonRepository {
     static customize<
       Customized extends BaseCustomizedRepository,
-      OmitKeys extends EnumType<typeof DefaultMethods>,
+      OmitKeys extends EnumType<typeof DefaultMethods> = never,
     >(
       customizer: (
         cls: typeof BaseCustomizedRepository,


### PR DESCRIPTION
@andrewmurraydavid @bryanjnelson both of you guys hit this with project & language repos.
With no omit array given, TS inferred the `OmitKeys` type to be all of the enum members.
Giving it a default value of `never` suppresses that, so it will infer if the array is given or fallback to this default value which removes nothing.
Honestly TS is amazing.