### PR TITLE
Fix current report due prioritizing the final report

### DIFF
--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -454,7 +454,10 @@ export const matchCurrentDue =
       ])
       .raw(`WHERE end.value < date()`)
       .with('node, start')
-      .orderBy('start.value', 'desc')
+      .orderBy([
+        ['end.value', 'desc'],
+        ['start.value', 'asc'],
+      ])
       .limit(1);
 
 export const periodicReportSorters = defineSorters(IPeriodicReport, {});


### PR DESCRIPTION
This was supposed to be fixed with #3200

Now the _current report due_ is the most recently ending report (of the reports that have already ended) and of the reports with the same end date, the one that started first.