### PR TITLE
Add filters & sorting for pnp extraction errors on Progress Reports

### DIFF
--- a/src/components/pnp/extraction-result/extraction-result.dto.ts
+++ b/src/components/pnp/extraction-result/extraction-result.dto.ts
@@ -1,10 +1,11 @@
-import { Field, InterfaceType, ObjectType } from '@nestjs/graphql';
+import { Field, InputType, InterfaceType, ObjectType } from '@nestjs/graphql';
 import { many, Many } from '@seedcompany/common';
 import { stripIndent } from 'common-tags';
 import { UUID } from 'node:crypto';
+import { keys as keysOf } from 'ts-transformer-keys';
 import { Merge } from 'type-fest';
 import * as uuid from 'uuid';
-import { EnumType, ID, IdField, makeEnum } from '~/common';
+import { EnumType, ID, IdField, makeEnum, SecuredProps } from '~/common';
 import { InlineMarkdownScalar } from '~/common/markdown.scalar';
 import { Cell } from '~/common/xlsx.util';
 
@@ -118,8 +119,20 @@ export type StoredProblem = Pick<PnpProblem, 'id'> & {
   context: { [x: string]: unknown };
 };
 
+@InputType()
+export class PnpExtractionResultFilters {
+  @Field(() => Boolean, {
+    nullable: true,
+    description: 'Only extraction results containing errors',
+  })
+  readonly hasError?: boolean;
+}
+
 @InterfaceType()
 export abstract class PnpExtractionResult {
+  static readonly Props = keysOf<PnpExtractionResult>();
+  static readonly SecuredProps = keysOf<SecuredProps<PnpExtractionResult>>();
+
   constructor(private readonly fileVersionId: ID<'FileVersion'>) {}
 
   readonly problems = new Map<ID, StoredProblem>();

--- a/src/components/progress-report/dto/progress-report-list.dto.ts
+++ b/src/components/progress-report/dto/progress-report-list.dto.ts
@@ -8,6 +8,7 @@ import {
 } from '~/common';
 import { EngagementFilters } from '../../engagement/dto';
 import { PeriodicReportListInput } from '../../periodic-report/dto';
+import { PnpExtractionResultFilters } from '../../pnp/extraction-result';
 import { ProgressSummaryFilters } from '../../progress-summary/dto';
 import { ProgressReportStatus } from './progress-report-status.enum';
 import { ProgressReport } from './progress-report.entity';
@@ -27,6 +28,9 @@ export abstract class ProgressReportFilters extends PickType(
 
   @FilterField(() => EngagementFilters)
   readonly engagement?: EngagementFilters & {};
+
+  @FilterField(() => PnpExtractionResultFilters)
+  readonly pnpExtractionResult?: PnpExtractionResultFilters & {};
 }
 
 @InputType()

--- a/src/components/progress-report/progress-report-extra-for-periodic-interface.repository.ts
+++ b/src/components/progress-report/progress-report-extra-for-periodic-interface.repository.ts
@@ -16,6 +16,7 @@ import {
 } from '~/core/database/query';
 import { engagementSorters } from '../engagement/engagement.repository';
 import { MergePeriodicReports } from '../periodic-report/dto';
+import { pnpExtractionResultSorters } from '../pnp/extraction-result/pnp-extraction-result.neo4j.repository';
 import { SummaryPeriod } from '../progress-summary/dto';
 import { progressSummarySorters } from '../progress-summary/progress-summary.repository';
 import { ProgressReport, ProgressReportStatus as Status } from './dto';
@@ -49,6 +50,18 @@ export class ProgressReportExtraForPeriodicInterfaceRepository {
 export const progressReportExtrasSorters: DefinedSorters<
   SortFieldOf<typeof ProgressReport>
 > = defineSorters(ProgressReport, {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  'pnpExtractionResult.*': (query, input) =>
+    query
+      .with('node as report')
+      .match([
+        node('report'),
+        relation('out', '', 'reportFileNode'),
+        node('file', 'File'),
+        relation('out', '', 'pnpExtractionResult'),
+        node('node', 'PnpExtractionResult'),
+      ])
+      .apply(sortWith(pnpExtractionResultSorters, input)),
   // eslint-disable-next-line @typescript-eslint/naming-convention
   'engagement.*': (query, input) =>
     query

--- a/src/components/progress-report/progress-report.repository.ts
+++ b/src/components/progress-report/progress-report.repository.ts
@@ -15,6 +15,7 @@ import {
 } from '~/core/database/query';
 import { engagementFilters } from '../engagement/engagement.repository';
 import { progressReportSorters } from '../periodic-report/periodic-report.repository';
+import { pnpExtractionResultFilters } from '../pnp/extraction-result/pnp-extraction-result.neo4j.repository';
 import { SummaryPeriod } from '../progress-summary/dto';
 import { progressSummaryFilters } from '../progress-summary/progress-summary.repository';
 import {
@@ -107,6 +108,15 @@ export const progressReportFilters = filter.define(
         node('outer'),
         relation('in', '', 'report'),
         node('node', 'Engagement'),
+      ]),
+    ),
+    pnpExtractionResult: filter.sub(() => pnpExtractionResultFilters)((sub) =>
+      sub.match([
+        node('outer'),
+        relation('out', '', 'reportFileNode'),
+        node('file', 'File'),
+        relation('out', '', 'pnpExtractionResult'),
+        node('node', 'PnpExtractionResult'),
       ]),
     ),
   },


### PR DESCRIPTION
Adds filter
```ts
ProgressReportFilters.pnpExtractionResult.hasError
```
and sorting
```ts
ProgressReport.pnpExtractionResult.totalErrors
```

[Monday](https://seed-company-squad.monday.com/boards/5989610236/views/131962501/pulses/7893107215)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced filtering capabilities for extraction results with a new filter class.
	- Added optional error tracking in extraction results.
	- Enhanced progress report filtering to include conditions based on extraction results.
	- Added sorting functionality for extraction results based on error counts.

- **Bug Fixes**
	- Improved error handling in extraction result queries.

- **Documentation**
	- Updated documentation to reflect new filtering options and error tracking features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->