### PR TITLE
New way to merge interfaces that's variadic and DRY for TS & GQL

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -91,6 +91,121 @@ export const IntersectionType = BaseIntersectionType as <
   decorator?: ClassDecoratorFactory,
 ) => Class<A & B, Args>;
 
+export function IntersectTypes<A, Args extends unknown[]>(
+  type1: AbstractClass<A, Args>,
+): IntersectedType<A, Args>;
+export function IntersectTypes<A, B, Args extends unknown[]>(
+  type1: AbstractClass<A, Args>,
+  type2: AbstractClass<B>,
+): IntersectedType<A & B, Args>;
+export function IntersectTypes<A, B, C, Args extends unknown[]>(
+  type1: AbstractClass<A, Args>,
+  type2: AbstractClass<B>,
+  type3: AbstractClass<C>,
+): IntersectedType<A & B & C, Args>;
+export function IntersectTypes<A, B, C, D, Args extends unknown[]>(
+  type1: AbstractClass<A, Args>,
+  type2: AbstractClass<B>,
+  type3: AbstractClass<C>,
+  type4: AbstractClass<D>,
+): IntersectedType<A & B & C & D, Args>;
+export function IntersectTypes<A, B, C, D, E, Args extends unknown[]>(
+  type1: AbstractClass<A, Args>,
+  type2: AbstractClass<B>,
+  type3: AbstractClass<C>,
+  type4: AbstractClass<D>,
+  type5: AbstractClass<E>,
+): IntersectedType<A & B & C & D & E, Args>;
+export function IntersectTypes<A, B, C, D, E, F, Args extends unknown[]>(
+  type1: AbstractClass<A, Args>,
+  type2: AbstractClass<B>,
+  type3: AbstractClass<C>,
+  type4: AbstractClass<D>,
+  type5: AbstractClass<E>,
+  type6: AbstractClass<F>,
+): IntersectedType<A & B & C & D & E & F, Args>;
+export function IntersectTypes<A, B, C, D, E, F, G, Args extends unknown[]>(
+  type1: AbstractClass<A, Args>,
+  type2: AbstractClass<B>,
+  type3: AbstractClass<C>,
+  type4: AbstractClass<D>,
+  type5: AbstractClass<E>,
+  type6: AbstractClass<F>,
+  type7: AbstractClass<G>,
+): IntersectedType<A & B & C & D & E & F & G, Args>;
+export function IntersectTypes<A, B, C, D, E, F, G, H, Args extends unknown[]>(
+  type1: AbstractClass<A, Args>,
+  type2: AbstractClass<B>,
+  type3: AbstractClass<C>,
+  type4: AbstractClass<D>,
+  type5: AbstractClass<E>,
+  type6: AbstractClass<F>,
+  type7: AbstractClass<G>,
+  type8: AbstractClass<H>,
+): IntersectedType<A & B & C & D & E & F & G & H, Args>;
+export function IntersectTypes<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  Args extends unknown[],
+>(
+  type1: AbstractClass<A, Args>,
+  type2: AbstractClass<B>,
+  type3: AbstractClass<C>,
+  type4: AbstractClass<D>,
+  type5: AbstractClass<E>,
+  type6: AbstractClass<F>,
+  type7: AbstractClass<G>,
+  type8: AbstractClass<H>,
+  type9: AbstractClass<I>,
+): IntersectedType<A & B & C & D & E & F & G & H & I, Args>;
+export function IntersectTypes<
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  Args extends unknown[],
+>(
+  type1: AbstractClass<A, Args>,
+  type2: AbstractClass<B>,
+  type3: AbstractClass<C>,
+  type4: AbstractClass<D>,
+  type5: AbstractClass<E>,
+  type6: AbstractClass<F>,
+  type7: AbstractClass<G>,
+  type8: AbstractClass<H>,
+  type9: AbstractClass<I>,
+  ...types: Array<AbstractClass<any>>
+): IntersectedType<unknown, Args>;
+export function IntersectTypes<T, Args extends unknown[]>(
+  ...types: Array<AbstractClass<T, Args>>
+): IntersectedType<T, Args> {
+  return Object.assign(
+    (types as any).reduce(
+      (a: any, b: any) => (a ? IntersectionType(a, b) : b),
+      undefined,
+    ),
+    {
+      members: types,
+    },
+  );
+}
+
+type IntersectedType<T, Args extends unknown[]> = Class<T, Args> & {
+  members: Array<Class<unknown>>;
+};
+
 function TODOFn(..._args: any[]) {
   throw new NotImplementedException();
 }

