### PR TITLE
Expose canCreate flags for Comments

### DIFF
--- a/src/components/comments/comment-thread.loader.ts
+++ b/src/components/comments/comment-thread.loader.ts
@@ -20,7 +20,7 @@ export class CommentThreadLoader extends OrderedNestDataLoader<CommentThread> {
       threads.map(async (thread) => {
         try {
           await this.service.verifyCanView(thread.parent, session);
-          return await this.service.secureThread(thread, session);
+          return this.service.secureThread(thread, session);
         } catch (error) {
           return { key: thread.id, error };
         }

--- a/src/components/comments/comment-thread.resolver.ts
+++ b/src/components/comments/comment-thread.resolver.ts
@@ -61,11 +61,15 @@ export class CommentThreadResolver {
   })
   async comments(
     @AnonSession() session: Session,
-    @Parent() { id }: CommentThread,
+    @Parent() thread: CommentThread,
     @ListArg(CommentListInput) input: CommentListInput,
     @Loader(CommentLoader) comments: LoaderOf<CommentLoader>,
   ): Promise<CommentList> {
-    const list = await this.service.listCommentsByThreadId(id, input, session);
+    const list = await this.service.listCommentsByThreadId(
+      thread,
+      input,
+      session,
+    );
     comments.primeAll(list.items);
     return list;
   }

--- a/src/components/comments/dto/list-comment-thread.dto.ts
+++ b/src/components/comments/dto/list-comment-thread.dto.ts
@@ -1,5 +1,5 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
-import { Order, PaginatedList, SortablePaginationInput } from '~/common';
+import { Order, SecuredList, SortablePaginationInput } from '~/common';
 import { CommentThread } from './comment-thread.dto';
 import { Commentable } from './commentable.dto';
 
@@ -12,7 +12,7 @@ export class CommentThreadListInput extends SortablePaginationInput<
 }) {}
 
 @ObjectType()
-export class CommentThreadList extends PaginatedList(CommentThread) {
+export class CommentThreadList extends SecuredList(CommentThread) {
   @Field()
   readonly parent: Commentable;
 }

--- a/src/components/comments/dto/list-comment.dto.ts
+++ b/src/components/comments/dto/list-comment.dto.ts
@@ -1,5 +1,5 @@
 import { InputType, ObjectType } from '@nestjs/graphql';
-import { Order, PaginatedList, SortablePaginationInput } from '~/common';
+import { Order, SecuredList, SortablePaginationInput } from '~/common';
 import { Comment } from './comment.dto';
 
 @InputType()
@@ -9,4 +9,4 @@ export class CommentListInput extends SortablePaginationInput<keyof Comment>({
 }) {}
 
 @ObjectType()
-export abstract class CommentList extends PaginatedList(Comment) {}
+export abstract class CommentList extends SecuredList(Comment) {}


### PR DESCRIPTION
Currently the comments canCreate just points to threads canCreate. I think this is fine, until it's not.
It's probable that we'd want to simplify and remove threads from authorization, since they just group comments.
But first we'd need to do the policy refactor for embedded resources
```diff
- r.X.children(c => c.comments...)
+ r.Comment.for('X')...
```

https://seed-company-squad.monday.com/boards/3451697530/pulses/7124883698