### PR TITLE
Refactor root user creation

### DIFF
--- a/dbschema/seeds/001.root-user.ts
+++ b/dbschema/seeds/001.root-user.ts
@@ -1,0 +1,27 @@
+import { EnvironmentService } from '~/core/config/environment.service';
+import { determineRootUser } from '~/core/config/root-user.config';
+import type { SeedFn } from '~/core/edgedb/seeds.run';
+
+export default (async function ({ e, db, print }) {
+  const env = new EnvironmentService();
+  const rootUser = determineRootUser(env);
+
+  try {
+    await e.cast(e.User, e.uuid(rootUser.id)).run(db);
+    return;
+  } catch {
+    // doesn't exist, create below
+  }
+
+  const query = e.insert(e.User, {
+    id: rootUser.id,
+    email: rootUser.email,
+    realFirstName: 'Root',
+    realLastName: 'Admin',
+    roles: ['Administrator'],
+    createdAt: e.datetime('2021-02-13T15:29:18.603Z'),
+    modifiedAt: e.datetime('2021-02-13T15:29:18.603Z'),
+  });
+  await query.run(db);
+  print('Added Root User');
+} satisfies SeedFn);

--- a/dbschema/seeds/002.field-zones-regions.edgeql
+++ b/dbschema/seeds/002.field-zones-regions.edgeql
@@ -1,5 +1,5 @@
 with
