### PR TITLE
[EdgeDB] Fix delete cascade

### DIFF
--- a/dbschema/migrations/00079.edgeql
+++ b/dbschema/migrations/00079.edgeql
@@ -1,0 +1,9 @@
+CREATE MIGRATION m1sfauxznuxghwg6pwtxfo5fk6azud5xl6m4fhqqboriroejwpeegq
+    ONTO m1ku55m2qkjmqjhurge3iiolac7zkf76zuzrs2y7u7djghui4fhima
+{
+  ALTER TYPE Project::ContextAware {
+      ALTER LINK projectContext {
+          ON TARGET DELETE DELETE SOURCE;
+      };
+  };
+};

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -149,7 +149,9 @@ module Project {
       A type that has a project context, which allows it to be
       aware of the sensitivity & current user membership for the associated context.";
     
-    required projectContext: Context;
+    required projectContext: Context {
+      on target delete delete source;
+    }
     index on (.projectContext);
     
     optional ownSensitivity: default::Sensitivity {


### PR DESCRIPTION
Following up on #3132

That PR added a on Project delete, delete ProjectContext.
All project children are also configured to delete with Project as well. ([src](https://github.com/SeedCompany/cord-api-v3/blob/95af5f9041cd91bda38e3c9401571271e94a832e/dbschema/project.esdl#L136))
But this sibling deletion chain was not respecting that sibling deletion chain.

So setting them both to chain deletes works.

In practice, I could see `delete Project::Context` deleting all directly associated objects (like this PR does), but I could also see it restricting because it still has things referenced.
I guess our hand is forced though. These contexts should be rarely referenced anyways, and would/should never be deleted directly.