### PR TITLE
GQL Subscriptions over WebSockets

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@fastify/compress": "^8.0.1",
     "@fastify/cookie": "^11.0.1",
     "@fastify/cors": "^11.0.1",
+    "@fastify/websocket": "^11.0.2",
     "@ffprobe-installer/ffprobe": "^2.1.2",
     "@golevelup/nestjs-discovery": "^4.0.0",
     "@graphql-hive/yoga": ">=0.41.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "graphql": "^16.9.0",
     "graphql-parse-resolve-info": "^4.14.0",
     "graphql-scalars": "^1.22.4",
+    "graphql-ws": "^6.0.4",
     "graphql-yoga": "^5.13.4",
     "human-format": "^1.2.0",
     "image-size": "^2.0.2",

--- a/src/core/graphql/driver.ts
+++ b/src/core/graphql/driver.ts
@@ -5,11 +5,15 @@ import {
   type GqlModuleOptions,
 } from '@nestjs/graphql';
 import type { RouteOptions as FastifyRoute } from 'fastify';
+import type { ExecutionArgs } from 'graphql';
+import { makeHandler as makeGqlWSHandler } from 'graphql-ws/use/@fastify/websocket';
 import {
   createYoga,
+  type envelop,
   type YogaServerInstance,
   type YogaServerOptions,
 } from 'graphql-yoga';
+import type { WebSocket } from 'ws';
 import { type GqlContextType } from '~/common';
 import { HttpAdapter, type IRequest } from '../http';
 import { type IResponse } from '../http/types';
@@ -55,7 +59,14 @@ export class Driver extends AbstractDriver<DriverConfig> {
     });
 
     fastify.route({
-      method: ['GET', 'POST', 'OPTIONS'],
+      method: 'GET',
+      url: this.yoga.graphqlEndpoint,
+      handler: this.httpHandler,
+      // Allow this same path to handle websocket upgrade requests.
+      wsHandler: this.makeWsHandler(options),
+    });
+    fastify.route({
+      method: ['POST', 'OPTIONS'],
       url: this.yoga.graphqlEndpoint,
       handler: this.httpHandler,
     });
@@ -76,6 +87,82 @@ export class Driver extends AbstractDriver<DriverConfig> {
       .status(res.status)
       .send(res.body);
   };
+
+  /**
+   * This code ties fastify, yoga, and graphql-ws together.
+   * Execution layers in order:
+   * 1. fastify route (http path matching)
+   * 2. fastify's websocket plugin (http upgrade request & websocket open/close)
+   *    This allows our fastify hooks to be executed.
+   *    And provides a consistent Fastify `Request` type,
+   *    instead of a raw `IncomingMessage`.
+   * 3. `graphql-ws`'s fastify handler (adapts #2 to graphql-ws)
+   * 4. `graphql-ws` (handles specific gql protocol over websockets)
+   * 5. `graphql-yoga` is unwrapped to `envelop`.
+   *    Yoga just wraps `envelop` and handles more of the http layer.
+   *    We really just reference `envelop` hooks with our "Yoga Plugins".
+   *    So this allows our "yoga" plugins to be executed.
+   */
+  private makeWsHandler(options: DriverConfig) {
+    interface WsExecutionArgs extends ExecutionArgs {
+      envelop: ReturnType<ReturnType<typeof envelop>>;
+    }
+
+    // The graphql-ws handler which accepts the fastify websocket/request and
+    // orchestrates the subscription setup & execution.
+    // This forwards to yoga/envelop.
+    // This was adapted from yoga's graphql-ws example.
+    // https://github.com/dotansimha/graphql-yoga/tree/main/examples/graphql-ws
+    const wsHandler = makeGqlWSHandler<
+      Record<string, unknown>,
+      { socket: WebSocket; request: IRequest }
+    >({
+      schema: options.schema!,
+      // Custom execute/subscribe functions that really just defer to a
+      // unique envelop (yoga) instance per request.
+      execute: (wsArgs) => {
+        const { envelop, ...args } = wsArgs as WsExecutionArgs;
+        return envelop.execute(args);
+      },
+      subscribe: (wsArgs) => {
+        const { envelop, ...args } = wsArgs as WsExecutionArgs;
+        return envelop.subscribe(args);
+      },
+      // Create a unique envelop/yoga instance for each subscription.
+      // This allows "yoga" plugins that are really just envelop hooks
+      // to be executed.
+      onSubscribe: async (ctx, id, payload) => {
+        const {
+          extra: { request, socket },
+        } = ctx;
+        const envelop = this.yoga.getEnveloped({
+          req: request,
+          socket,
+          params: payload, // Same(ish?) shape as YogaInitialContext.params
+        });
+
+        const args: WsExecutionArgs = {
+          schema: envelop.schema,
+          operationName: payload.operationName,
+          document: envelop.parse(payload.query),
+          variableValues: payload.variables,
+          contextValue: await envelop.contextFactory(),
+          // These are needed in our execute()/subscribe() declared above.
+          // Public examples put these functions in the context, but I don't
+          // like exposing that implementation detail to the rest of the app.
+          envelop,
+        };
+
+        const errors = envelop.validate(args.schema, args.document);
+        if (errors.length) {
+          return errors;
+        }
+        return args;
+      },
+    });
+
+    return wsHandler;
+  }
 
   async stop() {
     // noop

--- a/src/core/graphql/gql-context.host.ts
+++ b/src/core/graphql/gql-context.host.ts
@@ -52,6 +52,17 @@ export class GqlContextHostImpl implements GqlContextHost, OnModuleDestroy {
     });
   };
 
