### PR TITLE
Neo4j order nulls last always

### DIFF
--- a/src/core/database/query/sorting.ts
+++ b/src/core/database/query/sorting.ts
@@ -67,7 +67,12 @@ export const sortWith = <Field extends string>(
     query.comment`sorting(${input.sort})`
       .subQuery('*', (sub) => matcher(sub, subInput))
       .with('*')
-      .orderBy(`${transformerRef.current('sortValue')}`, order);
+      .apply((query) => {
+        const val = String(transformerRef.current('sortValue'));
+        return order === 'ASC'
+          ? query.orderBy(val)
+          : query.orderBy([`${val} IS NOT NULL`, val], order);
+      });
 };
 
 /**


### PR DESCRIPTION
They were already last by default when sorting `ASC`, but neo4j defaults to putting them first when sorting `DESC`.
This changes `DESC` logic/query to have them also come last there.

```cql
order by name is not null desc, name desc
```
The first sort value is a boolean: nulls are 1, others are 0.
Following that sort normally on the value.