### PR TITLE
Neo4j Filter Performance

### DIFF
--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -757,31 +757,25 @@ export const engagementFilters = filter.define(() => EngagementFilters, {
     () => projectFilters,
     'requestingUser',
   )((sub) =>
-    sub
-      .with('node as eng, requestingUser')
-      .match([
-        node('eng'),
-        relation('in', '', 'engagement'),
-        node('node', 'Project'),
-      ]),
+    sub.match([
+      node('outer'),
+      relation('in', '', 'engagement'),
+      node('node', 'Project'),
+    ]),
   ),
   language: filter.sub(() => languageFilters)((sub) =>
-    sub
-      .with('node as eng')
-      .match([
-        node('eng'),
-        relation('out', '', 'language'),
-        node('node', 'Language'),
-      ]),
+    sub.match([
+      node('outer'),
+      relation('out', '', 'language'),
+      node('node', 'Language'),
+    ]),
   ),
   intern: filter.sub(() => userFilters)((sub) =>
-    sub
-      .with('node as eng')
-      .match([
-        node('eng'),
-        relation('out', '', 'intern'),
-        node('node', 'User'),
-      ]),
+    sub.match([
+      node('outer'),
+      relation('out', '', 'intern'),
+      node('node', 'User'),
+    ]),
   ),
   startDate: filter.dateTime(({ query }) => {
     query.optionalMatch([

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -699,6 +699,59 @@ export const engagementFilters = filter.define(() => EngagementFilters, {
     ),
   }),
   status: filter.stringListProp(),
+  projectId: filter.pathExists((id) => [
+    node('node'),
+    relation('in', '', 'engagement'),
+    node('project', 'Project', { id }),
+  ]),
+  partnerId: filter.pathExists((id) => [
+    node('node'),
+    relation('in', '', 'engagement'),
+    node('', 'Project'),
+    relation('out', '', 'partnership', ACTIVE),
+    node('', 'Partnership'),
+    relation('out', '', 'partner'),
+    node('', 'Partner', { id }),
+  ]),
+  languageId: filter.pathExists((id) => [
+    node('node'),
+    relation('out', '', 'language'),
+    node('', 'Language', { id }),
+  ]),
+  startDate: filter.dateTime(({ query }) => {
+    query.optionalMatch([
+      [
+        node('node'),
+        relation('out', '', 'startDateOverride', ACTIVE),
+        node('startDateOverride', 'Property'),
+      ],
+      [
+        node('node'),
+        relation('in', '', 'engagement'),
+        node('project', 'Project'),
+        relation('out', '', 'mouStart', ACTIVE),
+        node('mouStart', 'Property'),
+      ],
+    ]);
+    return coalesce('startDateOverride.value', 'mouStart.value');
+  }),
+  endDate: filter.dateTime(({ query }) => {
+    query.optionalMatch([
+      [
+        node('node'),
+        relation('out', '', 'endDateOverride', ACTIVE),
+        node('endDateOverride', 'Property'),
+      ],
+      [
+        node('node'),
+        relation('in', '', 'engagement'),
+        node('project', 'Project'),
+        relation('out', '', 'mouEnd', ACTIVE),
+        node('mouEnd', 'Property'),
+      ],
+    ]);
+    return coalesce('endDateOverride.value', 'mouEnd.value');
+  }),
   name: filter.fullText({
     index: () => NameIndex,
     matchToNode: (q) =>
@@ -734,25 +787,6 @@ export const engagementFilters = filter.define(() => EngagementFilters, {
     separateQueryForEachWord: true,
     minScore: 0.9,
   }),
-  projectId: filter.pathExists((id) => [
-    node('node'),
-    relation('in', '', 'engagement'),
-    node('project', 'Project', { id }),
-  ]),
-  partnerId: filter.pathExists((id) => [
-    node('node'),
-    relation('in', '', 'engagement'),
-    node('', 'Project'),
-    relation('out', '', 'partnership', ACTIVE),
-    node('', 'Partnership'),
-    relation('out', '', 'partner'),
-    node('', 'Partner', { id }),
-  ]),
-  languageId: filter.pathExists((id) => [
-    node('node'),
-    relation('out', '', 'language'),
-    node('', 'Language', { id }),
-  ]),
   project: filter.sub(
     () => projectFilters,
     'requestingUser',
@@ -777,40 +811,6 @@ export const engagementFilters = filter.define(() => EngagementFilters, {
       node('node', 'User'),
     ]),
   ),
-  startDate: filter.dateTime(({ query }) => {
-    query.optionalMatch([
-      [
-        node('node'),
-        relation('out', '', 'startDateOverride', ACTIVE),
-        node('startDateOverride', 'Property'),
-      ],
-      [
-        node('node'),
-        relation('in', '', 'engagement'),
-        node('project', 'Project'),
-        relation('out', '', 'mouStart', ACTIVE),
-        node('mouStart', 'Property'),
-      ],
-    ]);
-    return coalesce('startDateOverride.value', 'mouStart.value');
-  }),
-  endDate: filter.dateTime(({ query }) => {
-    query.optionalMatch([
-      [
-        node('node'),
-        relation('out', '', 'endDateOverride', ACTIVE),
-        node('endDateOverride', 'Property'),
-      ],
-      [
-        node('node'),
-        relation('in', '', 'engagement'),
-        node('project', 'Project'),
-        relation('out', '', 'mouEnd', ACTIVE),
-        node('mouEnd', 'Property'),
-      ],
-    ]);
-    return coalesce('endDateOverride.value', 'mouEnd.value');
-  }),
 });
 
 export const engagementSorters = defineSorters(IEngagement, {

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -280,15 +280,7 @@ export class LanguageRepository extends DtoRepository<
 }
 
 export const languageFilters = filter.define(() => LanguageFilters, {
-  name: filter.fullText({
-    index: () => NameIndex,
-    matchToNode: (q) =>
-      q.match([
-        node('node', 'Language'),
-        relation('out', '', undefined, ACTIVE),
-        node('match'),
-      ]),
-  }),
+  pinned: filter.isPinned,
   sensitivity: filter.stringListProp(),
   leastOfThese: filter.propVal(),
   isSignLanguage: filter.propVal(),
@@ -308,12 +300,15 @@ export const languageFilters = filter.define(() => LanguageFilters, {
     relation('out', '', 'partner', ACTIVE),
     node('', 'Partner', { id }),
   ]),
-  presetInventory: ({ value, query }) => {
-    query.apply(isPresetInventory).with('*');
-    const condition = equals('true', true);
-    return { presetInventory: value ? condition : not(condition) };
-  },
-  pinned: filter.isPinned,
+  name: filter.fullText({
+    index: () => NameIndex,
+    matchToNode: (q) =>
+      q.match([
+        node('node', 'Language'),
+        relation('out', '', undefined, ACTIVE),
+        node('match'),
+      ]),
+  }),
   ethnologue: filter.sub(() => ethnologueFilters)((sub) =>
     sub.match([
       node('outer'),
@@ -321,6 +316,11 @@ export const languageFilters = filter.define(() => LanguageFilters, {
       node('node', 'EthnologueLanguage'),
     ]),
   ),
+  presetInventory: ({ value, query }) => {
+    query.apply(isPresetInventory).with('*');
+    const condition = equals('true', true);
+    return { presetInventory: value ? condition : not(condition) };
+  },
 });
 
 const ethnologueFilters = filter.define(() => EthnologueLanguageFilters, {

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -315,13 +315,11 @@ export const languageFilters = filter.define(() => LanguageFilters, {
   },
   pinned: filter.isPinned,
   ethnologue: filter.sub(() => ethnologueFilters)((sub) =>
-    sub
-      .with('node as lang')
-      .match([
-        node('lang'),
-        relation('out', '', 'ethnologue'),
-        node('node', 'EthnologueLanguage'),
-      ]),
+    sub.match([
+      node('outer'),
+      relation('out', '', 'ethnologue'),
+      node('node', 'EthnologueLanguage'),
+    ]),
   ),
 });
 

--- a/src/components/location/location.repository.ts
+++ b/src/components/location/location.repository.ts
@@ -245,6 +245,11 @@ export class LocationRepository extends DtoRepository(Location) {
 export const locationSorters = defineSorters(Location, {});
 
 export const locationFilters = filter.define(() => LocationFilters, {
+  fundingAccountId: filter.pathExists((id) => [
+    node('node'),
+    relation('out', '', 'fundingAccount', ACTIVE),
+    node('', 'FundingAccount', { id }),
+  ]),
   name: filter.fullText({
     index: () => NameIndex,
     matchToNode: (q) =>
@@ -254,11 +259,6 @@ export const locationFilters = filter.define(() => LocationFilters, {
         node('match'),
       ]),
   }),
-  fundingAccountId: filter.pathExists((id) => [
-    node('node'),
-    relation('out', '', 'fundingAccount', ACTIVE),
-    node('', 'FundingAccount', { id }),
-  ]),
 });
 
 const NameIndex = FullTextIndex({

--- a/src/components/partner/partner.repository.ts
+++ b/src/components/partner/partner.repository.ts
@@ -312,13 +312,11 @@ export const partnerFilters = filters.define(() => PartnerFilters, {
     node('', 'User', { id }),
   ]),
   organization: filter.sub(() => organizationFilters)((sub) =>
-    sub
-      .with('node as partner')
-      .match([
-        node('partner'),
-        relation('out', '', 'organization'),
-        node('node', 'Organization'),
-      ]),
+    sub.match([
+      node('outer'),
+      relation('out', '', 'organization'),
+      node('node', 'Organization'),
+    ]),
   ),
 });
 

--- a/src/components/partnership/partnership.repository.ts
+++ b/src/components/partnership/partnership.repository.ts
@@ -429,13 +429,11 @@ export const partnershipFilters = filter.define(() => PartnershipFilters, {
   projectId: filter.skip,
   types: filter.intersectsProp(),
   partner: filter.sub(() => partnerFilters)((sub) =>
-    sub
-      .with('node as partnership')
-      .match([
-        node('partnership'),
-        relation('out', '', 'partner'),
-        node('node', 'Partner'),
-      ]),
+    sub.match([
+      node('outer'),
+      relation('out', '', 'partner'),
+      node('node', 'Partner'),
+    ]),
   ),
 });
 

--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -190,18 +190,7 @@ export class PeriodicReportRepository extends DtoRepository<
     const result = await this.db
       .query()
       .matchNode('node', 'PeriodicReport')
-      .apply(
-        filter.builder(filters, {
-          parent: filter.pathExists((id) => [
-            node('', 'BaseNode', { id }),
-            relation('out', '', 'report', ACTIVE),
-            node('node'),
-          ]),
-          start: filter.dateTimeProp(),
-          end: filter.dateTimeProp(),
-          type: ({ value }) => ({ node: hasLabel(`${value}Report`) }),
-        }),
-      )
+      .apply(periodicReportFilters(filters))
       .apply(sorting(resource, input))
       .apply(paginate(input, this.hydrate(session)))
       .first();
@@ -459,6 +448,19 @@ export const matchCurrentDue =
         ['start.value', 'asc'],
       ])
       .limit(1);
+
+export const periodicReportFilters = filter.define<
+  Pick<PeriodicReportListInput, 'type' | 'start' | 'end' | 'parent'>
+>(() => undefined as any, {
+  parent: filter.pathExists((id) => [
+    node('', 'BaseNode', { id }),
+    relation('out', '', 'report', ACTIVE),
+    node('node'),
+  ]),
+  start: filter.dateTimeProp(),
+  end: filter.dateTimeProp(),
+  type: ({ value }) => ({ node: hasLabel(`${value}Report`) }),
+});
 
 export const periodicReportSorters = defineSorters(IPeriodicReport, {});
 

--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -452,6 +452,7 @@ export const matchCurrentDue =
 export const periodicReportFilters = filter.define<
   Pick<PeriodicReportListInput, 'type' | 'start' | 'end' | 'parent'>
 >(() => undefined as any, {
+  type: ({ value }) => ({ node: hasLabel(`${value}Report`) }),
   parent: filter.pathExists((id) => [
     node('', 'BaseNode', { id }),
     relation('out', '', 'report', ACTIVE),
@@ -459,7 +460,6 @@ export const periodicReportFilters = filter.define<
   ]),
   start: filter.dateTimeProp(),
   end: filter.dateTimeProp(),
-  type: ({ value }) => ({ node: hasLabel(`${value}Report`) }),
 });
 
 export const periodicReportSorters = defineSorters(IPeriodicReport, {});

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -54,6 +54,7 @@ import {
   ProducibleType,
   Product,
   ProductCompletionDescriptionSuggestionsInput,
+  ProductFilters,
   ProductListInput,
   ProgressMeasurement,
   UpdateDirectScriptureProduct,
@@ -505,14 +506,10 @@ export class ProductRepository extends CommonRepository {
           ...(approach ? ApproachToMethodologies[approach] : []),
           ...(methodology ? [methodology] : []),
         ];
-        filter.builder(
-          { ...rest, ...(merged.length ? { methodology: merged } : {}) },
-          {
-            engagementId: filter.skip,
-            placeholder: filter.isPropNotNull('placeholderDescription'),
-            methodology: filter.propVal(),
-          },
-        )(q);
+        productFilters({
+          ...rest,
+          ...(merged.length ? { methodology: merged } : {}),
+        })(q);
       })
       .apply(sorting(Product, input))
       .apply(paginate(input, this.hydrate(session)))
@@ -582,6 +579,16 @@ export class ProductRepository extends CommonRepository {
     return this.getConstraintsFor(Product);
   }
 }
+
+export const productFilters = filter.define<
+  Omit<ProductFilters, 'approach' | 'methodology'> & {
+    methodology?: Methodology[];
+  }
+>(() => undefined as any, {
+  engagementId: filter.skip,
+  placeholder: filter.isPropNotNull('placeholderDescription'),
+  methodology: filter.propVal(),
+});
 
 const ProductCompletionDescriptionIndex = FullTextIndex({
   indexName: 'ProductCompletionDescription',

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -587,7 +587,7 @@ export const productFilters = filter.define<
 >(() => undefined as any, {
   engagementId: filter.skip,
   placeholder: filter.isPropNotNull('placeholderDescription'),
-  methodology: filter.propVal(),
+  methodology: filter.stringListProp(),
 });
 
 const ProductCompletionDescriptionIndex = FullTextIndex({

--- a/src/components/progress-report/media/progress-report-media.repository.ts
+++ b/src/components/progress-report/media/progress-report-media.repository.ts
@@ -48,16 +48,7 @@ export class ProgressReportMediaRepository extends DtoRepository<
         relation('out', '', 'child', ACTIVE),
         node('node', this.resource.dbLabel),
       ])
-      .apply(
-        filter.builder(
-          { variants: args.variants },
-          {
-            variants: ({ value }) => ({
-              'node.variant': inArray(value.map((v) => v.key)),
-            }),
-          },
-        ),
-      )
+      .apply(progressReportMediaFilters({ variants: args.variants }))
       .match(requestingUser(session))
       .apply(projectFromProgressReportChild)
       .apply(
@@ -298,3 +289,11 @@ export class ProgressReportMediaRepository extends DtoRepository<
         );
   }
 }
+
+export const progressReportMediaFilters = filter.define<
+  Pick<ListArgs, 'variants'>
+>(() => ListArgs, {
+  variants: ({ value }) => ({
+    'node.variant': inArray(value.map((v) => v.key)),
+  }),
+});

--- a/src/components/progress-report/progress-report.repository.ts
+++ b/src/components/progress-report/progress-report.repository.ts
@@ -42,6 +42,7 @@ export class ProgressReportRepository extends DtoRepository<
         relation('in', '', 'engagement'),
         node('project', 'Project'),
       ])
+      .logIt()
       .match(requestingUser(session))
       .apply(progressReportFilters(input.filter))
       .apply(

--- a/src/components/progress-report/progress-report.repository.ts
+++ b/src/components/progress-report/progress-report.repository.ts
@@ -88,13 +88,11 @@ export const progressReportFilters = filter.define(
       () => engagementFilters,
       'requestingUser',
     )((sub) =>
-      sub
-        .with('node as report, requestingUser')
-        .match([
-          node('report'),
-          relation('in', '', 'report'),
-          node('node', 'Engagement'),
-        ]),
+      sub.match([
+        node('outer'),
+        relation('in', '', 'report'),
+        node('node', 'Engagement'),
+      ]),
     ),
   },
 );

--- a/src/components/project/project-filters.query.ts
+++ b/src/components/project/project-filters.query.ts
@@ -103,32 +103,26 @@ export const projectFilters = filter.define(() => ProjectFilters, {
             .where({ sensitivity: inArray(value) })
         : query,
   partnerships: filter.sub(() => partnershipFilters)((sub) =>
-    sub
-      .with('node as project')
-      .match([
-        node('project'),
-        relation('out', '', 'partnership', ACTIVE),
-        node('node', 'Partnership'),
-      ]),
+    sub.match([
+      node('outer'),
+      relation('out', '', 'partnership', ACTIVE),
+      node('node', 'Partnership'),
+    ]),
   ),
   primaryPartnership: filter.sub(() => partnershipFilters)((sub) =>
-    sub
-      .with('node as project')
-      .match([
-        node('project'),
-        relation('out', '', 'partnership', ACTIVE),
-        node('node', 'Partnership'),
-        relation('out', '', 'primary', ACTIVE),
-        node('', 'Property', { value: variable('true') }),
-      ]),
+    sub.match([
+      node('outer'),
+      relation('out', '', 'partnership', ACTIVE),
+      node('node', 'Partnership'),
+      relation('out', '', 'primary', ACTIVE),
+      node('', 'Property', { value: variable('true') }),
+    ]),
   ),
   primaryLocation: filter.sub(() => locationFilters)((sub) =>
-    sub
-      .with('node as project')
-      .match([
-        node('project'),
-        relation('out', '', 'primaryLocation', ACTIVE),
-        node('node', 'Location'),
-      ]),
+    sub.match([
+      node('outer'),
+      relation('out', '', 'primaryLocation', ACTIVE),
+      node('node', 'Location'),
+    ]),
   ),
 });

--- a/src/components/project/project-filters.query.ts
+++ b/src/components/project/project-filters.query.ts
@@ -1,4 +1,10 @@
-import { greaterThan, inArray, node, relation } from 'cypher-query-builder';
+import {
+  equals,
+  greaterThan,
+  inArray,
+  node,
+  relation,
+} from 'cypher-query-builder';
 import {
   ACTIVE,
   filter,
@@ -70,19 +76,15 @@ export const projectFilters = filter.define(() => ProjectFilters, {
       ]),
     ],
   }),
