### PR TITLE
Remove/replace `isResourceClass`

### DIFF
--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -337,11 +337,6 @@ export interface EnhancedRelation<TResourceStatic extends ResourceShape<any>> {
   readonly resource?: EnhancedResource<any>;
 }
 
-export const isResourceClass = <T>(
-  cls: AbstractClassType<T>,
-): cls is ResourceShape<T> =>
-  'Props' in cls && Array.isArray(cls.Props) && cls.Props.length > 0;
-
 export type DBType<TResourceStatic extends ResourceShape<any>> =
   ResourceShape<any> extends TResourceStatic
     ? typeof e.Resource // short-circuit non-specific types

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -252,8 +252,9 @@ export class EnhancedResource<T extends ResourceShape<any>> {
         const type: ResourceShape<any> | undefined = list
           ? rawType[0]!
           : rawType;
-        const resource: EnhancedResource<any> | undefined =
-          type && isResourceClass(type) ? EnhancedResource.of(type) : undefined;
+        const resource: EnhancedResource<any> | undefined = type?.prototype
+          ? EnhancedResource.of(type)
+          : undefined;
         const rel: EnhancedRelation<T> = { name, list, type, resource };
         return [name, rel];
       }),

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -161,14 +161,20 @@ export class EnhancedResource<T extends ResourceShape<any>> {
   }
 
   /**
-   * An semi-ordered set of interfaces the resource.
+   * A semi-ordered set of interfaces the resource.
    */
   @Once()
   get interfaces(): ReadonlySet<EnhancedResource<any>> {
     return new Set(
-      getParentTypes(this.type)
-        .slice(1) // not self
-        .filter(isResourceClass)
+      getParentTypes(this.type, [])
+        .filter(
+          (cls): cls is ResourceShape<any> =>
+            // Is declared as interface. i.e. avoids DataObject.
+            GqlClassType.get(cls) === 'interface' &&
+            // Avoid intersected classes.
+            // getParentTypes will give us the intersect-ees directly.
+            !cls.name.startsWith('Intersection'),
+        )
         .map(EnhancedResource.of),
     );
   }


### PR DESCRIPTION
With `Props`/`SecuredProps` on the chopping block, we don't really a have a way at runtime to check if a class is a resource.

But really what is a "resource"? It has some kind of alignment with GQL's `Resource` interface, but it is kinda fuzzy. It really could be any class model at this point. I think this is ok. We need to facilitate some inner workings that we don't want exposed to the GraphQL schema. Models need to be registered for dynamic lookup, be used in policies, but maybe there are situations we don't want to officially declare them, with `@RegisterResource`.
Some current examples are `Pinnable`, `ChangesetAware`.

I'm not sure. I'm not sure I believe the above. Fuzziness just leads to confusion.

The alternative to this, is to just check if the resource has been registered, and force that for consistency.
Maybe that's the next step.

This at least moves us away from depending on the `Props` array.

Aside: 80a9510a4f4e12390afa10a2106d99fe5ee680e8 is in that other PR, but it contributes to this notion here.