### PR TITLE
Fix search filtering out concrete type filters

### DIFF
--- a/src/components/search/search.service.ts
+++ b/src/components/search/search.service.ts
@@ -63,9 +63,12 @@ export class SearchService {
           // are within this `types` filter
           // and those results are the concretes not the interfaces.
           input.type
-            .flatMap((type) =>
-              this.resources.getImplementations(this.resources.enhance(type)),
-            )
+            .flatMap((type) => {
+              const resource = this.resources.enhance(type);
+              const implementations =
+                this.resources.getImplementations(resource);
+              return [resource, ...implementations];
+            })
             .flatMap((type) =>
               setHas(SearchResultTypes, type.name) ? type.name : [],
             ),


### PR DESCRIPTION
Concrete types do not include themselves in their implementations list. Nor should it really, it is a weird ask.
We'll add the input resource to this list, it could be a concrete or an abstract, and let the search types filter check directly below filter appropriately.