### PR TITLE
Fix Engagement Date Filtering

### DIFF
--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -733,7 +733,7 @@ export const engagementFilters = filter.define(() => EngagementFilters, {
     node('', 'Language', { id }),
   ]),
   startDate: filter.dateTime(({ query }) => {
-    query.optionalMatch([
+    query.match([
       [
         node('node'),
         relation('out', '', 'startDateOverride', ACTIVE),
@@ -747,10 +747,11 @@ export const engagementFilters = filter.define(() => EngagementFilters, {
         node('mouStart', 'Property'),
       ],
     ]);
+
     return coalesce('startDateOverride.value', 'mouStart.value');
   }),
   endDate: filter.dateTime(({ query }) => {
-    query.optionalMatch([
+    query.match([
       [
         node('node'),
         relation('out', '', 'endDateOverride', ACTIVE),
@@ -764,6 +765,7 @@ export const engagementFilters = filter.define(() => EngagementFilters, {
         node('mouEnd', 'Property'),
       ],
     ]);
+
     return coalesce('endDateOverride.value', 'mouEnd.value');
   }),
   name: filter.fullText({

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -747,7 +747,6 @@ export const engagementFilters = filter.define(() => EngagementFilters, {
         node('mouStart', 'Property'),
       ],
     ]);
-
     return coalesce('startDateOverride.value', 'mouStart.value');
   }),
   endDate: filter.dateTime(({ query }) => {
@@ -765,7 +764,6 @@ export const engagementFilters = filter.define(() => EngagementFilters, {
         node('mouEnd', 'Property'),
       ],
     ]);
-
     return coalesce('endDateOverride.value', 'mouEnd.value');
   }),
   name: filter.fullText({


### PR DESCRIPTION
The `WITH` clause here acts to carry forward the node along with date override(`startDateOverride`, `endDateOverride`) and project date(`mouStart`, `mouEnd`) into the next part of the query. 