### PR TITLE
Add sorting for progress summaries

### DIFF
--- a/src/components/progress-summary/dto/progress-summary.dto.ts
+++ b/src/components/progress-summary/dto/progress-summary.dto.ts
@@ -13,6 +13,7 @@ import { LinkTo } from '~/core/resources';
 export abstract class ProgressSummary {
   static readonly Props = keysOf<ProgressSummary>();
   static readonly SecuredProps = keysOf<SecuredProps<ProgressSummary>>();
+  static readonly BaseNodeProps = ['planned', 'actual'];
 
   @Field(() => Float)
   planned: number;

--- a/src/components/progress-summary/progress-summary.repository.ts
+++ b/src/components/progress-summary/progress-summary.repository.ts
@@ -1,8 +1,15 @@
 import { Injectable } from '@nestjs/common';
-import { inArray, node, relation } from 'cypher-query-builder';
+import { mapValues } from '@seedcompany/common';
+import { inArray, node, Query, relation } from 'cypher-query-builder';
 import { ID } from '~/common';
 import { CommonRepository } from '~/core/database';
-import { ACTIVE, listConcat, merge } from '~/core/database/query';
+import {
+  ACTIVE,
+  defineSorters,
+  listConcat,
+  merge,
+  SortCol,
+} from '~/core/database/query';
 import { ProgressReport } from '../progress-report/dto';
 import { FetchedSummaries, ProgressSummary, SummaryPeriod } from './dto';
 
@@ -80,3 +87,11 @@ export class ProgressSummaryRepository extends CommonRepository {
       .run();
   }
 }
+
+export const progressSummarySorters = defineSorters(ProgressSummary, {
+  ...mapValues.fromList(
+    ['variance', 'scheduleStatus'],
+    () => (query: Query) =>
+      query.return<SortCol>('(node.actual - node.planned) as sortValue'),
+  ).asRecord,
+});

--- a/src/core/database/query/sorting.ts
+++ b/src/core/database/query/sorting.ts
@@ -171,7 +171,7 @@ export interface SortCol {
 export type SortFieldOf<TResourceStatic extends ResourceShape<any>> =
   LiteralUnion<keyof TResourceStatic['prototype'] & string, string>;
 
-type SortMatcher<Field extends string> = (
+export type SortMatcher<Field extends string> = (
   query: Query,
   input: Sort<Field> & SortInternals,
 ) => Query<SortCol>;


### PR DESCRIPTION
```gql
progressReports(input: {
   sort: "cumulativeSummary.variance"
   sort: "fiscalYearSummary.planned"
   sort: "periodSummary.scheduleStatus"
}) {
  ...
}
```

https://seed-company-squad.monday.com/boards/5989610236/pulses/7551148894