### PR TITLE
Refactor & polish search service code

### DIFF
--- a/src/components/search/dto/search-results.dto.ts
+++ b/src/components/search/dto/search-results.dto.ts
@@ -1,5 +1,5 @@
 import { createUnionType } from '@nestjs/graphql';
-import { entries, simpleSwitch } from '@seedcompany/common';
+import { entries, setOf, simpleSwitch } from '@seedcompany/common';
 import { uniq } from 'lodash';
 import { EnumType, makeEnum } from '~/common';
 import { ResourceMap } from '~/core';
@@ -88,7 +88,9 @@ export type SearchableMap = {
   >;
 };
 
-export const SearchResultTypes = entries(publicSearchable).map(([k]) => k);
+export const SearchResultTypes = setOf(
+  entries(publicSearchable).map(([k]) => k),
+);
 
 // __typename is a GQL thing to identify type at runtime
 // It makes sense to use this key to not conflict with actual properties and

--- a/src/components/search/search.repository.ts
+++ b/src/components/search/search.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
+import { Merge } from 'type-fest';
 import { CommonRepository, OnIndex, OnIndexParams } from '~/core/database';
 import {
   ACTIVE,
@@ -7,6 +8,7 @@ import {
   FullTextIndex,
 } from '~/core/database/query';
 import { BaseNode } from '~/core/database/results';
+import type { ResourceMap } from '~/core/resources';
 import { SearchInput } from './dto';
 
 @Injectable()
@@ -20,7 +22,7 @@ export class SearchRepository extends CommonRepository {
    * Search for nodes based on input, only returning their id and "type"
    * which is based on their first valid search label.
    */
-  async search(input: SearchInput) {
+  async search(input: Merge<SearchInput, { type: Array<keyof ResourceMap> }>) {
     const escaped = escapeLuceneSyntax(input.query);
     // Emphasize exact matches but allow fuzzy as well
     const lucene = `"${escaped}"^2 ${escaped}*`;


### PR DESCRIPTION
This mainly hasn't been touched in 3 years and it needed some love.
This has been pulled out of #3357.

This is mainly naming changes & type tweaks.

Functionally though there are a few changes:
- We actually ensure that the resource types returned are within the search types filter
- Because of this we also expand the interfaces listed in the `types` filter to their searchable concretes.
- We ensure that the results are unique. I don't believe this affects anything currently, but with #3357 there could be matches on two different objects that are then hydrated to the same object.

## Future
A big outstanding piece I want to do here is to convert this to use the data loaders.
This way there's only `O(1+R)` requests where `R` is the number of resources.
Currently it's `O(1+M)` where `M` is the number of matches.
So a search result of 3 projects, is 4 DB queries, but it could be reduced to 2 DB queries.