### PR TITLE
[Gel] - Add triggers to create/update periodic reports upon project creation

### DIFF
--- a/dbschema/periodic-report.gel
+++ b/dbschema/periodic-report.gel
@@ -3,6 +3,7 @@ module default {
     required period: range<cal::local_date>;
     `start` := range_get_lower(.period);
     `end` := date_range_get_upper(.period);
+    constraint expression on (.`end` >= .`start`);
     
     skippedReason: str;
     

--- a/dbschema/project.gel
+++ b/dbschema/project.gel
@@ -60,6 +60,7 @@ module default {
     status := Project::statusFromStep(.step);
     latestWorkflowEvent := (select .workflowEvents order by .at desc limit 1);
     workflowEvents := .<project[is Project::WorkflowEvent];
+
     trigger assertMatchingLatestWorkflowEvent after insert, update for each do (
       assert(
         __new__.latestWorkflowEvent.to ?= __new__.step
@@ -130,7 +131,13 @@ module default {
       }
     );
 
-    trigger createPeriodicReports after insert for each do (
+    trigger createPeriodicReports after insert for each 
+      when (
+        exists __new__.financialReportPeriod
+        and exists __new__.mouStart
+        and exists __new__.mouEnd
+      )  
+      do (
       with
         interval := (select 
           if __new__.financialReportPeriod = default::ReportPeriod.Monthly then '1' else '3'),
@@ -138,30 +145,9 @@ module default {
           __new__.mouStart,
           __new__.mouEnd,
           interval
-        )
-      for reportRange in reportRanges 
-      union (
-        (insert default::FinancialReport {
-          createdAt := datetime_of_statement(),
-          modifiedAt := datetime_of_statement(),
-          createdBy := assert_exists(global currentActor),
-          modifiedBy := assert_exists(global currentActor),
-          project := __new__,
-          projectContext := __new__.projectContext,
-          container := __new__,
-          period := reportRange
-        }),
-        (insert default::NarrativeReport {
-          createdAt := datetime_of_statement(),
-          modifiedAt := datetime_of_statement(),
-          createdBy := assert_exists(global currentActor),
-          modifiedBy := assert_exists(global currentActor),
-          project := __new__,
-          projectContext := __new__.projectContext,
-          container := __new__,
-          period := reportRange
-        })
-      )
+        ),
+        insertedReports := Project::insert_reports(array_agg(reportRanges), __new__)
+      select insertedReports
     );
 
     trigger addRemovePeriodicReports after update for each 
@@ -192,86 +178,44 @@ module default {
             select existingReports
             filter not exists .reportFile
         )  
-      select if not exists __new__.mouStart or not exists __new__.mouEnd then (     
+      select
+      # start date, end date, or financial report period were deleted
+      if not exists __new__.mouStart
+        or not exists __new__.mouEnd
+        or not exists __new__.financialReportPeriod then (
         for report in reportsForDeletion 
         union (
           delete report 
         )
       )
+      # financial report period changes, start date is moved forward, or end date is moved backward
       else if __old__.financialReportPeriod ?!= __new__.financialReportPeriod
         or (__new__.mouStart > __old__.mouStart) ?? false 
         or (__new__.mouEnd < __old__.mouEnd) ?? false then (
         with
-          requestedReportPeriodsForInsertion := (
-            select requestedReportPeriods
-            filter requestedReportPeriods not in existingReports.period
+          periodsForInsertion := Project::determine_requested_report_periods(
+            array_agg(requestedReportPeriods), 
+            array_agg(existingReports)
           ),
-          financialReports := (for reportPeriod in requestedReportPeriodsForInsertion
+          insertedReports := Project::insert_reports(array_agg(periodsForInsertion), __new__),
+          deletedReports := (for report in reportsForDeletion 
           union (
-            insert default::FinancialReport {
-              createdAt := datetime_of_statement(),
-              modifiedAt := datetime_of_statement(),
-              createdBy := assert_exists(global currentActor),
-              modifiedBy := assert_exists(global currentActor),
-              project := __new__,
-              projectContext := __new__.projectContext,
-              container := __new__,
-              period := reportPeriod,
-            }
-          )),
-          narrativeReports := (for reportPeriod in requestedReportPeriodsForInsertion
-          union (
-            insert default::NarrativeReport {
-              createdAt := datetime_of_statement(),
-              modifiedAt := datetime_of_statement(),
-              createdBy := assert_exists(global currentActor),
-              modifiedBy := assert_exists(global currentActor),
-              project := __new__,
-              projectContext := __new__.projectContext,
-              container := __new__,
-              period := reportPeriod,
-            }
+            delete report
+            filter report.period not in requestedReportPeriods
           ))
-        for report in reportsForDeletion 
-        union (
-          delete report
-          filter report.period not in requestedReportPeriods
-        )  
-      ) 
+        select insertedReports
+      )
+      # start or end dates otherwise change
       else if newMouStart ?!= oldMouStart 
         or newMouEnd ?!= oldMouEnd then (
         with
-          requestedReportPeriodsForInsertion := (
-            select requestedReportPeriods
-            filter requestedReportPeriods not in existingReports.period
-          ),
-          financialReports := (for reportPeriod in requestedReportPeriodsForInsertion
-          union (
-            insert default::FinancialReport {
-              createdAt := datetime_of_statement(),
-              modifiedAt := datetime_of_statement(),
-              createdBy := assert_exists(global currentActor),
-              modifiedBy := assert_exists(global currentActor),
-              project := __new__,
-              projectContext := __new__.projectContext,
-              container := __new__,
-              period := reportPeriod,
-            }
-          )),
-          narrativeReports := (for reportPeriod in requestedReportPeriodsForInsertion
-          union (
-            insert default::NarrativeReport {
-              createdAt := datetime_of_statement(),
-              modifiedAt := datetime_of_statement(),
-              createdBy := assert_exists(global currentActor),
-              modifiedBy := assert_exists(global currentActor),
-              project := __new__,
-              projectContext := __new__.projectContext,
-              container := __new__,
-              period := reportPeriod,
-            }
-          ))
-        select financialReports union narrativeReports
+          periodsForInsertion := Project::determine_requested_report_periods(
+            array_agg(requestedReportPeriods), 
+            array_agg(existingReports)
+          ),        
+          insertedReports := Project::insert_reports(array_agg(periodsForInsertion), __new__)
+        select insertedReports
+      # nothing changes
       ) else (
         select <PeriodicReport>{}
       )
@@ -375,47 +319,58 @@ module Project {
           for firstDayOfMonth in reportPeriodStartDates
           union (
             with
-              firstDayOfNextMonth := (select firstDayOfMonth + <cal::relative_duration>(monthInterval ++ ' month')),
-              lastDayOfMonth := firstDayOfNextMonth - <cal::relative_duration>'1 day'
-            select range(<cal::local_date>firstDayOfMonth, <cal::local_date>lastDayOfMonth)
-          ))
+              firstDayOfNextPeriod := (select firstDayOfMonth + <cal::relative_duration>(monthInterval ++ ' month')),
+            select range(<cal::local_date>firstDayOfMonth, <cal::local_date>firstDayOfNextPeriod)
+          )
+        )
       select reportPeriodRanges
   );
 
-  # function insertReports(requestedReportPeriods: set of range<cal::local_date>,
-  #   existingReports: array<PeriodicReport>, newProject: default::Project) -> optional str
-  #   using (
-  #     with
-  #       requestedReportPeriodsForInsertion := (
-  #         select requestedReportPeriods
-  #         filter requestedReportPeriods not in existingReports.period
-  #       ),
-  #       financialReports := (for reportPeriod in requestedReportPeriodsForInsertion
-  #       union (
-  #         insert default::FinancialReport {
-  #           createdAt := datetime_of_statement(),
-  #           modifiedAt := datetime_of_statement(),
-  #           createdBy := assert_exists(global default::currentActor),
-  #           modifiedBy := assert_exists(global default::currentActor),
-  #           project := __new__,
-  #           projectContext := __new__.projectContext,
-  #           container := __new__,
-  #           period := reportPeriod,
-  #         }
-  #       )),
-  #       narrativeReports := (for reportPeriod in requestedReportPeriodsForInsertion
-  #       union (
-  #         insert default::NarrativeReport {
-  #           createdAt := datetime_of_statement(),
-  #           modifiedAt := datetime_of_statement(),
-  #           createdBy := assert_exists(global default::currentActor),
-  #           modifiedBy := assert_exists(global default::currentActor),
-  #           project := __new__,
-  #           projectContext := __new__.projectContext,
-  #           container := __new__,
-  #           period := reportPeriod,
-  #         }
-  #       ))
-  #     select financialReports union narrativeReports
-  #   )
+  function determine_requested_report_periods(requestedReportPeriods: array<range<cal::local_date>>,
+    existingReports: array<default::PeriodicReport>) -> set of range<cal::local_date>
+    using (
+      with
+        distinctRequestedReportPeriods := distinct array_unpack(requestedReportPeriods),
+        periodsForInsertion := (
+          select distinctRequestedReportPeriods
+          filter distinctRequestedReportPeriods not in (
+            for report in array_unpack(existingReports)
+            select report.period
+          )
+        )
+     select periodsForInsertion
+  );
+
+  function insert_reports(requestedReportPeriodsForInsertion: array<range<cal::local_date>>,
+    newProject: default::Project) -> set of default::PeriodicReport
+    using (
+      with
+        financialReports := (for reportPeriod in array_unpack(requestedReportPeriodsForInsertion)
+        union (
+          insert default::FinancialReport {
+            createdAt := datetime_of_statement(),
+            modifiedAt := datetime_of_statement(),
+            createdBy := assert_exists(global default::currentActor),
+            modifiedBy := assert_exists(global default::currentActor),
+            project := newProject,
+            projectContext := newProject.projectContext,
+            container := newProject,
+            period := reportPeriod,
+          }
+        )),
+        narrativeReports := (for reportPeriod in array_unpack(requestedReportPeriodsForInsertion)
+        union (
+          insert default::NarrativeReport {
+            createdAt := datetime_of_statement(),
+            modifiedAt := datetime_of_statement(),
+            createdBy := assert_exists(global default::currentActor),
+            modifiedBy := assert_exists(global default::currentActor),
+            project := newProject,
+            projectContext := newProject.projectContext,
+            container := newProject,
+            period := reportPeriod,
+          }
+        ))
+      select financialReports union narrativeReports
+    );
 }

--- a/dbschema/project.gel
+++ b/dbschema/project.gel
@@ -322,8 +322,11 @@ module Project {
               firstDayOfNextPeriod := (select firstDayOfMonth + <cal::relative_duration>(monthInterval ++ ' month')),
             select range(<cal::local_date>firstDayOfMonth, <cal::local_date>firstDayOfNextPeriod)
           )
+        ),
+        additionalReportPeriodRange := (
+          select range(<cal::local_date>endDate, <cal::local_date>endDate, inc_upper := true)
         )
