### PR TITLE
Owner -> Audited / Actor / SystemAgent / Self

### DIFF
--- a/dbschema/comments.esdl
+++ b/dbschema/comments.esdl
@@ -3,7 +3,7 @@ module Comments {
     commentThreads := .<container[is Thread];
   }
 
-  type Thread extending default::Resource, Mixin::Embedded, Mixin::Owned {
+  type Thread extending default::Resource, Mixin::Embedded {
     overloaded required single link container: Aware {
       on target delete delete source;
     };
@@ -12,7 +12,7 @@ module Comments {
     latestComment := (select .comments order by .createdAt desc limit 1);
   }
 
-  type Comment extending default::Resource, Mixin::Owned {
+  type Comment extending default::Resource {
     required thread: Thread {
       on target delete delete source;
     };

--- a/dbschema/common.esdl
+++ b/dbschema/common.esdl
@@ -2,7 +2,8 @@ module default {
   global currentActorId: uuid;
   global currentActor := (select Actor filter .id = global currentActorId);
   global currentUser := (select User filter .id = global currentActorId);
-  
+  global currentRoles := (global currentActor).roles;
+
   scalar type ReportPeriod extending enum<Monthly, Quarterly>;
   
   # Helper function to workaround native support for sort ignoring accents

--- a/dbschema/common.esdl
+++ b/dbschema/common.esdl
@@ -1,6 +1,7 @@
 module default {
-  global currentUserId: uuid;
-  alias currentUser := <User>(global currentUserId);
+  global currentActorId: uuid;
+  global currentActor := (select Actor filter .id = global currentActorId);
+  global currentUser := (select User filter .id = global currentActorId);
   
   scalar type ReportPeriod extending enum<Monthly, Quarterly>;
   

--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -76,8 +76,8 @@ module default {
       insert Engagement::DedicationCeremony {
         createdAt := datetime_of_statement(),
         modifiedAt := datetime_of_statement(),
-        createdBy := assert_exists(currentUser),
-        modifiedBy := assert_exists(currentUser),
+        createdBy := assert_exists(global currentActor),
+        modifiedBy := assert_exists(global currentActor),
         engagement := __new__,
         project := __new__.project,
         projectContext := __new__.projectContext,
@@ -130,8 +130,8 @@ module default {
       insert Engagement::CertificationCeremony {
         createdAt := datetime_of_statement(),
         modifiedAt := datetime_of_statement(),
-        createdBy := assert_exists(currentUser),
-        modifiedBy := assert_exists(currentUser),
+        createdBy := assert_exists(global currentActor),
+        modifiedBy := assert_exists(global currentActor),
         engagement := __new__,
         project := __new__.project,
         projectContext := __new__.projectContext,

--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -76,6 +76,8 @@ module default {
       insert Engagement::DedicationCeremony {
         createdAt := datetime_of_statement(),
         modifiedAt := datetime_of_statement(),
+        createdBy := assert_exists(currentUser),
+        modifiedBy := assert_exists(currentUser),
         engagement := __new__,
         project := __new__.project,
         projectContext := __new__.projectContext,
@@ -128,6 +130,8 @@ module default {
       insert Engagement::CertificationCeremony {
         createdAt := datetime_of_statement(),
         modifiedAt := datetime_of_statement(),
+        createdBy := assert_exists(currentUser),
+        modifiedBy := assert_exists(currentUser),
         engagement := __new__,
         project := __new__.project,
         projectContext := __new__.projectContext,

--- a/dbschema/file.esdl
+++ b/dbschema/file.esdl
@@ -25,15 +25,9 @@ module File {
     # optional to have tri-state. idk if needed but that's what I implemented in neo4j
     public: bool;
     
-    required createdBy: default::User {
-      default := default::currentUser;
-    };
-    required modifiedBy: default::User {
-      default := default::currentUser;
-      rewrite update using (default::currentUser);
-      # TODO trigger change up the tree
-      # TODO trigger re-eval on node delete?
-    };
+    # TODO trigger change up the tree
+    # TODO trigger re-eval on node delete?
+    # modifiedBy: default::User
     
     # TODO trigger directories evaluate
     required size: int64;

--- a/dbschema/migrations/00006.edgeql
+++ b/dbschema/migrations/00006.edgeql
@@ -1,0 +1,687 @@
+create migration m1rxhi72zd43b4hwanwavpsfx7yo5vfngfr4ngmxq4thpuvi3t45qa
+    onto m1jmb5p3ypawyyn6yvctr5of2zp2mw5rd5iyzrxnqmn75eyp3viroq
+{
+  # Drop all APs temporarily
+  alter type Budget::Record {
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForBudgetRecord;
+    drop access policy CanUpdateWriteInsertDeleteGeneratedFromAppPoliciesForBudgetRecord;
+  };
+  alter type Comments::Aware {
+    drop access policy CanInsertDeleteGeneratedFromAppPoliciesForCommentable;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForCommentable;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForCommentable;
+  };
+  alter type Comments::Comment {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForComment;
+    drop access policy CanInsertGeneratedFromAppPoliciesForComment;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForComment;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForComment;
+  };
+  alter type Comments::Thread {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForCommentThread;
+    drop access policy CanInsertGeneratedFromAppPoliciesForCommentThread;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForCommentThread;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForCommentThread;
+  };
+  alter type Engagement::Ceremony {
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForCeremony;
+    drop access policy CanUpdateWriteInsertDeleteGeneratedFromAppPoliciesForCeremony;
+  };
+  alter type Ethnologue::Language {
+    drop access policy CanInsertDeleteGeneratedFromAppPoliciesForEthnologueLanguage;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForEthnologueLanguage;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForEthnologueLanguage;
+  };
+  alter type File::Node {
+    drop access policy CanInsertDeleteGeneratedFromAppPoliciesForFileNode;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForFileNode;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForFileNode;
+  };
+  alter type default::Media {
+    drop access policy CanInsertDeleteGeneratedFromAppPoliciesForMedia;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForMedia;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForMedia;
+  };
+  alter type Mixin::Postable {
+    drop access policy CanInsertDeleteGeneratedFromAppPoliciesForPostable;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForPostable;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForPostable;
+  };
+  alter type ProgressReport::CommunityStory {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForProgressReportCommunityStory;
+    drop access policy CanInsertGeneratedFromAppPoliciesForProgressReportCommunityStory;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportCommunityStory;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForProgressReportCommunityStory;
+  };
+  alter type ProgressReport::Highlight {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForProgressReportHighlight;
+    drop access policy CanInsertGeneratedFromAppPoliciesForProgressReportHighlight;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportHighlight;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForProgressReportHighlight;
+  };
+  alter type ProgressReport::Media {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForProgressReportMedia;
+    drop access policy CanInsertGeneratedFromAppPoliciesForProgressReportMedia;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportMedia;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForProgressReportMedia;
+  };
+  alter type ProgressReport::TeamNews {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForProgressReportTeamNews;
+    drop access policy CanInsertGeneratedFromAppPoliciesForProgressReportTeamNews;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportTeamNews;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForProgressReportTeamNews;
+  };
+  alter type ProgressReport::VarianceExplanation {
+    drop access policy CanInsertDeleteGeneratedFromAppPoliciesForProgressReportVarianceExplanation;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportVarianceExplanation;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForProgressReportVarianceExplanation;
+  };
+  alter type ProgressReport::WorkflowEvent {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForProgressReportWorkflowEvent;
+    drop access policy CanInsertGeneratedFromAppPoliciesForProgressReportWorkflowEvent;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportWorkflowEvent;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForProgressReportWorkflowEvent;
+  };
+  alter type ProgressReport::ProductProgress::Step {
+    drop access policy CanInsertDeleteGeneratedFromAppPoliciesForStepProgress;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForStepProgress;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForStepProgress;
+  };
+  alter type Project::Member {
+    drop access policy CanInsertDeleteGeneratedFromAppPoliciesForProjectMember;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForProjectMember;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForProjectMember;
+  };
+  alter type User::Education {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForEducation;
+    drop access policy CanInsertGeneratedFromAppPoliciesForEducation;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForEducation;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForEducation;
+  };
+  alter type User::Unavailability {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForUnavailability;
+    drop access policy CanInsertGeneratedFromAppPoliciesForUnavailability;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForUnavailability;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForUnavailability;
+  };
+  alter type default::Budget {
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForBudget;
+    drop access policy CanUpdateWriteInsertDeleteGeneratedFromAppPoliciesForBudget;
+  };
+  alter type default::Directory {
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForDirectory;
+  };
+  alter type default::Engagement {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForEngagement;
+    drop access policy CanInsertGeneratedFromAppPoliciesForEngagement;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForEngagement;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForEngagement;
+  };
+  alter type default::Producible {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForProducible;
+    drop access policy CanInsertGeneratedFromAppPoliciesForProducible;
+    drop access policy CanSelectUpdateReadUpdateWriteGeneratedFromAppPoliciesForProducible;
+  };
+  alter type default::FieldRegion {
+    drop access policy CanInsertDeleteGeneratedFromAppPoliciesForFieldRegion;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForFieldRegion;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForFieldRegion;
+  };
+  alter type default::FieldZone {
+    drop access policy CanInsertDeleteGeneratedFromAppPoliciesForFieldZone;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForFieldZone;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForFieldZone;
+  };
+  alter type default::PeriodicReport {
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForPeriodicReport;
+    drop access policy CanUpdateWriteInsertDeleteGeneratedFromAppPoliciesForPeriodicReport;
+  };
+  alter type default::FundingAccount {
+    drop access policy CanInsertDeleteGeneratedFromAppPoliciesForFundingAccount;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForFundingAccount;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForFundingAccount;
+  };
+  alter type default::Project {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForProject;
+    drop access policy CanInsertGeneratedFromAppPoliciesForProject;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForProject;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForProject;
+  };
+  alter type default::Language {
+    drop access policy CanInsertDeleteGeneratedFromAppPoliciesForLanguage;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForLanguage;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForLanguage;
+  };
+  alter type default::LanguageEngagement {
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForLanguageEngagement;
+  };
+  alter type default::Location {
+    drop access policy CanInsertDeleteGeneratedFromAppPoliciesForLocation;
+    drop access policy CanSelectUpdateReadUpdateWriteGeneratedFromAppPoliciesForLocation;
+  };
+  alter type default::NarrativeReport {
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForNarrativeReport;
+  };
+  alter type default::Organization {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForOrganization;
+    drop access policy CanInsertGeneratedFromAppPoliciesForOrganization;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForOrganization;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForOrganization;
+  };
+  alter type default::Partner {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForPartner;
+    drop access policy CanInsertGeneratedFromAppPoliciesForPartner;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForPartner;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForPartner;
+  };
+  alter type default::Partnership {
+    drop access policy CanInsertDeleteGeneratedFromAppPoliciesForPartnership;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForPartnership;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForPartnership;
+  };
+  alter type default::Post {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForPost;
+    drop access policy CanInsertGeneratedFromAppPoliciesForPost;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForPost;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForPost;
+  };
+  alter type default::ProgressReport {
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReport;
+  };
+  alter type default::User {
+    drop access policy CanDeleteGeneratedFromAppPoliciesForUser;
+    drop access policy CanInsertGeneratedFromAppPoliciesForUser;
+    drop access policy CanSelectUpdateReadGeneratedFromAppPoliciesForUser;
+    drop access policy CanUpdateWriteGeneratedFromAppPoliciesForUser;
+  };
+
+  # Introduce Actor / SystemAgents
+  create abstract type default::Actor {
+    create multi property roles: default::Role;
+  };
+  alter type default::User {
+    extending default::Actor before Mixin::Pinnable;
+    alter property roles {
+      reset cardinality;
+      drop owned;
+      reset type;
+    };
+  };
+  create type default::SystemAgent extending default::Actor, Mixin::Named {
+    alter property name {
+      set owned;
+      create constraint std::exclusive;
+    };
+  };
+  insert SystemAgent { name := "Ghost" };
+  insert SystemAgent { name := "Anonymous" };
+  insert SystemAgent { name := "External Mailing Group", roles := Role.Leadership };
+
+  # Stub Audited
+  create abstract type Mixin::Audited extending Mixin::Timestamped;
+
+  create global default::currentActor := (select Actor filter .id = global currentUserId);
+
+  # Switch to extend Resource & Audited
+  alter type default::Resource {
+    extending Mixin::Audited before Mixin::Timestamped;
+  };
+  alter type default::Resource {
+    drop extending Mixin::Timestamped;
+  };
+  alter type Prompt::PromptVariantResponse {
+    drop extending Mixin::Timestamped;
+    extending default::Resource before Mixin::Embedded;
+  };
+  alter type Prompt::VariantResponse {
+    drop extending Mixin::Timestamped;
+    extending Mixin::Audited;
+  };
+
+  # Drop audited fields that will be inherited
+  alter type File::Node {
+    drop link createdBy;
+    drop link modifiedBy;
+  };
+
+  # Add createdBy/modifiedBy to Audited, back-fill from owner
+  alter type Mixin::Audited {
+    create required link createdBy: default::Actor {
+      set default := global default::currentActor;
+      set required using (assert_single(
+        Mixin::Audited[is Mixin::Owned].owner
+        ?? assert_exists((select default::SystemAgent filter .name = 'Ghost'))
+      ));
+      set readonly := true;
+    };
+    create required link modifiedBy: default::Actor {
+      set default := global default::currentActor;
+      set required using (.createdBy);
+      create rewrite update using (global default::currentActor);
+    };
+  };
+
+  # Drop Owned
+  alter type Mixin::Owned {
+    drop property isOwner;
+    drop link owner;
+  };
+  alter type default::User drop extending Mixin::Owned;
+  alter type Comments::Comment drop extending Mixin::Owned;
+  alter type Comments::Thread drop extending Mixin::Owned;
+  alter type Prompt::PromptVariantResponse drop extending Mixin::Owned;
+  alter type Prompt::VariantResponse drop extending Mixin::Owned;
+  alter type ProgressReport::Media drop extending Mixin::Owned;
+  alter type default::Post drop extending Mixin::Owned;
+  drop type Mixin::Owned;
+
+  # Adjust globals
+  alter type Mixin::Pinnable {
+    drop property pinned;
+  };
+  alter type default::Post {
+    drop property isMember;
+  };
+  alter type Project::ContextAware {
+    drop property isMember;
+  };
+  alter type default::Project {
+    drop link membership;
+  };
+  alter type ProgressReport::WorkflowEvent {
+    alter link who {
+      reset default;
+    };
+  };
+  drop alias currentUser;
+  alter global currentUserId rename to currentActorId;
+  create global currentUser := (select User filter .id = global currentActorId);
+  create global currentRoles := (global currentActor).roles;
+  alter type ProgressReport::WorkflowEvent {
+    alter link who {
+      set default := global default::currentUser;
+    };
+  };
+  alter type default::Project {
+    create single link membership := (select .members filter .user = global default::currentUser limit 1);
+  };
+  alter type Project::ContextAware {
+    create required single property isMember := exists .projectContext.projects.membership;
+  };
+  alter type default::Post {
+    create single property isMember := .container[is Project::ContextAware].isMember;
+  };
+  alter type Mixin::Pinnable {
+    create property pinned := (
+      with user := (select default::User filter .id = global default::currentActorId)
+      select __source__ in user.pins
+    );
+  };
+
+  alter type Mixin::Audited {
+    create required property isCreator := (.createdBy ?= global default::currentActor);
+  };
+
+  # Adjust triggers to assign defaults explicitly, because bug.
+  alter type default::InternshipEngagement {
+    alter trigger connectCertificationCeremony using (
+      insert Engagement::CertificationCeremony {
+        createdAt := std::datetime_of_statement(),
+        modifiedAt := std::datetime_of_statement(),
+        createdBy := std::assert_exists(global default::currentActor),
+        modifiedBy := std::assert_exists(global default::currentActor),
+        engagement := __new__,
+        project := __new__.project,
+        projectContext := __new__.projectContext
+      }
+    );
+  };
+  alter type default::LanguageEngagement {
+    alter trigger connectDedicationCeremony using (
+      insert Engagement::DedicationCeremony {
+        createdAt := std::datetime_of_statement(),
+        modifiedAt := std::datetime_of_statement(),
+        createdBy := std::assert_exists(global default::currentActor),
+        modifiedBy := std::assert_exists(global default::currentActor),
+        engagement := __new__,
+        project := __new__.project,
+        projectContext := __new__.projectContext
+      }
+    );
+  };
+  alter type default::Project {
+    alter trigger createBudgetOnInsert using (
+      insert default::Budget {
+        createdAt := std::datetime_of_statement(),
+        modifiedAt := std::datetime_of_statement(),
+        createdBy := std::assert_exists(global default::currentActor),
+        modifiedBy := std::assert_exists(global default::currentActor),
+        project := __new__,
+        projectContext := __new__.projectContext
+      }
+    );
+  };
+
+  # Regenerate policies
+  ALTER TYPE Budget::Record {
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForBudgetRecord
+            ALLOW SELECT, UPDATE READ USING ((EXISTS ((<default::Role>{'Administrator', 'FieldOperationsDirector', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'Marketing', 'Fundraising', 'ExperienceOperations', 'Leadership', 'ProjectManager', 'RegionalDirector'} INTERSECT GLOBAL default::currentRoles)) OR ((default::Role.ConsultantManager IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))));
+        CREATE ACCESS POLICY CanUpdateWriteInsertDeleteGeneratedFromAppPoliciesForBudgetRecord
+            ALLOW UPDATE WRITE, DELETE, INSERT ;
+    };
+    ALTER TYPE Comments::Aware {
+        CREATE ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForCommentable
+            ALLOW DELETE, INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForCommentable
+            ALLOW SELECT, UPDATE READ USING (EXISTS ((<default::Role>{'Administrator', 'Leadership'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForCommentable
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE Comments::Comment {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForComment
+            ALLOW DELETE USING (((default::Role.Administrator IN GLOBAL default::currentRoles) OR .isCreator));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForComment
+            ALLOW INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForComment
+            ALLOW SELECT, UPDATE READ USING ((EXISTS ((<default::Role>{'Administrator', 'Leadership'} INTERSECT GLOBAL default::currentRoles)) OR .isCreator));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForComment
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE Comments::Thread {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForCommentThread
+            ALLOW DELETE USING (((default::Role.Administrator IN GLOBAL default::currentRoles) OR .isCreator));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForCommentThread
+            ALLOW INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForCommentThread
+            ALLOW SELECT, UPDATE READ USING ((EXISTS ((<default::Role>{'Administrator', 'Leadership'} INTERSECT GLOBAL default::currentRoles)) OR .isCreator));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForCommentThread
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE Engagement::Ceremony {
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForCeremony
+            ALLOW SELECT, UPDATE READ USING ((EXISTS ((<default::Role>{'Administrator', 'FieldOperationsDirector', 'FieldPartner', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Marketing', 'Fundraising', 'ExperienceOperations', 'Leadership', 'ProjectManager', 'RegionalDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'Intern', 'Mentor', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+        CREATE ACCESS POLICY CanUpdateWriteInsertDeleteGeneratedFromAppPoliciesForCeremony
+            ALLOW UPDATE WRITE, DELETE, INSERT ;
+    };
+    ALTER TYPE Ethnologue::Language {
+        CREATE ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForEthnologueLanguage
+            ALLOW DELETE, INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForEthnologueLanguage
+            ALLOW SELECT, UPDATE READ USING (((((EXISTS ((<default::Role>{'Administrator', 'ExperienceOperations', 'Leadership', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) OR ((default::Role.ConsultantManager IN GLOBAL default::currentRoles) AND (.sensitivity <= default::Sensitivity.Medium))) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)) OR ((default::Role.Fundraising IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))) OR (EXISTS ((<default::Role>{'Marketing', 'Fundraising', 'ExperienceOperations'} INTERSECT GLOBAL default::currentRoles)) AND (.sensitivity <= default::Sensitivity.Low))));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForEthnologueLanguage
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE File::Node {
+        CREATE ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForFileNode
+            ALLOW DELETE, INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForFileNode
+            ALLOW SELECT, UPDATE READ USING (EXISTS ((<default::Role>{'Administrator', 'Leadership'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForFileNode
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE default::Directory {
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForDirectory
+            ALLOW SELECT, UPDATE READ USING (EXISTS ((<default::Role>{'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller'} INTERSECT GLOBAL default::currentRoles)));
+    };
+    ALTER TYPE default::Media {
+        CREATE ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForMedia
+            ALLOW DELETE, INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForMedia
+            ALLOW SELECT, UPDATE READ USING (EXISTS ((<default::Role>{'Administrator', 'Leadership'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForMedia
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE Mixin::Postable {
+        CREATE ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForPostable
+            ALLOW DELETE, INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForPostable
+            ALLOW SELECT, UPDATE READ USING (EXISTS ((<default::Role>{'Administrator', 'Leadership'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForPostable
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE default::Project {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForProject
+            ALLOW DELETE USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForProject
+            ALLOW INSERT USING (EXISTS ((<default::Role>{'Administrator', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProject
+            ALLOW SELECT, UPDATE READ USING ((EXISTS ((<default::Role>{'Administrator', 'ConsultantManager', 'ExperienceOperations', 'FieldOperationsDirector', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Fundraising', 'Leadership', 'Marketing', 'ProjectManager', 'RegionalDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'Intern', 'Mentor', 'RegionalDirector', 'FieldOperationsDirector', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForProject
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE default::Language {
+        CREATE ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForLanguage
+            ALLOW DELETE, INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForLanguage
+            ALLOW SELECT, UPDATE READ USING ((EXISTS ((<default::Role>{'Administrator', 'ConsultantManager', 'ExperienceOperations', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'Fundraising', 'Marketing', 'Leadership', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'Intern', 'Mentor', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForLanguage
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE default::Partner {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForPartner
+            ALLOW DELETE USING (EXISTS ((<default::Role>{'Administrator', 'Controller'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForPartner
+            ALLOW INSERT USING (EXISTS ((<default::Role>{'Administrator', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForPartner
+            ALLOW SELECT, UPDATE READ USING (((((EXISTS ((<default::Role>{'Administrator', 'ConsultantManager', 'FieldOperationsDirector', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'Leadership', 'ProjectManager', 'RegionalDirector'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)) OR (EXISTS ((<default::Role>{'ExperienceOperations', 'Fundraising'} INTERSECT GLOBAL default::currentRoles)) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))) OR ((default::Role.Marketing IN GLOBAL default::currentRoles) AND ((.isMember AND (.sensitivity <= default::Sensitivity.Medium)) OR (.sensitivity <= default::Sensitivity.Low)))) OR ((default::Role.StaffMember IN GLOBAL default::currentRoles) AND (.sensitivity <= default::Sensitivity.Low))));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForPartner
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE ProgressReport::CommunityStory {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForProgressReportCommunityStory
+            ALLOW DELETE USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForProgressReportCommunityStory
+            ALLOW INSERT USING (((default::Role.Administrator IN GLOBAL default::currentRoles) OR (EXISTS ((<default::Role>{'FieldPartner', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportCommunityStory
+            ALLOW SELECT, UPDATE READ USING (((EXISTS ((<default::Role>{'Administrator', 'Leadership', 'Marketing', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) OR ((default::Role.ConsultantManager IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForProgressReportCommunityStory
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE ProgressReport::Highlight {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForProgressReportHighlight
+            ALLOW DELETE USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForProgressReportHighlight
+            ALLOW INSERT USING (((default::Role.Administrator IN GLOBAL default::currentRoles) OR (EXISTS ((<default::Role>{'FieldPartner', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportHighlight
+            ALLOW SELECT, UPDATE READ USING (((EXISTS ((<default::Role>{'Administrator', 'Leadership', 'Marketing', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) OR ((default::Role.ConsultantManager IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForProgressReportHighlight
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE ProgressReport::Media {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForProgressReportMedia
+            ALLOW DELETE USING (((default::Role.Administrator IN GLOBAL default::currentRoles) OR .isCreator));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForProgressReportMedia
+            ALLOW INSERT USING ((((((default::Role.Administrator IN GLOBAL default::currentRoles) OR (((default::Role.FieldPartner IN GLOBAL default::currentRoles) AND .isMember) AND (<std::str>.variant = 'draft'))) OR ((default::Role.Marketing IN GLOBAL default::currentRoles) AND (<std::str>.variant = 'published'))) OR ((EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND .isMember) AND (<std::str>.variant IN {'draft', 'translated', 'fpm'}))) OR (((default::Role.Translator IN GLOBAL default::currentRoles) AND .isMember) AND (<std::str>.variant = 'translated'))));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportMedia
+            ALLOW SELECT, UPDATE READ USING (((((((EXISTS ((<default::Role>{'Administrator', 'Leadership', 'Marketing'} INTERSECT GLOBAL default::currentRoles)) OR ((default::Role.ConsultantManager IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)) OR (((default::Role.FieldPartner IN GLOBAL default::currentRoles) AND .isMember) AND (<std::str>.variant = 'draft'))) OR (EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND (((.isMember AND (<std::str>.variant IN {'draft', 'translated', 'fpm'})) OR ((.sensitivity <= default::Sensitivity.Low) AND (<std::str>.variant IN {'fpm', 'published'}))) OR .isMember))) OR ((default::Role.Translator IN GLOBAL default::currentRoles) AND ((.isMember AND (<std::str>.variant = 'translated')) OR .isMember))) OR .isCreator));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForProgressReportMedia
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE ProgressReport::TeamNews {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForProgressReportTeamNews
+            ALLOW DELETE USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForProgressReportTeamNews
+            ALLOW INSERT USING (((default::Role.Administrator IN GLOBAL default::currentRoles) OR (EXISTS ((<default::Role>{'FieldPartner', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportTeamNews
+            ALLOW SELECT, UPDATE READ USING (((EXISTS ((<default::Role>{'Administrator', 'Leadership', 'Marketing', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) OR ((default::Role.ConsultantManager IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForProgressReportTeamNews
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE ProgressReport::VarianceExplanation {
+        CREATE ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForProgressReportVarianceExplanation
+            ALLOW DELETE, INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportVarianceExplanation
+            ALLOW SELECT, UPDATE READ USING (((EXISTS ((<default::Role>{'Administrator', 'Leadership', 'Marketing', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) OR ((default::Role.ConsultantManager IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForProgressReportVarianceExplanation
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE ProgressReport::WorkflowEvent {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForProgressReportWorkflowEvent
+            ALLOW DELETE USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForProgressReportWorkflowEvent
+            ALLOW INSERT USING ((((((default::Role.Administrator IN GLOBAL default::currentRoles) OR ((default::Role.FieldPartner IN GLOBAL default::currentRoles) AND ((.transitionId IN {'5da76b5163', 'cb18f58cbf', '651d2a4dcc', 'e14c52346b'}) ?? false))) OR ((default::Role.Marketing IN GLOBAL default::currentRoles) AND ((.transitionId = '2d88e3cd6e') ?? false))) OR (EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND ((.transitionId IN {'5da76b5163', 'cb18f58cbf', '651d2a4dcc', '580377ea2b', '0d854e832e', 'e14c52346b', '2b137bcd66', 'a0c0c48a8c', 'e3e11c86b9'}) ?? false))) OR ((default::Role.Translator IN GLOBAL default::currentRoles) AND ((.transitionId IN {'580377ea2b', '0d854e832e'}) ?? false))));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportWorkflowEvent
+            ALLOW SELECT, UPDATE READ USING (EXISTS ((<default::Role>{'Administrator', 'Leadership', 'Marketing', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForProgressReportWorkflowEvent
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE ProgressReport::ProductProgress::Step {
+        CREATE ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForStepProgress
+            ALLOW DELETE, INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForStepProgress
+            ALLOW SELECT, UPDATE READ USING (((((EXISTS ((<default::Role>{'Administrator', 'FieldOperationsDirector', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Marketing', 'Fundraising', 'ExperienceOperations', 'Leadership', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (((default::Role.FieldPartner IN GLOBAL default::currentRoles) AND .isMember) AND (<std::str>.variant = 'partner'))) OR ((EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND .isMember) AND (<std::str>.variant IN {'official', 'partner'}))) OR ((default::Role.ConsultantManager IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'Intern', 'Mentor'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForStepProgress
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE Project::Member {
+        CREATE ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForProjectMember
+            ALLOW DELETE, INSERT USING ((EXISTS ((<default::Role>{'Administrator', 'ConsultantManager', 'ExperienceOperations', 'FieldOperationsDirector', 'LeadFinancialAnalyst', 'Controller'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProjectMember
+            ALLOW SELECT, UPDATE READ USING ((EXISTS ((<default::Role>{'Administrator', 'ConsultantManager', 'ExperienceOperations', 'FieldOperationsDirector', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'Marketing', 'Fundraising', 'Leadership', 'ProjectManager', 'RegionalDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'Intern', 'Mentor', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForProjectMember
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE User::Education {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForEducation
+            ALLOW DELETE USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForEducation
+            ALLOW INSERT USING (EXISTS ((<default::Role>{'Administrator', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForEducation
+            ALLOW SELECT, UPDATE READ USING (EXISTS ((<default::Role>{'Administrator', 'ConsultantManager', 'FieldOperationsDirector', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Marketing', 'Fundraising', 'ExperienceOperations', 'Leadership', 'ProjectManager', 'RegionalDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForEducation
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE User::Unavailability {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForUnavailability
+            ALLOW DELETE USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForUnavailability
+            ALLOW INSERT USING (EXISTS ((<default::Role>{'Administrator', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForUnavailability
+            ALLOW SELECT, UPDATE READ USING ((EXISTS ((<default::Role>{'Administrator', 'Consultant', 'ConsultantManager', 'FieldPartner', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Marketing', 'Fundraising', 'ExperienceOperations', 'Leadership', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Intern', 'Mentor'} INTERSECT GLOBAL default::currentRoles)) AND EXISTS ({'Stubbed .isMember for User/Unavailability'}))));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForUnavailability
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE default::Budget {
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForBudget
+            ALLOW SELECT, UPDATE READ USING ((EXISTS ((<default::Role>{'Administrator', 'FieldOperationsDirector', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'Marketing', 'Fundraising', 'ExperienceOperations', 'Leadership', 'ProjectManager', 'RegionalDirector'} INTERSECT GLOBAL default::currentRoles)) OR ((default::Role.ConsultantManager IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))));
+        CREATE ACCESS POLICY CanUpdateWriteInsertDeleteGeneratedFromAppPoliciesForBudget
+            ALLOW UPDATE WRITE, DELETE, INSERT ;
+    };
+    ALTER TYPE default::Engagement {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForEngagement
+            ALLOW DELETE USING (((default::Role.Administrator IN GLOBAL default::currentRoles) OR ((EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller'} INTERSECT GLOBAL default::currentRoles)) AND .isMember) AND (<std::str>.status = 'InDevelopment'))));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForEngagement
+            ALLOW INSERT USING (((default::Role.Administrator IN GLOBAL default::currentRoles) OR ((EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller'} INTERSECT GLOBAL default::currentRoles)) AND .isMember) AND (<std::str>.project.status = 'InDevelopment'))));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForEngagement
+            ALLOW SELECT, UPDATE READ USING ((EXISTS ((<default::Role>{'Administrator', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Marketing', 'Fundraising', 'ExperienceOperations', 'Leadership', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'Intern', 'Mentor', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForEngagement
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE default::LanguageEngagement {
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForLanguageEngagement
+            ALLOW SELECT, UPDATE READ USING ((default::Role.ConsultantManager IN GLOBAL default::currentRoles));
+    };
+    ALTER TYPE default::Producible {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForProducible
+            ALLOW DELETE USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForProducible
+            ALLOW INSERT USING (EXISTS ((<default::Role>{'Administrator', 'FieldOperationsDirector', 'ProjectManager', 'RegionalDirector'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanSelectUpdateReadUpdateWriteGeneratedFromAppPoliciesForProducible
+            ALLOW SELECT, UPDATE ;
+    };
+    ALTER TYPE default::FieldRegion {
+        CREATE ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForFieldRegion
+            ALLOW DELETE, INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForFieldRegion
+            ALLOW SELECT, UPDATE READ USING (EXISTS ((<default::Role>{'Administrator', 'Consultant', 'ConsultantManager', 'FieldPartner', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Marketing', 'Fundraising', 'ExperienceOperations', 'Leadership', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForFieldRegion
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE default::FieldZone {
+        CREATE ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForFieldZone
+            ALLOW DELETE, INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForFieldZone
+            ALLOW SELECT, UPDATE READ USING (EXISTS ((<default::Role>{'Administrator', 'Consultant', 'ConsultantManager', 'FieldPartner', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Marketing', 'Fundraising', 'ExperienceOperations', 'Leadership', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForFieldZone
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE default::PeriodicReport {
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForPeriodicReport
+            ALLOW SELECT, UPDATE READ USING (WITH
+                isMember := 
+                    (.container[IS Project::ContextAware].isMember ?? false)
+                ,
+                sensitivity := 
+                    (.container[IS Project::ContextAware].sensitivity ?? default::Sensitivity.High)
+            SELECT
+                ((EXISTS ((<default::Role>{'Administrator', 'ExperienceOperations', 'FieldOperationsDirector', 'FieldPartner', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'Leadership', 'ProjectManager', 'RegionalDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'ConsultantManager', 'Marketing', 'Fundraising', 'ExperienceOperations'} INTERSECT GLOBAL default::currentRoles)) AND (isMember OR (sensitivity <= default::Sensitivity.Medium)))) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'Intern', 'Mentor', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND isMember))
+            );
+        CREATE ACCESS POLICY CanUpdateWriteInsertDeleteGeneratedFromAppPoliciesForPeriodicReport
+            ALLOW UPDATE WRITE, DELETE, INSERT ;
+    };
+    ALTER TYPE default::FundingAccount {
+        CREATE ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForFundingAccount
+            ALLOW DELETE, INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForFundingAccount
+            ALLOW SELECT, UPDATE READ USING (EXISTS ((<default::Role>{'Administrator', 'ConsultantManager', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Leadership', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForFundingAccount
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE default::Location {
+        CREATE ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForLocation
+            ALLOW DELETE, INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanSelectUpdateReadUpdateWriteGeneratedFromAppPoliciesForLocation
+            ALLOW SELECT, UPDATE ;
+    };
+    ALTER TYPE default::NarrativeReport {
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForNarrativeReport
+            ALLOW SELECT, UPDATE READ USING (WITH
+                isMember := 
+                    (.container[IS Project::ContextAware].isMember ?? false)
+            SELECT
+                (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager'} INTERSECT GLOBAL default::currentRoles)) AND isMember)
+            );
+    };
+    ALTER TYPE default::Organization {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForOrganization
+            ALLOW DELETE USING (EXISTS ((<default::Role>{'Administrator', 'Controller'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForOrganization
+            ALLOW INSERT USING (EXISTS ((<default::Role>{'Administrator', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForOrganization
+            ALLOW SELECT, UPDATE READ USING ((((EXISTS ((<default::Role>{'Administrator', 'ConsultantManager', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'Leadership', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)) OR (EXISTS ((<default::Role>{'ExperienceOperations', 'Fundraising'} INTERSECT GLOBAL default::currentRoles)) AND (.sensitivity <= default::Sensitivity.Medium))) OR ((default::Role.Marketing IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Low)))));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForOrganization
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE default::Partnership {
+        CREATE ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForPartnership
+            ALLOW DELETE, INSERT USING (((EXISTS ((<default::Role>{'Administrator', 'FieldOperationsDirector', 'LeadFinancialAnalyst', 'Controller'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)) OR (EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForPartnership
+            ALLOW SELECT, UPDATE READ USING ((((EXISTS ((<default::Role>{'Administrator', 'ConsultantManager', 'ExperienceOperations', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'Marketing', 'Fundraising', 'Leadership', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)) OR (EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))) OR ((default::Role.StaffMember IN GLOBAL default::currentRoles) AND (.sensitivity <= default::Sensitivity.Low))));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForPartnership
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE default::ProgressReport {
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReport
+            ALLOW SELECT, UPDATE READ USING ((EXISTS ((<default::Role>{'FieldPartner', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND .isMember));
+    };
+    ALTER TYPE default::Post {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForPost
+            ALLOW DELETE USING (((default::Role.Administrator IN GLOBAL default::currentRoles) OR .isCreator));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForPost
+            ALLOW INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForPost
+            ALLOW SELECT, UPDATE READ USING ((EXISTS ((<default::Role>{'Administrator', 'Leadership'} INTERSECT GLOBAL default::currentRoles)) OR .isCreator));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForPost
+            ALLOW UPDATE WRITE ;
+    };
+    ALTER TYPE default::User {
+        CREATE ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForUser
+            ALLOW DELETE USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+        CREATE ACCESS POLICY CanInsertGeneratedFromAppPoliciesForUser
+            ALLOW INSERT USING (EXISTS ((<default::Role>{'Administrator', 'Consultant', 'ConsultantManager', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)));
+        CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForUser
+            ALLOW SELECT, UPDATE READ USING (((EXISTS ((<default::Role>{'Administrator', 'Consultant', 'ConsultantManager', 'FieldPartner', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Marketing', 'Fundraising', 'ExperienceOperations', 'Leadership', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (.id ?= GLOBAL default::currentActorId)) OR (EXISTS ((<default::Role>{'Intern', 'Mentor'} INTERSECT GLOBAL default::currentRoles)) AND EXISTS ({'Stubbed .isMember for User/Unavailability'}))));
+        CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForUser
+            ALLOW UPDATE WRITE ;
+    };
+};

--- a/dbschema/post.esdl
+++ b/dbschema/post.esdl
@@ -1,5 +1,5 @@
 module default {
-  type Post extending Resource, Mixin::Embedded, Mixin::Owned {
+  type Post extending Resource, Mixin::Embedded {
     overloaded required single link container: Mixin::Postable {
       on target delete delete source;
     };

--- a/dbschema/progress-report.esdl
+++ b/dbschema/progress-report.esdl
@@ -54,7 +54,7 @@ module ProgressReport {
   module Media {
     type VariantGroup;
   }
-  type Media extending ProgressReport::Child, Mixin::Owned {
+  type Media extending ProgressReport::Child {
     required file: default::File;
     required single media := assert_exists(.file.media);
 

--- a/dbschema/progress-report.esdl
+++ b/dbschema/progress-report.esdl
@@ -75,7 +75,7 @@ module ProgressReport {
     };
     required who: default::User {
       readonly := true;
-      default := default::currentUser;
+      default := global default::currentUser;
     };
     required at: datetime {
       readonly := true;

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -72,7 +72,7 @@ module default {
     financialReportPeriod: ReportPeriod;
     
     multi link members := .<project[is Project::Member];
-    single link membership := (select .members filter .user.id = global default::currentUserId limit 1);
+    single link membership := (select .members filter .user = global default::currentUser limit 1);
     
 #     multi link engagements := .<project[is Engagement];
     property engagementTotal := count(.<project[is Engagement]);
@@ -106,8 +106,8 @@ module default {
       insert default::Budget {
         createdAt := datetime_of_statement(),
         modifiedAt := datetime_of_statement(),
-        createdBy := assert_exists(currentUser),
-        modifiedBy := assert_exists(currentUser),
+        createdBy := assert_exists(global currentActor),
+        modifiedBy := assert_exists(global currentActor),
         project := __new__,
         projectContext := __new__.projectContext,
       }

--- a/dbschema/project.esdl
+++ b/dbschema/project.esdl
@@ -106,6 +106,8 @@ module default {
       insert default::Budget {
         createdAt := datetime_of_statement(),
         modifiedAt := datetime_of_statement(),
+        createdBy := assert_exists(currentUser),
+        modifiedBy := assert_exists(currentUser),
         project := __new__,
         projectContext := __new__.projectContext,
       }

--- a/dbschema/prompt-variant-response.esdl
+++ b/dbschema/prompt-variant-response.esdl
@@ -6,7 +6,7 @@ module Prompt {
     responses := .<pvr[is VariantResponse];
   }
 
-  type VariantResponse extending Mixin::UserStamped, Mixin::Timestamped {
+  type VariantResponse extending Mixin::Audited {
     annotation description := "A response (for a variant) to an instance of a prompt.";
 
     required pvr: PromptVariantResponse;

--- a/dbschema/prompt-variant-response.esdl
+++ b/dbschema/prompt-variant-response.esdl
@@ -1,12 +1,12 @@
 module Prompt {
-  abstract type PromptVariantResponse extending Mixin::Embedded, Mixin::Timestamped, Mixin::Owned {
+  abstract type PromptVariantResponse extending default::Resource, Mixin::Embedded {
     annotation description := "An instance of a prompt and the responses per variant.";
 
     promptId: default::nanoid;
     responses := .<pvr[is VariantResponse];
   }
 
-  type VariantResponse extending Mixin::Timestamped, Mixin::Owned {
+  type VariantResponse extending Mixin::UserStamped, Mixin::Timestamped {
     annotation description := "A response (for a variant) to an instance of a prompt.";
 
     required pvr: PromptVariantResponse;

--- a/dbschema/resource.esdl
+++ b/dbschema/resource.esdl
@@ -1,3 +1,3 @@
 module default {
-  abstract type Resource extending Mixin::UserStamped, Mixin::Timestamped;
+  abstract type Resource extending Mixin::Audited;
 }

--- a/dbschema/resource.esdl
+++ b/dbschema/resource.esdl
@@ -1,3 +1,3 @@
 module default {
-  abstract type Resource extending Mixin::Timestamped {}
+  abstract type Resource extending Mixin::UserStamped, Mixin::Timestamped;
 }

--- a/dbschema/seeds/000.system-agents.ts
+++ b/dbschema/seeds/000.system-agents.ts
@@ -6,7 +6,7 @@ const agents = [
   { name: 'External Mailing Group', roles: ['Leadership'] },
 ];
 
-export default (async function ({ runAndPrint }) {
+export default (async function ({ runAndPrint, e, db, actorId }) {
   await runAndPrint(
     `
       with
@@ -24,4 +24,12 @@ export default (async function ({ runAndPrint }) {
     `,
     { agentsJson: agents },
   );
+
+  const getGhost = e.assert_exists(
+    e.select(e.SystemAgent, () => ({
+      filter_single: { name: 'Ghost' },
+    })),
+  );
+  const ghost = await getGhost.run(db);
+  actorId.next(ghost.id);
 } satisfies SeedFn);

--- a/dbschema/seeds/000.system-agents.ts
+++ b/dbschema/seeds/000.system-agents.ts
@@ -1,0 +1,27 @@
+import type { SeedFn } from '~/core/edgedb/seeds.run';
+
+const agents = [
+  { name: 'Ghost' },
+  { name: 'Anonymous' },
+  { name: 'External Mailing Group', roles: ['Leadership'] },
+];
+
+export default (async function ({ runAndPrint }) {
+  await runAndPrint(
+    `
+      with
+      agentsJson := json_array_unpack(<json>$agentsJson),
+      newAgents := (select agentsJson filter <str>agentsJson['name'] not in SystemAgent.name),
+      added := (
+        for entry in newAgents union (
+        insert SystemAgent {
+          name := <str>entry['name'],
+          roles := <str>json_array_unpack(json_get(entry, 'roles'))
+        })
+      )
+      select { \`Added System Agents\` := added.name }
+      filter count(added) > 0;
+    `,
+    { agentsJson: agents },
+  );
+} satisfies SeedFn);

--- a/dbschema/user.esdl
+++ b/dbschema/user.esdl
@@ -1,5 +1,9 @@
 module default {
-  type User extending Resource, Mixin::Pinnable {
+  abstract type Actor {
+    multi roles: Role;
+  }
+
+  type User extending Resource, Actor, Mixin::Pinnable {
     email: str {
       constraint exclusive;
     };
@@ -19,7 +23,6 @@ module default {
     required status: User::Status {
       default := User::Status.Active;
     };
-    multi roles: Role;
     title: str;
     multi link pins: Mixin::Pinnable {
       on target delete allow;
@@ -33,6 +36,10 @@ module default {
       on source delete delete target;
     }
     multi locations: Location;
+  }
+
+  type SystemAgent extending Actor, Mixin::Named {
+    overloaded name { constraint exclusive };
   }
 }
  

--- a/dbschema/user.esdl
+++ b/dbschema/user.esdl
@@ -1,5 +1,5 @@
 module default {
-  type User extending Resource, Mixin::Pinnable, Mixin::Owned {
+  type User extending Resource, Mixin::Pinnable {
     email: str {
       constraint exclusive;
     };

--- a/dbschema/z.owned.esdl
+++ b/dbschema/z.owned.esdl
@@ -1,8 +1,0 @@
-module Mixin {
-  abstract type Owned {
-    link owner: default::User {
-      default := default::currentUser;
-    };
-    property isOwner := .owner = <default::User>(global default::currentUserId);
-  }
-}

--- a/dbschema/z.pinnable.esdl
+++ b/dbschema/z.pinnable.esdl
@@ -1,5 +1,8 @@
 module Mixin {
   abstract type Pinnable {
-    property pinned := __source__ in (<default::User>global default::currentUserId).pins;
+    property pinned := (
+      with user := (select default::User filter .id = global default::currentActorId) 
+      select __source__ in user.pins
+    );
   };
 };

--- a/dbschema/z.stamped.esdl
+++ b/dbschema/z.stamped.esdl
@@ -1,15 +1,15 @@
 module Mixin {
-  abstract type UserStamped {
-    required createdBy: default::User {
+  abstract type Audited extending Timestamped {
+    required createdBy: default::Actor {
       readonly := true;
-      default := default::currentUser;
+      default := global default::currentActor;
     };
-    required modifiedBy: default::User {
-      default := default::currentUser;
-      rewrite update using (default::currentUser);
+    required modifiedBy: default::Actor {
+      default := global default::currentActor;
+      rewrite update using (global default::currentActor);
     };
 
-    required isCreator := .createdBy ?= <default::User>(global default::currentUserId) 
+    required isCreator := .createdBy ?= global default::currentActor;
   }
 
   abstract type Timestamped {

--- a/dbschema/z.stamped.esdl
+++ b/dbschema/z.stamped.esdl
@@ -8,6 +8,8 @@ module Mixin {
       default := default::currentUser;
       rewrite update using (default::currentUser);
     };
+
+    required isCreator := .createdBy ?= <default::User>(global default::currentUserId) 
   }
 
   abstract type Timestamped {

--- a/dbschema/z.stamped.esdl
+++ b/dbschema/z.stamped.esdl
@@ -1,4 +1,15 @@
 module Mixin {
+  abstract type UserStamped {
+    required createdBy: default::User {
+      readonly := true;
+      default := default::currentUser;
+    };
+    required modifiedBy: default::User {
+      default := default::currentUser;
+      rewrite update using (default::currentUser);
+    };
+  }
+
   abstract type Timestamped {
     required createdAt: datetime {
       default := datetime_of_statement();
@@ -8,5 +19,5 @@ module Mixin {
       default := datetime_of_statement(); # default here helps editor know it's not required.
       rewrite update using (datetime_of_statement());
     };
-  };
+  }
 }

--- a/src/components/admin/admin.module.ts
+++ b/src/components/admin/admin.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { splitDb } from '~/core';
 import { AuthorizationModule } from '../authorization/authorization.module';
+import { UserModule } from '../user/user.module';
 import { AdminEdgeDBRepository } from './admin.edgedb.repository';
 import { AdminEdgeDBService } from './admin.edgedb.service';
 import { AdminRepository } from './admin.repository';
@@ -9,7 +10,7 @@ import { NormalizeCreatorBaseNodeMigration } from './migrations/normalize-creato
 import { NormalizeCreatorMigration } from './migrations/normalize-creator.migration';
 
 @Module({
-  imports: [AuthorizationModule],
+  imports: [AuthorizationModule, UserModule],
   providers: [
     splitDb(AdminService, AdminEdgeDBService),
     splitDb(

--- a/src/components/authentication/current-user.provider.ts
+++ b/src/components/authentication/current-user.provider.ts
@@ -72,10 +72,10 @@ export class EdgeDBCurrentUserProvider
   ) {
     // TODO temporarily check if UUID before applying global.
     // Once migration is complete this can be removed.
-    const currentUserId =
+    const currentActorId =
       session?.userId && isUUID(session.userId) ? session.userId : undefined;
     optionsHolder.next((options) =>
-      currentUserId ? options.withGlobals({ currentUserId }) : options,
+      currentActorId ? options.withGlobals({ currentActorId }) : options,
     );
   }
 }

--- a/src/components/authorization/policies/by-feature/progress-report-media-owner.policy.ts
+++ b/src/components/authorization/policies/by-feature/progress-report-media-owner.policy.ts
@@ -1,4 +1,4 @@
-import { owner, Policy } from '../util';
+import { creator, Policy } from '../util';
 
-@Policy('all', (r) => r.ProgressReportMedia.when(owner).edit.delete)
+@Policy('all', (r) => r.ProgressReportMedia.when(creator).edit.delete)
 export class ProgressReportMediaOwnerPolicy {}

--- a/src/components/authorization/policies/by-feature/user-can-edit-self.policy.ts
+++ b/src/components/authorization/policies/by-feature/user-can-edit-self.policy.ts
@@ -1,4 +1,4 @@
-import { owner, Policy } from '../util';
+import { Policy, self } from '../util';
 
-@Policy('all', (r) => r.User.when(owner).edit)
+@Policy('all', (r) => r.User.when(self).edit)
 export class UserCanEditSelfPolicy {}

--- a/src/components/authorization/policies/by-feature/user-can-manage-own-comments.policy.ts
+++ b/src/components/authorization/policies/by-feature/user-can-manage-own-comments.policy.ts
@@ -1,8 +1,8 @@
-import { owner, Policy } from '../util';
+import { creator, Policy } from '../util';
 
-@Policy('all', (r) => [
-  r.Post.when(owner).edit.delete,
-  r.CommentThread.when(owner).edit.delete,
-  r.Comment.when(owner).edit.delete,
-])
+@Policy('all', (r) =>
+  [r.Post, r.CommentThread, r.Comment].flatMap(
+    (it) => it.when(creator).edit.delete,
+  ),
+)
 export class UserCanManageOwnCommentsPolicy {}

--- a/src/components/authorization/policies/by-feature/user-can-manage-own-prompts.policy.ts
+++ b/src/components/authorization/policies/by-feature/user-can-manage-own-prompts.policy.ts
@@ -1,10 +1,10 @@
-import { owner, Policy } from '../util';
+import { creator, Policy } from '../util';
 
 @Policy('all', (r) => [
   [
     r.ProgressReportCommunityStory,
     r.ProgressReportHighlight,
     r.ProgressReportTeamNews,
-  ].map((it) => it.specifically((p) => p.prompt.when(owner).edit)),
+  ].map((it) => it.specifically((p) => p.prompt.when(creator).edit)),
 ])
 export class UserCanManageOwnPromptsPolicy {}

--- a/src/components/authorization/policies/conditions/index.ts
+++ b/src/components/authorization/policies/conditions/index.ts
@@ -1,5 +1,5 @@
 export * from './member.condition';
-export * from './owner.condition';
+export * from './creator.condition';
 export * from './sensitivity.condition';
 export * from './enum-field.condition';
 export * from './variant.condition';

--- a/src/components/authorization/policies/conditions/index.ts
+++ b/src/components/authorization/policies/conditions/index.ts
@@ -4,3 +4,4 @@ export * from './sensitivity.condition';
 export * from './enum-field.condition';
 export * from './variant.condition';
 export * from './role.condition';
+export * from './self.condition';

--- a/src/components/authorization/policies/conditions/role.condition.ts
+++ b/src/components/authorization/policies/conditions/role.condition.ts
@@ -21,17 +21,11 @@ export class RoleCondition implements Condition {
     return 'false';
   }
 
-  setupEdgeQLContext({ namespace }: AsEdgeQLParams<any>) {
-    const User = fqnRelativeTo('default::User', namespace);
-    const currentUserId = fqnRelativeTo('default::currentUserId', namespace);
-    return {
-      givenRoles: `(<${User}>(global ${currentUserId})).roles`,
-    };
-  }
-
   asEdgeQLCondition({ namespace }: AsEdgeQLParams<any>) {
+    const currentRoles =
+      'global ' + fqnRelativeTo('default::currentRoles', namespace);
     const roleType = fqnRelativeTo('default::Role', namespace);
-    return eqlDoesIntersect('givenRoles', this.allowed, roleType);
+    return eqlDoesIntersect(currentRoles, this.allowed, roleType);
   }
 
   union(this: void, conditions: this[]) {

--- a/src/components/authorization/policies/conditions/self.condition.ts
+++ b/src/components/authorization/policies/conditions/self.condition.ts
@@ -3,7 +3,9 @@ import { inspect, InspectOptionsStylized } from 'util';
 import { User } from '../../../user/dto';
 import {
   AsCypherParams,
+  AsEdgeQLParams,
   Condition,
+  fqnRelativeTo,
   IsAllowedParams,
 } from '../../policy/conditions';
 
@@ -40,8 +42,9 @@ class SelfCondition<TResourceStatic extends typeof User>
     return `node:User AND node.id = ${requester}`;
   }
 
-  asEdgeQLCondition() {
-    return '.id ?= global default::currentUserId';
+  asEdgeQLCondition({ namespace }: AsEdgeQLParams<any>) {
+    const currentId = fqnRelativeTo('default::currentActorId', namespace);
+    return `.id ?= global ${currentId}`;
   }
 
   union(this: void, conditions: this[]) {

--- a/src/components/authorization/policies/conditions/self.condition.ts
+++ b/src/components/authorization/policies/conditions/self.condition.ts
@@ -1,0 +1,63 @@
+import { Query } from 'cypher-query-builder';
+import { inspect, InspectOptionsStylized } from 'util';
+import { User } from '../../../user/dto';
+import {
+  AsCypherParams,
+  Condition,
+  IsAllowedParams,
+} from '../../policy/conditions';
+
+const CQL_VAR = 'requestingUser';
+
+class SelfCondition<TResourceStatic extends typeof User>
+  implements Condition<TResourceStatic>
+{
+  isAllowed({ object, session }: IsAllowedParams<TResourceStatic>) {
+    if (!object) {
+      throw new Error("Needed user object but wasn't given");
+    }
+    return object.id === session.userId;
+  }
+
+  setupCypherContext(
+    query: Query,
+    prevApplied: Set<any>,
+    other: AsCypherParams<TResourceStatic>,
+  ) {
+    if (prevApplied.has('self')) {
+      return query;
+    }
+    prevApplied.add('self');
+
+    const param = query.params.addParam(other.session.userId, CQL_VAR);
+    Reflect.set(other, CQL_VAR, param);
+
+    return query;
+  }
+
+  asCypherCondition(_query: Query, other: AsCypherParams<TResourceStatic>) {
+    const requester = String(Reflect.get(other, CQL_VAR));
+    return `node:User AND node.id = ${requester}`;
+  }
+
+  asEdgeQLCondition() {
+    return '.id ?= global default::currentUserId';
+  }
+
+  union(this: void, conditions: this[]) {
+    return conditions[0];
+  }
+
+  intersect(this: void, conditions: this[]) {
+    return conditions[0];
+  }
+
+  [inspect.custom](_depth: number, _options: InspectOptionsStylized) {
+    return `Self`;
+  }
+}
+
+/**
+ * The following actions only apply if the requester is this user object.
+ */
+export const self = new SelfCondition();

--- a/src/components/user/actor.edgedb.repository.ts
+++ b/src/components/user/actor.edgedb.repository.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { Role } from '~/common';
+import { disableAccessPolicies, EdgeDB, edgeql } from '~/core/edgedb';
+import { ActorRepository } from './actor.repository';
+
+@Injectable()
+export class ActorEdgeDBRepository extends ActorRepository {
+  private readonly db: EdgeDB;
+  constructor(edgedb: EdgeDB) {
+    super();
+    this.db = edgedb.withOptions(disableAccessPolicies);
+  }
+
+  protected async upsertAgent(name: string, roles?: readonly Role[]) {
+    const query = edgeql(`
+      select (
+        (select SystemAgent filter .name = <str>$name) ??
+        (insert SystemAgent {
+          name := <str>$name,
+          roles := array_unpack(<optional array<Role>>$roles)
+        })
+      ) {*}
+    `);
+    return await this.db.run(query, { name, roles });
+  }
+}

--- a/src/components/user/actor.neo4j.repository.ts
+++ b/src/components/user/actor.neo4j.repository.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { node } from 'cypher-query-builder';
+import { ID, Role } from '~/common';
+import { DatabaseService } from '~/core';
+import { ActorRepository } from './actor.repository';
+
+@Injectable()
+export class ActorNeo4jRepository extends ActorRepository {
+  constructor(private readonly db: DatabaseService) {
+    super();
+  }
+
+  protected async upsertAgent(name: string, roles?: readonly Role[]) {
+    const res = await this.db
+      .query()
+      .merge(node('agent', 'SystemAgent', { name }))
+      .onCreate.set({
+        variables: {
+          'agent.id': 'apoc.create.uuid()',
+        },
+        values: {
+          'agent.roles': roles ?? [],
+        },
+      })
+      .return<{ agent: { id: ID; name: string; roles: readonly Role[] } }>(
+        'apoc.convert.toMap(agent) AS agent',
+      )
+      .first();
+    return res!.agent;
+  }
+}

--- a/src/components/user/actor.repository.ts
+++ b/src/components/user/actor.repository.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CachedByArg } from '@seedcompany/common';
+import { ID, Role } from '~/common';
+
+@Injectable()
+export abstract class ActorRepository {
+  @CachedByArg()
+  async getAnonymous() {
+    return await this.upsertAgent('Anonymous');
+  }
+
+  @CachedByArg()
+  async getGhost() {
+    return await this.upsertAgent('Ghost');
+  }
+
+  @CachedByArg()
+  async getExternalMailingGroup() {
+    return await this.upsertAgent('External Mailing Group', ['Leadership']);
+  }
+
+  protected abstract upsertAgent(
+    name: string,
+    roles?: readonly Role[],
+  ): Promise<{ id: ID; name: string; roles: readonly Role[] }>;
+}

--- a/src/components/user/user.module.ts
+++ b/src/components/user/user.module.ts
@@ -7,6 +7,9 @@ import { LocationModule } from '../location/location.module';
 import { OrganizationModule } from '../organization/organization.module';
 import { PartnerModule } from '../partner/partner.module';
 import { TimeZoneModule } from '../timezone';
+import { ActorEdgeDBRepository } from './actor.edgedb.repository';
+import { ActorNeo4jRepository } from './actor.neo4j.repository';
+import { ActorRepository } from './actor.repository';
 import { AssignableRolesResolver } from './assignable-roles.resolver';
 import { EducationModule } from './education/education.module';
 import { KnownLanguageRepository } from './known-language.repository';
@@ -38,7 +41,17 @@ import { UserService } from './user.service';
     UserService,
     splitDb(UserRepository, UserEdgeDBRepository),
     KnownLanguageRepository,
+    {
+      ...splitDb(ActorNeo4jRepository, ActorEdgeDBRepository),
+      provide: ActorRepository,
+    },
   ],
-  exports: [UserService, UserRepository, EducationModule, UnavailabilityModule],
+  exports: [
+    UserService,
+    UserRepository,
+    ActorRepository,
+    EducationModule,
+    UnavailabilityModule,
+  ],
 })
 export class UserModule {}

--- a/src/core/database/split-db.provider.ts
+++ b/src/core/database/split-db.provider.ts
@@ -6,12 +6,13 @@ import { ConfigService } from '../config/config.service';
 export const splitDb = <T>(
   neo4jRepository: Type<T>,
   edgeDbRepository: Type<PublicOf<T>>,
-): Provider => ({
-  provide: neo4jRepository,
-  inject: [ModuleRef, ConfigService],
-  useFactory: async (moduleRef: ModuleRef, config: ConfigService) => {
-    const cls =
-      config.databaseEngine === 'edgedb' ? edgeDbRepository : neo4jRepository;
-    return await moduleRef.create<T>(cls);
-  },
-});
+) =>
+  ({
+    provide: neo4jRepository,
+    inject: [ModuleRef, ConfigService],
+    useFactory: async (moduleRef: ModuleRef, config: ConfigService) => {
+      const cls =
+        config.databaseEngine === 'edgedb' ? edgeDbRepository : neo4jRepository;
+      return await moduleRef.create<T>(cls);
+    },
+  } satisfies Provider);

--- a/src/core/edgedb/edgedb.module.ts
+++ b/src/core/edgedb/edgedb.module.ts
@@ -40,7 +40,7 @@ import { TransactionContext } from './transaction.context';
           ...connectConfig,
         });
 
-        Object.assign(client, { options: options.currentAsLazyRef });
+        options.attachToClient(client);
 
         if (config.databaseEngine === 'edgedb') {
           await registerCustomScalarCodecs(client, codecs);

--- a/src/core/edgedb/edgedb.service.ts
+++ b/src/core/edgedb/edgedb.service.ts
@@ -127,7 +127,7 @@ export class EdgeDB {
       segment.sql = {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         database_version: 'EdgeDB',
-        user: this.optionsContext.current.session.globals.currentUserId,
+        user: this.optionsContext.current.session.globals.currentActorId,
       };
 
       try {

--- a/src/core/edgedb/options.context.ts
+++ b/src/core/edgedb/options.context.ts
@@ -1,5 +1,6 @@
 import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import { AsyncLocalStorage } from 'async_hooks';
+import type { Client } from 'edgedb';
 import {
   BehaviorSubject,
   combineLatest,
@@ -89,6 +90,9 @@ export class OptionsContext
   }
   get currentAsLazyRef() {
     return lazyRef(() => this.current);
+  }
+  attachToClient(client: Client) {
+    Object.assign(client, { options: this.currentAsLazyRef });
   }
 
   onModuleDestroy() {


### PR DESCRIPTION
This kinda ballooned into several related refactors.

Our authorization system is rule based. i.e. we don't have an ACL lists in our data. We felt like `owners` violated this principle. It served as the object's creator, but also was mutable to allow an owner change. The waters mudded more with Users, and how they were "owned".

So `owner` (schema & policy conditions) is replaced by `createdBy/creator`.
This has clearer split between raw data & authorization rules based on real data.

Related, we've also wanted to track who creates & modifies most things.
So to solve this we have `Audited` that holds `createdBy` & `modifiedBy`.
`Resource` was updated to extend `Audited` so most things can have this tracked now in a standard way.

We wanted these creators/modifiers to be required, as it's always someone that's making these changes. But there are edge cases.
So now we have `Actor` type that's barebones and have `User` & `SystemAgent` extend from that.
Hopefully a few pre-defined `SystemAgents` help fulfill these edge cases.
- _Ghost_ - we don't know who did it. Legacy migrated data.
- _Anonymous_ - It was actually an anonymous actor that did the action. Currently the only anonymous mutation we have is _register_. So this will allow us to know the user was created by someone else already logged in, or they registered themselves, or they were migrated in. Idk how helpful this will be.
- _External Mailing Group_ - For email notifications that reference mailing groups. I want to migrate to this reference instead of the _Root User_. It's possible that RootUser goes away soon after this change, as the ties to this user get clipped.


Finally I replaced the `currentUser` `alias` with a few `globals`.
https://github.com/SeedCompany/cord-api-v3/blob/0c18f9b7501d34c07b95291000a449531014ffec/dbschema/common.esdl#L3-L6
Globals (single, not multi) are evaluated once per query, so this should help with performance. And be less ambiguous in use.