### PR TITLE
Shuffle `~/core/graphql` code around

### DIFF
--- a/src/components/changeset/enforce-changeset-editable.pipe.ts
+++ b/src/components/changeset/enforce-changeset-editable.pipe.ts
@@ -10,7 +10,7 @@ import {
   isIdLike,
   loadManyIgnoreMissingThrowAny,
 } from '~/common';
-import { GqlContextHost, NotGraphQLContext } from '~/core';
+import { GqlContextHost, NotGraphQLContext } from '~/core/graphql';
 import { ResourceLoaderRegistry } from '~/core/resources/loader.registry';
 import { Changeset } from './dto';
 import { shouldValidateEditability } from './validate-editability.decorator';

--- a/src/components/progress-report/media/handlers/update-media-metadata-check.handler.ts
+++ b/src/components/progress-report/media/handlers/update-media-metadata-check.handler.ts
@@ -1,5 +1,6 @@
 import { sessionFromContext } from '~/common/session';
-import { EventsHandler, GqlContextHost, ResourceLoader } from '~/core';
+import { EventsHandler, ResourceLoader } from '~/core';
+import { GqlContextHost } from '~/core/graphql';
 import { Privileges } from '../../../authorization';
 import { CanUpdateMediaUserMetadataEvent } from '../../../file/media/events/can-update-event';
 import { ProgressReportMedia as ReportMedia } from '../dto';

--- a/src/core/graphql/graphql-error-formatter.ts
+++ b/src/core/graphql/graphql-error-formatter.ts
@@ -6,6 +6,7 @@ import {
   GraphQLFormattedError as FormattedError,
   GraphQLError,
 } from 'graphql';
+import { LazyGetter } from 'lazy-get-decorator';
 import { JsonSet } from '~/common';
 import { ExceptionFilter } from '../exception/exception.filter';
 import { ExceptionNormalizer } from '../exception/exception.normalizer';
