### PR TITLE
Change toThrowGqlError message failure to support asymmetric matchers

### DIFF
--- a/test/utility/edgedb-setup.ts
+++ b/test/utility/edgedb-setup.ts
@@ -18,7 +18,7 @@ export const ephemeralEdgeDB = async () => {
   await db.execute(`create schema branch ${branch} from ${main}`);
 
   const cleanup = async () => {
-    await db.execute(`drop branch ${branch}`);
+    await db.execute(`drop branch ${branch} force`);
     await db.close();
   };
 

--- a/test/utility/expect-gql-error.ts
+++ b/test/utility/expect-gql-error.ts
@@ -60,8 +60,8 @@ expect.extend({
           !messagePassed
             ? stripIndent`
                 Message:
-                  ${this.utils.EXPECTED_COLOR(expectedObj.message)}
-                  ${this.utils.RECEIVED_COLOR(actualObj.message)}
+                  ${this.utils.printExpected(expectedObj.message)}
+                  ${this.utils.printReceived(actualObj.message)}
               `.replace(/\n/g, '\n        ')
             : ''
         }


### PR DESCRIPTION
Missed in #3183

This previous code avoided quoting the message string.
I was trying to reduce syntax to sort through in error message.

Compromising to include quotes here to be consistent & support the matchers.
```
Message:
  StringMatching: /not found/
  "Server Error"
```
```
Message:
  "Not Found"
  "Server Error"
```