### PR TITLE
[Neo4j] `DtoRepo.delete`

### DIFF
--- a/src/core/database/dto.repository.ts
+++ b/src/core/database/dto.repository.ts
@@ -16,7 +16,7 @@ import { DbChanges, getChanges } from './changes';
 import { CommonRepository } from './common.repository';
 import { DbTypeOf } from './db-type';
 import { OnIndex } from './indexer';
-import { matchProps } from './query';
+import { deleteBaseNode, matchProps } from './query';
 
 export const privileges = Symbol.for('DtoRepository.privileges');
 
@@ -102,6 +102,15 @@ export const DtoRepository = <
         .apply(this.hydrate(...args))
         .map('dto')
         .run();
+    }
+
+    async delete(id: ID) {
+      const query = this.db
+        .query()
+        .matchNode('node', this.resource.dbLabel, { id })
+        .apply(deleteBaseNode('node'))
+        .return('*');
+      await query.run();
     }
 
     protected async updateProperties<

--- a/src/core/exception/exception.normalizer.ts
+++ b/src/core/exception/exception.normalizer.ts
@@ -138,7 +138,7 @@ export class ExceptionNormalizer {
 
     if (ex instanceof ExclusivityViolationError) {
       ex = DuplicateException.fromDB(ex, gqlContext);
-    } else if (ex instanceof Edge.EdgeDBError) {
+    } else if (ex instanceof Edge.EdgeDBError || Neo.isNeo4jError(ex)) {
       // Mask actual DB error with a nicer user error message.
       let message = 'Failed';
       if (gqlContext) {


### PR DESCRIPTION
- Add `DtoRepo.delete` to replace `deleteNode`
  This query is specific to the resource type of the class, which is safer (assumes less) than any type.
  It also matches the EdgeDB version so migration should be seamless.
- Mask generic Neo4j errors just like with EdgeDB
  There shouldn't be any need to:
  ```ts
  } catch (e) {
    ...
    throw new ServerException('Failed to do X');
  }
  ```
  Now you can `throw e` or skip `catch` all together if there's no other logic.