### PR TITLE
[Neo4j] Migrate creator on BaseNode to normalized relationship

### DIFF
--- a/src/components/admin/admin.module.ts
+++ b/src/components/admin/admin.module.ts
@@ -5,6 +5,7 @@ import { AdminEdgeDBRepository } from './admin.edgedb.repository';
 import { AdminEdgeDBService } from './admin.edgedb.service';
 import { AdminRepository } from './admin.repository';
 import { AdminService } from './admin.service';
+import { NormalizeCreatorBaseNodeMigration } from './migrations/normalize-creator-base-node.migration';
 import { NormalizeCreatorMigration } from './migrations/normalize-creator.migration';
 
 @Module({
@@ -18,6 +19,7 @@ import { NormalizeCreatorMigration } from './migrations/normalize-creator.migrat
       AdminEdgeDBRepository,
     ),
     NormalizeCreatorMigration,
+    NormalizeCreatorBaseNodeMigration,
   ],
 })
 export class AdminModule {}

--- a/src/components/admin/migrations/normalize-creator-base-node.migration.ts
+++ b/src/components/admin/migrations/normalize-creator-base-node.migration.ts
@@ -1,0 +1,24 @@
+import { BaseMigration, Migration } from '~/core/database';
+
+@Migration('2024-04-18T09:00:00')
+export class NormalizeCreatorBaseNodeMigration extends BaseMigration {
+  async up() {
+    // Handle RootUser first specially.
+    // Since denormalized creator IDs for RootUser currently reference a non-existent user ID
+    await this.db.query().raw`
+      match (user:RootUser)
+      match (bn:BaseNode)
+      where bn.creator is not null and not exists { (:User { id: bn.creator }) }
+      create (bn)-[:creator { active: true, createdAt: bn.createdAt }]->(user)
+      set bn.creator = null
+    `.executeAndLogStats();
+
+    await this.db.query().raw`
+      match (bn:BaseNode)
+      where bn.creator is not null
+      match (user:User { id: bn.creator })
+      create (bn)-[:creator { active: true, createdAt: bn.createdAt }]->(user)
+      set bn.creator = null
+    `.executeAndLogStats();
+  }
+}


### PR DESCRIPTION
Another miss from #3172 / #3163

The new schema is
```cql
(:BaseNode)-[:creator]->(:User { id: "user id" })
```
The data migration in that PR handled
```cql
(:BaseNode)-[:creator]->(:Property { value: "user id" })
```
But it missed places where we did
```cql
(:BaseNode { creator: "user id" })
```

I did already run these in dev to test.