--- a/src/components/budget/dto/budget-record.dto.ts
+++ b/src/components/budget/dto/budget-record.dto.ts
@@ -3,7 +3,7 @@ import { keys as keysOf } from 'ts-transformer-keys';
 import {
   Calculated,
   ID,
-  IntersectionType,
+  IntersectTypes,
   Resource,
   Secured,
   SecuredFloatNullable,
@@ -19,12 +19,14 @@ import { ChangesetAware } from '../../changeset/dto';
 import { BudgetStatus } from './budget-status.enum';
 import { Budget } from './budget.dto';
 
+const Interfaces = IntersectTypes(Resource, ChangesetAware);
+
 @Calculated()
 @RegisterResource({ db: e.Budget.Record })
 @ObjectType({
-  implements: [Resource, ChangesetAware],
+  implements: Interfaces.members,
 })
-export class BudgetRecord extends IntersectionType(ChangesetAware, Resource) {
+export class BudgetRecord extends Interfaces {
   static readonly Props = keysOf<BudgetRecord>();
   static readonly SecuredProps = keysOf<SecuredProps<BudgetRecord>>();
   static readonly Parent = import('./budget.dto').then((m) => m.Budget);

--- a/src/components/budget/dto/budget.dto.ts
+++ b/src/components/budget/dto/budget.dto.ts
@@ -3,7 +3,7 @@ import { keys as keysOf } from 'ts-transformer-keys';
 import {
   Calculated,
   DbLabel,
-  IntersectionType,
+  IntersectTypes,
   Resource,
   ResourceRelationsShape,
   SecuredProperty,
@@ -20,12 +20,14 @@ import { IProject } from '../../project/dto';
 import { BudgetRecord } from './budget-record.dto';
 import { BudgetStatus } from './budget-status.enum';
 
+const Interfaces = IntersectTypes(Resource, ChangesetAware);
+
 @Calculated()
 @RegisterResource({ db: e.Budget })
 @ObjectType({
-  implements: [Resource, ChangesetAware],
+  implements: Interfaces.members,
 })
-export class Budget extends IntersectionType(ChangesetAware, Resource) {
+export class Budget extends Interfaces {
   static readonly Props = keysOf<Budget>();
   static readonly SecuredProps = keysOf<SecuredProps<Budget>>();
   static readonly Relations = (() => ({

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -1,4 +1,3 @@
-import { Type } from '@nestjs/common';
 import { Field, InterfaceType, ObjectType } from '@nestjs/graphql';
 import { DateTime } from 'luxon';
 import { keys as keysOf } from 'ts-transformer-keys';
@@ -9,7 +8,7 @@ import {
   DateTimeField,
   DbLabel,
   ID,
-  IntersectionType,
+  IntersectTypes,
   parentIdMiddleware,
   Resource,
   ResourceRelationsShape,
@@ -48,8 +47,7 @@ export type AnyEngagement = MergeExclusive<
   InternshipEngagement
 >;
 
-const ChangesetAwareResource: Type<Resource & ChangesetAware> =
-  IntersectionType(Resource, ChangesetAware);
+const Interfaces = IntersectTypes(Resource, ChangesetAware);
 
 export const resolveEngagementType = (val: Pick<AnyEngagement, '__typename'>) =>
   val.__typename === 'LanguageEngagement'
@@ -59,12 +57,12 @@ export const resolveEngagementType = (val: Pick<AnyEngagement, '__typename'>) =>
 @RegisterResource({ db: e.Engagement })
 @InterfaceType({
   resolveType: resolveEngagementType,
-  implements: [Resource, ChangesetAware],
+  implements: Interfaces.members,
 })
 /**
  * This should be used for GraphQL but never for TypeScript types.
  */
-class Engagement extends ChangesetAwareResource {
+class Engagement extends Interfaces {
   static readonly Props: string[] = keysOf<Engagement>();
   static readonly SecuredProps: string[] = keysOf<SecuredProps<Engagement>>();
   static readonly Parent = import('../../project/dto').then((m) => m.IProject);

--- a/src/components/language/dto/language.dto.ts
+++ b/src/components/language/dto/language.dto.ts
@@ -1,4 +1,3 @@
-import { Type } from '@nestjs/common';
 import { Field, ObjectType } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { GraphQLString } from 'graphql';
@@ -8,7 +7,7 @@ import {
   DbLabel,
   DbUnique,
   ID,
-  IntersectionType,
+  IntersectTypes,
   NameField,
   Resource,
   ResourceRelationsShape,
@@ -32,11 +31,6 @@ import { Location } from '../../location/dto';
 import { Pinnable } from '../../pin/dto';
 import { Postable } from '../../post/dto';
 import { UpdateEthnologueLanguage } from './update-language.dto';
-
-const Interfaces: Type<Resource & Pinnable & Postable> = IntersectionType(
-  Resource,
-  IntersectionType(Pinnable, Postable),
-);
 
 @ObjectType({
   description: SecuredPropertyList.descriptionFor('tags'),
@@ -85,9 +79,11 @@ export class EthnologueLanguage {
   readonly sensitivity: Sensitivity;
 }
 
+const Interfaces = IntersectTypes(Resource, Pinnable, Postable);
+
 @RegisterResource({ db: e.Language })
 @ObjectType({
-  implements: [Resource, Pinnable, Postable],
+  implements: Interfaces.members,
 })
 export class Language extends Interfaces {
   static readonly Props = keysOf<Language>();

--- a/src/components/partner/dto/partner.dto.ts
+++ b/src/components/partner/dto/partner.dto.ts
@@ -1,10 +1,9 @@
-import { Type } from '@nestjs/common';
 import { Field, ObjectType } from '@nestjs/graphql';
 import { DateTime } from 'luxon';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
   DateTimeField,
-  IntersectionType,
+  IntersectTypes,
   Resource,
   ResourceRelationsShape,
   Secured,
@@ -24,14 +23,11 @@ import { Postable } from '../../post/dto';
 import { IProject } from '../../project/dto';
 import { SecuredPartnerTypes } from './partner-type.enum';
 
-const Interfaces: Type<Resource & Pinnable & Postable> = IntersectionType(
-  Resource,
-  IntersectionType(Pinnable, Postable),
-);
+const Interfaces = IntersectTypes(Resource, Pinnable, Postable);
 
 @RegisterResource({ db: e.Partner })
 @ObjectType({
-  implements: [Resource, Pinnable, Postable],
+  implements: Interfaces.members,
 })
 export class Partner extends Interfaces {
   static readonly Props = keysOf<Partner>();

--- a/src/components/partner/dto/partner.dto.ts
+++ b/src/components/partner/dto/partner.dto.ts
@@ -10,7 +10,6 @@ import {
   Secured,
   SecuredBoolean,
   SecuredDateNullable,
-  SecuredEnumList,
   SecuredProperty,
   SecuredProps,
   SecuredStringNullable,
@@ -19,7 +18,7 @@ import {
 } from '~/common';
 import { e } from '~/core/edgedb';
 import { LinkTo, RegisterResource } from '~/core/resources';
-import { FinancialReportingType } from '../../partnership/dto';
+import { SecuredFinancialReportingTypes } from '../../partnership/dto';
 import { Pinnable } from '../../pin/dto';
 import { Postable } from '../../post/dto';
 import { IProject } from '../../project/dto';
@@ -29,13 +28,6 @@ const Interfaces: Type<Resource & Pinnable & Postable> = IntersectionType(
   Resource,
   IntersectionType(Pinnable, Postable),
 );
-
-@ObjectType({
-  description: SecuredEnumList.descriptionFor('financial reporting types'),
-})
-export abstract class SecuredFinancialReportingTypes extends SecuredEnumList(
-  FinancialReportingType,
-) {}
 
 @RegisterResource({ db: e.Partner })
 @ObjectType({

--- a/src/components/partnership/dto/financial-reporting-type.enum.ts
+++ b/src/components/partnership/dto/financial-reporting-type.enum.ts
@@ -1,7 +1,23 @@
-import { EnumType, makeEnum } from '~/common';
+import { ObjectType } from '@nestjs/graphql';
+import { EnumType, makeEnum, SecuredEnum, SecuredEnumList } from '~/common';
 
 export type FinancialReportingType = EnumType<typeof FinancialReportingType>;
 export const FinancialReportingType = makeEnum({
   name: 'FinancialReportingType',
   values: ['Funded', 'FieldEngaged', 'Hybrid'],
 });
+
+@ObjectType({
+  description: SecuredEnumList.descriptionFor('financial reporting types'),
+})
+export abstract class SecuredFinancialReportingTypes extends SecuredEnumList(
+  FinancialReportingType,
+) {}
+
+@ObjectType({
+  description: SecuredEnum.descriptionFor('financial reporting type'),
+})
+export abstract class SecuredFinancialReportingType extends SecuredEnum(
+  FinancialReportingType,
+  { nullable: true },
+) {}

--- a/src/components/partnership/dto/partnership-agreement-status.enum.ts
+++ b/src/components/partnership/dto/partnership-agreement-status.enum.ts
@@ -1,4 +1,5 @@
-import { EnumType, makeEnum } from '~/common';
+import { ObjectType } from '@nestjs/graphql';
+import { EnumType, makeEnum, SecuredEnum } from '~/common';
 
 export type PartnershipAgreementStatus = EnumType<
   typeof PartnershipAgreementStatus
@@ -7,3 +8,10 @@ export const PartnershipAgreementStatus = makeEnum({
   name: 'PartnershipAgreementStatus',
   values: ['NotAttached', 'AwaitingSignature', 'Signed'],
 });
+
+@ObjectType({
+  description: SecuredEnum.descriptionFor('a partnership agreement status'),
+})
+export abstract class SecuredPartnershipAgreementStatus extends SecuredEnum(
+  PartnershipAgreementStatus,
+) {}

--- a/src/components/partnership/dto/partnership.dto.ts
+++ b/src/components/partnership/dto/partnership.dto.ts
@@ -8,7 +8,6 @@ import {
   Secured,
   SecuredBoolean,
   SecuredDateNullable,
-  SecuredEnum,
   SecuredProps,
   Sensitivity,
   SensitivityField,
@@ -20,23 +19,8 @@ import { ChangesetAware } from '../../changeset/dto';
 import { Organization } from '../../organization/dto';
 import { SecuredPartnerTypes } from '../../partner/dto';
 import { IProject } from '../../project/dto';
-import { FinancialReportingType } from './financial-reporting-type.enum';
-import { PartnershipAgreementStatus } from './partnership-agreement-status.enum';
-
-@ObjectType({
-  description: SecuredEnum.descriptionFor('a partnership agreement status'),
-})
-export abstract class SecuredPartnershipAgreementStatus extends SecuredEnum(
-  PartnershipAgreementStatus,
-) {}
-
-@ObjectType({
-  description: SecuredEnum.descriptionFor('partnership funding type'),
-})
-export abstract class SecuredFinancialReportingType extends SecuredEnum(
-  FinancialReportingType,
-  { nullable: true },
-) {}
+import { SecuredFinancialReportingType } from './financial-reporting-type.enum';
+import { SecuredPartnershipAgreementStatus } from './partnership-agreement-status.enum';
 
 @RegisterResource({ db: e.Partnership })
 @ObjectType({

--- a/src/components/partnership/dto/partnership.dto.ts
+++ b/src/components/partnership/dto/partnership.dto.ts
@@ -2,7 +2,7 @@ import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
   Calculated,
-  IntersectionType,
+  IntersectTypes,
   Resource,
   ResourceRelationsShape,
   Secured,
@@ -22,11 +22,13 @@ import { IProject } from '../../project/dto';
 import { SecuredFinancialReportingType } from './financial-reporting-type.enum';
 import { SecuredPartnershipAgreementStatus } from './partnership-agreement-status.enum';
 
+const Interfaces = IntersectTypes(Resource, ChangesetAware);
+
 @RegisterResource({ db: e.Partnership })
 @ObjectType({
-  implements: [Resource, ChangesetAware],
+  implements: Interfaces.members,
 })
-export class Partnership extends IntersectionType(ChangesetAware, Resource) {
+export class Partnership extends Interfaces {
   static readonly Props = keysOf<Partnership>();
   static readonly SecuredProps = keysOf<SecuredProps<Partnership>>();
   static readonly Relations = {

--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -1,4 +1,3 @@
-import { Type } from '@nestjs/common';
 import { Field, InterfaceType, ObjectType } from '@nestjs/graphql';
 import { simpleSwitch } from '@seedcompany/common';
 import { stripIndent } from 'common-tags';
@@ -11,7 +10,7 @@ import {
   DbLabel,
   DbSort,
   DbUnique,
-  IntersectionType,
+  IntersectTypes,
   NameField,
   parentIdMiddleware,
   Resource,
@@ -54,14 +53,12 @@ type AnyProject = MergeExclusive<
   MergeExclusive<MultiplicationTranslationProject, InternshipProject>
 >;
 
-const Interfaces: Type<
-  Resource & Postable & ChangesetAware & Pinnable & Commentable
-> = IntersectionType(
+const Interfaces = IntersectTypes(
   Resource,
-  IntersectionType(
-    Commentable,
-    IntersectionType(Postable, IntersectionType(ChangesetAware, Pinnable)),
-  ),
+  ChangesetAware,
+  Pinnable,
+  Postable,
+  Commentable,
 );
 
 export const resolveProjectType = (val: Pick<AnyProject, 'type'>) => {
@@ -75,7 +72,7 @@ export const resolveProjectType = (val: Pick<AnyProject, 'type'>) => {
 @RegisterResource({ db: e.Project })
 @InterfaceType({
   resolveType: resolveProjectType,
-  implements: [Resource, Pinnable, Postable, ChangesetAware, Commentable],
+  implements: Interfaces.members,
 })
 class Project extends Interfaces {
   static readonly Props: string[] = keysOf<Project>();

--- a/src/components/user/dto/user-status.enum.ts
+++ b/src/components/user/dto/user-status.enum.ts
@@ -1,7 +1,13 @@
-import { EnumType, makeEnum } from '~/common';
+import { ObjectType } from '@nestjs/graphql';
+import { EnumType, makeEnum, SecuredEnum, SecuredProperty } from '~/common';
 
 export type UserStatus = EnumType<typeof UserStatus>;
 export const UserStatus = makeEnum({
   name: 'UserStatus',
   values: ['Active', 'Disabled'],
 });
+
+@ObjectType({
+  description: SecuredProperty.descriptionFor('a user status'),
+})
+export abstract class SecuredUserStatus extends SecuredEnum(UserStatus) {}

--- a/src/components/user/dto/user.dto.ts
+++ b/src/components/user/dto/user.dto.ts
@@ -1,9 +1,8 @@
-import { Type } from '@nestjs/common';
 import { Field, ObjectType } from '@nestjs/graphql';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
   DbUnique,
-  IntersectionType,
+  IntersectTypes,
   NameField,
   Resource,
   ResourceRelationsShape,
@@ -25,16 +24,13 @@ import { Unavailability } from '../unavailability/dto';
 import { KnownLanguage } from './known-language.dto';
 import { SecuredUserStatus } from './user-status.enum';
 
-const PinnableResource: Type<Resource & Pinnable> = IntersectionType(
-  Resource,
-  Pinnable,
-);
+const Interfaces = IntersectTypes(Resource, Pinnable);
 
 @RegisterResource({ db: e.User })
 @ObjectType({
-  implements: [Resource, Pinnable],
+  implements: Interfaces.members,
 })
-export class User extends PinnableResource {
+export class User extends Interfaces {
   static readonly Props = keysOf<User>();
   static readonly SecuredProps = keysOf<SecuredProps<User>>();
   static readonly Relations = () =>

--- a/src/components/user/dto/user.dto.ts
+++ b/src/components/user/dto/user.dto.ts
@@ -7,7 +7,6 @@ import {
   NameField,
   Resource,
   ResourceRelationsShape,
-  SecuredEnum,
   SecuredProperty,
   SecuredProps,
   SecuredRoles,
@@ -24,17 +23,12 @@ import { IProject as Project } from '../../project/dto';
 import { Education } from '../education/dto';
 import { Unavailability } from '../unavailability/dto';
 import { KnownLanguage } from './known-language.dto';
-import { UserStatus } from './user-status.enum';
+import { SecuredUserStatus } from './user-status.enum';
 
 const PinnableResource: Type<Resource & Pinnable> = IntersectionType(
   Resource,
   Pinnable,
 );
-
-@ObjectType({
-  description: SecuredProperty.descriptionFor('a user status'),
-})
-export abstract class SecuredUserStatus extends SecuredEnum(UserStatus) {}
 
 @RegisterResource({ db: e.User })
 @ObjectType({


### PR DESCRIPTION
I held off on this because TS doesn't natively support variadic generic parameters, so the conventional workaround is to add overloads for 1-10ish parameters before giving up.

But what we do right now is so clunky and we need up enumerating each interface 3 times.
So I bit the bullet. The type code is long, but cleans up the business logic nicely.

I also moved the remaining secured enum wrappers to their respective files. Most were already there, but there were some stragglers.