### PR TITLE
Fix current report picking final prematurely

### DIFF
--- a/src/components/periodic-report/dto/list-periodic-reports.dto.ts
+++ b/src/components/periodic-report/dto/list-periodic-reports.dto.ts
@@ -17,7 +17,7 @@ import { ReportType } from './report-type.enum';
 export class PeriodicReportListInput extends SortablePaginationInput<
   keyof PeriodicReport
 >({
-  defaultSort: 'end',
+  defaultSort: 'start',
 }) {
   @Field(() => ReportType, {
     description: stripIndent`

--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -205,15 +205,22 @@ export class PeriodicReportRepository extends DtoRepository<
     return (query: Query) =>
       query.comment`matchCurrentDue()`
         .match([
-          node('baseNode', 'BaseNode', { id: parentId }),
-          relation('out', '', 'report', ACTIVE),
-          node('node', `${reportType}Report`),
-          relation('out', '', 'end', ACTIVE),
-          node('end', 'Property'),
+          [
+            node('baseNode', 'BaseNode', { id: parentId }),
+            relation('out', '', 'report', ACTIVE),
+            node('node', `${reportType}Report`),
+            relation('out', '', 'end', ACTIVE),
+            node('end', 'Property'),
+          ],
+          [
+            node('node'),
+            relation('out', '', 'start', ACTIVE),
+            node('start', 'Property'),
+          ],
         ])
         .raw(`WHERE end.value < date()`)
-        .with('node, end')
-        .orderBy('end.value', 'desc')
+        .with('node, start')
+        .orderBy('start.value', 'desc')
         .limit(1);
   }
 


### PR DESCRIPTION
Sort periodic reports by `start` date instead of `end` date.

This fixes incorrectly matching the current report to the final one.
Given reports:
Last regular:  1/1/2024 - 3/31/2024
Final:        3/31/2024 - 3/31/2024

So if using the end date, one of those two is arbitrarily picked, and has so far just been a coincidence to have been picked correctly.
