### PR TITLE
Infer/Decouple Platform types (HTTP/GraphQL)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -78,6 +78,16 @@ const restrictedImports = [
     replacement: { importName: 'IntersectTypes', path: '~/common' },
     message: 'Use our wrapper that allows for varargs & provides members array',
   },
+  {
+    importNames: 'HttpAdapterHost',
+    path: '@nestjs/core',
+    replacement: { path: '~/core/http' },
+  },
+  {
+    importNames: 'NestMiddleware',
+    path: '@nestjs/common',
+    replacement: { importName: 'HttpMiddleware', path: '~/core/http' },
+  },
 ];
 
 const namingConvention = [

--- a/src/common/context.type.ts
+++ b/src/common/context.type.ts
@@ -1,6 +1,6 @@
-import { Request, Response } from 'express';
 import { OperationDefinitionNode } from 'graphql';
 import { BehaviorSubject } from 'rxjs';
+import type { IRequest, IResponse } from '~/core/http';
 import { Session } from './session';
 
 /**
@@ -8,7 +8,7 @@ import { Session } from './session';
  */
 export interface GqlContextType {
   operation: OperationDefinitionNode;
-  request?: Request;
-  response?: Response;
+  request?: IRequest;
+  response?: IResponse;
   readonly session$: BehaviorSubject<Session | undefined>;
 }

--- a/src/common/exceptions/input.exception.ts
+++ b/src/common/exceptions/input.exception.ts
@@ -1,8 +1,5 @@
 import { ArgumentsHost } from '@nestjs/common';
-import {
-  GqlContextType as ContextKey,
-  GqlExecutionContext,
-} from '@nestjs/graphql';
+import { GqlExecutionContext } from '@nestjs/graphql';
 import { ClientException } from './exception';
 
 export type InputExceptionArgs =
@@ -111,7 +108,7 @@ export class InputException extends ClientException {
   }
 
   static getFlattenInput(context?: ArgumentsHost) {
-    if (!context || context.getType<ContextKey>() !== 'graphql') {
+    if (!context || context.getType() !== 'graphql') {
       return {};
     }
     const gqlContext =

--- a/src/components/authentication/current-user.provider.ts
+++ b/src/components/authentication/current-user.provider.ts
@@ -58,8 +58,7 @@ export class EdgeDBCurrentUserProvider
     } else if (type === 'http') {
       const request = context.switchToHttp().getRequest();
       const optionsHolder = this.optionsHolderByRequest.get(request)!;
-      const session: Session | undefined = request.session;
-      this.applyToOptions(session, optionsHolder);
+      this.applyToOptions(request.session, optionsHolder);
     }
 
     return next.handle();

--- a/src/components/authentication/current-user.provider.ts
+++ b/src/components/authentication/current-user.provider.ts
@@ -5,13 +5,10 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import {
-  GqlExecutionContext,
-  GqlContextType as GqlRequestType,
-} from '@nestjs/graphql';
+import { GqlExecutionContext } from '@nestjs/graphql';
 import { isUUID } from 'class-validator';
 import { BehaviorSubject, identity } from 'rxjs';
-import { GqlContextType, Session } from '~/common';
+import { Session } from '~/common';
 import { EdgeDB, OptionsFn } from '~/core/edgedb';
 import { HttpMiddleware } from '~/core/http';
 
@@ -44,11 +41,11 @@ export class EdgeDBCurrentUserProvider
    * Connect the session to the options' holder
    */
   intercept(context: ExecutionContext, next: CallHandler) {
-    const type = context.getType<GqlRequestType>();
+    const type = context.getType();
 
     if (type === 'graphql') {
       const { request, session$ } =
-        GqlExecutionContext.create(context).getContext<GqlContextType>();
+        GqlExecutionContext.create(context).getContext();
       if (request) {
         const optionsHolder = this.optionsHolderByRequest.get(request)!;
         session$.subscribe((session) => {

--- a/src/components/authentication/current-user.provider.ts
+++ b/src/components/authentication/current-user.provider.ts
@@ -4,33 +4,32 @@ import {
   ExecutionContext,
   Injectable,
   NestInterceptor,
-  NestMiddleware,
 } from '@nestjs/common';
 import {
   GqlExecutionContext,
   GqlContextType as GqlRequestType,
 } from '@nestjs/graphql';
 import { isUUID } from 'class-validator';
-import { Request, Response } from 'express';
 import { BehaviorSubject, identity } from 'rxjs';
 import { GqlContextType, Session } from '~/common';
 import { EdgeDB, OptionsFn } from '~/core/edgedb';
+import { HttpMiddleware } from '~/core/http';
 
 @Injectable()
 @Plugin()
 export class EdgeDBCurrentUserProvider
-  implements NestMiddleware, NestInterceptor
+  implements HttpMiddleware, NestInterceptor
 {
   // A map to transfer the options' holder
   // between the creation in middleware and the use in the interceptor.
   private readonly optionsHolderByRequest = new WeakMap<
-    Request,
+    Parameters<HttpMiddleware['use']>[0],
     BehaviorSubject<OptionsFn>
   >();
 
   constructor(private readonly edgedb: EdgeDB) {}
 
-  use = (req: Request, res: Response, next: () => void) => {
+  use: HttpMiddleware['use'] = (req, res, next) => {
     // Create holder to use later to add current user to globals after it is fetched
     const optionsHolder = new BehaviorSubject<OptionsFn>(identity);
     this.optionsHolderByRequest.set(req, optionsHolder);

--- a/src/components/authentication/session.interceptor.ts
+++ b/src/components/authentication/session.interceptor.ts
@@ -11,7 +11,6 @@ import {
   GqlContextType as GqlRequestType,
 } from '@nestjs/graphql';
 import { csv } from '@seedcompany/common';
-import { Request } from 'express';
 import { GraphQLResolveInfo } from 'graphql';
 import {
   GqlContextType,
@@ -25,6 +24,7 @@ import {
   UnauthenticatedException,
 } from '~/common';
 import { ConfigService } from '~/core';
+import { IRequest } from '~/core/http';
 import { rolesForScope } from '../authorization/dto';
 import { AuthenticationService } from './authentication.service';
 
@@ -87,7 +87,7 @@ export class SessionInterceptor implements NestInterceptor {
     );
   }
 
-  private getTokenFromAuthHeader(req: Request | undefined): string | null {
+  private getTokenFromAuthHeader(req: IRequest | undefined): string | null {
     const header = req?.headers?.authorization;
 
     if (!header) {
@@ -100,7 +100,7 @@ export class SessionInterceptor implements NestInterceptor {
     return header.replace('Bearer ', '');
   }
 
-  private getTokenFromCookie(req: Request | undefined): string | null {
+  private getTokenFromCookie(req: IRequest | undefined): string | null {
     return req?.cookies?.[this.config.sessionCookie.name] || null;
   }
 

--- a/src/components/authentication/session.interceptor.ts
+++ b/src/components/authentication/session.interceptor.ts
@@ -6,12 +6,8 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import {
-  GqlExecutionContext,
-  GqlContextType as GqlRequestType,
-} from '@nestjs/graphql';
+import { GqlExecutionContext } from '@nestjs/graphql';
 import { csv } from '@seedcompany/common';
-import { GraphQLResolveInfo } from 'graphql';
 import {
   GqlContextType,
   ID,
@@ -37,7 +33,7 @@ export class SessionInterceptor implements NestInterceptor {
   ) {}
 
   async intercept(executionContext: ExecutionContext, next: CallHandler) {
-    const type = executionContext.getType<GqlRequestType>();
+    const type = executionContext.getType();
     if (type === 'graphql') {
       await this.handleGql(executionContext);
     } else if (type === 'http') {
@@ -62,8 +58,8 @@ export class SessionInterceptor implements NestInterceptor {
 
   private async handleGql(executionContext: ExecutionContext) {
     const gqlExecutionContext = GqlExecutionContext.create(executionContext);
-    const ctx = gqlExecutionContext.getContext<GqlContextType>();
-    const info = gqlExecutionContext.getInfo<GraphQLResolveInfo>();
+    const ctx = gqlExecutionContext.getContext();
+    const info = gqlExecutionContext.getInfo();
 
     if (!ctx.session$.value && info.fieldName !== 'session') {
       const session = await this.hydrateSession(ctx);

--- a/src/components/file/file-url.controller.ts
+++ b/src/components/file/file-url.controller.ts
@@ -9,10 +9,9 @@ import {
   Request,
   Response,
 } from '@nestjs/common';
-import { HttpAdapterHost } from '@nestjs/core';
-import { Request as IRequest } from 'express';
 import { ID } from '~/common';
 import { loggedInSession as verifyLoggedIn } from '~/common/session';
+import { HttpAdapterHost, IRequest, IResponse } from '~/core/http';
 import { SessionInterceptor } from '../authentication/session.interceptor';
 import { FileService } from './file.service';
 
@@ -32,7 +31,7 @@ export class FileUrlController {
     @Param('fileId') fileId: ID,
     @Query('download') download: '' | undefined,
     @Request() request: IRequest,
-    @Response() res: unknown,
+    @Response() res: IResponse,
   ) {
     const node = await this.files.getFileNode(fileId);
 

--- a/src/components/file/local-bucket.controller.ts
+++ b/src/components/file/local-bucket.controller.ts
@@ -7,11 +7,11 @@ import {
   Response,
   StreamableFile,
 } from '@nestjs/common';
-import { Request as IRequest, Response as IResponse } from 'express';
 import { DateTime } from 'luxon';
 import { URL } from 'node:url';
 import rawBody from 'raw-body';
 import { InputException } from '~/common';
+import { IRequest, IResponse } from '~/core/http';
 import { FileBucket, InvalidSignedUrlException } from './bucket';
 
 /**

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -1,10 +1,8 @@
-import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
 import { csv } from '@seedcompany/common';
 import {
   EmailModuleOptions,
   EmailOptionsFactory,
 } from '@seedcompany/nestjs-email';
-import { CookieOptions } from 'express';
 import type { Server as HttpServer } from 'http';
 import { LRUCache } from 'lru-cache';
 import { Duration, DurationLike } from 'luxon';
@@ -19,6 +17,7 @@ import { ProgressReportStatus } from '../../components/progress-report/dto/progr
 import type { TransitionName as ProgressReportTransitionName } from '../../components/progress-report/workflow/transitions';
 import { DefaultTimezoneWrapper } from '../email/templates/formatted-date-time';
 import { FrontendUrlWrapper } from '../email/templates/frontend-url';
+import type { CookieOptions, CorsOptions } from '../http';
 import { LogLevel } from '../logger/logger.interface';
 import { EnvironmentService } from './environment.service';
 import { determineRootUser } from './root-user.config';

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -15,6 +15,7 @@ import { EventsModule } from './events';
 import { ExceptionFilter } from './exception/exception.filter';
 import { ExceptionNormalizer } from './exception/exception.normalizer';
 import { GraphqlModule } from './graphql';
+import { HttpModule } from './http';
 import { ResourceModule } from './resources/resource.module';
 import { ScalarProviders } from './scalars.resolver';
 import { ShutdownHookProvider } from './shutdown.hook';
@@ -26,6 +27,7 @@ import { WaitResolver } from './wait.resolver';
 @Global()
 @Module({
   imports: [
+    HttpModule,
     ConfigModule,
     CacheModule,
     CliModule,
@@ -51,6 +53,7 @@ import { WaitResolver } from './wait.resolver';
   ],
   controllers: [CoreController],
   exports: [
+    HttpModule,
     AwsS3Factory,
     ConfigModule,
     CacheModule,

--- a/src/core/database/abstract-transactional-mutations.interceptor.ts
+++ b/src/core/database/abstract-transactional-mutations.interceptor.ts
@@ -4,8 +4,7 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import { GqlContextType, GqlExecutionContext } from '@nestjs/graphql';
-import { GraphQLResolveInfo } from 'graphql';
+import { GqlExecutionContext } from '@nestjs/graphql';
 import { from, lastValueFrom } from 'rxjs';
 import { RollbackManager } from './rollback-manager';
 
@@ -20,12 +19,12 @@ export abstract class TransactionalMutationsInterceptor
   constructor(private readonly rollbacks: RollbackManager) {}
 
   async intercept(context: ExecutionContext, next: CallHandler) {
-    if (context.getType<GqlContextType>() !== 'graphql') {
+    if (context.getType() !== 'graphql') {
       return next.handle();
     }
 
     const ctx = GqlExecutionContext.create(context);
-    const info = ctx.getInfo<GraphQLResolveInfo>();
+    const info = ctx.getInfo();
     if (info.operation.operation !== 'mutation') {
       return next.handle();
     }

--- a/src/core/exception/exception.filter.ts
+++ b/src/core/exception/exception.filter.ts
@@ -1,7 +1,7 @@
 import { ArgumentsHost, Catch, HttpStatus, Injectable } from '@nestjs/common';
-import { HttpAdapterHost } from '@nestjs/core';
 import { GqlContextType, GqlExceptionFilter } from '@nestjs/graphql';
 import { mapValues } from '@seedcompany/common';
+import { HttpAdapterHost } from '~/core/http';
 import { ConfigService } from '../config/config.service';
 import { ILogger, Logger, LogLevel } from '../logger';
 import { ValidationException } from '../validation';

--- a/src/core/exception/exception.filter.ts
+++ b/src/core/exception/exception.filter.ts
@@ -1,5 +1,5 @@
 import { ArgumentsHost, Catch, HttpStatus, Injectable } from '@nestjs/common';
-import { GqlContextType, GqlExceptionFilter } from '@nestjs/graphql';
+import { GqlExceptionFilter } from '@nestjs/graphql';
 import { mapValues } from '@seedcompany/common';
 import { HttpAdapterHost } from '~/core/http';
 import { ConfigService } from '../config/config.service';
@@ -40,7 +40,7 @@ export class ExceptionFilter implements GqlExceptionFilter {
 
     this.logIt(normalized, exception);
 
-    if (args.getType<GqlContextType>() === 'graphql') {
+    if (args.getType() === 'graphql') {
       this.respondToGraphQL(normalized, args);
     }
     this.respondToHttp(normalized, args);

--- a/src/core/exception/exception.normalizer.test.ts
+++ b/src/core/exception/exception.normalizer.test.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
+// eslint-disable-next-line no-restricted-imports,@seedcompany/no-restricted-imports
 import * as Nest from '@nestjs/common';
 import { InputException, ServerException } from '~/common';
 import { ConstraintError } from '../database';

--- a/src/core/exception/exception.normalizer.ts
+++ b/src/core/exception/exception.normalizer.ts
@@ -2,10 +2,7 @@ import { ApolloServerErrorCode as ApolloCode } from '@apollo/server/errors';
 import { ArgumentsHost, Inject, Injectable } from '@nestjs/common';
 // eslint-disable-next-line no-restricted-imports,@seedcompany/no-restricted-imports
 import * as Nest from '@nestjs/common';
-import {
-  GqlContextType as ContextKey,
-  GqlExecutionContext,
-} from '@nestjs/graphql';
+import { GqlExecutionContext } from '@nestjs/graphql';
 import {
   entries,
   isNotFalsy,
@@ -15,7 +12,7 @@ import {
 } from '@seedcompany/common';
 import * as Edge from 'edgedb';
 import * as EdgeDBTags from 'edgedb/dist/errors/tags.js';
-import { GraphQLError, GraphQLResolveInfo } from 'graphql';
+import { GraphQLError } from 'graphql';
 import addIndent from 'indent-string';
 import { lowerCase, uniq } from 'lodash';
 import {
@@ -130,7 +127,7 @@ export class ExceptionNormalizer {
     }
 
     const gqlContext =
-      context && context.getType<ContextKey>() === 'graphql'
+      context && context.getType() === 'graphql'
         ? GqlExecutionContext.create(context as any)
         : undefined;
 
@@ -142,7 +139,7 @@ export class ExceptionNormalizer {
       // Mask actual DB error with a nicer user error message.
       let message = 'Failed';
       if (gqlContext) {
-        const info = gqlContext.getInfo<GraphQLResolveInfo>();
+        const info = gqlContext.getInfo();
         if (info.operation.operation === 'mutation') {
           message += ` to ${lowerCase(info.fieldName)}`;
         }

--- a/src/core/exception/exception.normalizer.ts
+++ b/src/core/exception/exception.normalizer.ts
@@ -1,6 +1,6 @@
 import { ApolloServerErrorCode as ApolloCode } from '@apollo/server/errors';
 import { ArgumentsHost, Inject, Injectable } from '@nestjs/common';
-// eslint-disable-next-line no-restricted-imports
+// eslint-disable-next-line no-restricted-imports,@seedcompany/no-restricted-imports
 import * as Nest from '@nestjs/common';
 import {
   GqlContextType as ContextKey,

--- a/src/core/exception/is-from-hack-attempt.ts
+++ b/src/core/exception/is-from-hack-attempt.ts
@@ -3,7 +3,6 @@ import {
   // eslint-disable-next-line no-restricted-imports
   NotFoundException as NestjsNotFoundException,
 } from '@nestjs/common';
-import { IncomingMessage } from 'http';
 
 export const isFromHackAttempt = (error: Error, args: ArgumentsHost) => {
   if (
@@ -13,7 +12,7 @@ export const isFromHackAttempt = (error: Error, args: ArgumentsHost) => {
     process.env.NODE_ENV === 'production' &&
     args.getType() === 'http'
   ) {
-    return args.switchToHttp().getRequest<IncomingMessage>();
+    return args.switchToHttp().getRequest();
   }
   return undefined;
 };

--- a/src/core/graphql/gql-context.host.ts
+++ b/src/core/graphql/gql-context.host.ts
@@ -9,13 +9,12 @@ import {
   ExecutionContext,
   Injectable,
   NestInterceptor,
-  NestMiddleware,
   OnModuleDestroy,
 } from '@nestjs/common';
 import { GqlContextType as ContextKey } from '@nestjs/graphql';
 import { AsyncLocalStorage } from 'async_hooks';
-import { Request, Response } from 'express';
 import { GqlContextType as ContextType } from '~/common';
+import { HttpMiddleware as NestMiddleware } from '~/core/http';
 import { AsyncLocalStorageNoContextException } from '../async-local-storage-no-context.exception';
 
 /**
@@ -70,7 +69,7 @@ export class GqlContextHostImpl
     throw new Error(message);
   }
 
-  use = (req: Request, res: Response, next: () => void) => {
+  use: NestMiddleware['use'] = (req, res, next) => {
     // Connect middleware is the only place we get a function where we can
     // completely wrap the request for the use of an ALS context.
     this.attachScope(next);

--- a/src/core/graphql/gql-context.host.ts
+++ b/src/core/graphql/gql-context.host.ts
@@ -11,7 +11,6 @@ import {
   NestInterceptor,
   OnModuleDestroy,
 } from '@nestjs/common';
-import { GqlContextType as ContextKey } from '@nestjs/graphql';
 import { AsyncLocalStorage } from 'async_hooks';
 import { GqlContextType as ContextType } from '~/common';
 import { HttpMiddleware as NestMiddleware } from '~/core/http';
@@ -62,7 +61,7 @@ export class GqlContextHostImpl
     if (
       !store.ctx &&
       store.execution &&
-      store.execution.getType<ContextKey>() !== 'graphql'
+      store.execution.getType() !== 'graphql'
     ) {
       throw new NotGraphQLContext(message);
     }

--- a/src/core/graphql/graphql.module.ts
+++ b/src/core/graphql/graphql.module.ts
@@ -10,6 +10,8 @@ import { GraphqlSessionPlugin } from './graphql-session.plugin';
 import { GraphqlTracingPlugin } from './graphql-tracing.plugin';
 import { GraphQLConfig } from './graphql.config';
 
+import './types';
+
 @Module({
   imports: [TracingModule],
   providers: [

--- a/src/core/graphql/types.ts
+++ b/src/core/graphql/types.ts
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/method-signature-style */
+
+import type { GqlContextType as GqlRequestType } from '@nestjs/graphql/dist/services/gql-execution-context';
+import type { GraphQLResolveInfo } from 'graphql';
+import type { GqlContextType } from '~/common';
+
+type AllRequestTypes = GqlRequestType;
+
+declare module '@nestjs/common/interfaces/features/arguments-host.interface' {
+  export interface ArgumentsHost {
+    getType(): AllRequestTypes;
+  }
+}
+
+declare module '@nestjs/core/helpers/execution-context-host' {
+  export interface ExecutionContextHost {
+    getType(): AllRequestTypes;
+  }
+}
+
+declare module '@nestjs/graphql' {
+  export interface GqlExecutionContext {
+    getContext(): GqlContextType;
+    getInfo(): GraphQLResolveInfo;
+  }
+}

--- a/src/core/http/http.adapter.ts
+++ b/src/core/http/http.adapter.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @seedcompany/no-restricted-imports
+import { HttpAdapterHost as HttpAdapterHostImpl } from '@nestjs/core';
+import {
+  ExpressAdapter as HttpAdapter,
+  NestExpressApplication as NestHttpApplication,
+} from '@nestjs/platform-express';
+
+export { HttpAdapter, type NestHttpApplication };
+
+export class HttpAdapterHost extends HttpAdapterHostImpl<HttpAdapter> {}

--- a/src/core/http/http.module.ts
+++ b/src/core/http/http.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+// eslint-disable-next-line @seedcompany/no-restricted-imports
+import { HttpAdapterHost as HttpAdapterHostImpl } from '@nestjs/core';
+import { HttpAdapterHost } from './http.adapter';
+
+@Module({
+  providers: [
+    {
+      provide: HttpAdapterHost,
+      useExisting: HttpAdapterHostImpl,
+    },
+  ],
+  exports: [HttpAdapterHost],
+})
+export class HttpModule {}

--- a/src/core/http/index.ts
+++ b/src/core/http/index.ts
@@ -1,0 +1,3 @@
+export type * from './types';
+export * from './http.adapter';
+export * from './http.module';

--- a/src/core/http/types.ts
+++ b/src/core/http/types.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/method-signature-style */
+// eslint-disable-next-line @seedcompany/no-restricted-imports
+import type { NestMiddleware } from '@nestjs/common';
+import type { Request, Response } from 'express';
+
+// Exporting with I prefix to avoid ambiguity with web global types
+export type { Request as IRequest, Response as IResponse };
+
+export type HttpMiddleware = NestMiddleware<Request, Response>;
+
+export { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
+export { CookieOptions } from 'express';

--- a/src/core/http/types.ts
+++ b/src/core/http/types.ts
@@ -10,3 +10,11 @@ export type HttpMiddleware = NestMiddleware<Request, Response>;
 
 export { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
 export { CookieOptions } from 'express';
+
+declare module '@nestjs/common/interfaces/features/arguments-host.interface' {
+  export interface HttpArgumentsHost {
+    getRequest(): Request;
+    getResponse(): Response;
+    getNext(): (error?: Error) => void;
+  }
+}

--- a/src/core/http/types.ts
+++ b/src/core/http/types.ts
@@ -2,6 +2,7 @@
 // eslint-disable-next-line @seedcompany/no-restricted-imports
 import type { NestMiddleware } from '@nestjs/common';
 import type { Request, Response } from 'express';
+import type { Session } from '~/common';
 
 // Exporting with I prefix to avoid ambiguity with web global types
 export type { Request as IRequest, Response as IResponse };
@@ -10,6 +11,12 @@ export type HttpMiddleware = NestMiddleware<Request, Response>;
 
 export { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
 export { CookieOptions } from 'express';
+
+declare module 'express' {
+  export interface Request {
+    session?: Session;
+  }
+}
 
 declare module '@nestjs/common/interfaces/features/arguments-host.interface' {
   export interface HttpArgumentsHost {

--- a/src/core/timeout.interceptor.ts
+++ b/src/core/timeout.interceptor.ts
@@ -4,13 +4,10 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import {
-  GqlExecutionContext,
-  GqlContextType as GqlExeType,
-} from '@nestjs/graphql';
+import { GqlExecutionContext } from '@nestjs/graphql';
 import { fromEvent, Observable, race } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { GqlContextType, ServiceUnavailableException } from '~/common';
+import { ServiceUnavailableException } from '~/common';
 
 /**
  * Throws error when response timeouts.
@@ -20,10 +17,9 @@ import { GqlContextType, ServiceUnavailableException } from '~/common';
 export class TimeoutInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const response =
-      context.getType<GqlExeType>() !== 'graphql'
+      context.getType() !== 'graphql'
         ? context.switchToHttp().getResponse()
-        : GqlExecutionContext.create(context).getContext<GqlContextType>()
-            .response;
+        : GqlExecutionContext.create(context).getContext().response;
 
     if (!response) {
       return next.handle();

--- a/src/core/timeout.interceptor.ts
+++ b/src/core/timeout.interceptor.ts
@@ -8,10 +8,10 @@ import {
   GqlExecutionContext,
   GqlContextType as GqlExeType,
 } from '@nestjs/graphql';
-import { Response } from 'express';
 import { fromEvent, Observable, race } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { GqlContextType, ServiceUnavailableException } from '~/common';
+import { IResponse as Response } from '~/core/http';
 
 /**
  * Throws error when response timeouts.

--- a/src/core/timeout.interceptor.ts
+++ b/src/core/timeout.interceptor.ts
@@ -11,7 +11,6 @@ import {
 import { fromEvent, Observable, race } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { GqlContextType, ServiceUnavailableException } from '~/common';
-import { IResponse as Response } from '~/core/http';
 
 /**
  * Throws error when response timeouts.
@@ -22,7 +21,7 @@ export class TimeoutInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const response =
       context.getType<GqlExeType>() !== 'graphql'
-        ? context.switchToHttp().getResponse<Response>()
+        ? context.switchToHttp().getResponse()
         : GqlExecutionContext.create(context).getContext<GqlContextType>()
             .response;
 

--- a/src/core/tracing/xray-sampler.ts
+++ b/src/core/tracing/xray-sampler.ts
@@ -21,6 +21,10 @@ export class XraySampler implements Sampler {
             .request
         : context.switchToHttp().getRequest();
 
+    if (!req) {
+      return false;
+    }
+
     // eslint-disable-next-line @typescript-eslint/ban-types
     const rule: String | string | boolean | null | undefined =
       // @ts-expect-error not typed but it exists

--- a/src/core/tracing/xray-sampler.ts
+++ b/src/core/tracing/xray-sampler.ts
@@ -1,10 +1,6 @@
 import { ExecutionContext, Injectable } from '@nestjs/common';
-import {
-  GqlExecutionContext,
-  GqlContextType as GqlExeType,
-} from '@nestjs/graphql';
+import { GqlExecutionContext } from '@nestjs/graphql';
 import XRay from 'aws-xray-sdk-core';
-import { GqlContextType } from '~/common';
 import { Sampler } from './sampler';
 import { Segment } from './tracing.service';
 
@@ -16,9 +12,8 @@ export class XraySampler implements Sampler {
   async shouldTrace(context: ExecutionContext, segment: Segment) {
     // Pretty specific to configuration outside of this module...
     const req =
-      context.getType<GqlExeType>() === 'graphql'
-        ? GqlExecutionContext.create(context).getContext<GqlContextType>()
-            .request
+      context.getType() === 'graphql'
+        ? GqlExecutionContext.create(context).getContext().request
         : context.switchToHttp().getRequest();
 
     if (!req) {

--- a/src/core/tracing/xray.middleware.ts
+++ b/src/core/tracing/xray.middleware.ts
@@ -3,15 +3,17 @@ import {
   ExecutionContext,
   Injectable,
   NestInterceptor,
-  NestMiddleware,
 } from '@nestjs/common';
 import {
   GqlExecutionContext,
   GqlContextType as GqlExeType,
 } from '@nestjs/graphql';
 import XRay from 'aws-xray-sdk-core';
-import { Request, Response } from 'express';
 import { GqlContextType } from '~/common';
+import {
+  HttpMiddleware as NestMiddleware,
+  IResponse as Response,
+} from '~/core/http';
 import { ConfigService } from '../config/config.service';
 import { Sampler } from './sampler';
 import { TracingService } from './tracing.service';
@@ -27,7 +29,7 @@ export class XRayMiddleware implements NestMiddleware, NestInterceptor {
   /**
    * Setup root segment for request/response.
    */
-  use(req: Request, res: Response, next: () => void) {
+  use: NestMiddleware['use'] = (req, res, next) => {
     const traceData = XRay.utils.processTraceData(
       req.header('x-amzn-trace-id'),
     );
@@ -62,7 +64,7 @@ export class XRayMiddleware implements NestMiddleware, NestInterceptor {
     });
 
     this.tracing.segmentStorage.run(root, next);
-  }
+  };
 
   /**
    * Determine if segment should be traced/sampled.

--- a/src/core/tracing/xray.middleware.ts
+++ b/src/core/tracing/xray.middleware.ts
@@ -10,10 +10,7 @@ import {
 } from '@nestjs/graphql';
 import XRay from 'aws-xray-sdk-core';
 import { GqlContextType } from '~/common';
-import {
-  HttpMiddleware as NestMiddleware,
-  IResponse as Response,
-} from '~/core/http';
+import { HttpMiddleware as NestMiddleware } from '~/core/http';
 import { ConfigService } from '../config/config.service';
 import { Sampler } from './sampler';
 import { TracingService } from './tracing.service';
@@ -107,7 +104,7 @@ export class XRayMiddleware implements NestMiddleware, NestInterceptor {
       context.getType<GqlExeType>() === 'graphql'
         ? GqlExecutionContext.create(context).getContext<GqlContextType>()
             .response
-        : context.switchToHttp().getResponse<Response>();
+        : context.switchToHttp().getResponse();
 
     if (res && root instanceof XRay.Segment) {
       res.setHeader(

--- a/src/core/tracing/xray.middleware.ts
+++ b/src/core/tracing/xray.middleware.ts
@@ -4,12 +4,8 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import {
-  GqlExecutionContext,
-  GqlContextType as GqlExeType,
-} from '@nestjs/graphql';
+import { GqlExecutionContext } from '@nestjs/graphql';
 import XRay from 'aws-xray-sdk-core';
-import { GqlContextType } from '~/common';
 import { HttpMiddleware as NestMiddleware } from '~/core/http';
 import { ConfigService } from '../config/config.service';
 import { Sampler } from './sampler';
@@ -101,9 +97,8 @@ export class XRayMiddleware implements NestMiddleware, NestInterceptor {
 
     // Pretty specific to configuration outside of this module...
     const res =
-      context.getType<GqlExeType>() === 'graphql'
-        ? GqlExecutionContext.create(context).getContext<GqlContextType>()
-            .response
+      context.getType() === 'graphql'
+        ? GqlExecutionContext.create(context).getContext().response
         : context.switchToHttp().getResponse();
 
     if (res && root instanceof XRay.Segment) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,23 +1,34 @@
 import { Logger } from '@nestjs/common';
-import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
 import { NestFactory } from '@nestjs/core';
 import cookieParser from 'cookie-parser';
+import type { CorsOptions, NestHttpApplication } from '~/core/http';
 import './polyfills';
 
 async function bootstrap() {
   // Ensure src files are initialized here were init errors can be caught
   const { AppModule } = await import('./app.module');
   const { bootstrapLogger, ConfigService } = await import('./core');
+  const { HttpAdapter } = await import('./core/http');
 
   if (process.argv.includes('--gen-schema')) {
-    const app = await NestFactory.create(AppModule, { logger: false });
+    const app = await NestFactory.create<NestHttpApplication>(
+      AppModule,
+      new HttpAdapter(),
+      {
+        logger: false,
+      },
+    );
     await app.init();
     process.exit(0);
   }
 
-  const app = await NestFactory.create(AppModule, {
-    logger: bootstrapLogger,
-  });
+  const app = await NestFactory.create<NestHttpApplication>(
+    AppModule,
+    new HttpAdapter(),
+    {
+      logger: bootstrapLogger,
+    },
+  );
   const config = app.get(ConfigService);
 
   app.enableCors(config.cors as CorsOptions); // typecast to undo deep readonly

--- a/test/utility/create-app.ts
+++ b/test/utility/create-app.ts
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { andCall } from '~/common';
+import { HttpAdapter } from '~/core/http';
 import { LogLevel } from '~/core/logger';
 import { LevelMatcher } from '~/core/logger/level-matcher';
 import { AppModule } from '../../src/app.module';
@@ -33,7 +34,7 @@ export const createTestApp = async () => {
       .useValue(db?.options)
       .compile();
 
-    const app = moduleFixture.createNestApplication<TestApp>();
+    const app = moduleFixture.createNestApplication<TestApp>(new HttpAdapter());
     await app.init();
     app.graphql = await createGraphqlClient(app);
 


### PR DESCRIPTION
I've created `~/core/http` to hold all http platform specifics. The codebase can reference this now and we don't have implementation details littered all over the codebase.

---

Also `.switchToHttp()` & `GqlExecutionContext` have strict return types (via declaration merging).
So the default return values of `any` is avoided and there's no need to give explicit generic at every usage.
