### PR TITLE
Optimize Project/Engagement updates without date changes

### DIFF
--- a/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
+++ b/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
@@ -70,9 +70,17 @@ export class SyncBudgetRecordsToFundingPartners
       // Partnership was not funding, so do nothing.
       return;
     }
+    if (
+      event instanceof ProjectUpdatedEvent &&
+      event.changes.mouStart === undefined &&
+      event.changes.mouEnd === undefined
+    ) {
+      // Project dates haven't changed, so do nothing.
+      return;
+    }
 
-    const projectId = await this.determineProjectId(event);
-    const changeset = await this.determineChangeset(event);
+    const projectId = this.determineProjectId(event);
+    const changeset = this.determineChangeset(event);
 
     // Fetch budget & only continue if it is pending
     const budget = await this.budgetRepo.listRecordsForSync(
@@ -88,7 +96,7 @@ export class SyncBudgetRecordsToFundingPartners
     }
   }
 
-  private async determineProjectId(event: SubscribedEvent) {
+  private determineProjectId(event: SubscribedEvent) {
     if (event instanceof ProjectUpdatedEvent) {
       return event.updated.id;
     }
@@ -98,7 +106,7 @@ export class SyncBudgetRecordsToFundingPartners
     return event.partnership.project.id;
   }
 
-  private async determineChangeset(event: SubscribedEvent) {
+  private determineChangeset(event: SubscribedEvent) {
     if (event instanceof ProjectUpdatedEvent) {
       return event.updated.changeset;
     }

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -167,7 +167,7 @@ export class EngagementService {
       );
     }
 
-    const { methodology: _, ...maybeChanges } = input;
+    const { methodology, ...maybeChanges } = input;
     const changes = this.repo.getActualLanguageChanges(object, maybeChanges);
     this.privileges
       .for(session, LanguageEngagement, object)
@@ -182,7 +182,12 @@ export class EngagementService {
       changeset,
     );
 
-    const event = new EngagementUpdatedEvent(updated, previous, input, session);
+    const event = new EngagementUpdatedEvent(
+      updated,
+      previous,
+      { id: object.id, methodology, ...changes },
+      session,
+    );
     if (Object.keys(changes).length > 0) {
       await this.eventBus.publish(event);
     }
@@ -220,7 +225,12 @@ export class EngagementService {
       changeset,
     );
 
-    const event = new EngagementUpdatedEvent(updated, previous, input, session);
+    const event = new EngagementUpdatedEvent(
+      updated,
+      previous,
+      { id: object.id, ...changes },
+      session,
+    );
     if (Object.keys(changes).length > 0) {
       await this.eventBus.publish(event);
     }

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -183,7 +183,9 @@ export class EngagementService {
     );
 
     const event = new EngagementUpdatedEvent(updated, previous, input, session);
-    await this.eventBus.publish(event);
+    if (Object.keys(changes).length > 0) {
+      await this.eventBus.publish(event);
+    }
 
     return this.secure(event.updated, session) as LanguageEngagement;
   }
@@ -219,7 +221,9 @@ export class EngagementService {
     );
 
     const event = new EngagementUpdatedEvent(updated, previous, input, session);
-    await this.eventBus.publish(event);
+    if (Object.keys(changes).length > 0) {
+      await this.eventBus.publish(event);
+    }
 
     return this.secure(event.updated, session) as InternshipEngagement;
   }

--- a/src/components/periodic-report/handlers/sync-progress-report-to-engagement.handler.ts
+++ b/src/components/periodic-report/handlers/sync-progress-report-to-engagement.handler.ts
@@ -58,6 +58,14 @@ export class SyncProgressReportToEngagementDateRange
       // Project dates haven't changed, so do nothing.
       return;
     }
+    if (
+      event instanceof EngagementUpdatedEvent &&
+      event.input.startDateOverride === undefined &&
+      event.input.endDateOverride === undefined
+    ) {
+      // Engagement dates haven't changed, so do nothing.
+      return;
+    }
 
     if (
       (event instanceof EngagementCreatedEvent && event.engagement.changeset) ||

--- a/src/components/periodic-report/handlers/sync-progress-report-to-engagement.handler.ts
+++ b/src/components/periodic-report/handlers/sync-progress-report-to-engagement.handler.ts
@@ -51,6 +51,15 @@ export class SyncProgressReportToEngagementDateRange
     }
 
     if (
+      event instanceof ProjectUpdatedEvent &&
+      event.changes.mouStart === undefined &&
+      event.changes.mouEnd === undefined
+    ) {
+      // Project dates haven't changed, so do nothing.
+      return;
+    }
+
+    if (
       (event instanceof EngagementCreatedEvent && event.engagement.changeset) ||
       (event instanceof EngagementUpdatedEvent && event.updated.changeset)
     ) {

--- a/src/components/project/events/project-updated.event.ts
+++ b/src/components/project/events/project-updated.event.ts
@@ -5,7 +5,7 @@ export class ProjectUpdatedEvent {
   constructor(
     public updated: UnsecuredDto<Project>,
     readonly previous: UnsecuredDto<Project>,
-    readonly updates: UpdateProject,
+    readonly changes: UpdateProject,
     readonly session: Session,
   ) {}
 }

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -286,6 +286,9 @@ export class ProjectService {
     this.privileges
       .for(session, resolveProjectType(currentProject), currentProject)
       .verifyChanges(changes, { pathPrefix: 'project' });
+    if (!changedStep && Object.keys(changes).length === 0) {
+      return await this.readOneUnsecured(input.id, session, changeset);
+    }
 
     let updated = currentProject;
     if (changedStep) {

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -336,7 +336,7 @@ export class ProjectService {
     const event = new ProjectUpdatedEvent(
       updated,
       currentProject,
-      input,
+      { id: updated.id, ...changes },
       session,
     );
     await this.eventBus.publish(event);

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs/promises';
 // eslint-disable-next-line no-restricted-imports
 import * as lodash from 'lodash';
 import { DateTime, Duration, Interval } from 'luxon';
-import { CalendarDate, DateInterval, many, maybeMany } from '~/common';
+import { CalendarDate, DateInterval } from '~/common';
 import * as common from '~/common';
 import './polyfills';
 
@@ -34,8 +34,8 @@ runRepl({
       Interval,
       CalendarDate,
       DateInterval,
-      many,
-      maybeMany,
+      now: DateTime.now,
+      today: CalendarDate.now,
       common: { ...commonLib, ...common },
       scripture,
       ...lodash.pick(scripture, 'Book', 'Chapter', 'Verse'),


### PR DESCRIPTION
- `ProjectUpdatedEvent`/`EngagementUpdatedEvent` are only published when there are actual changes
- They have unchanged input stripped out
- Handlers listening for date changes short circuit when there are no date changes in the event.
