### PR TITLE
[EdgeDB] castToEnum QB helper

### DIFF
--- a/src/core/edgedb/generator/query-builder.ts
+++ b/src/core/edgedb/generator/query-builder.ts
@@ -30,6 +30,7 @@ export async function generateQueryBuilder({
   changeImplicitIDType(qbDir);
   allowOrderingByEnums(qbDir);
   adjustToImmutableTypes(qbDir);
+  addTypeNarrowingToStdScalars(qbDir);
 }
 
 function addJsExtensionDeepPathsOfEdgedbLibrary(qbDir: Directory) {
@@ -137,6 +138,16 @@ function adjustToImmutableTypes(qbDir: Directory) {
       .replaceAll('? T[]', '? readonly T[]')
       .replaceAll('? [T, ...T[]]', '? readonly [T, ...T[]]'),
   );
+}
+
+function addTypeNarrowingToStdScalars(qbDir: Directory) {
+  const std = qbDir.addSourceFileAtPath('modules/std.ts');
+  replaceText(std.getTypeAliasOrThrow('$str'), () => {
+    return `export type $str<E extends string = string> = $.ScalarType<'std::str', E>;`;
+  });
+  replaceText(std.getTypeAliasOrThrow('$json'), () => {
+    return `export type $json<E = unknown> = $.ScalarType<"std::json", E>;`;
+  });
 }
 
 const replaceText = <N extends ts.Node>(

--- a/src/core/edgedb/index.ts
+++ b/src/core/edgedb/index.ts
@@ -8,3 +8,4 @@ export * from './exclusivity-violation.error';
 export * from './common.repository';
 export * from './dto.repository';
 export * from './query-util/disable-access-policies.option';
+export * from './query-util/cast-to-enum';

--- a/src/core/edgedb/query-util/cast-to-enum.ts
+++ b/src/core/edgedb/query-util/cast-to-enum.ts
@@ -1,0 +1,24 @@
+import { Merge } from 'type-fest';
+import { $str } from '../generated-client/modules/std';
+import { BaseType } from '../generated-client/typesystem';
+
+/**
+ * This is an unsafe helper to assert that the given str expression
+ * is actually a string literal union of the given enum.
+ *
+ * @example
+ * const expr = e.str('red') // edgeql str literal whose TS value is `string`
+ * castToEnum(expr, ['red', 'blue']) // expression TS value is now `'red' | 'blue'`
+ */
+export const castToEnum = <Expr extends $el<$str>, const TS extends string>(
+  expr: Expr,
+  // eslint-disable-next-line @seedcompany/no-unused-vars
+  tsValues: TS | Iterable<TS>,
+) => expr as any as SetEl<Expr, $str<TS>>;
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions,@typescript-eslint/naming-convention
+type $el<T> = { __element__: T };
+type SetEl<T extends $el<BaseType>, NewType extends BaseType> = Merge<
+  T,
+  $el<NewType>
+>;

--- a/src/core/edgedb/withScope.ts
+++ b/src/core/edgedb/withScope.ts
@@ -2,6 +2,7 @@ import { Role } from '~/common';
 import type { AuthScope } from '../../components/authorization';
 import e from './generated-client';
 import { orScalarLiteral } from './generated-client/castMaps';
+import { $str } from './generated-client/modules/std';
 import * as $ from './generated-client/reflection';
 
 /**
@@ -20,9 +21,6 @@ export const withScope = <
   roles: RoleExpr,
 ) =>
   e.op(e.str(scope + ':'), '++', e.cast(e.str, roles)) as $.$expr_Operator<
-    $.ScalarType<
-      'std::str',
-      `${Scope}:${Role}` // <-- TS str literal here
-    >,
+    $str<`${Scope}:${Role}`>,
     $.cardutil.paramCardinality<RoleExpr>
   >;


### PR DESCRIPTION
This is an unsafe helper to assert that the given str expression
is actually a string literal union of the given enum.

```ts
const expr = e.str('red') // edgeql str literal whose TS value is `string`

castToEnum(expr, ['red', 'blue']) // expression TS value is now `'red' | 'blue'`
```