### PR TITLE
Change EnforceChangesetEditablePipe to use injected, request-scoped GQL context

### DIFF
--- a/src/core/graphql/gql-context.host.ts
+++ b/src/core/graphql/gql-context.host.ts
@@ -16,6 +16,10 @@ import { GqlContextType as ContextType } from '~/common';
 import { HttpMiddleware as NestMiddleware } from '~/core/http';
 import { AsyncLocalStorageNoContextException } from '../async-local-storage-no-context.exception';
 
+export const isGqlContext = (object: unknown): object is ContextType =>
+  object != null && typeof object === 'object' && isGqlContext.KEY in object;
+isGqlContext.KEY = Symbol('GqlContext');
+
 /**
  * A service holding the current GraphQL context
  */

--- a/src/core/graphql/graphql.options.ts
+++ b/src/core/graphql/graphql.options.ts
@@ -15,6 +15,7 @@ import { GqlContextType, ServerException, Session } from '~/common';
 import { getRegisteredScalars } from '~/common/scalars';
 import { ConfigService } from '../config/config.service';
 import { VersionService } from '../config/version.service';
+import { isGqlContext } from './gql-context.host';
 import { GraphqlErrorFormatter } from './graphql-error-formatter';
 import { GraphqlTracingPlugin } from './graphql-tracing.plugin';
 
@@ -81,6 +82,7 @@ export class GraphqlOptions implements GqlOptionsFactory {
 
   context: ContextFunction<[ExpressContextFunctionArgument], GqlContextType> =
     async ({ req, res }) => ({
+      [isGqlContext.KEY]: true,
       request: req,
       response: res,
       operation: createFakeStubOperation(),

--- a/src/core/graphql/index.ts
+++ b/src/core/graphql/index.ts
@@ -1,2 +1,6 @@
 export * from './graphql.module';
-export { GqlContextHost, NotGraphQLContext } from './gql-context.host';
+export {
+  GqlContextHost,
+  isGqlContext,
+  NotGraphQLContext,
+} from './gql-context.host';


### PR DESCRIPTION
This wasn't possible at the time.
Since then https://github.com/nestjs/graphql/issues/325 has been resolved & released in v11.0.0


This is better because this is a global pipe, so it runs for GQL requests & HTTP requests.
This check is easier because it doesn't assume that you are looking for a GQL context.
The ALS getter does assume this, so here we had to try/catch check for specific exception to ignore.

In general this is easier, and works now.