### PR TITLE
[Tests] E2E File upload/download

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "fastest-levenshtein": "^1.0.16",
     "file-type": "^18.6.0",
     "glob": "^10.3.10",
-    "got": "^13.0.0",
+    "got": "^14.3.0",
     "graphql": "^16.8.1",
     "graphql-parse-resolve-info": "^4.14.0",
     "graphql-scalars": "^1.22.4",

--- a/src/components/file/bucket/local-bucket.ts
+++ b/src/components/file/bucket/local-bucket.ts
@@ -8,6 +8,7 @@ import { Command } from '@smithy/smithy-client';
 import { pickBy } from 'lodash';
 import { DateTime, Duration } from 'luxon';
 import { URL } from 'node:url';
+import { firstValueFrom, Observable } from 'rxjs';
 import { Readable } from 'stream';
 import { assert } from 'ts-essentials';
 import {
@@ -19,7 +20,7 @@ import {
 } from './file-bucket';
 
 export interface LocalBucketOptions {
-  baseUrl: URL;
+  baseUrl: Observable<URL>;
 }
 
 export type FakeAwsFile = Required<Pick<GetObjectOutput, 'ContentType'>> &
@@ -96,7 +97,8 @@ export abstract class LocalBucket<
           .toMillis(),
       },
     });
