### PR TITLE
New ProgramApprover model by SC Groups & Programs

### DIFF
--- a/dbschema/approver.gel
+++ b/dbschema/approver.gel
@@ -1,0 +1,29 @@
+module Business {
+  scalar type `Group` extending enum<
+    Development,
+    FieldGrowth,
+    FieldOperations,
+    Finance,
+    MarketingCommunications,
+    OfficeOfThePresident,
+    People,
+    Technology,
+  > {
+    annotation description := "\
+      Each group (formerly domain) within Seed Company. \
+      OrganizationGroup was avoided to not be ambiguous with our Organizations here.";
+  }
+}
+
+module Program {
+  type Approver {
+    annotation description := "\
+      Certain users are approvers on behalf of their group for certain programs / project types.";
+
+    required user: default::User {
+      constraint exclusive;
+    };
+    required multi programs: Project::Type;
+    required multi groups: Business::Group;
+  }
+}

--- a/dbschema/migrations/00015-m16fwsg.edgeql
+++ b/dbschema/migrations/00015-m16fwsg.edgeql
@@ -1,0 +1,37 @@
+CREATE MIGRATION m16fwsgh2jrwv2pxyw3ej36uywbt7dhnyfankwp4sq3oqwtv2alydq
+    ONTO m1l7uuqm3my5klng3a2m6wqoswaq63h6jb63gvioafpj2t5yffxduq
+{
+  CREATE MODULE Business IF NOT EXISTS;
+  CREATE MODULE Program IF NOT EXISTS;
+  CREATE SCALAR TYPE Business::`Group` EXTENDING enum<Development, FieldGrowth, FieldOperations, Finance, MarketingCommunications, OfficeOfThePresident, People, Technology> {
+      CREATE ANNOTATION std::description := 'Each group (formerly domain) within Seed Company. OrganizationGroup was avoided to not be ambiguous with our Organizations here.';
+  };
+  CREATE TYPE Program::Approver {
+      CREATE REQUIRED LINK user: default::User {
+          CREATE CONSTRAINT std::exclusive;
+      };
+      CREATE REQUIRED MULTI PROPERTY groups: Business::`Group`;
+      CREATE REQUIRED MULTI PROPERTY programs: Project::Type;
+      CREATE ANNOTATION std::description := 'Certain users are approvers on behalf of their group for certain programs / project types.';
+  };
+  ALTER TYPE default::Project {
+      CREATE MULTI LINK approvers := (SELECT
+          Program::Approver
+      FILTER
+          (default::Project.type IN .programs)
+      );
+      CREATE SINGLE LINK approver := (SELECT
+          .approvers FILTER
+              (.user = GLOBAL default::currentUser)
+      LIMIT
+          1
+      );
+  };
+  ALTER TYPE Project::ContextAware {
+      CREATE REQUIRED SINGLE PROPERTY isFinancialApprover := (EXISTS ((SELECT
+          .projectContext.projects.approver
+      FILTER
+          (Business::`Group`.Finance IN .groups)
+      )));
+  };
+};

--- a/dbschema/project.gel
+++ b/dbschema/project.gel
@@ -80,7 +80,10 @@ module default {
     
     multi link members := .<project[is Project::Member];
     single link membership := (select .members filter .user = global default::currentUser limit 1);
-    
+
+    multi link approvers := (select Program::Approver filter Project.type in .programs);
+    single link approver := (select .approvers filter .user = global default::currentUser limit 1);
+
 #     multi link engagements := .<project[is Engagement];
     property engagementTotal := count(.<project[is Engagement]);
     
@@ -181,6 +184,10 @@ module Project {
       max(.projectContext.projects.ownSensitivity)
       ?? (.ownSensitivity ?? default::Sensitivity.High);
     required single property isMember := exists .projectContext.projects.membership;
+    required single property isFinancialApprover := exists (
+      select .projectContext.projects.approver
+      filter Business::Group.Finance in .groups
+    );
   }
   
   scalar type Type extending enum<


### PR DESCRIPTION
The goal here is to replace `ProjectTypeFinancialApprover` with one that is generic for all groups not just finance.
For example, we also have certain field approvers for internships & and consultant approvers for momentum.

I'm not exactly sure that the our organizational groups (`Business::Group`) capture this though.
- Finance makes sense, and could apply to both FAs & LFAs (not constrained here, yet?).
- FieldOps might be too coarse though. Consultants need to approve goal changes for momentum projects. Tonia needs to approve something for internships.

So many this group enum needs to be different. Like describing some business concept/process.

---

Anyways the schema is like this:

`Project.approvers` are all global approvers that match the project's program/type.
`Project.approver` is the approver for the current user, if any.

`Project.isFinancialApprover` is if the current user is an approver for the project type with the Finance group. Since this is a property it will be selected with `*` allowing the app to somewhat transparently get this auth info for our policy calculations.
This is actually on any ContextAware object, so there's also `Engagement.isFinancialApprover`, etc.