@@ -20,14 +21,13 @@ declare module 'graphql' {
 
 @Injectable()
 export class GraphqlErrorFormatter {
-  private readonly normalizer: ExceptionNormalizer;
-  private readonly filter: ExceptionFilter;
+  constructor(private readonly moduleRef: ModuleRef) {}
 
-  constructor(moduleRef: ModuleRef) {
-    [this.normalizer, this.filter] = [
-      moduleRef.get(ExceptionNormalizer, { strict: false }),
-      moduleRef.get(ExceptionFilter, { strict: false }),
-    ];
+  @LazyGetter() private get normalizer() {
+    return this.moduleRef.get(ExceptionNormalizer, { strict: false });
+  }
+  @LazyGetter() private get filter() {
+    return this.moduleRef.get(ExceptionFilter, { strict: false });
   }
 
   formatError = (

--- a/src/core/graphql/graphql-error-formatter.ts
+++ b/src/core/graphql/graphql-error-formatter.ts
@@ -1,0 +1,89 @@
+import { unwrapResolverError } from '@apollo/server/errors';
+import { Injectable } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import {
+  GraphQLErrorExtensions as ErrorExtensions,
+  GraphQLFormattedError as FormattedError,
+  GraphQLError,
+} from 'graphql';
+import { JsonSet } from '~/common';
+import { ExceptionFilter } from '../exception/exception.filter';
+import { ExceptionNormalizer } from '../exception/exception.normalizer';
+
+declare module 'graphql' {
+  interface GraphQLErrorExtensions {
+    code?: string;
+    codes?: ReadonlySet<string>;
+    stacktrace?: string[];
+  }
+}
+
+@Injectable()
+export class GraphqlErrorFormatter {
+  private readonly normalizer: ExceptionNormalizer;
+  private readonly filter: ExceptionFilter;
+
+  constructor(moduleRef: ModuleRef) {
+    [this.normalizer, this.filter] = [
+      moduleRef.get(ExceptionNormalizer, { strict: false }),
+      moduleRef.get(ExceptionFilter, { strict: false }),
+    ];
+  }
+
+  formatError = (
+    formatted: FormattedError,
+    error: unknown | /* but probably a */ GraphQLError,
+  ): FormattedError => {
+    const { message, ...extensions } = this.getErrorExtensions(
+      formatted,
+      error,
+    );
+
+    const codes = (extensions.codes ??= new JsonSet(['Server']));
+    delete extensions.code;
+
+    // Schema & validation errors don't have meaningful stack traces, so remove them
+    const worthlessTrace = codes.has('Validation') || codes.has('GraphQL');
+    if (worthlessTrace) {
+      delete extensions.stacktrace;
+    }
+
+    return {
+      message:
+        message && typeof message === 'string' ? message : formatted.message,
+      extensions,
+      locations: formatted.locations,
+      path: formatted.path,
+    };
+  };
+
+  private getErrorExtensions(
+    formatted: FormattedError,
+    error: unknown | /* but probably a */ GraphQLError,
+  ): ErrorExtensions {
+    // ExceptionNormalizer has already been called
+    if (formatted.extensions?.codes instanceof Set) {
+      return { ...formatted.extensions };
+    }
+
+    const original = unwrapResolverError(error);
+    // Safety check
+    if (!(original instanceof Error)) {
+      return { ...formatted.extensions };
+    }
+
+    // Some errors do not go through the global exception filter.
+    // ResolveField() calls is one of them.
+    // Normalized & log here.
+    const normalized = this.normalizer.normalize({
+      ex: original,
+      gql: error instanceof GraphQLError ? error : undefined,
+    });
+    this.filter.logIt(normalized, original);
+    const { stack, ...extensions } = normalized;
+    return {
+      ...extensions,
+      stacktrace: stack.split('\n'),
+    };
+  }
+}

--- a/src/core/graphql/graphql.module.ts
+++ b/src/core/graphql/graphql.module.ts
@@ -5,6 +5,7 @@ import { GraphQLModule as NestGraphqlModule } from '@nestjs/graphql';
 import createUploadMiddleware from 'graphql-upload/graphqlUploadExpress.mjs';
 import { TracingModule } from '../tracing';
 import { GqlContextHost, GqlContextHostImpl } from './gql-context.host';
+import { GraphqlErrorFormatter } from './graphql-error-formatter';
 import { GraphqlLoggingPlugin } from './graphql-logging.plugin';
 import { GraphqlSessionPlugin } from './graphql-session.plugin';
 import { GraphqlTracingPlugin } from './graphql-tracing.plugin';
@@ -16,6 +17,7 @@ import './types';
   imports: [TracingModule],
   providers: [
     GraphqlOptions,
+    GraphqlErrorFormatter,
     GraphqlLoggingPlugin,
     GraphqlTracingPlugin,
     GraphqlSessionPlugin,

--- a/src/core/graphql/graphql.module.ts
+++ b/src/core/graphql/graphql.module.ts
@@ -8,28 +8,28 @@ import { GqlContextHost, GqlContextHostImpl } from './gql-context.host';
 import { GraphqlLoggingPlugin } from './graphql-logging.plugin';
 import { GraphqlSessionPlugin } from './graphql-session.plugin';
 import { GraphqlTracingPlugin } from './graphql-tracing.plugin';
-import { GraphQLConfig } from './graphql.config';
+import { GraphqlOptions } from './graphql.options';
 
 import './types';
 
 @Module({
   imports: [TracingModule],
   providers: [
-    GraphQLConfig,
+    GraphqlOptions,
     GraphqlLoggingPlugin,
     GraphqlTracingPlugin,
     GraphqlSessionPlugin,
   ],
-  exports: [GraphQLConfig],
+  exports: [GraphqlOptions],
 })
-export class GraphqlConfigModule {}
+export class GraphqlOptionsModule {}
 
 @Module({
   imports: [
     NestGraphqlModule.forRootAsync({
       driver: ApolloDriver,
-      useExisting: GraphQLConfig,
-      imports: [GraphqlConfigModule],
+      useExisting: GraphqlOptions,
+      imports: [GraphqlOptionsModule],
     }),
   ],
   providers: [

--- a/src/core/graphql/graphql.options.ts
+++ b/src/core/graphql/graphql.options.ts
@@ -36,7 +36,7 @@ declare module 'graphql/error/GraphQLError' {
 }
 
 @Injectable()
-export class GraphQLConfig implements GqlOptionsFactory {
+export class GraphqlOptions implements GqlOptionsFactory {
   private readonly exceptionNormalizer: ExceptionNormalizer;
   private readonly exceptionFilter: ExceptionFilter;
 

--- a/src/core/graphql/graphql.options.ts
+++ b/src/core/graphql/graphql.options.ts
@@ -1,5 +1,4 @@
 import { ContextFunction } from '@apollo/server';
-import { unwrapResolverError } from '@apollo/server/errors';
 import { ExpressContextFunctionArgument } from '@apollo/server/express4';
 import {
   ApolloServerPluginLandingPageLocalDefault,
@@ -7,51 +6,27 @@ import {
 } from '@apollo/server/plugin/landingPage/default';
 import { ApolloDriverConfig } from '@nestjs/apollo';
 import { Injectable } from '@nestjs/common';
-import { ModuleRef } from '@nestjs/core';
 import { GqlOptionsFactory } from '@nestjs/graphql';
 import { CacheService } from '@seedcompany/cache';
 import { mapKeys } from '@seedcompany/common';
-import {
-  GraphQLErrorExtensions as ErrorExtensions,
-  GraphQLFormattedError as FormattedError,
-  GraphQLError,
-  GraphQLScalarType,
-  OperationDefinitionNode,
-} from 'graphql';
+import { GraphQLScalarType, OperationDefinitionNode } from 'graphql';
 import { BehaviorSubject } from 'rxjs';
-import { GqlContextType, JsonSet, ServerException, Session } from '~/common';
+import { GqlContextType, ServerException, Session } from '~/common';
 import { getRegisteredScalars } from '~/common/scalars';
 import { ConfigService } from '../config/config.service';
 import { VersionService } from '../config/version.service';
-import { ExceptionFilter } from '../exception/exception.filter';
-import { ExceptionNormalizer } from '../exception/exception.normalizer';
+import { GraphqlErrorFormatter } from './graphql-error-formatter';
 import { GraphqlTracingPlugin } from './graphql-tracing.plugin';
-
-declare module 'graphql/error/GraphQLError' {
-  interface GraphQLErrorExtensions {
-    code?: string;
-    codes?: ReadonlySet<string>;
-    stacktrace?: string[];
-  }
-}
 
 @Injectable()
 export class GraphqlOptions implements GqlOptionsFactory {
-  private readonly exceptionNormalizer: ExceptionNormalizer;
-  private readonly exceptionFilter: ExceptionFilter;
-
   constructor(
     private readonly config: ConfigService,
     private readonly cache: CacheService,
     private readonly tracing: GraphqlTracingPlugin,
     private readonly versionService: VersionService,
-    moduleRef: ModuleRef,
-  ) {
-    [this.exceptionNormalizer, this.exceptionFilter] = [
-      moduleRef.get(ExceptionNormalizer, { strict: false }),
-      moduleRef.get(ExceptionFilter, { strict: false }),
-    ];
-  }
+    private readonly errorFormatter: GraphqlErrorFormatter,
+  ) {}
 
   async createGqlOptions(): Promise<ApolloDriverConfig> {
     // Apply git hash to Apollo Studio.
@@ -72,7 +47,7 @@ export class GraphqlOptions implements GqlOptionsFactory {
       context: this.context,
       playground: false,
       introspection: true,
-      formatError: this.formatError,
+      formatError: this.errorFormatter.formatError,
       includeStacktraceInErrorResponses: true,
       status400ForVariableCoercionErrors: true, // will be default in v5
       sortSchema: true,
@@ -111,63 +86,6 @@ export class GraphqlOptions implements GqlOptionsFactory {
       operation: createFakeStubOperation(),
       session$: new BehaviorSubject<Session | undefined>(undefined),
     });
-
-  formatError = (
-    formatted: FormattedError,
-    error: unknown | /* but probably a */ GraphQLError,
-  ): FormattedError => {
-    const { message, ...extensions } = this.getErrorExtensions(
-      formatted,
-      error,
-    );
-
-    const codes = (extensions.codes ??= new JsonSet(['Server']));
-    delete extensions.code;
-
-    // Schema & validation errors don't have meaningful stack traces, so remove them
-    const worthlessTrace = codes.has('Validation') || codes.has('GraphQL');
-    if (worthlessTrace) {
-      delete extensions.stacktrace;
-    }
-
-    return {
-      message:
-        message && typeof message === 'string' ? message : formatted.message,
-      extensions,
-      locations: formatted.locations,
-      path: formatted.path,
-    };
-  };
-
-  private getErrorExtensions(
-    formatted: FormattedError,
-    error: unknown | /* but probably a */ GraphQLError,
-  ): ErrorExtensions {
-    // ExceptionNormalizer has already been called
-    if (formatted.extensions?.codes instanceof Set) {
-      return { ...formatted.extensions };
-    }
-
-    const original = unwrapResolverError(error);
-    // Safety check
-    if (!(original instanceof Error)) {
-      return { ...formatted.extensions };
-    }
-
-    // Some errors do not go through the global exception filter.
-    // ResolveField() calls is one of them.
-    // Normalized & log here.
-    const normalized = this.exceptionNormalizer.normalize({
-      ex: original,
-      gql: error instanceof GraphQLError ? error : undefined,
-    });
-    this.exceptionFilter.logIt(normalized, original);
-    const { stack, ...extensions } = normalized;
-    return {
-      ...extensions,
-      stacktrace: stack.split('\n'),
-    };
-  }
 }
 
 export const createFakeStubOperation = () => {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,7 +3,6 @@ export * from './logger';
 export { ConfigService } from './config/config.service';
 export * from './core.module';
 export * from './cli';
-export * from './graphql';
 export { splitDb, splitDb2 } from './database';
 export * from './events';
 export * from './resources';


### PR DESCRIPTION
No logical changes here, just code shuffling.

- Don't export graphql from `core/index.ts` following suit of other core modules.
  IMO that DX context is key/identifiable and shouldn't be flattened into `~/core`
- Rename `graphql.config.ts` so it isn't mistaken for IDE config.
  My IDE (prob vscode too) tries to read/parse it as like a gql client configuration file.
- Move graphql error handling logic to a separate class.
  Just a lot of code that could be segregated off.