### PR TITLE
Revisions to PnP Validation Severity

### DIFF
--- a/src/components/pnp/extract-scripture.ts
+++ b/src/components/pnp/extract-scripture.ts
@@ -78,7 +78,7 @@ export const extractScripture = (
   // Otherwise, fallback to unspecified scripture.
   !mismatchError &&
     result.addProblem({
-      severity: 'Warning',
+      severity: 'Notice',
       groups: 'Unspecified scripture reference',
       message: `"${book.name}" \`${bookCell.ref}\` does not a have specified scripture reference (either in the _Books_ or _My Notes_ column)`,
       source: totalVersesCell,

--- a/src/components/pnp/isGoalRow.ts
+++ b/src/components/pnp/isGoalRow.ts
@@ -27,7 +27,7 @@ export const isGoalRow = (
 
   if (!rawBook) {
     result?.addProblem({
-      severity: 'Warning',
+      severity: 'Error',
       groups: 'No book name given',
       message: `Ignoring row with no book name \`${bookCell.ref}\` even though there are **${versesToTranslate}** verses to translate \`${versesCell.ref}\``,
       source: cell,


### PR DESCRIPTION
Modified severity checks of level "Warning" in order to reduce to just either "Error" or "Notice".  Created a corresponding PR in Cordfield Repo to temporarily hide all problems with severity level of "Notice".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for scripture extraction and goal row validation.
  
- **Bug Fixes**
	- Adjusted severity levels for error reporting: unspecified scripture references now logged as 'Notice' and missing book names as 'Error'.
  
- **Refactor**
	- Improved control flow and validation logic for scripture reference parsing and verse counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->