### PR TITLE
Fix inheritance reflection with IntersectTypes()

### DIFF
--- a/dbschema/migrations/00006-m13cjeo.edgeql
+++ b/dbschema/migrations/00006-m13cjeo.edgeql
@@ -1,0 +1,185 @@
+CREATE MIGRATION m17ecruskq3k5hphihs23fnzzaf7fjd2obhafu3mvgbefnsn2an5iq
+    ONTO m1yeyjrzkznhb2fr4txj432k3nlumdnjwsdyuhinrfmt64je5lwfta
+{
+  ALTER TYPE default::Resource {
+      CREATE ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForResource
+          ALLOW DELETE, INSERT USING ((default::Role.Administrator IN GLOBAL default::currentRoles));
+      CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForResource
+          ALLOW SELECT, UPDATE READ USING (EXISTS ((<default::Role>{'Administrator', 'Leadership'} INTERSECT GLOBAL default::currentRoles)));
+      CREATE ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForResource
+          ALLOW UPDATE WRITE;
+  };
+  ALTER TYPE Budget::Record {
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForBudgetRecord USING ((((default::Role.ConsultantManager IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium))) OR EXISTS ((<default::Role>{'FieldOperationsDirector', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'Marketing', 'Fundraising', 'ExperienceOperations', 'ProjectManager', 'RegionalDirector'} INTERSECT GLOBAL default::currentRoles))));
+      DROP ACCESS POLICY CanUpdateWriteInsertDeleteGeneratedFromAppPoliciesForBudgetRecord;
+  };
+  ALTER TYPE Comments::Aware {
+      DROP ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForCommentable;
+      DROP ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForCommentable;
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForCommentable;
+  };
+  ALTER TYPE Comments::Comment {
+      CREATE ACCESS POLICY CanSelectUpdateReadDeleteGeneratedFromAppPoliciesForComment
+          ALLOW SELECT, UPDATE READ, DELETE USING (.isCreator);
+      DROP ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForComment;
+      DROP ACCESS POLICY CanInsertGeneratedFromAppPoliciesForComment;
+      DROP ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForComment;
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForComment;
+  };
+  ALTER TYPE Comments::Thread {
+      CREATE ACCESS POLICY CanSelectUpdateReadDeleteGeneratedFromAppPoliciesForCommentThread
+          ALLOW SELECT, UPDATE READ, DELETE USING (.isCreator);
+      DROP ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForCommentThread;
+      DROP ACCESS POLICY CanInsertGeneratedFromAppPoliciesForCommentThread;
+      DROP ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForCommentThread;
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForCommentThread;
+  };
+  ALTER TYPE Engagement::Ceremony {
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForCeremony USING ((EXISTS ((<default::Role>{'FieldOperationsDirector', 'FieldPartner', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Marketing', 'Fundraising', 'ExperienceOperations', 'ProjectManager', 'RegionalDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'Intern', 'Mentor', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+      DROP ACCESS POLICY CanUpdateWriteInsertDeleteGeneratedFromAppPoliciesForCeremony;
+  };
+  ALTER TYPE File::Node {
+      DROP ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForFileNode;
+      DROP ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForFileNode;
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForFileNode;
+  };
+  ALTER TYPE ProgressReport::CommunityStory {
+      DROP ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForProgressReportCommunityStory;
+      ALTER ACCESS POLICY CanInsertGeneratedFromAppPoliciesForProgressReportCommunityStory USING (((default::Role.Marketing IN GLOBAL default::currentRoles) OR (EXISTS ((<default::Role>{'FieldPartner', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportCommunityStory USING (((EXISTS ((<default::Role>{'Marketing', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) OR ((default::Role.ConsultantManager IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForProgressReportCommunityStory;
+  };
+  ALTER TYPE ProgressReport::Highlight {
+      DROP ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForProgressReportHighlight;
+      ALTER ACCESS POLICY CanInsertGeneratedFromAppPoliciesForProgressReportHighlight USING (((default::Role.Marketing IN GLOBAL default::currentRoles) OR (EXISTS ((<default::Role>{'FieldPartner', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportHighlight USING (((EXISTS ((<default::Role>{'Marketing', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) OR ((default::Role.ConsultantManager IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForProgressReportHighlight;
+  };
+  ALTER TYPE ProgressReport::Media {
+      ALTER ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForProgressReportMedia USING (.isCreator);
+      ALTER ACCESS POLICY CanInsertGeneratedFromAppPoliciesForProgressReportMedia USING (((((((default::Role.FieldPartner IN GLOBAL default::currentRoles) AND .isMember) AND (<std::str>.variant = 'draft')) OR ((default::Role.Marketing IN GLOBAL default::currentRoles) AND (<std::str>.variant = 'published'))) OR ((EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND .isMember) AND (<std::str>.variant IN {'draft', 'translated', 'fpm'}))) OR (((default::Role.Translator IN GLOBAL default::currentRoles) AND .isMember) AND (<std::str>.variant = 'translated'))));
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportMedia USING (((((((((default::Role.ConsultantManager IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium))) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)) OR (((default::Role.FieldPartner IN GLOBAL default::currentRoles) AND .isMember) AND (<std::str>.variant = 'draft'))) OR (EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND (((.isMember AND (<std::str>.variant IN {'draft', 'translated', 'fpm'})) OR ((.sensitivity <= default::Sensitivity.Low) AND (<std::str>.variant IN {'fpm', 'published'}))) OR .isMember))) OR ((default::Role.Translator IN GLOBAL default::currentRoles) AND ((.isMember AND (<std::str>.variant = 'translated')) OR .isMember))) OR (default::Role.Marketing IN GLOBAL default::currentRoles)) OR .isCreator));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForProgressReportMedia;
+  };
+  ALTER TYPE ProgressReport::TeamNews {
+      DROP ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForProgressReportTeamNews;
+      ALTER ACCESS POLICY CanInsertGeneratedFromAppPoliciesForProgressReportTeamNews USING (((default::Role.Marketing IN GLOBAL default::currentRoles) OR (EXISTS ((<default::Role>{'FieldPartner', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProgressReportTeamNews USING (((EXISTS ((<default::Role>{'Marketing', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) OR ((default::Role.ConsultantManager IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForProgressReportTeamNews;
+  };
+  ALTER TYPE Project::Member {
+      ALTER ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForProjectMember USING ((EXISTS ((<default::Role>{'ConsultantManager', 'ExperienceOperations', 'FieldOperationsDirector', 'LeadFinancialAnalyst', 'Controller'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProjectMember USING ((EXISTS ((<default::Role>{'ConsultantManager', 'ExperienceOperations', 'FieldOperationsDirector', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'Marketing', 'Fundraising', 'ProjectManager', 'RegionalDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'Intern', 'Mentor', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForProjectMember;
+  };
+  ALTER TYPE User::Education {
+      DROP ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForEducation;
+      ALTER ACCESS POLICY CanInsertGeneratedFromAppPoliciesForEducation USING (EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)));
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForEducation USING (EXISTS ((<default::Role>{'ConsultantManager', 'FieldOperationsDirector', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Marketing', 'Fundraising', 'ExperienceOperations', 'ProjectManager', 'RegionalDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForEducation;
+  };
+  ALTER TYPE User::Unavailability {
+      DROP ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForUnavailability;
+      ALTER ACCESS POLICY CanInsertGeneratedFromAppPoliciesForUnavailability USING (EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)));
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForUnavailability USING ((EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Marketing', 'Fundraising', 'ExperienceOperations', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Intern', 'Mentor'} INTERSECT GLOBAL default::currentRoles)) AND EXISTS ({'Stubbed .isMember for User/Unavailability'}))));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForUnavailability;
+  };
+  ALTER TYPE default::Budget {
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForBudget USING ((((default::Role.ConsultantManager IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium))) OR EXISTS ((<default::Role>{'FieldOperationsDirector', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'Marketing', 'Fundraising', 'ExperienceOperations', 'ProjectManager', 'RegionalDirector'} INTERSECT GLOBAL default::currentRoles))));
+      DROP ACCESS POLICY CanUpdateWriteInsertDeleteGeneratedFromAppPoliciesForBudget;
+  };
+  ALTER TYPE default::Engagement {
+      ALTER ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForEngagement USING (((EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller'} INTERSECT GLOBAL default::currentRoles)) AND .isMember) AND (<std::str>.status = 'InDevelopment')));
+      ALTER ACCESS POLICY CanInsertGeneratedFromAppPoliciesForEngagement USING (((EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller'} INTERSECT GLOBAL default::currentRoles)) AND .isMember) AND (<std::str>.project.status = 'InDevelopment')));
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForEngagement USING ((EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Marketing', 'Fundraising', 'ExperienceOperations', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'Intern', 'Mentor', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForEngagement;
+  };
+  ALTER TYPE default::Producible {
+      DROP ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForProducible;
+      ALTER ACCESS POLICY CanInsertGeneratedFromAppPoliciesForProducible USING (EXISTS ((<default::Role>{'FieldOperationsDirector', 'ProjectManager', 'RegionalDirector'} INTERSECT GLOBAL default::currentRoles)));
+  };
+  ALTER TYPE default::Producible {
+      CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProducible
+          ALLOW SELECT, UPDATE READ;
+  };
+  ALTER TYPE default::Producible {
+      DROP ACCESS POLICY CanSelectUpdateReadUpdateWriteGeneratedFromAppPoliciesForProducible;
+  };
+  ALTER TYPE default::FieldRegion {
+      DROP ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForFieldRegion;
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForFieldRegion USING (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Marketing', 'Fundraising', 'ExperienceOperations', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForFieldRegion;
+  };
+  ALTER TYPE default::FieldZone {
+      DROP ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForFieldZone;
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForFieldZone USING (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Marketing', 'Fundraising', 'ExperienceOperations', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForFieldZone;
+  };
+  ALTER TYPE default::PeriodicReport {
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForPeriodicReport USING (
+        WITH
+          isMember := (.container[IS Project::ContextAware].isMember ?? false),
+          sensitivity := (.container[IS Project::ContextAware].sensitivity ?? default::Sensitivity.High)
+      SELECT
+          ((EXISTS ((<default::Role>{'ExperienceOperations', 'FieldOperationsDirector', 'FieldPartner', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'ProjectManager', 'RegionalDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'ConsultantManager', 'Marketing', 'Fundraising', 'ExperienceOperations'} INTERSECT GLOBAL default::currentRoles)) AND (isMember OR (sensitivity <= default::Sensitivity.Medium)))) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'Intern', 'Mentor', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND isMember))
+      );
+      DROP ACCESS POLICY CanUpdateWriteInsertDeleteGeneratedFromAppPoliciesForPeriodicReport;
+  };
+  ALTER TYPE default::FundingAccount {
+      DROP ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForFundingAccount;
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForFundingAccount USING (EXISTS ((<default::Role>{'ConsultantManager', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForFundingAccount;
+  };
+  ALTER TYPE default::Project {
+      DROP ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForProject;
+      ALTER ACCESS POLICY CanInsertGeneratedFromAppPoliciesForProject USING (EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)));
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForProject USING ((EXISTS ((<default::Role>{'ConsultantManager', 'ExperienceOperations', 'FieldOperationsDirector', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Fundraising', 'Marketing', 'ProjectManager', 'RegionalDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'Intern', 'Mentor', 'RegionalDirector', 'FieldOperationsDirector', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForProject;
+  };
+  ALTER TYPE default::Language {
+      DROP ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForLanguage;
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForLanguage USING ((EXISTS ((<default::Role>{'ConsultantManager', 'ExperienceOperations', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'Fundraising', 'Marketing', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'Intern', 'Mentor', 'Translator'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForLanguage;
+  };
+  ALTER TYPE default::Location {
+      DROP ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForLocation;
+  };
+  ALTER TYPE default::Location {
+      CREATE ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForLocation
+          ALLOW SELECT, UPDATE READ;
+  };
+  ALTER TYPE default::Location {
+      DROP ACCESS POLICY CanSelectUpdateReadUpdateWriteGeneratedFromAppPoliciesForLocation;
+  };
+  ALTER TYPE default::Organization {
+      ALTER ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForOrganization USING ((default::Role.Controller IN GLOBAL default::currentRoles));
+      ALTER ACCESS POLICY CanInsertGeneratedFromAppPoliciesForOrganization USING (EXISTS ((<default::Role>{'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller'} INTERSECT GLOBAL default::currentRoles)));
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForOrganization USING ((((EXISTS ((<default::Role>{'ConsultantManager', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)) OR (EXISTS ((<default::Role>{'ExperienceOperations', 'Fundraising'} INTERSECT GLOBAL default::currentRoles)) AND (.sensitivity <= default::Sensitivity.Medium))) OR ((default::Role.Marketing IN GLOBAL default::currentRoles) AND (.isMember OR (.sensitivity <= default::Sensitivity.Low)))));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForOrganization;
+  };
+  ALTER TYPE default::Partner {
+      ALTER ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForPartner USING ((default::Role.Controller IN GLOBAL default::currentRoles));
+      ALTER ACCESS POLICY CanInsertGeneratedFromAppPoliciesForPartner USING (EXISTS ((<default::Role>{'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller'} INTERSECT GLOBAL default::currentRoles)));
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForPartner USING (((((EXISTS ((<default::Role>{'ConsultantManager', 'FieldOperationsDirector', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'ProjectManager', 'RegionalDirector'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)) OR (EXISTS ((<default::Role>{'ExperienceOperations', 'Fundraising'} INTERSECT GLOBAL default::currentRoles)) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))) OR ((default::Role.Marketing IN GLOBAL default::currentRoles) AND ((.isMember AND (.sensitivity <= default::Sensitivity.Medium)) OR (.sensitivity <= default::Sensitivity.Low)))) OR ((default::Role.StaffMember IN GLOBAL default::currentRoles) AND (.sensitivity <= default::Sensitivity.Low))));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForPartner;
+  };
+  ALTER TYPE default::Partnership {
+      ALTER ACCESS POLICY CanInsertDeleteGeneratedFromAppPoliciesForPartnership USING (((EXISTS ((<default::Role>{'FieldOperationsDirector', 'LeadFinancialAnalyst', 'Controller'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)) OR (EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))));
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForPartnership USING ((((EXISTS ((<default::Role>{'ConsultantManager', 'ExperienceOperations', 'LeadFinancialAnalyst', 'Controller', 'FinancialAnalyst', 'Marketing', 'Fundraising', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) OR (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner'} INTERSECT GLOBAL default::currentRoles)) AND .isMember)) OR (EXISTS ((<default::Role>{'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)) AND (.isMember OR (.sensitivity <= default::Sensitivity.Medium)))) OR ((default::Role.StaffMember IN GLOBAL default::currentRoles) AND (.sensitivity <= default::Sensitivity.Low))));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForPartnership;
+  };
+  ALTER TYPE default::Post {
+      CREATE ACCESS POLICY CanSelectUpdateReadDeleteGeneratedFromAppPoliciesForPost
+          ALLOW SELECT, UPDATE READ, DELETE USING (.isCreator);
+      DROP ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForPost;
+      DROP ACCESS POLICY CanInsertGeneratedFromAppPoliciesForPost;
+      DROP ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForPost;
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForPost;
+  };
+  ALTER TYPE default::User {
+      DROP ACCESS POLICY CanDeleteGeneratedFromAppPoliciesForUser;
+      ALTER ACCESS POLICY CanInsertGeneratedFromAppPoliciesForUser USING (EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector'} INTERSECT GLOBAL default::currentRoles)));
+      ALTER ACCESS POLICY CanSelectUpdateReadGeneratedFromAppPoliciesForUser USING (((EXISTS ((<default::Role>{'Consultant', 'ConsultantManager', 'FieldPartner', 'FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller', 'Marketing', 'Fundraising', 'ExperienceOperations', 'ProjectManager', 'RegionalDirector', 'FieldOperationsDirector', 'StaffMember'} INTERSECT GLOBAL default::currentRoles)) OR (.id ?= GLOBAL default::currentActorId)) OR (EXISTS ((<default::Role>{'Intern', 'Mentor'} INTERSECT GLOBAL default::currentRoles)) AND EXISTS ({'Stubbed .isMember for User/Unavailability'}))));
+      DROP ACCESS POLICY CanUpdateWriteGeneratedFromAppPoliciesForUser;
+  };
+};

--- a/src/common/parent-types.ts
+++ b/src/common/parent-types.ts
@@ -1,4 +1,5 @@
-import { AbstractClassType } from './types';
+import { cmpBy } from '@seedcompany/common';
+import { AbstractClassType, IntersectTypes } from './types';
 
 /**
  * Returns a list of all the parent class types including the given one.
@@ -7,6 +8,20 @@ export function getParentTypes(
   type: AbstractClassType<unknown>,
   types: ReadonlyArray<AbstractClassType<unknown>> = [type],
 ): ReadonlyArray<AbstractClassType<unknown>> {
+  // Special handling of classes coming from IntersectTypes()
+  const members = Object.getOwnPropertyDescriptor(type, 'members')?.value as
+    | ReturnType<typeof IntersectTypes>['members']
+    | undefined;
+  if (members && Array.isArray(members)) {
+    const intersectedAncestors = members
+      .flatMap((member) => [...getParentTypes(member).entries()])
+      // Try to maintain order when merging ancestors
+      .sort(cmpBy(([idx]) => idx))
+      .map(([_, type]) => type);
+    const uniqueAncestors = [...new Set(intersectedAncestors)];
+    return [...types, ...uniqueAncestors];
+  }
+
   const parent = Object.getPrototypeOf(type);
   if (parent == null) {
     // if no parent we are at native Object. We are done but drop the last two
@@ -14,5 +29,6 @@ export function getParentTypes(
     // These are never explicitly declared in user-land code, and we don't care about them.
     return types.slice(0, -2);
   }
+
   return getParentTypes(parent, [...types, parent]);
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,8 +1,8 @@
 import {
-  IntersectionType as BaseIntersectionType,
   OmitType as BaseOmitType,
   PartialType as BasePartialType,
   PickType as BasePickType,
+  IntersectionType,
 } from '@nestjs/graphql';
 import { ClassDecoratorFactory } from '@nestjs/graphql/dist/interfaces/class-decorator-factory.interface';
 import { AbstractClass, Class } from 'type-fest';
@@ -73,23 +73,6 @@ export const OmitType = BaseOmitType as <
   keys: readonly K[],
   decorator?: ClassDecoratorFactory,
 ) => Class<Omit<T, (typeof keys)[number]>, Args>;
-
-/**
- * The IntersectionType() function combines two types into one new type (class).
- *
- * This just changes the signature to work with abstract classes.
- *
- * @see https://docs.nestjs.com/graphql/mapped-types#intersection
- */
-export const IntersectionType = BaseIntersectionType as <
-  A,
-  B,
-  Args extends unknown[],
->(
-  classARef: AbstractClass<A, Args>,
-  classBRef: AbstractClass<B>,
-  decorator?: ClassDecoratorFactory,
-) => Class<A & B, Args>;
 
 export function IntersectTypes<A, Args extends unknown[]>(
   type1: AbstractClass<A, Args>,

--- a/src/components/file/media/media.dto.ts
+++ b/src/components/file/media/media.dto.ts
@@ -15,7 +15,7 @@ import {
   ID,
   IdField,
   IdOf,
-  IntersectionType,
+  IntersectTypes,
   NameField,
   SecuredProps,
   ServerException,
@@ -127,8 +127,7 @@ export class Image extends VisualMedia {
 @ObjectType({
   implements: [VisualMedia, TemporalMedia, Media],
 })
-@DbLabel('Video', 'VisualMedia', 'TemporalMedia', 'Media') // IntersectionType blocks label inheritance
-export class Video extends IntersectionType(VisualMedia, TemporalMedia) {
+export class Video extends IntersectTypes(VisualMedia, TemporalMedia) {
   static readonly Props = keysOf<Video>();
   static readonly SecuredProps = keysOf<SecuredProps<Video>>();
 

--- a/src/components/product/dto/update-product.dto.ts
+++ b/src/components/product/dto/update-product.dto.ts
@@ -3,7 +3,7 @@ import { stripIndent } from 'common-tags';
 import {
   ID,
   IdField,
-  IntersectionType,
+  IntersectTypes,
   NameField,
   OmitType,
   PickType,
@@ -26,7 +26,7 @@ export abstract class UpdateBaseProduct extends OmitType(CreateBaseProduct, [
 }
 
 @InputType()
-export abstract class UpdateDirectScriptureProduct extends IntersectionType(
+export abstract class UpdateDirectScriptureProduct extends IntersectTypes(
   UpdateBaseProduct,
   PickType(CreateDirectScriptureProduct, [
     'scriptureReferences',
@@ -38,7 +38,7 @@ export abstract class UpdateDirectScriptureProduct extends IntersectionType(
 }
 
 @InputType()
-export abstract class UpdateDerivativeScriptureProduct extends IntersectionType(
+export abstract class UpdateDerivativeScriptureProduct extends IntersectTypes(
   UpdateBaseProduct,
   PickType(CreateDerivativeScriptureProduct, [
     'scriptureReferencesOverride',

--- a/src/components/progress-report/media/dto/upload.dto.ts
+++ b/src/components/progress-report/media/dto/upload.dto.ts
@@ -3,7 +3,7 @@ import { stripIndent } from 'common-tags';
 import {
   IdField,
   IdOf,
-  IntersectionType as Merge,
+  IntersectTypes as Merge,
   PickType,
   Variant,
   VariantInputField,

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -7,9 +7,11 @@ import { mapValues } from 'lodash';
 import {
   EnhancedResource,
   InvalidIdForTypeException,
+  Resource,
   ResourceShape,
   ServerException,
 } from '~/common';
+import { e } from '../edgedb/reexports';
 import { ResourceMap } from './map';
 import { __privateDontUseThis } from './resource-map-holder';
 import {
@@ -18,6 +20,7 @@ import {
   ResourceNameLike,
   ResourceStaticFromName,
 } from './resource-name.types';
+import { RegisterResource } from './resource.decorator';
 
 export type EnhancedResourceMap = {
   [K in keyof ResourceMap]: EnhancedResource<ResourceMap[K]>;
@@ -27,6 +30,16 @@ export type ResourceLike =
   | ResourceShape<any>
   | EnhancedResource<any>
   | ResourceNameLike;
+
+RegisterResource({ db: e.Resource })(Resource);
+declare module '~/core/resources/map' {
+  interface ResourceMap {
+    Resource: typeof Resource;
+  }
+  interface ResourceDBMap {
+    Resource: typeof e.Resource;
+  }
+}
 
 @Injectable()
 export class ResourcesHost {

--- a/src/core/resources/resources.host.ts
+++ b/src/core/resources/resources.host.ts
@@ -131,34 +131,8 @@ export class ResourcesHost {
       : EnhancedResource.of(ref);
   }
 
+  @CachedByArg()
   getInterfaces(
-    resource: EnhancedResource<any>,
-  ): ReadonlyArray<EnhancedResource<any>> {
-    // Use interfaces from GQL schema if it's available.
-    // Otherwise, fallback to the interfaces from DTO class hierarchy.
-    // The former doesn't work with CLI.
-    // The latter doesn't work for IntersectionTypes.
-    // Hoping to resolve with https://github.com/nestjs/graphql/pull/2435
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-      this.gqlSchema.schema;
-    } catch (e) {
-      return this.getInterfacesFromClassType(resource);
-    }
-    return this.getInterfacesFromGQLSchema(resource);
-  }
-
-  @CachedByArg()
-  private getInterfacesFromClassType(
-    resource: EnhancedResource<any>,
-  ): ReadonlyArray<EnhancedResource<any>> {
-    const map = this.getEnhancedMap();
-    const resSet = new Set<EnhancedResource<any>>(Object.values(map));
-    return [...resource.interfaces].filter((i) => resSet.has(i));
-  }
-
-  @CachedByArg()
-  private getInterfacesFromGQLSchema(
     resource: EnhancedResource<any>,
   ): ReadonlyArray<EnhancedResource<any>> {
     const { schema } = this.gqlSchema;


### PR DESCRIPTION
- Adjust `getParentTypes` to work with `IntersectTypes()`
  This is possible now that we have our own that adds a static `members` array.
- Replace the remaining usage of `IntersectionType` with our `IntersectTypes`
  Notice how this removes the workaround needed on `Video`'s `DbLabels`.
- Remove split between GQL schema & class types in `ResourcesHost.getInterfaces`
	The GQL schema is always available now that my PR got merged.
	The class types (aka `EnhancedResource.interfaces`) now works for `IntersectTypes`
	
	Still, having the split between our class type inheritance and GQL schema gives me pause for thought.
	They should be in sync, so maybe one should just be picked always over the other?
	I guess class types could still be private, not exposed to GQL schema.
	And GQL schema needs the app to be booted & use service, instead of just accessing on `EnhancedResource`...

    Perhaps I should've picked the class type logic going forward. This would be a logical change from using the GQL schema, but it should work the same now with the first fix in this PR. This would align it with the `getImplementations` logic which uses the class types interfaces, not the GQL schema.
   The original introduction of the GQL schema usage was to workaround the fact that class types would not work with IntersectTypes, so maybe it should be stripped out now.

- This fix had an impact on AP calculations. `Resource` is now considered as an interface s its implementations now had some of its permission actions stripped out because they should be declared on `Resource`. I'm not sure why it was only partial, but I took it all the way. I registered `Resource` on the `ResourceMap` and associated it to the EdgeDB type. So now `Resource` has APs applied correctly. Now all actions that can be pulled up to the `Resource` level are, which removes all of the AP logic on the implementations.