### PR TITLE
Fix MadeEnum type to provide value & label from entries implicitly

### DIFF
--- a/src/common/make-enum.ts
+++ b/src/common/make-enum.ts
@@ -10,12 +10,15 @@ export type EnumType<Enum> = Enum extends MadeEnum<infer Values, any, any>
 
 export type MadeEnum<
   Values extends string,
-  Extra = unknown,
   ValueDeclaration = EnumValueDeclarationShape,
+  Extra = unknown,
 > = {
   readonly [Value in Values & string]: Value;
-} & Readonly<Extra> &
-  EnumHelpers<Values, ValueDeclaration & ImplicitValueDeclarationShape<Values>>;
+} & EnumHelpers<
+  Values,
+  ValueDeclaration & ImplicitValueDeclarationShape<Values>
+> &
+  Readonly<Extra>;
 
 interface EnumOptions<
   ValueDeclaration extends EnumValueDeclarationShape,
@@ -72,8 +75,8 @@ export const makeEnum = <
   input: EnumOptions<ValueDeclaration, Extra>,
 ): MadeEnum<
   ValuesOfDeclarations<ValueDeclaration>,
-  [Extra] extends [never] ? unknown : Extra,
-  NormalizedValueDeclaration<ValueDeclaration>
+  NormalizedValueDeclaration<ValueDeclaration>,
+  [Extra] extends [never] ? unknown : Extra
 > => {
   const {
     name,


### PR DESCRIPTION
## Fix type to provide value & label from entries implicitly

Currently:
```ts
const Status = makeEnum(...);
Status.entry(...) // => { value: Status, label: string }
```
BUT if referencing the type generically:
```ts
const statusEnum: MadeEnum<Status>;
```
The entries didn't have a shape:
```ts
statusEnum.entry(...) // => empty object
```
Now they have the implicit shape:
```ts
statusEnum.entry(...) // => { value: Status, label: string }
```

## Flip `Extra` positional generic

This allows declaring extra entry declarations easier, by making it the second arg instead of third.
```ts
const statusEnum: MadeEnum<Status, { color: string }>;
statusEnum.entry(...).color // => string
```

This `Extra` generic really has nothing to do with the enum functionality, it's just extra "statics".
The type could be written as:
```ts
MadeEnum<Status> & { <Extras> }
```
Which we can still do now when needing to reference a generic enum with extra "statics".

I decided to keep the generic though as that helps TS infer how to emit the type.
```ts
const X = makeEnum(...); // X is represented as "MadeEnum<...>"
```
As opposed to some obtuse object literal shape.
