### PR TITLE
Fix null input handling

### DIFF
--- a/src/common/id-field.ts
+++ b/src/common/id-field.ts
@@ -1,16 +1,20 @@
 import { applyDecorators } from '@nestjs/common';
-import { Field, FieldOptions, ID as IDType } from '@nestjs/graphql';
+import { ID as IDType } from '@nestjs/graphql';
 import { ValidationOptions } from 'class-validator';
 import { IsAny, IsNever, Tagged } from 'type-fest';
 import type { ResourceName, ResourceNameLike } from '~/core';
+import { OptionalField, OptionalFieldOptions } from './optional-field';
 import { IsId } from './validators';
 
 export const IdField = ({
   validation,
   ...options
-}: FieldOptions & { validation?: ValidationOptions } = {}) =>
+}: OptionalFieldOptions & { validation?: ValidationOptions } = {}) =>
   applyDecorators(
-    Field(() => IDType, options),
+    OptionalField(() => IDType, {
+      optional: false,
+      ...options,
+    }),
     IsId(validation),
   );
 

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -27,6 +27,7 @@ export * from './lazy-ref';
 export * from './lazy-record';
 export { DateField, DateTimeField } from './luxon.graphql';
 export * from './map-or-else';
+export * from './optional-field';
 export * from './order.enum';
 export * from './pagination.input';
 export * from './pagination-list';

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -24,6 +24,7 @@ export * from './fiscal-year';
 export * from './generate-id';
 export * from './id.arg';
 export * from './lazy-ref';
+export * from './list-field';
 export * from './lazy-record';
 export { DateField, DateTimeField } from './luxon.graphql';
 export * from './map-or-else';

--- a/src/common/list-field.ts
+++ b/src/common/list-field.ts
@@ -1,0 +1,16 @@
+import { applyDecorators } from '@nestjs/common';
+import { OptionalField, OptionalFieldOptions } from './optional-field';
+
+export type ListFieldOptions = OptionalFieldOptions;
+
+export const ListField = (typeFn: () => any, options: ListFieldOptions) =>
+  applyDecorators(
+    OptionalField(() => [typeFn()], {
+      optional: false,
+      ...options,
+      transform: (value) => {
+        const deduped = value ? [...new Set(value)] : value;
+        return options.transform ? options.transform(deduped) : value;
+      },
+    }),
+  );

--- a/src/common/luxon.graphql.ts
+++ b/src/common/luxon.graphql.ts
@@ -1,9 +1,10 @@
 import { applyDecorators } from '@nestjs/common';
-import { CustomScalar, Field, FieldOptions, Scalar } from '@nestjs/graphql';
+import { CustomScalar, Scalar } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { Kind, ValueNode } from 'graphql';
 import { DateTime, Settings } from 'luxon';
 import { InputException } from './exceptions';
+import { OptionalField, OptionalFieldOptions } from './optional-field';
 import { CalendarDate } from './temporal';
 import { Transform } from './transform.decorator';
 import { ValidateBy } from './validators/validateBy';
@@ -24,9 +25,12 @@ const IsIsoDate = () =>
     },
   });
 
