### PR TITLE
Server errors for creation failures

### DIFF
--- a/src/common/exceptions/creation-failed.exception.ts
+++ b/src/common/exceptions/creation-failed.exception.ts
@@ -1,0 +1,15 @@
+import { EnhancedResource } from '~/common';
+import type { ResourceLike } from '~/core';
+import { ServerException } from './exception';
+
+export class CreationFailed extends ServerException {
+  readonly resource: EnhancedResource<any>;
+  constructor(
+    resource: ResourceLike,
+    options?: { message?: string; cause?: Error },
+  ) {
+    const res = EnhancedResource.resolve(resource);
+    super(options?.message ?? `Failed to create ${res.name}`, options?.cause);
+    this.resource = res;
+  }
+}

--- a/src/common/exceptions/creation-failed.exception.ts
+++ b/src/common/exceptions/creation-failed.exception.ts
@@ -13,3 +13,16 @@ export class CreationFailed extends ServerException {
     this.resource = res;
   }
 }
+
+export class ReadAfterCreationFailed extends CreationFailed {
+  constructor(
+    resource: ResourceLike,
+    options?: { message?: string; cause?: Error },
+  ) {
+    const res = EnhancedResource.resolve(resource);
+    super(res, {
+      message: `Failed to retrieve ${res.name} after creation`,
+      ...options,
+    });
+  }
+}

--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -7,3 +7,4 @@ export * from './unauthenticated.exception';
 export * from './unauthorized.exception';
 export * from './service-unavailable.exception';
 export * from './invalid-id-for-type.exception';
+export * from './creation-failed.exception';

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -4,6 +4,7 @@ import {
   FnLike,
   mapValues,
   setInspectOnClass,
+  setToJson,
 } from '@seedcompany/common';
 import { LazyGetter as Once } from 'lazy-get-decorator';
 import { DateTime } from 'luxon';
@@ -295,6 +296,7 @@ export class EnhancedResource<T extends ResourceShape<any>> {
 setInspectOnClass(EnhancedResource, (res) => ({ collapsed }) => {
   return collapsed(res.name, 'Enhanced');
 });
+setToJson(EnhancedResource, (res) => ({ name: res.name }));
 
 export interface EnhancedRelation<TResourceStatic extends ResourceShape<any>> {
   readonly name: RelKey<TResourceStatic>;

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -107,6 +107,9 @@ export class EnhancedResource<T extends ResourceShape<any>> {
   >();
 
   static resolve(ref: ResourceLike) {
+    if (ref && typeof ref !== 'string') {
+      return EnhancedResource.of(ref);
+    }
     if (!EnhancedResource.resourcesHost) {
       throw new ServerException('Cannot resolve without ResourcesHost');
     }

--- a/src/components/budget/budget-record.repository.ts
+++ b/src/components/budget/budget-record.repository.ts
@@ -2,11 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
 import { pickBy } from 'lodash';
 import {
+  CreationFailed,
   ID,
   labelForView,
   NotFoundException,
   ObjectView,
-  ServerException,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -69,7 +69,7 @@ export class BudgetRecordRepository extends DtoRepository<
       .return<{ id: ID }>('node.id as id')
       .first();
     if (!result) {
-      throw new ServerException('Failed to create a budget record');
+      throw new CreationFailed(BudgetRecord);
     }
     return result.id;
   }

--- a/src/components/budget/budget.repository.ts
+++ b/src/components/budget/budget.repository.ts
@@ -2,11 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { inArray, node, Query, relation } from 'cypher-query-builder';
 import { pickBy } from 'lodash';
 import {
+  CreationFailed,
   ID,
   labelForView,
   NotFoundException,
   ObjectView,
-  ServerException,
   Session,
   UnsecuredDto,
   viewOfChangeset,
@@ -64,7 +64,7 @@ export class BudgetRepository extends DtoRepository<
       .first();
 
     if (!result) {
-      throw new ServerException('Failed to create budget');
+      throw new CreationFailed(Budget);
     }
 
     return result.id;

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import {
+  CreationFailed,
   DuplicateException,
   generateId,
   ID,
@@ -78,7 +79,7 @@ export class BudgetService {
         userId: session.userId,
         exception,
       });
-      throw new ServerException('Could not create budget', exception);
+      throw new CreationFailed(Budget, { cause: exception });
     }
   }
 
@@ -119,7 +120,7 @@ export class BudgetService {
         userId: session.userId,
         exception,
       });
-      throw new ServerException('Could not create Budget Record', exception);
+      throw new CreationFailed(BudgetRecord, { cause: exception });
     }
   }
 

