### PR TITLE
Stop assuming PnP project end date is the end of the month

### DIFF
--- a/src/components/pnp/planning-sheet.ts
+++ b/src/components/pnp/planning-sheet.ts
@@ -24,12 +24,9 @@ export abstract class PlanningSheet extends Sheet {
   }
   protected abstract revisionCell: Cell;
 
-  // Note that the user specified date range on the PnP is only in months
   @Once() get projectDateRange(): DateInterval {
-    const range = DateInterval.tryFrom(
-      this.projectStartDateCell.asDate,
-      this.projectEndDateCell.asDate?.endOf('month'),
-    );
+    const { start, end } = this.projectDateCells;
+    const range = DateInterval.tryFrom(start.asDate, end.asDate);
     if (!range) {
       throw new Error('Could not find project date range');
     }

--- a/src/components/progress-report/migrations/reextract-all-progress-reports.migration.ts
+++ b/src/components/progress-report/migrations/reextract-all-progress-reports.migration.ts
@@ -8,7 +8,7 @@ import { FileVersion } from '../../file/dto';
 import { PeriodicReportUploadedEvent } from '../../periodic-report/events';
 import { ProgressReport } from '../dto';
 
-@Migration('2024-12-17T16:00:00')
+@Migration('2025-01-06T09:00:00')
 export class ReextractPnpProgressReportsMigration extends BaseMigration {
   constructor(
     private readonly eventBus: IEventBus,


### PR DESCRIPTION
I'm not sure why we were doing this in the first place. Presumably, authors would mistakenly write the first day of the month when they meant the last, and this was to help "correct" that for them.

Now we're hitting cases where the project doesn't end on the last day of the month, and we need to allow that.

Reverts 291f47f4bddf6fad8e9dda45f06f6e4817956720
