### PR TITLE
Fix `MadeEnum<'a'>` to be compatible with `MadeEnum<string>`

### DIFF
--- a/src/common/make-enum.ts
+++ b/src/common/make-enum.ts
@@ -12,13 +12,18 @@ export type MadeEnum<
   Values extends string,
   ValueDeclaration = EnumValueDeclarationShape,
   Extra = unknown,
-> = {
-  readonly [Value in Values & string]: Value;
-} & EnumHelpers<
+> = EnumHelpers<
   Values,
   ValueDeclaration & ImplicitValueDeclarationShape<Values>
 > &
-  Readonly<Extra>;
+  Readonly<Extra> &
+  // Allow direct access to the values if they're strict.
+  // For generic `string` we don't allow this.
+  // This allows strict values to be compatible with generic values.
+  // MadeEnum<string> = MadeEnum<X>
+  (string extends Values
+    ? unknown // ignore addition
+    : { readonly [Value in Values & string]: Value });
 
 interface EnumOptions<
   ValueDeclaration extends EnumValueDeclarationShape,
@@ -217,7 +222,7 @@ type NormalizedValueDeclaration<Declaration extends EnumValueDeclarationShape> =
 interface EnumHelpers<Values extends string, ValueDeclaration> {
   readonly values: ReadonlySet<Values>;
   readonly entries: ReadonlyArray<Readonly<ValueDeclaration>>;
-  readonly entry: (value: Values) => Readonly<ValueDeclaration>;
+  readonly entry: <V extends Values>(value: V) => Readonly<ValueDeclaration>;
   readonly has: <In extends string>(
     value: In & {},
   ) => value is In & Values & {};


### PR DESCRIPTION
```ts
// Given
let Color: MadeEnum<'red' | 'blue'>;
let AnEnum: MadeEnum<string>;

// Now
AnEnum = Color;
```
Two changes to make this compatible.

First, disallow direct access to member values when referencing generically.

Without this change `Color` can't be assigned to `AnEnum`, because the TS defines the member values as an index: `{ [x: string]: string }`. So since one has an index accessor and one doesn't, making them incompatible.

Secondly, The `entry()` arg type change also allows them to be compatible. Without it TS thinks something like `entry()` fn accepting any `string` is not compatible with `entry()` fn only accepting `'red' | 'blue'`. Using another generic at the function level somehow works around this, while still maintaining all the strictness.

