### PR TITLE
Updated `departmentId` generation for Multiplication Projects

### DIFF
--- a/dbschema/migrations/00003.edgeql
+++ b/dbschema/migrations/00003.edgeql
@@ -1,0 +1,52 @@
+CREATE MIGRATION m1nrdwc3vdx7w2iui6bxlxxe3urjirypmaw5ft33yehtq33dgeyovq
+    ONTO m1jtglkzb7fc5jezkxnximpq4uqqykdyevfvsnkzf26fv4ouxv274a
+{
+  ALTER TYPE default::Project {
+      ALTER PROPERTY departmentId {
+          DROP REWRITE
+              INSERT ;
+          };
+      };
+  ALTER TYPE default::Project {
+      ALTER PROPERTY departmentId {
+          CREATE REWRITE
+              INSERT 
+              USING ((IF ((NOT (EXISTS (.departmentId)) AND (.status <= Project::Status.Active)) AND (.step >= Project::Step.PendingFinanceConfirmation)) THEN (WITH
+                  info := 
+                      (IF (__subject__ IS default::MultiplicationTranslationProject) THEN (
+                          prefix := 8,
+                          startingOffset := 201
+                      ) ELSE (
+                          prefix := (std::assert_exists(__subject__.primaryLocation.fundingAccount, message := 'Project must have a primary location')).accountNumber,
+                          startingOffset := 11
+                      ))
+              SELECT
+                  std::min((<std::str>std::range_unpack(std::range(((info.prefix * 10000) + info.startingOffset), ((info.prefix * 10000) + 9999))) EXCEPT (DETACHED default::Project).departmentId))
+              ) ELSE .departmentId));
+      };
+  };
+  ALTER TYPE default::Project {
+      ALTER PROPERTY departmentId {
+          DROP REWRITE
+              UPDATE ;
+          };
+      };
+  ALTER TYPE default::Project {
+      ALTER PROPERTY departmentId {
+          CREATE REWRITE
+              UPDATE 
+              USING ((IF ((NOT (EXISTS (.departmentId)) AND (.status <= Project::Status.Active)) AND (.step >= Project::Step.PendingFinanceConfirmation)) THEN (WITH
+                  info := 
+                      (IF (__subject__ IS default::MultiplicationTranslationProject) THEN (
+                          prefix := 8,
+                          startingOffset := 201
+                      ) ELSE (
+                          prefix := (std::assert_exists(__subject__.primaryLocation.fundingAccount, message := 'Project must have a primary location')).accountNumber,
+                          startingOffset := 11
+                      ))
+              SELECT
+                  std::min((<std::str>std::range_unpack(std::range(((info.prefix * 10000) + info.startingOffset), ((info.prefix * 10000) + 9999))) EXCEPT (DETACHED default::Project).departmentId))
+              ) ELSE .departmentId));
+      };
+  };
+};


### PR DESCRIPTION
<!--- replace the text in parentheses with Monday link for your task -->
## [Monday task](https://seed-company-squad.monday.com/boards/3451697530/views/78801614/pulses/5771105218)

<!--- or if you don't have a Monday task, you can remove the line above and give the reason here -->
<!--- 
## Reason for this PR
...

-->

## Description
<!--- Describe the changes in this pull request and include screenshots if needed -->
Updated the EdgeDB trigger for update and insert on projects to account for the new style of department ID generation, special for the Multiplication Translation Projects.


![Screenshot 2024-04-17 at 5 59 22 PM](https://github.com/SeedCompany/cord-api-v3/assets/4716734/6fad7440-5e2e-408c-a7a0-2e5cc95522e6)


## Ready for review checklist
> Use `[N/A]` if the item is not applicable to this PR or remove the item
- [x] Change the task url above to the actual Monday task
- [ ] Add/update tests if needed
- [ ] Add reviewers to this PR
