### PR TITLE
Remove legacy APIs & transitional code for project workflow

### DIFF
--- a/src/components/project/dto/create-project.dto.ts
+++ b/src/components/project/dto/create-project.dto.ts
@@ -17,7 +17,6 @@ import {
 } from '~/common';
 import { type Location } from '../../location/dto';
 import { ReportPeriod } from '../../periodic-report/dto';
-import { ProjectStep } from './project-step.enum';
 import { ProjectType } from './project-type.enum';
 import { IProject, type Project } from './project.dto';
 
@@ -68,9 +67,6 @@ export abstract class CreateProject {
 
   @DateField({ nullable: true })
   readonly estimatedSubmission?: CalendarDate;
-
-  @Field(() => ProjectStep, { nullable: true })
-  readonly step?: ProjectStep;
 
   @SensitivityField({
     description: 'Defaults to High, only available on internship projects',

--- a/src/components/project/dto/update-project.dto.ts
+++ b/src/components/project/dto/update-project.dto.ts
@@ -18,7 +18,6 @@ import {
 import { ChangesetIdField } from '../../changeset';
 import { type Location } from '../../location/dto';
 import { ReportPeriod } from '../../periodic-report/dto';
-import { ProjectStep } from './project-step.enum';
 import { IProject, type Project } from './project.dto';
 
 @InputType()
@@ -63,11 +62,6 @@ export abstract class UpdateProject {
 
   @DateField({ nullable: true })
   readonly estimatedSubmission?: CalendarDate | null;
-
-  @OptionalField(() => ProjectStep, {
-    deprecationReason: 'Use `transitionProject` mutation instead',
-  })
-  readonly step?: ProjectStep;
 
   @SensitivityField({
     description: 'Update only available to internship projects',

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -157,7 +157,7 @@ export class ProjectRepository extends CommonRepository {
   }
 
   async create(input: CreateProject) {
-    const step = input.step ?? ProjectStep.EarlyConversations;
+    const step = ProjectStep.EarlyConversations;
     const now = DateTime.local();
     const {
       primaryLocationId,

--- a/src/components/project/workflow/dto/workflow-transition.dto.ts
+++ b/src/components/project/workflow/dto/workflow-transition.dto.ts
@@ -2,7 +2,7 @@ import { ObjectType } from '@nestjs/graphql';
 import { WorkflowTransition } from '../../../workflow/dto';
 import { ProjectStep } from '../../dto';
 
-@ObjectType('ProjectStepTransition', {
+@ObjectType({
   description: WorkflowTransition.descriptionFor('project'),
 })
 export abstract class ProjectWorkflowTransition extends WorkflowTransition(

--- a/src/components/project/workflow/migrations/step-history-to-workflow-events.migration.ts
+++ b/src/components/project/workflow/migrations/step-history-to-workflow-events.migration.ts
@@ -77,6 +77,7 @@ export class StepHistoryToWorkflowEventsMigration extends BaseMigration {
           {
             project: fakeProject,
             moduleRef: this.moduleRef,
+            // @ts-expect-error removed from src, but keeping this file for reference for now.
             migrationPrevSteps: prev,
           },
           project,

--- a/src/components/project/workflow/project-workflow.service.ts
+++ b/src/components/project/workflow/project-workflow.service.ts
@@ -13,7 +13,7 @@ import {
   findTransition,
   WorkflowService,
 } from '../../workflow/workflow.service';
-import { IProject, type Project, type ProjectStep } from '../dto';
+import { IProject, type Project } from '../dto';
 import { ProjectService } from '../project.service';
 import {
   type ExecuteProjectTransitionInput,
@@ -109,28 +109,5 @@ export class ProjectWorkflowService extends WorkflowService(
     await this.eventBus.publish(event);
 
     return this.projects.secure(event.project, session);
-  }
-
-  /** @deprecated */
-  async executeTransitionLegacy(
-    currentProject: Project,
-    step: ProjectStep,
-    session: Session,
-  ) {
-    const transitions = await this.getAvailableTransitions(
-      currentProject,
-      session,
-    );
-    // Pick the first matching to step.
-    // Lack of detail is one of the reasons why this is legacy logic.
-    const transition = transitions.find((t) => t.to === step);
-
-    await this.executeTransition(
-      {
-        project: currentProject.id,
-        ...(transition ? { transition: transition.key } : { bypassTo: step }),
-      },
-      session,
-    );
   }
 }

--- a/src/components/project/workflow/transitions/dynamic-step.ts
+++ b/src/components/project/workflow/transitions/dynamic-step.ts
@@ -8,7 +8,6 @@ export interface ResolveParams {
   project: MaybeSecured<Project>;
   previousStep?: Step;
   moduleRef: ModuleRef;
-  migrationPrevSteps?: ProjectStep[];
 }
 
 export const BackTo = (
@@ -16,10 +15,7 @@ export const BackTo = (
 ): DynamicState<Step, ResolveParams> => ({
   description: 'Back',
   relatedStates: steps,
-  async resolve({ project, moduleRef, migrationPrevSteps }) {
-    if (migrationPrevSteps) {
-      return migrationPrevSteps.find((s) => steps.includes(s)) ?? steps[0];
-    }
+  async resolve({ project, moduleRef }) {
     const repo = moduleRef.get(ProjectWorkflowRepository);
     const found = await repo.mostRecentStep(project.id, steps);
     return found ?? steps[0] ?? ProjectStep.EarlyConversations;


### PR DESCRIPTION
UI is migrated to new paths & doesn't reference these type names.