### PR TITLE
Enable batching up to 25 GQL operations over http

### DIFF
--- a/src/core/graphql/driver.ts
+++ b/src/core/graphql/driver.ts
@@ -51,6 +51,7 @@ export class Driver extends AbstractDriver<DriverConfig> {
       ...options,
       graphqlEndpoint: options.path,
       logging: false,
+      batching: { limit: 25 },
     });
 
     fastify.route({


### PR DESCRIPTION
The default limit is 10. I'm not really sure if we should use that or 25 is fine or what.

This allows a single HTTP request instead of 25 requests for 25 operations.
So this is an optimization for this protocol layer.
All of these operations are still processed individually/independently.

But it is possible for future work to optimize more. Like the data loaders could be cached by batched request instead of each operation.