### PR TITLE
Validate Project/Engagement date ranges

### DIFF
--- a/dbschema/common.gel
+++ b/dbschema/common.gel
@@ -18,7 +18,12 @@ module default {
        )
     )
   );
-  
+
+  function array_join_maybe(array: array<str>, delimiter: str) -> optional str using (
+    with joined := array_join(array, delimiter)
+    select if joined = "" then <str>{} else joined
+  );
+
   scalar type nanoid extending str;
   
   scalar type RichText extending json;

--- a/dbschema/migrations/00018-m1jf7p4.edgeql
+++ b/dbschema/migrations/00018-m1jf7p4.edgeql
@@ -1,0 +1,8 @@
+CREATE MIGRATION m1jf7p43qsddgdjn2fues62z6hemf2eshuiedx64dod5nkgrrssaaq
+    ONTO m1d2nmzhgsu7jc75xtbjt4zdvroszkfcbtmdrap2kohcto4fbpqoia
+{
+  CREATE FUNCTION default::array_join_maybe(array: array<std::str>, delimiter: std::str) -> OPTIONAL std::str USING (
+    WITH joined := std::array_join(array, delimiter)
+    SELECT (IF (joined = '') THEN <std::str>{} ELSE joined)
+  );
+};

--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -1,5 +1,6 @@
 export * from './exception';
 export * from './input.exception';
+export * from './range.exception';
 export * from './duplicate.exception';
 export * from './not-found.exception';
 export * from './not-implemented.exception';

--- a/src/common/exceptions/range.exception.ts
+++ b/src/common/exceptions/range.exception.ts
@@ -1,0 +1,7 @@
+import { InputException } from '~/common';
+
+export class RangeException extends InputException {
+  constructor(options?: { message?: string; field?: string; cause?: Error }) {
+    super(options?.message ?? `Invalid range`, options?.field, options?.cause);
+  }
+}

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -81,6 +81,12 @@ class Engagement extends Interfaces {
   @Field(() => IProject)
   declare readonly parent: BaseNode;
 
+  readonly label: Readonly<{
+    project: string;
+    language: string | null;
+    intern: string | null;
+  }>;
+
   @Field(() => SecuredEngagementStatus, {
     middleware: [parentIdMiddleware],
   })

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -49,6 +49,7 @@ import {
   requestingUser,
   SortCol,
   sortWith,
+  textJoinMaybe,
   whereNotDeletedInChangeset,
 } from '~/core/database/query';
 import { Privileges } from '../authorization';
@@ -168,6 +169,7 @@ export class EngagementRepository extends CommonRepository {
           relation('out', '', 'mouEnd', ACTIVE),
           node('mouEnd'),
         ])
