### PR TITLE
EdgeDB v5-rc.1 allows config changes inside sessions

### DIFF
--- a/edgedb.toml
+++ b/edgedb.toml
@@ -1,2 +1,2 @@
 [edgedb]
-server-version = "5.0-beta.2"
+server-version = "5.0-rc.1"

--- a/src/components/authentication/authentication.edgedb.repository.ts
+++ b/src/components/authentication/authentication.edgedb.repository.ts
@@ -12,7 +12,7 @@ export class AuthenticationEdgeDBRepository
 {
   private readonly db: EdgeDB;
   constructor(db: EdgeDB) {
-    this.db = db.outsideOfTransactions().withOptions(disableAccessPolicies);
+    this.db = db.withOptions(disableAccessPolicies);
   }
 
   async waitForRootUserId() {

--- a/src/core/edgedb/edgedb.service.ts
+++ b/src/core/edgedb/edgedb.service.ts
@@ -69,7 +69,7 @@ export class EdgeDB {
    *   await EdgeDB.run(...);
    * });
    */
-  get usingOptions() {
+  get usingOptions(): OptionsContext['usingOptions'] {
     return this.optionsContext.usingOptions.bind(this.optionsContext);
   }
 

--- a/src/core/edgedb/transaction.context.ts
+++ b/src/core/edgedb/transaction.context.ts
@@ -1,8 +1,7 @@
 import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import { AsyncLocalStorage } from 'async_hooks';
-import { EdgeDBError, Executor, Session } from 'edgedb';
-import { getPreviousList, ServerException } from '~/common';
-import { OptionsContext } from './options.context';
+import { EdgeDBError, Executor } from 'edgedb';
+import { getPreviousList } from '~/common';
 import { Client } from './reexports';
 
 @Injectable()
@@ -10,30 +9,17 @@ export class TransactionContext
   extends AsyncLocalStorage<Executor>
   implements OnModuleDestroy
 {
-  constructor(
-    private readonly client: Client,
-    private readonly optionsContext: OptionsContext,
-  ) {
+  constructor(private readonly client: Client) {
     super();
   }
 
   async inTx<R>(fn: () => Promise<R>): Promise<R> {
     const errorMap = new WeakMap<Error, Error>();
 
-    const txSession = this.optionsContext.current.session;
-
     try {
       return await this.client.transaction(async (tx) => {
-        const txx = new Proxy(tx, {
-          get: (target: typeof tx, p: string, receiver: any) => {
-            const current = this.optionsContext.current.session;
-            ensureCompatibleSession(txSession, current);
-            return Reflect.get(target, p, receiver);
-          },
-        });
-
         try {
-          return await this.run(txx, fn);
+          return await this.run(tx, fn);
         } catch (error) {
           // If the error "wraps" an EdgeDB error, then
           // throw that here and save the original.
@@ -61,19 +47,5 @@ export class TransactionContext
 
   onModuleDestroy() {
     this.disable();
-  }
-}
-
-function ensureCompatibleSession(txSession: Session, current: Session) {
-  // This should work, but is bugged right now.
-  // https://github.com/edgedb/edgedb/issues/7138
-  // It's hard to reason about, so I'm making sure it errors loud.
-  if (
-    txSession.config.apply_access_policies !==
-    current.config.apply_access_policies
-  ) {
-    throw new ServerException(
-      'Access policies cannot be toggled within a transaction',
-    );
   }
 }


### PR DESCRIPTION
This updates min version and removes workaround for avoiding transactions when disabling access policies.
https://github.com/edgedb/edgedb/issues/7138