-    const url = new URL(this.options.baseUrl.toString());
+    const baseUrl = await firstValueFrom(this.options.baseUrl);
+    const url = new URL(baseUrl.toString());
     url.searchParams.set('signed', signed);
     return url.toString();
   }

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -144,7 +144,7 @@ export class FileService {
 
   async getUrl(node: FileNode, download: boolean) {
     const url = withAddedPath(
-      this.config.hostUrl,
+      this.config.hostUrl$.value,
       FileUrl.path,
       isFile(node) ? node.latestVersionId : node.id,
       encodeURIComponent(node.name),

--- a/src/components/file/files-bucket.factory.ts
+++ b/src/components/file/files-bucket.factory.ts
@@ -1,6 +1,7 @@
 import { S3 } from '@aws-sdk/client-s3';
 import { FactoryProvider } from '@nestjs/common';
 import { resolve } from 'path';
+import { map } from 'rxjs/operators';
 import { withAddedPath } from '~/common/url.util';
 import { ConfigService } from '~/core';
 import {
@@ -21,7 +22,9 @@ export const FilesBucketFactory: FactoryProvider = {
   useFactory: (s3: S3, config: ConfigService) => {
     const { sources } = config.files;
 
-    const baseUrl = withAddedPath(config.hostUrl, LocalBucketController.path);
+    const baseUrl = config.hostUrl$.pipe(
+      map((hostUrl) => withAddedPath(hostUrl, LocalBucketController.path)),
+    );
 
     const files: FileFactory = ({ path }) =>
       new FilesystemBucket({

--- a/src/components/file/local-bucket.controller.ts
+++ b/src/components/file/local-bucket.controller.ts
@@ -5,6 +5,7 @@ import {
   Put,
   Request,
   Response,
+  StreamableFile,
 } from '@nestjs/common';
 import { Request as IRequest, Response as IResponse } from 'express';
 import { DateTime } from 'luxon';
@@ -49,7 +50,10 @@ export class LocalBucketController {
   }
 
   @Get()
-  async download(@Request() req: IRequest, @Response() res: IResponse) {
+  async download(
+    @Request() req: IRequest,
+    @Response({ passthrough: true }) res: IResponse,
+  ) {
     const url = new URL(`https://localhost${req.url}`);
     const { Key, operation, ...rest } = await this.bucket.parseSignedUrl(url);
     if (operation !== 'GetObject') {
@@ -84,6 +88,6 @@ export class LocalBucketController {
       }
     }
 
-    out.Body.pipe(res);
+    return new StreamableFile(out.Body);
   }
 }

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -10,6 +10,7 @@ import LRUCache from 'lru-cache';
 import { Duration, DurationLike } from 'luxon';
 import { nanoid } from 'nanoid';
 import { Config as Neo4JDriverConfig } from 'neo4j-driver';
+import { BehaviorSubject } from 'rxjs';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { Class, Merge, ReadonlyDeep } from 'type-fest';
 import { ID } from '~/common';
@@ -35,9 +36,9 @@ export const makeConfig = (env: EnvironmentService) =>
     port = env.number('port').optional(3000);
     // The port where the app is being hosted. i.e. a docker bound port
     publicPort = env.number('public_port').optional(this.port);
-    hostUrl = env
-      .url('host_url')
-      .optional(`http://localhost:${this.publicPort}`);
+    hostUrl$ = new BehaviorSubject(
+      env.url('host_url').optional(`http://localhost:${this.publicPort}`),
+    );
 
     graphQL = {
       persistedQueries: {

--- a/src/core/tracing/tracing.module.ts
+++ b/src/core/tracing/tracing.module.ts
@@ -47,12 +47,15 @@ export class TracingModule implements OnModuleInit, NestModule {
       XRay.middleware.disableCentralizedSampling();
     }
 
-    XRay.SegmentUtils.setServiceData({
-      name: this.config.hostUrl.toString(),
-      version: (await this.version.version).toString(),
-      runtime: process.release?.name ?? 'unknown',
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      runtime_version: process.version,
+    const version = await this.version.version;
+    this.config.hostUrl$.subscribe((hostUrl) => {
+      XRay.SegmentUtils.setServiceData({
+        name: hostUrl.toString(),
+        version: version.toString(),
+        runtime: process.release?.name ?? 'unknown',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        runtime_version: process.version,
+      });
     });
 
     if (this.config.xray.daemonAddress) {

--- a/src/core/tracing/xray.middleware.ts
+++ b/src/core/tracing/xray.middleware.ts
@@ -36,7 +36,8 @@ export class XRayMiddleware implements NestMiddleware, NestInterceptor {
     root.addIncomingRequestData(reqData);
     // Use public DNS as url instead of specific IP
     // @ts-expect-error xray library types suck
-    root.http.request.url = this.config.hostUrl + req.originalUrl.slice(1);
+    root.http.request.url =
+      this.config.hostUrl$.value + req.originalUrl.slice(1);
 
     // Add to segment so interceptor can access without having to calculate again.
     Object.defineProperty(reqData, 'traceData', {

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,13 +23,13 @@ async function bootstrap() {
   app.enableCors(config.cors as CorsOptions); // typecast to undo deep readonly
   app.use(cookieParser());
 
-  app.setGlobalPrefix(config.hostUrl.pathname.slice(1));
+  app.setGlobalPrefix(config.hostUrl$.value.pathname.slice(1));
 
   config.applyTimeouts(app.getHttpServer(), config.httpTimeouts);
 
   app.enableShutdownHooks();
   await app.listen(config.port, () => {
-    app.get(Logger).log(`Listening at ${config.hostUrl}graphql`);
+    app.get(Logger).log(`Listening at ${config.hostUrl$.value}graphql`);
   });
 }
 bootstrap().catch((err) => {

--- a/test/file.e2e-spec.ts
+++ b/test/file.e2e-spec.ts
@@ -161,7 +161,7 @@ describe('File e2e', () => {
       expect(modifiedAt.diffNow().as('seconds')).toBeGreaterThan(-30);
       const createdAt = DateTime.fromISO(file.createdAt);
       expect(createdAt.diffNow().as('seconds')).toBeGreaterThan(-30);
-      await expectEqualContent(app, file.downloadUrl, fakeFile);
+      await expectEqualContent(app, file.url, fakeFile);
       expect(file.parents[0].id).toEqual(root.id);
     }
   });
@@ -182,7 +182,7 @@ describe('File e2e', () => {
     expect(version.createdBy.id).toEqual(me.id);
     const createdAt = DateTime.fromISO(version.createdAt);
     expect(createdAt.diffNow().as('seconds')).toBeGreaterThan(-30);
-    await expectEqualContent(app, file.downloadUrl, fakeFile);
+    await expectEqualContent(app, file.url, fakeFile);
     expect(version.parents[0].id).toEqual(file.id);
   });
 
@@ -221,7 +221,7 @@ describe('File e2e', () => {
     input: FakeFile,
   ) {
     expect(updated.id).toEqual(initial.id);
-    await expectEqualContent(app, updated.downloadUrl, input);
+    await expectEqualContent(app, updated.url, input);
     expect(updated.size).toEqual(input.size);
     expect(updated.mimeType).toEqual(input.mimeType);
     const createdAt = DateTime.fromISO(updated.createdAt);

--- a/test/file.e2e-spec.ts
+++ b/test/file.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { bufferFromStream } from '@seedcompany/common';
+import got from 'got';
 import { startCase, times } from 'lodash';
 import {
   DateTime,
@@ -104,13 +104,18 @@ function resetNow() {
 }
 
 const expectEqualContent = async (
-  bucket: LocalBucket,
+  app: TestApp,
   url: string,
   expected: FakeFile,
 ) => {
-  const actualFile = await bucket.download(url);
-  const contents = await bufferFromStream(actualFile.Body);
-  expect(contents.toString()).toEqual(expected.content.toString());
+  const expectedContents = expected.content;
+  const actualContents = await got(url, {
+    headers: {
+      Authorization: `Bearer ${app.graphql.authToken}`,
+    },
+    enableUnixSockets: true,
+  }).buffer();
+  expect(expectedContents).toEqual(actualContents);
 };
 
 describe('File e2e', () => {
@@ -156,7 +161,7 @@ describe('File e2e', () => {
       expect(modifiedAt.diffNow().as('seconds')).toBeGreaterThan(-30);
       const createdAt = DateTime.fromISO(file.createdAt);
       expect(createdAt.diffNow().as('seconds')).toBeGreaterThan(-30);
-      await expectEqualContent(bucket, file.downloadUrl, fakeFile);
+      await expectEqualContent(app, file.downloadUrl, fakeFile);
       expect(file.parents[0].id).toEqual(root.id);
     }
   });
@@ -177,7 +182,7 @@ describe('File e2e', () => {
     expect(version.createdBy.id).toEqual(me.id);
     const createdAt = DateTime.fromISO(version.createdAt);
     expect(createdAt.diffNow().as('seconds')).toBeGreaterThan(-30);
-    await expectEqualContent(bucket, file.downloadUrl, fakeFile);
+    await expectEqualContent(app, file.downloadUrl, fakeFile);
     expect(version.parents[0].id).toEqual(file.id);
   });
 
@@ -216,7 +221,7 @@ describe('File e2e', () => {
     input: FakeFile,
   ) {
     expect(updated.id).toEqual(initial.id);
-    await expectEqualContent(bucket, updated.downloadUrl, input);
+    await expectEqualContent(app, updated.downloadUrl, input);
     expect(updated.size).toEqual(input.size);
     expect(updated.mimeType).toEqual(input.mimeType);
     const createdAt = DateTime.fromISO(updated.createdAt);

--- a/test/utility/create-file.ts
+++ b/test/utility/create-file.ts
@@ -13,15 +13,18 @@ import { RawFile, RawFileNode, RawFileNodeChildren } from './fragments';
 import * as fragments from './fragments';
 import { gql } from './gql-tag';
 
-export const generateFakeFile = () => ({
-  name: faker.system.fileName(),
-  content: Buffer.from(
+export const generateFakeFile = () => {
+  const content = Buffer.from(
     faker.image.dataUri({ width: 200, height: 200 }).split(',')[1],
     'base64',
-  ),
-  size: faker.number.int(1_000_000),
-  mimeType: faker.helpers.arrayElement(mimeTypes).name,
-});
+  );
+  return {
+    name: faker.system.fileName(),
+    content: content,
+    size: content.length,
+    mimeType: faker.helpers.arrayElement(mimeTypes).name,
+  };
+};
 
 export type FakeFile = ReturnType<typeof generateFakeFile>;
 

--- a/test/utility/create-file.ts
+++ b/test/utility/create-file.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
-import { assert, MarkOptional } from 'ts-essentials';
+import got from 'got';
+import { MarkOptional } from 'ts-essentials';
 import { ID } from '~/common';
-import { FileBucket, LocalBucket } from '../../src/components/file/bucket';
 import {
   CreateFileVersionInput,
   FileListInput,
@@ -52,18 +52,14 @@ export const uploadFileContents = async (
     ...generateFakeFile(),
     ...input,
   };
-  const {
-    content: Body,
-    mimeType: ContentType,
-    size: ContentLength,
-  } = completeInput;
+  const { content, mimeType } = completeInput;
 
-  const bucket = app.get(FileBucket);
-  assert(bucket instanceof LocalBucket);
-  await bucket.upload(url, {
-    Body,
-    ContentType,
-    ContentLength,
+  await got.put(url, {
+    headers: {
+      'Content-Type': mimeType,
+    },
+    body: content,
+    enableUnixSockets: true,
   });
 
   return completeInput;

--- a/test/utility/create-graphql-client.ts
+++ b/test/utility/create-graphql-client.ts
@@ -7,6 +7,7 @@ import {
   print,
 } from 'graphql';
 import { Merge } from 'type-fest';
+import { ConfigService } from '~/core';
 // eslint-disable-next-line import/no-duplicates
 import { ErrorExpectations } from './expect-gql-error';
 // eslint-disable-next-line import/no-duplicates -- ensures runtime execution
@@ -29,6 +30,7 @@ export const createGraphqlClient = async (
 ): Promise<GraphQLTestClient> => {
   await app.listen(0);
   const url = await app.getUrl();
+  app.get(ConfigService).hostUrl$.next(new URL(url) as URL & string);
 
   let authToken = '';
 

--- a/test/utility/fragments.ts
+++ b/test/utility/fragments.ts
@@ -394,12 +394,12 @@ export const fileNode = gql`
     ... on FileVersion {
       mimeType
       size
-      downloadUrl
+      url
     }
     ... on File {
       mimeType
       size
-      downloadUrl
+      url
       modifiedAt
       modifiedBy {
         ...user
@@ -421,7 +421,7 @@ export type RawBaseFileNode = RawNode<
 >;
 export type RawDirectory = RawBaseFileNode;
 export type RawFileVersion = RawBaseFileNode &
-  RawNode<FileVersion, keyof IFileNode, { downloadUrl: string }>;
+  RawNode<FileVersion, keyof IFileNode, { url: string }>;
 export type RawFile = RawFileVersion &
   RawNode<
     File,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2559,6 +2559,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sec-ant/readable-stream@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@sec-ant/readable-stream@npm:0.4.1"
+  checksum: 10c0/64e9e9cf161e848067a5bf60cdc04d18495dc28bb63a8d9f8993e4dd99b91ad34e4b563c85de17d91ffb177ec17a0664991d2e115f6543e73236a906068987af
+  languageName: node
+  linkType: hard
+
 "@seedcompany/common@npm:>0.3 <1, @seedcompany/common@npm:>=0.10.0 <1.0.0, @seedcompany/common@npm:>=0.13.1 <1, @seedcompany/common@npm:>=0.3.0 <1.0.0":
   version: 0.13.2
   resolution: "@seedcompany/common@npm:0.13.2"
@@ -2687,10 +2694,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sindresorhus/is@npm:^5.2.0":
-  version: 5.6.0
-  resolution: "@sindresorhus/is@npm:5.6.0"
-  checksum: 10c0/66727344d0c92edde5760b5fd1f8092b717f2298a162a5f7f29e4953e001479927402d9d387e245fb9dc7d3b37c72e335e93ed5875edfc5203c53be8ecba1b52
+"@sindresorhus/is@npm:^6.3.1":
+  version: 6.3.1
+  resolution: "@sindresorhus/is@npm:6.3.1"
+  checksum: 10c0/2432ca411aafe7840818493360ba795db07ce7e8efd2bc994736fdbda175e99fa7d6614c7f41a72b28bae68603a86dbd0d810ba45d1ba7c5881929d54049360c
   languageName: node
   linkType: hard
 
@@ -3502,10 +3509,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/http-cache-semantics@npm:^4.0.2":
-  version: 4.0.3
-  resolution: "@types/http-cache-semantics@npm:4.0.3"
-  checksum: 10c0/46e8e4d9ff8d032f0a12d08fb7250fc67ede0d566f9a5b3d92384098fb46a3892d3ec377600a1d73ea8a67a979b882f7b9ff5e29524fb76b8e1c44a0dbe04ecf
+"@types/http-cache-semantics@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "@types/http-cache-semantics@npm:4.0.4"
+  checksum: 10c0/51b72568b4b2863e0fe8d6ce8aad72a784b7510d72dc866215642da51d84945a9459fa89f49ec48f1e9a1752e6a78e85a4cda0ded06b1c73e727610c925f9ce6
   languageName: node
   linkType: hard
 
@@ -4709,18 +4716,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacheable-request@npm:^10.2.8":
-  version: 10.2.14
-  resolution: "cacheable-request@npm:10.2.14"
+"cacheable-request@npm:^12.0.1":
+  version: 12.0.1
+  resolution: "cacheable-request@npm:12.0.1"
   dependencies:
-    "@types/http-cache-semantics": "npm:^4.0.2"
-    get-stream: "npm:^6.0.1"
+    "@types/http-cache-semantics": "npm:^4.0.4"
+    get-stream: "npm:^9.0.1"
     http-cache-semantics: "npm:^4.1.1"
-    keyv: "npm:^4.5.3"
+    keyv: "npm:^4.5.4"
     mimic-response: "npm:^4.0.0"
-    normalize-url: "npm:^8.0.0"
+    normalize-url: "npm:^8.0.1"
     responselike: "npm:^3.0.0"
-  checksum: 10c0/41b6658db369f20c03128227ecd219ca7ac52a9d24fc0f499cc9aa5d40c097b48b73553504cebd137024d957c0ddb5b67cf3ac1439b136667f3586257763f88d
+  checksum: 10c0/3ccc26519c8dd0821fcb21fa00781e55f05ab6e1da1487fbbee9c8c03435a3cf72c29a710a991cebe398fb9a5274e2a772fc488546d402db8dc21310764ed83a
   languageName: node
   linkType: hard
 
@@ -5402,7 +5409,7 @@ __metadata:
     fastest-levenshtein: "npm:^1.0.16"
     file-type: "npm:^18.6.0"
     glob: "npm:^10.3.10"
-    got: "npm:^13.0.0"
+    got: "npm:^14.3.0"
     graphql: "npm:^16.8.1"
     graphql-parse-resolve-info: "npm:^4.14.0"
     graphql-scalars: "npm:^1.22.4"
@@ -7000,10 +7007,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data-encoder@npm:^2.1.2":
-  version: 2.1.4
-  resolution: "form-data-encoder@npm:2.1.4"
-  checksum: 10c0/4c06ae2b79ad693a59938dc49ebd020ecb58e4584860a90a230f80a68b026483b022ba5e4143cff06ae5ac8fd446a0b500fabc87bbac3d1f62f2757f8dabcaf7
+"form-data-encoder@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "form-data-encoder@npm:4.0.2"
+  checksum: 10c0/559d3130e265316452434eaf68d68560fb36392ff4d04614683419de4fb43c3dbe152dc303599fae382ce24d3451a6d3d289d3bcc182ae3d8ad32e7ce8e35e53
   languageName: node
   linkType: hard
 
@@ -7182,6 +7189,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-stream@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "get-stream@npm:9.0.1"
+  dependencies:
+    "@sec-ant/readable-stream": "npm:^0.4.1"
+    is-stream: "npm:^4.0.1"
+  checksum: 10c0/d70e73857f2eea1826ac570c3a912757dcfbe8a718a033fa0c23e12ac8e7d633195b01710e0559af574cbb5af101009b42df7b6f6b29ceec8dbdf7291931b948
+  languageName: node
+  linkType: hard
+
 "get-symbol-description@npm:^1.0.0":
   version: 1.0.0
   resolution: "get-symbol-description@npm:1.0.0"
@@ -7323,22 +7340,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "got@npm:13.0.0"
+"got@npm:^14.3.0":
+  version: 14.3.0
+  resolution: "got@npm:14.3.0"
   dependencies:
-    "@sindresorhus/is": "npm:^5.2.0"
+    "@sindresorhus/is": "npm:^6.3.1"
     "@szmarczak/http-timer": "npm:^5.0.1"
     cacheable-lookup: "npm:^7.0.0"
-    cacheable-request: "npm:^10.2.8"
+    cacheable-request: "npm:^12.0.1"
     decompress-response: "npm:^6.0.0"
-    form-data-encoder: "npm:^2.1.2"
-    get-stream: "npm:^6.0.1"
-    http2-wrapper: "npm:^2.1.10"
+    form-data-encoder: "npm:^4.0.2"
+    get-stream: "npm:^8.0.1"
+    http2-wrapper: "npm:^2.2.1"
     lowercase-keys: "npm:^3.0.0"
-    p-cancelable: "npm:^3.0.0"
+    p-cancelable: "npm:^4.0.1"
     responselike: "npm:^3.0.0"
-  checksum: 10c0/d6a4648dc46f1f9df2637b8730d4e664349a93cb6df62c66dfbb48f7887ba79742a1cc90739a4eb1c15f790ca838ff641c5cdecdc877993627274aeb0f02b92d
+  checksum: 10c0/c2fe6a1411cd6f3334bda48b4b027035e0c4a0587344c652f193d4ca7b782d43ec29b1781c796572f4621676eeafe36d2bd9e371cb7e1d1982e65f3630a4dcb6
   languageName: node
   linkType: hard
 
@@ -7628,13 +7645,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http2-wrapper@npm:^2.1.10":
-  version: 2.2.0
-  resolution: "http2-wrapper@npm:2.2.0"
+"http2-wrapper@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "http2-wrapper@npm:2.2.1"
   dependencies:
     quick-lru: "npm:^5.1.1"
     resolve-alpn: "npm:^1.2.0"
-  checksum: 10c0/cb4a41a9b4948a607bb27b4e745af5396e01a5e074da4c7ea0d3ce41acd9cef69de373a67d321728bb651fd9701a23c80e8991c9ad5128dab10e9da28a8b6c72
+  checksum: 10c0/7207201d3c6e53e72e510c9b8912e4f3e468d3ecc0cf3bf52682f2aac9cd99358b896d1da4467380adc151cf97c412bedc59dc13dae90c523f42053a7449eedb
   languageName: node
   linkType: hard
 
@@ -8172,6 +8189,13 @@ __metadata:
   version: 3.0.0
   resolution: "is-stream@npm:3.0.0"
   checksum: 10c0/eb2f7127af02ee9aa2a0237b730e47ac2de0d4e76a4a905a50a11557f2339df5765eaea4ceb8029f1efa978586abe776908720bfcb1900c20c6ec5145f6f29d8
+  languageName: node
+  linkType: hard
+
+"is-stream@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "is-stream@npm:4.0.1"
+  checksum: 10c0/2706c7f19b851327ba374687bc4a3940805e14ca496dc672b9629e744d143b1ad9c6f1b162dece81c7bfbc0f83b32b61ccc19ad2e05aad2dd7af347408f60c7f
   languageName: node
   linkType: hard
 
@@ -9030,7 +9054,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keyv@npm:^4.5.3":
+"keyv@npm:^4.5.3, keyv@npm:^4.5.4":
   version: 4.5.4
   resolution: "keyv@npm:4.5.4"
   dependencies:
@@ -10444,10 +10468,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "normalize-url@npm:8.0.0"
-  checksum: 10c0/09582d56acd562d89849d9239852c2aff225c72be726556d6883ff36de50006803d32a023c10e917bcc1c55f73f3bb16434f67992fe9b61906a3db882192753c
+"normalize-url@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "normalize-url@npm:8.0.1"
+  checksum: 10c0/eb439231c4b84430f187530e6fdac605c5048ef4ec556447a10c00a91fc69b52d8d8298d9d608e68d3e0f7dc2d812d3455edf425e0f215993667c3183bcab1ef
   languageName: node
   linkType: hard
 
@@ -10698,10 +10722,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-cancelable@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "p-cancelable@npm:3.0.0"
-  checksum: 10c0/948fd4f8e87b956d9afc2c6c7392de9113dac817cb1cecf4143f7a3d4c57ab5673614a80be3aba91ceec5e4b69fd8c869852d7e8048bc3d9273c4c36ce14b9aa
+"p-cancelable@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "p-cancelable@npm:4.0.1"
+  checksum: 10c0/12636623f46784ba962b6fe7a1f34d021f1d9a2cc12c43e270baa715ea872d5c8c7d9f086ed420b8b9817e91d9bbe92c14c90e5dddd4a9968c81a2a7aef7089d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Previously we were faking the upload/download process by talking to the _assumed_ `LocalBucket` storage.
Where as in actual usage we are expecting PUT/GET HTTP requests.

This changes the tests to actually use that code path.

The reasoning for this previous decision was because we weren't actually serving the GQL API over a server, but executing the operations directly. So without a web server setup, we couldn't do these requests either. That has since changed.

The last hard part here was that we use a unix socket for the test web server which assigns a random port when we start listening.
The app needs to know where it is hosting/listening on so it can generate those PUT/GET urls.
But app boot happens before listening so the port can't be known ahead of time.
I switched the `ConfigService.hostUrl` to be a `BehaviorSubject` so we can adjust the url later, after listening starts.
[Here's](https://github.com/SeedCompany/cord-api-v3/compare/tests/real-file-handling?expand=1#diff-6c3d06e4c56f18613f52c00647213ce9e6099ff7eb3faceb53fe4cd8fb4aeb98R33) where it is set in the test suite setup.
It's worth noting that Nest's usage of this, like _global prefix_, does not listen for changes to this value, and only uses the initial one. I've updated all of our usages to respect the current value.