### PR TITLE
Express/Connect Middleware -> Fastify Hooks

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -79,9 +79,9 @@ const restrictedImports = [
     replacement: { path: '~/core/http' },
   },
   {
-    importNames: 'NestMiddleware',
+    importNames: ['NestMiddleware', 'NestModule'],
     path: '@nestjs/common',
-    replacement: { importName: 'HttpMiddleware', path: '~/core/http' },
+    message: 'Do not use express/connect middleware',
   },
   {
     importNames: ['RouteConfig', 'RouteConstraints'],

--- a/src/common/discovery-unique-methods.ts
+++ b/src/common/discovery-unique-methods.ts
@@ -1,0 +1,25 @@
+import { DiscoveredMethodWithMeta } from '@golevelup/nestjs-discovery';
+
+export const uniqueDiscoveredMethods = <T>(
+  methods: Array<DiscoveredMethodWithMeta<T>>,
+) => {
+  const seenClasses = new Map<object, Map<string, Set<unknown>>>();
+  const uniqueMethods = [] as typeof methods;
+  for (const method of methods) {
+    const clsInstance = method.discoveredMethod.parentClass.instance;
+    const methodName = method.discoveredMethod.methodName;
+    if (!seenClasses.has(clsInstance)) {
+      seenClasses.set(clsInstance, new Map());
+    }
+    const seenMethods = seenClasses.get(clsInstance)!;
+    if (!seenMethods.has(methodName)) {
+      seenMethods.set(methodName, new Set());
+    }
+    const seenMetadata = seenMethods.get(methodName)!;
+    if (!seenMetadata.has(method.meta)) {
+      seenMetadata.add(method.meta);
+      uniqueMethods.push(method);
+    }
+  }
+  return uniqueMethods;
+};

--- a/src/components/authentication/authentication.module.ts
+++ b/src/components/authentication/authentication.module.ts
@@ -1,10 +1,4 @@
-import {
-  forwardRef,
-  Global,
-  MiddlewareConsumer,
-  Module,
-  NestModule,
-} from '@nestjs/common';
+import { forwardRef, Global, Module } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { splitDb } from '~/core';
 import { AuthorizationModule } from '../authorization/authorization.module';
@@ -54,12 +48,4 @@ import { SessionResolver } from './session.resolver';
     AuthenticationRepository,
   ],
 })
-export class AuthenticationModule implements NestModule {
-  constructor(
-    private readonly currentUserProvider: EdgeDBCurrentUserProvider,
-  ) {}
-
-  configure(consumer: MiddlewareConsumer) {
-    consumer.apply(this.currentUserProvider.use).forRoutes('*');
-  }
-}
+export class AuthenticationModule {}

--- a/src/core/graphql/driver.ts
+++ b/src/core/graphql/driver.ts
@@ -20,7 +20,7 @@ export class Driver extends YogaDriver<'fastify'> {
     );
     options.plugins = [
       ...(options.plugins ?? []),
-      ...discoveredPlugins.map((cls) => cls.discoveredClass.instance),
+      ...new Set(discoveredPlugins.map((cls) => cls.discoveredClass.instance)),
     ];
 
     await super.start(options);

--- a/src/core/http/decorators.ts
+++ b/src/core/http/decorators.ts
@@ -6,6 +6,7 @@ import { Many } from '@seedcompany/common';
 import { createMetadataDecorator } from '@seedcompany/nest';
 import { FastifyContextConfig } from 'fastify';
 import type { RouteConstraint } from 'fastify/types/route';
+import { HttpHooks } from './types';
 
 export const RouteConstraints = createMetadataDecorator({
   key: FASTIFY_ROUTE_CONSTRAINTS_METADATA,
@@ -54,3 +55,10 @@ export const RawBody = createMetadataDecorator({
     } = {},
   ) => config,
 });
+
+export const GlobalHttpHook = createMetadataDecorator({
+  types: ['method'],
+  setter: (hook: keyof HttpHooks = 'preHandler') => hook,
+});
+export type GlobalHttpHook<Name extends keyof HttpHooks = 'preHandler'> =
+  HttpHooks[Name];

--- a/src/core/http/http.adapter.ts
+++ b/src/core/http/http.adapter.ts
@@ -135,6 +135,13 @@ export class HttpAdapter extends PatchedFastifyAdapter {
     return this.instance.route(route);
   }
 
