### PR TITLE
Fix requestingUser not being forward to project filters

### DIFF
--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -571,9 +571,12 @@ export const engagementFilters = filter.define(() => EngagementFilters, {
     relation('out', '', 'language'),
     node('', 'Language', { id }),
   ]),
-  project: filter.sub(() => projectFilters)((sub) =>
+  project: filter.sub(
+    () => projectFilters,
+    'requestingUser',
+  )((sub) =>
     sub
-      .with('node as eng')
+      .with('node as eng, requestingUser')
       .match([
         node('eng'),
         relation('in', '', 'engagement'),

--- a/src/core/database/query/filters.ts
+++ b/src/core/database/query/filters.ts
@@ -1,4 +1,4 @@
-import { cleanSplit, entries, Nil } from '@seedcompany/common';
+import { cleanSplit, entries, many, Many, Nil } from '@seedcompany/common';
 import {
   comparisions,
   greaterThan,
@@ -219,6 +219,7 @@ export const comparisonOfDateTimeFilter = (
 export const sub =
   <Input extends Record<string, any>>(
     subBuilder: () => (input: Partial<Input>) => (q: Query) => void,
+    extraInput?: Many<string>,
   ) =>
   <
     // TODO this doesn't enforce Input type on Outer property
@@ -229,7 +230,7 @@ export const sub =
   ): Builder<Outer, K> =>
   ({ key, value, query }) =>
     query
-      .subQuery('node', (sub) =>
+      .subQuery(['node', ...many(extraInput ?? [])], (sub) =>
         sub
           .apply(matchSubNode)
           .apply(subBuilder()(value))


### PR DESCRIPTION
This is a quick fix. I don't really like it. I want to pursue passing the current user to neo4j in a similar fashion to EdgeDB.