### PR TITLE
Change marketing location policy to enable edit for leadership and ex…

### DIFF
--- a/src/components/authorization/policies/by-role/experience-operations.policy.ts
+++ b/src/components/authorization/policies/by-role/experience-operations.policy.ts
@@ -13,7 +13,7 @@ import { member, Policy, Role, sensMediumOrLower } from '../util';
     .children((c) => c.posts.edit),
   r.Partnership.read,
   r.PeriodicReport.read,
-  r.Project.read,
+  r.Project.read.specifically((p) => [p.marketingLocation.edit]),
   r.ProjectMember.edit.create.delete,
 ])
 export class ExperienceOperationsPolicy {}

--- a/src/components/authorization/policies/by-role/leadership.policy.ts
+++ b/src/components/authorization/policies/by-role/leadership.policy.ts
@@ -1,5 +1,8 @@
 import { allowAll, Policy, Role } from '../util';
 
 // NOTE: There could be other permissions for this role from other policies
-@Policy(Role.Leadership, allowAll('read'))
+@Policy(Role.Leadership, (r) => [
+  ...allowAll('read')(r),
+  r.Project.read.specifically((p) => [p.marketingLocation.edit]),
+])
 export class LeadershipPolicy {}


### PR DESCRIPTION
## Description
Changed marketingLocation policies for Leadership and Experience Operations allowing them permission to edit.

https://seed-company-squad.monday.com/boards/5989610236/pulses/6561812549