-  onlyMultipleEngagements:
-    ({ value, query }) =>
-    () =>
-      value
-        ? query
-            .match([
-              node('node'),
-              relation('out', '', 'engagement', ACTIVE),
-              node('engagement', 'Engagement'),
-            ])
-            .with('node, count(engagement) as engagementCount')
-            .where({ engagementCount: greaterThan(1) })
-        : null,
+  onlyMultipleEngagements: ({ value, query }) =>
+    query
+      .match([
+        node('node'),
+        relation('out', '', 'engagement', ACTIVE),
+        node('engagement', 'Engagement'),
+      ])
+      .with('node, count(engagement) as engagementCount')
+      .where({ engagementCount: value ? greaterThan(1) : equals(1) }),
   name: filter.fullText({
     index: () => ProjectNameIndex,
     matchToNode: (q) =>
@@ -100,15 +102,11 @@ export const projectFilters = filter.define(() => ProjectFilters, {
       node('node', 'Location'),
     ]),
   ),
-  sensitivity:
-    ({ value, query }) =>
-    () =>
-      value
-        ? query
-            .apply(matchProjectSens('node'))
-            .with('*')
-            .where({ sensitivity: inArray(value) })
-        : query,
+  sensitivity: ({ value, query }) =>
+    query
+      .apply(matchProjectSens('node'))
+      .with('*')
+      .where({ sensitivity: inArray(value) }),
   primaryPartnership: filter.sub(() => partnershipFilters)((sub) =>
     sub.match([
       node('outer'),

--- a/src/core/database/query/filters.ts
+++ b/src/core/database/query/filters.ts
@@ -20,7 +20,6 @@ import { intersects } from './comparators';
 import { collect } from './cypher-functions';
 import { escapeLuceneSyntax, FullTextIndex } from './full-text';
 import { ACTIVE } from './matching';
-import { WhereAndList } from './where-and-list';
 import { path as pathPattern } from './where-path';
 
 export type Builder<T, K extends keyof T = keyof T> = (
@@ -60,7 +59,6 @@ const builder =
     const type = filters.constructor === Object ? null : filters.constructor;
     query.comment(type?.name ?? 'Filters');
 
-    const conditions = [];
     for (const key of Object.keys(builders)) {
       const value = filters[key];
       if (value == null) {
@@ -70,15 +68,7 @@ const builder =
       if (!res || res instanceof Query) {
         continue;
       }
-      if (isFunction(res)) {
-        afters.push(res);
-        continue;
-      }
-      conditions.push(res);
-    }
-
-    if (conditions.length > 0) {
-      query.where(new WhereAndList(conditions));
+      query.where(res);
     }
   };
 

--- a/src/core/database/query/filters.ts
+++ b/src/core/database/query/filters.ts
@@ -54,7 +54,7 @@ export const define =
  * Functions can do nothing, adjust query, return an object to add conditions to
  * the where clause, or return a function which will be called after the where clause.
  */
-export const builder =
+const builder =
   <T extends Record<string, any>>(filters: T, builders: Builders<T>) =>
   (query: Query) => {
     const type = filters.constructor === Object ? null : filters.constructor;

--- a/src/core/database/query/filters.ts
+++ b/src/core/database/query/filters.ts
@@ -25,7 +25,7 @@ import { path as pathPattern } from './where-path';
 
 export type Builder<T, K extends keyof T = keyof T> = (
   args: BuilderArgs<T, K>,
-) => Query | null | Record<string, any> | void | ((query: Query) => Query);
+) => Record<string, any> | Query | Nil;
 export interface BuilderArgs<T, K extends keyof T = keyof T> {
   key: K & string;
   value: NonNullable<T[K]>;
@@ -61,7 +61,6 @@ const builder =
     query.comment(type?.name ?? 'Filters');
 
     const conditions = [];
-    const afters: Array<(query: Query) => Query> = [];
     for (const key of Object.keys(builders)) {
       const value = filters[key];
       if (value == null) {
@@ -80,9 +79,6 @@ const builder =
 
     if (conditions.length > 0) {
       query.where(new WhereAndList(conditions));
-    }
-    for (const after of afters) {
-      after(query);
     }
   };
 


### PR DESCRIPTION
# Previously
Previously we'd group where conditions into a single-ish where clause. If filters needed to select additional data they'd do so before declaring their where condition.
```cypher
match (node)-[:start { active: true }]->(start:Property)
match (node)-[:end { active: true }]->(end:Property)
...
where start.value >= $start and end.value <= $end
```

What this meant though is that filter work could have to be done on all of the `(node)`s instead of filtering immediately.

This was happening with ProgressReports trying to filter by project name.
All of the work to navigate to the project and run the full text search was happening on every report, before we filtered down to just reports for the given quarter.

# Now

Now I have changed it to have each filter produce its own where clause instead of grouping them together.
For simple cases, the cypher performance is the same.
```cypher
match (node)-[:start { active: true }]->(start:Property)
where start.value >= $start
match (node)-[:end { active: true }]->(end:Property)
where end.value <= $end
```
But this makes a big impact on reducing the data for subsequent filters that are more complex.

## Merging sibling WHERE clauses
One of the reasons the former logic existed was because where clauses cannot follow another.
```cypher
where node.type = "TranslationProject"
where node.createdAt > date("2024")
```
```ts
.where({ node: { type: 'TranslationProject' } })
.where({ node: { createdAt: greaterThan('2024') } })
```
I updated the QB to look for this case when chaining and merge them.

# Results

So to take full advantage of this I've sorted the filters to have the cheapest and most effective ones first (just based on gut feeling).

```diff
- 47,719,790 total db hits in 332,911 ms
+  3,142,563 total db hits in  10,509 ms
```
15x better 🎉 
But still 10s query 🫤

<details>
<summary>Query Before</summary>

```cypher
MATCH (node:ProgressReport)<-[:report]-(:LanguageEngagement)<-[:engagement]-(project:Project)
MATCH (requestingUser:User { id: '5c521b098a0ddd9231b84a4a' })
// ProgressReportFilters
MATCH (node)-[:start { active: true }]->(start:Property)
MATCH (node)-[:end { active: true }]->(end:Property)
CALL {
  WITH node, requestingUser
  WITH node as report, requestingUser
  MATCH (report)<-[:report]-(node:Engagement)
  // EngagementFilters
  CALL {
    WITH node, requestingUser
    WITH node as eng, requestingUser
    MATCH (eng)<-[:engagement]-(node:Project)
    // ProjectFilters
    RETURN true as projectFiltersApplied
    limit 1
  }
  WITH *
  CALL {
    WITH node
    WITH node as eng
    MATCH (eng)-[:language]->(node:Language)
    // LanguageFilters
    CALL {
      UNWIND ['(gaut~^2 OR *gaut*)'] AS query
      CALL {
        WITH query
        CALL db.index.fulltext.queryNodes('LanguageName', query, { limit: 100 })
        YIELD node as match, score
        WHERE score > 0
        MATCH (node:Language)-[{ active: true }]->(match)
        RETURN collect(distinct node) as nameMatches
      }
      RETURN collect(nameMatches) as nameMatchSets
    }
    WITH *
    WHERE all(nameMatches in nameMatchSets where node in nameMatches)
    RETURN true as languageFiltersApplied
    limit 1
  }
  WITH *
  RETURN true as engagementFiltersApplied
  limit 1
}
WITH *
WHERE start.value >= date('2024-07-01') AND end.value <= date('2024-09-30')
// sorting(start)
CALL {
  WITH *
  MATCH (node)-[:start { active: true }]->(sortProp:Property)
  RETURN sortProp.value as sortValue
}
WITH *
ORDER BY sortValue
// paginate()
WITH collect(distinct node) as list
WITH list, list[..25] as page
CALL {
  WITH page
  UNWIND page as node
  WITH node, apoc.coll.indexOf(page, node) as order
  // Hydrating node
  CALL {
    WITH node
    MATCH (node)<-[:report { active: true }]-(parent:LanguageEngagement)<-[:engagement { active: true }]-(project:Project)
    // matchPropsAndProjectSensAndScopedRoles()
    CALL {
      WITH node, project
      // matchProjectSens()
      CALL {
        WITH project
        WITH project
        WHERE project IS NOT NULL AND project.type = "Internship"
        MATCH (project)-[:sensitivity { active: true }]->(projSens:Property)
        RETURN projSens.value as sensitivity
        UNION
        WITH project
        WITH project
        WHERE project IS NOT NULL AND project.type <> "Internship"
        OPTIONAL MATCH (project)-[:engagement { active: true }]->(:LanguageEngagement)-[:language { active: true }]->(:Language)-[:sensitivity { active: true }]->(langSens:Property)
        WITH *
        ORDER BY case langSens.value when 'High' then 3 when 'Medium' then 2 when 'Low' then 1 end DESC
        LIMIT 1
        RETURN coalesce(langSens.value, "High") as sensitivity
        UNION
        WITH project
        WITH project
        WHERE project IS NULL
        RETURN "High" as sensitivity
      }
      // matchProps(node)
      CALL {
        WITH node
        MATCH (node)-[r { active: true }]->(prop:Property)
        WITH node, collect(apoc.map.fromValues([type(r), prop.value])) as collectedProps
        WITH [node] + collectedProps as propList
        RETURN apoc.map.mergeList(propList) as props
      }
      // matchProjectScopedRoles()
      CALL {
        WITH project
        MATCH (project)-[:member]->(projectMember)-[:user]->(requestingUser:User { id: '5c521b098a0ddd9231b84a4a' }),
            (projectMember)-[:roles { active: true }]->(rolesProp:Property)
        WITH collect(rolesProp.value) as memberRoleProps
        RETURN case size(memberRoleProps) > 0 when true then ["member:true"] else [] end + reduce(scopedRoles = [], role IN apoc.coll.flatten(memberRoleProps) | scopedRoles + ["project:" + role]) as scopedRoles
        UNION
        WITH project
        WITH project
        WHERE project IS NULL
        RETURN [] as scopedRoles
      }
      RETURN apoc.map.merge(props, { sensitivity: sensitivity, scope: scopedRoles }) as props
    }
    CALL {
      WITH node
      RETURN { `__typename`: "ProgressReport" } as extra
    }
    RETURN apoc.map.mergeList([props, { parent: parent }, extra]) as dto
  }
  WITH *
  ORDER BY order
  RETURN collect(dto) as hydratedPage
}
RETURN hydratedPage as items, size(list) as total, size(page) > 0 and page[-1] <> list[-1] as hasMore
```

</details>

<details>
<summary>Profile Before</summary>

![Plan (6)](https://github.com/user-attachments/assets/e74710e1-4594-47aa-ac94-00a5791cc1e0)

</details>

<details>
<summary>Query After</summary>

```cypher
MATCH (node:ProgressReport)<-[:report]-(:LanguageEngagement)<-[:engagement]-(project:Project)
MATCH (requestingUser:User { id: '5c521b098a0ddd9231b84a4a' })
// ProgressReportFilters
MATCH (node)-[:start { active: true }]->(start:Property)
WHERE start.value >= date('2024-07-01')
MATCH (node)-[:end { active: true }]->(end:Property)
where end.value <= date('2024-09-30')
CALL {
  WITH node, requestingUser
  WITH node as report, requestingUser
  MATCH (report)<-[:report]-(node:Engagement)
  // EngagementFilters
  CALL {
    WITH node, requestingUser
    WITH node as eng, requestingUser
    MATCH (eng)<-[:engagement]-(node:Project)
    // ProjectFilters
    RETURN true as projectFiltersApplied
    limit 1
  }
  WITH *
  CALL {
    WITH node
    WITH node as eng
    MATCH (eng)-[:language]->(node:Language)
    // LanguageFilters
    CALL {
      UNWIND ['(gaut~^2 OR *gaut*)'] AS query
      CALL {
        WITH query
        CALL db.index.fulltext.queryNodes('LanguageName', query, { limit: 100 })
        YIELD node as match, score
        WHERE score > 0
        MATCH (node:Language)-[{ active: true }]->(match)
        RETURN collect(distinct node) as nameMatches
      }
      RETURN collect(nameMatches) as nameMatchSets
    }
    WITH *
    WHERE all(nameMatches in nameMatchSets where node in nameMatches)
    RETURN true as languageFiltersApplied
    limit 1
  }
  WITH *
  RETURN true as engagementFiltersApplied
  limit 1
}
WITH *
// sorting(start)
CALL {
  WITH *
  MATCH (node)-[:start { active: true }]->(sortProp:Property)
  RETURN sortProp.value as sortValue
}
WITH *
ORDER BY sortValue
// paginate()
WITH collect(distinct node) as list
WITH list, list[..25] as page
CALL {
  WITH page
  UNWIND page as node
  WITH node, apoc.coll.indexOf(page, node) as order
  // Hydrating node
  CALL {
    WITH node
    MATCH (node)<-[:report { active: true }]-(parent:LanguageEngagement)<-[:engagement { active: true }]-(project:Project)
    // matchPropsAndProjectSensAndScopedRoles()
    CALL {
      WITH node, project
      // matchProjectSens()
      CALL {
        WITH project
        WITH project
        WHERE project IS NOT NULL AND project.type = "Internship"
        MATCH (project)-[:sensitivity { active: true }]->(projSens:Property)
        RETURN projSens.value as sensitivity
        UNION
        WITH project
        WITH project
        WHERE project IS NOT NULL AND project.type <> "Internship"
        OPTIONAL MATCH (project)-[:engagement { active: true }]->(:LanguageEngagement)-[:language { active: true }]->(:Language)-[:sensitivity { active: true }]->(langSens:Property)
        WITH *
        ORDER BY case langSens.value when 'High' then 3 when 'Medium' then 2 when 'Low' then 1 end DESC
        LIMIT 1
        RETURN coalesce(langSens.value, "High") as sensitivity
        UNION
        WITH project
        WITH project
        WHERE project IS NULL
        RETURN "High" as sensitivity
      }
      // matchProps(node)
      CALL {
        WITH node
        MATCH (node)-[r { active: true }]->(prop:Property)
        WITH node, collect(apoc.map.fromValues([type(r), prop.value])) as collectedProps
        WITH [node] + collectedProps as propList
        RETURN apoc.map.mergeList(propList) as props
      }
      // matchProjectScopedRoles()
      CALL {
        WITH project
        MATCH (project)-[:member]->(projectMember)-[:user]->(requestingUser:User { id: 'd1bebdaa-efcf-57ee-84cd-0b2bfa01eaa7' }),
            (projectMember)-[:roles { active: true }]->(rolesProp:Property)
        WITH collect(rolesProp.value) as memberRoleProps
        RETURN case size(memberRoleProps) > 0 when true then ["member:true"] else [] end + reduce(scopedRoles = [], role IN apoc.coll.flatten(memberRoleProps) | scopedRoles + ["project:" + role]) as scopedRoles
        UNION
        WITH project
        WITH project
        WHERE project IS NULL
        RETURN [] as scopedRoles
      }
      RETURN apoc.map.merge(props, { sensitivity: sensitivity, scope: scopedRoles }) as props
    }
    CALL {
      WITH node
      RETURN { `__typename`: "ProgressReport" } as extra
    }
    RETURN apoc.map.mergeList([props, { parent: parent }, extra]) as dto
  }
  WITH *
  ORDER BY order
  RETURN collect(dto) as hydratedPage
}
RETURN hydratedPage as items, size(list) as total, size(page) > 0 and page[-1] <> list[-1] as hasMore
```

</details>

<details>
<summary>Profile After</summary>

![Plan (5)](https://github.com/user-attachments/assets/a8f4b94d-0525-4b78-b87e-c19385dfb545)

</details>
