### PR TITLE
Fix failing to find an engagement status transition when the status hasn't changed

### DIFF
--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -155,7 +155,10 @@ export class EngagementService {
   ): Promise<LanguageEngagement> {
     const view: ObjectView = viewOfChangeset(changeset);
 
-    if (input.status) {
+    const previous = await this.repo.readOne(input.id, session, view);
+    const object = this.secure(previous, session) as LanguageEngagement;
+
+    if (input.status && input.status !== previous.status) {
       await this.engagementRules.verifyStatusChange(
         input.id,
         session,
@@ -163,9 +166,6 @@ export class EngagementService {
         changeset,
       );
     }
-
-    const previous = await this.repo.readOne(input.id, session, view);
-    const object = this.secure(previous, session) as LanguageEngagement;
 
     const { methodology: _, ...maybeChanges } = input;
     const changes = this.repo.getActualLanguageChanges(object, maybeChanges);
@@ -195,7 +195,10 @@ export class EngagementService {
   ): Promise<InternshipEngagement> {
     const view: ObjectView = viewOfChangeset(changeset);
 
-    if (input.status) {
+    const previous = await this.repo.readOne(input.id, session, view);
+    const object = this.secure(previous, session) as InternshipEngagement;
+
+    if (input.status && input.status !== previous.status) {
       await this.engagementRules.verifyStatusChange(
         input.id,
         session,
@@ -203,9 +206,6 @@ export class EngagementService {
         changeset,
       );
     }
-
-    const previous = await this.repo.readOne(input.id, session, view);
-    const object = this.secure(previous, session) as InternshipEngagement;
 
     const changes = this.repo.getActualInternshipChanges(object, input);
     this.privileges


### PR DESCRIPTION
Sad that this as existed for so long. The src change is very obvious.

This is especially a pain point, because users will transition a project that then triggers logic to change the status to follow suit, then that fails because there is no transition found for engagements already in that status we are trying to change to (e.g. "Active to Active"), so we fail the whole project transition.