### PR TITLE
Retry whole transactions on department id collisions

### DIFF
--- a/src/components/project/handlers/set-department-id.handler.ts
+++ b/src/components/project/handlers/set-department-id.handler.ts
@@ -1,8 +1,7 @@
 import { isNull, node, not, relation } from 'cypher-query-builder';
 import { ClientException, ID, ServerException, UnsecuredDto } from '~/common';
-import { Retry } from '~/common/retry';
 import { ConfigService, EventsHandler, IEventHandler } from '~/core';
-import { DatabaseService, UniquenessError } from '~/core/database';
+import { DatabaseService } from '~/core/database';
 import {
   ACTIVE,
   apoc,
@@ -62,11 +61,6 @@ export class SetDepartmentId implements IEventHandler<SubscribedEvent> {
     };
   }
 
-  @Retry({
-    shouldRetry: (e) => Boolean(e.cause && e.cause instanceof UniquenessError),
-    randomize: true,
-    maxTimeout: '5 secs',
-  })
   private async assignDepartmentIdForProject(
     project: UnsecuredDto<Project>,
     block: { id: ID },

--- a/src/core/database/cypher.factory.ts
+++ b/src/core/database/cypher.factory.ts
@@ -24,6 +24,7 @@ import { highlight } from './highlight-cypher.util';
 import { ParameterTransformer } from './parameter-transformer.service';
 // eslint-disable-next-line import/no-duplicates
 import { Neo4jTransaction as Transaction } from './transaction';
+import { TransactionRetryInformer } from './transaction-retry.informer';
 import { MyTransformer } from './transformer';
 // eslint-disable-next-line import/no-duplicates
 import './transaction'; // import our transaction augmentation
@@ -55,6 +56,7 @@ export type PatchedConnection = Merge<
     transformer: MyTransformer;
     open: boolean;
     driver: Driver;
+    retryInformer: TransactionRetryInformer;
   }
 >;
 
@@ -64,6 +66,7 @@ export const CypherFactory: FactoryProvider<Connection> = {
     config: ConfigService,
     tracing: TracingService,
     parameterTransformer: ParameterTransformer,
+    retryInformer: TransactionRetryInformer,
     logger: ILogger,
     driverLogger: ILogger,
   ) => {
@@ -125,6 +128,8 @@ export const CypherFactory: FactoryProvider<Connection> = {
       driverConstructor,
       driverConfig: resolvedDriverConfig,
     });
+
+    conn.retryInformer = retryInformer;
 
     // Holder for the current transaction using native async storage context.
     conn.transactionStorage = new AsyncLocalStorage();
@@ -235,6 +240,7 @@ export const CypherFactory: FactoryProvider<Connection> = {
     ConfigService,
     TracingService,
     ParameterTransformer,
+    TransactionRetryInformer,
     LoggerToken('database:query'),
     LoggerToken('database:driver'),
   ],

--- a/src/core/database/database.module.ts
+++ b/src/core/database/database.module.ts
@@ -10,6 +10,7 @@ import { IndexerModule } from './indexer/indexer.module';
 import { MigrationModule } from './migration/migration.module';
 import { ParameterTransformer } from './parameter-transformer.service';
 import { RollbackManager } from './rollback-manager';
+import { TransactionRetryInformer } from './transaction-retry.informer';
 import { Neo4jTransactionalMutationsInterceptor as TransactionalMutationsInterceptor } from './transactional-mutations.interceptor';
 
 @Module({
@@ -20,8 +21,15 @@ import { Neo4jTransactionalMutationsInterceptor as TransactionalMutationsInterce
     ParameterTransformer,
     { provide: APP_INTERCEPTOR, useClass: TransactionalMutationsInterceptor },
     RollbackManager,
+    TransactionRetryInformer,
   ],
-  exports: [CypherFactory, DatabaseService, IndexerModule, RollbackManager],
+  exports: [
+    CypherFactory,
+    DatabaseService,
+    IndexerModule,
+    RollbackManager,
+    TransactionRetryInformer,
+  ],
 })
 export class DatabaseModule implements OnApplicationShutdown {
   constructor(

--- a/src/core/database/index.ts
+++ b/src/core/database/index.ts
@@ -8,4 +8,5 @@ export * from './indexer';
 export * from './migration';
 export * from './db-type';
 export * from './rollback-manager';
+export * from './transaction-retry.informer';
 export * from './split-db.provider';

--- a/src/core/database/transaction-retry.informer.ts
+++ b/src/core/database/transaction-retry.informer.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import type { Nil } from '@seedcompany/common';
+
+/**
+ * A service used to allow the codebase to inform the database transactions
+ * that a certain error should be retried (or not) regardless of defaults.
+ *
+ * Currently, it is expected that only database errors are marked & checked.
+ * But this limitation could be lifted in the future if needed.
+ */
+@Injectable()
+export class TransactionRetryInformer {
+  private readonly errors = new WeakMap<Error, boolean>();
+
+  /**
+   * Inform the transaction that this error should be retried (or not),
+   * regardless of what the defaults are.
+   *
+   * The driver config still informs the number of retries & the delay.
+   */
+  markForRetry(error: Error, retry = true) {
+    this.errors.set(error, retry);
+  }
+
+  /**
+   * Check whether the error has been overridden to retry or not.
+   *
+   * @internal
+   */
+  shouldRetry(error: Error): boolean | Nil {
+    return this.errors.get(error);
+  }
+}

--- a/src/core/database/transaction.ts
+++ b/src/core/database/transaction.ts
@@ -123,6 +123,11 @@ Connection.prototype.runInTransaction = async function withTransaction<R>(
           const maybeRetryableError = getCauseList(error).find(isNeo4jError);
           if (maybeRetryableError) {
             errorMap.set(maybeRetryableError, error);
+            const override =
+              this.retryInformer.shouldRetry(maybeRetryableError);
+            if (override != null) {
+              maybeRetryableError.retriable = override;
+            }
             throw maybeRetryableError;
           }
           throw error;

--- a/src/core/gel/index.ts
+++ b/src/core/gel/index.ts
@@ -8,3 +8,4 @@ export * from './common.repository';
 export * from './dto.repository';
 export * from './query-util/disable-access-policies.option';
 export * from './query-util/cast-to-enum';
+export * from '../database/transaction-retry.informer';


### PR DESCRIPTION
Since the collision produces a database constraint error, the whole transaction is in a rollback state, and it is not valid to continue making queries.
Thus it is the entire transaction work (GQL mutation in our setup) that needs to be retried.

This introduces a `TransactionRetryInformer` service as a decoupled way to allow the codebase to inform the database transaction layer that a certain error should be retried.

I've also applied this to the Gel path for assigning department IDs, so it is no longer left in the cold for this path.

This only addresses race conditions when two distinct mutations are trying to assign the same ID.

It is still not possible to have a single gql-mutation/db-transaction/db-query assigning multiple department IDs (using the same id block space), but this is not something we have currently.