### PR TITLE
Fix PnP named range crashes

### DIFF
--- a/src/common/xlsx.util.ts
+++ b/src/common/xlsx.util.ts
@@ -57,7 +57,8 @@ export class WorkBook {
   @Once() private get namedRanges(): Record<string, Range> {
     const rawList = this.book.Workbook?.Names ?? [];
     return mapEntries(rawList, ({ Ref: ref, Name: name }, { SKIP }) => {
-      const matched = /^'?([^']+)'?!([$\dA-Z]+(?::[$\dA-Z]+)?)$/.exec(ref);
+      const matched =
+        /^(?:\[\d+])?'?([^']+)'?!([$\dA-Z]+(?::[$\dA-Z]+)?)$/.exec(ref);
       if (!matched) {
         return SKIP;
       }

--- a/src/components/product/pnp-product-sync.service.ts
+++ b/src/components/product/pnp-product-sync.service.ts
@@ -67,7 +67,7 @@ export class PnpProductSyncService {
         result,
       );
     } catch (e) {
-      this.logger.warning(e.message, {
+      this.logger.error(e.message, {
         id: pnp.id,
         exception: e,
       });


### PR DESCRIPTION
If an excel file is saved while there are multiple open, it can add internal index workbook references in named ranges (probably all formulas?)
Like:
```
[1]SheetName!A1
```
This can be safely parsed to mean `A1` on `SheetName`.
The index is an internal thing that I don't think is even presented to users in Excel, but it does leak through in our navigation tools.

Now we ignore those optional `[N]` prefixes.

We also just ignore any named ranges that correspond to nonexistent sheets now.
This will prevent an all out extract crash just from a named range that we do not care about.