### PR TITLE
Optimize automatic DB query names with TraceLayer & ALS

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -39,6 +39,7 @@ export * from './secured-property';
 export * from './secured-date';
 export * from './secured-mapper';
 export * from './sensitivity.enum';
+export * from './trace-layer';
 export * from './util';
 export { Session, LoggedInSession, AnonSession } from './session';
 export * from './types';

--- a/src/common/trace-layer.ts
+++ b/src/common/trace-layer.ts
@@ -1,0 +1,148 @@
+import { cacheable, cached, patchMethod } from '@seedcompany/common';
+import { AsyncLocalStorage } from 'async_hooks';
+import { AbstractClass } from 'type-fest';
+import { getParentTypes as getHierarchyList } from './parent-types';
+
+export type TraceNames = Readonly<{
+  cls: string;
+  /** The parent class that declares the method when it is not the current class */
+  ownCls?: string;
+  method: string;
+}>;
+
+/**
+ * A performant way to identify certain methods in the call stack.
+ *
+ * This class helps to wrap class methods
+ * and store their names in an AsyncLocalStorage.
+ * This allows helper methods to identify who called them,
+ * assuming they've been preconfigured.
+ *
+ * Traces are wrapped with a "layer"/"group" name.
+ * This allows different groups of methods to be intertwined in the call
+ * stack without conflicting with each other.
+ * Multiple layers can be applied to the same method, independently.
+ *
+ * Best starting point is {@link applyToInstance}
+ * ```ts
+ * class Foo {
+ *   constructor() {
+ *     TraceLayer.as('logic').applyToInstance(this);
+ *   }
+ * }
+ * ```
+ * This capture approach is best because it automatically
+ * applies to subclasses and applies to inherited methods.
+ *
+ * Next best is {@link applyToClass}
+ * ```ts
+ * @TraceLayer.as('logic').applyToClass()
+ * class Foo {}
+ * ```
+ * This applies to all owned & inherited methods.
+ *
+ * The current stack can be pulled anywhere with
+ * ```ts
+ * TraceLayer.as('logic').currentStack;
+ * ```
+ * This gives a list of call names ordered by most recent.
+ * ```ts
+ *  const { cls, method } = currentStack?.[0] ?? {};
+ * ```
+ */
+export class TraceLayer {
+  private static readonly layers = new AsyncLocalStorage<{
+    readonly [layer in string]?: readonly TraceNames[];
+  }>();
+  private static readonly instances = new Map<string, TraceLayer>();
+  private static readonly getNameCacheForInstance = cacheable<
+    object,
+    Map<string, TraceNames>
+  >(new WeakMap(), () => new Map());
+
+  private readonly seenClasses = new WeakSet<AbstractClass<unknown>>();
+
+  private constructor(readonly layer: string) {}
+
+  static as(layer: string) {
+    return cached(TraceLayer.instances, layer, () => new TraceLayer(layer));
+  }
+
+  /**
+   * This gives a list of call names, if any, ordered by most recent.
+   * The identity of these entries is maintained,
+   * allowing them to be used as cache keys.
+   */
+  get currentStack() {
+    const layers = TraceLayer.layers.getStore();
+    return layers?.[this.layer];
+  }
+
+  /**
+   * A shortcut to create a memoized function that takes the current trace
+   * and converts it to another shape.
+   */
+  makeGetter<T>(mapFnCached: (names: TraceNames) => T) {
+    const cache = new WeakMap();
+    return () => {
+      const names = this.currentStack?.[0];
+      return names ? cached(cache, names, mapFnCached) : undefined;
+    };
+  }
+
+  applyToClass(): ClassDecorator {
+    return (target) => {
+      this.applyToStaticClass(target as any);
+    };
+  }
+
+  applyToInstance(obj: InstanceType<AbstractClass<any>>) {
+    this.applyToStaticClass(obj.constructor);
+  }
+
+  applyToStaticClass(cls: AbstractClass<unknown>) {
+    for (const aClass of getHierarchyList(cls)) {
+      this.applyToOwnStaticClass(aClass);
+    }
+  }
+
+  applyToOwnStaticClass(cls: AbstractClass<unknown>) {
+    if (this.seenClasses.has(cls)) {
+      return;
+    }
+    this.seenClasses.add(cls);
+
+    const proto = cls.prototype;
+    const descriptors = Object.getOwnPropertyDescriptors(proto);
+    const methods = Object.entries(descriptors).flatMap(([key, descriptor]) => {
+      return key !== 'constructor' && typeof descriptor.value === 'function'
+        ? [key]
+        : [];
+    });
+
+    const layer = this.layer;
+    for (const name of methods) {
+      patchMethod(proto as any, name, (original) => {
+        return function (...args) {
+          const nameCache = TraceLayer.getNameCacheForInstance(this);
+          const names = cached(nameCache, name, (): TraceNames => {
+            const cls = this.constructor.name;
+            const ownCls = proto.constructor.name;
+            return {
+              cls: cls,
+              ...(cls !== ownCls && { ownCls }),
+              method: name,
+            };
+          });
+
+          const prev = TraceLayer.layers.getStore();
+          const next = {
+            ...prev,
+            [layer]: [names, ...(prev?.[layer] ?? [])],
+          };
+          return TraceLayer.layers.run(next, original, ...args);
+        };
+      });
+    }
+  }
+}

