### PR TITLE
PnP: Mismatched Reporting Quarter / Missing Summary % -> 0

### DIFF
--- a/src/common/fiscal-year.ts
+++ b/src/common/fiscal-year.ts
@@ -2,6 +2,9 @@ import { range } from 'lodash';
 import { DateTime } from 'luxon';
 import { CalendarDate, DateInterval } from './temporal';
 
+export const fiscalQuarterLabel = (date: CalendarDate) =>
+  `Q${fiscalQuarter(date)} FY${fiscalYear(date)}`;
+
 export const fiscalYear = (dt: DateTime) => dt.year + (dt.month >= 10 ? 1 : 0);
 
 export const fiscalYears = (start?: DateTime, end?: DateTime) =>
@@ -44,3 +47,12 @@ export const fullFiscalQuarter = (
     fiscalQuarterStartDate.endOf('quarter'),
   );
 };
+
+export const isReasonableYear = (year: unknown) =>
+  isInt(year) && year >= 1970 && year <= 3000;
+
+export const isQuarterNumber = (quarter: unknown) =>
+  isInt(quarter) && quarter >= 1 && quarter <= 4;
+
+// Not true for falsy case, thus not built-in, but fine for our cases here.
+const isInt = (x: unknown): x is number => Number.isInteger(x);

--- a/src/components/pnp/progress-sheet.ts
+++ b/src/components/pnp/progress-sheet.ts
@@ -1,4 +1,5 @@
 import { LazyGetter as Once } from 'lazy-get-decorator';
+import { fullFiscalQuarter, isQuarterNumber, isReasonableYear } from '~/common';
 import { Column, Range, Row, Sheet, WorkBook } from '~/common/xlsx.util';
 
 export abstract class ProgressSheet extends Sheet {
@@ -46,6 +47,25 @@ export abstract class ProgressSheet extends Sheet {
 
   get summaryFiscalYears() {
     return this.namedRange('PrcntFinishedYears');
+  }
+
+  /**
+   * This is just an artificial filter.
+   * It can be greater than the quarter we need, and we can still extract data fine.
+   */
+  @Once() get reportingQuarter() {
+    const year = this.reportingQuarterCells.year.asNumber!;
+    const quarterStr = this.reportingQuarterCells.quarter.asString;
+    const quarter = Number(quarterStr?.slice(1));
+    return isReasonableYear(year) && isQuarterNumber(quarter)
+      ? fullFiscalQuarter(quarter, year)
+      : undefined;
+  }
+  @Once() get reportingQuarterCells() {
+    return {
+      quarter: this.namedRange('RptQtr').start,
+      year: this.namedRange('RptYr').start,
+    };
   }
 
   columnForQuarterSummary(fiscalQuarter: number) {


### PR DESCRIPTION
Consider all "missing" summary percents to be 0

We don't really know if an empty cell is a valid 0 or coming from other cells not being updated.

As long as the reporting quarter is valid, we'll count these zeros as valid.
That appeared to be the root of the problem that we were trying to solve before,
plus just trying to guard against bad xlsx navigation which has been vetted at this point.

Also see this for "missing" details: https://github.com/SeedCompany/cord-api-v3/pull/3324#issuecomment-2455038346

[Monday](https://seed-company-squad.monday.com/boards/3451697530/pulses/7763761968)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new getter method for calculating the reporting quarter, enhancing data accuracy.
	- Added new functions for improved validation of fiscal year and quarter data.
- **Bug Fixes**
	- Enhanced error handling for reporting quarters, providing clearer error messages when invalid data is encountered.
	- Improved handling of planned and actual values to ensure accurate data reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->