+  onSubscribe: Plugin['onSubscribe'] = ({
+    subscribeFn,
+    setSubscribeFn,
+    args,
+  }) => {
+    const ctx = args.contextValue;
+    setSubscribeFn((...args) => {
+      return this.als.run(ctx, subscribeFn, ...args);
+    });
+  };
+
   onModuleDestroy() {
     this.als.disable();
   }

--- a/src/core/graphql/graphql-error-formatter.ts
+++ b/src/core/graphql/graphql-error-formatter.ts
@@ -51,6 +51,13 @@ export class GraphqlErrorFormatter {
       }),
   });
 
+  onSubscribe: Plugin['onSubscribe'] = () => ({
+    onSubscribeError: ({ error, setError }) => {
+      const formatted = this.formatError(error);
+      setError(formatted);
+    },
+  });
+
   formatError = (error: unknown) => {
     if (!(error instanceof GraphQLError)) {
       // I don't think this happens.

--- a/src/core/graphql/graphql-session.plugin.ts
+++ b/src/core/graphql/graphql-session.plugin.ts
@@ -9,4 +9,11 @@ export class GraphqlSessionPlugin {
       args.contextValue.session$.complete();
     },
   });
+  onSubscribe: Plugin['onSubscribe'] = () => ({
+    onSubscribeResult: ({ args }) => ({
+      onEnd: () => {
+        args.contextValue.session$.complete();
+      },
+    }),
+  });
 }

--- a/src/core/http/http.adapter.ts
+++ b/src/core/http/http.adapter.ts
@@ -1,6 +1,7 @@
 import compression from '@fastify/compress';
 import cookieParser from '@fastify/cookie';
 import cors from '@fastify/cors';
