### PR TITLE
Fix delete auth check for posts delete

### DIFF
--- a/src/components/post/post.service.ts
+++ b/src/components/post/post.service.ts
@@ -76,11 +76,7 @@ export class PostService {
   async delete(id: ID, session: Session): Promise<void> {
     const object = await this.repo.readOne(id, session);
 
-    const perms = await this.getPermissionsFromPostable(
-      object.parent.properties.id,
-      session,
-    );
-    perms.verifyCan('delete');
+    this.privileges.for(session, Post, object).verifyCan('delete');
 
     try {
       await this.repo.deleteNode(object);


### PR DESCRIPTION
Assume the post object is all that is needed to check permissions. This is because we know we want the creator to be able to delete.

Previously other members could delete any post - this seems like a mistake. So this new code prevents that by not having the member context.

This kinda breaks the isolation I wanted these to have from policies. I wanted policies to be in full control of the permissions.

But we have to provide the right context/attributes. The project doesn't have the creator attribute (or even the right one).

We could do a better job exposing exactly what attributes are given to the privileges service instead of the dto object wholesale.

The policies are also ill-equipped to declare permissions for these "embedded" resources.
A rewrite is needed there.
