### PR TITLE
Split TranslationProject into Momentum and Multiplication

### DIFF
--- a/dbschema/migrations/00080.edgeql
+++ b/dbschema/migrations/00080.edgeql
@@ -1,0 +1,7 @@
+CREATE MIGRATION m165jniqsw3z3zqp7yfhfo6x7tjiaalkxsjnk2cphundlg6ct37vvq
+    ONTO m1sfauxznuxghwg6pwtxfo5fk6azud5xl6m4fhqqboriroejwpeegq
+{
+  ALTER TYPE default::TranslationProject SET ABSTRACT;
+  CREATE TYPE default::MomentumTranslationProject EXTENDING default::TranslationProject;
+  CREATE TYPE default::MultiplicationTranslationProject EXTENDING default::TranslationProject;
+};

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -107,7 +107,7 @@ module default {
     );
   }
   
-  type TranslationProject extending Project {
+  abstract type TranslationProject extending Project {
     multi link engagements := .<project[is LanguageEngagement];
     multi link languages := .engagements.language;
     
@@ -119,6 +119,11 @@ module default {
       )
     );
   }
+
+  type MomentumTranslationProject extending TranslationProject {
+    uid: uuid;
+  }
+  type MultiplicationTranslationProject extending TranslationProject;
   
   type InternshipProject extending Project {
     multi link engagements := .<project[is InternshipEngagement];

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -120,9 +120,7 @@ module default {
     );
   }
 
