### PR TITLE
Fix field condition not unwrapping secured values

### DIFF
--- a/src/components/authorization/policies/conditions/enum-field.condition.ts
+++ b/src/components/authorization/policies/conditions/enum-field.condition.ts
@@ -3,7 +3,7 @@ import { Query } from 'cypher-query-builder';
 import { get, startCase } from 'lodash';
 import { Get, Paths } from 'type-fest';
 import { inspect, InspectOptionsStylized } from 'util';
-import { ResourceShape, UnwrapSecured } from '~/common';
+import { ResourceShape, unwrapSecured, UnwrapSecured } from '~/common';
 import {
   Condition,
   eqlInLiteralSet,
@@ -26,9 +26,10 @@ export class EnumFieldCondition<
     if (!object) {
       throw new Error(`Needed object's ${this.path} but object wasn't given`);
     }
-    const actual = get(object, this.path) as
-      | ValueOfPath<TResourceStatic, Path>
+    const value = get(object, this.path) as
+      | Get<InstanceType<TResourceStatic>, Path>
       | undefined;
+    const actual = unwrapSecured(value);
     if (!actual) {
       throw new Error(`Needed object's ${this.path} but it wasn't found`);
     }


### PR DESCRIPTION
Looking back, the former `StatusCondition` also didn't do this.

Due to calling code, this condition always worked fine when securing the object because the object wasn't secured.
(Which is also what declares the `canDelete` boolean.)
It is only when using a secured object as the context, that this bug was hit.

So this did in fact work correctly when it was written: #2863
It was only after we changed the `delete` check, which _did_ use a secured object, that this bug was exposed: #2976

FYI @renatorossiter
