### PR TITLE
Simplify EdgeDB Repo customize

### DIFF
--- a/src/components/ceremony/ceremony.edgedb.repository.ts
+++ b/src/components/ceremony/ceremony.edgedb.repository.ts
@@ -12,10 +12,7 @@ export class CeremonyEdgeDBRepository
       engagement: true,
       type: castToEnum(ceremony.__type__.name.slice(12, -8), CeremonyType),
     }),
-  }).customize((cls, { defaults }) => {
-    return class extends cls {
-      static omit = [defaults.create];
-    };
+    omit: ['create'],
   })
   implements PublicOf<CeremonyRepository>
 {

--- a/src/components/field-region/field-region.edgedb.repository.ts
+++ b/src/components/field-region/field-region.edgedb.repository.ts
@@ -12,5 +12,5 @@ export class FieldRegionEdgeDBRepository
       director: true,
       fieldZone: true,
     }),
-  }).withDefaults()
+  })
   implements PublicOf<FieldRegionRepository> {}

--- a/src/components/field-zone/field-zone.edgedb.repository.ts
+++ b/src/components/field-zone/field-zone.edgedb.repository.ts
@@ -11,5 +11,5 @@ export class FieldZoneEdgeDBRepository
       ...zone['*'],
       director: true,
     }),
-  }).withDefaults()
+  })
   implements PublicOf<FieldZoneRepository> {}

--- a/src/components/funding-account/funding-account.edgedb.repository.ts
+++ b/src/components/funding-account/funding-account.edgedb.repository.ts
@@ -8,5 +8,5 @@ import { FundingAccountRepository } from './funding-account.repository';
 export class FundingAccountEdgeDBRepository
   extends RepoFor(FundingAccount, {
     hydrate: (fa) => fa['*'],
-  }).withDefaults()
+  })
   implements PublicOf<FundingAccountRepository> {}

--- a/src/components/language/ethnologue-language/ethnologue-language.edgedb.repository.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.edgedb.repository.ts
@@ -11,5 +11,5 @@ export class EthnologueLanguageEdgeDBRepository
       ...ethnoLang['*'],
       language: ethnoLang.language['*'],
     }),
-  }).withDefaults()
+  })
   implements PublicOf<EthnologueLanguageRepository> {}

--- a/src/components/language/language.edgedb.repository.ts
+++ b/src/components/language/language.edgedb.repository.ts
@@ -15,28 +15,27 @@ export class LanguageEdgeDBRepository
       effectiveSensitivity: lang.sensitivity,
       presetInventory: e.bool(false), // Not implemented going forward
     }),
-  }).customize((cls) => {
-    return class extends cls {
-      async create(input: CreateLanguage) {
-        const { sensitivity, ethnologue, ...props } = input;
-
-        const createdLanguage = e.insert(e.Language, {
-          ...props,
-          ownSensitivity: input.sensitivity,
-        });
-        const { language } = e.insert(e.Ethnologue.Language, {
-          language: createdLanguage,
-          projectContext: createdLanguage.projectContext,
-          ...ethnologue,
-        });
-        const query = e.select(language, this.hydrate);
-
-        return await this.db.run(query);
-      }
-    };
+    omit: ['create'],
   })
   implements PublicOf<LanguageRepository>
 {
+  async create(input: CreateLanguage) {
+    const { sensitivity, ethnologue, ...props } = input;
+
+    const createdLanguage = e.insert(e.Language, {
+      ...props,
+      ownSensitivity: input.sensitivity,
+    });
+    const { language } = e.insert(e.Ethnologue.Language, {
+      language: createdLanguage,
+      projectContext: createdLanguage.projectContext,
+      ...ethnologue,
+    });
+    const query = e.select(language, this.hydrate);
+
+    return await this.db.run(query);
+  }
+
   async getEngagementIdsForLanguage(language: Language) {
     const lang = e.cast(e.Language, e.uuid(language.id));
     const query = lang.engagements.id;

--- a/src/components/location/location.edgedb.repository.ts
+++ b/src/components/location/location.edgedb.repository.ts
@@ -14,7 +14,7 @@ export class LocationEdgeDBRepository
       mapImage: true,
       defaultMarketingRegion: true,
     }),
