### PR TITLE
Fix default last chapter/verse in scripture input

### DIFF
--- a/src/components/scripture/dto/scripture-reference.dto.ts
+++ b/src/components/scripture/dto/scripture-reference.dto.ts
@@ -17,7 +17,17 @@ export abstract class ScriptureReferenceInput {
     description: 'The Bible book',
   })
   @IsValidBook()
-  readonly book: string;
+  get book(): string {
+    return undefined as any;
+  }
+  protected set book(book: string) {
+    Object.defineProperty(this, 'book', {
+      value: book,
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+  }
 
   @Field(() => Int, {
     description: stripIndent`

--- a/src/components/scripture/dto/scripture-reference.transformer.ts
+++ b/src/components/scripture/dto/scripture-reference.transformer.ts
@@ -11,21 +11,17 @@ class ScriptureReferenceStartInput extends ScriptureReferenceInput {
 }
 
 class ScriptureReferenceEndInput extends ScriptureReferenceInput {
-  private bookName: string;
-
-  // @ts-expect-error Yes we are clobbering the property definition from the parent.
-  // It's ok for this use case and the parent decorators are still applied.
   get book() {
-    return this.bookName;
+    return super.book;
   }
+  protected set book(name: string) {
+    super.book = name;
 
-  set book(value: string) {
-    this.bookName = value;
     // When the book is set, default the chapter & verse to last.
     // If they are also given on input, then they will just be overridden
     // after this. Also ignoring errors, as the validator reports better.
     try {
-      const book = Book.named(value);
+      const book = Book.named(name);
       (this as Mutable<this>).chapter = book.lastChapter.index;
       (this as Mutable<this>).verse = book.lastChapter.lastVerse.index;
     } catch (e) {

--- a/src/components/scripture/gel.utils.ts
+++ b/src/components/scripture/gel.utils.ts
@@ -4,10 +4,11 @@ import {
   labelOfVerseRanges,
   Verse,
 } from '@seedcompany/scripture';
+import { Simplify } from 'type-fest';
 import { $, e } from '~/core/gel';
 import { $expr_Param } from '~/core/gel/generated-client/params';
 import { $expr_PathNode } from '~/core/gel/generated-client/path';
-import { ScriptureRangeInput } from './dto';
+import { ScriptureRangeInput, ScriptureReferenceInput } from './dto';
 
 const verse = e.tuple({
   book: e.str,
@@ -44,11 +45,11 @@ export const value = (input: readonly ScriptureRangeInput[]) => ({
   verses: input.map((verseRange) => ({
     label: labelOfVerseRange(verseRange),
     start: {
-      ...verseRange.start,
+      ...(verseRange.start as Simplify<ScriptureReferenceInput>),
       verseId: Verse.from(verseRange.start).id,
     },
     end: {
-      ...verseRange.end,
+      ...(verseRange.end as Simplify<ScriptureReferenceInput>),
       verseId: Verse.from(verseRange.end).id,
     },
   })),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3118,12 +3118,12 @@ __metadata:
   linkType: hard
 
 "@seedcompany/scripture@npm:>=0.8.0":
-  version: 0.8.1
-  resolution: "@seedcompany/scripture@npm:0.8.1"
+  version: 0.8.2
+  resolution: "@seedcompany/scripture@npm:0.8.2"
   dependencies:
     "@seedcompany/common": "npm:>=0.17 <1.0.0"
     type-fest: "npm:^4.37.0"
-  checksum: 10c0/fc291c76af7efb21d04d57b5b6ca6284cd7c18cc37ca4c6c588b821a8f01f11826e001747ed965e2113e16e572404615de2de5214b164b54708afca28e8a3f88
+  checksum: 10c0/c968465815360fa4f0cf7968c5b0dada3225029d91d6331bab8a58216531d1085d16b2b37a14107cb72dcc464f874265c4a547bc5a1e8627e1b281ee9faad877
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I'm guessing this regressed with a7187c6.
Fixed by using an actual getter/setter for the `book` in the initial `ScriptureReferenceInput` class. This allows for overriding in `ScriptureReferenceEndInput`. The getter/setter is re-defined to be a normal property on the first set. So this makes it function like it did before at runtime.

This issue was exacerbated by the fact that this failure to produce a valid scripture reference still produced a `Verse` object that happened to be invalid. This invalid `Verse` object caused an infinite loop in `mergeVerseRanges`. This was fixed here:
https://github.com/SeedCompany/libs/commit/b02ae4033c5bc573eb3d392c4e424051b3df45b8 Where runtime checks were added to prevent those invalid objects from being created, thus avoiding the infinite loop.

For some reason Gel doesn't like this getter/setter change. Typecasting to a `Simplify`ed version restores the type compat.