### PR TITLE
Restore 3rd party session cookies for localhost (for Chromium & FF)

### DIFF
--- a/src/components/authentication/session.interceptor.ts
+++ b/src/components/authentication/session.interceptor.ts
@@ -97,7 +97,7 @@ export class SessionInterceptor implements NestInterceptor {
   }
 
   private getTokenFromCookie(req: IRequest | undefined): string | null {
-    return req?.cookies?.[this.config.sessionCookie.name] || null;
+    return req?.cookies?.[this.config.sessionCookie(req).name] || null;
   }
 
   getImpersonateeFromContext(

--- a/src/components/authentication/session.resolver.ts
+++ b/src/components/authentication/session.resolver.ts
@@ -72,7 +72,9 @@ export class SessionResolver {
     const userFromSession = session.anonymous ? undefined : session.userId;
 
     if (browser) {
-      const { name, expires, ...options } = this.config.sessionCookie;
+      const { name, expires, ...options } = this.config.sessionCookie(
+        context.request!,
+      );
       if (!context.response) {
         throw new ServerException(
           'Cannot use cookie session without a response object',

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -17,7 +17,7 @@ import { ProgressReportStatus } from '../../components/progress-report/dto/progr
 import type { TransitionName as ProgressReportTransitionName } from '../../components/progress-report/workflow/transitions';
 import { DefaultTimezoneWrapper } from '../email/templates/formatted-date-time';
 import { FrontendUrlWrapper } from '../email/templates/frontend-url';
-import type { CookieOptions, CorsOptions } from '../http';
+import type { CookieOptions, CorsOptions, IRequest } from '../http';
 import { LogLevel } from '../logger/logger.interface';
 import { EnvironmentService } from './environment.service';
 import { determineRootUser } from './root-user.config';
@@ -248,10 +248,9 @@ export const makeConfig = (env: EnvironmentService) =>
       } satisfies CorsOptions;
     })();
 
-    sessionCookie = ((): Merge<
-      CookieOptions,
-      { name: string; expires?: DurationLike }
-    > => {
+    sessionCookie = (
+      req: IRequest,
+    ): Merge<CookieOptions, { name: string; expires?: DurationLike }> => {
       const name = env.string('SESSION_COOKIE_NAME').optional('cordsession');
 
       let domain = env.string('SESSION_COOKIE_DOMAIN').optional();
@@ -260,6 +259,10 @@ export const makeConfig = (env: EnvironmentService) =>
       if (domain && !domain.startsWith('.')) {
         domain = '.' + domain;
       }
+
+      const userAgent = req.headers['user-agent'];
+      const isSafari =
+        userAgent && /^((?!chrome|android).)*safari/i.test(userAgent);
 
       return {
         name,
@@ -270,14 +273,14 @@ export const makeConfig = (env: EnvironmentService) =>
         httpOnly: true,
         // All paths, not just the current one
         path: '/',
-        ...(!isDev && {
+        ...(!(isSafari && isDev) && {
           // Require HTTPS (required for SameSite)
           secure: true,
           // Allow 3rd party (other domains)
           sameSite: 'none',
         }),
       };
-    })();
+    };
 
     xray = {
       daemonAddress: this.jest


### PR DESCRIPTION
Partially reverts f29286574bebd73c5ec66cd8cb74e5e991f77aff

We want to allow 3rd party cookies (aka SameSite=none && Secured). FF & Chromium have exceptions that allow `Secured` to work with `localhost`. This restores that support when running locally.
One example of this is https://studio.apollographql.com/sandbox That is hosted by a 3rd party and points to our localhost.

We also want the UI to actually work.
Safari does not have this exception.
So when trying to establish a session in Safari,
the set-cookie header is ignored because it had the Secured requirement, and we were loading it over http (localhost).

So now we allow 3rd party cookies, except for Safari/localhost combo.