+import websocket from '@fastify/websocket';
 import { DiscoveryService } from '@golevelup/nestjs-discovery';
 import {
   VERSION_NEUTRAL,
@@ -64,6 +65,8 @@ export class HttpAdapter extends PatchedFastifyAdapter {
 
     // Only on routes we've decorated.
     await app.register(rawBody, { global: false });
+
+    await app.register(websocket);
 
     app.setGlobalPrefix(config.hostUrl$.value.pathname.slice(1));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1425,6 +1425,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fastify/websocket@npm:^11.0.2":
+  version: 11.0.2
+  resolution: "@fastify/websocket@npm:11.0.2"
+  dependencies:
+    duplexify: "npm:^4.1.3"
+    fastify-plugin: "npm:^5.0.0"
+    ws: "npm:^8.16.0"
+  checksum: 10c0/ccdaf645d768f427542d5133d3a0f8b4ce49e4bc2496543e1fb6f1d4b8c4e07af6fb80bde7bf50acf7536cb35c839c54d94a0a6b6f1aec76d413f0e68b92e04e
+  languageName: node
+  linkType: hard
+
 "@ffprobe-installer/darwin-arm64@npm:5.0.1":
   version: 5.0.1
   resolution: "@ffprobe-installer/darwin-arm64@npm:5.0.1"
@@ -5816,6 +5827,7 @@ __metadata:
     "@fastify/compress": "npm:^8.0.1"
     "@fastify/cookie": "npm:^11.0.1"
     "@fastify/cors": "npm:^11.0.1"
+    "@fastify/websocket": "npm:^11.0.2"
     "@ffprobe-installer/ffprobe": "npm:^2.1.2"
     "@gel/generate": "npm:^0.7.0-canary.20250422T080308"
     "@golevelup/nestjs-discovery": "npm:^4.0.0"
@@ -6482,7 +6494,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"duplexify@npm:^4.1.1":
+"duplexify@npm:^4.1.1, duplexify@npm:^4.1.3":
   version: 4.1.3
   resolution: "duplexify@npm:4.1.3"
   dependencies:
@@ -14286,7 +14298,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.18.1, ws@npm:^8.17.1":
+"ws@npm:8.18.1, ws@npm:^8.16.0, ws@npm:^8.17.1":
   version: 8.18.1
   resolution: "ws@npm:8.18.1"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5893,6 +5893,7 @@ __metadata:
     graphql: "npm:^16.9.0"
     graphql-parse-resolve-info: "npm:^4.14.0"
     graphql-scalars: "npm:^1.22.4"
+    graphql-ws: "npm:^6.0.4"
     graphql-yoga: "npm:^5.13.4"
     human-format: "npm:^1.2.0"
     husky: "npm:^4.3.8"
@@ -8091,7 +8092,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-ws@npm:6.0.4, graphql-ws@npm:^6.0.3":
+"graphql-ws@npm:6.0.4, graphql-ws@npm:^6.0.3, graphql-ws@npm:^6.0.4":
   version: 6.0.4
   resolution: "graphql-ws@npm:6.0.4"
   peerDependencies:


### PR DESCRIPTION
This PR is pushed the need for #3330 

Yoga already has built-in support for Subscriptions over SSE (which I forgot until today).
These work fine when deployed to AWS which uses HTTP/2.
Locally, over HTTP/1, however there is the a 6 connection limit.

Apollo Sandbox/Explorer/Studio also does not support SSE, they have a similar "apollo http multipart" protocol.

Websockets are supported, so this is for them, and just to have flexibility in subscription protocol.
UI client could use either going forward.

# How it works

This ties `fastify`, `yoga`, and `graphql-ws` together.
Execution layers in order:
1. fastify route (http path matching)
2. fastify's websocket plugin (http upgrade request & websocket open/close)
    This allows our fastify hooks to be executed.
    And provides a consistent Fastify `Request` type,
    instead of a raw `IncomingMessage`.
 3. `graphql-ws`'s fastify handler (adapts # 2 to graphql-ws)
 4. `graphql-ws` (handles specific gql protocol over websockets)
 5. `graphql-yoga` is unwrapped to `envelop`.
    Yoga just wraps `envelop` and handles more of the http layer.
    We really just reference `envelop` hooks with our "Yoga Plugins".
    So this allows our "yoga" plugins to be executed.

`@graphql-yoga/nestjs` goes a completely different direction with its subscription logic, which is why I abandoned it. It adapts from the `ApolloDriver`, doing a bunch of unnecessary low level work. It couldn't assume fastify, because express is also supported.
This approach here fully embraces fastify & yoga, and both of their lifecycle hooks. 

@coderabbitai ignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added support for WebSocket connections and GraphQL subscriptions, enhancing real-time capabilities.
	- Introduced new methods to handle subscription operations and errors within the GraphQL context.

- **Bug Fixes**
	- Improved error handling for subscription-related issues.

- **Chores**
	- Updated project dependencies to include `@fastify/websocket` and `graphql-ws`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->