-      select reportPeriodRanges
+      select reportPeriodRanges union additionalReportPeriodRange
   );
 
   function determine_requested_report_periods(requestedReportPeriods: array<range<cal::local_date>>,

--- a/dbschema/project.gel
+++ b/dbschema/project.gel
@@ -132,22 +132,16 @@ module default {
     );
 
     trigger createPeriodicReports after insert for each 
-      when (
-        exists __new__.financialReportPeriod
-        and exists __new__.mouStart
-        and exists __new__.mouEnd
-      )  
-      do (
+    when (exists __new__.mouStart and exists __new__.mouEnd)  
+    do (
       with
-        interval := (select 
-          if __new__.financialReportPeriod = default::ReportPeriod.Monthly then '1' else '3'),
-        reportRanges := Project::create_periodic_report_ranges(
-          __new__.mouStart,
-          __new__.mouEnd,
-          interval
-        ),
-        insertedReports := Project::insert_reports(array_agg(reportRanges), __new__)
-      select insertedReports
+        insertedFinancialReports := Project::create_financial_reports(__new__, 
+          <array<FinancialReport>>{}),
+        insertedNarrativeReports := Project::create_narrative_reports(__new__,
+          <array<NarrativeReport>>{}),
+        insertedProgressReports := Project::create_progress_reports(__new__,
+          <array<ProgressReport>>{})      
+      select <PeriodicReport>{}
     );
 
     trigger addRemovePeriodicReports after update for each 
@@ -162,59 +156,97 @@ module default {
         oldMouStart := __old__.mouStart,
         newMouEnd := __new__.mouEnd,
         oldMouEnd := __old__.mouEnd,
-        existingReports := (
-          select FinancialReport union NarrativeReport
+        allReportRanges := Project::get_all_report_ranges(__new__),
+        financialReports := (
+          select default::FinancialReport
           filter .container.id = __old__.id
         ),
-        interval := (
-          select (if __new__.financialReportPeriod = default::ReportPeriod.Monthly then '1' else '3')
+        narrativeReports := (
+          select default::NarrativeReport
+          filter .container.id = __old__.id
         ),
-        requestedReportPeriods := Project::create_periodic_report_ranges(
-          __new__.mouStart,
-          __new__.mouEnd,
-          interval
-        ),
-        reportsForDeletion := (
-            select existingReports
+        progressReports := (
+          select default::ProgressReport
+          filter .container.id = __old__.id
+        ),                
+        allReports := (
+          select PeriodicReport
+          filter .container.id = __old__.id
+        ),        
+        financialReportsForDeletion := (
+            select financialReports
             filter not exists .reportFile
-        )  
-      select
-      # start date, end date, or financial report period were deleted
-      if not exists __new__.mouStart
-        or not exists __new__.mouEnd
-        or not exists __new__.financialReportPeriod then (
-        for report in reportsForDeletion 
-        union (
-          delete report 
+        ),                 
+        allReportsForDeletion := (
+            select allReports
+            filter not exists .reportFile
         )
-      )
-      # financial report period changes, start date is moved forward, or end date is moved backward
-      else if __old__.financialReportPeriod ?!= __new__.financialReportPeriod
-        or (__new__.mouStart > __old__.mouStart) ?? false 
-        or (__new__.mouEnd < __old__.mouEnd) ?? false then (
+      select
+      # start or end date was deleted - delete all reports
+      if not exists __new__.mouStart or not exists __new__.mouEnd then (
+       for report in allReportsForDeletion
+        union (
+          delete report
+        )
+      # financial report period was deleted - delete financial reports
+      ) else if not exists __new__.financialReportPeriod then (
+        for report in financialReportsForDeletion 
+        union (
+          delete report
+        )
+      # start date is moved forward (contraction) - delete all reports that are not in the new range
+      ) else if (__new__.mouStart > __old__.mouStart) ?? false then (
+        for report in allReportsForDeletion  
+        union (
+          delete report
+          filter report.period not in (allReportRanges)
+        )
+      # end date is moved backward (contraction) - delete all reports that are not in the new range
+      # and add an additional report period range
+      ) else if (__new__.mouEnd < __old__.mouEnd) ?? false then (
         with
-          periodsForInsertion := Project::determine_requested_report_periods(
-            array_agg(requestedReportPeriods), 
-            array_agg(existingReports)
-          ),
-          insertedReports := Project::insert_reports(array_agg(periodsForInsertion), __new__),
-          deletedReports := (for report in reportsForDeletion 
-          union (
-            delete report
-            filter report.period not in requestedReportPeriods
-          ))
-        select insertedReports
-      )
-      # start or end dates otherwise change
-      else if newMouStart ?!= oldMouStart 
-        or newMouEnd ?!= oldMouEnd then (
+          deletedReports := (
+            for report in allReportsForDeletion  
+            union (
+              delete report
+              filter report.period not in (allReportRanges)
+            )),
+          additionalReportPeriodRange := (select range(<cal::local_date>newMouEnd, <cal::local_date>newMouEnd, inc_upper := true)),
+          insertedFinancialReports := Project::insert_financial_reports(__new__, array_agg(additionalReportPeriodRange)),
+          insertedNarrativeReports := Project::insert_narrative_reports(__new__, array_agg(additionalReportPeriodRange)),
+          insertedProgressReports := Project::insert_progress_reports(__new__, array_agg(additionalReportPeriodRange))
+        select <PeriodicReport>{}
+      # financial report period changes - delete all financial reports and insert new ones
+      ) else if __old__.financialReportPeriod ?!= __new__.financialReportPeriod then (
         with
-          periodsForInsertion := Project::determine_requested_report_periods(
-            array_agg(requestedReportPeriods), 
-            array_agg(existingReports)
-          ),        
-          insertedReports := Project::insert_reports(array_agg(periodsForInsertion), __new__)
-        select insertedReports
+          deletedFinancialReports := (
+            for report in financialReportsForDeletion 
+            union (
+              delete report
+              filter ( .`start` != .`end` ) # keep additional report (it's still applicable)
+            )),
+          insertedFinancialReports := Project::create_financial_reports(__new__, array_agg(financialReports))
+       select <PeriodicReport>{} 
+      # start date is moved backwards (expansion) - insert new reports
+      ) else if newMouStart < oldMouStart then (
+        with
+          insertedFinancialReports := Project::create_financial_reports(__new__, array_agg(financialReports)),
+          insertedNarrativeReports := Project::create_narrative_reports(__new__, array_agg(narrativeReports)),
+          insertedProgressReports := Project::create_progress_reports(__new__, array_agg(progressReports))
+        select <PeriodicReport>{}
+      # end date is moved forward (expansion) - delete existing additional report and insert new reports
+      ) else if newMouEnd > oldMouEnd then (
+        with
+          deletedAdditionalReports := (
+            for report in allReportsForDeletion
+            union (
+              delete report
+              filter ( .`start` = .`end` )
+            )),
+          insertedFinancialReports := Project::create_financial_reports(__new__, array_agg(financialReports)),
+          insertedNarrativeReports := Project::create_narrative_reports(__new__, array_agg(narrativeReports)),
+          insertedProgressReports := Project::create_progress_reports(__new__, array_agg(progressReports))
+        select <PeriodicReport>{}
       # nothing changes
       ) else (
         select <PeriodicReport>{}
@@ -308,72 +340,186 @@ module Project {
     };
   }
 
-  # creates the ranges for the given start and end dates based upon the given month interval
-  function create_periodic_report_ranges(startDate: cal::local_date, endDate: cal::local_date, 
-    monthInterval: str) -> set of range<cal::local_date>
+  # creates the ranges for the given start and end dates based upon the given month interval,
+  # and creates a single additional range that is bound by the given end date, with the upper 
+  # bound inclusive
+  function create_periodic_report_ranges(project: default::Project, monthInterval: str) 
+    -> set of range<cal::local_date>
+    using (
+      select
+      if not exists project.mouStart or not exists project.mouEnd or not exists monthInterval then (
+        select <range<cal::local_date>>{}
+      ) else ( 
+        with
+          reportingPeriod := range(<cal::local_date>project.mouStart, <cal::local_date>project.mouEnd),
+          reportPeriodStartDates := range_unpack(reportingPeriod, <cal::date_duration>(monthInterval ++ ' month')),
+          reportPeriodRanges := (
+            for firstDayOfMonth in reportPeriodStartDates
+            union (
+              with
+                firstDayOfNextPeriod := (select firstDayOfMonth + <cal::relative_duration>(monthInterval ++ ' month')),
+              select range(<cal::local_date>firstDayOfMonth, <cal::local_date>firstDayOfNextPeriod)
+            )
+          ),
+          additionalReportPeriodRange := (select range(<cal::local_date>project.mouEnd, <cal::local_date>project.mouEnd, inc_upper := true))
+        select reportPeriodRanges union additionalReportPeriodRange
+      )
+  );
+
+  function get_all_report_ranges(project: default::Project) -> set of range<cal::local_date> {
     using (
       with
-        reportingPeriod := range(<cal::local_date>startDate, <cal::local_date>endDate),
-        reportPeriodStartDates := range_unpack(reportingPeriod, <cal::date_duration>(monthInterval ++ ' month')),
-        reportPeriodRanges := (
-          for firstDayOfMonth in reportPeriodStartDates
+        monthlyReportRanges := (
+          select Project::create_periodic_report_ranges(assert_exists(project), '1')
+        ),        
+        quarterlyReportRanges := (
+          select Project::create_periodic_report_ranges(assert_exists(project), '3')
+        )
+      select monthlyReportRanges union quarterlyReportRanges
+    );
+  }
+
+  function determine_requested_report_periods(monthInterval: str, newProject: default::Project,
+    existingReports: optional array<default::PeriodicReport>) -> set of range<cal::local_date> {
+    volatility := 'Modifying';
+    using (
+      with
+        requestedReportPeriods := Project::create_periodic_report_ranges(newProject, monthInterval),
+        distinctRequestedReportPeriods := distinct requestedReportPeriods
+      select
+      if exists existingReports then (
+        with
+          newReportPeriodsOnly := (
+            select distinctRequestedReportPeriods
+            # filter out report periods that already exist in current reports
+            filter distinctRequestedReportPeriods not in (
+              for report in array_unpack(existingReports)
+              select report.period
+            )
+          ),
+        select newReportPeriodsOnly
+      ) else (
+        select distinctRequestedReportPeriods
+      )
+    );
+  }
+
+  function create_financial_reports(newProject: default::Project,    
+    financialReports: optional array<default::FinancialReport>) -> set of default::FinancialReport
+    using (
+      select
+      if exists newProject.financialReportPeriod then (
+        with
+          periodsForInsertion := (
+            select
+            if newProject.financialReportPeriod ?= default::ReportPeriod.Monthly then (
+              select Project::determine_requested_report_periods(
+                 '1',
+                  newProject,
+                  financialReports
+                )
+            ) else (
+              select Project::determine_requested_report_periods(
+                '3',
+                newProject,
+                financialReports
+              ) 
+            )
+          ),
+          project := newProject
+        select Project::insert_financial_reports(project, array_agg(periodsForInsertion))
+      ) else (
+        select <default::FinancialReport>{}
+      )
+    );
+
+  function create_narrative_reports(newProject: default::Project,
+    narrativeReports: optional array<default::NarrativeReport>) -> set of default::NarrativeReport
+    using (
+      with
+        periodsForInsertion := Project::determine_requested_report_periods(
+          '3',
+          newProject,
+          narrativeReports
+        )
+        select Project::insert_narrative_reports(newProject, array_agg(periodsForInsertion))
+    );
+
+  function create_progress_reports(newProject: default::Project,
+    progressReports: optional array<default::ProgressReport>) -> set of default::ProgressReport
+    using (
+      with
+        periodsForInsertion := Project::determine_requested_report_periods(
+          '3',
+          newProject,
+          progressReports
+        )
+        select Project::insert_progress_reports(newProject, array_agg(periodsForInsertion))
+    );
+
+  function insert_financial_reports(newProject: default::Project,
+    periodsForInsertion: array<range<cal::local_date>>) -> set of default::FinancialReport
+    using (
+      for reportPeriod in array_unpack(periodsForInsertion)
+      union (
+        insert default::FinancialReport {
+          createdAt := datetime_of_statement(),
+          modifiedAt := datetime_of_statement(),
+          createdBy := assert_exists(global default::currentActor),
+          modifiedBy := assert_exists(global default::currentActor),
+          project := newProject,
+          projectContext := newProject.projectContext,
+          container := newProject,
+          period := reportPeriod,
+        }
+      )
+    );
+
+  function insert_narrative_reports(newProject: default::Project,
+    periodsForInsertion: array<range<cal::local_date>>) -> set of default::NarrativeReport
+    using (
+      for reportPeriod in array_unpack(periodsForInsertion)
+      union (
+        insert default::NarrativeReport {
+          createdAt := datetime_of_statement(),
+          modifiedAt := datetime_of_statement(),
+          createdBy := assert_exists(global default::currentActor),
+          modifiedBy := assert_exists(global default::currentActor),
+          project := newProject,
+          projectContext := newProject.projectContext,
+          container := newProject,
+          period := reportPeriod,
+        }
+      )
+    );
+
+  function insert_progress_reports(newProject: default::Project,
+    periodsForInsertion: array<range<cal::local_date>>) -> set of default::ProgressReport
+    using (
+      with
+        projectWithEngagements := (
+          select newProject {
+            engagements := .<project[is default::LanguageEngagement]
+          }
+        )
+      select (
+        for reportPeriod in array_unpack(periodsForInsertion)
+        union (
+          for engagement in projectWithEngagements.engagements
           union (
-            with
-              firstDayOfNextPeriod := (select firstDayOfMonth + <cal::relative_duration>(monthInterval ++ ' month')),
-            select range(<cal::local_date>firstDayOfMonth, <cal::local_date>firstDayOfNextPeriod)
-          )
-        ),
-        additionalReportPeriodRange := (
-          select range(<cal::local_date>endDate, <cal::local_date>endDate, inc_upper := true)
-        )
-      select reportPeriodRanges union additionalReportPeriodRange
-  );
-
-  function determine_requested_report_periods(requestedReportPeriods: array<range<cal::local_date>>,
-    existingReports: array<default::PeriodicReport>) -> set of range<cal::local_date>
-    using (
-      with
-        distinctRequestedReportPeriods := distinct array_unpack(requestedReportPeriods),
-        periodsForInsertion := (
-          select distinctRequestedReportPeriods
-          filter distinctRequestedReportPeriods not in (
-            for report in array_unpack(existingReports)
-            select report.period
+            insert default::ProgressReport {
+              createdAt := datetime_of_statement(),
+              modifiedAt := datetime_of_statement(),
+              createdBy := assert_exists(global default::currentActor),
+              modifiedBy := assert_exists(global default::currentActor),
+              project := newProject,
+              projectContext := newProject.projectContext,
+              engagement := engagement,
+              container := engagement,
+              period := reportPeriod,
+            }
           )
         )
-     select periodsForInsertion
-  );
-
-  function insert_reports(requestedReportPeriodsForInsertion: array<range<cal::local_date>>,
-    newProject: default::Project) -> set of default::PeriodicReport
-    using (
-      with
-        financialReports := (for reportPeriod in array_unpack(requestedReportPeriodsForInsertion)
-        union (
-          insert default::FinancialReport {
-            createdAt := datetime_of_statement(),
-            modifiedAt := datetime_of_statement(),
-            createdBy := assert_exists(global default::currentActor),
-            modifiedBy := assert_exists(global default::currentActor),
-            project := newProject,
-            projectContext := newProject.projectContext,
-            container := newProject,
-            period := reportPeriod,
-          }
-        )),
-        narrativeReports := (for reportPeriod in array_unpack(requestedReportPeriodsForInsertion)
-        union (
-          insert default::NarrativeReport {
-            createdAt := datetime_of_statement(),
-            modifiedAt := datetime_of_statement(),
-            createdBy := assert_exists(global default::currentActor),
-            modifiedBy := assert_exists(global default::currentActor),
-            project := newProject,
-            projectContext := newProject.projectContext,
-            container := newProject,
-            period := reportPeriod,
-          }
-        ))
-      select financialReports union narrativeReports
+      )
     );
 }

--- a/dbschema/project.gel
+++ b/dbschema/project.gel
@@ -130,7 +130,7 @@ module default {
       }
     );
 
-    trigger createPeriodicReportsOnInsert after insert for each do (
+    trigger createPeriodicReports after insert for each do (
       with
         interval := (select 
           if __new__.financialReportPeriod = default::ReportPeriod.Monthly then '1' else '3'),
@@ -150,7 +150,6 @@ module default {
           projectContext := __new__.projectContext,
           container := __new__,
           period := reportRange
-          #receivedDate := __new__.financialReportReceivedAt, //TODO - what is this at the project level?
         }),
         (insert default::NarrativeReport {
           createdAt := datetime_of_statement(),
@@ -163,7 +162,120 @@ module default {
           period := reportRange
         })
       )
-    )
+    );
+
+    trigger addRemovePeriodicReports after update for each 
+      when (
+        __old__.mouStart ?!= __new__.mouStart
+        or __old__.mouEnd ?!= __new__.mouEnd
+        or __old__.financialReportPeriod ?!= __new__.financialReportPeriod
+      ) 
+      do (
+      with
+        newMouStart := __new__.mouStart,
+        oldMouStart := __old__.mouStart,
+        newMouEnd := __new__.mouEnd,
+        oldMouEnd := __old__.mouEnd,
+        existingReports := (
+          select FinancialReport union NarrativeReport
+          filter .container.id = __old__.id
+        ),
+        interval := (
+          select (if __new__.financialReportPeriod = default::ReportPeriod.Monthly then '1' else '3')
+        ),
+        requestedReportPeriods := Project::create_periodic_report_ranges(
+          __new__.mouStart,
+          __new__.mouEnd,
+          interval
+        ),
+        reportsForDeletion := (
+            select existingReports
+            filter not exists .reportFile
+        )  
+      select if not exists __new__.mouStart or not exists __new__.mouEnd then (     
+        for report in reportsForDeletion 
+        union (
+          delete report 
+        )
+      )
+      else if __old__.financialReportPeriod ?!= __new__.financialReportPeriod
+        or (__new__.mouStart > __old__.mouStart) ?? false 
+        or (__new__.mouEnd < __old__.mouEnd) ?? false then (
+        with
+          requestedReportPeriodsForInsertion := (
+            select requestedReportPeriods
+            filter requestedReportPeriods not in existingReports.period
+          ),
+          financialReports := (for reportPeriod in requestedReportPeriodsForInsertion
+          union (
+            insert default::FinancialReport {
+              createdAt := datetime_of_statement(),
+              modifiedAt := datetime_of_statement(),
+              createdBy := assert_exists(global currentActor),
+              modifiedBy := assert_exists(global currentActor),
+              project := __new__,
+              projectContext := __new__.projectContext,
+              container := __new__,
+              period := reportPeriod,
+            }
+          )),
+          narrativeReports := (for reportPeriod in requestedReportPeriodsForInsertion
+          union (
+            insert default::NarrativeReport {
+              createdAt := datetime_of_statement(),
+              modifiedAt := datetime_of_statement(),
+              createdBy := assert_exists(global currentActor),
+              modifiedBy := assert_exists(global currentActor),
+              project := __new__,
+              projectContext := __new__.projectContext,
+              container := __new__,
+              period := reportPeriod,
+            }
+          ))
+        for report in reportsForDeletion 
+        union (
+          delete report
+          filter report.period not in requestedReportPeriods
+        )  
+      ) 
+      else if newMouStart ?!= oldMouStart 
+        or newMouEnd ?!= oldMouEnd then (
+        with
+          requestedReportPeriodsForInsertion := (
+            select requestedReportPeriods
+            filter requestedReportPeriods not in existingReports.period
+          ),
+          financialReports := (for reportPeriod in requestedReportPeriodsForInsertion
+          union (
+            insert default::FinancialReport {
+              createdAt := datetime_of_statement(),
+              modifiedAt := datetime_of_statement(),
+              createdBy := assert_exists(global currentActor),
+              modifiedBy := assert_exists(global currentActor),
+              project := __new__,
+              projectContext := __new__.projectContext,
+              container := __new__,
+              period := reportPeriod,
+            }
+          )),
+          narrativeReports := (for reportPeriod in requestedReportPeriodsForInsertion
+          union (
+            insert default::NarrativeReport {
+              createdAt := datetime_of_statement(),
+              modifiedAt := datetime_of_statement(),
+              createdBy := assert_exists(global currentActor),
+              modifiedBy := assert_exists(global currentActor),
+              project := __new__,
+              projectContext := __new__.projectContext,
+              container := __new__,
+              period := reportPeriod,
+            }
+          ))
+        select financialReports union narrativeReports
+      ) else (
+        select <PeriodicReport>{}
+      )
+    );
   }
   
   abstract type TranslationProject extending Project {
@@ -268,5 +380,42 @@ module Project {
             select range(<cal::local_date>firstDayOfMonth, <cal::local_date>lastDayOfMonth)
           ))
       select reportPeriodRanges
-  )
+  );
+
+  # function insertReports(requestedReportPeriods: set of range<cal::local_date>,
+  #   existingReports: array<PeriodicReport>, newProject: default::Project) -> optional str
+  #   using (
+  #     with
+  #       requestedReportPeriodsForInsertion := (
+  #         select requestedReportPeriods
+  #         filter requestedReportPeriods not in existingReports.period
+  #       ),
+  #       financialReports := (for reportPeriod in requestedReportPeriodsForInsertion
+  #       union (
+  #         insert default::FinancialReport {
+  #           createdAt := datetime_of_statement(),
+  #           modifiedAt := datetime_of_statement(),
+  #           createdBy := assert_exists(global default::currentActor),
+  #           modifiedBy := assert_exists(global default::currentActor),
+  #           project := __new__,
+  #           projectContext := __new__.projectContext,
+  #           container := __new__,
+  #           period := reportPeriod,
+  #         }
+  #       )),
+  #       narrativeReports := (for reportPeriod in requestedReportPeriodsForInsertion
+  #       union (
+  #         insert default::NarrativeReport {
+  #           createdAt := datetime_of_statement(),
+  #           modifiedAt := datetime_of_statement(),
+  #           createdBy := assert_exists(global default::currentActor),
+  #           modifiedBy := assert_exists(global default::currentActor),
+  #           project := __new__,
+  #           projectContext := __new__.projectContext,
+  #           container := __new__,
+  #           period := reportPeriod,
+  #         }
+  #       ))
+  #     select financialReports union narrativeReports
+  #   )
 }

--- a/dbschema/project.gel
+++ b/dbschema/project.gel
@@ -129,6 +129,41 @@ module default {
         projectContext := __new__.projectContext,
       }
     );
