### PR TITLE
[EdgeDB] Polymorphic queries & Engagement Repo

### DIFF
--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -51,7 +51,20 @@ module default {
     property firstScripture := (
       exists .language.firstScriptureEngagement
     );
-    
+
+    trigger denyDuplicateFirstScriptureBasedOnExternal after insert, update for each do ( 
+      assert(
+        not __new__.firstScripture or not exists __new__.language.hasExternalFirstScripture,
+        message := "First scripture has already been marked as having been done externally"
+      )
+    );
+    trigger denyDuplicateFirstScriptureBasedOnOtherEngagement after insert, update for each do (
+      assert( 
+        not exists (select __new__.language.engagements filter .firstScripture),
+        message := "Another engagement has already been marked as having done the first scripture"
+      )
+    );
+
     required lukePartnership: bool {
       default := false;
     };

--- a/dbschema/engagement.esdl
+++ b/dbschema/engagement.esdl
@@ -24,7 +24,7 @@ module default {
       .<engagement[is Engagement::Ceremony]
     ));
     
-    completedDate: cal::local_date {
+    completeDate: cal::local_date {
       annotation description := "Translation / Growth Plan complete date";
     }
     disbursementCompleteDate: cal::local_date;

--- a/dbschema/migrations/00005-m1yeyjr.edgeql
+++ b/dbschema/migrations/00005-m1yeyjr.edgeql
@@ -1,0 +1,21 @@
+CREATE MIGRATION m1yeyjrzkznhb2fr4txj432k3nlumdnjwsdyuhinrfmt64je5lwfta
+    ONTO m1yphrx7buk7mltbmsuabovma34ukfn7dkllc3pfggljlkadasw2gq
+{
+  ALTER TYPE default::Engagement {
+      ALTER PROPERTY completedDate {
+          RENAME TO completeDate;
+      };
+  };
+  ALTER TYPE default::LanguageEngagement {
+      CREATE TRIGGER denyDuplicateFirstScriptureBasedOnExternal
+          AFTER UPDATE, INSERT 
+          FOR EACH DO (std::assert((NOT (__new__.firstScripture) OR NOT (EXISTS (__new__.language.hasExternalFirstScripture))), message := 'First scripture has already been marked as having been done externally'));
+      CREATE TRIGGER denyDuplicateFirstScriptureBasedOnOtherEngagement
+          AFTER UPDATE, INSERT 
+          FOR EACH DO (std::assert(NOT (EXISTS ((SELECT
+              __new__.language.engagements
+          FILTER
+              .firstScripture
+          ))), message := 'Another engagement has already been marked as having done the first scripture'));
+  };
+};

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "cypher-query-builder": "patch:cypher-query-builder@npm%3A6.0.4#~/.yarn/patches/cypher-query-builder-npm-6.0.4-e8707a5e8e.patch",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",
-    "edgedb": "^1.6.0-canary.20240506T235920",
+    "edgedb": "^1.6.0-canary.20240827T111834",
     "execa": "^8.0.1",
     "express": "^4.18.2",
     "extensionless": "^1.7.0",
@@ -107,7 +107,7 @@
     "yaml": "^2.3.3"
   },
   "devDependencies": {
-    "@edgedb/generate": "^0.6.0-canary.20240506T235941",
+    "@edgedb/generate": "github:CarsonF/edgedb-js#workspace=@edgedb/generate&head=temp-host",
     "@nestjs/cli": "^10.2.1",
     "@nestjs/schematics": "^10.0.3",
     "@nestjs/testing": "^10.2.7",

--- a/src/common/id-field.ts
+++ b/src/common/id-field.ts
@@ -2,11 +2,7 @@ import { applyDecorators } from '@nestjs/common';
 import { Field, FieldOptions, ID as IDType } from '@nestjs/graphql';
 import { ValidationOptions } from 'class-validator';
 import { IsAny, IsNever, Tagged } from 'type-fest';
-import type {
-  AllResourceDBNames,
-  ResourceName,
-  ResourceNameLike,
-} from '~/core';
+import type { ResourceName, ResourceNameLike } from '~/core';
 import { IsId } from './validators';
 
 export const IdField = ({
@@ -40,4 +36,4 @@ type IDTag<Kind> = IsAny<Kind> extends true
     : Kind
   : never;
 
-type IDKindLike = ResourceNameLike | AllResourceDBNames | object;
+type IDKindLike = ResourceNameLike | object;

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -319,7 +319,17 @@ export type DBType<TResourceStatic extends ResourceShape<any>> =
       : never
     : never;
 
+/**
+ * The name of the EdgeDB type, it could be abstract.
+ */
 export type DBName<T extends $.TypeSet> = T['__element__']['__name__'];
+/**
+ * The name(s) of the concrete EdgeDB types.
+ * If the type is abstract, then it is a string union of the concrete type's names.
+ * If the type is concrete, then it is just the name, just as {@link DBName}.
+ */
+export type DBNames<T extends $.ObjectTypeSet> =
+  T['__element__']['__polyTypenames__'];
 
 export type MaybeUnsecuredInstance<TResourceStatic extends ResourceShape<any>> =
   MaybeSecured<InstanceType<TResourceStatic>>;

--- a/src/components/ceremony/handlers/create-engagement-default-ceremony.handler.ts
+++ b/src/components/ceremony/handlers/create-engagement-default-ceremony.handler.ts
@@ -2,6 +2,7 @@ import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { ConfigService, EventsHandler, IEventHandler } from '~/core';
 import { DatabaseService } from '~/core/database';
+import { LanguageEngagement } from '../../engagement/dto';
 import { EngagementCreatedEvent } from '../../engagement/events';
 import { CeremonyService } from '../ceremony.service';
 import { CeremonyType } from '../dto';
@@ -20,7 +21,7 @@ export class CreateEngagementDefaultCeremonyHandler
     const { engagement } = event;
     const input = {
       type:
-        engagement.__typename === 'LanguageEngagement'
+        LanguageEngagement.resolve(engagement) === LanguageEngagement
           ? CeremonyType.Dedication
           : CeremonyType.Certification,
     };

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -63,6 +63,7 @@ class Engagement extends Interfaces {
   static readonly Props: string[] = keysOf<Engagement>();
   static readonly SecuredProps: string[] = keysOf<SecuredProps<Engagement>>();
   static readonly Parent = import('../../project/dto').then((m) => m.IProject);
+  static readonly resolve = resolveEngagementType;
 
   declare readonly __typename: 'LanguageEngagement' | 'InternshipEngagement';
 

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -222,6 +222,11 @@ export class InternshipEngagement extends Engagement {
 export const engagementRange = (engagement: UnsecuredDto<Engagement>) =>
   DateInterval.tryFrom(engagement.startDate, engagement.endDate);
 
+export const EngagementConcretes = {
+  LanguageEngagement,
+  InternshipEngagement,
+};
+
 declare module '~/core/resources/map' {
   interface ResourceMap {
     Engagement: typeof Engagement;

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -7,6 +7,7 @@ import {
   DateInterval,
   DateTimeField,
   DbLabel,
+  DBNames,
   IntersectTypes,
   parentIdMiddleware,
   Resource,
@@ -47,7 +48,7 @@ export type AnyEngagement = MergeExclusive<
 const Interfaces = IntersectTypes(Resource, ChangesetAware);
 
 export const resolveEngagementType = (val: Pick<AnyEngagement, '__typename'>) =>
-  val.__typename === 'LanguageEngagement'
+  val.__typename === 'default::LanguageEngagement'
     ? LanguageEngagement
     : InternshipEngagement;
 
@@ -65,7 +66,7 @@ class Engagement extends Interfaces {
   static readonly Parent = import('../../project/dto').then((m) => m.IProject);
   static readonly resolve = resolveEngagementType;
 
-  declare readonly __typename: 'LanguageEngagement' | 'InternshipEngagement';
+  declare readonly __typename: DBNames<typeof e.Engagement>;
 
   readonly project: LinkTo<'Project'> & Pick<IProject, 'status' | 'type'>;
 
@@ -155,7 +156,7 @@ export class LanguageEngagement extends Engagement {
     (m) => m.TranslationProject,
   );
 
-  declare readonly __typename: 'LanguageEngagement';
+  declare readonly __typename: DBNames<typeof e.LanguageEngagement>;
 
   @Field(() => TranslationProject)
   declare readonly parent: BaseNode;
@@ -196,7 +197,7 @@ export class InternshipEngagement extends Engagement {
     (m) => m.InternshipProject,
   );
 
-  declare readonly __typename: 'InternshipEngagement';
+  declare readonly __typename: DBNames<typeof e.InternshipEngagement>;
 
   @Field(() => InternshipProject)
   declare readonly parent: BaseNode;

--- a/src/components/engagement/engagement.edgedb.repository.ts
+++ b/src/components/engagement/engagement.edgedb.repository.ts
@@ -1,0 +1,130 @@
+import { Injectable, Type } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import { LazyGetter } from 'lazy-get-decorator';
+import { PublicOf } from '~/common';
+import { grabInstances } from '~/common/instance-maps';
+import { e, RepoFor } from '~/core/edgedb';
+import {
+  EngagementConcretes as ConcreteTypes,
+  CreateInternshipEngagement,
+  CreateLanguageEngagement,
+  IEngagement,
+  UpdateInternshipEngagement,
+  UpdateLanguageEngagement,
+} from './dto';
+import { EngagementRepository } from './engagement.repository';
+
+const baseHydrate = e.shape(e.Engagement, (engagement) => ({
+  ...engagement['*'],
+  __typename: engagement.__type__.name,
+  project: {
+    id: true,
+    status: true,
+    type: true,
+  },
+  parent: e.tuple({
+    identity: engagement.project.id,
+    labels: e.array_agg(e.set(engagement.project.__type__.name.slice(9, null))),
+    properties: e.tuple({
+      id: engagement.project.id,
+      createdAt: engagement.project.createdAt,
+    }),
+  }),
+  ceremony: true,
+  completeDate: engagement.completedDate, // TODO fix in schema
+}));
+
+const languageExtraHydrate = {
+  language: true,
+  firstScripture: true,
+  lukePartnership: true,
+  openToInvestorVisit: true,
+  sentPrintingDate: true,
+  paratextRegistryId: true,
+  pnp: true,
+  historicGoal: true,
+} as const;
+
+const internshipExtraHydrate = {
+  countryOfOrigin: true,
+  intern: true,
+  mentor: true,
+  position: true,
+  methodologies: true,
+  growthPlan: true,
+} as const;
+
+const languageHydrate = e.shape(e.LanguageEngagement, (le) => ({
+  ...baseHydrate(le),
+  __typename: le.__type__.name,
+  ...languageExtraHydrate,
+}));
+
+const internshipHydrate = e.shape(e.InternshipEngagement, (ie) => ({
+  ...baseHydrate(ie),
+  __typename: ie.__type__.name,
+  ...internshipExtraHydrate,
+}));
+
+const hydrate = e.shape(e.Engagement, (engagement) => ({
+  ...baseHydrate(engagement),
+  ...e.is(e.LanguageEngagement, languageExtraHydrate),
+  ...e.is(e.InternshipEngagement, internshipExtraHydrate),
+}));
+
+export const ConcreteRepos = {
+  LanguageEngagement: class LanguageEngagementRepository extends RepoFor(
+    ConcreteTypes.LanguageEngagement,
+    {
+      hydrate: languageHydrate,
+    },
+  ) {},
+
+  InternshipEngagement: class InternshipEngagementRepository extends RepoFor(
+    ConcreteTypes.InternshipEngagement,
+    {
+      hydrate: internshipHydrate,
+    },
+  ) {},
+} satisfies Record<keyof typeof ConcreteTypes, Type>;
+
+@Injectable()
+export class EngagementEdgeDBRepository
+  extends RepoFor(IEngagement, {
+    hydrate,
+    omit: ['create', 'update'],
+  })
+  implements PublicOf<EngagementRepository>
+{
+  constructor(private readonly moduleRef: ModuleRef) {
+    super();
+  }
+
+  @LazyGetter() protected get concretes() {
+    return grabInstances(this.moduleRef, ConcreteRepos);
+  }
+
+  async createLanguageEngagement(input: CreateLanguageEngagement) {
+    return await this.concretes.LanguageEngagement.create(input);
+  }
+
+  async createInternshipEngagement(input: CreateInternshipEngagement) {
+    return await this.concretes.InternshipEngagement.create(input);
+  }
+
+  get getActualLanguageChanges() {
+    return this.concretes.LanguageEngagement.getActualChanges;
+  }
+
+  get getActualInternshipChanges() {
+    return this.concretes.InternshipEngagement.getActualChanges;
+  }
+
+  async updateLanguage(input: UpdateLanguageEngagement) {
+    return await this.concretes.LanguageEngagement.update(input);
+  }
+
+  async updateInternship(input: UpdateInternshipEngagement) {
+    return await this.concretes.InternshipEngagement.update(input);
+  }
+}

--- a/src/components/engagement/engagement.edgedb.repository.ts
+++ b/src/components/engagement/engagement.edgedb.repository.ts
@@ -33,7 +33,7 @@ const baseHydrate = e.shape(e.Engagement, (engagement) => ({
     }),
   }),
   ceremony: true,
-  completeDate: engagement.completedDate, // TODO fix in schema
+  completeDate: true,
 }));
 
 const languageExtraHydrate = {

--- a/src/components/engagement/engagement.module.ts
+++ b/src/components/engagement/engagement.module.ts
@@ -1,4 +1,5 @@
 import { forwardRef, Module } from '@nestjs/common';
+import { splitDb } from '~/core';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { CeremonyModule } from '../ceremony/ceremony.module';
 import { FileModule } from '../file/file.module';
@@ -7,6 +8,7 @@ import { LocationModule } from '../location/location.module';
 import { ProductModule } from '../product/product.module';
 import { ProjectModule } from '../project/project.module';
 import { EngagementStatusResolver } from './engagement-status.resolver';
+import { EngagementEdgeDBRepository } from './engagement.edgedb.repository';
 import { EngagementLoader } from './engagement.loader';
 import { EngagementRepository } from './engagement.repository';
 import { EngagementResolver } from './engagement.resolver';
@@ -38,7 +40,7 @@ import { EngagementProductConnectionResolver } from './product-connection.resolv
     EngagementProductConnectionResolver,
     EngagementRules,
     EngagementService,
-    EngagementRepository,
+    splitDb(EngagementRepository, EngagementEdgeDBRepository),
     EngagementLoader,
     ...Object.values(handlers),
     FixNullMethodologiesMigration,

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -36,6 +36,7 @@ import {
   filter,
   FullTextIndex,
   INACTIVE,
+  listConcat,
   matchChangesetAndChangedProps,
   matchProjectSens,
   matchPropsAndProjectSensAndScopedRoles,
@@ -169,9 +170,12 @@ export class EngagementRepository extends CommonRepository {
         ])
         .return<{ dto: UnsecuredDto<Engagement> }>(
           merge('props', 'changedProps', {
-            __typename: typenameForView(
-              ['LanguageEngagement', 'InternshipEngagement'],
-              view,
+            __typename: listConcat(
+              '"default::"',
+              typenameForView(
+                ['LanguageEngagement', 'InternshipEngagement'],
+                view,
+              ),
             ),
             parent: 'project',
             project: {

--- a/src/components/engagement/engagement.resolver.ts
+++ b/src/components/engagement/engagement.resolver.ts
@@ -60,7 +60,7 @@ export class EngagementResolver {
     @Loader(EngagementLoader) engagements: LoaderOf<EngagementLoader>,
   ): Promise<Engagement> {
     const engagement = await engagements.load(key);
-    if (engagement.__typename !== 'LanguageEngagement') {
+    if (LanguageEngagement.resolve(engagement) !== LanguageEngagement) {
       throw new InvalidIdForTypeException();
     }
     return engagement;

--- a/src/components/engagement/events/engagement-created.event.ts
+++ b/src/components/engagement/events/engagement-created.event.ts
@@ -18,13 +18,13 @@ export class EngagementCreatedEvent {
     engagement: UnsecuredDto<LanguageEngagement>;
     input: CreateLanguageEngagement;
   } {
-    return this.engagement.__typename === 'LanguageEngagement';
+    return LanguageEngagement.resolve(this.engagement) === LanguageEngagement;
   }
 
   isInternshipEngagement(): this is EngagementCreatedEvent & {
     engagement: UnsecuredDto<InternshipEngagement>;
     input: CreateInternshipEngagement;
   } {
-    return this.engagement.__typename === 'InternshipEngagement';
+    return LanguageEngagement.resolve(this.engagement) === InternshipEngagement;
   }
 }

--- a/src/components/engagement/events/engagement-updated.event.ts
+++ b/src/components/engagement/events/engagement-updated.event.ts
@@ -19,13 +19,13 @@ export class EngagementUpdatedEvent {
     updated: UnsecuredDto<LanguageEngagement>;
     input: UpdateLanguageEngagement;
   } {
-    return this.updated.__typename === 'LanguageEngagement';
+    return LanguageEngagement.resolve(this.updated) === LanguageEngagement;
   }
 
   isInternshipEngagement(): this is EngagementUpdatedEvent & {
     updated: UnsecuredDto<InternshipEngagement>;
     input: UpdateInternshipEngagement;
   } {
-    return this.updated.__typename === 'InternshipEngagement';
+    return LanguageEngagement.resolve(this.updated) === InternshipEngagement;
   }
 }

--- a/src/components/engagement/handlers/set-initial-end-date.handler.ts
+++ b/src/components/engagement/handlers/set-initial-end-date.handler.ts
@@ -6,7 +6,7 @@ import {
   ILogger,
   Logger,
 } from '~/core';
-import { EngagementStatus } from '../dto';
+import { EngagementStatus, LanguageEngagement } from '../dto';
 import { EngagementRepository } from '../engagement.repository';
 import { EngagementService } from '../engagement.service';
 import { EngagementCreatedEvent, EngagementUpdatedEvent } from '../events';
@@ -49,7 +49,7 @@ export class SetInitialEndDate implements IEventHandler<SubscribedEvent> {
       const initialEndDate = engagement.endDate;
 
       const type =
-        engagement.__typename === 'LanguageEngagement'
+        LanguageEngagement.resolve(engagement) === LanguageEngagement
           ? 'Language'
           : 'Internship';
       await this.engagementRepo[`update${type}`](

--- a/src/components/engagement/handlers/set-last-status-date.handler.ts
+++ b/src/components/engagement/handlers/set-last-status-date.handler.ts
@@ -7,11 +7,7 @@ import {
   Logger,
 } from '~/core';
 import { DatabaseService } from '~/core/database';
-import {
-  EngagementStatus,
-  InternshipEngagement,
-  LanguageEngagement,
-} from '../dto';
+import { EngagementStatus, IEngagement } from '../dto';
 import { EngagementUpdatedEvent } from '../events';
 
 @EventsHandler(EngagementUpdatedEvent)
@@ -48,10 +44,7 @@ export class SetLastStatusDate
       } as const;
 
       event.updated = await this.db.updateProperties({
-        type:
-          updated.__typename === 'LanguageEngagement'
-            ? LanguageEngagement
-            : InternshipEngagement,
+        type: IEngagement.resolve(updated),
         object: updated,
         changes,
       });

--- a/src/core/edgedb/dto.repository.ts
+++ b/src/core/edgedb/dto.repository.ts
@@ -66,7 +66,9 @@ export const RepoFor = <
     $.ObjectType<
       DBName<Root>,
       Root['__element__']['__pointers__'],
-      normaliseShape<HydratedShape>
+      normaliseShape<HydratedShape>,
+      Root['__element__']['__exclusives__'],
+      Root['__element__']['__polyTypenames__']
     >
   >;
 
@@ -198,7 +200,7 @@ export const RepoFor = <
         limit: input.count,
       }));
       const query = e.select({
-        items,
+        items: items as any,
         total: e.count(listOfAllQuery),
         hasMore: e.op(e.count(thisPage), '>', input.count),
       });

--- a/src/core/edgedb/index.ts
+++ b/src/core/edgedb/index.ts
@@ -9,3 +9,12 @@ export * from './common.repository';
 export * from './dto.repository';
 export * from './query-util/disable-access-policies.option';
 export * from './query-util/cast-to-enum';
+
+declare module './generated-client/typesystem' {
+  export interface SetTypesystemOptions {
+    future: {
+      polymorphismAsDiscriminatedUnions: true;
+      strictTypeNames: true;
+    };
+  }
+}

--- a/src/core/resources/resource-name.types.ts
+++ b/src/core/resources/resource-name.types.ts
@@ -2,8 +2,9 @@ import { ConditionalKeys, IsAny, LiteralUnion, ValueOf } from 'type-fest';
 import { DBName, ResourceShape } from '~/common';
 import { ResourceDBMap, ResourceMap } from './map';
 
-export type AllResourceNames = keyof ResourceMap;
+export type AllResourceAppNames = keyof ResourceMap;
 export type AllResourceDBNames = DBName<ValueOf<ResourceDBMap>>;
+export type AllResourceNames = AllResourceAppNames | AllResourceDBNames;
 export type ResourceNameLike = LiteralUnion<AllResourceNames, string>;
 
 //region ResourceName
@@ -32,13 +33,13 @@ export type ResourceName<
   T,
   IncludeSubclasses extends boolean = false,
 > = IsAny<T> extends true
-  ? AllResourceNames // short-circuit and prevent many seemly random circular definitions
+  ? AllResourceAppNames // short-circuit and prevent many seemly random circular definitions
   : T extends AllResourceDBNames
   ? ResourceNameFromStatic<
       ResourceMap[ResourceNameFromDBName<T>],
       IncludeSubclasses
     >
-  : T extends AllResourceNames
+  : T extends AllResourceAppNames
   ? ResourceNameFromStatic<ResourceMap[T], IncludeSubclasses>
   : T extends ResourceShape<any>
   ? ResourceNameFromStatic<T, IncludeSubclasses>

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -14,7 +14,6 @@ import {
 import { ResourceMap } from './map';
 import { __privateDontUseThis } from './resource-map-holder';
 import {
-  AllResourceDBNames,
   ResourceName,
   ResourceNameLike,
   ResourceStaticFromName,
@@ -70,7 +69,7 @@ export class ResourcesHost {
     return this.getByName(name as any);
   }
 
-  getByEdgeDB<Name extends ResourceNameLike | AllResourceDBNames>(
+  getByEdgeDB<Name extends ResourceNameLike>(
     name: Name,
   ): EnhancedResource<
     string extends Name

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -30,7 +30,9 @@ export type ResourceLike =
 
 @Injectable()
 export class ResourcesHost {
-  constructor(private readonly gqlSchema: GraphQLSchemaHost) {}
+  constructor(private readonly gqlSchema: GraphQLSchemaHost) {
+    EnhancedResource.resourcesHost = this;
+  }
 
   getMap() {
     // @ts-expect-error Yeah we are assuming each type has been correctly

--- a/yarn.lock
+++ b/yarn.lock
@@ -1485,16 +1485,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@edgedb/generate@npm:^0.6.0-canary.20240506T235941":
-  version: 0.6.0-canary.20240506T235941
-  resolution: "@edgedb/generate@npm:0.6.0-canary.20240506T235941"
+"@edgedb/generate@github:CarsonF/edgedb-js#workspace=@edgedb/generate&head=temp-host":
+  version: 0.5.5
+  resolution: "@edgedb/generate@https://github.com/CarsonF/edgedb-js.git#workspace=%40edgedb%2Fgenerate&commit=4c238572cae9762323c5ed359f399f6c76c3d2e5"
   dependencies:
     "@iarna/toml": "npm:^2.2.5"
+    debug: "npm:^4.3.4"
   peerDependencies:
-    edgedb: ^1.5.0
+    edgedb: ^1.5.10
   bin:
     generate: dist/cli.js
-  checksum: 10c0/67f42c695caa0d586f62bd62d1d5ffd810d78bdc60f88d2135cb6fec3f065a31f2e69a45ca8745be05f9f881f22d739f2f8053505354dba497876c3742fb2d8a
+  checksum: 10c0/b6527c8d92b53be49c4d859b2267224f52651eaf53fed5120a3954c6f1b82b6b1cb8afc4e1d99ee936f02be914d944ca69e39d057d618d456090e19d9756c49a
   languageName: node
   linkType: hard
 
@@ -5339,7 +5340,7 @@ __metadata:
     "@apollo/subgraph": "npm:^2.5.6"
     "@aws-sdk/client-s3": "npm:^3.440.0"
     "@aws-sdk/s3-request-presigner": "npm:^3.440.0"
-    "@edgedb/generate": "npm:^0.6.0-canary.20240506T235941"
+    "@edgedb/generate": "github:CarsonF/edgedb-js#workspace=@edgedb/generate&head=temp-host"
     "@faker-js/faker": "npm:^8.2.0"
     "@ffprobe-installer/ffprobe": "npm:^2.1.2"
     "@golevelup/nestjs-discovery": "npm:^4.0.0"
@@ -5390,7 +5391,7 @@ __metadata:
     debugger-is-attached: "npm:^1.2.0"
     dotenv: "npm:^16.3.1"
     dotenv-expand: "npm:^10.0.0"
-    edgedb: "npm:^1.6.0-canary.20240506T235920"
+    edgedb: "npm:^1.6.0-canary.20240827T111834"
     eslint: "npm:^8.52.0"
     eslint-plugin-no-only-tests: "npm:^3.1.0"
     eslint-plugin-typescript-sort-keys: "npm:^2.3.0"
@@ -5984,17 +5985,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"edgedb@npm:^1.6.0-canary.20240506T235920":
-  version: 1.6.0-canary.20240506T235920
-  resolution: "edgedb@npm:1.6.0-canary.20240506T235920"
+"edgedb@npm:^1.6.0-canary.20240827T111834":
+  version: 1.6.0-canary.20240827T111834
+  resolution: "edgedb@npm:1.6.0-canary.20240827T111834"
   dependencies:
     debug: "npm:^4.3.4"
     env-paths: "npm:^3.0.0"
-    semver: "npm:^7.6.0"
+    semver: "npm:^7.6.2"
+    shell-quote: "npm:^1.8.1"
     which: "npm:^4.0.0"
   bin:
     edgedb: dist/cli.mjs
-  checksum: 10c0/3bff45a41ac35a1b92a776caedb48d53d568c8e0b4a56f28405490b8e8570f5261b032fcb659914185def3c422c5ae944a5dcc3853d1efaf86b2eec7d60da98c
+  checksum: 10c0/9bdf05484f2bbffc398bd6ca75628b056baaa51114bbfecc72382fd593619510ae319adfe15879138a90f64ff52ab9b159a87bed0472e05046a0ab19493f257e
   languageName: node
   linkType: hard
 
@@ -9407,15 +9409,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "lru-cache@npm:6.0.0"
-  dependencies:
-    yallist: "npm:^4.0.0"
-  checksum: 10c0/cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
-  languageName: node
-  linkType: hard
-
 "lru-cache@npm:^7.10.1, lru-cache@npm:^7.14.1, lru-cache@npm:^7.18.3":
   version: 7.18.3
   resolution: "lru-cache@npm:7.18.3"
@@ -11772,14 +11765,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0":
-  version: 7.6.0
-  resolution: "semver@npm:7.6.0"
-  dependencies:
-    lru-cache: "npm:^6.0.0"
+"semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.2":
+  version: 7.6.3
+  resolution: "semver@npm:7.6.3"
   bin:
     semver: bin/semver.js
-  checksum: 10c0/fbfe717094ace0aa8d6332d7ef5ce727259815bd8d8815700853f4faf23aacbd7192522f0dc5af6df52ef4fa85a355ebd2f5d39f554bd028200d6cf481ab9b53
+  checksum: 10c0/88f33e148b210c153873cb08cfe1e281d518aaa9a666d4d148add6560db5cd3c582f3a08ccb91f38d5f379ead256da9931234ed122057f40bb5766e65e58adaf
   languageName: node
   linkType: hard
 
@@ -11878,6 +11869,13 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 10c0/1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
+  languageName: node
+  linkType: hard
+
+"shell-quote@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "shell-quote@npm:1.8.1"
+  checksum: 10c0/8cec6fd827bad74d0a49347057d40dfea1e01f12a6123bf82c4649f3ef152fc2bc6d6176e6376bffcd205d9d0ccb4f1f9acae889384d20baff92186f01ea455a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Allow our `__typename` fields to be EdgeDB FQN names
- Switch to temp unreleased `@edgedb/generate` branch
  edgedb/edgedb-js#1090
- Use `Engagement.resolve` function instead of `.__typename === '...'` to decouple the strings
- Created EdgeDB version of the Engagements repo with polymorphic hydration.
  What's here is working which is the main thing, but it could be better.
  The QB types could still be better to allow merging shapes & automatically handling EdgeQL type intersections & TS discrimated unions. One day.
- Pulled the rest of Bryan's queries & work from #3219

[Monday Task](https://seed-company-squad.monday.com/boards/5989610236/pulses/5792966980)