### PR TITLE
Fix HttpAdapter proxy `this` scoping

### DIFF
--- a/src/core/http/http.module.ts
+++ b/src/core/http/http.module.ts
@@ -22,11 +22,8 @@ import { HttpAdapter, HttpAdapterHost } from './http.adapter';
           ]),
         );
         return new Proxy(host, {
-          get(_, key, receiver) {
+          get(_, key) {
             const { httpAdapter } = host;
-            if (key === 'httpAdapter') {
-              return httpAdapter;
-            }
             if (key === 'constructor') {
               return HttpAdapter.constructor;
             }
@@ -36,7 +33,8 @@ import { HttpAdapter, HttpAdapterHost } from './http.adapter';
             if (!httpAdapter) {
               throw new Error('HttpAdapter is not yet available');
             }
-            return Reflect.get(httpAdapter, key, receiver);
+            const val = Reflect.get(httpAdapter, key, httpAdapter);
+            return typeof val === 'function' ? val.bind(httpAdapter) : val;
           },
         });
       },


### PR DESCRIPTION
Previously method calls still had `this` bound to the proxy instead of the `HttpAdapter`.
So
```ts
class HttpAdapter {
  getInstance() {
    return this.instance;
  }
}
```
Previously this calling the proxy `getInstance()` would ask the proxy for get `instance`. Obviously this is wrong `this` should be the actual class instance here, not the proxy.

Now we correctly scope `this` on getters with the `Reflect.get` 3rd parameter change.
Doing this fixed the need to have a special case for `httpAdapter` for the `HttpAdapterHost`.

And correctly explicitly bind functions to `HttpAdapter` instance instead of letting them be implicitly bound to the proxy.