--- a/src/components/ceremony/ceremony.repository.ts
+++ b/src/components/ceremony/ceremony.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
-import { ID, ServerException, Session, UnsecuredDto } from '~/common';
+import { CreationFailed, ID, Session, UnsecuredDto } from '~/common';
 import { DtoRepository } from '~/core/database';
 import {
   ACTIVE,
@@ -38,7 +38,7 @@ export class CeremonyRepository extends DtoRepository<
       .first();
 
     if (!result) {
-      throw new ServerException('failed to create a ceremony');
+      throw new CreationFailed(Ceremony);
     }
     return result;
   }

--- a/src/components/comments/comment.service.ts
+++ b/src/components/comments/comment.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { difference } from 'lodash';
 import {
+  CreationFailed,
   ID,
   InvalidIdForTypeException,
   isIdLike,
@@ -52,7 +53,7 @@ export class CommentService {
     try {
       const result = await this.repo.create(input, session);
       if (!result) {
-        throw new ServerException('Failed to create comment');
+        throw new CreationFailed(Comment);
       }
       dto = await this.repo.readOne(result.id);
     } catch (exception) {
@@ -66,7 +67,7 @@ export class CommentService {
         );
       }
 
-      throw new ServerException('Failed to create comment', exception);
+      throw new CreationFailed(Comment, { cause: exception });
     }
 
     const mentionees = this.mentionNotificationService.extract(dto);

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -20,6 +20,7 @@ import {
   labelForView,
   NotFoundException,
   ObjectView,
+  ReadAfterCreationFailed,
   ServerException,
   Session,
   typenameForView,
@@ -286,7 +287,11 @@ export class EngagementRepository extends CommonRepository {
       result.id,
       session,
       viewOfChangeset(changeset),
-    )) as UnsecuredDto<LanguageEngagement>;
+    ).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(LanguageEngagement)
+        : e;
+    })) as UnsecuredDto<LanguageEngagement>;
   }
 
   async createInternshipEngagement(
@@ -377,7 +382,11 @@ export class EngagementRepository extends CommonRepository {
       result.id,
       session,
       viewOfChangeset(changeset),
-    )) as UnsecuredDto<InternshipEngagement>;
+    ).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(InternshipEngagement)
+        : e;
+    })) as UnsecuredDto<InternshipEngagement>;
   }
 
   getActualLanguageChanges = getChanges(LanguageEngagement);

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -12,6 +12,7 @@ import { difference, pickBy, upperFirst } from 'lodash';
 import { DateTime } from 'luxon';
 import { MergeExclusive } from 'type-fest';
 import {
+  CreationFailed,
   DuplicateException,
   generateId,
   ID,
@@ -268,7 +269,7 @@ export class EngagementRepository extends CommonRepository {
 
     const result = await query.first();
     if (!result) {
-      throw new ServerException('Could not create Language Engagement');
+      throw new CreationFailed(LanguageEngagement);
     }
 
     await this.files.createDefinedFile(
@@ -359,7 +360,7 @@ export class EngagementRepository extends CommonRepository {
         );
       }
 
-      throw new ServerException('Could not create Internship Engagement');
+      throw new CreationFailed(InternshipEngagement);
     }
 
     await this.files.createDefinedFile(

--- a/src/components/ethno-art/ethno-art.repository.ts
+++ b/src/components/ethno-art/ethno-art.repository.ts
@@ -4,7 +4,9 @@ import {
   CreationFailed,
   DuplicateException,
   ID,
+  NotFoundException,
   PaginatedListType,
+  ReadAfterCreationFailed,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -64,7 +66,11 @@ export class EthnoArtRepository extends DtoRepository(EthnoArt) {
       session,
     );
 
-    return await this.readOne(result.id);
+    return await this.readOne(result.id).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(EthnoArt)
+        : e;
+    });
   }
 
   async update(input: UpdateEthnoArt) {

--- a/src/components/ethno-art/ethno-art.repository.ts
+++ b/src/components/ethno-art/ethno-art.repository.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { Query } from 'cypher-query-builder';
 import {
+  CreationFailed,
   DuplicateException,
   ID,
   PaginatedListType,
-  ServerException,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -55,7 +55,7 @@ export class EthnoArtRepository extends DtoRepository(EthnoArt) {
       .first();
 
     if (!result) {
-      throw new ServerException('Failed to create ethno art');
+      throw new CreationFailed(EthnoArt);
     }
 
     await this.scriptureRefsService.create(

--- a/src/components/field-region/field-region.repository.ts
+++ b/src/components/field-region/field-region.repository.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
 import {
+  CreationFailed,
   DuplicateException,
   ID,
   SecuredList,
-  ServerException,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -55,7 +55,7 @@ export class FieldRegionRepository extends DtoRepository(FieldRegion) {
 
     const result = await query.first();
     if (!result) {
-      throw new ServerException('failed to create field region');
+      throw new CreationFailed(FieldRegion);
     }
 
     return await this.readOne(result.id);

--- a/src/components/field-region/field-region.repository.ts
+++ b/src/components/field-region/field-region.repository.ts
@@ -4,6 +4,8 @@ import {
   CreationFailed,
   DuplicateException,
   ID,
+  NotFoundException,
+  ReadAfterCreationFailed,
   SecuredList,
   Session,
   UnsecuredDto,
@@ -58,7 +60,11 @@ export class FieldRegionRepository extends DtoRepository(FieldRegion) {
       throw new CreationFailed(FieldRegion);
     }
 
-    return await this.readOne(result.id);
+    return await this.readOne(result.id).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(FieldRegion)
+        : e;
+    });
   }
 
   async update(changes: UpdateFieldRegion) {

--- a/src/components/field-zone/field-zone.repository.ts
+++ b/src/components/field-zone/field-zone.repository.ts
@@ -2,10 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import {
+  CreationFailed,
   DuplicateException,
   ID,
   SecuredList,
-  ServerException,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -55,7 +55,7 @@ export class FieldZoneRepository extends DtoRepository(FieldZone) {
 
     const result = await query.first();
     if (!result) {
-      throw new ServerException('failed to create field zone');
+      throw new CreationFailed(FieldZone);
     }
 
     return await this.readOne(result.id);

--- a/src/components/field-zone/field-zone.repository.ts
+++ b/src/components/field-zone/field-zone.repository.ts
@@ -5,6 +5,8 @@ import {
   CreationFailed,
   DuplicateException,
   ID,
+  NotFoundException,
+  ReadAfterCreationFailed,
   SecuredList,
   Session,
   UnsecuredDto,
@@ -58,7 +60,11 @@ export class FieldZoneRepository extends DtoRepository(FieldZone) {
       throw new CreationFailed(FieldZone);
     }
 
-    return await this.readOne(result.id);
+    return await this.readOne(result.id).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(FieldZone)
+        : e;
+    });
   }
 
   protected hydrate() {

--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -13,7 +13,13 @@ import {
 import { Direction } from 'cypher-query-builder/dist/typings/clauses/order-by';
 import { AnyConditions } from 'cypher-query-builder/dist/typings/clauses/where-utils';
 import { DateTime } from 'luxon';
-import { ID, NotFoundException, ServerException, Session } from '~/common';
+import {
+  CreationFailed,
+  ID,
+  NotFoundException,
+  ServerException,
+  Session,
+} from '~/common';
 import { ILogger, LinkTo, Logger } from '~/core';
 import { CommonRepository, OnIndex } from '~/core/database';
 import {
@@ -382,7 +388,7 @@ export class FileRepository extends CommonRepository {
 
     const result = await createFile.first();
     if (!result) {
-      throw new ServerException('Failed to create directory');
+      throw new CreationFailed(Directory);
     }
     return result.id;
   }
@@ -418,7 +424,7 @@ export class FileRepository extends CommonRepository {
 
     const result = await query.first();
     if (!result) {
-      throw new ServerException('Failed to create directory');
+      throw new CreationFailed(Directory);
     }
     return result.id;
   }
@@ -465,7 +471,7 @@ export class FileRepository extends CommonRepository {
 
     const result = await createFile.first();
     if (!result) {
-      throw new ServerException('Failed to create file');
+      throw new CreationFailed(File);
     }
     return result.id;
   }
@@ -504,7 +510,7 @@ export class FileRepository extends CommonRepository {
 
     const result = await createFile.first();
     if (!result) {
-      throw new ServerException('Failed to create file version');
+      throw new CreationFailed(FileVersion);
     }
     return result.dto as FileVersion;
   }

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -11,6 +11,7 @@ import mime from 'mime';
 import sanitizeFilename from 'sanitize-filename';
 import { Readable } from 'stream';
 import {
+  CreationFailed,
   DuplicateException,
   DurationIn,
   generateId,
@@ -325,7 +326,7 @@ export class FileService {
       if (tempUpload.reason instanceof NotFoundException) {
         throw new NotFoundException('Could not find upload', 'uploadId');
       }
-      throw new ServerException('Unable to create file version');
+      throw new CreationFailed(FileVersion);
     } else if (
       tempUpload.status === 'fulfilled' &&
       existingUpload.status === 'fulfilled'
@@ -336,7 +337,7 @@ export class FileService {
           'uploadId',
         );
       }
-      throw new ServerException('Unable to create file version');
+      throw new CreationFailed(FileVersion);
     } else if (
       tempUpload.status === 'rejected' &&
       existingUpload.status === 'fulfilled'

--- a/src/components/film/film.repository.ts
+++ b/src/components/film/film.repository.ts
@@ -4,7 +4,9 @@ import {
   CreationFailed,
   DuplicateException,
   ID,
+  NotFoundException,
   PaginatedListType,
+  ReadAfterCreationFailed,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -59,7 +61,11 @@ export class FilmRepository extends DtoRepository(Film) {
       session,
     );
 
-    return await this.readOne(result.id);
+    return await this.readOne(result.id).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(Film)
+        : e;
+    });
   }
 
   async update(input: UpdateFilm) {

--- a/src/components/film/film.repository.ts
+++ b/src/components/film/film.repository.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { Query } from 'cypher-query-builder';
 import {
+  CreationFailed,
   DuplicateException,
   ID,
   PaginatedListType,
-  ServerException,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -50,7 +50,7 @@ export class FilmRepository extends DtoRepository(Film) {
       .first();
 
     if (!result) {
-      throw new ServerException('failed to create a film');
+      throw new CreationFailed(Film);
     }
 
     await this.scriptureRefsService.create(

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import {
+  CreationFailed,
   DuplicateException,
   ID,
   NotFoundException,
@@ -45,7 +46,7 @@ export class FundingAccountService {
       const result = await this.repo.create(input);
 
       if (!result) {
-        throw new ServerException('Failed to create funding account');
+        throw new CreationFailed(FundingAccount);
       }
 
       this.logger.info(`funding account created`, { id: result.id });
@@ -56,7 +57,7 @@ export class FundingAccountService {
         exception: err,
         userId: session.userId,
       });
-      throw new ServerException('Could not create funding account');
+      throw new CreationFailed(FundingAccount, { cause: err });
     }
   }
 

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -5,6 +5,7 @@ import {
   ID,
   NotFoundException,
   ObjectView,
+  ReadAfterCreationFailed,
   SecuredList,
   ServerException,
   Session,
@@ -51,7 +52,11 @@ export class FundingAccountService {
 
       this.logger.info(`funding account created`, { id: result.id });
 
-      return await this.readOne(result.id, session);
+      return await this.readOne(result.id, session).catch((e) => {
+        throw e instanceof NotFoundException
+          ? new ReadAfterCreationFailed(FundingAccount)
+          : e;
+      });
     } catch (err) {
       this.logger.error('Could not create funding account for user', {
         exception: err,

--- a/src/components/language/ethnologue-language/ethnologue-language.repository.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.repository.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { simpleSwitch } from '@seedcompany/common';
-import { DuplicateException, ID, ServerException } from '~/common';
+import {
+  CreationFailed,
+  DuplicateException,
+  ID,
+  ServerException,
+} from '~/common';
 import { DtoRepository, UniquenessError } from '~/core/database';
 import { createNode } from '~/core/database/query';
 import {
@@ -44,11 +49,11 @@ export class EthnologueLanguageRepository extends DtoRepository(
         );
       }
 
-      throw new ServerException('Could not create ethnologue language', e);
+      throw new CreationFailed(EthnologueLanguage, { cause: e });
     }
 
     if (!result) {
-      throw new ServerException('Failed to create ethnologue language');
+      throw new CreationFailed(EthnologueLanguage);
     }
 
     return await this.readOne(result.id);

--- a/src/components/language/ethnologue-language/ethnologue-language.repository.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.repository.ts
@@ -4,6 +4,8 @@ import {
   CreationFailed,
   DuplicateException,
   ID,
+  NotFoundException,
+  ReadAfterCreationFailed,
   ServerException,
 } from '~/common';
 import { DtoRepository, UniquenessError } from '~/core/database';
@@ -56,7 +58,11 @@ export class EthnologueLanguageRepository extends DtoRepository(
       throw new CreationFailed(EthnologueLanguage);
     }
 
-    return await this.readOne(result.id);
+    return await this.readOne(result.id).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(EthnologueLanguage)
+        : e;
+    });
   }
 
   async update(changes: UpdateEthnologueLanguage & { id: ID }) {

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -15,6 +15,7 @@ import {
   labelForView,
   NotFoundException,
   ObjectView,
+  ReadAfterCreationFailed,
   ServerException,
   Session,
   UnsecuredDto,
@@ -126,7 +127,11 @@ export class LanguageRepository extends DtoRepository<
       throw new CreationFailed(Language);
     }
 
-    return await this.readOne(result.id, session);
+    return await this.readOne(result.id, session).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(Language)
+        : e;
+    });
   }
 
   async update(

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -9,6 +9,7 @@ import {
   relation,
 } from 'cypher-query-builder';
 import {
+  CreationFailed,
   DuplicateException,
   ID,
   labelForView,
@@ -118,11 +119,11 @@ export class LanguageRepository extends DtoRepository<
         );
       }
 
-      throw new ServerException('Could not create language', e);
+      throw new CreationFailed(Language, { cause: e });
     }
 
     if (!result) {
-      throw new ServerException('Failed to create language');
+      throw new CreationFailed(Language);
     }
 
     return await this.readOne(result.id, session);

--- a/src/components/location/location.repository.ts
+++ b/src/components/location/location.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import {
+  CreationFailed,
   DuplicateException,
   generateId,
   ID,
@@ -70,7 +71,7 @@ export class LocationRepository extends DtoRepository(Location) {
 
     const result = await query.first();
     if (!result) {
-      throw new ServerException('Failed to create location');
+      throw new CreationFailed(Location);
     }
 
     const dto = await this.readOne(result.id);

--- a/src/components/location/location.repository.ts
+++ b/src/components/location/location.repository.ts
@@ -6,6 +6,8 @@ import {
   DuplicateException,
   generateId,
   ID,
+  NotFoundException,
+  ReadAfterCreationFailed,
   ServerException,
   Session,
   UnsecuredDto,
@@ -74,7 +76,11 @@ export class LocationRepository extends DtoRepository(Location) {
       throw new CreationFailed(Location);
     }
 
-    const dto = await this.readOne(result.id);
+    const dto = await this.readOne(result.id).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(Location)
+        : e;
+    });
 
     await this.files.createDefinedFile(
       mapImageId,

--- a/src/components/organization/organization.repository.ts
+++ b/src/components/organization/organization.repository.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
 import {
+  CreationFailed,
   DuplicateException,
   ID,
-  ServerException,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -61,7 +61,7 @@ export class OrganizationRepository extends DtoRepository<
 
     const result = await query.first();
     if (!result) {
-      throw new ServerException('Failed to create organization');
+      throw new CreationFailed(Organization);
     }
 
     return await this.readOne(result.id, session);

--- a/src/components/organization/organization.repository.ts
+++ b/src/components/organization/organization.repository.ts
@@ -4,6 +4,8 @@ import {
   CreationFailed,
   DuplicateException,
   ID,
+  NotFoundException,
+  ReadAfterCreationFailed,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -64,7 +66,11 @@ export class OrganizationRepository extends DtoRepository<
       throw new CreationFailed(Organization);
     }
 
-    return await this.readOne(result.id, session);
+    return await this.readOne(result.id, session).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(Organization)
+        : e;
+    });
   }
 
   async update(changes: UpdateOrganization, session: Session) {

--- a/src/components/partner/partner.repository.ts
+++ b/src/components/partner/partner.repository.ts
@@ -7,6 +7,8 @@ import {
   DuplicateException,
   ID,
   InputException,
+  NotFoundException,
+  ReadAfterCreationFailed,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -104,7 +106,11 @@ export class PartnerRepository extends DtoRepository<
       throw new CreationFailed(Partner);
     }
 
-    return await this.readOne(result.id, session);
+    return await this.readOne(result.id, session).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(Partner)
+        : e;
+    });
   }
 
   async update(changes: UpdatePartner, session: Session) {

--- a/src/components/partner/partner.repository.ts
+++ b/src/components/partner/partner.repository.ts
@@ -3,10 +3,10 @@ import { node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import {
   CalendarDate,
+  CreationFailed,
   DuplicateException,
   ID,
   InputException,
-  ServerException,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -101,7 +101,7 @@ export class PartnerRepository extends DtoRepository<
       .return<{ id: ID }>('node.id as id')
       .first();
     if (!result) {
-      throw new ServerException('Failed to create partner');
+      throw new CreationFailed(Partner);
     }
 
     return await this.readOne(result.id, session);

--- a/src/components/partnership/partnership.repository.ts
+++ b/src/components/partnership/partnership.repository.ts
@@ -3,13 +3,13 @@ import { Node, node, Query, relation } from 'cypher-query-builder';
 import { pickBy } from 'lodash';
 import { DateTime } from 'luxon';
 import {
+  CreationFailed,
   DuplicateException,
   generateId,
   ID,
   labelForView,
   NotFoundException,
   ObjectView,
-  ServerException,
   Session,
   UnsecuredDto,
   viewOfChangeset,
@@ -93,7 +93,7 @@ export class PartnershipRepository extends DtoRepository<
       .return<{ id: ID }>('node.id as id')
       .first();
     if (!result) {
-      throw new ServerException('Failed to create partnership');
+      throw new CreationFailed(Partnership);
     }
 
     await this.files.createDefinedFile(

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -1,5 +1,6 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import {
+  CreationFailed,
   ID,
   InputException,
   ObjectView,
@@ -104,7 +105,7 @@ export class PartnershipService {
       if (exception instanceof InputException) {
         throw exception;
       }
-      throw new ServerException('Failed to create partnership', exception);
+      throw new CreationFailed(Partnership, { cause: exception });
     }
   }
 

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -3,7 +3,9 @@ import {
   CreationFailed,
   ID,
   InputException,
+  NotFoundException,
   ObjectView,
+  ReadAfterCreationFailed,
   ServerException,
   Session,
   UnsecuredDto,
@@ -90,7 +92,11 @@ export class PartnershipService {
         result.id,
         session,
         viewOfChangeset(changeset),
-      );
+      ).catch((e) => {
+        throw e instanceof NotFoundException
+          ? new ReadAfterCreationFailed(Partnership)
+          : e;
+      });
 
       this.privileges
         .for(session, Partnership, partnership)

--- a/src/components/periodic-report/periodic-report.service.ts
+++ b/src/components/periodic-report/periodic-report.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import {
   CalendarDate,
+  CreationFailed,
   DateInterval,
   ID,
   NotFoundException,
   ObjectView,
   Range,
-  ServerException,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -55,7 +55,8 @@ export class PeriodicReportService {
         ),
       });
     } catch (exception) {
-      throw new ServerException('Could not create periodic reports', exception);
+      const Report = resolveReportType({ type: input.type });
+      throw new CreationFailed(Report);
     }
   }
 

--- a/src/components/post/post.service.ts
+++ b/src/components/post/post.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import {
+  CreationFailed,
   ID,
   InputException,
   InvalidIdForTypeException,
@@ -46,7 +47,7 @@ export class PostService {
     try {
       const result = await this.repo.create(input, session);
       if (!result) {
-        throw new ServerException('Failed to create post');
+        throw new CreationFailed(Post);
       }
 
       return this.secure(result.dto, session);
@@ -59,7 +60,7 @@ export class PostService {
         throw new InputException('parentId is invalid', 'post.parentId');
       }
 
-      throw new ServerException('Failed to create post', exception);
+      throw new CreationFailed(Post, { cause: exception });
     }
   }
 

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -10,13 +10,7 @@ import {
 } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { Except, Merge } from 'type-fest';
-import {
-  getDbClassLabels,
-  ID,
-  Range,
-  ServerException,
-  Session,
-} from '~/common';
+import { CreationFailed, getDbClassLabels, ID, Range, Session } from '~/common';
 import { CommonRepository, DbTypeOf, OnIndex } from '~/core/database';
 import { DbChanges, getChanges } from '~/core/database/changes';
 import {
@@ -359,7 +353,7 @@ export class ProductRepository extends CommonRepository {
       .return<{ id: ID }>('node.id as id');
     const result = await query.first();
     if (!result) {
-      throw new ServerException('Failed to create product');
+      throw new CreationFailed(Product);
     }
     return result.id;
   }
@@ -395,7 +389,7 @@ export class ProductRepository extends CommonRepository {
       .return<{ id: ID }>('node.id as id');
     const result = await query.first();
     if (!result) {
-      throw new ServerException('Failed to create product');
+      throw new CreationFailed(OtherProduct);
     }
     return result.id;
   }

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -6,6 +6,7 @@ import {
   InputException,
   NotFoundException,
   ObjectView,
+  ReadAfterCreationFailed,
   ServerException,
   Session,
   UnsecuredDto,
@@ -154,7 +155,11 @@ export class ProductService {
           });
 
     this.logger.debug(`product created`, { id });
-    const created = await this.readOne(id, session);
+    const created = await this.readOne(id, session).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(Product)
+        : e;
+    });
 
     this.privileges
       .for(session, resolveProductType(created), created)

--- a/src/components/progress-report/media/progress-report-media.repository.ts
+++ b/src/components/progress-report/media/progress-report-media.repository.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { inArray, node, not, Query, relation } from 'cypher-query-builder';
 import {
+  CreationFailed,
   generateId,
   ID,
   IdOf,
   InputException,
   NotFoundException,
-  ServerException,
   Session,
 } from '~/common';
 import { DbTypeOf, DtoRepository } from '~/core/database';
@@ -214,7 +214,7 @@ export class ProgressReportMediaRepository extends DtoRepository<
       );
     }
 
-    throw new ServerException('Failed to create report media');
+    throw new CreationFailed(ReportMedia);
   }
 
   async update({ id, category }: UpdateMedia) {

--- a/src/components/project-change-request/project-change-request.repository.ts
+++ b/src/components/project-change-request/project-change-request.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { node, Query, relation } from 'cypher-query-builder';
-import { ID, ServerException, Session, UnsecuredDto } from '~/common';
+import { CreationFailed, ID, Session, UnsecuredDto } from '~/common';
 import { DtoRepository } from '~/core/database';
 import {
   ACTIVE,
@@ -45,7 +45,7 @@ export class ProjectChangeRequestRepository extends DtoRepository<
       .return<{ id: ID }>('node.id as id')
       .first();
     if (!result) {
-      throw new ServerException('Failed to create project change request');
+      throw new CreationFailed(ProjectChangeRequest);
     }
     return result.id;
   }

--- a/src/components/project-change-request/project-change-request.service.ts
+++ b/src/components/project-change-request/project-change-request.service.ts
@@ -2,7 +2,9 @@ import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import {
   ID,
   InputException,
+  NotFoundException,
   ObjectView,
+  ReadAfterCreationFailed,
   ServerException,
   Session,
   UnsecuredDto,
@@ -52,7 +54,11 @@ export class ProjectChangeRequestService {
 
     const id = await this.repo.create(input);
 
-    return await this.readOne(id, session);
+    return await this.readOne(id, session).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(ProjectChangeRequest)
+        : e;
+    });
   }
 
   @HandleIdLookup(ProjectChangeRequest)

--- a/src/components/project/project-member/project-member.repository.ts
+++ b/src/components/project/project-member/project-member.repository.ts
@@ -2,12 +2,12 @@ import { Injectable } from '@nestjs/common';
 import { Node, node, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import {
+  CreationFailed,
   DuplicateException,
   ID,
   isIdLike,
   NotFoundException,
   Role,
-  ServerException,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -107,7 +107,7 @@ export class ProjectMemberRepository extends DtoRepository<
       .map('dto')
       .first();
     if (!created) {
-      throw new ServerException('Failed to create project member');
+      throw new CreationFailed(ProjectMember);
     }
     return created;
   }

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -2,11 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { inArray, node, not, Query, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import {
+  CreationFailed,
   DuplicateException,
   ID,
   NotFoundException,
   Sensitivity,
-  ServerException,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -183,10 +183,11 @@ export class ProjectRepository extends CommonRepository {
       canDelete: true,
     };
 
+    const Project = resolveProjectType({ type });
     const query = this.db
       .query()
       .apply(
-        await createNode(resolveProjectType({ type }), {
+        await createNode(Project, {
           initialProps,
           baseNodeProps: { type },
         }),
@@ -226,7 +227,7 @@ export class ProjectRepository extends CommonRepository {
       }
     }
     if (!result) {
-      throw new ServerException('Failed to create project');
+      throw new CreationFailed(Project);
     }
     return result;
   }

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -10,6 +10,7 @@ import {
   many,
   NotFoundException,
   ObjectView,
+  ReadAfterCreationFailed,
   Role,
   SecuredList,
   ServerException,
@@ -151,7 +152,11 @@ export class ProjectService {
 
     try {
       const { id } = await this.repo.create(input);
-      const project = await this.readOneUnsecured(id, session);
+      const project = await this.readOneUnsecured(id, session).catch((e) => {
+        throw e instanceof NotFoundException
+          ? new ReadAfterCreationFailed(IProject)
+          : e;
+      });
 
       // Add creator to the project team with their global roles
       await this.projectMembers.create(

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -2,6 +2,7 @@ import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { Many } from '@seedcompany/common';
 import {
   ClientException,
+  CreationFailed,
   EnhancedResource,
   ID,
   InputException,
@@ -179,7 +180,7 @@ export class ProjectService {
       if (e instanceof ClientException) {
         throw e;
       }
-      throw new ServerException(`Could not create project`, e);
+      throw new CreationFailed(IProject, { cause: e });
     }
   }
 

--- a/src/components/story/story.repository.ts
+++ b/src/components/story/story.repository.ts
@@ -4,7 +4,9 @@ import {
   CreationFailed,
   DuplicateException,
   ID,
+  NotFoundException,
   PaginatedListType,
+  ReadAfterCreationFailed,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -59,7 +61,11 @@ export class StoryRepository extends DtoRepository(Story) {
       session,
     );
 
-    return await this.readOne(result.id);
+    return await this.readOne(result.id).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(Story)
+        : e;
+    });
   }
 
   async update(input: UpdateStory) {

--- a/src/components/story/story.repository.ts
+++ b/src/components/story/story.repository.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { Query } from 'cypher-query-builder';
 import {
+  CreationFailed,
   DuplicateException,
   ID,
   PaginatedListType,
-  ServerException,
   Session,
   UnsecuredDto,
 } from '~/common';
@@ -50,7 +50,7 @@ export class StoryRepository extends DtoRepository(Story) {
       .first();
 
     if (!result) {
-      throw new ServerException('failed to create a story');
+      throw new CreationFailed(Story);
     }
 
     await this.scriptureRefsService.create(

--- a/src/components/user/education/education.repository.ts
+++ b/src/components/user/education/education.repository.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
-import { CreationFailed, ID, NotFoundException } from '~/common';
+import {
+  CreationFailed,
+  ID,
+  NotFoundException,
+  ReadAfterCreationFailed,
+} from '~/common';
 import { DtoRepository } from '~/core/database';
 import {
   ACTIVE,
@@ -39,7 +44,11 @@ export class EducationRepository extends DtoRepository(Education) {
     if (!result) {
       throw new CreationFailed(Education);
     }
-    return await this.readOne(result.id);
+    return await this.readOne(result.id).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(Education)
+        : e;
+    });
   }
 
   async getUserIdByEducation(id: ID) {

--- a/src/components/user/education/education.repository.ts
+++ b/src/components/user/education/education.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
-import { ID, NotFoundException, ServerException } from '~/common';
+import { CreationFailed, ID, NotFoundException } from '~/common';
 import { DtoRepository } from '~/core/database';
 import {
   ACTIVE,
@@ -37,7 +37,7 @@ export class EducationRepository extends DtoRepository(Education) {
 
     const result = await query.first();
     if (!result) {
-      throw new ServerException('failed to create education');
+      throw new CreationFailed(Education);
     }
     return await this.readOne(result.id);
   }

--- a/src/components/user/unavailability/unavailability.repository.ts
+++ b/src/components/user/unavailability/unavailability.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
-import { ID, NotFoundException, ServerException } from '~/common';
+import { CreationFailed, ID, NotFoundException } from '~/common';
 import { DtoRepository } from '~/core/database';
 import {
   ACTIVE,
@@ -35,7 +35,7 @@ export class UnavailabilityRepository extends DtoRepository(Unavailability) {
       .return<{ id: ID }>('node.id as id');
     const result = await query.first();
     if (!result) {
-      throw new ServerException('Could not create unavailability');
+      throw new CreationFailed(Unavailability);
     }
     return await this.readOne(result.id);
   }

--- a/src/components/user/unavailability/unavailability.repository.ts
+++ b/src/components/user/unavailability/unavailability.repository.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { node, relation } from 'cypher-query-builder';
-import { CreationFailed, ID, NotFoundException } from '~/common';
+import {
+  CreationFailed,
+  ID,
+  NotFoundException,
+  ReadAfterCreationFailed,
+} from '~/common';
 import { DtoRepository } from '~/core/database';
 import {
   ACTIVE,
@@ -37,7 +42,11 @@ export class UnavailabilityRepository extends DtoRepository(Unavailability) {
     if (!result) {
       throw new CreationFailed(Unavailability);
     }
-    return await this.readOne(result.id);
+    return await this.readOne(result.id).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(Unavailability)
+        : e;
+    });
   }
 
   async update(changes: UpdateUnavailability) {

--- a/src/components/user/user.repository.ts
+++ b/src/components/user/user.repository.ts
@@ -3,6 +3,7 @@ import { inArray, node, Query, relation } from 'cypher-query-builder';
 import { difference } from 'lodash';
 import { DateTime } from 'luxon';
 import {
+  CreationFailed,
   DuplicateException,
   ID,
   Role,
@@ -104,10 +105,10 @@ export class UserRepository extends DtoRepository<typeof User, [Session | ID]>(
           e,
         );
       }
-      throw new ServerException('Failed to create user', e);
+      throw new CreationFailed(User, { cause: e });
     }
     if (!result) {
-      throw new ServerException('Failed to create user');
+      throw new CreationFailed(User);
     }
     return result;
   }

--- a/src/components/user/user.resolver.ts
+++ b/src/components/user/user.resolver.ts
@@ -15,6 +15,8 @@ import {
   IdField,
   ListArg,
   LoggedInSession,
+  NotFoundException,
+  ReadAfterCreationFailed,
   Session,
 } from '~/common';
 import { Loader, LoaderOf } from '~/core';
@@ -221,7 +223,11 @@ export class UserResolver {
     @Args('input') { person: input }: CreatePersonInput,
   ): Promise<CreatePersonOutput> {
     const userId = await this.userService.create(input, session);
-    const user = await this.userService.readOne(userId, session);
+    const user = await this.userService.readOne(userId, session).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(User)
+        : e;
+    });
     return { user };
   }
 


### PR DESCRIPTION
- `CreationFailed` error class
   This DRYs the strings and allows for identification programmatically & statically
- Ensure that invalid reads immediately following a creation throw a server error: `ReadAfterCreationFailed`
  This is a server problem, not a client one. Having the API should communicate this, allows other processes to know that they could try again later, without needing an input change.
