### PR TITLE
Replace remaining direct usages of static Props/SecuredProps

### DIFF
--- a/src/components/authentication/extra-info.resolver.ts
+++ b/src/components/authentication/extra-info.resolver.ts
@@ -1,6 +1,11 @@
 import { ResolveField, Resolver } from '@nestjs/graphql';
 import { mapValues } from '@seedcompany/common';
-import { type AbstractClassType, AnonSession, type Session } from '~/common';
+import {
+  type AbstractClassType,
+  AnonSession,
+  EnhancedResource,
+  type Session,
+} from '~/common';
 import { Privileges } from '../authorization';
 import { BetaFeatures } from '../authorization/dto/beta-features.dto';
 import { LoginOutput, RegisterOutput, SessionOutput } from './dto';
@@ -13,7 +18,8 @@ function AuthExtraInfoResolver(concreteClass: AbstractClassType<any>) {
     @ResolveField(() => BetaFeatures)
     betaFeatures(@AnonSession() session: Session): BetaFeatures {
       const privileges = this.privileges.for(session, BetaFeatures);
-      return mapValues.fromList(BetaFeatures.Props, (prop) =>
+      const { props } = EnhancedResource.of(BetaFeatures);
+      return mapValues.fromList([...props], (prop) =>
         privileges.can('edit', prop),
       ).asRecord;
     }

--- a/src/components/file/media/media.dto.ts
+++ b/src/components/file/media/media.dto.ts
@@ -41,6 +41,7 @@ export const resolveMedia = (val: Pick<AnyMedia, '__typename'>) => {
 @DbLabel(null)
 export class MediaUserMetadata extends DataObject {
   static readonly Props: string[] = keysOf<MediaUserMetadata>();
+  static readonly SecuredProps: string[] = [];
 
   @NameField({
     description: stripIndent`

--- a/src/components/file/media/media.repository.ts
+++ b/src/components/file/media/media.repository.ts
@@ -84,6 +84,8 @@ export class MediaRepository extends CommonRepository {
     const res = input.__typename
       ? EnhancedResource.of(resolveMedia(input as AnyMedia))
       : undefined;
+    const metadata = EnhancedResource.of(MediaUserMetadata);
+
     const tempId = await generateId();
     const query = this.db
       .query()
@@ -147,7 +149,7 @@ export class MediaRepository extends CommonRepository {
           node: String(
             apoc.map.submap(
               apoc.map.merge('node', 'prevMedia'),
-              MediaUserMetadata.Props.map((k) => `'${k}'`),
+              [...metadata.props].map((k) => `'${k}'`),
               [],
               false,
             ),

--- a/src/components/notifications/notification.repository.ts
+++ b/src/components/notifications/notification.repository.ts
@@ -51,7 +51,7 @@ export class NotificationRepository extends CommonRepository {
     input: Record<string, any>,
     session: Session,
   ) {
-    const extra = omit(input, Notification.Props);
+    const extra = omit(input, [...EnhancedResource.of(Notification).props]);
     const res = await this.db
       .query()
       .create(

--- a/src/components/progress-report/media/dto/media.dto.ts
+++ b/src/components/progress-report/media/dto/media.dto.ts
@@ -2,6 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { setOf } from '@seedcompany/common';
 import { keys as keysOf } from 'ts-transformer-keys';
 import {
+  EnhancedResource,
   IdField,
   type IdOf,
   Resource,
@@ -27,7 +28,12 @@ export type VariantGroup = IdOf<'ProgressReportMediaVariantGroup'>;
 export class ProgressReportMedia extends Resource {
   static Props = keysOf<ProgressReportMedia>();
   static SecuredProps = keysOf<SecuredProps<ProgressReportMedia>>();
-  static BaseNodeProps = [...Resource.Props, 'category', 'creator', 'variant'];
+  static BaseNodeProps = [
+    ...EnhancedResource.of(Resource).props,
+    'category',
+    'creator',
+    'variant',
+  ];
   static readonly Parent = () =>
     import('../../dto/progress-report.dto').then((m) => m.ProgressReport);
   static readonly ConfirmThisClassPassesSensitivityToPolicies = true;

--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -12,6 +12,7 @@ import {
   DbSort,
   DbUnique,
   Disabled,
+  EnhancedResource,
   IntersectTypes,
   NameField,
   parentIdMiddleware,
@@ -86,7 +87,10 @@ const RequiredWhenNotInDev = RequiredWhen(() => Project)({
 class Project extends Interfaces {
   static readonly Props: string[] = keysOf<Project>();
   static readonly SecuredProps: string[] = keysOf<SecuredProps<Project>>();
-  static readonly BaseNodeProps = [...Resource.Props, 'type'];
+  static readonly BaseNodeProps = [
+    ...EnhancedResource.of(Resource).props,
+    'type',
+  ];
   static readonly Relations = () =>
     ({
       rootDirectory: Directory,

--- a/src/core/database/changes.ts
+++ b/src/core/database/changes.ts
@@ -129,7 +129,8 @@ export const getChanges =
       Record<Exclude<keyof Changes, keyof AnyChangesOf<TResource>>, never>,
   ): ChangesOf<TResource, Changes> => {
     const res = EnhancedResource.of(resource);
-    const actual = pickBy(omit(changes, Resource.Props), (change, prop) => {
+    const baseImmutable = [...EnhancedResource.of(Resource).props];
+    const actual = pickBy(omit(changes, baseImmutable), (change, prop) => {
       if (change === undefined) {
         return false;
       }
@@ -159,7 +160,7 @@ export const getChanges =
 
     if (
       Object.keys(actual).length > 0 &&
-      resource.Props.includes('modifiedAt') &&
+      res.props.has('modifiedAt') &&
       !(actual as any).modifiedAt
     ) {
       return {

--- a/src/core/database/common.repository.ts
+++ b/src/core/database/common.repository.ts
@@ -169,12 +169,10 @@ export class CommonRepository {
   }
 
   protected getConstraintsFor(resource: ResourceShape<any>) {
-    const { dbLabel } = EnhancedResource.of(resource);
+    const { dbLabel, props } = EnhancedResource.of(resource);
     return [
-      ...(resource.Props.includes('id')
-        ? [createUniqueConstraint(dbLabel, 'id')]
-        : []),
-      ...resource.Props.flatMap((prop) => {
+      ...(props.has('id') ? [createUniqueConstraint(dbLabel, 'id')] : []),
+      ...[...props].flatMap((prop) => {
         const label = DbUnique.get(resource, prop);
         return label
           ? createUniqueConstraint(label, 'value', `${resource.name}_${prop}`)

--- a/src/core/database/dto.repository.ts
+++ b/src/core/database/dto.repository.ts
@@ -65,8 +65,8 @@ export const DtoRepository = <
       return !exists;
     }
     @Once() private get uniqueLabel() {
-      const labels = resource.Props.flatMap(
-        (p) => DbUnique.get(resource, p) ?? [],
+      const labels = [...this.resource.props].flatMap(
+        (p: string) => DbUnique.get(resource, p) ?? [],
       );
       if (labels.length === 0) {
         return new ServerException(

--- a/src/core/database/query/sorting.ts
+++ b/src/core/database/query/sorting.ts
@@ -3,6 +3,7 @@ import { node, type Query, relation } from 'cypher-query-builder';
 import { identity } from 'rxjs';
 import { type LiteralUnion } from 'type-fest';
 import {
+  EnhancedResource,
   type MadeEnum,
   type Order,
   Resource,
@@ -146,8 +147,10 @@ export const defineSorters = <TResourceStatic extends ResourceShape<any>>(
       return { ...common, matcher: subCustom, sort: subField };
     }
 
-    const baseNodeProps = resource.BaseNodeProps ?? Resource.Props;
-    const isBaseNodeProp = baseNodeProps.includes(sort);
+    const baseNodeProps = new Set(
+      resource.BaseNodeProps ?? EnhancedResource.of(Resource).props,
+    );
+    const isBaseNodeProp = baseNodeProps.has(sort);
     const matcher = (isBaseNodeProp ? basePropSorter : propSorter)(sort);
     return { ...common, matcher };
   };


### PR DESCRIPTION
This indirection allows them to be provided in different ways, like with a transformer, or external metadata generation.

The `BaseNodeProps` stuff here is clunky. I don't like it, and it could be refined more. But it is not wide spread and maybe we just wait and delete it with Gel migration.