### PR TITLE
Limit `DtoRepo.deleteNode` to filter to the resource type by default

### DIFF
--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -265,7 +265,7 @@ export class BudgetService {
 
   async deleteRecord(id: ID, session: Session, changeset?: ID): Promise<void> {
     try {
-      await this.budgetRecordsRepo.deleteNode(id, changeset);
+      await this.budgetRecordsRepo.deleteNode(id, { changeset });
     } catch (e) {
       this.logger.warning('Failed to delete Budget Record', {
         exception: e,

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -367,7 +367,7 @@ export class EngagementService {
     await this.eventBus.publish(new EngagementWillDeleteEvent(object, session));
 
     try {
-      await this.repo.deleteNode(object, changeset);
+      await this.repo.deleteNode(object, { changeset });
     } catch (e) {
       this.logger.warning('Failed to delete Engagement', {
         exception: e,

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -224,7 +224,7 @@ export class PartnershipService {
     );
 
     try {
-      await this.repo.deleteNode(object, changeset);
+      await this.repo.deleteNode(object, { changeset });
     } catch (exception) {
       this.logger.error('Failed to delete', { id, exception });
       throw new ServerException('Failed to delete', exception);

--- a/src/components/progress-report/media/progress-report-media.service.ts
+++ b/src/components/progress-report/media/progress-report-media.service.ts
@@ -126,9 +126,7 @@ export class ProgressReportMediaService {
       .verifyCan('delete');
 
     await this.repo.deleteNode(id);
-    if (await this.repo.isVariantGroupEmpty(media.variantGroup)) {
-      await this.repo.deleteNode(media.variantGroup);
-    }
+    await this.repo.deleteVariantGroupIfEmpty(media.variantGroup);
 
     return media.report;
   }

--- a/src/core/database/common.repository.ts
+++ b/src/core/database/common.repository.ts
@@ -130,7 +130,10 @@ export class CommonRepository {
     return res.stats;
   }
 
-  async deleteNode(objectOrId: { id: ID } | ID, changeset?: ID) {
+  async deleteNode(
+    objectOrId: { id: ID } | ID,
+    { changeset }: { changeset?: ID } = {},
+  ) {
     if (!changeset) {
       await this.db.deleteNode(objectOrId);
       return;

--- a/src/core/database/dto.repository.ts
+++ b/src/core/database/dto.repository.ts
@@ -12,6 +12,7 @@ import {
   UnsecuredDto,
 } from '~/common';
 import { Privileges } from '../../components/authorization';
+import { ResourceLike } from '../resources';
 import { DbChanges, getChanges } from './changes';
 import { CommonRepository } from './common.repository';
 import { DbTypeOf } from './db-type';
@@ -102,6 +103,16 @@ export const DtoRepository = <
         .apply(this.hydrate(...args))
         .map('dto')
         .run();
+    }
+
+    async deleteNode(
+      objectOrId: { id: ID } | ID,
+      options: { changeset?: ID; resource?: ResourceLike } = {},
+    ) {
+      await super.deleteNode(objectOrId, {
+        resource: this.resource,
+        ...options,
+      });
     }
 
     protected async updateProperties<

--- a/src/core/edgedb/common.repository.ts
+++ b/src/core/edgedb/common.repository.ts
@@ -61,9 +61,13 @@ export class CommonRepository implements PublicOf<Neo4jCommonRepository> {
     );
   }
 
-  async deleteNode(objectOrId: { id: ID } | ID, _: { changeset?: ID } = {}) {
+  async deleteNode(
+    objectOrId: { id: ID } | ID,
+    { resource }: { changeset?: ID; resource?: ResourceLike } = {},
+  ) {
     const id = isIdLike(objectOrId) ? objectOrId : objectOrId.id;
-    const query = e.delete(e.Object, () => ({
+    const type = resource ? this.resources.enhance(resource).db : e.Object;
+    const query = e.delete(type, () => ({
       filter_single: { id },
     }));
     await this.db.run(query);

--- a/src/core/edgedb/common.repository.ts
+++ b/src/core/edgedb/common.repository.ts
@@ -61,7 +61,7 @@ export class CommonRepository implements PublicOf<Neo4jCommonRepository> {
     );
   }
 
-  async deleteNode(objectOrId: { id: ID } | ID, _changeset?: ID) {
+  async deleteNode(objectOrId: { id: ID } | ID, _: { changeset?: ID } = {}) {
     const id = isIdLike(objectOrId) ? objectOrId : objectOrId.id;
     const query = e.delete(e.Object, () => ({
       filter_single: { id },

--- a/src/core/edgedb/dto.repository.ts
+++ b/src/core/edgedb/dto.repository.ts
@@ -232,6 +232,16 @@ export const RepoFor = <
     async getBaseNodes(ids: readonly ID[], fqn?: ResourceLike) {
       return await super.getBaseNodes(ids, fqn ?? resource);
     }
+
+    async deleteNode(
+      objectOrId: { id: ID } | ID,
+      options: { changeset?: ID; resource?: ResourceLike } = {},
+    ) {
+      await super.deleteNode(objectOrId, {
+        resource: this.resource,
+        ...options,
+      });
+    }
   }
 
   const readManyQuery = e.params({ ids: e.array(e.uuid) }, ({ ids }) => {


### PR DESCRIPTION
So one doesn't accidentally delete something legit but of the wrong type