### PR TITLE
Allow ResourceLoader within CLI migrations

### DIFF
--- a/src/components/authentication/authentication.module.ts
+++ b/src/components/authentication/authentication.module.ts
@@ -35,6 +35,7 @@ import { SessionResolver } from './session.resolver';
     RegisterExtraInfoResolver,
     AuthenticationService,
     splitDb(AuthenticationRepository, AuthenticationEdgeDBRepository),
+    { provide: 'AUTHENTICATION', useExisting: AuthenticationService },
     CryptoService,
     SessionInterceptor,
     { provide: APP_INTERCEPTOR, useExisting: SessionInterceptor },
@@ -44,6 +45,7 @@ import { SessionResolver } from './session.resolver';
   exports: [
     SessionInterceptor,
     AuthenticationService,
+    'AUTHENTICATION',
     CryptoService,
     AuthenticationRepository,
   ],

--- a/src/components/authentication/authentication.service.ts
+++ b/src/components/authentication/authentication.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
+import { CachedByArg } from '@seedcompany/common';
 import { EmailService } from '@seedcompany/nestjs-email';
 import JWT from 'jsonwebtoken';
 import { DateTime } from 'luxon';
@@ -179,8 +180,9 @@ export class AuthenticationService {
     return session;
   }
 
+  @CachedByArg()
   lazySessionForRootUser(input?: Partial<Session>) {
-    const promiseOfRootId = this.repo.waitForRootUserId().then((id) => {
+    const promiseOfRootId = this.waitForRootUserIdOnce().then((id) => {
       (session as Writable<Session>).userId = id;
       return id;
     });
@@ -216,6 +218,12 @@ export class AuthenticationService {
       },
     }) as LazySession;
   }
+
+  @CachedByArg()
+  private waitForRootUserIdOnce() {
+    return this.repo.waitForRootUserId();
+  }
+
   async sessionForUser(userId: ID): Promise<Session> {
     const roles = await this.repo.rolesForUser(userId);
     const session: Session = {

--- a/src/components/progress-report/migrations/reextract-all-progress-reports.migration.ts
+++ b/src/components/progress-report/migrations/reextract-all-progress-reports.migration.ts
@@ -8,7 +8,7 @@ import { FileVersion } from '../../file/dto';
 import { PeriodicReportUploadedEvent } from '../../periodic-report/events';
 import { ProgressReport } from '../dto';
 
-@Migration('2024-12-16T13:00:00')
+@Migration('2024-12-16T16:33:00')
 export class ReextractPnpProgressReportsMigration extends BaseMigration {
   constructor(
     private readonly eventBus: IEventBus,

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -86,6 +86,10 @@ export const makeConfig = (env: EnvironmentService) =>
 
     /** Is this a REPL process? */
     isRepl = process.argv.join(' ').includes('repl');
+    /** Is this a console command process? */
+    isConsole = process.argv.join(' ').includes('console');
+    /** Is this a REPL / console command process? */
+    isCli = this.isRepl || this.isConsole;
 
     /** Is this a jest process? */
     jest = Boolean(env.string('JEST_WORKER_ID').optional());

--- a/src/core/data-loader/data-loader.config.ts
+++ b/src/core/data-loader/data-loader.config.ts
@@ -1,9 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { DataLoaderOptions } from '@seedcompany/data-loader';
 import { NotFoundException } from '~/common';
+import { ConfigService } from '../config/config.service';
 
 @Injectable()
 export class DataLoaderConfig {
+  constructor(private readonly config: ConfigService) {}
+
   create(): DataLoaderOptions<any, any> {
     return {
       // Increase the batching timeframe from the same nodejs frame to 10ms
@@ -13,6 +16,7 @@ export class DataLoaderConfig {
         new NotFoundException(
           `Could not find ${String(typeName)} (${String(cacheKey)})`,
         ),
+      cache: !this.config.isCli,
     };
   }
 }

--- a/src/core/data-loader/session-aware-loader.strategy.ts
+++ b/src/core/data-loader/session-aware-loader.strategy.ts
@@ -1,7 +1,9 @@
 import { Inject } from '@nestjs/common';
 import { DataLoaderStrategy } from '@seedcompany/data-loader';
-import { ID } from '~/common';
+import { ID, Session } from '~/common';
 import { sessionFromContext } from '~/common/session';
+import type { AuthenticationService } from '../../components/authentication';
+import { ConfigService } from '../config/config.service';
 import { GqlContextHost } from '../graphql';
 
 export abstract class SessionAwareLoaderStrategy<T, Key = ID, CachedKey = Key>
@@ -14,7 +16,17 @@ export abstract class SessionAwareLoaderStrategy<T, Key = ID, CachedKey = Key>
   @Inject(GqlContextHost)
   private readonly contextHost: GqlContextHost;
 
-  get session() {
+  @Inject(ConfigService)
+  private readonly config: ConfigService;
+
+  @Inject('AUTHENTICATION')
+  private readonly auth: AuthenticationService & {};
+
+  get session(): Session {
+    if (this.config.isCli) {
+      return this.auth.lazySessionForRootUser();
+    }
+
     return sessionFromContext(this.contextHost.context);
   }
 }

--- a/src/core/resources/resource.loader.ts
+++ b/src/core/resources/resource.loader.ts
@@ -5,6 +5,7 @@ import {
 } from '@seedcompany/data-loader';
 import { ConditionalKeys, Merge, ValueOf } from 'type-fest';
 import { ID, Many, ObjectView, ServerException } from '~/common';
+import { ConfigService } from '../config/config.service';
 import { BaseNode } from '../database/results';
 import { GqlContextHost } from '../graphql';
 import { ResourceLoaderRegistry } from './loader.registry';
@@ -41,6 +42,7 @@ export class ResourceLoader {
   constructor(
     private readonly loaderRegistry: ResourceLoaderRegistry,
     private readonly contextHost: GqlContextHost,
+    private readonly config: ConfigService,
     private readonly loaderContext: DataLoaderContext,
     private readonly resourceResolver: ResourceResolver,
   ) {}
@@ -108,7 +110,7 @@ export class ResourceLoader {
   ) {
     return await this.loaderContext.getLoader<T, Key, CachedKey>(
       type,
-      this.contextHost.context,
+      this.config.isCli ? CLI_CONTEXT_ID : this.contextHost.context,
     );
   }
 
@@ -134,3 +136,5 @@ export class ResourceLoader {
     return { resolvedType, ...found };
   }
 }
+
+const CLI_CONTEXT_ID = {};


### PR DESCRIPTION
#3342 added usage of data loader (via `ResourceLoader`) which was triggered during a data migration. But those do not have a GQL Context, which is what holds the data data loaders.

This creates a global context for data loaders for CLI (REPL/Console/Jest).
So the entire process, short-lived, will share loaders. But I have caching disabled.
So this is more to allow the process to continue to work vs trying to improve performance.
Since CLI processes are not hot path.

I've created a bit of a mess trying to get a fake-ish root session established which the data loaders reference.
Creating an ALS unique for session/current user makes a lot of sense, and has been on the mental whiteboard for a while.
This should allow current user/session to be declared at will for:
- GQL requests pull from auth token
- overridden for system actions for another user, like notifications.
- Assumed agent for CLI / migrations.