### PR TITLE
BUG: Don't create ProgressReports for InternshipEngagements

### DIFF
--- a/src/components/periodic-report/handlers/sync-progress-report-to-engagement.handler.ts
+++ b/src/components/periodic-report/handlers/sync-progress-report-to-engagement.handler.ts
@@ -37,10 +37,18 @@ export class SyncProgressReportToEngagementDateRange
   }
 
   async handle(event: SubscribedEvent) {
-    this.logger.debug('Engagement mutation, syncing progress reports', {
-      ...event,
-      event: event.constructor.name,
-    });
+    // Only LanguageEngagements
+    if (
+      !(
+        ((event instanceof EngagementCreatedEvent ||
+          event instanceof EngagementUpdatedEvent) &&
+          event.isLanguageEngagement()) ||
+        (event instanceof ProjectUpdatedEvent &&
+          event.updated.type.includes('Translation'))
+      )
+    ) {
+      return;
+    }
 
     if (
       (event instanceof EngagementCreatedEvent && event.engagement.changeset) ||
@@ -50,6 +58,11 @@ export class SyncProgressReportToEngagementDateRange
       // until changeset is approved and another update event is fired.
       return;
     }
+
+    this.logger.debug('Engagement mutation, syncing progress reports', {
+      ...event,
+      event: event.constructor.name,
+    });
 
     const engagements =
       event instanceof ProjectUpdatedEvent

--- a/src/components/progress-report/migrations/drop-internship-progress-reports.migration.ts
+++ b/src/components/progress-report/migrations/drop-internship-progress-reports.migration.ts
@@ -1,0 +1,21 @@
+import { node, relation } from 'cypher-query-builder';
+import { BaseMigration, Migration } from '~/core/database';
+import { path } from '~/core/database/query';
+
+@Migration('2024-09-23T00:00:00')
+export class DropInternshipProgressReportsMigration extends BaseMigration {
+  async up() {
+    await this.db
+      .query()
+      .match(node('report', 'ProgressReport'))
+      .where(
+        path([
+          node('report'),
+          relation('either'),
+          node('', 'InternshipEngagement'),
+        ]),
+      )
+      .detachDelete('report')
+      .executeAndLogStats();
+  }
+}

--- a/src/components/progress-report/progress-report.module.ts
+++ b/src/components/progress-report/progress-report.module.ts
@@ -8,6 +8,7 @@ import { ProgressReportHighlightsRepository } from './highlights/progress-report
 import { ProgressReportHighlightsResolver } from './highlights/progress-report-highlights.resolver';
 import { ProgressReportHighlightsService } from './highlights/progress-report-highlights.service';
 import { ProgressReportMediaModule } from './media/progress-report-media.module';
+import { DropInternshipProgressReportsMigration } from './migrations/drop-internship-progress-reports.migration';
 import { ProgressReportExtraForPeriodicInterfaceRepository } from './progress-report-extra-for-periodic-interface.repository';
 import { ProgressReportRepository } from './progress-report.repository';
 import { ProgressReportService } from './progress-report.service';
@@ -46,6 +47,7 @@ import { ProgressReportWorkflowModule } from './workflow/progress-report-workflo
     ProgressReportService,
     ProgressReportRepository,
     ProgressReportExtraForPeriodicInterfaceRepository,
+    DropInternshipProgressReportsMigration,
   ],
   exports: [ProgressReportExtraForPeriodicInterfaceRepository],
 })


### PR DESCRIPTION
Remarkably we never checked the project/engagement type before creating/syncing progress reports.
These should only be for TranslationProjects/LanguageEngagements.

Add migration to drop these rogue entries that are never accessed.
