### PR TITLE
Add Partner filters for globalInnovationsClient, types, financialReportingTypes

### DIFF
--- a/src/components/partner/dto/list-partner.dto.ts
+++ b/src/components/partner/dto/list-partner.dto.ts
@@ -7,6 +7,8 @@ import {
   SortablePaginationInput,
 } from '~/common';
 import { OrganizationFilters } from '../../organization/dto';
+import { FinancialReportingType } from '../../partnership/dto/financial-reporting-type.enum';
+import { PartnerType } from './partner-type.enum';
 import { Partner } from './partner.dto';
 
 @InputType()
@@ -20,8 +22,23 @@ export abstract class PartnerFilters {
   })
   readonly pinned?: boolean;
 
+  @Field({
+    nullable: true,
+  })
+  readonly globalInnovationsClient?: boolean;
+
   @FilterField(() => OrganizationFilters)
   readonly organization?: OrganizationFilters & {};
+
+  @Field(() => [PartnerType], {
+    nullable: true,
+  })
+  readonly types?: PartnerType[];
+
+  @Field(() => [FinancialReportingType], {
+    nullable: true,
+  })
+  readonly financialReportingTypes?: FinancialReportingType[];
 }
 
 @InputType()

--- a/src/components/partner/partner.repository.ts
+++ b/src/components/partner/partner.repository.ts
@@ -319,6 +319,9 @@ export const partnerFilters = filters.define(() => PartnerFilters, {
       node('node', 'Organization'),
     ]),
   ),
+  types: filter.intersectsProp(),
+  financialReportingTypes: filter.intersectsProp(),
+  globalInnovationsClient: filter.propVal(),
 });
 
 export const partnerSorters = defineSorters(Partner, {


### PR DESCRIPTION
This adds 3 new filters to Partners: `globalInnovationsClient`, `types`, and `financialReportingTypes`.
