### PR TITLE
Refactor EdgeDB currentUser global provider context tracking

### DIFF
--- a/src/components/authentication/current-user.provider.ts
+++ b/src/components/authentication/current-user.provider.ts
@@ -5,57 +5,69 @@ import {
   NestInterceptor,
 } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
+import { AsyncLocalStorage } from 'async_hooks';
 import { isUUID } from 'class-validator';
 import { BehaviorSubject, identity } from 'rxjs';
 import { Session } from '~/common';
 import { EdgeDB, OptionsFn } from '~/core/edgedb';
 import { GlobalHttpHook } from '~/core/http';
 
+/**
+ * This sets the currentUser EdgeDB global based on
+ * - GQL: {@link GqlContextType.session$} (updates to this will also be carried forward here)
+ * - HTTP: {@link IRequest.session}
+ */
 @Injectable()
 export class EdgeDBCurrentUserProvider implements NestInterceptor {
-  // A map to transfer the options' holder
-  // between the creation in middleware and the use in the interceptor.
-  private readonly optionsHolderByRequest = new WeakMap<
-    Parameters<GlobalHttpHook>[0]['raw'],
+  constructor(private readonly edgedb: EdgeDB) {}
+
+  // Storage for the current options' holder layer
+  private readonly currentHolder = new AsyncLocalStorage<
     BehaviorSubject<OptionsFn>
   >();
 
-  constructor(private readonly edgedb: EdgeDB) {}
-
   @GlobalHttpHook()
-  onRequest(...[req, _reply, next]: Parameters<GlobalHttpHook>) {
-    // Create holder to use later to add current user to globals after it is fetched
-    const optionsHolder = new BehaviorSubject<OptionsFn>(identity);
-    this.optionsHolderByRequest.set(req.raw, optionsHolder);
+  onRequest(...[_req, _reply, next]: Parameters<GlobalHttpHook>) {
+    this.usingOptionsLayer(next);
+  }
 
-    // These options should apply to the entire HTTP/GQL operation.
-    // Connect middleware is the only place we get a function which has all of
-    // this in scope for the use of an ALS context.
-    this.edgedb.usingOptions(optionsHolder, next);
+  usingOptionsLayer<R>(next: () => R): R {
+    // Create a holder to use later to add the current user to globals after it is fetched
+    const optionsHolder = new BehaviorSubject<OptionsFn>(identity);
+
+    // Set this holder as the current holder for the current request.
+    return this.currentHolder.run(optionsHolder, () =>
+      // Add these options to the EdgeDB options context.
+      // These options should apply to the entire HTTP/GQL operation.
+      this.edgedb.usingOptions(optionsHolder, next),
+    );
   }
 
   /**
    * Connect the session to the options' holder
    */
   intercept(context: ExecutionContext, next: CallHandler) {
-    const type = context.getType();
-
-    if (type === 'graphql') {
-      const { request, session$ } =
-        GqlExecutionContext.create(context).getContext();
-      if (request) {
-        const optionsHolder = this.optionsHolderByRequest.get(request.raw)!;
-        session$.subscribe((session) => {
-          this.applyToOptions(session, optionsHolder);
-        });
-      }
-    } else if (type === 'http') {
-      const request = context.switchToHttp().getRequest();
-      const optionsHolder = this.optionsHolderByRequest.get(request.raw)!;
-      this.applyToOptions(request.session, optionsHolder);
+    const optionsHolder = this.currentHolder.getStore();
+    if (!optionsHolder) {
+      throw new Error('Current user options holder is not in async context');
     }
-
+    this.getSession(context)?.subscribe((session) => {
+      this.applyToOptions(session, optionsHolder);
+    });
     return next.handle();
+  }
+
+  private getSession(context: ExecutionContext) {
+    const type = context.getType();
+    if (type === 'graphql') {
+      const { session$ } = GqlExecutionContext.create(context).getContext();
+      return session$;
+    }
+    if (type === 'http') {
+      const request = context.switchToHttp().getRequest();
+      return new BehaviorSubject(request.session);
+    }
+    return undefined;
   }
 
   private applyToOptions(


### PR DESCRIPTION
Switch to ALS instead of Map by Request for EdgeDB currentUser global provider 

This is the same as before, it just doesn't depend on the request object.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved session management within the authentication process, enhancing the handling of user options during requests.

- **Bug Fixes**
	- Streamlined logic for accessing session data, ensuring more reliable session handling across different contexts.

- **Documentation**
	- Updated comments for better clarity on the functionality of session and options management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->