### PR TITLE
Fix PnP init regression from e14cb87

### DIFF
--- a/src/components/pnp/planning-sheet.ts
+++ b/src/components/pnp/planning-sheet.ts
@@ -65,10 +65,12 @@ export abstract class PlanningSheet extends Sheet {
     return this.column('Q');
   }
 
-  get goals(): Range<PlanningSheet> {
+  @Once() get goals(): Range<PlanningSheet> {
     return this.range(this.goalsStart, this.goalsEnd);
   }
-  protected goalsStart = this.cell(this.goalColumn, 23);
+  @Once() protected get goalsStart() {
+    return this.cell(this.goalColumn, 23);
+  }
   @Once() protected get goalsEnd() {
     return this.sheetRange.end.row.cell(this.goalColumn);
   }


### PR DESCRIPTION
This regressed with  e14cb8771b3dd6405dd15569344601e581ca2b0f / #3385, which went live on Monday (2 days ago).

1. The base `PlanningSheet` class initializing `goalStart`
2. `goalColumn` was read, which read the `revisionCell`
3. `revisionCell` wasn't initialized yet, because it is defined in child classes.

Switching `goalStart` to be lazy fixes this.
It was also the only property in the base class that was eagerly initialized.
