### PR TITLE
[Neo4j] Nested Sorting + Engagement expanded usage

### DIFF
--- a/src/common/db-sort.decorator.ts
+++ b/src/common/db-sort.decorator.ts
@@ -5,7 +5,7 @@ const DbSortSymbol = Symbol('DbSortSymbol');
 /**
  * A function given a cypher variable will output cypher to transform it for sorting.
  */
-type SortTransformer = (value: string) => string;
+export type SortTransformer = (value: string) => string;
 
 /**
  * Customize the way this field is sorted upon.

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -9,7 +9,7 @@ export * from './data-object';
 export * from './date-filter.input';
 export { DbLabel } from './db-label.decorator';
 export * from './db-label.helpers';
-export * from './db-sort.decorator';
+export { DbSort } from './db-sort.decorator';
 export * from './db-unique.decorator';
 export * from './disabled.decorator';
 export * from './mutation-placeholder.output';

--- a/src/common/pagination.input.ts
+++ b/src/common/pagination.input.ts
@@ -100,7 +100,7 @@ export const SortablePaginationInput = <SortKey extends string = string>({
       description: 'The field in which to sort on',
       defaultValue: defaultSort,
     })
-    @Matches(/^[A-Za-z0-9_]+$/)
+    @Matches(/^[A-Za-z0-9_.]+$/)
     readonly sort: SortKey = defaultSort;
 
     @Field(() => Order, {

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -23,6 +23,7 @@ import {
   coalesce,
   createNode,
   createRelationships,
+  defineSorters,
   filter,
   INACTIVE,
   matchChangesetAndChangedProps,
@@ -31,7 +32,7 @@ import {
   oncePerProject,
   paginate,
   requestingUser,
-  sorting,
+  sortWith,
   whereNotDeletedInChangeset,
 } from '~/core/database/query';
 import { Privileges } from '../authorization';
@@ -379,7 +380,7 @@ export class EngagementRepository extends CommonRepository {
           wrapContext: oncePerProject,
         }),
       )
-      .apply(sorting(IEngagement, input))
+      .apply(sortWith(engagementSorters, input))
       .apply(paginate(input, this.hydrate(session, viewOfChangeset(changeset))))
       .first();
     return result!; // result from paginate() will always have 1 row.
@@ -514,3 +515,5 @@ export class EngagementRepository extends CommonRepository {
     return this.getConstraintsFor(IEngagement);
   }
 }
+
+export const engagementSorters = defineSorters(IEngagement, {});

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -42,6 +42,7 @@ import {
 import { ProjectStatus } from '../project/dto';
 import {
   CreateLanguage,
+  EthnologueLanguage,
   Language,
   LanguageListInput,
   UpdateLanguage,
@@ -324,4 +325,17 @@ export class LanguageRepository extends DtoRepository<
   }
 }
 
-export const languageSorters = defineSorters(Language, {});
+export const languageSorters = defineSorters(Language, {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  'ethnologue.*': (query, input) =>
+    query
+      .with('node as lang')
+      .match([
+        node('lang'),
+        relation('out', '', 'ethnologue'),
+        node('node', 'EthnologueLanguage'),
+      ])
+      .apply(sortWith(ethnologueSorters, input)),
+});
+
+const ethnologueSorters = defineSorters(EthnologueLanguage, {});

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -24,6 +24,7 @@ import {
   collect,
   createNode,
   createRelationships,
+  defineSorters,
   exp,
   filter,
   matchChangesetAndChangedProps,
@@ -35,7 +36,7 @@ import {
   paginate,
   rankSens,
   requestingUser,
-  sorting,
+  sortWith,
   variable,
 } from '~/core/database/query';
 import { ProjectStatus } from '../project/dto';
@@ -245,7 +246,7 @@ export class LanguageRepository extends DtoRepository<
           wrapContext: oncePerProject,
         }),
       )
-      .apply(sorting(Language, input))
+      .apply(sortWith(languageSorters, input))
       .apply(paginate(input, this.hydrate(session)))
       .first();
     return result!; // result from paginate() will always have 1 row.
@@ -322,3 +323,5 @@ export class LanguageRepository extends DtoRepository<
       );
   }
 }
+
+export const languageSorters = defineSorters(Language, {});

--- a/src/components/location/location.repository.ts
+++ b/src/components/location/location.repository.ts
@@ -14,10 +14,11 @@ import {
   ACTIVE,
   createNode,
   createRelationships,
+  defineSorters,
   matchProps,
   merge,
   paginate,
-  sorting,
+  sortWith,
 } from '~/core/database/query';
 import { FileService } from '../file';
 import { FileId } from '../file/dto';
@@ -160,7 +161,7 @@ export class LocationRepository extends DtoRepository(Location) {
     const result = await this.db
       .query()
       .matchNode('node', 'Location')
-      .apply(sorting(Location, input))
+      .apply(sortWith(locationSorters, input))
       .apply(paginate(input, this.hydrate()))
       .first();
     return result!; // result from paginate() will always have 1 row.
@@ -216,7 +217,7 @@ export class LocationRepository extends DtoRepository(Location) {
         relation('in', '', rel, ACTIVE),
         node(`${label.toLowerCase()}`, label, { id }),
       ])
-      .apply(sorting(Location, input))
+      .apply(sortWith(locationSorters, input))
       .apply(paginate(input, this.hydrate()))
       .first();
     return result!; // result from paginate() will always have 1 row.
@@ -231,3 +232,5 @@ export class LocationRepository extends DtoRepository(Location) {
     return !!result;
   }
 }
+
+export const locationSorters = defineSorters(Location, {});

--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -209,26 +209,7 @@ export class PeriodicReportRepository extends DtoRepository<
   }
 
   matchCurrentDue(parentId: ID | Variable, reportType: ReportType) {
-    return (query: Query) =>
-      query.comment`matchCurrentDue()`
-        .match([
-          [
-            node('baseNode', 'BaseNode', { id: parentId }),
-            relation('out', '', 'report', ACTIVE),
-            node('node', `${reportType}Report`),
-            relation('out', '', 'end', ACTIVE),
-            node('end', 'Property'),
-          ],
-          [
-            node('node'),
-            relation('out', '', 'start', ACTIVE),
-            node('start', 'Property'),
-          ],
-        ])
-        .raw(`WHERE end.value < date()`)
-        .with('node, start')
-        .orderBy('start.value', 'desc')
-        .limit(1);
+    return matchCurrentDue(parentId, reportType);
   }
 
   async getByDate(
@@ -280,7 +261,7 @@ export class PeriodicReportRepository extends DtoRepository<
     const res = await this.db
       .query()
       .match([
-        node('baseNode', 'BaseNode', { id: parentId }),
+        node('parent', 'BaseNode', { id: parentId }),
         relation('out', '', 'report', ACTIVE),
         node('node', `${reportType}Report`),
         relation('out', '', 'end', ACTIVE),
@@ -452,6 +433,29 @@ export class PeriodicReportRepository extends DtoRepository<
         );
   }
 }
+
+export const matchCurrentDue =
+  (parentId: ID | Variable | undefined, reportType: ReportType) =>
+  (query: Query) =>
+    query.comment`matchCurrentDue()`
+      .match([
+        [
+          node('parent', 'BaseNode', parentId ? { id: parentId } : undefined),
+          relation('out', '', 'report', ACTIVE),
+          node('node', `${reportType}Report`),
+          relation('out', '', 'end', ACTIVE),
+          node('end', 'Property'),
+        ],
+        [
+          node('node'),
+          relation('out', '', 'start', ACTIVE),
+          node('start', 'Property'),
+        ],
+      ])
+      .raw(`WHERE end.value < date()`)
+      .with('node, start')
+      .orderBy('start.value', 'desc')
+      .limit(1);
 
 export const periodicReportSorters = defineSorters(IPeriodicReport, {});
 

--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -23,6 +23,7 @@ import {
   ACTIVE,
   createNode,
   createRelationships,
+  defineSorters,
   deleteBaseNode,
   filter,
   matchPropsAndProjectSensAndScopedRoles,
@@ -33,8 +34,14 @@ import {
   Variable,
 } from '~/core/database/query';
 import { File } from '../file/dto';
-import { ProgressReportStatus as ProgressStatus } from '../progress-report/dto';
-import { ProgressReportExtraForPeriodicInterfaceRepository } from '../progress-report/progress-report-extra-for-periodic-interface.repository';
+import {
+  ProgressReport,
+  ProgressReportStatus as ProgressStatus,
+} from '../progress-report/dto';
+import {
+  ProgressReportExtraForPeriodicInterfaceRepository,
+  progressReportExtrasSorters,
+} from '../progress-report/progress-report-extra-for-periodic-interface.repository';
 import {
   IPeriodicReport,
   MergePeriodicReports,
@@ -445,3 +452,10 @@ export class PeriodicReportRepository extends DtoRepository<
         );
   }
 }
+
+export const periodicReportSorters = defineSorters(IPeriodicReport, {});
+
+export const progressReportSorters = defineSorters(ProgressReport, {
+  ...periodicReportSorters.matchers,
+  ...progressReportExtrasSorters.matchers,
+});

--- a/src/components/progress-report/dto/progress-report.entity.ts
+++ b/src/components/progress-report/dto/progress-report.entity.ts
@@ -2,11 +2,13 @@ import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
   Calculated,
+  DbSort,
   parentIdMiddleware,
   ResourceRelationsShape,
   SecuredProperty,
   SecuredProps,
 } from '~/common';
+import { sortingForEnumIndex } from '~/core/database/query';
 import { BaseNode } from '~/core/database/results';
 import { e } from '~/core/edgedb';
 import { RegisterResource } from '~/core/resources';
@@ -15,7 +17,10 @@ import { DefinedFile } from '../../file/dto';
 import { IPeriodicReport } from '../../periodic-report/dto/periodic-report.dto';
 import { ProgressReportCommunityStory } from './community-stories.dto';
 import { ProgressReportHighlight } from './highlights.dto';
-import { SecuredProgressReportStatus as SecuredStatus } from './progress-report-status.enum';
+import {
+  SecuredProgressReportStatus as SecuredStatus,
+  ProgressReportStatus as Status,
+} from './progress-report-status.enum';
 import { ProgressReportTeamNews } from './team-news.dto';
 
 @RegisterResource({ db: e.ProgressReport })
@@ -46,6 +51,7 @@ export class ProgressReport extends IPeriodicReport {
     middleware: [parentIdMiddleware],
   })
   @Calculated()
+  @DbSort(sortingForEnumIndex(Status))
   readonly status: SecuredStatus;
 }
 

--- a/src/components/progress-report/progress-report-extra-for-periodic-interface.repository.ts
+++ b/src/components/progress-report/progress-report-extra-for-periodic-interface.repository.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { CreateNodeOptions, QueryFragment } from '~/core/database/query';
+import {
+  CreateNodeOptions,
+  defineSorters,
+  QueryFragment,
+} from '~/core/database/query';
 import { MergePeriodicReports } from '../periodic-report/dto';
 import { ProgressReport, ProgressReportStatus as Status } from './dto';
 
@@ -23,3 +27,5 @@ export class ProgressReportExtraForPeriodicInterfaceRepository {
     return (query) => query.return('{} as extra');
   }
 }
+
+export const progressReportExtrasSorters = defineSorters(ProgressReport, {});

--- a/src/components/user/user.repository.ts
+++ b/src/components/user/user.repository.ts
@@ -16,13 +16,14 @@ import {
   createNode,
   createProperty,
   deactivateProperty,
+  defineSorters,
   filter,
   matchProps,
   merge,
   paginate,
   property,
   requestingUser,
-  sorting,
+  sortWith,
 } from '~/core/database/query';
 import {
   AssignOrganizationToUser,
@@ -207,7 +208,7 @@ export class UserRepository extends DtoRepository<typeof User, [Session | ID]>(
         }),
       )
       .apply(this.privileges.forUser(session).filterToReadable())
-      .apply(sorting(User, input))
+      .apply(sortWith(userSorters, input))
       .apply(paginate(input, this.hydrate(session.userId)))
       .first();
     return result!; // result from paginate() will always have 1 row.
@@ -342,3 +343,5 @@ export class UserRepository extends DtoRepository<typeof User, [Session | ID]>(
     return this.hydrate(session);
   }
 }
+
+export const userSorters = defineSorters(User, {});

--- a/src/core/database/query/index.ts
+++ b/src/core/database/query/index.ts
@@ -13,6 +13,7 @@ export * from './cypher-expression';
 export * from './cypher-functions';
 export * from './full-text';
 export * from './lists';
+export * from './sorting';
 export * from './matching';
 export * from './deletes';
 export * from './match-project-based-props';

--- a/src/core/database/query/lists.ts
+++ b/src/core/database/query/lists.ts
@@ -1,17 +1,6 @@
-import { node, Query, relation } from 'cypher-query-builder';
-import { identity } from 'rxjs';
-import {
-  getDbSortTransformer,
-  ID,
-  MadeEnum,
-  Order,
-  PaginatedListType,
-  PaginationInput,
-  Resource,
-  ResourceShape,
-} from '~/common';
-import { apoc, collect } from './cypher-functions';
-import { ACTIVE } from './matching';
+import { Query } from 'cypher-query-builder';
+import { ID, PaginatedListType, PaginationInput } from '~/common';
+import { collect } from './cypher-functions';
 
 /**
  * Adds pagination to a query based on input.
@@ -69,57 +58,6 @@ export const paginate =
         'size(page) > 0 and page[-1] <> list[-1] as hasMore',
       ]);
   };
-
-/**
- * Applies sorting to rows given the input.
- *
- * Optionally custom property matchers can be passed in that override the
- * default property matching queries.
- * These are given a query and are expected to have a return clause with a `sortValue`
- */
-export const sorting =
-  <TResourceStatic extends ResourceShape<any>>(
-    resource: TResourceStatic,
-    { sort, order }: { sort: string; order: Order },
-    customPropMatchers: {
-      [SortKey in string]?: (query: Query) => Query<{ sortValue: unknown }>;
-    } = {},
-  ) =>
-  (query: Query) => {
-    const sortTransformer = getDbSortTransformer(resource, sort) ?? identity;
-
-    const baseNodeProps = resource.BaseNodeProps ?? Resource.Props;
-    const isBaseNodeProp = baseNodeProps.includes(sort);
-
-    const matcher =
-      customPropMatchers[sort] ??
-      (isBaseNodeProp ? matchBasePropSort : matchPropSort)(sort);
-
-    return query.comment`sorting(${sort})`
-      .subQuery('*', matcher)
-      .with('*')
-      .orderBy(`${sortTransformer('sortValue')}`, order);
-  };
-
-const matchPropSort = (prop: string) => (query: Query) =>
-  query
-    .match([
-      node('node'),
-      relation('out', '', prop, ACTIVE),
-      node('sortProp', 'Property'),
-    ])
-    .return('sortProp.value as sortValue');
-
-const matchBasePropSort = (prop: string) => (query: Query) =>
-  query.return(`node.${prop} as sortValue`);
-
-export const sortingForEnumIndex =
-  <T extends string>(theEnum: MadeEnum<T>) =>
-  (variable: string) =>
-    apoc.coll.indexOf(
-      [...theEnum.values].map((v) => `"${v}"`),
-      variable,
-    );
 
 export const whereNotDeletedInChangeset = (changeset?: ID) => (query: Query) =>
   changeset

