### PR TITLE
Fastify actually supports WhatWG/Web Responses natively as of v4.26.0

### DIFF
--- a/src/core/graphql/driver.ts
+++ b/src/core/graphql/driver.ts
@@ -78,16 +78,11 @@ export class Driver extends AbstractDriver<DriverConfig> {
     );
   }
 
-  httpHandler: FastifyRoute['handler'] = async (req, reply) => {
-    const res = await this.yoga.handleNodeRequestAndResponse(req, reply, {
+  httpHandler: FastifyRoute['handler'] = (req, reply) =>
+    this.yoga.handleNodeRequestAndResponse(req, reply, {
       req,
       response: reply,
     });
-    return await reply
-      .headers(Object.fromEntries(res.headers))
-      .status(res.status)
-      .send(res.body);
-  };
 
   /**
    * This code ties fastify, yoga, and graphql-ws together.


### PR DESCRIPTION
This just simplifies our code
