### PR TITLE
[Hotfix] Change `Promise.all` to `for await` in project status handler to catch UnauthorizedException

### DIFF
--- a/src/components/engagement/engagement.rules.ts
+++ b/src/components/engagement/engagement.rules.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-case-declarations */
 import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
-import { first, intersection } from 'lodash';
+import { first, intersection, startCase } from 'lodash';
 import {
   ID,
   ServerException,
@@ -383,7 +383,9 @@ export class EngagementRules {
     );
     if (!validNextStatus) {
       throw new UnauthorizedException(
-        'This status is not in an authorized sequence',
+        `One or more engagements cannot be changed to ${startCase(
+          nextStatus,
+        )}. Please check engagement statuses.`,
         'engagement.status',
       );
     }

--- a/src/components/engagement/handlers/update-project-status.handler.ts
+++ b/src/components/engagement/handlers/update-project-status.handler.ts
@@ -115,22 +115,20 @@ export class UpdateProjectStatusHandler
     type: ProjectType,
     session: Session,
   ) {
-    await Promise.all(
-      engagementIds.map(async (id) => {
-        const updateInput = {
-          id,
-          status,
-        };
-        type !== ProjectType.Internship
-          ? await this.engagementService.updateLanguageEngagement(
-              updateInput,
-              session,
-            )
-          : await this.engagementService.updateInternshipEngagement(
-              updateInput,
-              session,
-            );
-      }),
-    );
+    for await (const id of engagementIds) {
+      const updateInput = {
+        id,
+        status,
+      };
+      type !== ProjectType.Internship
+        ? await this.engagementService.updateLanguageEngagement(
+            updateInput,
+            session,
+          )
+        : await this.engagementService.updateInternshipEngagement(
+            updateInput,
+            session,
+          );
+    }
   }
 }


### PR DESCRIPTION
<!--- replace the text in parentheses with Monday link for your task -->
## [Cord API memory leak causing AWS crash](https://seed-company-squad.monday.com/boards/3451697530/views/78801638/pulses/6639250219)

## Description
This PR changes how the engagements are updated in the project handler.
There seems to be an issue, either with the the way `Promise.all` handles the UnauthorizedException for the edgecase where a project has 3 engagements, one (or more) of them being in a step previous (for example 2 in `Active change plan` and 1 in `Discussing change plan`), the engagement update would fail with the UnauthorizedException. 

It is assumed that because Promis.all not handling the exception properly, would cause a neo4j transaction creation to retry in an infinite loop.

This infinite loop caused the API service to crash completely being OOM (out of memory).


## Steps to reproduce the bug
In the description

## Expected behavior
Not crash, lol


## Ready for review checklist
> Use `[N/A]` if the item is not applicable to this PR or remove the item
- [x] Change the task url above to the actual Monday task
- [x] Add reviewers to this PR
- [x] THIS IS A HOTFIX
