### PR TITLE
Fix file redirect route match regression

### DIFF
--- a/src/components/file/file-url.controller.ts
+++ b/src/components/file/file-url.controller.ts
@@ -26,7 +26,7 @@ export class FileUrlController {
     private readonly http: HttpAdapter,
   ) {}
 
-  @Get(':fileId/:fileName?')
+  @Get([':fileId', ':fileId/*'])
   async download(
     @Param('fileId') fileId: ID,
     @Query('download') download: '' | undefined,


### PR DESCRIPTION
Fastify appears to handle this differently than Express. If the variable segment is too long (~135 chars in this case), Fastify gives up.
Maybe for security? IDK

Changing now to a (optional) wildcard route.
We don't care what is after the file id - it is just for UX/DX.