+        .apply(matchNames)
         .match([
           [
             node('project'),
@@ -193,6 +195,11 @@ export class EngagementRepository extends CommonRepository {
               step: 'step.value',
             },
             language: 'language { .id }',
+            label: {
+              project: 'projectName.value',
+              language: 'languageName.value',
+              intern: textJoinMaybe(['dfn.value', 'dln.value']),
+            },
             pnp: { id: 'props.pnp' },
             growthPlan: { id: 'props.growthPlan' },
             ceremony: 'ceremony { .id }',

--- a/src/components/engagement/handlers/index.ts
+++ b/src/components/engagement/handlers/index.ts
@@ -1,3 +1,4 @@
+export * from './validate-eng-date-overrides-on-project-change.handler';
 export * from './set-initial-end-date.handler';
 export * from './update-engagement-status.handler';
 export * from './set-last-status-date.handler';

--- a/src/components/engagement/handlers/validate-eng-date-overrides-on-project-change.handler.ts
+++ b/src/components/engagement/handlers/validate-eng-date-overrides-on-project-change.handler.ts
@@ -1,0 +1,93 @@
+import { isNotFalsy, NonEmptyArray } from '@seedcompany/common';
+import { CalendarDate, ID, RangeException, type UnsecuredDto } from '~/common';
+import { EventsHandler, IEventHandler } from '~/core';
+import type { Project } from '../../project/dto';
+import { ProjectUpdatedEvent } from '../../project/events';
+import { EngagementService } from '../engagement.service';
+
+@EventsHandler(ProjectUpdatedEvent)
+export class ValidateEngDateOverridesOnProjectChangeHandlerSetLastStatusDate
+  implements IEventHandler<ProjectUpdatedEvent>
+{
+  constructor(private readonly engagements: EngagementService) {}
+
+  async handle(event: ProjectUpdatedEvent) {
+    const { changes, updated, session } = event;
+
+    if (changes.mouStart === undefined && changes.mouEnd === undefined) {
+      return;
+    }
+
+    const project = {
+      id: updated.id,
+      name: updated.name,
+      mouStart: updated.mouStart,
+      mouEnd: updated.mouEnd,
+    };
+    const engagements = await this.engagements.listAllByProjectId(
+      project.id,
+      session,
+    );
+    const errors = engagements
+      .flatMap<
+        EngagementDateOverrideConflictException['engagements'][0] | null
+      >((eng) => {
+        const common = {
+          id: eng.id,
+        } as const;
+        const { startDateOverride: start, endDateOverride: end } = eng;
+        return [
+          project.mouStart && start && project.mouStart > start
+            ? {
+                ...common,
+                point: 'start' as const,
+                date: start,
+              }
+            : null,
+          project.mouEnd && end && project.mouEnd < end
+            ? {
+                ...common,
+                point: 'end' as const,
+                date: end,
+              }
+            : null,
+        ];
+      })
+      .filter(isNotFalsy);
+    if (errors.length === 0) {
+      return;
+    }
+    throw new EngagementDateOverrideConflictException(project, [
+      errors[0]!,
+      ...errors.slice(1),
+    ]);
+  }
+}
+
+class EngagementDateOverrideConflictException extends RangeException {
+  constructor(
+    readonly project: Pick<
+      UnsecuredDto<Project>,
+      'id' | 'name' | 'mouStart' | 'mouEnd'
+    >,
+    readonly engagements: NonEmptyArray<
+      Readonly<{
+        id: ID<'Engagement'>;
+        point: 'start' | 'end';
+        date: CalendarDate;
+      }>
+    >,
+  ) {
+    const message = [
+      engagements.length === 1
+        ? 'An engagement has a date outside the new range'
+        : 'Some engagements have dates outside the new range',
+      ...engagements.map((eng) => {
+        const pointStr = eng.point === 'start' ? 'Start' : 'End';
+        const dateStr = eng.date.toISO();
+        return `  - ${pointStr} date of ${eng.id} is ${dateStr}`;
+      }),
+    ].join('\n');
+    super({ message });
+  }
+}

--- a/src/components/engagement/handlers/validate-eng-date-overrides-on-project-change.handler.ts
+++ b/src/components/engagement/handlers/validate-eng-date-overrides-on-project-change.handler.ts
@@ -34,6 +34,7 @@ export class ValidateEngDateOverridesOnProjectChangeHandlerSetLastStatusDate
       >((eng) => {
         const common = {
           id: eng.id,
+          label: (eng.label.language ?? eng.label.intern)!,
         } as const;
         const { startDateOverride: start, endDateOverride: end } = eng;
         return [
@@ -73,6 +74,7 @@ class EngagementDateOverrideConflictException extends RangeException {
     readonly engagements: NonEmptyArray<
       Readonly<{
         id: ID<'Engagement'>;
+        label: string;
         point: 'start' | 'end';
         date: CalendarDate;
       }>
@@ -85,7 +87,7 @@ class EngagementDateOverrideConflictException extends RangeException {
       ...engagements.map((eng) => {
         const pointStr = eng.point === 'start' ? 'Start' : 'End';
         const dateStr = eng.date.toISO();
-        return `  - ${pointStr} date of ${eng.id} is ${dateStr}`;
+        return `  - ${pointStr} date of ${eng.label} is ${dateStr}`;
       }),
     ].join('\n');
     super({ message });

--- a/src/core/database/query/cypher-functions.ts
+++ b/src/core/database/query/cypher-functions.ts
@@ -89,6 +89,26 @@ export const apoc = {
     setLabels: (node: ExpressionInput, labels: readonly string[]) =>
       procedure('apoc.create.setLabels', ['node'])({ node: exp(node), labels }),
   },
+  text: {
+    /**
+     * @see https://neo4j.com/docs/apoc/current/overview/apoc.text/apoc.text.join/
+     */
+    join: (list: ExpressionInput, delimiter: string) =>
+      fn('apoc.text.join')(list, delimiter),
+  },
+};
+
+export const cleanTextList = (list: ExpressionInput) =>
+  exp(`[x IN ${exp(list)} WHERE x IS NOT NULL AND trim(x) <> '' | trim(x)]`);
+
+export const textJoinMaybe = (items: ExpressionInput, delimiter = ' ') => {
+  const cleaned = cleanTextList(items);
+  return exp(
+    `CASE WHEN size(${cleaned}) = 0 THEN null ELSE ${apoc.text.join(
+      `${cleaned}`,
+      `"${delimiter}"`,
+    )} END`,
+  );
 };
 
 /**


### PR DESCRIPTION
- Project date range now has to be valid
- Engagement override date range now has to be valid
- Engagement override dates have to be within the project date range

`Engagement` now also hydrates _labels_ to help identity in various situations.

I still need to verify production data/fix