### PR TITLE
Fix TranslationProject sensitivity sync

### DIFF
--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -84,20 +84,18 @@ module default {
     
     trigger recalculateProjectSensOnInsert after insert for each do (
       update (
-        select TranslationProject
-        filter __new__ in .languages
-          # Filter out projects without change, so modifiedAt isn't bumped
-          and .ownSensitivity != max(.languages.ownSensitivity) ?? Sensitivity.High
+        select __new__.project
+        # Filter out projects without change, so modifiedAt isn't bumped
+        filter .ownSensitivity != max(.languages.ownSensitivity) ?? Sensitivity.High
       )
       set { ownSensitivity := max(.languages.ownSensitivity) ?? Sensitivity.High }
     );
     trigger recalculateProjectSensOnDelete after delete for each do (
       with removedLang := __old__.language
       update (
-        select TranslationProject
-        filter __old__ in .languages
-          # Filter out projects without change, so modifiedAt isn't bumped
-          and .ownSensitivity != max((.languages except removedLang).ownSensitivity) ?? Sensitivity.High
+        select __old__.project
+        # Filter out projects without change, so modifiedAt isn't bumped
+        filter .ownSensitivity != max((.languages except removedLang).ownSensitivity) ?? Sensitivity.High
       )
       set { ownSensitivity := max((.languages except removedLang).ownSensitivity) ?? Sensitivity.High }
     );

--- a/dbschema/language.esdl
+++ b/dbschema/language.esdl
@@ -12,10 +12,9 @@ module default {
     
     trigger recalculateProjectSens after update for each do (
       update (
-        select TranslationProject
-        filter __new__ in .languages
-          # Filter out projects without change, so modifiedAt isn't bumped
-          and .ownSensitivity != max(.languages.ownSensitivity) ?? Sensitivity.High
+        select __new__.projects
+        # Filter out projects without change, so modifiedAt isn't bumped
+        filter .ownSensitivity != max(.languages.ownSensitivity) ?? Sensitivity.High
       )
       set { ownSensitivity := max(.languages.ownSensitivity) ?? Sensitivity.High }
     );

--- a/dbschema/migrations/00075.edgeql
+++ b/dbschema/migrations/00075.edgeql
@@ -1,0 +1,38 @@
+CREATE MIGRATION m1w6sepotsepo4bbhstbvk7k3zajdjbjinhmmixuudgp3elcf66fiq
+    ONTO m1my4gnalxbdroxdfajzul5nmhg3jhwnmogtt2wxv2hrzv2p7tj2xa
+{
+  ALTER TYPE default::Language {
+      ALTER TRIGGER recalculateProjectSens USING (UPDATE
+          (SELECT
+              __new__.projects
+          FILTER
+              (.ownSensitivity != (std::max(.languages.ownSensitivity) ?? default::Sensitivity.High))
+          )
+      SET {
+          ownSensitivity := (std::max(.languages.ownSensitivity) ?? default::Sensitivity.High)
+      });
+  };
+  ALTER TYPE default::LanguageEngagement {
+      ALTER TRIGGER recalculateProjectSensOnDelete USING (WITH
+          removedLang := 
+              __old__.language
+      UPDATE
+          (SELECT
+              __old__.project
+          FILTER
+              (.ownSensitivity != (std::max(((.languages EXCEPT removedLang)).ownSensitivity) ?? default::Sensitivity.High))
+          )
+      SET {
+          ownSensitivity := (std::max(((.languages EXCEPT removedLang)).ownSensitivity) ?? default::Sensitivity.High)
+      });
+      ALTER TRIGGER recalculateProjectSensOnInsert USING (UPDATE
+          (SELECT
+              __new__.project
+          FILTER
+              (.ownSensitivity != (std::max(.languages.ownSensitivity) ?? default::Sensitivity.High))
+          )
+      SET {
+          ownSensitivity := (std::max(.languages.ownSensitivity) ?? default::Sensitivity.High)
+      });
+  };
+};


### PR DESCRIPTION
Mostly reverts 5829d35e588f7e20eee71e29c8569602df2a7c26
I'm not sure what the error was back then, but it works fine now in 4.7


The actual problem was that we were comparing the engagement to language list, so of course there was no overlap.
```diff
- in .languages
+ in .engagements
```

But the former expression of just selecting the linked project works and should be more performant. So going with that.