### PR TITLE
[Neo4j] Switch to the new subquery import syntax (again)

### DIFF
--- a/src/components/budget/budget-record.repository.ts
+++ b/src/components/budget/budget-record.repository.ts
@@ -155,9 +155,8 @@ export class BudgetRecordRepository extends DtoRepository<
     view,
   }: BudgetRecordHydrateArgs) {
     return (query: Query) =>
-      query.subQuery((sub) =>
+      query.subQuery([recordVar, projectVar], (sub) =>
         sub
-          .with([recordVar, projectVar]) // import
           // rename to constant, only apply if making a change otherwise cypher breaks
           .apply((q) =>
             recordVar !== 'node' || projectVar !== 'project'
@@ -199,9 +198,8 @@ export class BudgetRecordRepository extends DtoRepository<
     outputVar?: string;
   }) {
     return (query: Query) =>
-      query.subQuery((sub) =>
+      query.subQuery(budgetVar, (sub) =>
         sub
-          .with(budgetVar)
           .match([
             node(budgetVar),
             relation('out', '', 'record', ACTIVE),

--- a/src/components/budget/budget.repository.ts
+++ b/src/components/budget/budget.repository.ts
@@ -188,9 +188,8 @@ export class BudgetRepository extends DtoRepository<
     const result = await this.db
       .query()
       .apply(this.currentBudgetForProject(projectId, changeset))
-      .subQuery((sub) =>
+      .subQuery(['project', 'budget'], (sub) =>
         sub
-          .with('project, budget')
           .apply(this.records.recordsOfBudget({ view }))
           .apply(this.records.hydrate({ session, view }))
           .return('collect(dto) as records'),

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -904,7 +904,6 @@ export const engagementSorters = defineSorters(IEngagement, {
       .apply(sortWith(languageSorters, input))
       // Use null for all internship engagements
       .union()
-      .with('node')
       .with('node as eng')
       .raw('where eng:InternshipEngagement')
       .return<SortCol>('null as sortValue'),
@@ -929,7 +928,6 @@ export const engagementSorters = defineSorters(IEngagement, {
           .raw('where size(reports) = 0')
           .return('null as sortValue')
           .union()
-          .with('reports')
           .with('reports')
           .raw('where size(reports) <> 0')
           .raw('unwind reports as node')

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -899,26 +899,24 @@ export const engagementSorters = defineSorters(IEngagement, {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   'language.*': (query, input) =>
     query
-      .with('node as eng')
-      .match([node('eng'), relation('out', '', 'language'), node('node')])
+      .match([node('outer'), relation('out', '', 'language'), node('node')])
       .apply(sortWith(languageSorters, input))
       // Use null for all internship engagements
       .union()
-      .with('node as eng')
-      .raw('where eng:InternshipEngagement')
+      .with('outer')
+      .raw('where outer:InternshipEngagement')
       .return<SortCol>('null as sortValue'),
   // eslint-disable-next-line @typescript-eslint/naming-convention
   'project.*': (query, input) =>
     query
-      .with('node as eng')
-      .match([node('eng'), relation('in', '', 'engagement'), node('node')])
+      .match([node('outer'), relation('in', '', 'engagement'), node('node')])
       .apply(sortWith(projectSorters, input)),
   // eslint-disable-next-line @typescript-eslint/naming-convention
   'currentProgressReportDue.*': (query, input) =>
     query
-      .subQuery('node', (sub) =>
+      .with('outer as parent')
+      .subQuery('parent', (sub) =>
         sub
-          .with('node as parent')
           .apply(matchCurrentDue(undefined, 'Progress'))
           .return('collect(node) as reports'),
       )

--- a/src/components/engagement/handlers/apply-finalized-changeset-to-engagement.handler.ts
+++ b/src/components/engagement/handlers/apply-finalized-changeset-to-engagement.handler.ts
@@ -36,9 +36,8 @@ export class ApplyFinalizedChangesetToEngagement
           relation('out', '', 'changeset', ACTIVE),
           node('changeset', 'Changeset', { id: changeset.id }),
         ])
-        .subQuery((sub) =>
+        .subQuery(['project', 'changeset'], (sub) =>
           sub
-            .with('project, changeset')
             .match([
               node('project'),
               relation('out', 'engagementRel', 'engagement', ACTIVE),
@@ -63,9 +62,8 @@ export class ApplyFinalizedChangesetToEngagement
           relation('out', '', 'changeset', ACTIVE),
           node('changeset', 'Changeset', { id: changeset.id }),
         ])
-        .subQuery((sub) =>
+        .subQuery(['project', 'changeset'], (sub) =>
           sub
-            .with('project, changeset')
             .match([
               node('project'),
               relation('out', 'engagementRel', 'engagement', INACTIVE),
@@ -95,9 +93,8 @@ export class ApplyFinalizedChangesetToEngagement
           relation('out', '', 'changeset', ACTIVE),
           node('changeset', 'Changeset', { id: changeset.id }),
         ])
-        .subQuery((sub) =>
+        .subQuery(['project', 'changeset'], (sub) =>
           sub
-            .with('project, changeset')
             .match([
               node('project'),
               relation('out', 'engagement', ACTIVE),

--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -135,19 +135,16 @@ export class FileRepository extends CommonRepository {
   hydrate() {
     return (query: Query) =>
       query
-        .subQuery((sub) =>
+        .subQuery('node', (sub) =>
           sub
-            .with('node')
             .with('node')
             .where({ node: hasLabel(FileNodeType.File) })
             .apply(this.hydrateFile())
             .union()
             .with('node')
-            .with('node')
             .where({ node: hasLabel(FileNodeType.FileVersion) })
             .apply(this.hydrateFileVersion())
             .union()
-            .with('node')
             .with('node')
             .where({ node: hasLabel(FileNodeType.Directory) })
             .apply(this.hydrateDirectory()),

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -186,9 +186,8 @@ export class LanguageRepository extends DtoRepository<
         .apply(matchProps())
         .apply(matchChangesetAndChangedProps(view?.changeset))
         // get lowest sensitivity across all projects associated with each language.
-        .subQuery((sub) =>
+        .subQuery(['projList', 'props'], (sub) =>
           sub
-            .with('projList')
             .raw('UNWIND projList as project')
             .apply(matchProjectSens())
             .with('sensitivity')
@@ -196,7 +195,6 @@ export class LanguageRepository extends DtoRepository<
             .raw('LIMIT 1')
             .return('sensitivity as effectiveSensitivity')
             .union()
-            .with('projList, props')
             .with('projList, props')
             .raw('WHERE size(projList) = 0')
             .return(`props.sensitivity as effectiveSensitivity`),

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -380,9 +380,8 @@ export const languageSorters = defineSorters(Language, {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   'ethnologue.*': (query, input) =>
     query
-      .with('node as lang')
       .match([
-        node('lang'),
+        node('outer'),
         relation('out', '', 'ethnologue'),
         node('node', 'EthnologueLanguage'),
       ])

--- a/src/components/notifications/notification.repository.ts
+++ b/src/components/notifications/notification.repository.ts
@@ -148,14 +148,13 @@ export class NotificationRepository extends CommonRepository {
   protected hydrate(session: Session) {
     return (query: Query) =>
       query
-        .subQuery((q) => {
+        .subQuery('node', (q) => {
           const concreteHydrates = [...this.service.strategyMap].map(
             ([dtoCls, strategy]) =>
               (q: Query) => {
                 const type = this.getType(dtoCls);
                 const hydrate = strategy.hydrateExtraForNeo4j('extra');
                 return q
-                  .with('node')
                   .with('node')
                   .where({ 'node.type': type })
                   .apply(hydrate ?? ((q) => q.return('{} as extra')));

--- a/src/components/organization/organization.repository.ts
+++ b/src/components/organization/organization.repository.ts
@@ -91,9 +91,8 @@ export class OrganizationRepository extends DtoRepository<
           'collect(project) as projList',
           'keys(apoc.coll.frequenciesAsMap(apoc.coll.flatten(collect(scopedRoles)))) as scopedRoles',
         ])
-        .subQuery((sub) =>
+        .subQuery('projList', (sub) =>
           sub
-            .with('projList')
             .raw('UNWIND projList as project')
             .apply(matchProjectSens())
             .with('sensitivity')
@@ -101,7 +100,6 @@ export class OrganizationRepository extends DtoRepository<
             .raw('LIMIT 1')
             .return('sensitivity')
             .union()
-            .with('projList')
             .with('projList')
             .raw('WHERE size(projList) = 0')
             .return(`'High' as sensitivity`),

--- a/src/components/partner/partner.repository.ts
+++ b/src/components/partner/partner.repository.ts
@@ -209,9 +209,8 @@ export class PartnerRepository extends DtoRepository<
           'collect(project) as projList',
           'keys(apoc.coll.frequenciesAsMap(apoc.coll.flatten(collect(scopedRoles)))) as scopedRoles',
         ])
-        .subQuery((sub) =>
+        .subQuery('projList', (sub) =>
           sub
-            .with('projList')
             .raw('UNWIND projList as project')
             .apply(matchProjectSens())
             .with('sensitivity')
@@ -219,7 +218,6 @@ export class PartnerRepository extends DtoRepository<
             .raw('LIMIT 1')
             .return('sensitivity')
             .union()
-            .with('projList')
             .with('projList')
             .raw('WHERE size(projList) = 0')
             .return(`'High' as sensitivity`),

--- a/src/components/partner/partner.repository.ts
+++ b/src/components/partner/partner.repository.ts
@@ -350,9 +350,8 @@ export const partnerSorters = defineSorters(Partner, {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   'organization.*': (query, input) =>
     query
-      .with('node as partner')
       .match([
-        node('partner'),
+        node('outer'),
         relation('out', '', 'organization'),
         node('node', 'Organization'),
       ])

--- a/src/components/partnership/handlers/apply-finalized-changeset-to-partnership.handler.ts
+++ b/src/components/partnership/handlers/apply-finalized-changeset-to-partnership.handler.ts
@@ -33,9 +33,8 @@ export class ApplyFinalizedChangesetToPartnership
           relation('out', '', 'changeset', ACTIVE),
           node('changeset', 'Changeset', { id: changeset.id }),
         ])
-        .subQuery((sub) =>
+        .subQuery(['project', 'changeset'], (sub) =>
           sub
-            .with('project, changeset')
             .match([
               node('project'),
               relation('out', 'partnershipRel', 'partnership', ACTIVE),
@@ -58,9 +57,8 @@ export class ApplyFinalizedChangesetToPartnership
           relation('out', '', 'changeset', ACTIVE),
           node('changeset', 'Changeset', { id: changeset.id }),
         ])
-        .subQuery((sub) =>
+        .subQuery(['project', 'changeset'], (sub) =>
           sub
-            .with('project, changeset')
             .match([
               node('project'),
               relation('out', 'partnershipRel', 'partnership', INACTIVE),

--- a/src/components/partnership/partnership.repository.ts
+++ b/src/components/partnership/partnership.repository.ts
@@ -280,9 +280,8 @@ export class PartnershipRepository extends DtoRepository<
         .query()
         .optionalMatch(node('partner', 'Partner', { id: partnerId }))
         .optionalMatch(node('project', 'Project', { id: projectId }))
-        .subQuery((sub) =>
+        .subQuery(['project', 'partner'], (sub) =>
           sub
-            .with('project, partner')
             .optionalMatch([
               node('project'),
               relation('out', '', 'partnership', ACTIVE),
@@ -295,7 +294,6 @@ export class PartnershipRepository extends DtoRepository<
               changeset
                 ? q
                     .union()
-                    .with('project, partner')
                     .match([node('changeset', 'Changeset', { id: changeset })])
                     .optionalMatch([
                       node('project'),

--- a/src/components/partnership/partnership.repository.ts
+++ b/src/components/partnership/partnership.repository.ts
@@ -439,9 +439,8 @@ export const partnershipSorters = defineSorters(Partnership, {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   'partner.*': (query, input) =>
     query
-      .with('node as partnership')
       .match([
-        node('partnership'),
+        node('outer'),
         relation('out', '', 'partner'),
         node('node', 'Partner'),
       ])

--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -380,14 +380,12 @@ export class PeriodicReportRepository extends DtoRepository<
   protected hydrate(session: Session) {
     return (query: Query) =>
       query
-        .subQuery((sub) =>
+        .subQuery('node', (sub) =>
           sub
-            .with('node')
             .with('node')
             .where({ node: hasLabel('ProgressReport') })
             .apply(this.progressRepo.extraHydrate())
             .union()
-            .with('node')
             .with('node')
             .where({ node: not(hasLabel('ProgressReport')) })
             .return('{} as extra'),
@@ -401,7 +399,6 @@ export class PeriodicReportRepository extends DtoRepository<
             ])
             .return('project')
             .union()
-            .with('node')
             .match([
               node('node'),
               relation('in', '', 'report', ACTIVE),

--- a/src/components/progress-report/progress-report-extra-for-periodic-interface.repository.ts
+++ b/src/components/progress-report/progress-report-extra-for-periodic-interface.repository.ts
@@ -90,7 +90,6 @@ export const progressReportExtrasSorters: DefinedSorters<
           ])
           .apply(sortWith(progressSummarySorters, input))
           .union()
-          .with('node')
           .with('node as report')
           .where(
             not(

--- a/src/components/progress-report/variance-explanation/variance-explanation.repository.ts
+++ b/src/components/progress-report/variance-explanation/variance-explanation.repository.ts
@@ -39,12 +39,10 @@ export class ProgressReportVarianceExplanationRepository extends DtoRepository(
       reasons: [],
       comments: null,
     };
-    const ctx = ['report', 'node'];
     return (query: Query) =>
       query
-        .subQuery((sub) =>
+        .subQuery(['report', 'node'], (sub) =>
           sub
-            .with(ctx)
             .apply(matchProps({ optional: true, excludeBaseProps: true }))
             .return<{ dto: UnsecuredDto<VarianceExplanation> }>(
               merge(defaults, 'props').as('dto'),

--- a/src/components/project/handlers/apply-finalized-changeset-to-project.handler.ts
+++ b/src/components/project/handlers/apply-finalized-changeset-to-project.handler.ts
@@ -36,10 +36,9 @@ export class ApplyFinalizedChangesetToProject
           changeset.applied ? commitChangesetProps() : rejectChangesetProps(),
         )
         // Apply pending budget records
-        .subQuery((sub) =>
+        .subQuery(['node', 'changeset'], (sub) =>
           sub
             .comment('Apply pending budget records')
-            .with('node, changeset')
             .match([
               node('node'),
               relation('out', '', 'budget', ACTIVE),

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -373,7 +373,6 @@ export const projectSorters = defineSorters(IProject, {
       .match(getPath())
       .apply(sortWith(locationSorters, input))
       .union()
-      .with('node')
       .with('node as project')
       .where(not(path(getPath(true))))
       .return<SortCol>('null as sortValue');
@@ -392,7 +391,6 @@ export const projectSorters = defineSorters(IProject, {
       .match(getPath())
       .apply(sortWith(partnershipSorters, input))
       .union()
-      .with('node')
       .with('node as project')
       .where(not(path(getPath(true))))
       .return<SortCol>('null as sortValue');

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -364,34 +364,32 @@ export const projectSorters = defineSorters(IProject, {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   'primaryLocation.*': (query, input) => {
     const getPath = (anon = false) => [
-      node('project'),
+      node('outer'),
       relation('out', '', 'primaryLocation', ACTIVE),
       node(anon ? '' : 'node'),
     ];
     return query
-      .with('node as project')
       .match(getPath())
       .apply(sortWith(locationSorters, input))
       .union()
-      .with('node as project')
+      .with('outer')
       .where(not(path(getPath(true))))
       .return<SortCol>('null as sortValue');
   },
   // eslint-disable-next-line @typescript-eslint/naming-convention
   'primaryPartnership.*': (query, input) => {
     const getPath = (anon = false) => [
-      node('project'),
+      node('outer'),
       relation('out', '', 'partnership', ACTIVE),
       node(anon ? '' : 'node', 'Partnership'),
       relation('out', '', 'primary', ACTIVE),
       node('', 'Property', { value: variable('true') }),
     ];
     return query
-      .with('node as project')
       .match(getPath())
       .apply(sortWith(partnershipSorters, input))
       .union()
-      .with('node as project')
+      .with('outer')
       .where(not(path(getPath(true))))
       .return<SortCol>('null as sortValue');
   },

--- a/src/components/user/user.repository.ts
+++ b/src/components/user/user.repository.ts
@@ -277,9 +277,8 @@ export class UserRepository extends DtoRepository<typeof User, [Session | ID]>(
         [node('user', 'User', { id: userId })],
         [node('org', 'Organization', { id: orgId })],
       ])
-      .subQuery((sub) =>
+      .subQuery(['user', 'org'], (sub) =>
         sub
-          .with('user, org')
           .match([
             node('user'),
             relation('out', 'oldRel', 'organization', ACTIVE),
@@ -292,9 +291,8 @@ export class UserRepository extends DtoRepository<typeof User, [Session | ID]>(
       )
       .apply((q) => {
         if (primary) {
-          q.subQuery((sub) =>
+          q.subQuery(['user', 'org'], (sub) =>
             sub
-              .with('user, org')
               .match([
                 node('user'),
                 relation('out', 'oldRel', 'primaryOrganization', {

--- a/src/core/database/query-augmentation/subquery.ts
+++ b/src/core/database/query-augmentation/subquery.ts
@@ -7,16 +7,14 @@ import { SubClauseCollection } from './SubClauseCollection';
 declare module 'cypher-query-builder/dist/typings/query' {
   interface Query<Result = unknown> {
     /**
-     * Creates a sub-query clause (`CALL { ... }`) and calls the given function
+     * Creates a sub-query clause (`CALL (...) { ... }`) and calls the given function
      * to define it.
      *
      * @example
-     * .unwind([0, 1, 2], 'x')
      * .subQuery((sub) => sub
-     *   .with('x')
-     *   .return('x * 10 as y')
+     *   .match(node('user', 'User', { id }))
+     *   .return('user')
      * )
-     * .return(['x', 'y'])
      *
      * @example
      * .unwind([0, 1, 2], 'x')
@@ -42,26 +40,35 @@ Query.prototype.subQuery = function subQuery(
     | ((query: Query) => void),
   maybeSub?: (query: Query) => void,
 ) {
-  const subClause = new SubQueryClause();
-  const subQ = withParent(subClause.asQuery(), this);
-  if (typeof subOrImport === 'function') {
-    subOrImport(subQ);
-  } else {
-    const imports = setOf(
-      many(subOrImport)
+  const importsRaw = typeof subOrImport === 'function' ? [] : subOrImport!;
+  const sub = typeof subOrImport === 'function' ? subOrImport : maybeSub!;
+
+  const imports = [
+    ...setOf(
+      many(importsRaw)
         .flatMap((val) => (val instanceof Variable ? varInExp(val) : val))
         .filter(isNotFalsy),
-    );
-    subQ.with([...imports]);
-    maybeSub!(subQ);
-  }
+    ),
+  ];
+
+  const subClause = new SubQueryClause(imports);
+  const subQ = withParent(subClause.asQuery(), this);
+  sub(subQ);
 
   return this.continueChainClause(subClause);
 };
 
 class SubQueryClause extends SubClauseCollection {
+  constructor(readonly scope: string[]) {
+    super();
+  }
+
   build() {
-    return this.wrapBuild('CALL { ', ' }', super.build());
+    return this.wrapBuild(
+      `CALL (${this.scope.join(', ')}) { `,
+      ' }',
+      super.build(),
+    );
   }
 }
 

--- a/src/core/database/query/filters.ts
+++ b/src/core/database/query/filters.ts
@@ -242,9 +242,8 @@ export const sub =
   ({ key, value, query }) => {
     const input = [...many(extraInput ?? [])];
     return query
-      .subQuery((sub) =>
+      .subQuery(['node', ...input], (sub) =>
         sub
-          .with(['node', ...input])
           .with([`node as ${outerVar}`, ...input])
           .apply(matchSubNode)
           .apply(subBuilder()(value))

--- a/src/core/database/query/filters.ts
+++ b/src/core/database/query/filters.ts
@@ -245,13 +245,17 @@ export const sub =
       .subQuery(['node', ...input], (sub) =>
         sub
           .with([`node as ${outerVar}`, ...input])
-          .apply(matchSubNode)
-          .apply(subBuilder()(value))
-          .return(`true as ${key}FiltersApplied`)
-          // Prevent filter from increasing cardinality above 1.
-          // This happens with `1-Many` relationships matched in `matchSubNode`.
-          // Note they are allowed to reduce cardinality to 0.
-          .raw('limit 1'),
+          .subQuery([...outerVar, ...input], (sub2) =>
+            sub2
+              .apply(matchSubNode)
+              .apply(subBuilder()(value))
+              .return(`true as ${key}FiltersApplied`)
+              // Prevent filter from increasing cardinality above 1.
+              // This happens with `1-Many` relationships matched in `matchSubNode`.
+              // Note they are allowed to reduce cardinality to 0.
+              .raw('limit 1'),
+          )
+          .return(`${key}FiltersApplied`),
       )
       .with('*');
   };

--- a/src/core/database/query/match-project-based-props.ts
+++ b/src/core/database/query/match-project-based-props.ts
@@ -22,30 +22,31 @@ export const matchPropsAndProjectSensAndScopedRoles =
   <R>(query: Query<R>) =>
     query.comment`
       matchPropsAndProjectSensAndScopedRoles()
-    `.subQuery((sub) =>
-      sub
-        .with([
-          'node',
-          'project',
-          ...(session instanceof Variable ? [session.name] : []),
-        ])
-        .apply(matchProjectSens('project'))
-        .apply(
-          matchProps(
-            propsOptions?.view?.deleted
-              ? propsOptions
-              : { ...propsOptions, view: { active: true } },
-          ),
-        )
-        .apply((q) =>
-          !session ? q : q.apply(matchProjectScopedRoles({ session })),
-        )
-        .return([
-          merge(propsOptions?.outputVar ?? 'props', {
-            sensitivity: 'sensitivity',
-            scope: session ? `scopedRoles` : null,
-          }).as(propsOptions?.outputVar ?? 'props'),
-        ]),
+    `.subQuery(
+      [
+        'node',
+        'project',
+        ...(session instanceof Variable ? [session.name] : []),
+      ],
+      (sub) =>
+        sub
+          .apply(matchProjectSens('project'))
+          .apply(
+            matchProps(
+              propsOptions?.view?.deleted
+                ? propsOptions
+                : { ...propsOptions, view: { active: true } },
+            ),
+          )
+          .apply((q) =>
+            !session ? q : q.apply(matchProjectScopedRoles({ session })),
+          )
+          .return([
+            merge(propsOptions?.outputVar ?? 'props', {
+              sensitivity: 'sensitivity',
+              scope: session ? `scopedRoles` : null,
+            }).as(propsOptions?.outputVar ?? 'props'),
+          ]),
     );
 
 export const matchProjectScopedRoles =
@@ -94,7 +95,6 @@ export const matchProjectScopedRoles =
           )
           .union()
           .with('project')
-          .with('project')
           .raw('WHERE project IS NULL')
           .return(`[] as ${outputVar}`),
     );
@@ -105,9 +105,8 @@ export const matchProjectSens =
     output: Output = 'sensitivity' as Output,
   ) =>
   <R>(query: Query<R>) =>
-    query.comment`matchProjectSens()`.subQuery((sub) =>
+    query.comment`matchProjectSens()`.subQuery(projectVar, (sub) =>
       sub
-        .with(projectVar) // import
         .with(projectVar) // needed for where clause
         .raw(
           `WHERE ${projectVar} IS NOT NULL AND ${projectVar}.type = "${ProjectType.Internship}"`,
@@ -119,7 +118,6 @@ export const matchProjectSens =
         ])
         .return(`projSens.value as ${output}`)
         .union()
-        .with(projectVar) // import
         .with(projectVar) // needed for where clause
         .raw(
           `WHERE ${projectVar} IS NOT NULL AND ${projectVar}.type <> "${ProjectType.Internship}"`,
@@ -143,7 +141,6 @@ export const matchProjectSens =
         // https://neo4j.com/developer/kb/conditional-cypher-execution/#_the_subquery_must_return_a_row_for_the_outer_query_to_continue
         .union()
         .with(projectVar)
-        .with(projectVar)
         .raw(`WHERE ${projectVar} IS NULL`)
         // TODO this doesn't work for languages without projects. They should use their own sensitivity not High.
         .return<Record<Output, Sensitivity>>(`"High" as ${output}`),
@@ -155,24 +152,25 @@ export const matchUserGloballyScopedRoles =
     outputVar = 'globalRoles' as Output,
   ) =>
   <R>(query: Query<R>) =>
-    query.comment('matchUserGloballyScopedRoles()').subQuery((sub) =>
-      sub
-        .with(userVar)
-        .match([
-          node(userVar),
-          relation('out', '', 'roles', ACTIVE),
-          node('role', 'Property'),
-        ])
-        .return<{ [K in Output]: readonly GlobalScopedRole[] }>(
-          reduce(
-            'scopedRoles',
-            [],
-            apoc.coll.flatten(collect('role.value')),
-            'role',
-            listConcat('scopedRoles', [`"global:" + role`]),
-          ).as(outputVar),
-        ),
-    );
+    query
+      .comment('matchUserGloballyScopedRoles()')
+      .subQuery(userVar, (sub) =>
+        sub
+          .match([
+            node(userVar),
+            relation('out', '', 'roles', ACTIVE),
+            node('role', 'Property'),
+          ])
+          .return<{ [K in Output]: readonly GlobalScopedRole[] }>(
+            reduce(
+              'scopedRoles',
+              [],
+              apoc.coll.flatten(collect('role.value')),
+              'role',
+              listConcat('scopedRoles', [`"global:" + role`]),
+            ).as(outputVar),
+          ),
+      );
 
 // group by project so inner logic doesn't run multiple times for a single project
 export const oncePerProject =

--- a/src/core/database/query/properties/update-property.ts
+++ b/src/core/database/query/properties/update-property.ts
@@ -197,15 +197,13 @@ export const conditionalOn = <R>(
 ): QueryFragment<unknown, R> => {
   const imports = [...new Set([conditionVar, ...scope])];
   return (query) =>
-    query.subQuery((sub) =>
+    query.subQuery(imports, (sub) =>
       sub
-        .with(imports)
         .with(imports)
         .raw(`WHERE ${conditionVar}`)
         .apply(trueQuery)
 
         .union()
-        .with(imports)
         .with(imports)
         .raw(`WHERE NOT ${conditionVar}`)
         .apply(falseQuery),

--- a/src/core/database/query/sorting.ts
+++ b/src/core/database/query/sorting.ts
@@ -141,7 +141,12 @@ export const defineSorters = <TResourceStatic extends ResourceShape<any>>(
     ) ?? [null, null];
     if (matchedPrefix && subCustom) {
       const subField = sort.slice(matchedPrefix.length - 1);
-      return { ...common, matcher: subCustom, sort: subField };
+      const matcher: SortMatcher<string> = (query, input) =>
+        query
+          .with('node as outer')
+          .subQuery('outer', (sub) => sub.apply((q) => subCustom(q, input)))
+          .return('sortValue');
+      return { ...common, matcher, sort: subField };
     }
 
     const baseNodeProps = resource.BaseNodeProps ?? Resource.Props;


### PR DESCRIPTION
Trying #3382 again.

Accounting for import aliases this time, and avoiding match patterns that need to declare a new variable that is also an import name.