--- a/src/core/database/query/match-project-based-props.ts
+++ b/src/core/database/query/match-project-based-props.ts
@@ -100,7 +100,10 @@ export const matchProjectScopedRoles =
     );
 
 export const matchProjectSens =
-  (projectVar = 'project') =>
+  <const Output extends string = 'sensitivity'>(
+    projectVar = 'project',
+    output: Output = 'sensitivity' as Output,
+  ) =>
   <R>(query: Query<R>) =>
     query.comment`matchProjectSens()`.subQuery((sub) =>
       sub
@@ -114,7 +117,7 @@ export const matchProjectSens =
           relation('out', '', 'sensitivity', ACTIVE),
           node('projSens', 'Property'),
         ])
-        .return('projSens.value as sensitivity')
+        .return(`projSens.value as ${output}`)
         .union()
         .with(projectVar) // import
         .with(projectVar) // needed for where clause
@@ -134,7 +137,7 @@ export const matchProjectSens =
         .orderBy(rankSens('langSens.value'), 'DESC')
         // Prevent single row with project from expanding to more here via multiple engagement matches
         .raw('LIMIT 1')
-        .return(coalesce('langSens.value', '"High"').as('sensitivity'))
+        .return(coalesce('langSens.value', '"High"').as(output))
         // If the cardinality of this subquery is zero, no rows will be returned at all.
         // So, if no projects are matched (optional matching), we still need to have a cardinality > 0 in order to continue
         // https://neo4j.com/developer/kb/conditional-cypher-execution/#_the_subquery_must_return_a_row_for_the_outer_query_to_continue
