### PR TITLE
Neo4j: FullTextIndex / .call() / .yield()

### DIFF
--- a/src/components/file/media/media.repository.ts
+++ b/src/components/file/media/media.repository.ts
@@ -114,10 +114,9 @@ export class MediaRepository extends CommonRepository {
       // Update the labels if typename is given, and maybe changed.
       .apply((q) =>
         res
-          ? q.raw(
-              'CALL apoc.create.setLabels(node, $newLabels) yield node as labelsAdded',
-              { newLabels: res.dbLabels },
-            )
+          ? q
+              .call(apoc.create.setLabels('node', res.dbLabels))
+              .yield('node as labelsAdded')
           : q,
       )
       // Grab the previous media node or null

--- a/src/components/file/media/media.repository.ts
+++ b/src/components/file/media/media.repository.ts
@@ -114,9 +114,11 @@ export class MediaRepository extends CommonRepository {
       // Update the labels if typename is given, and maybe changed.
       .apply((q) =>
         res
-          ? q
-              .call(apoc.create.setLabels('node', res.dbLabels))
-              .yield('node as labelsAdded')
+          ? q.call(
+              apoc.create
+                .setLabels('node', res.dbLabels)
+                .yield({ node: 'labelsAdded' }),
+            )
           : q,
       )
       // Grab the previous media node or null

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -552,7 +552,9 @@ export class ProductRepository extends CommonRepository {
       .query()
       .apply((q) =>
         query
-          ? q.apply(ProductCompletionDescriptionIndex.search(query))
+          ? q.call(
+              ProductCompletionDescriptionIndex.search(query).yield('node'),
+            )
           : q.matchNode('node', 'ProductCompletionDescription'),
       )
       .apply((q) =>

--- a/src/components/search/search.repository.ts
+++ b/src/components/search/search.repository.ts
@@ -34,7 +34,7 @@ export class SearchRepository extends CommonRepository {
 
           .union()
 
-          .apply(GlobalIndex.search(lucene, { yield: 'node as property' }))
+          .call(GlobalIndex.search(lucene).yield({ node: 'property' }))
           .match([node('node'), relation('out', 'r', ACTIVE), node('property')])
           .return(['node', 'collect(type(r)) as matchedProps'])
           // The input.count is going to be applied once the results are 'filtered'

--- a/src/components/search/search.repository.ts
+++ b/src/components/search/search.repository.ts
@@ -4,7 +4,7 @@ import { CommonRepository, OnIndex, OnIndexParams } from '~/core/database';
 import {
   ACTIVE,
   escapeLuceneSyntax,
-  fullTextQuery,
+  FullTextIndex,
 } from '~/core/database/query';
 import { BaseNode } from '~/core/database/results';
 import { SearchInput } from './dto';
@@ -13,9 +13,7 @@ import { SearchInput } from './dto';
 export class SearchRepository extends CommonRepository {
   @OnIndex('schema')
   protected async applyIndexes({ db }: OnIndexParams) {
-    await db.createFullTextIndex('propValue', ['Property'], ['value'], {
-      analyzer: 'standard-folding',
-    });
+    await db.query().apply(GlobalIndex.create()).run();
   }
 
   /**
@@ -36,8 +34,7 @@ export class SearchRepository extends CommonRepository {
 
           .union()
 
-          .raw('', { query: lucene })
-          .apply(fullTextQuery('propValue', '$query', ['node as property']))
+          .apply(GlobalIndex.search(lucene, { yield: 'node as property' }))
           .match([node('node'), relation('out', 'r', ACTIVE), node('property')])
           .return(['node', 'collect(type(r)) as matchedProps'])
           // The input.count is going to be applied once the results are 'filtered'
@@ -62,3 +59,10 @@ export class SearchRepository extends CommonRepository {
     return await query.run();
   }
 }
+
+const GlobalIndex = FullTextIndex({
+  indexName: 'propValue',
+  labels: 'Property',
+  properties: 'value',
+  analyzer: 'standard-folding',
+});

--- a/src/core/database/query-augmentation/SubClauseCollection.ts
+++ b/src/core/database/query-augmentation/SubClauseCollection.ts
@@ -1,6 +1,23 @@
-import { ClauseCollection, Query } from 'cypher-query-builder';
+import { Clause, ClauseCollection, Query } from 'cypher-query-builder';
+import type { ParameterBag } from 'cypher-query-builder/dist/typings/parameter-bag';
 
 export class SubClauseCollection extends ClauseCollection {
+  useParameterBag(newBag: ParameterBag) {
+    super.useParameterBag(newBag);
+    this.assignBagRecursive(this, newBag);
+  }
+
+  private assignBagRecursive(clause: Clause, newBag: ParameterBag) {
+    // @ts-expect-error protected, but we want it to reference the outer one
+    // without having to import the parameters.
+    clause.parameterBag = newBag;
+    if (clause instanceof ClauseCollection) {
+      for (const sub of clause.getClauses()) {
+        this.assignBagRecursive(sub, newBag);
+      }
+    }
+  }
+
   build() {
     return this.clauses
       .flatMap((clause) => {

--- a/src/core/database/query-augmentation/index.ts
+++ b/src/core/database/query-augmentation/index.ts
@@ -11,3 +11,4 @@ import './map';
 import './pattern-formatting';
 import './subquery';
 import './summary';
+import './yield';

--- a/src/core/database/query-augmentation/yield.ts
+++ b/src/core/database/query-augmentation/yield.ts
@@ -1,0 +1,23 @@
+import { Many } from '@seedcompany/common';
+import { Clause, Query } from 'cypher-query-builder';
+
+declare module 'cypher-query-builder/dist/typings/query' {
+  interface Query {
+    yield(...terms: Array<Many<string>>): this;
+  }
+}
+
+Query.prototype.yield = function (this: Query, ...terms: Array<Many<string>>) {
+  const flattened = terms.flat();
+  if (flattened.length === 0) return this;
+  return this.continueChainClause(new Yield(flattened));
+};
+
+class Yield extends Clause {
+  constructor(public terms: readonly string[]) {
+    super();
+  }
+  build() {
+    return `YIELD ${this.terms.join(', ')}`;
+  }
+}

--- a/src/core/database/query-augmentation/yield.ts
+++ b/src/core/database/query-augmentation/yield.ts
@@ -1,14 +1,23 @@
-import { Many } from '@seedcompany/common';
+import { isPlainObject } from '@nestjs/common/utils/shared.utils.js';
+import { isNotFalsy, many, Many, Nil } from '@seedcompany/common';
 import { Clause, Query } from 'cypher-query-builder';
 
 declare module 'cypher-query-builder/dist/typings/query' {
   interface Query {
-    yield(...terms: Array<Many<string>>): this;
+    yield(terms: YieldTerms): this;
   }
 }
 
-Query.prototype.yield = function (this: Query, ...terms: Array<Many<string>>) {
-  const flattened = terms.flat();
+export type YieldTerms<T extends string = string> =
+  | Many<T | Nil>
+  | Partial<Record<T, string | boolean | Nil>>;
+
+Query.prototype.yield = function (this: Query, terms: YieldTerms) {
+  const flattened = isPlainObject(terms)
+    ? Object.entries(terms).flatMap(([k, v]) =>
+        v === false || v == null ? [] : v === true ? k : `${k} as ${v}`,
+      )
+    : many(terms).filter(isNotFalsy);
   if (flattened.length === 0) return this;
   return this.continueChainClause(new Yield(flattened));
 };

--- a/src/core/database/query/cypher-functions.ts
+++ b/src/core/database/query/cypher-functions.ts
@@ -76,6 +76,12 @@ export const apoc = {
     /** Converts Neo4j node to object/map of the node's properties */
     toMap: fn1('apoc.convert.toMap'),
   },
+  create: {
+    setLabels: (node: ExpressionInput, labels: readonly string[]) => ({
+      name: 'apoc.create.setLabels',
+      args: { node: exp(node), labels },
+    }),
+  },
 };
 
 /**

--- a/src/core/database/query/cypher-functions.ts
+++ b/src/core/database/query/cypher-functions.ts
@@ -1,3 +1,4 @@
+import { procedure } from '../query-augmentation/call';
 import { exp, ExpressionInput } from './cypher-expression';
 import { IndexFullTextQueryNodes } from './full-text';
 
@@ -77,10 +78,8 @@ export const apoc = {
     toMap: fn1('apoc.convert.toMap'),
   },
   create: {
-    setLabels: (node: ExpressionInput, labels: readonly string[]) => ({
-      name: 'apoc.create.setLabels',
-      args: { node: exp(node), labels },
-    }),
+    setLabels: (node: ExpressionInput, labels: readonly string[]) =>
+      procedure('apoc.create.setLabels', ['node'])({ node: exp(node), labels }),
   },
 };
 

--- a/src/core/database/query/cypher-functions.ts
+++ b/src/core/database/query/cypher-functions.ts
@@ -1,4 +1,5 @@
 import { exp, ExpressionInput } from './cypher-expression';
+import { IndexFullTextQueryNodes } from './full-text';
 
 /** Create a function with a name that takes a variable number of arguments */
 const fn =
@@ -111,3 +112,11 @@ export const any = (
   list: ExpressionInput,
   predicate: ExpressionInput,
 ) => fn('any')(`${variable} IN ${exp(list)} WHERE ${exp(predicate)}`);
+
+export const db = {
+  index: {
+    fulltext: {
+      queryNodes: IndexFullTextQueryNodes,
+    },
+  },
+};

--- a/src/core/database/query/full-text.ts
+++ b/src/core/database/query/full-text.ts
@@ -1,28 +1,160 @@
+import { entries, isNotNil, many, Many, mapKeys } from '@seedcompany/common';
 import { Query } from 'cypher-query-builder';
+import { pickBy } from 'lodash';
+import { LiteralUnion } from 'type-fest';
+import { CypherExpression, exp, isExp } from './cypher-expression';
+import { db } from './cypher-functions';
 
 /**
- * Query a full text index for results.
- *
- * NOTE: the `query` is Lucene syntax. If this is coming from user input, consider
- * using the {@link escapeLuceneSyntax} function.
+ * @see https://neo4j.com/docs/cypher-manual/current/indexes/semantic-indexes/full-text-indexes/
  */
-export const fullTextQuery =
-  (index: string, query: string, yieldTerms = ['node']) =>
-  (q: Query) =>
-    q.raw(
-      'CALL db.index.fulltext.queryNodes($index, $query)' +
-        (yieldTerms && yieldTerms.length > 0
-          ? ' YIELD ' + yieldTerms.join(', ')
-          : ''),
-      {
-        index,
-        // fallback to "" when no query is given, so that no results are
-        // returned instead of the procedure failing
-        query: query.trim() || '""',
-      },
-    );
+export const FullTextIndex = (config: {
+  indexName: string;
+  labels: Many<string>;
+  properties: Many<string>;
+  analyzer?: Analyzer;
+  /**
+   * This means that updates will be applied in a background thread "as soon as possible",
+   * instead of during a transaction commit, which is true for other indexes.
+   */
+  eventuallyConsistent?: boolean;
+}) => {
+  const quote = (q: string) => `'${q}'`;
+
+  const { indexName } = config;
+
+  return {
+    /**
+     * Query to create the full text index (if needed).
+     */
+    create: () => {
+      const parsedConfig = {
+        analyzer: config.analyzer ? quote(config.analyzer) : undefined,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        eventually_consistent: config.eventuallyConsistent
+          ? exp(config.eventuallyConsistent)
+          : undefined,
+      };
+      const options =
+        entries(pickBy(parsedConfig, (v) => v !== undefined)).length > 0
+          ? {
+              indexConfig: mapKeys(parsedConfig, (k) => `fulltext.${k}`)
+                .asRecord,
+            }
+          : undefined;
+      const query = `
+        CREATE FULLTEXT INDEX ${indexName} IF NOT EXISTS
+        FOR (n:${many(config.labels).join('|')})
+        ON EACH ${exp(many(config.properties).map((p) => `n.${p}`))}
+        ${options ? `OPTIONS ${exp(options)}` : ''}
+      `;
+      return (q: Query) => q.raw(query);
+    },
+
+    /**
+     * Query the full text index for results.
+     *
+     * NOTE: the `query` is Lucene syntax.
+     * If this is coming from user input, consider using the {@link escapeLuceneSyntax} function.
+     */
+    search: (
+      query: string,
+      config: {
+        yield?: Many<string>;
+        skip?: number;
+        limit?: number;
+        analyzer?: Analyzer;
+      } = {},
+    ) => {
+      const { yield: yieldTerms = ['node'], ...options } = config;
+
+      // fallback to "" when no query is given, so that no results are
+      // returned instead of the procedure failing
+      query = query.trim() || '""';
+
+      return (q: Query) =>
+        q
+          .call(db.index.fulltext.queryNodes(indexName, query, options))
+          .yield(yieldTerms);
+    },
+  };
+};
 
 export const escapeLuceneSyntax = (query: string) =>
   query
     .replace(/[![\]~)(+\-:?*"^&|{}\\/]/g, (char) => `\\${char}`)
     .replace(/\b(OR|AND|NOT)\b/g, (char) => `"${char}"`);
+
+export const IndexFullTextQueryNodes = (
+  indexName: string,
+  query: string,
+  options?:
+    | {
+        skip?: number;
+        limit?: number;
+        analyzer?: string;
+      }
+    | CypherExpression,
+) => ({
+  name: 'db.index.fulltext.queryNodes',
+  args: {
+    indexName,
+    query,
+    ...(options &&
+    (Object.values(options).filter(isNotNil).length > 0 || isExp(options))
+      ? { options }
+      : undefined),
+  },
+});
+
+type Analyzer = LiteralUnion<KnownAnalyzer, string>;
+
+/**
+ * List from Neo4j with:
+ * CALL db.index.fulltext.listAvailableAnalyzers()
+ */
+type KnownAnalyzer =
+  // Analyzer that uses ASCIIFoldingFilter to remove accents (diacritics).
+  // Otherwise, it behaves as a standard english analyzer.
+  // Note: This analyzer may have unexpected behavior, such as tokenizing, for all non-ASCII numbers and symbols.
+  | 'standard-folding'
+  // A simple analyzer that tokenizes at non-letter boundaries.
+  // No stemming or filtering.
+  // Works okay for most European languages, but is terrible for languages where words aren't separated by spaces, such as many Asian languages.
+  | 'simple'
+  // Stop analyzer tokenizes at non-letter characters, and filters out English stop words.
+  // This differs from the 'classic' and 'standard' analyzers in that it makes no effort to recognize special terms,
+  // like likely product names, URLs or email addresses.
+  | 'stop'
+  // Keyword analyzer "tokenizes" the text as a single term.
+  // Useful for zip-codes, ids, etc. Situations where complete and exact matches are desired.
+  | 'keyword'
+  // The standard analyzer.
+  // Tokenizes on non-letter and filters out English stop words and punctuation.
+  // Does no stemming, but takes care to keep likely product names, URLs and email addresses as single terms.
+  | 'standard'
+  // Breaks text into terms by characters that have the unicode WHITESPACE property.
+  | 'unicode_whitespace'
+  // Tokenizes into sequences of alphanumeric, numeric, URL, email, southeast asian terms,
+  // and into terms of individual ideographic and hiragana characters.
+  // English stop words are filtered out.
+  | 'url'
+  // English analyzer with stemming and stop word filtering.
+  | 'english'
+  // Tokenizes into sequences of alphanumeric, numeric, URL, email, southeast asian terms,
+  // and into terms of individual ideographic and hiragana characters.
+  // English stop words are filtered out.
+  | 'url_or_email'
+  // The default analyzer.
+  // Similar to the 'standard' analyzer, but filters no stop words.
+  // Tokenizes on non-letter boundaries filters out punctuation.
+  // Does no stemming, but takes care to keep likely product names, URLs and email addresses as single terms.
+  | 'standard-no-stop-words'
+  // Classic Lucene analyzer. Similar to 'standard', but with worse unicode support.
+  | 'classic'
+  // Tokenizes into sequences of alphanumeric, numeric, URL, email, southeast asian terms,
+  // and into terms of individual ideographic and hiragana characters.
+  // English stop words are filtered out.
+  | 'email'
+  // Breaks text into terms by characters that are considered "Java whitespace".
+  | 'whitespace';

--- a/src/core/database/query/index.ts
+++ b/src/core/database/query/index.ts
@@ -11,7 +11,7 @@ export * from './properties/update-relation-list';
 export * from './create-relationships';
 export * from './cypher-expression';
 export * from './cypher-functions';
-export * from './full-text';
+export { FullTextIndex, escapeLuceneSyntax } from './full-text';
 export * from './lists';
 export * from './sorting';
 export * from './matching';


### PR DESCRIPTION
# Full Text Index

This unifies how full text indexes are configured & then referenced.

```ts
const MyIndex = FullTextIndex({ ... });

Query.apply(MyIndex.create())
Query.call(MyIndex.search(...).yield('node'))
```

Previously the index name was a magic string referenced in multiple spots.

# CALL / YIELD

Also added support for `Query.call()` & `Query.yield()`, which mostly just means we have less big string blocks.

```ts
.call('foo.bar.baz')
.call('foo.bar.baz', ['arg1'])
```

```ts
.yield('node')
.yield(['node', 'score'])
.yield('node as result')
.yield({
  node: 'result',
  score: 'rank',
})
```

Procedures can be declared with `procedure()` which provides more strict types.
```ts
.call(
  apoc.create.setLabels('node', res.dbLabels)
    .yield({ node: 'labelsAdded' })
)
```

# Fixes

- Fix cypher nested subqueries not using the same parameter bag (f766b07fe7a4dbde6515101ad8efa2746d85b67b) 
This affected `where` clauses which added parameters at `build()`
- Simplify cypher variable handling by not even adding them to the parameter bag (01692d03a4064572319570e4323d5b343fad0458)
Previously, they would be kept unique: active, active2, active3.
But then stripped out on `getParams`, so this was wasted effort.
So this is faster and less confusing.