### PR TITLE
0286 growth plan upload failure

### DIFF
--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -380,15 +380,20 @@ export class EngagementRepository extends CommonRepository {
 
     if (pnp) {
       const engagement = await this.readOne(id, session);
-      if (engagement.pnp) {
-        await this.files.createFileVersion(
-          {
-            ...pnp,
-            parentId: engagement.pnp.id,
-          },
-          session,
+
+      if (!engagement.pnp) {
+        throw new ServerException(
+          'Expected PnP file to be created with the engagement',
         );
       }
+
+      await this.files.createFileVersion(
+        {
+          ...pnp,
+          parentId: engagement.pnp.id,
+        },
+        session,
+      );
     }
 
     if (changes.firstScripture) {
@@ -417,15 +422,20 @@ export class EngagementRepository extends CommonRepository {
 
     if (growthPlan) {
       const engagement = await this.readOne(id, session);
-      if (engagement.growthPlan) {
-        await this.files.createFileVersion(
-          {
-            ...growthPlan,
-            parentId: engagement.growthPlan.id,
-          },
-          session,
+
+      if (!engagement.growthPlan) {
+        throw new ServerException(
+          'Expected Growth Plan file to be created with the engagement',
         );
       }
+
+      await this.files.createFileVersion(
+        {
+          ...growthPlan,
+          parentId: engagement.growthPlan.id,
+        },
+        session,
+      );
     }
 
     if (mentorId !== undefined) {

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -18,7 +18,6 @@ import {
 } from '~/core';
 import { Privileges } from '../authorization';
 import { CeremonyService } from '../ceremony';
-import { FileService } from '../file';
 import { ProductService } from '../product';
 import { ProductListInput, SecuredProductList } from '../product/dto';
 import { ProjectService } from '../project';
@@ -52,7 +51,6 @@ export class EngagementService {
     @Inject(forwardRef(() => ProductService))
     private readonly products: ProductService & {},
     private readonly config: ConfigService,
-    private readonly files: FileService,
     private readonly engagementRules: EngagementRules,
     private readonly privileges: Privileges,
     @Inject(forwardRef(() => ProjectService))
@@ -209,13 +207,6 @@ export class EngagementService {
     this.privileges
       .for(session, InternshipEngagement, object)
       .verifyChanges(changes, { pathPrefix: 'engagement' });
-
-    await this.files.updateDefinedFile(
-      object.growthPlan,
-      'engagement.growthPlan',
-      changes.growthPlan,
-      session,
-    );
 
     const updated = await this.repo.updateInternship(
       { id: object.id, ...changes },


### PR DESCRIPTION
- Remove duplicate call to update growth plan
- Explicitly throw errors when updating files in engagement when expected files do not exist

[Monday Story 0286](https://seed-company-squad.monday.com/boards/3451697530/pulses/7815063635)