+
+    trigger createPeriodicReportsOnInsert after insert for each do (
+      with
+        interval := (select 
+          if __new__.financialReportPeriod = default::ReportPeriod.Monthly then '1' else '3'),
+        reportRanges := Project::create_periodic_report_ranges(
+          __new__.mouStart,
+          __new__.mouEnd,
+          interval
+        )
+      for reportRange in reportRanges 
+      union (
+        (insert default::FinancialReport {
+          createdAt := datetime_of_statement(),
+          modifiedAt := datetime_of_statement(),
+          createdBy := assert_exists(global currentActor),
+          modifiedBy := assert_exists(global currentActor),
+          project := __new__,
+          projectContext := __new__.projectContext,
+          container := __new__,
+          period := reportRange
+          #receivedDate := __new__.financialReportReceivedAt, //TODO - what is this at the project level?
+        }),
+        (insert default::NarrativeReport {
+          createdAt := datetime_of_statement(),
+          modifiedAt := datetime_of_statement(),
+          createdBy := assert_exists(global currentActor),
+          modifiedBy := assert_exists(global currentActor),
+          project := __new__,
+          projectContext := __new__.projectContext,
+          container := __new__,
+          period := reportRange
+        })
+      )
+    )
   }
   
   abstract type TranslationProject extending Project {
@@ -216,4 +251,22 @@ module Project {
       on target delete allow;
     };
   }
