### PR TITLE
Properly handle nils in filters

### DIFF
--- a/src/common/filter-field.ts
+++ b/src/common/filter-field.ts
@@ -1,9 +1,8 @@
 import { applyDecorators } from '@nestjs/common';
 import { Field } from '@nestjs/graphql';
-import { Transform, Type } from 'class-transformer';
+import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { Constructor, HasRequiredKeys } from 'type-fest';
-import { DefaultValue } from './default-value';
 import { AbstractClassType } from './types';
 
 /**
@@ -28,6 +27,4 @@ export const FilterField = <T extends object>(
         ]),
     Type(type),
     ValidateNested(),
-    DefaultValue.Set({}), // Default when omitted
-    Transform(({ value }) => value || {}), // null -> {}
   );

--- a/src/common/filter-field.ts
+++ b/src/common/filter-field.ts
@@ -24,7 +24,6 @@ export const FilterField = <T extends object>(
       : [
           Field(type as unknown as () => Constructor<T>, {
             nullable: true,
-            defaultValue: {} as unknown as T, // Only for GQL schema & not always applied in TS
           }),
         ]),
     Type(type),

--- a/src/common/pagination.input.ts
+++ b/src/common/pagination.input.ts
@@ -4,7 +4,6 @@ import { setHas } from '@seedcompany/common';
 import { Matches, Max, Min } from 'class-validator';
 import { stripIndent } from 'common-tags';
 import { DataObject } from './data-object';
-import { DefaultValue } from './default-value';
 import { Order } from './order.enum';
 import { AbstractClassType } from './types';
 
@@ -126,7 +125,7 @@ export const ListArg = <T extends PaginationInput>(
       name: 'input',
       type: () => input,
       nullable: true,
-      defaultValue: DataObject.defaultValue(input, DefaultValue.Get(input)),
+      defaultValue: DataObject.defaultValue(input),
       ...opts,
     },
     ...pipes,

--- a/src/components/budget/budget-record.repository.ts
+++ b/src/components/budget/budget-record.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
+import { pickBy } from 'lodash';
 import {
   ID,
   labelForView,
@@ -131,10 +132,14 @@ export class BudgetRecordRepository extends DtoRepository<
     session: Session,
     view?: ObjectView,
   ) {
-    const { budgetId } = input.filter;
+    const { budgetId } = input.filter ?? {};
     const result = await this.db
       .query()
-      .matchNode('budget', labelForView('Budget', view), { id: budgetId })
+      .matchNode(
+        'budget',
+        labelForView('Budget', view),
+        pickBy({ id: budgetId }),
+      )
       .apply(this.recordsOfBudget({ view }))
       .apply(sorting(BudgetRecord, input))
       .apply(paginate(input))

--- a/src/components/budget/budget.repository.ts
+++ b/src/components/budget/budget.repository.ts
@@ -108,7 +108,7 @@ export class BudgetRepository extends DtoRepository<
       .match([
         node('node', 'Budget'),
         relation('in', '', 'budget', ACTIVE),
-        node('project', 'Project', pickBy({ id: filter.projectId })),
+        node('project', 'Project', pickBy({ id: filter?.projectId })),
       ])
       .match(requestingUser(session))
       .apply(
@@ -126,7 +126,7 @@ export class BudgetRepository extends DtoRepository<
     const result = await this.db
       .query()
       .match([
-        ...(filter.projectId
+        ...(filter?.projectId
           ? [
               node('node', 'Budget'),
               relation('in', '', 'budget', ACTIVE),

--- a/src/components/budget/dto/list-budget.dto.ts
+++ b/src/components/budget/dto/list-budget.dto.ts
@@ -21,7 +21,7 @@ export class BudgetListInput extends SortablePaginationInput<keyof Budget>({
   defaultSort: 'status',
 }) {
   @FilterField(() => BudgetFilters, { internal: true })
-  readonly filter: BudgetFilters;
+  readonly filter?: BudgetFilters;
 }
 
 @ObjectType()
@@ -45,7 +45,7 @@ export class BudgetRecordListInput extends SortablePaginationInput<
 }) {
   @Type(() => BudgetRecordFilters)
   @ValidateNested()
-  readonly filter: BudgetRecordFilters;
+  readonly filter?: BudgetRecordFilters;
 }
 
 @ObjectType()

--- a/src/components/ceremony/ceremony.repository.ts
+++ b/src/components/ceremony/ceremony.repository.ts
@@ -72,7 +72,7 @@ export class CeremonyRepository extends DtoRepository<
         node('', 'Engagement'),
         relation('in', '', 'engagement', ACTIVE),
         node('project', 'Project'),
-        ...(filter.type
+        ...(filter?.type
           ? [
               relation('out', '', 'type', ACTIVE),
               node('name', 'Property', { value: filter.type }),

--- a/src/components/ceremony/dto/list-ceremony.dto.ts
+++ b/src/components/ceremony/dto/list-ceremony.dto.ts
@@ -19,7 +19,7 @@ export class CeremonyListInput extends SortablePaginationInput<
   defaultSort: 'projectName',
 }) {
   @FilterField(() => CeremonyFilters)
-  readonly filter: CeremonyFilters;
+  readonly filter?: CeremonyFilters;
 }
 
 @ObjectType()

--- a/src/components/engagement/dto/list-engagements.dto.ts
+++ b/src/components/engagement/dto/list-engagements.dto.ts
@@ -35,7 +35,7 @@ export class EngagementListInput extends SortablePaginationInput<
   defaultSort: 'createdAt',
 }) {
   @FilterField(() => EngagementFilters)
-  readonly filter: EngagementFilters;
+  readonly filter?: EngagementFilters;
 }
 
 @ObjectType()

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -336,7 +336,7 @@ export class EngagementRepository extends CommonRepository {
 
   async list(input: EngagementListInput, session: Session, changeset?: ID) {
     const label =
-      simpleSwitch(input.filter.type, {
+      simpleSwitch(input.filter?.type, {
         language: 'LanguageEngagement',
         internship: 'InternshipEngagement',
       }) ?? 'Engagement';
@@ -346,14 +346,14 @@ export class EngagementRepository extends CommonRepository {
       .subQuery((sub) =>
         sub
           .match([
-            node('project', 'Project', pickBy({ id: input.filter.projectId })),
+            node('project', 'Project', pickBy({ id: input.filter?.projectId })),
             relation('out', '', 'engagement', ACTIVE),
             node('node', label),
           ])
           .apply(whereNotDeletedInChangeset(changeset))
           .return(['node', 'project'])
           .apply((q) =>
-            changeset && input.filter.projectId
+            changeset && input.filter?.projectId
               ? q
                   .union()
                   .match([
@@ -369,7 +369,7 @@ export class EngagementRepository extends CommonRepository {
       )
       .match(requestingUser(session))
       .apply(
-        filter.builder(input.filter, {
+        filter.builder(input.filter ?? {}, {
           type: filter.skip,
           projectId: filter.skip,
           partnerId: filter.pathExists((id) => [

--- a/src/components/ethno-art/dto/list-ethno-art.dto.ts
+++ b/src/components/ethno-art/dto/list-ethno-art.dto.ts
@@ -10,7 +10,7 @@ export class EthnoArtListInput extends SortablePaginationInput<keyof EthnoArt>({
   defaultSort: 'name',
 }) {
   @FilterField(() => EthnoArtFilters, { internal: true })
-  readonly filter: EthnoArtFilters;
+  readonly filter?: EthnoArtFilters;
 }
 
 @ObjectType()

--- a/src/components/field-region/dto/list-field-region.dto.ts
+++ b/src/components/field-region/dto/list-field-region.dto.ts
@@ -20,7 +20,7 @@ export class FieldRegionListInput extends SortablePaginationInput<
   defaultSort: 'name',
 }) {
   @FilterField(() => FieldRegionFilters, { internal: true })
-  readonly filter: FieldRegionFilters;
+  readonly filter?: FieldRegionFilters;
 }
 
 @ObjectType()

--- a/src/components/field-zone/dto/list-field-zone.dto.ts
+++ b/src/components/field-zone/dto/list-field-zone.dto.ts
@@ -20,7 +20,7 @@ export class FieldZoneListInput extends SortablePaginationInput<
   defaultSort: 'name',
 }) {
   @FilterField(() => FieldZoneFilters, { internal: true })
-  readonly filter: FieldZoneFilters;
+  readonly filter?: FieldZoneFilters;
 }
 
 @ObjectType()

--- a/src/components/film/dto/list-film.dto.ts
+++ b/src/components/film/dto/list-film.dto.ts
@@ -10,7 +10,7 @@ export class FilmListInput extends SortablePaginationInput<keyof Film>({
   defaultSort: 'name',
 }) {
   @FilterField(() => FilmFilters, { internal: true })
-  readonly filter: FilmFilters;
+  readonly filter?: FilmFilters;
 }
 
 @ObjectType()

--- a/src/components/language/dto/list-language.dto.ts
+++ b/src/components/language/dto/list-language.dto.ts
@@ -56,7 +56,7 @@ export class LanguageListInput extends SortablePaginationInput<keyof Language>({
   defaultSort: 'name',
 }) {
   @FilterField(() => LanguageFilters)
-  readonly filter: LanguageFilters;
+  readonly filter?: LanguageFilters;
 }
 
 @ObjectType()

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -218,7 +218,7 @@ export class LanguageRepository extends DtoRepository<
       // match requesting user once (instead of once per row)
       .match(requestingUser(session))
       .apply(
-        filter.builder(input.filter, {
+        filter.builder(input.filter ?? {}, {
           sensitivity: filter.stringListProp(),
           leastOfThese: filter.propVal(),
           isSignLanguage: filter.propVal(),

--- a/src/components/location/dto/list-locations.dto.ts
+++ b/src/components/location/dto/list-locations.dto.ts
@@ -18,7 +18,7 @@ export class LocationListInput extends SortablePaginationInput<keyof Location>({
   defaultSort: 'name',
 }) {
   @FilterField(() => LocationFilters, { internal: true })
-  readonly filter: LocationFilters;
+  readonly filter?: LocationFilters;
 }
 
 @ObjectType()

--- a/src/components/organization/dto/list-organization.dto.ts
+++ b/src/components/organization/dto/list-organization.dto.ts
@@ -20,7 +20,7 @@ export class OrganizationListInput extends SortablePaginationInput<
   defaultSort: 'name',
 }) {
   @FilterField(() => OrganizationFilters, { internal: true })
-  readonly filter: OrganizationFilters;
+  readonly filter?: OrganizationFilters;
 }
 
 @ObjectType()

--- a/src/components/organization/organization.repository.ts
+++ b/src/components/organization/organization.repository.ts
@@ -116,7 +116,7 @@ export class OrganizationRepository extends DtoRepository<
       .query()
       .matchNode('node', 'Organization')
       .match([
-        ...(filter.userId && session.userId
+        ...(filter?.userId && session.userId
           ? [
               node('node'),
               relation('in', '', 'organization', ACTIVE),

--- a/src/components/partner/dto/list-partner.dto.ts
+++ b/src/components/partner/dto/list-partner.dto.ts
@@ -25,7 +25,7 @@ export class PartnerListInput extends SortablePaginationInput<keyof Partner>({
   defaultSort: 'createdAt',
 }) {
   @FilterField(() => PartnerFilters)
-  readonly filter: PartnerFilters;
+  readonly filter?: PartnerFilters;
 }
 
 @ObjectType()

--- a/src/components/partner/partner.repository.ts
+++ b/src/components/partner/partner.repository.ts
@@ -267,7 +267,7 @@ export class PartnerRepository extends DtoRepository<
       .query()
       .matchNode('node', 'Partner')
       .match([
-        ...(filter.userId && session.userId
+        ...(filter?.userId && session.userId
           ? [
               node('node'),
               relation('out', '', 'organization', ACTIVE),
@@ -279,7 +279,7 @@ export class PartnerRepository extends DtoRepository<
       ])
       .match(requestingUser(session))
       .apply(
-        filters.builder(filter, {
+        filters.builder(filter ?? {}, {
           pinned: filters.isPinned,
           userId: filters.skip, // already applied above
         }),

--- a/src/components/partnership/dto/list-partnership.dto.ts
+++ b/src/components/partnership/dto/list-partnership.dto.ts
@@ -20,7 +20,7 @@ export class PartnershipListInput extends SortablePaginationInput<
   defaultSort: 'createdAt',
 }) {
   @FilterField(() => PartnershipFilters, { internal: true })
-  readonly filter: PartnershipFilters;
+  readonly filter?: PartnershipFilters;
 }
 
 @ObjectType()

--- a/src/components/partnership/partnership.repository.ts
+++ b/src/components/partnership/partnership.repository.ts
@@ -211,14 +211,14 @@ export class PartnershipRepository extends DtoRepository<
       .subQuery((s) =>
         s
           .match([
-            node('project', 'Project', pickBy({ id: input.filter.projectId })),
+            node('project', 'Project', pickBy({ id: input.filter?.projectId })),
             relation('out', '', 'partnership', ACTIVE),
             node('node', 'Partnership'),
           ])
           .apply(whereNotDeletedInChangeset(changeset))
           .return(['node', 'project'])
           .apply((q) =>
-            changeset && input.filter.projectId
+            changeset && input.filter?.projectId
               ? q
                   .union()
                   .match([

--- a/src/components/post/dto/list-posts.dto.ts
+++ b/src/components/post/dto/list-posts.dto.ts
@@ -20,7 +20,7 @@ export class PostListInput extends SortablePaginationInput<keyof Post>({
   defaultOrder: Order.DESC,
 }) {
   @FilterField(() => PostFilters, { internal: true })
-  readonly filter: PostFilters;
+  readonly filter?: PostFilters;
 }
 
 @ObjectType()

--- a/src/components/post/post.repository.ts
+++ b/src/components/post/post.repository.ts
@@ -68,7 +68,7 @@ export class PostRepository extends DtoRepository<typeof Post, [Session] | []>(
       .query()
       .match([
         node('node', 'Post'),
-        ...(filter.parentId
+        ...(filter?.parentId
           ? [
               relation('in', '', 'post', ACTIVE),
               node('', 'BaseNode', {

--- a/src/components/product/dto/list-product.dto.ts
+++ b/src/components/product/dto/list-product.dto.ts
@@ -42,7 +42,7 @@ export class ProductListInput extends SortablePaginationInput<keyof Product>({
   defaultSort: 'createdAt',
 }) {
   @FilterField(() => ProductFilters)
-  readonly filter: ProductFilters;
+  readonly filter?: ProductFilters;
 }
 
 @ObjectType()

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -489,7 +489,7 @@ export class ProductRepository extends CommonRepository {
       .query()
       .matchNode('node', 'Product')
       .match([
-        ...(input.filter.engagementId
+        ...(input.filter?.engagementId
           ? [
               node('node'),
               relation('in', '', 'product', ACTIVE),
@@ -500,7 +500,7 @@ export class ProductRepository extends CommonRepository {
           : []),
       ])
       .apply((q) => {
-        const { approach, methodology, ...rest } = input.filter;
+        const { approach, methodology, ...rest } = input.filter ?? {};
         const merged = [
           ...(approach ? ApproachToMethodologies[approach] : []),
           ...(methodology ? [methodology] : []),

--- a/src/components/project-change-request/dto/project-change-request-list.dto.ts
+++ b/src/components/project-change-request/dto/project-change-request-list.dto.ts
@@ -20,7 +20,7 @@ export class ProjectChangeRequestListInput extends SortablePaginationInput<
   defaultSort: 'createdAt',
 }) {
   @FilterField(() => ProjectChangeRequestFilters, { internal: true })
-  readonly filter: ProjectChangeRequestFilters;
+  readonly filter?: ProjectChangeRequestFilters;
 }
 
 @ObjectType()

--- a/src/components/project-change-request/project-change-request.repository.ts
+++ b/src/components/project-change-request/project-change-request.repository.ts
@@ -72,7 +72,7 @@ export class ProjectChangeRequestRepository extends DtoRepository<
       .query()
       .match([
         node('node', 'ProjectChangeRequest'),
-        ...(input.filter.projectId
+        ...(input.filter?.projectId
           ? [
               relation('in', '', 'changeset', ACTIVE),
               node('project', 'Project', {

--- a/src/components/project/dto/list-projects.dto.ts
+++ b/src/components/project/dto/list-projects.dto.ts
@@ -101,7 +101,7 @@ export class ProjectListInput extends SortablePaginationInput<keyof IProject>({
   defaultSort: 'name',
 }) {
   @FilterField(() => ProjectFilters)
-  readonly filter: ProjectFilters;
+  readonly filter?: ProjectFilters;
 }
 
 @ObjectType()

--- a/src/components/project/list-filter.query.ts
+++ b/src/components/project/list-filter.query.ts
@@ -3,7 +3,7 @@ import { ACTIVE, filter, matchProjectSens, path } from '~/core/database/query';
 import { ProjectListInput } from './dto';
 
 export const projectListFilter = (input: ProjectListInput) =>
-  filter.builder(input.filter, {
+  filter.builder(input.filter ?? {}, {
     type: filter.stringListBaseNodeProp(),
     status: filter.stringListProp(),
     onlyMultipleEngagements:

--- a/src/components/project/project-member/dto/list-project-members.dto.ts
+++ b/src/components/project/project-member/dto/list-project-members.dto.ts
@@ -27,7 +27,7 @@ export class ProjectMemberListInput extends SortablePaginationInput<
   defaultSort: 'createdAt',
 }) {
   @FilterField(() => ProjectMemberFilters)
-  readonly filter: ProjectMemberFilters;
+  readonly filter?: ProjectMemberFilters;
 }
 
 @ObjectType()

--- a/src/components/project/project-member/project-member.edgedb.repository.ts
+++ b/src/components/project/project-member/project-member.edgedb.repository.ts
@@ -54,6 +54,7 @@ export class ProjectMemberEdgeDBRepository
     member: ScopeOf<typeof e.Project.Member>,
     { filter: input }: ProjectMemberListInput,
   ) {
+    if (!input) return [];
     return [
       (input.roles?.length ?? 0) > 0 &&
         e.op(

--- a/src/components/project/project-member/project-member.repository.ts
+++ b/src/components/project/project-member/project-member.repository.ts
@@ -148,13 +148,13 @@ export class ProjectMemberRepository extends DtoRepository<
         node(
           'project',
           'Project',
-          filter.projectId ? { id: filter.projectId } : {},
+          filter?.projectId ? { id: filter.projectId } : {},
         ),
         relation('out', '', 'member'),
         node('node', 'ProjectMember'),
       ])
       .apply((q) =>
-        filter.roles
+        filter?.roles
           ? q
               .match([
                 node('node'),

--- a/src/components/project/project.edgedb.repository.ts
+++ b/src/components/project/project.edgedb.repository.ts
@@ -101,6 +101,7 @@ export class ProjectEdgeDBRepository
     project: ScopeOf<typeof e.Project>,
     { filter: input }: ProjectListInput,
   ) {
+    if (!input) return [];
     return [
       (input.type?.length ?? 0) > 0 &&
         e.op(

--- a/src/components/story/dto/list-story.dto.ts
+++ b/src/components/story/dto/list-story.dto.ts
@@ -10,7 +10,7 @@ export class StoryListInput extends SortablePaginationInput<keyof Story>({
   defaultSort: 'name',
 }) {
   @FilterField(() => StoryFilters, { internal: true })
-  readonly filter: StoryFilters;
+  readonly filter?: StoryFilters;
 }
 
 @ObjectType()

--- a/src/components/user/dto/list-users.dto.ts
+++ b/src/components/user/dto/list-users.dto.ts
@@ -16,7 +16,7 @@ export class UserListInput extends SortablePaginationInput<keyof User>({
   defaultSort: 'id', // TODO How to sort on name?
 }) {
   @FilterField(() => UserFilters)
-  readonly filter: UserFilters;
+  readonly filter?: UserFilters;
 }
 
 @ObjectType()

--- a/src/components/user/education/dto/list-education.dto.ts
+++ b/src/components/user/education/dto/list-education.dto.ts
@@ -20,7 +20,7 @@ export class EducationListInput extends SortablePaginationInput<
   defaultSort: 'institution',
 }) {
   @FilterField(() => EducationFilters, { internal: true })
-  readonly filter: EducationFilters;
+  readonly filter?: EducationFilters;
 }
 
 @ObjectType()

--- a/src/components/user/education/education.repository.ts
+++ b/src/components/user/education/education.repository.ts
@@ -73,7 +73,7 @@ export class EducationRepository extends DtoRepository(Education) {
       .query()
       .matchNode('node', 'Education')
       .match([
-        ...(filter.userId
+        ...(filter?.userId
           ? [
               node('node'),
               relation('in', '', 'education', ACTIVE),

--- a/src/components/user/unavailability/dto/list-unavailabilities.dto.ts
+++ b/src/components/user/unavailability/dto/list-unavailabilities.dto.ts
@@ -22,7 +22,7 @@ export class UnavailabilityListInput extends SortablePaginationInput<
   defaultOrder: Order.DESC,
 }) {
   @FilterField(() => UnavailabilityFilters, { internal: true })
-  readonly filter: UnavailabilityFilters;
+  readonly filter?: UnavailabilityFilters;
 }
 
 @ObjectType()

--- a/src/components/user/unavailability/unavailability.edgedb.repository.ts
+++ b/src/components/user/unavailability/unavailability.edgedb.repository.ts
@@ -70,6 +70,7 @@ export class UnavailabilityEdgeDBRepository
     unavailability: ScopeOf<typeof e.User.Unavailability>,
     { filter: input }: UnavailabilityListInput,
   ) {
+    if (!input) return [];
     return [
       input.userId &&
         e.op(

--- a/src/components/user/user.edgedb.repository.ts
+++ b/src/components/user/user.edgedb.repository.ts
@@ -47,6 +47,7 @@ export class UserEdgeDBRepository
   }
 
   protected listFilters(user: ScopeOf<typeof e.User>, input: UserListInput) {
+    if (!input.filter) return [];
     return [
       input.filter.pinned != null &&
         e.op(user.pinned, '=', input.filter.pinned),

--- a/src/components/user/user.repository.ts
+++ b/src/components/user/user.repository.ts
@@ -224,7 +224,7 @@ export class UserRepository extends DtoRepository<typeof User, [Session | ID]>(
       .matchNode('node', 'User')
       .match(requestingUser(session))
       .apply(
-        filter.builder(input.filter, {
+        filter.builder(input.filter ?? {}, {
           pinned: filter.isPinned,
         }),
       )


### PR DESCRIPTION
Instead of weird hacks to try to default to empty objects.

This is cleaning in GQL schema, more straightforward, and doesn't cause inconsistencies with upcoming nested filters.

Basically the next iteration of #2709