### PR TITLE
[Neo4j] Mask errors out to GQL just like with EdgeDB

### DIFF
--- a/src/core/exception/exception.normalizer.ts
+++ b/src/core/exception/exception.normalizer.ts
@@ -138,7 +138,7 @@ export class ExceptionNormalizer {
 
     if (ex instanceof ExclusivityViolationError) {
       ex = DuplicateException.fromDB(ex, gqlContext);
-    } else if (ex instanceof Edge.EdgeDBError) {
+    } else if (ex instanceof Edge.EdgeDBError || Neo.isNeo4jError(ex)) {
       // Mask actual DB error with a nicer user error message.
       let message = 'Failed';
       if (gqlContext) {


### PR DESCRIPTION
Now there shouldn't be any need to:
```ts
} catch (e) {
  ...
  throw new ServerException('Failed to do X');
}
```
Now you can `throw e` or skip the `try/catch` all together if there's no other logic.