+  override registerMiddie() {
+    // no
+  }
+  override createMiddlewareFactory(): never {
+    throw new Error('Express/Connect Middleware should not be used');
+  }
+
   setCookie(
     response: IResponse,
     name: string,

--- a/src/core/http/http.adapter.ts
+++ b/src/core/http/http.adapter.ts
@@ -15,6 +15,7 @@ import {
 import type { FastifyInstance, HTTPMethods, RouteOptions } from 'fastify';
 import rawBody from 'fastify-raw-body';
 import * as zlib from 'node:zlib';
+import { uniqueDiscoveredMethods } from '~/common/discovery-unique-methods';
 import { ConfigService } from '~/core/config/config.service';
 import {
   GlobalHttpHook,
@@ -73,7 +74,7 @@ export class HttpAdapter extends PatchedFastifyAdapter {
       .get(DiscoveryService)
       .providerMethodsWithMetaAtKey<keyof HttpHooks>(GlobalHttpHook.KEY);
     const fastify = app.getHttpAdapter().getInstance();
-    for (const globalHook of globalHooks) {
+    for (const globalHook of uniqueDiscoveredMethods(globalHooks)) {
       const handler = globalHook.discoveredMethod.handler.bind(
         globalHook.discoveredMethod.parentClass.instance,
       );

--- a/src/core/http/types.ts
+++ b/src/core/http/types.ts
@@ -4,11 +4,19 @@ import type { NestMiddleware } from '@nestjs/common';
 import type {
   FastifyRequest as Request,
   FastifyReply as Response,
+  RouteShorthandOptions,
 } from 'fastify';
 import type { Session } from '~/common';
 
 // Exporting with I prefix to avoid ambiguity with web global types
 export type { Request as IRequest, Response as IResponse };
+
+export type HttpHooks = Required<{
+  [Hook in keyof RouteShorthandOptions as Exclude<
+    Extract<Hook, `${'pre' | 'on'}${string}`>,
+    `${'prefix'}${string}`
+  >]: Exclude<RouteShorthandOptions[Hook], any[]>;
+}>;
 
 export type HttpMiddleware = NestMiddleware<Request['raw'], Response['raw']>;
 

--- a/src/core/http/types.ts
+++ b/src/core/http/types.ts
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/method-signature-style */
-// eslint-disable-next-line @seedcompany/no-restricted-imports
-import type { NestMiddleware } from '@nestjs/common';
 import type {
   FastifyRequest as Request,
   FastifyReply as Response,
@@ -17,8 +15,6 @@ export type HttpHooks = Required<{
     `${'prefix'}${string}`
   >]: Exclude<RouteShorthandOptions[Hook], any[]>;
 }>;
-
-export type HttpMiddleware = NestMiddleware<Request['raw'], Response['raw']>;
 
 export { FastifyCorsOptions as CorsOptions } from '@fastify/cors';
 export { SerializeOptions as CookieOptions } from '@fastify/cookie';

--- a/src/core/tracing/tracing.module.ts
+++ b/src/core/tracing/tracing.module.ts
@@ -1,9 +1,4 @@
-import {
-  MiddlewareConsumer,
-  Module,
-  NestModule,
-  OnModuleInit,
-} from '@nestjs/common';
+import { Module, OnModuleInit } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import XRay from 'aws-xray-sdk-core';
 import { ConfigService } from '../config/config.service';
@@ -24,16 +19,12 @@ import { XRayMiddleware } from './xray.middleware';
   ],
   exports: [TracingService],
 })
-export class TracingModule implements OnModuleInit, NestModule {
+export class TracingModule implements OnModuleInit {
   constructor(
     @Logger('xray') private readonly logger: ILogger,
     private readonly config: ConfigService,
     private readonly version: VersionService,
   ) {}
-
-  configure(consumer: MiddlewareConsumer) {
-    consumer.apply(XRayMiddleware).forRoutes('*');
-  }
 
   async onModuleInit() {
     // Don't use cls-hooked lib. It's old and Node has AsyncLocalStorage now.


### PR DESCRIPTION
Nest's `Middleware` is just the Express/"Connect" middleware.
It does have some abstraction to only apply the middleware to certain routes.
This is basically worthless to us using GQL. We always want every route.

Fastify only supported this "middleware" via an adapter package called "middie"

We really don't need any of this.
Fastify has hooks that we can plug into and I wrote a small decorator/discovery to set this up globally.

I called this `GlobalHttpHook` in an effort to not be entirely coupled to Fastify.
But in reality the hooks & their signatures are Fastify's.
Just as "Connect" middleware is Express's.

There's only a few places in the app where we need to couple to this underlying http layer, so I'm fine with this.
And any other http server we go to will have the same concepts.

So IMO this is no more coupling than what we previously had, and it is more direct instead of going through an adapter layer.
Plus the decorator registration is more standard as well than Nest's consumer builder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a `GlobalHttpHook` decorator for enhanced request handling.
	- Added a new method for attaching global hooks in the `HttpAdapter` class.

- **Improvements**
	- Enhanced plugin management to prevent duplicates in the `Driver` class.
	- Streamlined the `EdgeDBCurrentUserProvider` and `XRayMiddleware` classes to utilize the new global HTTP hook mechanism.
	- Added a function to filter unique methods based on metadata.

- **Bug Fixes**
	- Removed outdated middleware configurations to improve clarity and maintainability.

- **Refactor**
	- Simplified `AuthenticationModule` and `TracingModule` by removing middleware interfaces.
	- Updated type definitions for better organization and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->