@@ -143,7 +146,7 @@ export const matchProjectSens =
         .with(projectVar)
         .raw(`WHERE ${projectVar} IS NULL`)
         // TODO this doesn't work for languages without projects. They should use their own sensitivity not High.
-        .return<{ sensitivity: Sensitivity }>('"High" as sensitivity'),
+        .return<Record<Output, Sensitivity>>(`"High" as ${output}`),
     );
 
 export const matchUserGloballyScopedRoles =

--- a/src/core/database/query/sorting.ts
+++ b/src/core/database/query/sorting.ts
@@ -1,0 +1,62 @@
+import { node, Query, relation } from 'cypher-query-builder';
+import { identity } from 'rxjs';
+import {
+  getDbSortTransformer,
+  MadeEnum,
+  Order,
+  Resource,
+  ResourceShape,
+} from '~/common';
+import { apoc } from './cypher-functions';
+import { ACTIVE } from './matching';
+
+export const sortingForEnumIndex =
+  <T extends string>(theEnum: MadeEnum<T>) =>
+  (variable: string) =>
+    apoc.coll.indexOf(
+      [...theEnum.values].map((v) => `"${v}"`),
+      variable,
+    );
+
+/**
+ * Applies sorting to rows given the input.
+ *
+ * Optionally custom property matchers can be passed in that override the
+ * default property matching queries.
+ * These are given a query and are expected to have a return clause with a `sortValue`
+ */
+export const sorting =
+  <TResourceStatic extends ResourceShape<any>>(
+    resource: TResourceStatic,
+    { sort, order }: { sort: string; order: Order },
+    customPropMatchers: {
+      [SortKey in string]?: (query: Query) => Query<{ sortValue: unknown }>;
+    } = {},
+  ) =>
+  (query: Query) => {
+    const sortTransformer = getDbSortTransformer(resource, sort) ?? identity;
+
+    const baseNodeProps = resource.BaseNodeProps ?? Resource.Props;
+    const isBaseNodeProp = baseNodeProps.includes(sort);
+
+    const matcher =
+      customPropMatchers[sort] ??
+      (isBaseNodeProp ? matchBasePropSort : matchPropSort)(sort);
+
+    return query.comment`sorting(${sort})`
+      .subQuery('*', matcher)
+      .with('*')
+      .orderBy(`${sortTransformer('sortValue')}`, order);
+  };
+
+const matchPropSort = (prop: string) => (query: Query) =>
+  query
+    .match([
+      node('node'),
+      relation('out', '', prop, ACTIVE),
+      node('sortProp', 'Property'),
+    ])
+    .return('sortProp.value as sortValue');
+
+const matchBasePropSort = (prop: string) => (query: Query) =>
+  query.return(`node.${prop} as sortValue`);

