### PR TITLE
fixed TODOs and incorrectly registered resources on EdgeDB Projects

### DIFF
--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -194,7 +194,7 @@ export class TranslationProject extends Project {
   static readonly SecuredProps = keysOf<SecuredProps<TranslationProject>>();
 }
 
-@RegisterResource({ db: e.TranslationProject })
+@RegisterResource({ db: e.MomentumTranslationProject })
 @ObjectType({
   implements: [TranslationProject],
   description: 'Formerly known as our TranslationProjects',
@@ -207,7 +207,7 @@ export class MomentumTranslationProject extends TranslationProject {
   declare readonly type: 'MomentumTranslation';
 }
 
-@RegisterResource({ db: e.TranslationProject })
+@RegisterResource({ db: e.MultiplicationTranslationProject })
 @ObjectType({
   implements: [TranslationProject],
 })
@@ -251,7 +251,7 @@ declare module '~/core/resources/map' {
     Project: typeof e.default.Project;
     InternshipProject: typeof e.default.InternshipProject;
     TranslationProject: typeof e.default.TranslationProject;
-    MomentumTranslationProject: typeof e.default.TranslationProject; // TODO
-    MultiplicationTranslationProject: typeof e.default.TranslationProject; // TODO
+    MomentumTranslationProject: typeof e.default.MomentumTranslationProject;
+    MultiplicationTranslationProject: typeof e.default.MultiplicationTranslationProject;
   }
 }


### PR DESCRIPTION
## Reason for this PR
Some TODOs were not addressed and the Projects DTO was not registering the correct EdgeDB concretes.
This meant that when creating a Momentum or Multiplication project, it would try to create a Translation project and fail.

## Description
Fixed/addressed the TODOs and fixed the the concrete resource registrations.


<!-- If this is a bug fix, uncomment the sections below, otherwise you can remove it -->
<!--
## Steps to reproduce the bug
1. ...
2. ...

## Expected behavior
...

-->


## Ready for review checklist
> Use `[N/A]` if the item is not applicable to this PR or remove the item
- [x] Change the task url above to the actual Monday task
- [N/A] Add/update tests if needed
- [x] Add reviewers to this PR