-  }).withDefaults()
+  })
   implements PublicOf<LocationRepository>
 {
   async addLocationToNode(label: string, id: ID, rel: string, locationId: ID) {

--- a/src/components/progress-report/variance-explanation/variance-explanation.edgedb.repository.ts
+++ b/src/components/progress-report/variance-explanation/variance-explanation.edgedb.repository.ts
@@ -11,5 +11,5 @@ export class VarianceExplanationEdgeDBRepository
       ...varianceExplanation['*'],
       report: true,
     }),
-  }).withDefaults()
+  })
   implements PublicOf<Neo4jRepository> {}

--- a/src/components/progress-report/workflow/progress-report-workflow.edgedb.repository.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.edgedb.repository.ts
@@ -16,18 +16,16 @@ export class ProgressReportWorkflowEdgeDBRepository
       who: true,
       transition: event.transitionId,
     }),
-  }).customize((cls, { defaults }) => {
-    return class extends cls {
-      static omit = [defaults.create, defaults.update, defaults.delete];
-      async list(reportId: ID) {
-        const progressReport = e.cast(e.ProgressReport, e.uuid(reportId));
-        const query = e.select(progressReport.workflowEvents, this.hydrate);
-        return await this.db.run(query);
-      }
-    };
+    omit: ['list', 'create', 'update', 'delete'],
   })
   implements PublicOf<ProgressReportWorkflowRepository>
 {
+  async list(reportId: ID) {
+    const progressReport = e.cast(e.ProgressReport, e.uuid(reportId));
+    const query = e.select(progressReport.workflowEvents, this.hydrate);
+    return await this.db.run(query);
+  }
+
   async recordEvent({
     report,
     ...props

--- a/src/components/project/project.edgedb.repository.ts
+++ b/src/components/project/project.edgedb.repository.ts
@@ -36,26 +36,22 @@ export const ConcreteRepos = {
   MomentumTranslation: class MomentumTranslationProjectRepository extends RepoFor(
     ConcreteTypes.MomentumTranslation,
     { hydrate },
-  ).withDefaults() {},
+  ) {},
 
   MultiplicationTranslation: class MultiplicationTranslationProjectRepository extends RepoFor(
     ConcreteTypes.MultiplicationTranslation,
     { hydrate },
-  ).withDefaults() {},
+  ) {},
 
   Internship: class InternshipProjectRepository extends RepoFor(
     ConcreteTypes.Internship,
     { hydrate },
-  ).withDefaults() {},
+  ) {},
 } satisfies Record<keyof typeof ConcreteTypes, Type>;
 
 @Injectable()
 export class ProjectEdgeDBRepository
