### PR TITLE
Adopt @graphql-yoga/nestjs driver code locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@golevelup/nestjs-discovery": "^4.0.0",
     "@graphql-hive/yoga": "^0.38.2",
     "@graphql-tools/utils": "^10.5.4",
-    "@graphql-yoga/nestjs": "^3.7.0",
     "@graphql-yoga/plugin-apq": "^3.7.0",
     "@leeoniya/ufuzzy": "^1.0.11",
     "@nestjs/common": "^10.2.7",

--- a/src/core/graphql/graphql.options.ts
+++ b/src/core/graphql/graphql.options.ts
@@ -1,8 +1,4 @@
 import { useHive } from '@graphql-hive/yoga';
-import {
-  YogaDriverConfig as DriverConfig,
-  YogaDriverServerContext,
-} from '@graphql-yoga/nestjs';
 import { useAPQ } from '@graphql-yoga/plugin-apq';
 import { Injectable } from '@nestjs/common';
 import { GqlOptionsFactory } from '@nestjs/graphql';
@@ -20,11 +16,11 @@ import { getRegisteredScalars } from '~/common/scalars';
 import { ConfigService } from '../config/config.service';
 import { VersionService } from '../config/version.service';
 import { apolloExplorer } from './apollo-explorer';
+import { DriverConfig, ServerContext } from './driver';
 import { isGqlContext } from './gql-context.host';
 import { GraphqlTracingPlugin } from './graphql-tracing.plugin';
 
 type Plugin = PluginNoContext<GqlContextType>;
-type ServerContext = YogaDriverServerContext<'fastify'>;
 
 @Injectable()
 export class GraphqlOptions implements GqlOptionsFactory {
@@ -96,14 +92,10 @@ export class GraphqlOptions implements GqlOptionsFactory {
     };
   }
 
-  context = ({
-    req: request,
-    reply: response,
-  }: ServerContext): Partial<GqlContextType> => {
+  context = ({ req: request }: ServerContext): Partial<GqlContextType> => {
     return {
       [isGqlContext.KEY]: true,
       request,
-      response,
       session$: new BehaviorSubject<Session | undefined>(undefined),
     };
   };

--- a/src/core/graphql/plugin.decorator.ts
+++ b/src/core/graphql/plugin.decorator.ts
@@ -1,13 +1,10 @@
-import { YogaDriverServerContext } from '@graphql-yoga/nestjs';
 import { createMetadataDecorator } from '@seedcompany/nest';
 import { Plugin as PluginNoContext } from 'graphql-yoga';
 import { GqlContextType } from '~/common';
+import { ServerContext } from './driver';
 
 export const Plugin = createMetadataDecorator({
   types: ['class'],
 });
 
-export type Plugin = PluginNoContext<
-  GqlContextType,
-  YogaDriverServerContext<'fastify'>
->;
+export type Plugin = PluginNoContext<GqlContextType, ServerContext>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1958,19 +1958,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-yoga/nestjs@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "@graphql-yoga/nestjs@npm:3.7.0"
-  peerDependencies:
-    "@nestjs/common": ^10.0.0
-    "@nestjs/core": ^10.0.0
-    "@nestjs/graphql": ^12.0.0
-    graphql: ^15.0.0 || ^16.0.0
-    graphql-yoga: ^5.7.0
-  checksum: 10c0/459f524504c276b2ddab6759d3d10ef1762c44f7907ff71c0f930d26fb9076441267ac4f764e4131ed6d08068d02a372990339259c0af49a8400e3ede29318f6
-  languageName: node
-  linkType: hard
-
 "@graphql-yoga/plugin-apq@npm:^3.7.0":
   version: 3.7.0
   resolution: "@graphql-yoga/plugin-apq@npm:3.7.0"
@@ -5663,7 +5650,6 @@ __metadata:
     "@graphql-hive/cli": "npm:^0.44.2"
     "@graphql-hive/yoga": "npm:^0.38.2"
     "@graphql-tools/utils": "npm:^10.5.4"
-    "@graphql-yoga/nestjs": "npm:^3.7.0"
     "@graphql-yoga/plugin-apq": "npm:^3.7.0"
     "@leeoniya/ufuzzy": "npm:^1.0.11"
     "@nestjs/cli": "npm:^10.2.1"


### PR DESCRIPTION
It turns out it wasn't doing that much.
It also had a lot we don't need, like `express` support, and the legacy ws protocol.

This gives us complete control which will help with ws protocol