--- a/src/core/database/query/sorting.ts
+++ b/src/core/database/query/sorting.ts
@@ -1,15 +1,23 @@
 import { node, Query, relation } from 'cypher-query-builder';
 import { identity } from 'rxjs';
+import { LiteralUnion } from 'type-fest';
+import { MadeEnum, Order, Resource, ResourceShape } from '~/common';
 import {
   getDbSortTransformer,
-  MadeEnum,
-  Order,
-  Resource,
-  ResourceShape,
-} from '~/common';
+  SortTransformer,
+} from '~/common/db-sort.decorator';
 import { apoc } from './cypher-functions';
 import { ACTIVE } from './matching';
 
+/**
+ * Declares a that an enum field, is to be sorted by the index of the enum members.
+ *
+ * @example
+ * ```ts
+ * @DbSort(sortingForEnumIndex(Status)
+ * status: Status
+ * ```
+ */
 export const sortingForEnumIndex =
   <T extends string>(theEnum: MadeEnum<T>) =>
   (variable: string) =>
@@ -21,32 +29,75 @@ export const sortingForEnumIndex =
 /**
  * Applies sorting to rows given the input.
  *
- * Optionally custom property matchers can be passed in that override the
+ * Optionally, custom property matchers can be passed in to override the
  * default property matching queries.
  * These are given a query and are expected to have a return clause with a `sortValue`
+ *
+ * @example
+ * query.apply(sorting(User, input))
  */
