### PR TITLE
Fix FPMs not being able to view other projects dates from 9988e85

### DIFF
--- a/src/components/authorization/policies/by-role/project-manager.policy.ts
+++ b/src/components/authorization/policies/by-role/project-manager.policy.ts
@@ -2,7 +2,6 @@ import { takeWhile } from 'lodash';
 import { ProjectStep } from '../../../project/dto';
 import { ProjectWorkflow } from '../../../project/workflow/project-workflow';
 import {
-  action,
   field,
   inherit,
   member,
@@ -144,11 +143,14 @@ export const momentumProjectsTransitions = () =>
       r.ProjectWorkflowEvent.isTransitions(momentumProjectsTransitions),
     ).execute,
     r.Project.read.create
-      .when(member)
-      .edit.specifically((p) => [
+      // eslint-disable-next-line prettier/prettier
+      .when(member).edit //
+      .or.specifically((p) => [
         p
           .many('rootDirectory', 'otherLocations', 'primaryLocation')
-          .edit.whenAny(member, sensMediumOrLower).read,
+          // eslint-disable-next-line prettier/prettier
+          .whenAny(member, sensMediumOrLower).read //
+          .when(member).edit,
         p
           .many('mouStart', 'mouEnd')
           .read //
@@ -157,8 +159,7 @@ export const momentumProjectsTransitions = () =>
             field('status', 'InDevelopment'),
             // Only allow until financial endorsement
             // field('step', stepsUntilFinancialEndorsement),
-          )
-          [action]('edit'),
+          ).edit,
       ])
       .children((c) => c.posts.read.create),
     r.ProjectMember.read.when(member).edit.create.delete,


### PR DESCRIPTION
I changed to use `.or.specifically` so the membership condition from the resource level isn't implicitly passed to properties. This is clearer & reads better here.

So the effective change is granting mou start/end [read](https://github.com/SeedCompany/cord-api-v3/compare/bugfix/project-date-perms?expand=1#diff-2ce6dc91076b6679b82573512d72c4b924876b2bde1e363c03f9353d4eb1e782R156) to all projects, not just projects with a membership.