+
+  # creates the ranges for the given start and end dates based upon the given month interval
+  function create_periodic_report_ranges(startDate: cal::local_date, endDate: cal::local_date, 
+    monthInterval: str) -> set of range<cal::local_date>
+    using (
+      with
+        reportingPeriod := range(<cal::local_date>startDate, <cal::local_date>endDate),
+        reportPeriodStartDates := range_unpack(reportingPeriod, <cal::date_duration>(monthInterval ++ ' month')),
+        reportPeriodRanges := (
+          for firstDayOfMonth in reportPeriodStartDates
+          union (
+            with
+              firstDayOfNextMonth := (select firstDayOfMonth + <cal::relative_duration>(monthInterval ++ ' month')),
+              lastDayOfMonth := firstDayOfNextMonth - <cal::relative_duration>'1 day'
+            select range(<cal::local_date>firstDayOfMonth, <cal::local_date>lastDayOfMonth)
+          ))
+      select reportPeriodRanges
+  )
 }


### PR DESCRIPTION
Closes #3478.

## Description
This adds `createPeriodicReports` and `addRemovePeriodicReports` triggers to create/update the appropriate number of periodic reports when a project is created, based upon project `mouStart`, `mouEnd`, and `financialReportPeriod`.

Open items:

- [ ] The biggest issue now is that only single points of change are accounted for in these triggers.  Meaning that an mou project start date change will be handled, and an mou project end date change will be handled, but if both change at the same time the update trigger might not handle that appropriately.  All single field updates are tested and accounted for however.
- [ ] Some functions could potentially be combined to take advantage of polymorphism, however, in practice this has caused issues
- [ ] Naming?
- [ ] Function refactoring for more concise code?