-export const sorting =
+export const sorting = <TResourceStatic extends ResourceShape<any>>(
+  resource: TResourceStatic,
+  input: Sort<SortFieldOf<TResourceStatic>>,
+  matchers: SortMatchers<SortFieldOf<TResourceStatic>> = {},
+) => sortWith(defineSorters(resource, matchers), input);
+
+/**
+ * Applies sorting to rows given the sorters & input.
+ *
+ * @example
+ * query.apply(sortWith(userSorters, input))
+ */
+export const sortWith = <Field extends string>(
+  config: (input: Sort<Field>) => Sort<Field> & SortMatch<Field>,
+  input: Sort<Field>,
+) => {
+  const { transformer, matcher, order } = config(input);
+
+  return (query: Query) =>
+    query.comment`sorting(${input.sort})`
+      .subQuery('*', (sub) => matcher(sub, input))
+      .with('*')
+      .orderBy(`${transformer('sortValue')}`, order);
+};
+
+/**
+ * Declares sorters for the given type.
+ *
+ * ```ts
+ * const userSorters = defineSorters(User, {
+ *   // The key is the sort field string that callers can pick
+ *   // This is a loose string, so it can be an existing field
+ *   // on the type or something completely new.
+ *   name: (query) => query
+ *     // Do whatever to calculate the sort value.
+ *     // `node` can be assumed to be the current type.
+ *     // One per row.
+ *     .match(...)
+ *     // This "matcher" function should end with a return clause that
+ *     // emits `sortValue`
+ *     .return<SortCol>('x as sortValue')
+ * });
+ * ```
+ */
+export const defineSorters =
   <TResourceStatic extends ResourceShape<any>>(
     resource: TResourceStatic,
-    { sort, order }: { sort: string; order: Order },
-    customPropMatchers: {
-      [SortKey in string]?: (query: Query) => Query<{ sortValue: unknown }>;
-    } = {},
+    matchers: SortMatchers<SortFieldOf<TResourceStatic>>,
   ) =>