-  extends RepoFor(IProject, { hydrate }).customize((cls, { defaults }) => {
-    return class extends cls {
-      static omit = [defaults.create, defaults.update];
-    };
-  })
+  extends RepoFor(IProject, { hydrate, omit: ['create', 'update'] })
   implements PublicOf<Neo4jRepository>
 {
   constructor(private readonly moduleRef: ModuleRef) {

--- a/src/components/user/education/education.edgedb.repository.ts
+++ b/src/components/user/education/education.edgedb.repository.ts
@@ -8,7 +8,7 @@ import { EducationRepository } from './education.repository';
 export class EducationEdgeDBRepository
   extends RepoFor(Education, {
     hydrate: (education) => education['*'],
-  }).withDefaults()
+  })
   implements PublicOf<EducationRepository>
 {
   async getUserIdByEducation(id: ID) {

--- a/src/components/user/unavailability/unavailability.edgedb.repository.ts
+++ b/src/components/user/unavailability/unavailability.edgedb.repository.ts
@@ -16,47 +16,46 @@ export class UnavailabilityEdgeDBRepository
     hydrate: (unavailability) => ({
       ...unavailability['*'],
     }),
-  }).customize((cls) => {
-    return class extends cls {
-      async create(input: CreateUnavailability) {
-        const user = e.cast(e.User, e.uuid(input.userId));
-        const inserted = e.insert(e.User.Unavailability, {
-          description: input.description,
-          dates: new Range(input.start, input.end),
-        });
-        const updatedUser = e.update(user, () => ({
-          set: {
-            unavailabilities: { '+=': inserted },
-          },
-        }));
-        const query = e.select(inserted, (u) => ({
-          ...this.hydrate(u),
-          updatedUser: e.alias(updatedUser), // Attach to query, so it is executed.
-        }));
-        return await this.db.run(query);
-      }
-
-      async update(input: UpdateUnavailability) {
-        const unavailability = e.cast(e.User.Unavailability, e.uuid(input.id));
-        const updated = e.update(unavailability, () => ({
-          set: {
-            description: input.description,
-            dates: e.cast(
-              e.range(e.datetime),
-              e.range(
-                input.start ?? e.range_get_lower(unavailability.dates),
-                input.end ?? e.range_get_upper(unavailability.dates),
-              ),
-            ),
-          },
-        }));
-        const query = e.select(updated, this.hydrate);
-        return await this.db.run(query);
-      }
-    };
+    omit: ['create', 'update'],
   })
   implements PublicOf<UnavailabilityRepository>
 {
+  async create(input: CreateUnavailability) {
+    const user = e.cast(e.User, e.uuid(input.userId));
+    const inserted = e.insert(e.User.Unavailability, {
+      description: input.description,
+      dates: new Range(input.start, input.end),
+    });
+    const updatedUser = e.update(user, () => ({
+      set: {
+        unavailabilities: { '+=': inserted },
+      },
+    }));
+    const query = e.select(inserted, (u) => ({
+      ...this.hydrate(u),
+      updatedUser: e.alias(updatedUser), // Attach to query, so it is executed.
+    }));
+    return await this.db.run(query);
+  }
+
+  async update(input: UpdateUnavailability) {
+    const unavailability = e.cast(e.User.Unavailability, e.uuid(input.id));
+    const updated = e.update(unavailability, () => ({
+      set: {
+        description: input.description,
+        dates: e.cast(
+          e.range(e.datetime),
+          e.range(
+            input.start ?? e.range_get_lower(unavailability.dates),
+            input.end ?? e.range_get_upper(unavailability.dates),
+          ),
+        ),
+      },
+    }));
+    const query = e.select(updated, this.hydrate);
+    return await this.db.run(query);
+  }
+
   async getUserIdByUnavailability(id: ID) {
     const unavailability = e.cast(e.User.Unavailability, e.uuid(id));
     const query = e.assert_exists(

--- a/src/components/user/user.edgedb.repository.ts
+++ b/src/components/user/user.edgedb.repository.ts
@@ -13,7 +13,7 @@ import type { UserRepository } from './user.repository';
 export class UserEdgeDBRepository
   extends RepoFor(User, {
     hydrate: (user) => user['*'],
-  }).withDefaults()
+  })
   implements PublicOf<UserRepository>
 {
   async doesEmailAddressExist(email: string) {

--- a/src/core/edgedb/dto.repository.ts
+++ b/src/core/edgedb/dto.repository.ts
@@ -52,12 +52,14 @@ export const RepoFor = <
   TResourceStatic extends ResourceShape<any>,
   Root extends GetDBType<TResourceStatic>,
   HydratedShape extends objectTypeToSelectShape<Root['__element__']>,
+  const OmitKeys extends EnumType<typeof DefaultMethods> = never,
 >(
   resourceIn: TResourceStatic,
   {
     hydrate,
   }: {
     hydrate: ShapeFn<Root, HydratedShape>;
+    omit?: readonly OmitKeys[];
   },
 ) => {
   type Dto = $.BaseTypeToTsType<
@@ -73,6 +75,7 @@ export const RepoFor = <
 
   @Injectable()
   abstract class Repository extends CommonRepository {
+    // TODO clean up
     static customize<
       Customized extends BaseCustomizedRepository,
       OmitKeys extends EnumType<typeof DefaultMethods> = never,
@@ -120,9 +123,6 @@ export const RepoFor = <
       });
 
       return customizedClass as any;
-    }
-    static withDefaults() {
-      return DefaultDtoRepository;
     }
 
     @Inject(Privileges)
@@ -309,7 +309,9 @@ export const RepoFor = <
     }
   }
 
-  return Repository;
+  return Repository.customize<BaseCustomizedRepository, OmitKeys & {}>(
+    (cls) => cls,
+  );
 };
 
 type ShapeFn<


### PR DESCRIPTION
Instead of putting customized methods in an intermediary class, they can now just go in the final class.
If the signature is compatible with the default one, then nothing more is needed, which is the same as before.
If the signature is _not_ compatible with the default one, then it can just be marked in the `omit` array to ignore the default signature.

Overall I think this simpler for customization cases.

For default cases, it doesn't appear that we will ever not want to start with default methods.
If we did we'd just extend from CommonRepo instead. Maybe future work here if needed.