### PR TITLE
Upsert actors outside of current transaction

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import process from 'node:process';
 import { assert } from 'ts-essentials';
 import { keys } from 'ts-transformer-keys';
 import { AdminModule } from './components/admin/admin.module';
@@ -42,6 +43,10 @@ assert(
   keys<{ foo: string }>().length === 1,
   'Sanity check for key transformer failed',
 );
+
+if (process.env.NODE_ENV !== 'production') {
+  Error.stackTraceLimit = Infinity;
+}
 
 @Module({
   imports: [

--- a/src/components/user/actor.edgedb.repository.ts
+++ b/src/components/user/actor.edgedb.repository.ts
@@ -8,7 +8,7 @@ export class ActorEdgeDBRepository extends ActorRepository {
   private readonly db: EdgeDB;
   constructor(edgedb: EdgeDB) {
     super();
-    this.db = edgedb.withOptions(disableAccessPolicies);
+    this.db = edgedb.outsideOfTransactions().withOptions(disableAccessPolicies);
   }
 
   protected async upsertAgent(name: string, roles?: readonly Role[]) {


### PR DESCRIPTION
Queries cannot run in parallel within a transaction.
https://github.com/SeedCompany/cord-api-v3/blob/1eb8d8b7b6db30146704486487f7def21e3b8f47/src/components/authentication/authentication.service.ts#L121-L124

The actor logic is not meant to be a part of the current mutation, so changed there.

Also removed the stacktrace limit for dev.