-  (query: Query) => {
-    const sortTransformer = getDbSortTransformer(resource, sort) ?? identity;
+  ({ sort, order }: Sort<SortFieldOf<TResourceStatic>>) => {
+    const transformer = getDbSortTransformer(resource, sort) ?? identity;
+    const common = { sort, order, transformer };
+
+    const exactCustom = matchers[sort];
+    if (exactCustom) {
+      return { ...common, matcher: exactCustom };
+    }
 
     const baseNodeProps = resource.BaseNodeProps ?? Resource.Props;
     const isBaseNodeProp = baseNodeProps.includes(sort);
-
-    const matcher =
-      customPropMatchers[sort] ??
-      (isBaseNodeProp ? matchBasePropSort : matchPropSort)(sort);
-
-    return query.comment`sorting(${sort})`
-      .subQuery('*', matcher)
-      .with('*')
-      .orderBy(`${sortTransformer('sortValue')}`, order);
+    const matcher = (isBaseNodeProp ? matchBasePropSort : matchPropSort)(sort);
+    return { ...common, matcher };
   };
 
 const matchPropSort = (prop: string) => (query: Query) =>
@@ -56,7 +107,36 @@ const matchPropSort = (prop: string) => (query: Query) =>
       relation('out', '', prop, ACTIVE),
       node('sortProp', 'Property'),
     ])