-  type MomentumTranslationProject extending TranslationProject {
-    uid: uuid;
-  }
+  type MomentumTranslationProject extending TranslationProject;
   type MultiplicationTranslationProject extending TranslationProject;
   
   type InternshipProject extending Project {

--- a/dbschema/seeds/008.projects.ts
+++ b/dbschema/seeds/008.projects.ts
@@ -2,7 +2,7 @@ import { entries, mapValues } from '@seedcompany/common';
 import type { e } from '~/core/edgedb';
 import type { SeedFn } from '~/core/edgedb/seeds.run';
 
-const translations: Input[] = [
+const momentumTranslation: Input[] = [
   {
     name: 'Misty Mountains',
     step: 'EarlyConversations',
@@ -102,7 +102,7 @@ export default (async function ({ e, db, print }) {
   const existing = new Set(await e.select(e.Project).name.run(db));
 
   const projectSeeds = entries({
-    Translation: translations,
+    MomentumTranslation: momentumTranslation,
     Internship: internships,
   }).flatMap(([type, list]) => list.map((item) => ({ type, ...item })));
 

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -71,7 +71,7 @@ class Engagement extends ChangesetAwareResource {
 
   declare readonly __typename: 'LanguageEngagement' | 'InternshipEngagement';
 
-  readonly project: LinkTo<'Project'> & Pick<IProject, 'status'>;
+  readonly project: LinkTo<'Project'> & Pick<IProject, 'status' | 'type'>;
 
   @Field(() => IProject)
   declare readonly parent: BaseNode;

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -144,6 +144,7 @@ export class EngagementRepository extends CommonRepository {
             parent: 'project',
             project: {
               id: 'project.id',
+              type: 'project.type',
               status: 'status.value',
             },
             language: 'language.id',

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -85,7 +85,7 @@ export class EngagementService {
     await this.verifyRelationshipEligibility(
       projectId,
       languageId,
-      ProjectType.Translation,
+      false,
       changeset,
     );
 
@@ -139,7 +139,7 @@ export class EngagementService {
     await this.verifyRelationshipEligibility(
       projectId,
       internId,
-      ProjectType.Internship,
+      true,
       changeset,
     );
 
@@ -437,15 +437,14 @@ export class EngagementService {
   protected async verifyRelationshipEligibility(
     projectId: ID,
     otherId: ID,
-    type: ProjectType,
+    isInternship: boolean,
     changeset?: ID,
   ): Promise<void> {
-    const isTranslation = type === ProjectType.Translation;
-    const property = isTranslation ? 'language' : 'intern';
+    const property = isInternship ? 'intern' : 'language';
     const result = await this.repo.verifyRelationshipEligibility(
       projectId,
       otherId,
-      isTranslation,
+      !isInternship,
       property,
       changeset,
     );
@@ -457,16 +456,21 @@ export class EngagementService {
       );
     }
 
-    if (result.project.properties.type !== type) {
+    if (
+      result.project.properties.type === ProjectType.Internship &&
+      !isInternship
+    ) {
       throw new InputException(
         `Only ${
-          isTranslation ? 'Language' : 'Internship'
-        } Engagements can be created on ${type} Projects`,
+          isInternship ? 'Internship' : 'Language'
+        } Engagements can be created on ${
+          isInternship ? 'Internship' : 'Translation'
+        } Projects`,
         `engagement.${property}Id`,
       );
     }
 
-    const label = isTranslation ? 'language' : 'person';
+    const label = isInternship ? 'person' : 'language';
     if (!result?.other) {
       throw new NotFoundException(
         `Could not find ${label}`,

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -456,10 +456,9 @@ export class EngagementService {
       );
     }
 
-    if (
-      result.project.properties.type === ProjectType.Internship &&
-      !isInternship
-    ) {
+    const isActuallyInternship =
+      result.project.properties.type === ProjectType.Internship;
+    if (isActuallyInternship !== isInternship) {
       throw new InputException(
         `Only ${
           isInternship ? 'Internship' : 'Language'

--- a/src/components/engagement/handlers/update-project-status.handler.ts
+++ b/src/components/engagement/handlers/update-project-status.handler.ts
@@ -121,7 +121,7 @@ export class UpdateProjectStatusHandler
           id,
           status,
         };
-        type === ProjectType.Translation
+        type !== ProjectType.Internship
           ? await this.engagementService.updateLanguageEngagement(
               updateInput,
               session,

--- a/src/components/project/dto/list-projects.dto.ts
+++ b/src/components/project/dto/list-projects.dto.ts
@@ -23,11 +23,11 @@ import {
 
 @InputType()
 export abstract class ProjectFilters {
-  @Field(() => ProjectType, {
-    description: 'Only projects of this type',
+  @Field(() => [ProjectType], {
+    description: 'Only projects of these types',
     nullable: true,
   })
-  readonly type?: ProjectType;
+  readonly type?: ProjectType[];
 
   @Field(() => [Sensitivity], {
     description: 'Only projects with these sensitivities',

--- a/src/components/project/dto/project-type.enum.ts
+++ b/src/components/project/dto/project-type.enum.ts
@@ -3,5 +3,9 @@ import { EnumType, makeEnum } from '~/common';
 export type ProjectType = EnumType<typeof ProjectType>;
 export const ProjectType = makeEnum({
   name: 'ProjectType',
-  values: ['MomentumTranslation', 'MultiplicationTranslation', 'Internship'],
+  values: [
+    { value: 'MomentumTranslation', label: 'Momentum' },
+    { value: 'MultiplicationTranslation', label: 'Multiplication' },
+    'Internship',
+  ],
 });

--- a/src/components/project/dto/project-type.enum.ts
+++ b/src/components/project/dto/project-type.enum.ts
@@ -3,5 +3,5 @@ import { EnumType, makeEnum } from '~/common';
 export type ProjectType = EnumType<typeof ProjectType>;
 export const ProjectType = makeEnum({
   name: 'ProjectType',
-  values: ['Translation', 'Internship'],
+  values: ['MomentumTranslation', 'MultiplicationTranslation', 'Internship'],
 });

--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -1,5 +1,6 @@
 import { Type } from '@nestjs/common';
 import { Field, InterfaceType, ObjectType } from '@nestjs/graphql';
+import { simpleSwitch } from '@seedcompany/common';
 import { stripIndent } from 'common-tags';
 import { DateTime } from 'luxon';
 import { keys as keysOf } from 'ts-transformer-keys';
@@ -13,7 +14,6 @@ import {
   IntersectionType,
   NameField,
   parentIdMiddleware,
-  resolveByTypename,
   Resource,
   ResourceRelationsShape,
   Secured,
@@ -26,6 +26,7 @@ import {
   SecuredStringNullable,
   Sensitivity,
   SensitivityField,
+  ServerException,
   UnsecuredDto,
 } from '~/common';
 import { sortingForEnumIndex } from '~/core/database/query';
@@ -48,7 +49,10 @@ import { ProjectStatus } from './project-status.enum';
 import { ProjectStep, SecuredProjectStep } from './project-step.enum';
 import { ProjectType } from './project-type.enum';
 
-type AnyProject = MergeExclusive<TranslationProject, InternshipProject>;
+type AnyProject = MergeExclusive<
+  MomentumTranslationProject,
+  MergeExclusive<MultiplicationTranslationProject, InternshipProject>
+>;
 
 const Interfaces: Type<
   Resource & Postable & ChangesetAware & Pinnable & Commentable
@@ -60,20 +64,17 @@ const Interfaces: Type<
   ),
 );
 
-export const resolveProjectType = (val: Pick<AnyProject, 'type'>) =>
-  val.type === 'Translation' ? TranslationProject : InternshipProject;
+export const resolveProjectType = (val: Pick<AnyProject, 'type'>) => {
+  const type = simpleSwitch(val.type, ProjectConcretes);
+  if (!type) {
+    throw new ServerException(`Could not resolve project type: '${val.type}'`);
+  }
+  return type;
+};
 
 @RegisterResource({ db: e.Project })
 @InterfaceType({
-  resolveType: (val: Project) => {
-    if (val.type === ProjectType.Translation) {
-      return TranslationProject;
-    }
-    if (val.type === ProjectType.Internship) {
-      return InternshipProject;
-    }
-    return resolveByTypename(Project.name)(val);
-  },
+  resolveType: resolveProjectType,
   implements: [Resource, Pinnable, Postable, ChangesetAware, Commentable],
 })
 class Project extends Interfaces {
@@ -184,14 +185,38 @@ class Project extends Interfaces {
 export { Project as IProject, AnyProject as Project };
 
 @RegisterResource({ db: e.TranslationProject })
-@ObjectType({
+@InterfaceType({
+  resolveType: resolveProjectType,
   implements: [Project],
 })
 export class TranslationProject extends Project {
   static readonly Props = keysOf<TranslationProject>();
   static readonly SecuredProps = keysOf<SecuredProps<TranslationProject>>();
+}
 
-  declare readonly type: 'Translation';
+@RegisterResource({ db: e.TranslationProject })
+@ObjectType({
+  implements: [TranslationProject],
+  description: 'Formerly known as our TranslationProjects',
+})
+export class MomentumTranslationProject extends TranslationProject {
+  static readonly Props = keysOf<MomentumTranslationProject>();
+  static readonly SecuredProps =
+    keysOf<SecuredProps<MomentumTranslationProject>>();
+
+  declare readonly type: 'MomentumTranslation';
+}
+
+@RegisterResource({ db: e.TranslationProject })
+@ObjectType({
+  implements: [TranslationProject],
+})
+export class MultiplicationTranslationProject extends TranslationProject {
+  static readonly Props = keysOf<MultiplicationTranslationProject>();
+  static readonly SecuredProps =
+    keysOf<SecuredProps<MultiplicationTranslationProject>>();
+
+  declare readonly type: 'MultiplicationTranslation';
 }
 
 @RegisterResource({ db: e.InternshipProject })
@@ -206,7 +231,8 @@ export class InternshipProject extends Project {
 }
 
 export const ProjectConcretes = {
-  Translation: TranslationProject,
+  MomentumTranslation: MomentumTranslationProject,
+  MultiplicationTranslation: MultiplicationTranslationProject,
   Internship: InternshipProject,
 } as const satisfies Record<ProjectType, typeof Project>;
 
@@ -218,10 +244,14 @@ declare module '~/core/resources/map' {
     Project: typeof Project;
     InternshipProject: typeof InternshipProject;
     TranslationProject: typeof TranslationProject;
+    MomentumTranslationProject: typeof MomentumTranslationProject;
+    MultiplicationTranslationProject: typeof MultiplicationTranslationProject;
   }
   interface ResourceDBMap {
     Project: typeof e.default.Project;
     InternshipProject: typeof e.default.InternshipProject;
     TranslationProject: typeof e.default.TranslationProject;
+    MomentumTranslationProject: typeof e.default.TranslationProject; // TODO
+    MultiplicationTranslationProject: typeof e.default.TranslationProject; // TODO
   }
 }

--- a/src/components/project/engagement-connection.resolver.ts
+++ b/src/components/project/engagement-connection.resolver.ts
@@ -1,15 +1,15 @@
 import { Info, Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { Fields, IsOnlyId, viewOfChangeset } from '../../common';
+import { Fields, IsOnly, viewOfChangeset } from '../../common';
 import { Loader, LoaderOf } from '../../core';
 import { IEngagement } from '../engagement';
-import { IProject, ProjectType } from './dto';
+import { IProject } from './dto';
 import { ProjectLoader } from './project.loader';
 
 @Resolver(IEngagement)
 export class ProjectEngagementConnectionResolver {
   @ResolveField(() => IProject)
   async project(
-    @Info(Fields, IsOnlyId) onlyId: boolean,
+    @Info(Fields, IsOnly(['id', 'type'])) onlyId: boolean,
     @Parent() engagement: IEngagement,
     @Loader(ProjectLoader) projects: LoaderOf<ProjectLoader>,
   ) {
@@ -18,10 +18,7 @@ export class ProjectEngagementConnectionResolver {
         id: engagement.project.id,
         changeset: engagement.changeset,
         // Used in Project.resolveType to resolve the concrete type
-        type:
-          engagement.__typename === 'LanguageEngagement'
-            ? ProjectType.Translation
-            : ProjectType.Internship,
+        type: engagement.project.type,
       };
     }
     return await projects.load({

--- a/src/components/project/handlers/set-step-changed-at.handler.ts
+++ b/src/components/project/handlers/set-step-changed-at.handler.ts
@@ -5,7 +5,7 @@ import {
   ILogger,
   Logger,
 } from '../../../core';
-import { InternshipProject, ProjectType, TranslationProject } from '../dto';
+import { resolveProjectType } from '../dto';
 import { ProjectUpdatedEvent } from '../events';
 import { ProjectService } from '../project.service';
 
@@ -27,10 +27,7 @@ export class ProjectStepChangedAtHandler
     try {
       const project = event.updated;
       event.updated = await this.db.updateProperties({
-        type:
-          project.type === ProjectType.Translation
-            ? TranslationProject
-            : InternshipProject,
+        type: resolveProjectType(project),
         object: project,
         changes: {
           stepChangedAt: project.modifiedAt,

--- a/src/components/project/list-filter.query.ts
+++ b/src/components/project/list-filter.query.ts
@@ -9,7 +9,7 @@ import { ProjectListInput } from './dto';
 
 export const projectListFilter = (input: ProjectListInput) =>
   filter.builder(input.filter, {
-    type: filter.skip, // already applied
+    type: filter.stringListBaseNodeProp(),
     status: filter.stringListProp(),
     onlyMultipleEngagements:
       ({ value, query }) =>

--- a/src/components/project/migrations/rename-translation-to-momentum.migration.ts
+++ b/src/components/project/migrations/rename-translation-to-momentum.migration.ts
@@ -1,0 +1,21 @@
+import { BaseMigration, Migration } from '~/core';
+
+@Migration('2024-04-08T12:51:00')
+export class RenameTranslationToMomentumMigration extends BaseMigration {
+  async up() {
+    await this.db
+      .query()
+      .matchNode('node', 'TranslationProject')
+      .setValues({ 'node.type': 'MomentumTranslation' }, true)
+      .setLabels({
+        node: [
+          'MomentumTranslationProject',
+          'TranslationProject',
+          'Project',
+          'BaseNode',
+        ],
+      })
+      .logIt()
+      .executeAndLogStats();
+  }
+}

--- a/src/components/project/project.edgedb.repository.ts
+++ b/src/components/project/project.edgedb.repository.ts
@@ -88,8 +88,11 @@ export class ProjectEdgeDBRepository
   ) {
     return [
       input.type != null &&
-        // https://github.com/edgedb/edgedb-js/issues/615
-        e.op(project.__type__.name, '=', `default::${input.type}Project`),
+        e.op(
+          project.__type__.name,
+          'in',
+          input.type.map((type) => `default::${type}Project`),
+        ),
       (input.status?.length ?? 0) > 0 &&
         e.op(
           project.status,

--- a/src/components/project/project.edgedb.repository.ts
+++ b/src/components/project/project.edgedb.repository.ts
@@ -87,10 +87,9 @@ export class ProjectEdgeDBRepository
     { filter: input }: ProjectListInput,
   ) {
     return [
-      // TODO: add back after edgedb piece is fixed
-      // input.type != null &&
-      // https://github.com/edgedb/edgedb-js/issues/615
-      // e.op(project.__type__.name, '=', `default::${input.type}Project`),
+      input.type != null &&
+        // https://github.com/edgedb/edgedb-js/issues/615
+        e.op(project.__type__.name, '=', `default::${input.type}Project`),
       (input.status?.length ?? 0) > 0 &&
         e.op(
           project.status,

--- a/src/components/project/project.edgedb.repository.ts
+++ b/src/components/project/project.edgedb.repository.ts
@@ -32,8 +32,13 @@ const hydrate = e.shape(e.Project, (project) => ({
 }));
 
 export const ConcreteRepos = {
-  Translation: class TranslationProjectRepository extends RepoFor(
-    ConcreteTypes.Translation,
+  MomentumTranslation: class MomentumTranslationProjectRepository extends RepoFor(
+    ConcreteTypes.MomentumTranslation,
+    { hydrate },
+  ).withDefaults() {},
+
+  MultiplicationTranslation: class MultiplicationTranslationProjectRepository extends RepoFor(
+    ConcreteTypes.MultiplicationTranslation,
     { hydrate },
   ).withDefaults() {},
 
@@ -82,9 +87,10 @@ export class ProjectEdgeDBRepository
     { filter: input }: ProjectListInput,
   ) {
     return [
-      input.type != null &&
-        // https://github.com/edgedb/edgedb-js/issues/615
-        e.op(project.__type__.name, '=', `default::${input.type}Project`),
+      // TODO: add back after edgedb piece is fixed
+      // input.type != null &&
+      // https://github.com/edgedb/edgedb-js/issues/615
+      // e.op(project.__type__.name, '=', `default::${input.type}Project`),
       (input.status?.length ?? 0) > 0 &&
         e.op(
           project.status,

--- a/src/components/project/project.edgedb.repository.ts
+++ b/src/components/project/project.edgedb.repository.ts
@@ -87,11 +87,11 @@ export class ProjectEdgeDBRepository
     { filter: input }: ProjectListInput,
   ) {
     return [
-      input.type != null &&
+      (input.type?.length ?? 0) > 0 &&
         e.op(
           project.__type__.name,
           'in',
-          input.type.map((type) => `default::${type}Project`),
+          e.set(...input.type!.map((type) => `default::${type}Project`)),
         ),
       (input.status?.length ?? 0) > 0 &&
         e.op(

--- a/src/components/project/project.loader.ts
+++ b/src/components/project/project.loader.ts
@@ -3,12 +3,20 @@ import { LoaderFactory, ObjectViewAwareLoader } from '../../core';
 import {
   InternshipProject,
   IProject,
+  MomentumTranslationProject,
+  MultiplicationTranslationProject,
   Project,
   TranslationProject,
 } from './dto';
 import { ProjectService } from './project.service';
 
-@LoaderFactory(() => [IProject, TranslationProject, InternshipProject])
+@LoaderFactory(() => [
+  IProject,
+  TranslationProject,
+  MomentumTranslationProject,
+  MultiplicationTranslationProject,
+  InternshipProject,
+])
 export class ProjectLoader extends ObjectViewAwareLoader<Project> {
   constructor(private readonly projects: ProjectService) {
     super();

--- a/src/components/project/project.module.ts
+++ b/src/components/project/project.module.ts
@@ -13,6 +13,7 @@ import { UserModule } from '../user/user.module';
 import { ProjectEngagementConnectionResolver } from './engagement-connection.resolver';
 import * as handlers from './handlers';
 import { InternshipProjectResolver } from './internship-project.resolver';
+import { RenameTranslationToMomentumMigration } from './migrations/rename-translation-to-momentum.migration';
 import { ProjectMemberModule } from './project-member/project-member.module';
 import { ProjectStepResolver } from './project-step.resolver';
 import {
@@ -54,6 +55,7 @@ import { ProjectUserConnectionResolver } from './user-connection.resolver';
     ...Object.values(ConcreteRepos),
     ProjectLoader,
     ...Object.values(handlers),
+    RenameTranslationToMomentumMigration,
   ],
   exports: [ProjectService, ProjectMemberModule, ProjectRules],
 })

--- a/src/components/project/project.resolver.ts
+++ b/src/components/project/project.resolver.ts
@@ -121,7 +121,10 @@ export class ProjectResolver {
         ...input,
         filter: {
           ...input.filter,
-          type: ProjectType.Translation,
+          type: [
+            ProjectType.MomentumTranslation,
+            ProjectType.MultiplicationTranslation,
+          ],
         },
       },
       session,
@@ -143,7 +146,7 @@ export class ProjectResolver {
         ...input,
         filter: {
           ...input.filter,
-          type: ProjectType.Internship,
+          type: [ProjectType.Internship],
         },
       },
       session,

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -99,9 +99,9 @@ export class ProjectService {
     input: CreateProject,
     session: Session,
   ): Promise<UnsecuredDto<Project>> {
-    if (input.type === ProjectType.Translation && input.sensitivity) {
+    if (input.type !== ProjectType.Internship && input.sensitivity) {
       throw new InputException(
-        'Cannot set sensitivity on translation project',
+        'Can only set sensitivity on Internship Projects',
         'project.sensitivity',
       );
     }
@@ -187,7 +187,7 @@ export class ProjectService {
     view?: ObjectView,
   ): Promise<TranslationProject> {
     const project = await this.readOne(id, session, view?.changeset);
-    if (project.type !== ProjectType.Translation) {
+    if (project.type === ProjectType.Internship) {
       throw new Error('Project is not a translation project');
     }
     return project as TranslationProject;
@@ -248,9 +248,9 @@ export class ProjectService {
       session,
       changeset,
     );
-    if (input.sensitivity && currentProject.type === ProjectType.Translation)
+    if (input.sensitivity && currentProject.type !== ProjectType.Internship)
       throw new InputException(
-        'Cannot update sensitivity on Translation Project',
+        'Can only set sensitivity on Internship Projects',
         'project.sensitivity',
       );
 

--- a/src/components/search/dto/search-results.dto.ts
+++ b/src/components/search/dto/search-results.dto.ts
@@ -26,6 +26,8 @@ import {
 import { ProgressReport } from '../../progress-report/dto';
 import {
   InternshipProject,
+  MomentumTranslationProject,
+  MultiplicationTranslationProject,
   IProject as Project,
   TranslationProject,
 } from '../../project/dto';
@@ -39,7 +41,8 @@ const publicSearchable = {
   Organization,
   Partner,
   Language,
-  TranslationProject,
+  MomentumTranslationProject,
+  MultiplicationTranslationProject,
   InternshipProject,
   User,
   Film,
@@ -67,6 +70,7 @@ const privateSearchable = {
 // Only use if not a concrete type.
 const searchableAbstracts = {
   Project,
+  TranslationProject,
   Product,
   PeriodicReport,
 } as const;

--- a/src/core/database/query/filters.ts
+++ b/src/core/database/query/filters.ts
@@ -110,6 +110,14 @@ export const stringListProp =
     return { [prop ?? key]: { value: inArray(value as any) } };
   };
 
+export const stringListBaseNodeProp =
+  <T, K extends ConditionalKeys<Required<T>, readonly string[]>>(
+    prop?: string,
+  ): Builder<T, K> =>
+  ({ key, value }) => ({
+    node: { [prop ?? key]: inArray(value as any) },
+  });
+
 type PatternInput = Exclude<PatternCollection, any[][]>;
 
 export const pathExists =

--- a/src/core/database/query/match-project-based-props.ts
+++ b/src/core/database/query/match-project-based-props.ts
@@ -119,7 +119,7 @@ export const matchProjectSens =
         .with(projectVar) // import
         .with(projectVar) // needed for where clause
         .raw(
-          `WHERE ${projectVar} IS NOT NULL AND ${projectVar}.type = "${ProjectType.Translation}"`,
+          `WHERE ${projectVar} IS NOT NULL AND ${projectVar}.type <> "${ProjectType.Internship}"`,
         )
         .optionalMatch([
           node(projectVar),

--- a/test/engagement-workflow.e2e-spec.ts
+++ b/test/engagement-workflow.e2e-spec.ts
@@ -43,7 +43,7 @@ describe('Engagement-Workflow e2e', () => {
   it("should have engagement status 'InDevelopment' when add language or internship engagement", async () => {
     // --- Translation Project with engagement
     const transProject = await createProject(app, {
-      type: ProjectType.Translation,
+      type: ProjectType.MomentumTranslation,
     });
     expect(transProject.step.value).toBe(ProjectStep.EarlyConversations);
 
@@ -66,7 +66,7 @@ describe('Engagement-Workflow e2e', () => {
     it('translation', async function () {
       // --- Translation project
       const transProject = await createProject(app, {
-        type: ProjectType.Translation,
+        type: ProjectType.MomentumTranslation,
       });
       const langEngagement = await createLanguageEngagement(app, {
         projectId: transProject.id,
@@ -130,7 +130,7 @@ describe('Engagement-Workflow e2e', () => {
     it('engagement completed', async function () {
       // --- Engagement to Active
       const transProject = await createProject(app, {
-        type: ProjectType.Translation,
+        type: ProjectType.MomentumTranslation,
       });
       const langEngagement = await createLanguageEngagement(app, {
         projectId: transProject.id,
@@ -169,7 +169,7 @@ describe('Engagement-Workflow e2e', () => {
 
     it('engagement terminated', async function () {
       const transProject = await createProject(app, {
-        type: ProjectType.Translation,
+        type: ProjectType.MomentumTranslation,
       });
       const langEngagement = await createLanguageEngagement(app, {
         projectId: transProject.id,

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -543,7 +543,9 @@ describe('Engagement e2e', () => {
   });
 
   it('updates ceremony for language engagement', async () => {
-    project = await createProject(app, { type: ProjectType.Translation });
+    project = await createProject(app, {
+      type: ProjectType.MomentumTranslation,
+    });
     language = await runAsAdmin(app, createLanguage);
     const languageEngagement = await createLanguageEngagement(app, {
       languageId: language.id,

--- a/test/project-workflow.e2e-spec.ts
+++ b/test/project-workflow.e2e-spec.ts
@@ -78,7 +78,7 @@ describe('Project-Workflow e2e', () => {
   });
 
   it('should have default status as Pending for first budget with project creation', async () => {
-    const type = ProjectType.Translation;
+    const type = ProjectType.MomentumTranslation;
     const project = await createProject(app, { type });
 
     const queryProject = await app.graphql.query(

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -200,7 +200,7 @@ describe('Project e2e', () => {
     await expect(
       createProject(app, {
         name: faker.string.uuid(),
-        type: ProjectType.Translation,
+        type: ProjectType.MomentumTranslation,
         fieldRegionId: 'invalid-location-id' as ID,
       }),
     ).rejects.toThrowGqlError(
@@ -214,7 +214,7 @@ describe('Project e2e', () => {
   it('create & read project with budget and field region by id', async () => {
     const proj: CreateProject = {
       name: faker.string.uuid(),
-      type: ProjectType.Translation,
+      type: ProjectType.MomentumTranslation,
       fieldRegionId: fieldRegion.id,
     };
 
@@ -363,7 +363,7 @@ describe('Project e2e', () => {
       unsorted.map(async (name) => {
         return await createProject(app, {
           name,
-          type: ProjectType.Translation,
+          type: ProjectType.MomentumTranslation,
           fieldRegionId: fieldRegion.id,
         });
       }),
@@ -393,7 +393,7 @@ describe('Project e2e', () => {
   it('List view of projects', async () => {
     // create 2 projects
     const numProjects = 2;
-    const type = ProjectType.Translation;
+    const type = ProjectType.MomentumTranslation;
     await Promise.all(
       times(numProjects).map(
         async () =>
@@ -406,7 +406,7 @@ describe('Project e2e', () => {
 
     const { projects } = await app.graphql.query(
       gql`
-        query projects($type: ProjectType!) {
+        query projects($type: [ProjectType!]) {
           projects(input: { filter: { type: $type } }) {
             items {
               ...project
@@ -532,7 +532,7 @@ describe('Project e2e', () => {
 
   it('List view of my projects', async () => {
     const numProjects = 2;
-    const type = ProjectType.Translation;
+    const type = ProjectType.MomentumTranslation;
     await Promise.all(
       times(numProjects).map(
         async () =>
@@ -563,7 +563,7 @@ describe('Project e2e', () => {
 
   it('List view of pinned/unpinned projects', async () => {
     const numProjects = 2;
-    const type = ProjectType.Translation;
+    const type = ProjectType.MomentumTranslation;
     await Promise.all(
       times(numProjects).map(
         async () =>
@@ -621,7 +621,7 @@ describe('Project e2e', () => {
 
   it('List view of presetInventory projects', async () => {
     const numProjects = 2;
-    const type = ProjectType.Translation;
+    const type = ProjectType.MomentumTranslation;
     await Promise.all(
       times(numProjects).map(
         async () =>
@@ -798,7 +798,7 @@ describe('Project e2e', () => {
   it('List view of partnerships by projectId', async () => {
     //create 2 partnerships in a project
     const numPartnerships = 2;
-    const type = ProjectType.Translation;
+    const type = ProjectType.MomentumTranslation;
     const project = await createProject(app, {
       type,
       fieldRegionId: fieldRegion.id,
@@ -897,7 +897,7 @@ describe('Project e2e', () => {
   it('can create without mouStart, mouEnd and estimatedSubmission', async () => {
     const project: CreateProject = {
       name: faker.string.uuid(),
-      type: ProjectType.Translation,
+      type: ProjectType.MomentumTranslation,
       fieldRegionId: fieldRegion.id,
     };
 
@@ -924,7 +924,7 @@ describe('Project e2e', () => {
   it('can create without mouStart, if mouEnd is defined', async () => {
     const project: CreateProject = {
       name: faker.string.uuid(),
-      type: ProjectType.Translation,
+      type: ProjectType.MomentumTranslation,
       mouEnd: CalendarDate.fromISO('1992-11-01'),
       estimatedSubmission: CalendarDate.fromISO('1993-11-01'),
       fieldRegionId: fieldRegion.id,

--- a/test/utility/create-project.ts
+++ b/test/utility/create-project.ts
@@ -17,7 +17,7 @@ export async function createProject(
 ) {
   const project: CreateProject = {
     name: faker.lorem.word() + ' ' + faker.string.uuid(),
-    type: ProjectType.Translation,
+    type: ProjectType.MomentumTranslation,
     mouStart: CalendarDate.fromISO('1991-01-01'),
     mouEnd: CalendarDate.fromISO('1992-01-01'),
     step: ProjectStep.EarlyConversations,


### PR DESCRIPTION
<!--- replace the text in parentheses with Monday link for your task -->
## [Monday task](https://seed-company-squad.monday.com/boards/5989610236/views/132288519/pulses/5979104412)

<!--- or if you don't have a Monday task, you can remove the line above and give the reason here -->
<!--- 
## Reason for this PR
...

-->

## Description
<!--- Describe the changes in this pull request and include screenshots if needed -->
A new Translation Project type was introduced, Multiplication Project. The old "Translation" project becomes "Momentum" from a business stand point, but from a data view, the Translation project becomes abstract and Momentum and Multiplication become "subtypes" of Translation.



<!-- If this is a bug fix, uncomment the sections below, otherwise you can remove it -->
<!--
## Steps to reproduce the bug
1. ...
2. ...

## Expected behavior
...

-->


## Ready for review checklist
> Use `[N/A]` if the item is not applicable to this PR or remove the item
- [x] Change the task url above to the actual Monday task
- [N/A] Add/update tests if needed
- [ ] Add reviewers to this PR