-  root := (select RootUser),
+  root := (select User order by .createdAt limit 1),
   zones := (
     for name in {
       "Americas, Pacific, Eurasia",
@@ -18,7 +18,7 @@ with
 select { `Added Field Zones` := new.name }
 filter count(new) > 0;
 with
-  root := (select RootUser),
+  root := (select User order by .createdAt limit 1),
   regions := (
     for item in {
       (zone := "Americas, Pacific, Eurasia", regions := {"Americas", "Pacific", "Eurasia"}),

--- a/dbschema/user.esdl
+++ b/dbschema/user.esdl
@@ -31,11 +31,6 @@ module default {
       on target delete allow;
     }
   }
-  
-  alias RootUser := (
-      SELECT User
-      FILTER .email = 'devops@tsco.org'
-  );
 }
  
 module User {

--- a/src/components/admin/admin.edgedb.service.ts
+++ b/src/components/admin/admin.edgedb.service.ts
@@ -1,0 +1,60 @@
+import { Inject, Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { ConfigService } from '~/core/config/config.service';
+import { ILogger, Logger } from '~/core/logger';
+import { CryptoService } from '../authentication/crypto.service';
+import { AdminEdgeDBRepository } from './admin.edgedb.repository';
+import { AdminRepository } from './admin.repository';
+
+@Injectable()
+export class AdminEdgeDBService implements OnApplicationBootstrap {
+  constructor(
+    private readonly config: ConfigService,
+    private readonly crypto: CryptoService,
+    @Inject(AdminRepository) private readonly repo: AdminEdgeDBRepository,
+    @Logger('admin:service') private readonly logger: ILogger,
+  ) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    const finishing = this.repo.finishing(() => this.setupRootUser());
+    // Wait for root object setup when running tests, else just let it run in
+    // the background and allow webserver to start.
+    if (this.config.jest) {
+      await finishing;
+    } else {
+      finishing.catch((exception) => {
+        this.logger.error('Failed to setup root objects', {
+          exception,
+        });
+      });
+    }
+  }
+
+  private async setupRootUser(): Promise<void> {
+    const root = this.config.rootUser;
+
+    const existing = await this.repo.doesRootUserExist(root.id);
+    if (!existing) {
+      this.logger.notice('Setting up root user');
+
+      // ID could've changed, so the old root user becomes stale here.
+      // This will also fail if trying to insert with an email that already exists.
+      // So if ID changes, but email doesn't, this will fail.
+      // I don't think it is safe to do anything else, so let this error happen.
+      const hashed = await this.crypto.hash(root.password);
+      await this.repo.createRootUser(root.id, root.email, hashed);
+      return;
+    }
+
+    const passwordSame = await this.crypto
+      .verify(existing.hash, root.password)
+      .catch(() => false);
+    if (existing.email !== root.email || !passwordSame) {
+      this.logger.notice('Updating root user to match app configuration');
+      await this.repo.updateEmail(root.id, root.email);
+      if (!passwordSame) {
+        const hashed = await this.crypto.hash(root.password);
+        await this.repo.auth.savePasswordHashOnUser(root.id, hashed);
+      }
+    }
+  }
+}

--- a/src/components/admin/admin.module.ts
+++ b/src/components/admin/admin.module.ts
@@ -2,12 +2,20 @@ import { Module } from '@nestjs/common';
 import { splitDb } from '~/core';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { AdminEdgeDBRepository } from './admin.edgedb.repository';
+import { AdminEdgeDBService } from './admin.edgedb.service';
 import { AdminRepository } from './admin.repository';
 import { AdminService } from './admin.service';
 
 @Module({
   imports: [AuthorizationModule],
-  providers: [AdminService, splitDb(AdminRepository, AdminEdgeDBRepository)],
-  exports: [AdminService],
+  providers: [
+    splitDb(AdminService, AdminEdgeDBService),
+    splitDb(
+      AdminRepository,
+      // @ts-expect-error types don't have to match since the service is split
+      // and each will only use their own.
+      AdminEdgeDBRepository,
+    ),
+  ],
 })
 export class AdminModule {}

--- a/src/components/admin/admin.repository.ts
+++ b/src/components/admin/admin.repository.ts
@@ -47,7 +47,7 @@ export class AdminRepository extends CommonRepository {
       .first();
   }
 
-  async mergeRootAdminUser(email: string, hashedPassword: string) {
+  async updateRootUser(id: ID, email: string, hashedPassword?: string) {
     await this.db
       .query()
       .match([
@@ -58,18 +58,19 @@ export class AdminRepository extends CommonRepository {
         node('pw', 'Property'),
       ])
       .setValues({
+        root: { id },
         email: { value: email },
-        pw: { value: hashedPassword },
+        ...(hashedPassword ? { pw: { value: hashedPassword } } : {}),
       })
       .run();
   }
 
-  async setUserLabel(powers: string[], id: string) {
+  async setRootUserLabel(tempId: ID, id: ID) {
     await this.db
       .query()
-      .matchNode('user', 'User', { id })
+      .matchNode('user', 'User', { id: tempId })
       .setLabels({ user: 'RootUser' })
-      .setValues({ user: { powers } }, true)
+      .setValues({ user: { id } })
       .run();
   }
 

--- a/src/components/authentication/authentication.service.ts
+++ b/src/components/authentication/authentication.service.ts
@@ -165,7 +165,7 @@ export class AuthenticationService {
     return session;
   }
 
-  lazySessionForRootAdminUser(input?: Partial<Session>) {
+  lazySessionForRootUser(input?: Partial<Session>) {
     const promiseOfRootId = this.repo.waitForRootUserId().then((id) => {
       (session as Writable<Session>).userId = id;
       return id;
@@ -190,7 +190,7 @@ export class AuthenticationService {
         }
         if (p === 'withRoles') {
           return (...roles: Role[]) =>
-            this.lazySessionForRootAdminUser({
+            this.lazySessionForRootUser({
               roles: roles.map(rolesForScope('global')),
             });
         }

--- a/src/components/progress-report/workflow/handlers/progress-report-workflow-notification.handler.ts
+++ b/src/components/progress-report/workflow/handlers/progress-report-workflow-notification.handler.ts
@@ -112,9 +112,7 @@ export class ProgressReportWorkflowNotificationHandler
     projectId: ID,
     languageId: ID,
   ): Promise<EmailReportStatusNotification> {
-    const recipientId = receiver.userId
-      ? receiver.userId
-      : this.configService.rootAdmin.id;
+    const recipientId = receiver.userId ?? this.configService.rootUser.id;
     const recipientSession = await this.auth.sessionForUser(recipientId);
 
     const recipient = receiver.userId

--- a/src/components/project/project.rules.ts
+++ b/src/components/project/project.rules.ts
@@ -1052,7 +1052,7 @@ export class ProjectRules {
     previousStep?: ProjectStep,
   ): Promise<EmailNotification> {
     const recipientId = notifier.includes('@')
-      ? this.configService.rootAdmin.id
+      ? this.configService.rootUser.id
       : (notifier as ID);
     const recipientSession = await this.auth.sessionForUser(recipientId);
     const recipient = notifier.includes('@')

--- a/src/core/config/environment.service.ts
+++ b/src/core/config/environment.service.ts
@@ -9,7 +9,8 @@ import { Duration } from 'luxon';
 import { URL } from 'node:url';
 import { join } from 'path';
 import { DurationIn } from '~/common';
-import { ILogger, Logger } from '../logger';
+import { Logger } from '../logger/logger.decorator';
+import type { ILogger } from '../logger/logger.interface';
 
 /**
  * Handle reading values from environment and env files.
@@ -21,7 +22,8 @@ export class EnvironmentService implements Iterable<[string, string]> {
   private readonly env: Record<string, string>;
 
   constructor(
-    @Logger('config:environment') private readonly logger: ILogger,
+    @Logger('config:environment')
+    private readonly logger: ILogger | undefined = undefined,
     @Optional() rootPath = process.cwd(),
     @Optional() env = process.env.NODE_ENV || 'development',
   ) {
@@ -38,10 +40,10 @@ export class EnvironmentService implements Iterable<[string, string]> {
 
     for (const file of files) {
       if (!fs.existsSync(file)) {
-        this.logger.debug(`Skipping file`, { file });
+        this.logger?.debug(`Skipping file`, { file });
         continue;
       }
-      this.logger.debug(`Loading file`, { file });
+      this.logger?.debug(`Loading file`, { file });
 
       const parsed = parseEnv(fs.readFileSync(file));
 
@@ -61,7 +63,7 @@ export class EnvironmentService implements Iterable<[string, string]> {
     // Convert all keys to uppercase
     this.env = mapKeys(this.env, (key) => key.toUpperCase()).asRecord;
 
-    this.logger.debug(`Loaded environment`, this.env);
+    this.logger?.debug(`Loaded environment`, this.env);
   }
 
   string(key: string) {

--- a/src/core/config/root-user.config.ts
+++ b/src/core/config/root-user.config.ts
@@ -1,0 +1,30 @@
+import { v5 as uuidV5 } from 'uuid';
+import type { ID } from '~/common';
+import { EnvironmentService } from './environment.service';
+
+const isDev = process.env.NODE_ENV === 'development';
+
+export const UserNs = '7ee19032-2a96-474a-824d-a9c950b06f14';
+
+export const determineRootUser = (env: EnvironmentService) => {
+  const user = JSON.parse(env.string('ROOT_USER').optional('{}')) as {
+    [_ in 'id' | 'email' | 'password']?: string;
+  };
+  const email =
+    env.string('ROOT_USER_EMAIL').optional() ?? user.email ?? 'devops@tsco.org';
+  const password =
+    env.string('ROOT_USER_PASSWORD').optional() ??
+    user.password ??
+    env.string('ROOT_ADMIN_PASSWORD').optional() ??
+    'admin';
+  const id =
+    env.string('ROOT_USER_ID').optional() ??
+    user.id ??
+    // Use static ID in dev, so that devs can change email/password while
+    // still sharing the same ID.
+    (isDev ? 'd1bebdaa-efcf-57ee-84cd-0b2bfa01eaa7' : undefined) ??
+    // Otherwise in production if ID has not been provided, hash it from
+    // the email & password.
+    uuidV5(`${email}\0${password}`, UserNs);
+  return { id: id as ID, email, password } as const;
+};

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -24,9 +24,7 @@ runRepl({
     );
     const { Pnp } = await import('./components/pnp');
 
-    const session = app
-      .get(AuthenticationService)
-      .lazySessionForRootAdminUser();
+    const session = app.get(AuthenticationService).lazySessionForRootUser();
     const Resources = app.get(ResourcesHost).getEnhancedMap();
 
     return {

--- a/test/utility/login.ts
+++ b/test/utility/login.ts
@@ -20,7 +20,7 @@ export async function login(app: TestApp, input: Partial<LoginInput> = {}) {
 }
 
 export const loginAsAdmin = async (app: TestApp) => {
-  const { email, password } = app.get(ConfigService).rootAdmin;
+  const { email, password } = app.get(ConfigService).rootUser;
   await login(app, { email, password });
 };
 


### PR DESCRIPTION
Now an ID & email can be given via environment.
The default fallback will be a static ID for dev,
and a hash of the email/password for prod
(though we'll configure a static one there too).

For EdgeDB, we now create the RootUser in both seeds and on app boot. This allows seeds to work after wiping data.
This also removes the need to have the root user in the migrations/ folder.