-    .return('sortProp.value as sortValue');
+    .return<SortCol>('sortProp.value as sortValue');
 
 const matchBasePropSort = (prop: string) => (query: Query) =>
-  query.return(`node.${prop} as sortValue`);
+  query.return<SortCol>(`node.${prop} as sortValue`);
+
+export interface SortCol {
+  sortValue: unknown;
+}
+
+// TODO stricter
+type SortFieldOf<TResourceStatic extends ResourceShape<any>> = LiteralUnion<
+  keyof TResourceStatic['prototype'] & string,
+  string
+>;
+
+type SortMatcher<Field extends string> = (
+  query: Query,
+  input: Sort<Field>,
+) => Query<SortCol>;
+
+type SortMatchers<Field extends string> = Partial<
+  Record<Field, SortMatcher<Field>>
+>;
+
+interface Sort<Field extends string> {
+  sort: Field;
+  order: Order;
+}
+
+interface SortMatch<SortKey extends string> {
+  matcher: SortMatcher<SortKey>;
+  transformer: SortTransformer;
+}


### PR DESCRIPTION
# Why? Engagement sorters
This new functionality is driven by the need for the new UI to sort by deep fields.
Now the engagements list supports sorting by:
- `nameProjectFirst` - project name, then language/intern name.
- `nameProjectLast` - language/intern name, then project name.
  (Yes yes I hear you thinking multi sorting. Some day.)
- `sensitivity`
- `project.primaryLocation.name`
- `language.ethnologue.code`
- `language.registryOfDialectsCode`
- `currentProgressReportDue.status`

# sorting -> sortWith
Previously we had
```ts
query.apply(sorting(User, input, {
  ...
}))
```
This still works, but now it's recommended to switch to declare the matchers/sorters separately from application in a query.
```ts
// top level
export const userSorters = defineSorters(User, {
  ...
});

// in list()
query.apply(sortWith(userSorters, input))
```

This split allows the sorters to be referenced as sub/nested sorting in other sorting calls.

# Basic sorter

Each key is the sort field string that callers can pick this is a loose string, so it can be an existing field on the type or something completely new.
```ts
const userSorters = defineSorters(User, {
  name: (query) => query
    // Do whatever to calculate the sort value.
    // `node` can be assumed to be the current type.
    // One per row.
    .match(...)
    // This "matcher" function should end with a return clause that
    // emits `sortValue`
    .return<SortCol>('x as sortValue'),
```

This hasn't changed from previous functionality.

# Nested sorter

The ability to nest sorting into relationships is possible.
This is done by appending `.*` to the key.
For example, the sort field could be "parent.name"
```ts
const userSorters = defineSorters(User, {
  'name': (query) => ...

  'parent.*': (query, input) => query
    // Again match as needed
    .match(...)
    // Call sortWith with the sorters of the relationship type.
    // These matchers are also given the current sort _input_
    // (second arg above) which can be passed down like this.
    // `sortWith` understands this nesting and will remove the `parent.`
    // prefix before matching the nested sorters.
    .apply(sortWith(userSorters, input))
});
```

# Extending other sorters
Sorters can "extend" others too.
Defined sorters have their declared matchers exposed on the `matchers` property.
So they can be spread/picked/etc. into a new object.
For example, say `Manager` extends `User`, and we want to add some sorters for that type but keep the User ones as well.
```ts
const managerSorters = defineSorters(Manager, {
  ...userSorters.matchers,
  // Add some new ones
});
```