### PR TITLE
Revert #3309 / 1fa42ad for EnforceChangesetEditablePipe

### DIFF
--- a/src/core/graphql/index.ts
+++ b/src/core/graphql/index.ts
@@ -1,3 +1,3 @@
 export * from './graphql.module';
-export { GqlContextHost, isGqlContext } from './gql-context.host';
+export { GqlContextHost, isGqlContext, ifGqlContext } from './gql-context.host';
 export * from './plugin.decorator';


### PR DESCRIPTION
I didn't realize it at the time, but because this is a global pipe, it applies as a dependency to all controllers/resolvers. Making this request scoped means all controllers/resolvers become request scoped as well.

Revert to using `GqlContextHost`/ALS and add `contextMaybe` to prevent the former try/catch need.