--- a/src/common/trace-layer.ts
+++ b/src/common/trace-layer.ts
@@ -1,4 +1,5 @@
-import { cacheable, cached, patchMethod } from '@seedcompany/common';
+import { cacheable, cached } from '@seedcompany/common';
+import { patchDecoratedMethod as patchMethod } from '@seedcompany/nest';
 import { AsyncLocalStorage } from 'async_hooks';
 import { AbstractClass } from 'type-fest';
 import { getParentTypes as getHierarchyList } from './parent-types';

--- a/src/components/admin/admin.gel.repository.ts
+++ b/src/components/admin/admin.gel.repository.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { ID, Role } from '~/common';
 import { RootUserAlias } from '~/core/config/root-user.config';
-import { disableAccessPolicies, e, Gel } from '~/core/gel';
+import { DbTraceLayer, disableAccessPolicies, e, Gel } from '~/core/gel';
 import { AuthenticationRepository } from '../authentication/authentication.repository';
 import { SystemAgentRepository } from '../user/system-agent.repository';
 
 @Injectable()
+@DbTraceLayer.applyToClass()
 export class AdminGelRepository {
   private readonly db: Gel;
   constructor(

--- a/src/components/authentication/authentication.gel.repository.ts
+++ b/src/components/authentication/authentication.gel.repository.ts
@@ -2,11 +2,18 @@ import { Injectable } from '@nestjs/common';
 import { IntegrityError } from 'gel';
 import { ID, PublicOf, ServerException, Session } from '~/common';
 import { RootUserAlias } from '~/core/config/root-user.config';
-import { disableAccessPolicies, e, Gel, withScope } from '~/core/gel';
+import {
+  DbTraceLayer,
+  disableAccessPolicies,
+  e,
+  Gel,
+  withScope,
+} from '~/core/gel';
 import type { AuthenticationRepository } from './authentication.repository';
 import { LoginInput } from './dto';
 
 @Injectable()
+@DbTraceLayer.applyToClass()
 export class AuthenticationGelRepository
   implements PublicOf<AuthenticationRepository>
 {

--- a/src/components/authentication/authentication.repository.ts
+++ b/src/components/authentication/authentication.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { ID, ServerException, Session } from '~/common';
-import { DatabaseService, OnIndex } from '~/core/database';
+import { DatabaseService, DbTraceLayer, OnIndex } from '~/core/database';
 import {
   ACTIVE,
   matchUserGloballyScopedRoles,
@@ -19,6 +19,7 @@ interface EmailToken {
 }
 
 @Injectable()
+@DbTraceLayer.applyToClass()
 export class AuthenticationRepository {
   constructor(private readonly db: DatabaseService) {}
 

--- a/src/components/pin/pin.repository.ts
+++ b/src/components/pin/pin.repository.ts
@@ -2,10 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { ID, Session } from '~/common';
-import { DatabaseService } from '~/core/database';
+import { DatabaseService, DbTraceLayer } from '~/core/database';
 import { requestingUser } from '~/core/database/query';
 
 @Injectable()
+@DbTraceLayer.applyToClass()
 export class PinRepository {
   constructor(private readonly db: DatabaseService) {}
 

--- a/src/components/user/system-agent.repository.ts
+++ b/src/components/user/system-agent.repository.ts
@@ -1,10 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import { CachedByArg } from '@seedcompany/common';
 import { Role } from '~/common';
+import { DbTraceLayer } from '~/core/database';
 import { SystemAgent } from './dto';
 
 @Injectable()
 export abstract class SystemAgentRepository {
+  constructor() {
+    DbTraceLayer.applyToInstance(this);
+  }
+
   @CachedByArg()
   async getAnonymous() {
     return await this.upsertAgent('Anonymous');

--- a/src/core/database/common.repository.ts
+++ b/src/core/database/common.repository.ts
@@ -14,7 +14,7 @@ import {
   ServerException,
 } from '~/common';
 import { ResourceLike, ResourcesHost } from '../resources';
-import { DatabaseService } from './database.service';
+import { DatabaseService, DbTraceLayer } from './database.service';
 import { createUniqueConstraint } from './indexer';
 import { ACTIVE, deleteBaseNode, updateRelationList } from './query';
 import { BaseNode } from './results';
@@ -26,6 +26,10 @@ import { BaseNode } from './results';
 export class CommonRepository {
   @Inject() protected db: DatabaseService;
   @Inject() protected readonly resources: ResourcesHost;
+
+  constructor() {
+    DbTraceLayer.applyToInstance(this);
+  }
 
   async getBaseNode(
     id: ID,

--- a/src/core/database/cypher.factory.ts
+++ b/src/core/database/cypher.factory.ts
@@ -14,6 +14,7 @@ import { jestSkipFileInExceptionSource } from '../exception';
 import { ILogger, LoggerToken, LogLevel } from '../logger';
 import { AFTER_MESSAGE } from '../logger/formatters';
 import { TracingService } from '../tracing';
+import { DbTraceLayer } from './database.service';
 import {
   createBetterError,
   isNeo4jError,
@@ -190,12 +191,12 @@ export const CypherFactory: FactoryProvider<Connection> = {
       }
 
       (q as any).__stacktrace = stack;
-      const frame = stack?.[0] ? /at (.+) \(/.exec(stack[0]) : undefined;
-      (q as any).name = frame?.[1].replace('Repository', '');
+      const queryName = getCurrentQueryName();
+      (q as any).name = queryName;
 
       const orig = q.run.bind(q);
       q.run = async () => {
-        return await tracing.capture((q as any).name ?? 'Query', (sub) => {
+        return await tracing.capture(queryName ?? 'Query', (sub) => {
           // Show this segment separately in service map
           sub.namespace = 'remote';
           // Help ID the segment as being for a database
@@ -218,7 +219,7 @@ export const CypherFactory: FactoryProvider<Connection> = {
           writable: true,
         });
         Object.defineProperty(result.params, '__origin', {
-          value: (q as any).name,
+          value: queryName,
           enumerable: false,
           configurable: true,
           writable: true,
@@ -319,3 +320,7 @@ const wrapQueryRun = (
     return result;
   };
 };
+
+const getCurrentQueryName = DbTraceLayer.makeGetter(({ cls, method }) => {
+  return `${cls.replace(/Repository$/, '')}.${method}`;
+});

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -13,6 +13,7 @@ import {
   MaybeUnsecuredInstance,
   ResourceShape,
   ServerException,
+  TraceLayer,
   UnwrapSecured,
 } from '~/common';
 import { AbortError, retry, RetryOptions } from '~/common/retry';
@@ -33,6 +34,8 @@ import {
   UpdatePropertyOptions,
   variable,
 } from './query';
+
+export const DbTraceLayer = TraceLayer.as('db');
 
 export interface ServerInfo {
   version: [major: number, minor: number, patch: number];

--- a/src/core/database/migration/migration-runner.service.ts
+++ b/src/core/database/migration/migration-runner.service.ts
@@ -3,13 +3,14 @@ import { node } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { ConfigService } from '../../config/config.service';
 import { ILogger, Logger } from '../../logger';
-import { DatabaseService } from '../database.service';
+import { DatabaseService, DbTraceLayer } from '../database.service';
 import {
   DiscoveredMigration,
   MigrationDiscovery,
 } from './migration-discovery.service';
 
 @Injectable()
+@DbTraceLayer.applyToClass()
 export class MigrationRunner {
   constructor(
     private readonly db: DatabaseService,

--- a/src/core/gel/common.repository.ts
+++ b/src/core/gel/common.repository.ts
@@ -3,7 +3,7 @@ import { EnhancedResource, ID, isIdLike, PublicOf } from '~/common';
 import type { CommonRepository as Neo4jCommonRepository } from '~/core/database';
 import { ResourceLike, ResourcesHost } from '~/core/resources/resources.host';
 import type { BaseNode } from '../database/results';
-import { Gel } from './gel.service';
+import { DbTraceLayer, Gel } from './gel.service';
 import { e } from './reexports';
 
 /**
@@ -13,6 +13,10 @@ import { e } from './reexports';
 export class CommonRepository implements PublicOf<Neo4jCommonRepository> {
   @Inject() protected readonly db: Gel;
   @Inject() protected readonly resources: ResourcesHost;
+
+  constructor() {
+    DbTraceLayer.applyToInstance(this);
+  }
 
   /**
    * Here for compatibility with the Neo4j version.

--- a/src/core/gel/gel.service.ts
+++ b/src/core/gel/gel.service.ts
@@ -4,6 +4,7 @@ import { $, ConstraintViolationError, Executor, GelError } from 'gel';
 import { QueryArgs } from 'gel/dist/ifaces';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
+import { TraceLayer } from '~/common';
 import { retry, RetryOptions } from '~/common/retry';
 import { TracingService } from '~/core/tracing';
 import { jestSkipFileInExceptionSource } from '../exception';
@@ -13,6 +14,8 @@ import { InlineQueryRuntimeMap } from './generated-client/inline-queries';
 import { ApplyOptions, OptionsContext } from './options.context';
 import { Client } from './reexports';
 import { TransactionContext } from './transaction.context';
+
+export const DbTraceLayer = TraceLayer.as('db');
 
 @Injectable()
 export class Gel {

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -1,6 +1,5 @@
 import { faker } from '@faker-js/faker';
 import { intersection, times } from 'lodash';
-import { DateTime } from 'luxon';
 import { v1 as uuid } from 'uuid';
 import {
   CalendarDate,
@@ -731,22 +730,6 @@ describe('Project e2e', () => {
     expect(
       queryProject.project.engagements.items.length,
     ).toBeGreaterThanOrEqual(numEngagements);
-  });
-
-  it('DB constraint for project.name uniqueness', async () => {
-    const projName = 'Fix the world ' + DateTime.local().toString();
-    await createProject(app, {
-      name: projName,
-      fieldRegionId: fieldRegion.id,
-    });
-    await expect(
-      createProject(app, { name: projName, fieldRegionId: fieldRegion.id }),
-    ).rejects.toThrowGqlError(
-      errors.duplicate({
-        message: 'Project with this name already exists',
-        field: 'project.name',
-      }),
-    );
   });
 
   it('List view of project members by projectId', async () => {


### PR DESCRIPTION
Previously we used the repository method names to identify the DB queries.
This was achieved via a stack trace.
This takes "a lot" of work (relatively) for the engine to calculate,
and since this is on the hot path it's bad.

Now, the strategy is to wrap all of these repository methods to run in an ALS context.
This essentially is an opt-in to allow inner logic to see what call it.
These names are also only calculated once and cached.

From my rough tests, previously the name generation could take up to a couple milliseconds, and **now it's 10-25x faster**.
Not a huge win but it is something that affects every db query call every time.

All of this work is wrapped up in an abstracted `TraceLayer`, and could be used for other tracing scopes. I'm aware this is fairly similar to actual tracing, but this doesn't assume anything, only provides names. Maybe something changes there in the future to connect to OTEL/XRay.

I've also provided this auto naming to the new [Gel v6 query stats](https://www.geldata.com/blog/gel-6-query-stats-and-in-place-upgrade#query-performance-log).