-export const DateTimeField = (options?: FieldOptions) =>
+export const DateTimeField = (options?: OptionalFieldOptions) =>
   applyDecorators(
-    Field(() => DateTime, options),
+    OptionalField(() => DateTime, {
+      optional: false,
+      ...options,
+    }),
     Transform(
       ({ value }) => {
         try {
@@ -43,9 +47,12 @@ export const DateTimeField = (options?: FieldOptions) =>
     IsIsoDate(),
   );
 
-export const DateField = (options?: FieldOptions) =>
+export const DateField = (options?: OptionalFieldOptions) =>
   applyDecorators(
-    Field(() => CalendarDate, options),
+    OptionalField(() => CalendarDate, {
+      optional: false,
+      ...options,
+    }),
     Transform(
       ({ value }) => {
         try {

--- a/src/common/optional-field.ts
+++ b/src/common/optional-field.ts
@@ -1,0 +1,48 @@
+import { applyDecorators } from '@nestjs/common';
+import { Field, FieldOptions } from '@nestjs/graphql';
+import { NullableList } from '@nestjs/graphql/dist/interfaces/base-type-options.interface';
+import { Transform } from 'class-transformer';
+
+export type OptionalFieldOptions = FieldOptions & {
+  /**
+   * If true, values can be omitted/undefined or null.
+   * This will override `optional` if truthy.
+   */
+  nullable?: boolean | NullableList;
+  /**
+   * If true, values can be omitted/undefined but not null.
+   */
+  optional?: boolean;
+  transform?: (value: any) => unknown;
+};
+
+/**
+ * A field that is optional/omissible/can be undefined.
+ * Whether it can be explicitly null is based on `nullable`.
+ */
+export function OptionalField(
+  typeFn: () => any,
+  options?: OptionalFieldOptions,
+): PropertyDecorator;
+export function OptionalField(
+  options?: OptionalFieldOptions,
+): PropertyDecorator;
+export function OptionalField(...args: any) {
+  const typeFn: (() => any) | undefined =
+    typeof args[0] === 'function' ? (args[0] as () => any) : undefined;
+  const options: OptionalFieldOptions | undefined =
+    typeof args[0] === 'function' ? args[1] : args[0];
+  const opts = {
+    ...options,
+    nullable: options?.nullable ?? options?.optional ?? true,
+  };
+  return applyDecorators(
+    typeFn ? Field(typeFn, opts) : Field(opts),
+    Transform(({ value }) => {
+      if (!options?.nullable && (options?.optional ?? true) && value == null) {
+        return undefined;
+      }
+      return options?.transform ? options.transform(value) : value;
+    }),
+  );
+}

--- a/src/common/rich-text.scalar.ts
+++ b/src/common/rich-text.scalar.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { Field, FieldOptions, ObjectType } from '@nestjs/graphql';
+import { ObjectType } from '@nestjs/graphql';
 import { setToStringTag } from '@seedcompany/common';
 import { markSkipClassTransformation } from '@seedcompany/nest';
 import { IsObject } from 'class-validator';
@@ -9,7 +9,7 @@ import { GraphQLJSONObject } from 'graphql-scalars';
 import { isEqual } from 'lodash';
 import { JsonObject } from 'type-fest';
 import { SecuredProperty } from '~/common/secured-property';
-import { Transform } from './transform.decorator';
+import { OptionalField, OptionalFieldOptions } from './optional-field';
 
 function hashId(name: string) {
   return createHash('shake256', { outputLength: 5 }).update(name).digest('hex');
@@ -76,11 +76,14 @@ export class RichTextDocument {
 setToStringTag(RichTextDocument, 'RichText');
 markSkipClassTransformation(RichTextDocument);
 
-export const RichTextField = (options?: FieldOptions) =>
+export const RichTextField = (options?: OptionalFieldOptions) =>
   applyDecorators(
-    Field(() => RichTextScalar, options),
-    IsObject(),
-    Transform(({ value }) => RichTextDocument.fromMaybe(value)),
+    OptionalField(() => RichTextScalar, {
+      optional: false,
+      ...options,
+      transform: RichTextDocument.fromMaybe,
+    }),
+    IsObject(), // TODO validate empty blocks becomes null becomes validation error
   );
 
 /** @internal */

--- a/src/common/sensitivity.enum.ts
+++ b/src/common/sensitivity.enum.ts
@@ -1,9 +1,8 @@
 import { applyDecorators } from '@nestjs/common';
 import { EnumType, makeEnum } from '@seedcompany/nest';
-import { Transform } from 'class-transformer';
-import { uniq } from 'lodash';
 import { rankSens } from '~/core/database/query';
 import { DbSort } from './db-sort.decorator';
+import { ListField, ListFieldOptions } from './list-field';
 import { OptionalField, OptionalFieldOptions } from './optional-field';
 
 export type Sensitivity = EnumType<typeof Sensitivity>;
@@ -22,8 +21,13 @@ export const SensitivityField = (options?: OptionalFieldOptions) =>
     DbSort(rankSens),
   );
 
-export const SensitivitiesFilter = () =>
-  Transform(({ value }) => {
-    const sens = uniq(value);
-    return sens.length > 0 && sens.length < 3 ? sens : undefined;
+export const SensitivitiesFilterField = (options?: ListFieldOptions) =>
+  ListField(() => Sensitivity, {
+    description: 'Only these sensitivities',
+    ...options,
+    optional: true,
+    empty: 'omit',
+    transform: (value) =>
+      // If given all options, there is no need to filter
+      !value || value.length === Sensitivity.values.size ? undefined : value,
   });

--- a/src/common/sensitivity.enum.ts
+++ b/src/common/sensitivity.enum.ts
@@ -1,10 +1,10 @@
 import { applyDecorators } from '@nestjs/common';
-import { Field, FieldOptions } from '@nestjs/graphql';
 import { EnumType, makeEnum } from '@seedcompany/nest';
 import { Transform } from 'class-transformer';
 import { uniq } from 'lodash';
 import { rankSens } from '~/core/database/query';
 import { DbSort } from './db-sort.decorator';
+import { OptionalField, OptionalFieldOptions } from './optional-field';
 
 export type Sensitivity = EnumType<typeof Sensitivity>;
 export const Sensitivity = makeEnum({
@@ -13,9 +13,12 @@ export const Sensitivity = makeEnum({
   exposeOrder: true,
 });
 
-export const SensitivityField = (options: FieldOptions = {}) =>
+export const SensitivityField = (options?: OptionalFieldOptions) =>
   applyDecorators(
-    Field(() => Sensitivity, options),
+    OptionalField(() => Sensitivity, {
+      optional: false,
+      ...options,
+    }),
     DbSort(rankSens),
   );
 

--- a/src/components/ceremony/dto/list-ceremony.dto.ts
+++ b/src/components/ceremony/dto/list-ceremony.dto.ts
@@ -1,13 +1,12 @@
-import { Field, InputType } from '@nestjs/graphql';
-import { FilterField, SortablePaginationInput } from '~/common';
+import { InputType } from '@nestjs/graphql';
+import { FilterField, OptionalField, SortablePaginationInput } from '~/common';
 import { CeremonyType } from './ceremony-type.enum';
 import { Ceremony } from './ceremony.dto';
 
 @InputType()
 export abstract class CeremonyFilters {
-  @Field(() => CeremonyType, {
+  @OptionalField(() => CeremonyType, {
     description: 'Only ceremonies of this type',
-    nullable: true,
   })
   readonly type?: CeremonyType;
 }

--- a/src/components/ceremony/dto/update-ceremony.dto.ts
+++ b/src/components/ceremony/dto/update-ceremony.dto.ts
@@ -13,10 +13,10 @@ export abstract class UpdateCeremony {
   readonly planned?: boolean;
 
   @DateField({ nullable: true })
-  readonly estimatedDate?: CalendarDate;
+  readonly estimatedDate?: CalendarDate | null;
 
   @DateField({ nullable: true })
-  readonly actualDate?: CalendarDate;
+  readonly actualDate?: CalendarDate | null;
 }
 
 @InputType()

--- a/src/components/comments/dto/update-comment.dto.ts
+++ b/src/components/comments/dto/update-comment.dto.ts
@@ -7,7 +7,7 @@ export abstract class UpdateCommentInput {
   @IdField()
   readonly id: ID;
 
-  @RichTextField({ nullable: true })
+  @RichTextField({ optional: true })
   readonly body?: RichTextDocument;
 }
 

--- a/src/components/engagement/dto/list-engagements.dto.ts
+++ b/src/components/engagement/dto/list-engagements.dto.ts
@@ -1,10 +1,12 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import {
   DateFilter,
   FilterField,
   ID,
+  ListField,
+  OptionalField,
   PaginatedList,
   SecuredList,
   SortablePaginationInput,
@@ -26,21 +28,20 @@ import { EngagementStatus } from './status.enum';
 
 @InputType()
 export abstract class EngagementFilters {
-  @Field({
+  @OptionalField({
     description: 'Only engagements matching this type',
-    nullable: true,
   })
   readonly type?: 'language' | 'internship';
 
-  @Field({
-    nullable: true,
+  @OptionalField({
     description:
       'Only engagements whose project or engaged entity (language / user) name match',
   })
   readonly name?: string;
 
-  @Field(() => [EngagementStatus], {
-    nullable: true,
+  @ListField(() => EngagementStatus, {
+    optional: true,
+    empty: 'omit',
   })
   readonly status?: readonly EngagementStatus[];
 
@@ -48,8 +49,7 @@ export abstract class EngagementFilters {
   @FilterField(() => ProjectFilters)
   readonly project?: ProjectFilters & {};
 
-  @Field({
-    nullable: true,
+  @OptionalField({
     description:
       'Only engagements whose engaged entity (language / user) name match',
   })
@@ -64,26 +64,26 @@ export abstract class EngagementFilters {
 
   readonly partnerId?: ID<'Partner'>;
 
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   @Type(() => DateFilter)
   @ValidateNested()
   readonly startDate?: DateFilter;
 
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   @Type(() => DateFilter)
   @ValidateNested()
   readonly endDate?: DateFilter;
 
-  @Field(() => [LanguageMilestone], {
-    nullable: true,
+  @ListField(() => LanguageMilestone, {
+    optional: true,
+    empty: 'omit',
   })
   readonly milestoneReached?: readonly LanguageMilestone[];
 
-  @Field(() => [AIAssistedTranslation], { nullable: true })
+  @ListField(() => AIAssistedTranslation, {
+    optional: true,
+    empty: 'omit',
+  })
   readonly usingAIAssistedTranslation?: readonly AIAssistedTranslation[];
 }
 

--- a/src/components/engagement/dto/update-engagement.dto.ts
+++ b/src/components/engagement/dto/update-engagement.dto.ts
@@ -58,8 +58,8 @@ export abstract class UpdateLanguageEngagement extends UpdateEngagement {
   @Field({ nullable: true })
   readonly openToInvestorVisit?: boolean;
 
-  @Field({ nullable: true })
-  readonly paratextRegistryId?: string;
+  @Field(() => String, { nullable: true })
+  readonly paratextRegistryId?: string | null;
 
   @Field({ nullable: true })
   @Type(() => CreateDefinedFileVersionInput)
@@ -76,8 +76,8 @@ export abstract class UpdateLanguageEngagement extends UpdateEngagement {
   })
   readonly methodology?: ProductMethodology;
 
-  @Field({ nullable: true })
-  readonly historicGoal?: string;
+  @Field(() => String, { nullable: true })
+  readonly historicGoal?: string | null;
 
   @Field(() => LanguageMilestone, { nullable: true })
   readonly milestoneReached?: LanguageMilestone;

--- a/src/components/engagement/dto/update-engagement.dto.ts
+++ b/src/components/engagement/dto/update-engagement.dto.ts
@@ -7,6 +7,7 @@ import {
   DateField,
   ID,
   IdField,
+  OptionalField,
   RichTextDocument,
   RichTextField,
 } from '~/common';
@@ -40,7 +41,7 @@ export abstract class UpdateEngagement {
 
   readonly initialEndDate?: CalendarDate | null;
 
-  @Field(() => EngagementStatus, { nullable: true })
+  @OptionalField(() => EngagementStatus)
   readonly status?: EngagementStatus;
 
   @RichTextField({ nullable: true })
@@ -79,10 +80,10 @@ export abstract class UpdateLanguageEngagement extends UpdateEngagement {
   @Field(() => String, { nullable: true })
   readonly historicGoal?: string | null;
 
-  @Field(() => LanguageMilestone, { nullable: true })
+  @OptionalField(() => LanguageMilestone)
   readonly milestoneReached?: LanguageMilestone;
 
-  @Field(() => AIAssistedTranslation, { nullable: true })
+  @OptionalField(() => AIAssistedTranslation)
   readonly usingAIAssistedTranslation?: AIAssistedTranslation;
 }
 

--- a/src/components/ethno-art/dto/update-ethno-art.dto.ts
+++ b/src/components/ethno-art/dto/update-ethno-art.dto.ts
@@ -10,7 +10,7 @@ export abstract class UpdateEthnoArt {
   @IdField()
   readonly id: ID;
 
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly name?: string;
 
   @ScriptureField({ nullable: true })

--- a/src/components/field-region/dto/update-field-region.dto.ts
+++ b/src/components/field-region/dto/update-field-region.dto.ts
@@ -9,18 +9,18 @@ export abstract class UpdateFieldRegion {
   @IdField()
   readonly id: ID;
 
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly name?: string;
 
   @IdField({
     description: 'The zone ID that the region will be associated with',
-    nullable: true,
+    optional: true,
   })
   readonly fieldZoneId?: ID;
 
   @IdField({
     description: 'A user ID that will be the director of the region',
-    nullable: true,
+    optional: true,
   })
   readonly directorId?: ID;
 }

--- a/src/components/field-zone/dto/update-field-zone.dto.ts
+++ b/src/components/field-zone/dto/update-field-zone.dto.ts
@@ -9,12 +9,12 @@ export abstract class UpdateFieldZone {
   @IdField()
   readonly id: ID;
 
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly name?: string;
 
   @IdField({
     description: 'A user ID that will be the director of the zone',
-    nullable: true,
+    optional: true,
   })
   readonly directorId?: ID;
 }

--- a/src/components/file/dto/list.ts
+++ b/src/components/file/dto/list.ts
@@ -1,19 +1,22 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
-import { FilterField, PaginatedList, SortablePaginationInput } from '~/common';
+import { InputType, ObjectType } from '@nestjs/graphql';
+import {
+  FilterField,
+  OptionalField,
+  PaginatedList,
+  SortablePaginationInput,
+} from '~/common';
 import { FileNodeType } from './file-node-type.enum';
 import { Directory, File, FileNode, IFileNode } from './node';
 
 @InputType()
 export abstract class FileFilters {
-  @Field({
+  @OptionalField({
     description: 'Only file nodes matching this name',
-    nullable: true,
   })
   readonly name?: string;
 
-  @Field(() => FileNodeType, {
+  @OptionalField(() => FileNodeType, {
     description: 'Only file nodes matching this type',
-    nullable: true,
   })
   readonly type?: FileNodeType;
 }

--- a/src/components/film/dto/update-film.dto.ts
+++ b/src/components/film/dto/update-film.dto.ts
@@ -10,7 +10,7 @@ export abstract class UpdateFilm {
   @IdField()
   readonly id: ID;
 
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly name?: string;
 
   @ScriptureField({ nullable: true })

--- a/src/components/funding-account/dto/update-funding-account.dto.ts
+++ b/src/components/funding-account/dto/update-funding-account.dto.ts
@@ -1,7 +1,7 @@
 import { Field, InputType, Int, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { Max, Min, ValidateNested } from 'class-validator';
-import { ID, IdField, NameField } from '~/common';
+import { ID, IdField, NameField, OptionalField } from '~/common';
 import { FundingAccount } from './funding-account.dto';
 
 @InputType()
@@ -9,10 +9,10 @@ export abstract class UpdateFundingAccount {
   @IdField()
   readonly id: ID;
 
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly name?: string;
 
-  @Field(() => Int, { nullable: true })
+  @OptionalField(() => Int)
   @Min(0)
   @Max(9)
   readonly accountNumber?: number;

--- a/src/components/language/dto/list-language.dto.ts
+++ b/src/components/language/dto/list-language.dto.ts
@@ -4,7 +4,7 @@ import {
   ID,
   PaginatedList,
   SecuredList,
-  SensitivitiesFilter,
+  SensitivitiesFilterField,
   Sensitivity,
   SortablePaginationInput,
 } from '~/common';
@@ -35,11 +35,7 @@ export abstract class LanguageFilters {
   })
   readonly name?: string;
 
-  @Field(() => [Sensitivity], {
-    description: 'Only languages with these sensitivities',
-    nullable: true,
-  })
-  @SensitivitiesFilter()
+  @SensitivitiesFilterField()
   readonly sensitivity?: Sensitivity[];
 
   @Field({

--- a/src/components/language/dto/list-language.dto.ts
+++ b/src/components/language/dto/list-language.dto.ts
@@ -1,7 +1,8 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { InputType, ObjectType } from '@nestjs/graphql';
 import {
   FilterField,
   ID,
+  OptionalField,
   PaginatedList,
   SecuredList,
   SensitivitiesFilterField,
@@ -12,68 +13,52 @@ import { Language } from './language.dto';
 
 @InputType()
 export abstract class EthnologueLanguageFilters {
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   readonly code?: string;
 
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   readonly provisionalCode?: string;
 
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   readonly name?: string;
 }
 
 @InputType()
 export abstract class LanguageFilters {
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   readonly name?: string;
 
   @SensitivitiesFilterField()
   readonly sensitivity?: Sensitivity[];
 
-  @Field({
-    nullable: true,
+  @OptionalField({
     description: 'Is a Least Of These partnership',
   })
   readonly leastOfThese?: boolean;
 
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   readonly isDialect?: boolean;
 
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   readonly isSignLanguage?: boolean;
 
-  @Field({
-    nullable: true,
+  @OptionalField({
     description: 'Only languages that are (not) in the "Preset Inventory"',
   })
   readonly presetInventory?: boolean;
 
-  @Field({
+  @OptionalField({
     description:
       'Only languages that are pinned/unpinned by the requesting user',
-    nullable: true,
   })
   readonly pinned?: boolean;
 
-  @Field({
-    nullable: true,
+  @OptionalField({
     deprecationReason: 'Use `registryOfLanguageVarietiesCode` instead',
   })
   readonly registryOfDialectsCode?: string;
 
-  @Field({ nullable: true })
+  @OptionalField()
   readonly registryOfLanguageVarietiesCode?: string;
 
   readonly partnerId?: ID;

--- a/src/components/language/dto/update-language.dto.ts
+++ b/src/components/language/dto/update-language.dto.ts
@@ -15,6 +15,7 @@ import {
   ID,
   IdField,
   NameField,
+  OptionalField,
   Sensitivity,
   SensitivityField,
 } from '~/common';
@@ -49,16 +50,16 @@ export abstract class UpdateLanguage {
   @IdField()
   readonly id: ID;
 
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly name?: string;
 
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly displayName?: string;
 
   @NameField({ nullable: true })
   readonly displayNamePronunciation?: string | null;
 
-  @Field({ nullable: true })
+  @OptionalField()
   readonly isDialect?: boolean;
 
   @Field({ nullable: true })
@@ -83,13 +84,13 @@ export abstract class UpdateLanguage {
   @IsNumberString()
   readonly registryOfLanguageVarietiesCode?: string | null;
 
-  @Field({ nullable: true })
+  @OptionalField()
   readonly leastOfThese?: boolean;
 
   @NameField({ nullable: true })
   readonly leastOfTheseReason?: string | null;
 
-  @Field({ nullable: true })
+  @OptionalField()
   readonly isSignLanguage?: boolean;
 
   @NameField({ nullable: true })
@@ -98,13 +99,13 @@ export abstract class UpdateLanguage {
   })
   readonly signLanguageCode?: string | null;
 
-  @SensitivityField({ nullable: true })
+  @SensitivityField({ optional: true })
   readonly sensitivity?: Sensitivity;
 
   @DateField({ nullable: true })
   readonly sponsorEstimatedEndDate?: CalendarDate | null;
 
-  @Field({ nullable: true })
+  @OptionalField()
   readonly hasExternalFirstScripture?: boolean;
 
   @Field(() => [String], { nullable: true })

--- a/src/components/language/dto/update-language.dto.ts
+++ b/src/components/language/dto/update-language.dto.ts
@@ -1,5 +1,5 @@
 import { Field, InputType, Int, ObjectType } from '@nestjs/graphql';
-import { Transform, Type } from 'class-transformer';
+import { Type } from 'class-transformer';
 import {
   IsAlpha,
   IsLowercase,
@@ -8,12 +8,12 @@ import {
   Matches,
   ValidateNested,
 } from 'class-validator';
-import { uniq } from 'lodash';
 import {
   CalendarDate,
   DateField,
   ID,
   IdField,
+  ListField,
   NameField,
   OptionalField,
   Sensitivity,
@@ -108,9 +108,8 @@ export abstract class UpdateLanguage {
   @OptionalField()
   readonly hasExternalFirstScripture?: boolean;
 
-  @Field(() => [String], { nullable: true })
-  @Transform(({ value }) => uniq(value))
-  readonly tags?: string[];
+  @ListField(() => String, { optional: true })
+  readonly tags?: readonly string[];
 }
 
 @InputType()

--- a/src/components/location/dto/list-locations.dto.ts
+++ b/src/components/location/dto/list-locations.dto.ts
@@ -1,7 +1,8 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { InputType, ObjectType } from '@nestjs/graphql';
 import {
   FilterField,
   ID,
+  OptionalField,
   PaginatedList,
   SecuredList,
   SortablePaginationInput,
@@ -10,9 +11,7 @@ import { Location } from './location.dto';
 
 @InputType()
 export abstract class LocationFilters {
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   readonly name?: string;
 
   readonly fundingAccountId?: ID;

--- a/src/components/location/dto/update-location.dto.ts
+++ b/src/components/location/dto/update-location.dto.ts
@@ -1,7 +1,13 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { ID, IdField, ISO31661Alpha3, NameField } from '~/common';
+import {
+  ID,
+  IdField,
+  ISO31661Alpha3,
+  NameField,
+  OptionalField,
+} from '~/common';
 import { Transform } from '~/common/transform.decorator';
 import { CreateDefinedFileVersionInput } from '../../file/dto';
 import { LocationType } from './location-type.enum';
@@ -12,10 +18,10 @@ export abstract class UpdateLocation {
   @IdField()
   readonly id: ID;
 
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly name?: string;
 
-  @Field(() => LocationType, { nullable: true })
+  @OptionalField(() => LocationType)
   readonly type?: LocationType;
 
   @Field(() => String, {

--- a/src/components/location/dto/update-location.dto.ts
+++ b/src/components/location/dto/update-location.dto.ts
@@ -1,7 +1,7 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { ID, IdField, IdOf, ISO31661Alpha3, NameField } from '~/common';
+import { ID, IdField, ISO31661Alpha3, NameField } from '~/common';
 import { Transform } from '~/common/transform.decorator';
 import { CreateDefinedFileVersionInput } from '../../file/dto';
 import { LocationType } from './location-type.enum';
@@ -33,7 +33,7 @@ export abstract class UpdateLocation {
   readonly defaultFieldRegionId?: ID | null;
 
   @IdField({ nullable: true })
-  readonly defaultMarketingRegionId?: IdOf<Location>;
+  readonly defaultMarketingRegionId?: ID<Location> | null;
 
   @Field({ nullable: true })
   @Type(() => CreateDefinedFileVersionInput)

--- a/src/components/notifications/dto/notification-list.input.ts
+++ b/src/components/notifications/dto/notification-list.input.ts
@@ -1,12 +1,16 @@
 import { Field, InputType, Int, ObjectType } from '@nestjs/graphql';
-import { FilterField, PaginatedList, PaginationInput } from '~/common';
+import {
+  FilterField,
+  OptionalField,
+  PaginatedList,
+  PaginationInput,
+} from '~/common';
 import { Notification } from './notification.dto';
 
 @InputType()
 export abstract class NotificationFilters {
-  @Field(() => Boolean, {
+  @OptionalField(() => Boolean, {
     description: 'Only read/unread notifications',
-    nullable: true,
   })
   readonly unread?: boolean;
 }

--- a/src/components/organization/dto/list-organization.dto.ts
+++ b/src/components/organization/dto/list-organization.dto.ts
@@ -1,7 +1,8 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { InputType, ObjectType } from '@nestjs/graphql';
 import {
   FilterField,
   ID,
+  OptionalField,
   PaginatedList,
   SecuredList,
   SortablePaginationInput,
@@ -10,9 +11,7 @@ import { Organization } from './organization.dto';
 
 @InputType()
 export abstract class OrganizationFilters {
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   readonly name?: string;
 
   readonly userId?: ID;

--- a/src/components/organization/dto/update-organization.dto.ts
+++ b/src/components/organization/dto/update-organization.dto.ts
@@ -1,7 +1,7 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { ID, IdField, NameField } from '~/common';
+import { ID, IdField, NameField, OptionalField } from '~/common';
 import { OrganizationReach } from './organization-reach.dto';
 import { OrganizationType } from './organization-type.dto';
 import { Organization } from './organization.dto';
@@ -11,7 +11,7 @@ export abstract class UpdateOrganization {
   @IdField()
   readonly id: ID;
 
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly name?: string;
 
   @NameField({ nullable: true })
@@ -20,10 +20,10 @@ export abstract class UpdateOrganization {
   @Field(() => String, { nullable: true })
   readonly address?: string | null;
 
-  @Field(() => [OrganizationType], { nullable: true })
+  @OptionalField(() => [OrganizationType])
   readonly types?: readonly OrganizationType[];
 
-  @Field(() => [OrganizationReach], { nullable: true })
+  @OptionalField(() => [OrganizationReach])
   readonly reach?: readonly OrganizationReach[];
 }
 

--- a/src/components/organization/dto/update-organization.dto.ts
+++ b/src/components/organization/dto/update-organization.dto.ts
@@ -17,8 +17,8 @@ export abstract class UpdateOrganization {
   @NameField({ nullable: true })
   readonly acronym?: string | null;
 
-  @Field({ nullable: true })
-  readonly address?: string;
+  @Field(() => String, { nullable: true })
+  readonly address?: string | null;
 
   @Field(() => [OrganizationType], { nullable: true })
   readonly types?: readonly OrganizationType[];

--- a/src/components/partner/dto/list-partner.dto.ts
+++ b/src/components/partner/dto/list-partner.dto.ts
@@ -1,4 +1,4 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import {
@@ -6,6 +6,8 @@ import {
   DateTimeFilter,
   FilterField,
   ID,
+  ListField,
+  OptionalField,
   PaginatedList,
   SecuredList,
   SortablePaginationInput,
@@ -19,41 +21,36 @@ import { Partner } from './partner.dto';
 export abstract class PartnerFilters {
   readonly userId?: ID;
 
-  @Field({
+  @OptionalField({
     description:
       'Only partners that are pinned/unpinned by the requesting user',
-    nullable: true,
   })
   readonly pinned?: boolean;
 
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   readonly globalInnovationsClient?: boolean;
 
   @FilterField(() => OrganizationFilters)
   readonly organization?: OrganizationFilters & {};
 
-  @Field(() => [PartnerType], {
-    nullable: true,
+  @ListField(() => PartnerType, {
+    optional: true,
+    empty: 'omit',
   })
-  readonly types?: PartnerType[];
+  readonly types?: readonly PartnerType[];
 
-  @Field(() => [FinancialReportingType], {
-    nullable: true,
+  @ListField(() => FinancialReportingType, {
+    optional: true,
+    empty: 'omit',
   })
-  readonly financialReportingTypes?: FinancialReportingType[];
+  readonly financialReportingTypes?: readonly FinancialReportingType[];
 
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   @Type(() => DateFilter)
   @ValidateNested()
   readonly startDate?: DateFilter;
 
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   @Type(() => DateTimeFilter)
   @ValidateNested()
   readonly createdAt?: DateTimeFilter;

--- a/src/components/partner/dto/update-partner.dto.ts
+++ b/src/components/partner/dto/update-partner.dto.ts
@@ -1,13 +1,13 @@
 import { Field, ID as IDType, InputType, ObjectType } from '@nestjs/graphql';
-import { Transform, Type } from 'class-transformer';
+import { Type } from 'class-transformer';
 import { Matches, ValidateNested } from 'class-validator';
-import { uniq } from 'lodash';
 import {
   CalendarDate,
   DateField,
   ID,
   IdField,
   IsId,
+  ListField,
   NameField,
 } from '~/common';
 import { FinanceDepartmentIdBlockInput } from '../../finance/department/dto/id-blocks.input';
@@ -24,12 +24,10 @@ export abstract class UpdatePartner {
   @IdField({ nullable: true })
   readonly pointOfContactId?: ID<'User'> | null;
 
-  @Field(() => [PartnerType], { nullable: true })
-  @Transform(({ value }) => uniq(value))
+  @ListField(() => PartnerType, { optional: true })
   readonly types?: readonly PartnerType[];
 
-  @Field(() => [FinancialReportingType], { nullable: true })
-  @Transform(({ value }) => uniq(value))
+  @ListField(() => FinancialReportingType, { optional: true })
   readonly financialReportingTypes?: readonly FinancialReportingType[];
 
   @Field(() => String, { nullable: true })
@@ -50,26 +48,23 @@ export abstract class UpdatePartner {
   @IdField({ nullable: true })
   readonly languageOfWiderCommunicationId?: ID<'Language'> | null;
 
-  @Field(() => [IDType], { nullable: true })
+  @ListField(() => IDType, { optional: true })
   @IsId({ each: true })
-  @Transform(({ value }) => (value ? uniq(value) : undefined))
   readonly countries?: ReadonlyArray<ID<'Location'>>;
 
-  @Field(() => [IDType], { nullable: true })
+  @ListField(() => IDType, { optional: true })
   @IsId({ each: true })
-  @Transform(({ value }) => (value ? uniq(value) : undefined))
   readonly fieldRegions?: ReadonlyArray<ID<'FieldRegion'>>;
 
-  @Field(() => [IDType], { name: 'languagesOfConsulting', nullable: true })
-  @Transform(({ value }) => (value ? uniq(value) : undefined))
+  @ListField(() => IDType, { optional: true })
+  @IsId({ each: true })
   readonly languagesOfConsulting?: ReadonlyArray<ID<'Language'>>;
 
   @DateField({ nullable: true })
   readonly startDate?: CalendarDate | null;
 
-  @Field(() => [ProjectType], { nullable: true })
-  @Transform(({ value }) => uniq(value))
-  readonly approvedPrograms?: ProjectType[];
+  @ListField(() => ProjectType, { optional: true })
+  readonly approvedPrograms?: readonly ProjectType[];
 
   @Field(() => FinanceDepartmentIdBlockInput, { nullable: true })
   @ValidateNested()

--- a/src/components/partner/dto/update-partner.dto.ts
+++ b/src/components/partner/dto/update-partner.dto.ts
@@ -22,7 +22,7 @@ export abstract class UpdatePartner {
   readonly id: ID;
 
   @IdField({ nullable: true })
-  readonly pointOfContactId?: ID | null;
+  readonly pointOfContactId?: ID<'User'> | null;
 
   @Field(() => [PartnerType], { nullable: true })
   @Transform(({ value }) => uniq(value))
@@ -32,11 +32,11 @@ export abstract class UpdatePartner {
   @Transform(({ value }) => uniq(value))
   readonly financialReportingTypes?: readonly FinancialReportingType[];
 
-  @Field({ nullable: true })
+  @Field(() => String, { nullable: true })
   @Matches(/^[A-Z]{3}$/, {
     message: 'Must be 3 uppercase letters',
   })
-  readonly pmcEntityCode?: string;
+  readonly pmcEntityCode?: string | null;
 
   @Field({ nullable: true })
   readonly globalInnovationsClient?: boolean;
@@ -45,7 +45,7 @@ export abstract class UpdatePartner {
   readonly active?: boolean;
 
   @NameField({ nullable: true })
-  readonly address?: string;
+  readonly address?: string | null;
 
   @IdField({ nullable: true })
   readonly languageOfWiderCommunicationId?: ID<'Language'> | null;

--- a/src/components/partnership/dto/list-partnership.dto.ts
+++ b/src/components/partnership/dto/list-partnership.dto.ts
@@ -1,9 +1,8 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
-import { Transform } from 'class-transformer';
-import { uniq } from 'lodash';
+import { InputType, ObjectType } from '@nestjs/graphql';
 import {
   FilterField,
   ID,
+  ListField,
   PaginatedList,
   SecuredList,
   SortablePaginationInput,
@@ -18,12 +17,12 @@ export abstract class PartnershipFilters {
   @FilterField(() => PartnerFilters)
   readonly partner?: PartnerFilters & {};
 
-  @Field(() => [PartnerType], { nullable: true })
-  @Transform(({ value }) => {
-    const types = uniq(value);
-    return types.length > 0 && types.length < PartnerType.values.size
-      ? types
-      : undefined;
+  @ListField(() => PartnerType, {
+    optional: true,
+    empty: 'omit',
+    transform: (value) =>
+      // If given all options, there is no need to filter
+      !value || value.length === PartnerType.values.size ? undefined : value,
   })
   readonly types?: readonly PartnerType[];
 }

--- a/src/components/partnership/dto/update-partnership.dto.ts
+++ b/src/components/partnership/dto/update-partnership.dto.ts
@@ -32,10 +32,10 @@ export abstract class UpdatePartnership {
   readonly mouStatus?: PartnershipAgreementStatus;
 
   @DateField({ nullable: true })
-  readonly mouStartOverride?: CalendarDate;
+  readonly mouStartOverride?: CalendarDate | null;
 
   @DateField({ nullable: true })
-  readonly mouEndOverride?: CalendarDate;
+  readonly mouEndOverride?: CalendarDate | null;
 
   @Field(() => [PartnerType], { nullable: true })
   @Transform(({ value }) => uniq(value))

--- a/src/components/partnership/dto/update-partnership.dto.ts
+++ b/src/components/partnership/dto/update-partnership.dto.ts
@@ -2,7 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Transform, Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { uniq } from 'lodash';
-import { CalendarDate, DateField, ID, IdField } from '~/common';
+import { CalendarDate, DateField, ID, IdField, OptionalField } from '~/common';
 import { ChangesetIdField } from '../../changeset';
 import { CreateDefinedFileVersionInput } from '../../file/dto';
 import { PartnerType } from '../../partner/dto';
@@ -15,7 +15,7 @@ export abstract class UpdatePartnership {
   @IdField()
   readonly id: ID;
 
-  @Field(() => PartnershipAgreementStatus, { nullable: true })
+  @OptionalField(() => PartnershipAgreementStatus)
   readonly agreementStatus?: PartnershipAgreementStatus;
 
   @Field({ description: 'The partner agreement', nullable: true })
@@ -28,7 +28,7 @@ export abstract class UpdatePartnership {
   @ValidateNested()
   readonly mou?: CreateDefinedFileVersionInput;
 
-  @Field(() => PartnershipAgreementStatus, { nullable: true })
+  @OptionalField(() => PartnershipAgreementStatus)
   readonly mouStatus?: PartnershipAgreementStatus;
 
   @DateField({ nullable: true })
@@ -44,7 +44,7 @@ export abstract class UpdatePartnership {
   @Field(() => FinancialReportingType, { nullable: true })
   readonly financialReportingType?: FinancialReportingType | null;
 
-  @Field({ nullable: true })
+  @OptionalField()
   readonly primary?: boolean;
 }
 

--- a/src/components/partnership/dto/update-partnership.dto.ts
+++ b/src/components/partnership/dto/update-partnership.dto.ts
@@ -1,8 +1,14 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
-import { Transform, Type } from 'class-transformer';
+import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { uniq } from 'lodash';
-import { CalendarDate, DateField, ID, IdField, OptionalField } from '~/common';
+import {
+  CalendarDate,
+  DateField,
+  ID,
+  IdField,
+  ListField,
+  OptionalField,
+} from '~/common';
 import { ChangesetIdField } from '../../changeset';
 import { CreateDefinedFileVersionInput } from '../../file/dto';
 import { PartnerType } from '../../partner/dto';
@@ -37,8 +43,7 @@ export abstract class UpdatePartnership {
   @DateField({ nullable: true })
   readonly mouEndOverride?: CalendarDate | null;
 
-  @Field(() => [PartnerType], { nullable: true })
-  @Transform(({ value }) => uniq(value))
+  @ListField(() => PartnerType, { optional: true })
   readonly types?: readonly PartnerType[];
 
   @Field(() => FinancialReportingType, { nullable: true })

--- a/src/components/periodic-report/dto/update-periodic-report.dto.ts
+++ b/src/components/periodic-report/dto/update-periodic-report.dto.ts
@@ -18,11 +18,11 @@ export abstract class UpdatePeriodicReportInput {
   readonly reportFile?: CreateDefinedFileVersionInput;
 
   @DateField({ nullable: true })
-  readonly receivedDate?: CalendarDate;
+  readonly receivedDate?: CalendarDate | null;
 
-  @Field({
+  @Field(() => String, {
     description: 'Why this report is skipped',
     nullable: true,
   })
-  readonly skippedReason?: string;
+  readonly skippedReason?: string | null;
 }

--- a/src/components/pnp/extraction-result/extraction-result.dto.ts
+++ b/src/components/pnp/extraction-result/extraction-result.dto.ts
@@ -5,7 +5,14 @@ import { UUID } from 'node:crypto';
 import { keys as keysOf } from 'ts-transformer-keys';
 import { Merge } from 'type-fest';
 import * as uuid from 'uuid';
-import { EnumType, ID, IdField, makeEnum, SecuredProps } from '~/common';
+import {
+  EnumType,
+  ID,
+  IdField,
+  makeEnum,
+  OptionalField,
+  SecuredProps,
+} from '~/common';
 import { InlineMarkdownScalar } from '~/common/markdown.scalar';
 import { Cell } from '~/common/xlsx.util';
 
@@ -121,8 +128,7 @@ export type StoredProblem = Pick<PnpProblem, 'id'> & {
 
 @InputType()
 export class PnpExtractionResultFilters {
-  @Field(() => Boolean, {
-    nullable: true,
+  @OptionalField(() => Boolean, {
     description: 'Only extraction results containing errors',
   })
   readonly hasError?: boolean;

--- a/src/components/product/dto/list-product.dto.ts
+++ b/src/components/product/dto/list-product.dto.ts
@@ -1,8 +1,9 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { InputType, ObjectType } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import {
   FilterField,
   ID,
+  OptionalField,
   PaginatedList,
   SecuredList,
   SortablePaginationInput,
@@ -13,24 +14,21 @@ import { AnyProduct, Product } from './product.dto';
 
 @InputType()
 export abstract class ProductFilters {
-  @Field(() => ProductApproach, {
+  @OptionalField(() => ProductApproach, {
     description: 'Only products matching this approach',
-    nullable: true,
   })
   readonly approach?: ProductApproach;
 
-  @Field(() => ProductMethodology, {
+  @OptionalField(() => ProductMethodology, {
     description: 'Only products matching this methodology',
-    nullable: true,
   })
   readonly methodology?: ProductMethodology;
 
-  @Field({
+  @OptionalField({
     description: stripIndent`
       Only products that are (or not) placeholders.
       This is based on the \`placeholderDescription\` field.
     `,
-    nullable: true,
   })
   readonly placeholder?: boolean;
 

--- a/src/components/product/dto/update-product.dto.ts
+++ b/src/components/product/dto/update-product.dto.ts
@@ -46,7 +46,7 @@ export abstract class UpdateDerivativeScriptureProduct extends IntersectTypes(
   ]),
 ) {
   @IdField({
-    nullable: true,
+    optional: true,
     description: stripIndent`
       An ID of a \`Producible\` object to change to.
     `,
@@ -59,7 +59,7 @@ export abstract class UpdateDerivativeScriptureProduct extends IntersectTypes(
 
 @InputType()
 export abstract class UpdateOtherProduct extends UpdateBaseProduct {
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly title?: string;
 
   @Field(() => String, { nullable: true })

--- a/src/components/progress-summary/dto/progress-summary-filters.dto.ts
+++ b/src/components/progress-summary/dto/progress-summary-filters.dto.ts
@@ -1,10 +1,11 @@
-import { Field, InputType } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
+import { ListField } from '~/common';
 import { ScheduleStatus } from './schedule-status.enum';
 
 @InputType()
 export abstract class ProgressSummaryFilters {
-  @Field(() => [ScheduleStatus], {
+  @ListField(() => ScheduleStatus, {
     nullable: 'itemsAndList',
     description: stripIndent`
       Filter by schedule status.

--- a/src/components/project-change-request/dto/create-project-change-request.dto.ts
+++ b/src/components/project-change-request/dto/create-project-change-request.dto.ts
@@ -2,7 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { NonEmptyArray } from '@seedcompany/common';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { ID, IdField, ListField } from '~/common';
+import { ID, IdField, ListField, NameField } from '~/common';
 import { ProjectChangeRequestType } from './project-change-request-type.enum';
 import { ProjectChangeRequest } from './project-change-request.dto';
 
@@ -16,7 +16,7 @@ export abstract class CreateProjectChangeRequest {
   @ListField(() => ProjectChangeRequestType, { empty: 'deny' })
   readonly types: NonEmptyArray<ProjectChangeRequestType>;
 
-  @Field()
+  @NameField()
   readonly summary: string;
 }
 

--- a/src/components/project-change-request/dto/create-project-change-request.dto.ts
+++ b/src/components/project-change-request/dto/create-project-change-request.dto.ts
@@ -1,7 +1,8 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { NonEmptyArray } from '@seedcompany/common';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { ID, IdField } from '~/common';
+import { ID, IdField, ListField } from '~/common';
 import { ProjectChangeRequestType } from './project-change-request-type.enum';
 import { ProjectChangeRequest } from './project-change-request.dto';
 
@@ -12,8 +13,8 @@ export abstract class CreateProjectChangeRequest {
   })
   readonly projectId: ID;
 
-  @Field(() => [ProjectChangeRequestType])
-  readonly types: ProjectChangeRequestType[];
+  @ListField(() => ProjectChangeRequestType, { empty: 'deny' })
+  readonly types: NonEmptyArray<ProjectChangeRequestType>;
 
   @Field()
   readonly summary: string;

--- a/src/components/project-change-request/dto/update-project-change-request.dto.ts
+++ b/src/components/project-change-request/dto/update-project-change-request.dto.ts
@@ -1,7 +1,7 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { ID, IdField, NameField, OptionalField } from '~/common';
+import { ID, IdField, ListField, NameField, OptionalField } from '~/common';
 import { ProjectChangeRequestStatus } from './project-change-request-status.enum';
 import { ProjectChangeRequestType } from './project-change-request-type.enum';
 import { ProjectChangeRequest } from './project-change-request.dto';
@@ -11,8 +11,8 @@ export abstract class UpdateProjectChangeRequest {
   @IdField()
   readonly id: ID;
 
-  @OptionalField(() => [ProjectChangeRequestType])
-  readonly types?: [ProjectChangeRequestType];
+  @ListField(() => ProjectChangeRequestType, { optional: true })
+  readonly types?: readonly ProjectChangeRequestType[];
 
   @NameField({ optional: true })
   readonly summary?: string;

--- a/src/components/project-change-request/dto/update-project-change-request.dto.ts
+++ b/src/components/project-change-request/dto/update-project-change-request.dto.ts
@@ -1,4 +1,5 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { NonEmptyArray } from '@seedcompany/common';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { ID, IdField, ListField, NameField, OptionalField } from '~/common';
@@ -11,8 +12,8 @@ export abstract class UpdateProjectChangeRequest {
   @IdField()
   readonly id: ID;
 
-  @ListField(() => ProjectChangeRequestType, { optional: true })
-  readonly types?: readonly ProjectChangeRequestType[];
+  @ListField(() => ProjectChangeRequestType, { optional: true, empty: 'deny' })
+  readonly types?: NonEmptyArray<ProjectChangeRequestType>;
 
   @NameField({ optional: true })
   readonly summary?: string;

--- a/src/components/project-change-request/dto/update-project-change-request.dto.ts
+++ b/src/components/project-change-request/dto/update-project-change-request.dto.ts
@@ -1,7 +1,7 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { ID, IdField } from '~/common';
+import { ID, IdField, NameField, OptionalField } from '~/common';
 import { ProjectChangeRequestStatus } from './project-change-request-status.enum';
 import { ProjectChangeRequestType } from './project-change-request-type.enum';
 import { ProjectChangeRequest } from './project-change-request.dto';
@@ -11,13 +11,13 @@ export abstract class UpdateProjectChangeRequest {
   @IdField()
   readonly id: ID;
 
-  @Field(() => [ProjectChangeRequestType], { nullable: true })
+  @OptionalField(() => [ProjectChangeRequestType])
   readonly types?: [ProjectChangeRequestType];
 
-  @Field(() => String, { nullable: true })
+  @NameField({ optional: true })
   readonly summary?: string;
 
-  @Field(() => ProjectChangeRequestStatus, { nullable: true })
+  @OptionalField(() => ProjectChangeRequestStatus)
   readonly status?: ProjectChangeRequestStatus;
 }
 

--- a/src/components/project/dto/list-projects.dto.ts
+++ b/src/components/project/dto/list-projects.dto.ts
@@ -1,4 +1,4 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import {
@@ -6,6 +6,8 @@ import {
   DateTimeFilter,
   FilterField,
   ID,
+  ListField,
+  OptionalField,
   PaginatedList,
   SecuredList,
   SensitivitiesFilterField,
@@ -26,90 +28,80 @@ import {
 
 @InputType()
 export abstract class ProjectFilters {
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   readonly name?: string;
 
-  @Field(() => [ProjectType], {
+  @ListField(() => ProjectType, {
     description: 'Only projects of these types',
-    nullable: true,
+    optional: true,
+    empty: 'omit',
   })
   readonly type?: ProjectType[];
 
   @SensitivitiesFilterField()
-  readonly sensitivity?: Sensitivity[];
+  readonly sensitivity?: readonly Sensitivity[];
 
-  @Field(() => [ProjectStatus], {
+  @ListField(() => ProjectStatus, {
     description: 'Only projects matching these statuses',
-    nullable: true,
+    optional: true,
+    empty: 'omit',
   })
-  readonly status?: ProjectStatus[];
+  readonly status?: readonly ProjectStatus[];
 
-  @Field(() => [ProjectStep], {
+  @ListField(() => ProjectStep, {
     description: 'Only projects matching these steps',
-    nullable: true,
+    optional: true,
+    empty: 'omit',
   })
   readonly step?: ProjectStep[];
 
-  @Field({
+  @OptionalField({
     description:
       'Only projects that are pinned/unpinned by the requesting user',
-    nullable: true,
   })
   readonly pinned?: boolean;
 
-  @Field({
-    nullable: true,
+  @OptionalField({
     description: 'Only projects created within this time range',
   })
   @Type(() => DateTimeFilter)
   @ValidateNested()
   readonly createdAt?: DateTimeFilter;
 
-  @Field({
-    nullable: true,
+  @OptionalField({
     description: 'Only projects modified within this time range',
   })
   @Type(() => DateTimeFilter)
   @ValidateNested()
   readonly modifiedAt?: DateTimeFilter;
 
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   @Type(() => DateFilter)
   @ValidateNested()
   readonly mouStart?: DateFilter;
 
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   @Type(() => DateFilter)
   @ValidateNested()
   readonly mouEnd?: DateFilter;
 
-  @Field({
-    nullable: true,
+  @OptionalField({
     description: 'only mine',
     deprecationReason: 'Use `isMember` instead.',
   })
   readonly mine?: boolean;
 
-  @Field({
-    nullable: true,
+  @OptionalField({
     description: 'Only projects that the requesting user is a member of',
   })
   readonly isMember?: boolean;
 
-  @Field({
-    nullable: true,
+  @OptionalField({
     description: 'Filter for projects with two or more engagements.',
   })
   readonly onlyMultipleEngagements?: boolean;
 
-  @Field({
-    nullable: true,
+  @OptionalField({
     description: 'Only projects that are (not) in the "Preset Inventory"',
   })
   readonly presetInventory?: boolean;

--- a/src/components/project/dto/list-projects.dto.ts
+++ b/src/components/project/dto/list-projects.dto.ts
@@ -8,7 +8,7 @@ import {
   ID,
   PaginatedList,
   SecuredList,
-  SensitivitiesFilter,
+  SensitivitiesFilterField,
   Sensitivity,
   SortablePaginationInput,
 } from '~/common';
@@ -37,11 +37,7 @@ export abstract class ProjectFilters {
   })
   readonly type?: ProjectType[];
 
-  @Field(() => [Sensitivity], {
-    description: 'Only projects with these sensitivities',
-    nullable: true,
-  })
-  @SensitivitiesFilter()
+  @SensitivitiesFilterField()
   readonly sensitivity?: Sensitivity[];
 
   @Field(() => [ProjectStatus], {

--- a/src/components/project/dto/update-project.dto.ts
+++ b/src/components/project/dto/update-project.dto.ts
@@ -1,7 +1,6 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
-import { Transform, Type } from 'class-transformer';
+import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { uniq } from 'lodash';
 import { DateTime } from 'luxon';
 import {
   CalendarDate,
@@ -10,6 +9,7 @@ import {
   ID,
   IdField,
   IdOf,
+  ListField,
   NameField,
   OptionalField,
   Sensitivity,
@@ -75,8 +75,7 @@ export abstract class UpdateProject {
   })
   readonly sensitivity?: Sensitivity;
 
-  @Field(() => [String], { nullable: true })
-  @Transform(({ value }) => uniq(value))
+  @ListField(() => String, { optional: true })
   readonly tags?: readonly string[];
 
   @DateTimeField({ nullable: true })

--- a/src/components/project/dto/update-project.dto.ts
+++ b/src/components/project/dto/update-project.dto.ts
@@ -11,6 +11,7 @@ import {
   IdField,
   IdOf,
   NameField,
+  OptionalField,
   Sensitivity,
   SensitivityField,
 } from '~/common';
@@ -25,7 +26,7 @@ export abstract class UpdateProject {
   @IdField()
   readonly id: ID;
 
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly name?: string;
 
   @IdField({
@@ -63,15 +64,14 @@ export abstract class UpdateProject {
   @DateField({ nullable: true })
   readonly estimatedSubmission?: CalendarDate | null;
 
-  @Field(() => ProjectStep, {
-    nullable: true,
+  @OptionalField(() => ProjectStep, {
     deprecationReason: 'Use `transitionProject` mutation instead',
   })
   readonly step?: ProjectStep;
 
   @SensitivityField({
     description: 'Update only available to internship projects',
-    nullable: true,
+    optional: true,
   })
   readonly sensitivity?: Sensitivity;
 
@@ -85,7 +85,7 @@ export abstract class UpdateProject {
   @Field(() => ReportPeriod, { nullable: true })
   readonly financialReportPeriod?: ReportPeriod | null;
 
-  @Field({ nullable: true })
+  @OptionalField()
   readonly presetInventory?: boolean;
 
   @Field(() => String, { nullable: true })

--- a/src/components/project/project-member/dto/list-project-members.dto.ts
+++ b/src/components/project/project-member/dto/list-project-members.dto.ts
@@ -1,7 +1,8 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { InputType, ObjectType } from '@nestjs/graphql';
 import {
   FilterField,
   ID,
+  ListField,
   PaginatedList,
   Role,
   SecuredList,
@@ -11,11 +12,12 @@ import { ProjectMember } from './project-member.dto';
 
 @InputType()
 export abstract class ProjectMemberFilters {
-  @Field(() => [Role], {
+  @ListField(() => Role, {
     description: 'Only members with these roles',
-    nullable: true,
+    optional: true,
+    empty: 'omit',
   })
-  readonly roles?: Role[];
+  readonly roles?: readonly Role[];
 
   readonly projectId?: ID;
 }

--- a/src/components/project/project-member/dto/update-project-member.dto.ts
+++ b/src/components/project/project-member/dto/update-project-member.dto.ts
@@ -1,7 +1,7 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { ID, IdField, OptionalField, Role } from '~/common';
+import { ID, IdField, ListField, Role } from '~/common';
 import { ProjectMember } from './project-member.dto';
 
 @InputType()
@@ -9,7 +9,7 @@ export abstract class UpdateProjectMember {
   @IdField()
   readonly id: ID;
 
-  @OptionalField(() => [Role])
+  @ListField(() => Role, { optional: true })
   readonly roles?: readonly Role[];
 }
 

--- a/src/components/project/project-member/dto/update-project-member.dto.ts
+++ b/src/components/project/project-member/dto/update-project-member.dto.ts
@@ -1,7 +1,7 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { ID, IdField, Role } from '~/common';
+import { ID, IdField, OptionalField, Role } from '~/common';
 import { ProjectMember } from './project-member.dto';
 
 @InputType()
@@ -9,7 +9,7 @@ export abstract class UpdateProjectMember {
   @IdField()
   readonly id: ID;
 
-  @Field(() => [Role], { nullable: true })
+  @OptionalField(() => [Role])
   readonly roles?: readonly Role[];
 }
 

--- a/src/components/story/dto/update-story.dto.ts
+++ b/src/components/story/dto/update-story.dto.ts
@@ -10,7 +10,7 @@ export abstract class UpdateStory {
   @IdField()
   readonly id: ID;
 
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly name?: string;
 
   @ScriptureField({ nullable: true })

--- a/src/components/user/dto/list-users.dto.ts
+++ b/src/components/user/dto/list-users.dto.ts
@@ -1,6 +1,8 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { InputType, ObjectType } from '@nestjs/graphql';
 import {
   FilterField,
+  ListField,
+  OptionalField,
   PaginatedList,
   Role,
   SortablePaginationInput,
@@ -9,24 +11,20 @@ import { User } from './user.dto';
 
 @InputType()
 export abstract class UserFilters {
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   readonly name?: string;
 
-  @Field({
-    nullable: true,
-  })
+  @OptionalField()
   readonly title?: string;
 
-  @Field(() => [Role], {
-    nullable: true,
+  @ListField(() => Role, {
+    optional: true,
+    empty: 'omit',
   })
   readonly roles?: Role[];
 
-  @Field({
+  @OptionalField({
     description: 'Only users that are pinned/unpinned by the requesting user',
-    nullable: true,
   })
   readonly pinned?: boolean;
 }

--- a/src/components/user/dto/update-user.dto.ts
+++ b/src/components/user/dto/update-user.dto.ts
@@ -8,6 +8,7 @@ import {
   IdField,
   IsIanaTimezone,
   NameField,
+  OptionalField,
   Role,
 } from '~/common';
 import { UserStatus } from './user-status.enum';
@@ -21,29 +22,29 @@ export abstract class UpdateUser {
   @EmailField({ nullable: true })
   readonly email?: string | null;
 
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly realFirstName?: string;
 
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly realLastName?: string;
 
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly displayFirstName?: string;
 
-  @NameField({ nullable: true })
+  @NameField({ optional: true })
   readonly displayLastName?: string;
 
   @Field(() => String, { nullable: true })
   readonly phone?: string | null;
 
-  @Field({ nullable: true })
+  @OptionalField()
   @IsIanaTimezone()
   readonly timezone?: string;
 
   @Field(() => String, { nullable: true })
   readonly about?: string | null;
 
-  @Field(() => UserStatus, { nullable: true })
+  @OptionalField(() => UserStatus)
   readonly status?: UserStatus;
 
   @Field(() => [Role], { nullable: true })

--- a/src/components/user/dto/update-user.dto.ts
+++ b/src/components/user/dto/update-user.dto.ts
@@ -1,12 +1,12 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
-import { Transform, Type } from 'class-transformer';
+import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { uniq } from 'lodash';
 import {
   EmailField,
   ID,
   IdField,
   IsIanaTimezone,
+  ListField,
   NameField,
   OptionalField,
   Role,
@@ -47,8 +47,7 @@ export abstract class UpdateUser {
   @OptionalField(() => UserStatus)
   readonly status?: UserStatus;
 
-  @Field(() => [Role], { nullable: true })
-  @Transform(({ value }) => uniq(value))
+  @ListField(() => Role, { optional: true })
   readonly roles?: readonly Role[];
 
   @Field(() => String, { nullable: true })

--- a/src/components/user/education/dto/update-education.dto.ts
+++ b/src/components/user/education/dto/update-education.dto.ts
@@ -1,7 +1,7 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { ID, IdField } from '~/common';
+import { ID, IdField, NameField, OptionalField } from '~/common';
 import { Degree, Education } from './education.dto';
 
 @InputType()
@@ -9,13 +9,13 @@ export abstract class UpdateEducation {
   @IdField()
   readonly id: ID;
 
-  @Field(() => Degree, { nullable: true })
+  @OptionalField(() => Degree)
   readonly degree?: Degree;
 
-  @Field({ nullable: true })
+  @NameField({ optional: true })
   readonly major?: string;
 
-  @Field({ nullable: true })
+  @NameField({ optional: true })
   readonly institution?: string;
 }
 

--- a/src/components/user/unavailability/dto/update-unavailability.dto.ts
+++ b/src/components/user/unavailability/dto/update-unavailability.dto.ts
@@ -2,7 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { DateTime } from 'luxon';
-import { DateTimeField, ID, IdField } from '~/common';
+import { DateTimeField, ID, IdField, OptionalField } from '~/common';
 import { Unavailability } from './unavailability.dto';
 
 @InputType()
@@ -10,13 +10,13 @@ export abstract class UpdateUnavailability {
   @IdField()
   readonly id: ID;
 
-  @Field({ nullable: true })
+  @OptionalField()
   readonly description?: string;
 
-  @DateTimeField({ nullable: true })
+  @DateTimeField({ optional: true })
   readonly start?: DateTime;
 
-  @DateTimeField({ nullable: true })
+  @DateTimeField({ optional: true })
   readonly end?: DateTime;
 }
 


### PR DESCRIPTION
Handle GraphQL nulls from "optional" fields as undefined.

GraphQL's / Nest's decorators have `nullable` option, which means the value can be null or omitted - which naturally translates to null or undefined in JS.

We actually care about this distinction, though, especially on update mutations.
undefined means no change.
null means clear the value.

We carelessly allowed both meaningly that nulls could mistakenly be stored in lots of spots that are unexpected.
Granted, this only would happen in Neo4j, as Gel's schema checks would prevent this.

Going forward we have a new `optional` option as a sibling to `nullable`.
`optional` lets the field be omitted or undefined. GraphQL can still give us nulls, but be will we convert them to undefined.
`nullable` continues to let null & undefined through.

---

I also added `null` types where we actually expect/allow nulls.

I also created `ListField` to help dedupe items, and convert empty lists to undefined (for filters), and to disallow empty arrays where expected.