### PR TITLE
Enum entry & default label

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "rimraf": "^5.0.5",
     "rxjs": "^7.8.1",
     "sanitize-filename": "^1.6.3",
+    "title-case": "^4.3.1",
     "ts-essentials": "^9.4.1",
     "winston": "^3.11.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.0/xlsx-0.20.0.tgz",

--- a/src/components/engagement/engagement.rules.ts
+++ b/src/components/engagement/engagement.rules.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-case-declarations */
 import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
-import { first, intersection, startCase } from 'lodash';
+import { first, intersection } from 'lodash';
 import {
   ID,
   Role,
@@ -384,9 +384,9 @@ export class EngagementRules {
     );
     if (!validNextStatus) {
       throw new UnauthorizedException(
-        `One or more engagements cannot be changed to ${startCase(
-          nextStatus,
-        )}. Please check engagement statuses.`,
+        `One or more engagements cannot be changed to ${
+          EngagementStatus.entry(nextStatus).label
+        }. Please check engagement statuses.`,
         'engagement.status',
       );
     }

--- a/src/components/progress-report/workflow/progress-report-workflow.flowchart.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.flowchart.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { startCase } from 'lodash';
 import open from 'open';
 import pako from 'pako';
 import { ProgressReportStatus as Status } from '../dto';
@@ -37,8 +36,8 @@ export class ProgressReportWorkflowFlowchart {
         return str ? `classDef ${type} ${str}` : [];
       }),
       '',
-      ...Object.keys(Status).map(
-        (status) => `${status}(${startCase(status)}):::State`,
+      ...Status.entries.map(
+        (status) => `${status.value}(${status.label}):::State`,
       ),
       '',
       ...Object.values(Transitions).flatMap((t) => {

--- a/src/core/email/templates/progress-report-status-changed.template.tsx
+++ b/src/core/email/templates/progress-report-status-changed.template.tsx
@@ -4,7 +4,6 @@ import {
   Section,
   Text,
 } from '@seedcompany/nestjs-email/templates';
-import { startCase } from 'lodash';
 import { fiscalQuarter, fiscalYear } from '~/common';
 import { Language } from '../../../components/language/dto';
 import { PeriodicReport } from '../../../components/periodic-report/dto';
@@ -49,8 +48,12 @@ export function ProgressReportStatusChanged({
     report.start,
   )} FY${fiscalYear(report.start)}`;
 
-  const oldStatus = startCase(previousStatusVal) || undefined;
-  const newStatus = startCase(newStatusVal) || undefined;
+  const oldStatus = previousStatusVal
+    ? ProgressReportStatus.entry(previousStatusVal).label
+    : undefined;
+  const newStatus = newStatusVal
+    ? ProgressReportStatus.entry(newStatusVal).label
+    : undefined;
 
   return (
     <EmailTemplate

--- a/yarn.lock
+++ b/yarn.lock
@@ -5442,6 +5442,7 @@ __metadata:
     rimraf: "npm:^5.0.5"
     rxjs: "npm:^7.8.1"
     sanitize-filename: "npm:^1.6.3"
+    title-case: "npm:^4.3.1"
     ts-essentials: "npm:^9.4.1"
     ts-jest: "npm:^29.1.1"
     ts-morph: "npm:^19.0.0"
@@ -12382,6 +12383,13 @@ __metadata:
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
+  languageName: node
+  linkType: hard
+
+"title-case@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "title-case@npm:4.3.1"
+  checksum: 10c0/10bb67f3ae5cf4043b4050f5c4b3ae7fdaeef6c55bcb646d08a3567d4233f02d10f3ea55add7d8dbf55e1a320b49b79cb0b5d4ce39701a500de62cc8860d9bc8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Added `EnumX.entry(EnumX.Y)` to retrieve the _entry_ for the given value.
  e.g.
  ```ts
  ProjectStep.entry('DiscussingChangeToPlan')
  ProjectStep.entry(ProjectStep.DiscussingChangeToPlan)
  ```
  I thought about calling it `.get()` instead. Thoughts?
- Added default `label` to all entries that didn't have one provided / handwritten.
- Swapped usage across app to use enum labels instead of adhoc conversion.

```ts
// handwritten
ProjectType.entry('MomentumTranslation').label // => "Momentum"
ProductMedium.entry('EBook').label // => "E-Book"
// automatic convention
ProjectStep.entry('DiscussingChangeToPlan').label // => "Discussing Change to Plan"
```