### PR TITLE
Bump Neo4j 5.26 -> 2025.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
     services:
       neo4j:
-        image: neo4j:5.26-enterprise
+        image: neo4j:2025.04-enterprise
         ports:
           - 7687:7687
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: neo4j:5.26-enterprise
+    image: neo4j:2025.04-enterprise
     ports:
       - 7474:7474
       - 7687:7687


### PR DESCRIPTION
Obviously, they have a new versioning schema, but this is not treated as a major.

It appears that 5.26.6 (released 2025-05-06, two days before this commit) has a regression with optional match clauses.
This upgrade is a hope to fix that.

Superceeds #3418, hopefully.