### PR TITLE
Limit roles assigned to the project creator's membership to only those applicable

### DIFF
--- a/src/common/role.dto.ts
+++ b/src/common/role.dto.ts
@@ -1,4 +1,5 @@
 import { ObjectType } from '@nestjs/graphql';
+import { setOf } from '@seedcompany/common';
 import { EnumType, makeEnum } from '@seedcompany/nest';
 import { SecuredEnumList } from '~/common/secured-property';
 import type { ResourcesGranter } from '../components/authorization';
@@ -40,6 +41,15 @@ export const Role = makeEnum({
        */
       assignable: (resources: ResourcesGranter, roles: readonly Role[]) =>
         resources.AssignableRoles.grant(roles),
+
+      applicableToProjectMembership: setOf<Role>([
+        'FinancialAnalyst',
+        'LeadFinancialAnalyst',
+        'Controller',
+        'ProjectManager',
+        'RegionalDirector',
+        'FieldOperationsDirector',
+      ]),
     };
   },
 });

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -1,5 +1,5 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
-import { Many } from '@seedcompany/common';
+import { Many, setOf } from '@seedcompany/common';
 import {
   DuplicateException,
   EnhancedResource,
@@ -9,6 +9,7 @@ import {
   many,
   NotFoundException,
   ObjectView,
+  Role,
   SecuredList,
   ServerException,
   Session,
@@ -71,6 +72,15 @@ import {
 } from './project-member/dto';
 import { ProjectRepository } from './project.repository';
 import { ProjectWorkflowService } from './workflow/project-workflow.service';
+
+const rolesApplicableToProjectMembership = setOf<Role>([
+  'FinancialAnalyst',
+  'LeadFinancialAnalyst',
+  'Controller',
+  'ProjectManager',
+  'RegionalDirector',
+  'FieldOperationsDirector',
+]);
 
 @Injectable()
 export class ProjectService {
@@ -155,7 +165,9 @@ export class ProjectService {
       await this.projectMembers.create(
         {
           userId: session.userId,
-          roles: session.roles.map(withoutScope),
+          roles: session.roles
+            .map(withoutScope)
+            .filter((role) => rolesApplicableToProjectMembership.has(role)),
           projectId: project,
         },
         session,

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -1,5 +1,5 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
-import { Many, setOf } from '@seedcompany/common';
+import { Many } from '@seedcompany/common';
 import {
   DuplicateException,
   EnhancedResource,
@@ -72,15 +72,6 @@ import {
 } from './project-member/dto';
 import { ProjectRepository } from './project.repository';
 import { ProjectWorkflowService } from './workflow/project-workflow.service';
-
-const rolesApplicableToProjectMembership = setOf<Role>([
-  'FinancialAnalyst',
-  'LeadFinancialAnalyst',
-  'Controller',
-  'ProjectManager',
-  'RegionalDirector',
-  'FieldOperationsDirector',
-]);
 
 @Injectable()
 export class ProjectService {
@@ -167,7 +158,7 @@ export class ProjectService {
           userId: session.userId,
           roles: session.roles
             .map(withoutScope)
-            .filter((role) => rolesApplicableToProjectMembership.has(role)),
+            .filter((role) => Role.applicableToProjectMembership.has(role)),
           projectId: project,
         },
         session,


### PR DESCRIPTION
Roles like "Leadership" or "Administrator" shouldn't be assigned to projects
