### PR TITLE
[Neo4j] Don't create empty nodes for optional, now null relationships

### DIFF
--- a/src/core/database/common.repository.ts
+++ b/src/core/database/common.repository.ts
@@ -12,7 +12,7 @@ import {
   NotFoundException,
   ResourceShape,
   ServerException,
-} from '../../common';
+} from '~/common';
 import { DatabaseService } from './database.service';
 import { createUniqueConstraint } from './indexer';
 import { ACTIVE, updateRelationList } from './query';
@@ -79,14 +79,19 @@ export class CommonRepository {
           // Ensure exactly one row is returned, for the create below
           .return('count(oldRel) as removedRelationCount'),
       )
-      .create([
-        node('node'),
-        relation('out', '', relationName, {
-          active: true,
-          createdAt: DateTime.local(),
-        }),
-        node('other'),
-      ])
+      .apply((q) =>
+        otherId
+          ? q.create([
+              node('node'),
+              relation('out', '', relationName, {
+                active: true,
+                createdAt: DateTime.local(),
+              }),
+              node('other'),
+            ])
+          : q,
+      )
+      .return('*')
       .run();
   }
 


### PR DESCRIPTION
Big big facepalm here. Can't believe this has lived for so long, we must've not been using it much. And I think we've made a recent push to fix the "update to nulls" in API/UI.

Creating these empty nodes does affect cardinality, which is why the DOMO sync was throwing a duplicate error.

I'll just drop these empty nodes in prod adhoc, I don't want to create a script.