### PR TITLE
[Neo4j] Migrate to currentUser global

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -198,6 +198,17 @@ const config = {
     ],
     // TODO Enable this and fix errors (both types & logic changes will be needed)
     '@typescript-eslint/no-unnecessary-condition': 'off',
+
+    // Allow unused session while we migrate
+    '@seedcompany/no-unused-vars': [
+      'warn',
+      {
+        args: 'after-used',
+        ignoreRestSiblings: true,
+        argsIgnorePattern: '(^_|^session$)',
+        varsIgnorePattern: '^_',
+      },
+    ],
   },
   overrides: [
     {

--- a/src/components/authentication/authentication.repository.ts
+++ b/src/components/authentication/authentication.repository.ts
@@ -5,8 +5,8 @@ import { type ID, ServerException, type Session } from '~/common';
 import { DatabaseService, DbTraceLayer, OnIndex } from '~/core/database';
 import {
   ACTIVE,
+  currentUser,
   matchUserGloballyScopedRoles,
-  requestingUser,
   variable,
 } from '~/core/database/query';
 import { type ScopedRole } from '../authorization/dto';
@@ -226,7 +226,7 @@ export class AuthenticationRepository {
     const result = await this.db
       .query()
       .match([
-        requestingUser(session),
+        currentUser,
         relation('out', '', 'password', ACTIVE),
         node('password', 'Property'),
       ])
@@ -243,7 +243,7 @@ export class AuthenticationRepository {
     await this.db
       .query()
       .match([
-        requestingUser(session),
+        currentUser,
         relation('out', '', 'password', ACTIVE),
         node('password', 'Property'),
       ])
@@ -331,7 +331,7 @@ export class AuthenticationRepository {
     await this.db
       .query()
       .match([
-        requestingUser(session),
+        currentUser,
         relation('out', 'oldRel', 'token', ACTIVE),
         node('token', 'Token'),
       ])

--- a/src/components/authorization/policies/conditions/member.condition.ts
+++ b/src/components/authorization/policies/conditions/member.condition.ts
@@ -2,7 +2,7 @@ import { type Query } from 'cypher-query-builder';
 import { intersection } from 'lodash';
 import { inspect, type InspectOptionsStylized } from 'util';
 import { type ResourceShape, type Role } from '~/common';
-import { matchProjectScopedRoles, variable } from '~/core/database/query';
+import { matchProjectScopedRoles } from '~/core/database/query';
 import { rolesForScope, type ScopedRole, splitScope } from '../../dto/role.dto';
 import {
   type AsCypherParams,
@@ -101,7 +101,6 @@ class MemberWithRolesCondition<TResourceStatic extends ResourceWithScope>
 
     return query.apply(
       matchProjectScopedRoles({
-        session: variable('requestingUser'),
         outputVar: CQL_VAR,
       }),
     );

--- a/src/components/authorization/policies/conditions/member.condition.ts
+++ b/src/components/authorization/policies/conditions/member.condition.ts
@@ -5,7 +5,6 @@ import { type ResourceShape, type Role } from '~/common';
 import { matchProjectScopedRoles } from '~/core/database/query';
 import { rolesForScope, type ScopedRole, splitScope } from '../../dto/role.dto';
 import {
-  type AsCypherParams,
   type AsEdgeQLParams,
   type Condition,
   eqlDoesIntersect,
@@ -32,24 +31,8 @@ class MemberCondition<TResourceStatic extends ResourceWithScope>
     return getScope(object).includes('member:true');
   }
 
-  setupCypherContext(
-    query: Query,
-    prevApplied: Set<any>,
-    other: AsCypherParams<TResourceStatic>,
-  ) {
-    if (prevApplied.has('membership')) {
-      return query;
-    }
-    prevApplied.add('membership');
-
-    const param = query.params.addParam(other.session.userId, 'requestingUser');
-    Reflect.set(other, CQL_VAR, param);
-    return query;
-  }
-
-  asCypherCondition(query: Query, other: AsCypherParams<TResourceStatic>) {
-    const requester = String(Reflect.get(other, CQL_VAR));
-    return `exists((project)-[:member { active: true }]->(:ProjectMember)-[:user]->(:User { id: ${requester} }))`;
+  asCypherCondition() {
+    return 'exists((project)-[:member { active: true }]->(:ProjectMember)-[:user]->(:User { id: $currentUser }))';
   }
 
   setupEdgeQLContext({

--- a/src/components/authorization/policies/conditions/self.condition.ts
+++ b/src/components/authorization/policies/conditions/self.condition.ts
@@ -1,16 +1,12 @@
-import { type Query } from 'cypher-query-builder';
 import { inspect, type InspectOptionsStylized } from 'util';
 import { type User } from '../../../user/dto';
 import {
-  type AsCypherParams,
   type AsEdgeQLParams,
   type Condition,
   fqnRelativeTo,
   type IsAllowedParams,
   MissingContextException,
 } from '../../policy/conditions';
-
-const CQL_VAR = 'requestingUser';
 
 class SelfCondition<TResourceStatic extends typeof User>
   implements Condition<TResourceStatic>
@@ -22,25 +18,8 @@ class SelfCondition<TResourceStatic extends typeof User>
     return object.id === session.userId;
   }
 
-  setupCypherContext(
-    query: Query,
-    prevApplied: Set<any>,
-    other: AsCypherParams<TResourceStatic>,
-  ) {
-    if (prevApplied.has('self')) {
-      return query;
-    }
-    prevApplied.add('self');
-
-    const param = query.params.addParam(other.session.userId, CQL_VAR);
-    Reflect.set(other, CQL_VAR, param);
-
-    return query;
-  }
-
-  asCypherCondition(_query: Query, other: AsCypherParams<TResourceStatic>) {
-    const requester = String(Reflect.get(other, CQL_VAR));
-    return `node:User AND node.id = ${requester}`;
+  asCypherCondition() {
+    return 'node:User AND node.id = $currentUser';
   }
 
   asEdgeQLCondition({ namespace }: AsEdgeQLParams<any>) {

--- a/src/components/budget/budget-record.repository.ts
+++ b/src/components/budget/budget-record.repository.ts
@@ -177,7 +177,7 @@ export class BudgetRecordRepository extends DtoRepository<
             node('organization', 'Organization'),
           ])
           .apply(matchChangesetAndChangedProps(view?.changeset))
-          .apply(matchPropsAndProjectSensAndScopedRoles(session, { view }))
+          .apply(matchPropsAndProjectSensAndScopedRoles({ view }))
           .return<{ dto: UnsecuredDto<BudgetRecord> }>(
             merge('props', 'changedProps', {
               parent: 'budget',

--- a/src/components/budget/budget.repository.ts
+++ b/src/components/budget/budget.repository.ts
@@ -22,7 +22,6 @@ import {
   merge,
   oncePerProject,
   paginate,
-  requestingUser,
   sorting,
 } from '~/core/database/query';
 import { type FileId } from '../file/dto';
@@ -110,7 +109,6 @@ export class BudgetRepository extends DtoRepository<
         relation('in', '', 'budget', ACTIVE),
         node('project', 'Project', pickBy({ id: filter?.projectId })),
       ])
-      .match(requestingUser(session))
       .apply(
         this.privileges.forUser(session).filterToReadable({
           wrapContext: oncePerProject,

--- a/src/components/budget/budget.repository.ts
+++ b/src/components/budget/budget.repository.ts
@@ -90,7 +90,7 @@ export class BudgetRepository extends DtoRepository<
         node('node', label),
       ])
       .where({ 'node.id': inArray(ids) })
-      .apply(matchPropsAndProjectSensAndScopedRoles(session, { view }))
+      .apply(matchPropsAndProjectSensAndScopedRoles({ view }))
       .apply(matchChangesetAndChangedProps(view?.changeset))
       .return<{ dto: UnsecuredDto<Budget> }>(
         merge('props', 'changedProps', {

--- a/src/components/ceremony/ceremony.repository.ts
+++ b/src/components/ceremony/ceremony.repository.ts
@@ -13,7 +13,6 @@ import {
   matchPropsAndProjectSensAndScopedRoles,
   oncePerProject,
   paginate,
-  requestingUser,
   sorting,
 } from '~/core/database/query';
 import {
@@ -84,7 +83,6 @@ export class CeremonyRepository extends DtoRepository<
             ]
           : []),
       ])
-      .match(requestingUser(session))
       .apply(
         this.privileges.forUser(session).filterToReadable({
           wrapContext: oncePerProject,

--- a/src/components/ceremony/ceremony.repository.ts
+++ b/src/components/ceremony/ceremony.repository.ts
@@ -64,7 +64,7 @@ export class CeremonyRepository extends DtoRepository<
           relation('out', '', ACTIVE),
           node('node'),
         ])
-        .apply(matchPropsAndProjectSensAndScopedRoles(session))
+        .apply(matchPropsAndProjectSensAndScopedRoles())
         .return<{ dto: UnsecuredDto<Ceremony> }>('props as dto');
   }
 

--- a/src/components/comments/comment-thread.repository.ts
+++ b/src/components/comments/comment-thread.repository.ts
@@ -6,6 +6,7 @@ import {
   ACTIVE,
   createNode,
   createRelationships,
+  currentUser,
   merge,
   paginate,
   sorting,
@@ -30,7 +31,7 @@ export class CommentThreadRepository extends DtoRepository(CommentThread) {
         .apply(
           createRelationships(CommentThread, {
             in: { commentThread: ['BaseNode', parent] },
-            out: { creator: ['User', session.userId] },
+            out: { creator: currentUser },
           }),
         )
         .return('node as thread');

--- a/src/components/comments/comment-thread.repository.ts
+++ b/src/components/comments/comment-thread.repository.ts
@@ -8,7 +8,6 @@ import {
   createRelationships,
   merge,
   paginate,
-  requestingUser,
   sorting,
 } from '~/core/database/query';
 import { CommentRepository } from './comment.repository';
@@ -83,7 +82,6 @@ export class CommentThreadRepository extends DtoRepository(CommentThread) {
   ) {
     const result = await this.db
       .query()
-      .match(requestingUser(session))
       .match([
         node('node', 'CommentThread'),
         ...(parent

--- a/src/components/comments/comment.repository.ts
+++ b/src/components/comments/comment.repository.ts
@@ -8,6 +8,7 @@ import {
   ACTIVE,
   createNode,
   createRelationships,
+  currentUser,
   matchProps,
   merge,
   paginate,
@@ -50,7 +51,7 @@ export class CommentRepository extends DtoRepository(Comment) {
       .apply(
         createRelationships(Comment, {
           in: { comment: variable('thread') },
-          out: { creator: ['User', session.userId] },
+          out: { creator: currentUser },
         }),
       )
       .return<{ id: ID; threadId: ID }>([

--- a/src/components/comments/comment.repository.ts
+++ b/src/components/comments/comment.repository.ts
@@ -11,7 +11,6 @@ import {
   matchProps,
   merge,
   paginate,
-  requestingUser,
   sorting,
   variable,
 } from '~/core/database/query';
@@ -92,7 +91,6 @@ export class CommentRepository extends DtoRepository(Comment) {
   async list(threadId: ID, input: CommentListInput, session: Session) {
     const result = await this.db
       .query()
-      .match(requestingUser(session))
       .match([
         node('thread', 'CommentThread', { id: threadId }),
         relation('out', '', 'comment', ACTIVE),

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -46,7 +46,6 @@ import {
   multiPropsAsSortString,
   oncePerProject,
   paginate,
-  requestingUser,
   type SortCol,
   sortWith,
   textJoinMaybe,
@@ -547,7 +546,7 @@ export class EngagementRepository extends CommonRepository {
               : q,
           ),
       )
-      .match(requestingUser(session))
+      .with('*') // needed between call & where
       .apply(engagementFilters(input.filter))
       .apply(
         this.privileges.for(session, IEngagement).filterToReadable({
@@ -857,10 +856,7 @@ export const engagementFilters = filter.define(() => EngagementFilters, {
     separateQueryForEachWord: true,
     minScore: 0.9,
   }),
-  project: filter.sub(
-    () => projectFilters,
-    'requestingUser',
-  )((sub) =>
+  project: filter.sub(() => projectFilters)((sub) =>
     sub.match([
       node('outer'),
       relation('in', '', 'engagement'),

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -132,7 +132,7 @@ export class EngagementRepository extends CommonRepository {
           relation('out', '', 'engagement'),
           node('node'),
         ])
-        .apply(matchPropsAndProjectSensAndScopedRoles(session, { view }))
+        .apply(matchPropsAndProjectSensAndScopedRoles({ view }))
         .apply(matchChangesetAndChangedProps(view?.changeset))
         .optionalMatch([
           node('node'),

--- a/src/components/field-region/field-region.repository.ts
+++ b/src/components/field-region/field-region.repository.ts
@@ -18,7 +18,6 @@ import {
   matchProps,
   merge,
   paginate,
-  requestingUser,
   sorting,
 } from '~/core/database/query';
 import {
@@ -111,7 +110,6 @@ export class FieldRegionRepository extends DtoRepository(FieldRegion) {
     }
     const result = await this.db
       .query()
-      .match(requestingUser(session))
       .match(node('node', 'FieldRegion'))
       .apply(sorting(FieldRegion, input))
       .apply(paginate(input, this.hydrate()))

--- a/src/components/field-zone/field-zone.repository.ts
+++ b/src/components/field-zone/field-zone.repository.ts
@@ -19,7 +19,6 @@ import {
   matchProps,
   merge,
   paginate,
-  requestingUser,
   sorting,
 } from '~/core/database/query';
 import {
@@ -129,7 +128,6 @@ export class FieldZoneRepository extends DtoRepository(FieldZone) {
     }
     const result = await this.db
       .query()
-      .match(requestingUser(session))
       .match(node('node', 'FieldZone'))
       .apply(sorting(FieldZone, input))
       .apply(paginate(input, this.hydrate()))

--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -27,6 +27,7 @@ import {
   createNode,
   createProperty,
   createRelationships,
+  currentUser,
   matchProps,
   merge,
   paginate,
@@ -379,7 +380,7 @@ export class FileRepository extends CommonRepository {
       .apply(await createNode(Directory, { initialProps }))
       .apply(
         createRelationships(Directory, 'out', {
-          createdBy: ['User', session.userId],
+          createdBy: currentUser,
           parent: ['Directory', parentId],
         }),
       )
@@ -417,7 +418,7 @@ export class FileRepository extends CommonRepository {
       .apply(
         createRelationships(Directory, {
           in: { [relation]: ['BaseNode', resource.id] },
-          out: { createdBy: ['User', session.userId] },
+          out: { createdBy: currentUser },
         }),
       )
       .return<{ id: ID }>('node.id as id');
@@ -458,7 +459,7 @@ export class FileRepository extends CommonRepository {
       .apply(
         createRelationships(File, {
           out: {
-            createdBy: ['User', session.userId],
+            createdBy: currentUser,
             parent: ['Directory', parentId],
           },
           in: {
@@ -501,7 +502,7 @@ export class FileRepository extends CommonRepository {
       )
       .apply(
         createRelationships(FileVersion, 'out', {
-          createdBy: ['User', session.userId],
+          createdBy: currentUser,
           parent: ['File', fileId],
         }),
       )

--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -399,13 +399,11 @@ export class FileRepository extends CommonRepository {
     relation,
     name,
     public: isPublic,
-    session,
   }: {
     resource: LinkTo<any>;
     relation: string;
     name: string;
     public?: boolean;
-    session: Session;
   }) {
     const initialProps = {
       name,

--- a/src/components/file/handlers/attach-project-root-directory.handler.ts
+++ b/src/components/file/handlers/attach-project-root-directory.handler.ts
@@ -15,7 +15,6 @@ export class AttachProjectRootDirectoryHandler
       resource: project,
       relation: 'rootDirectory',
       name: `${project.id} root directory`,
-      session,
     });
 
     event.project = {

--- a/src/components/funding-account/funding-account.repository.ts
+++ b/src/components/funding-account/funding-account.repository.ts
@@ -9,7 +9,6 @@ import {
   matchProps,
   merge,
   paginate,
-  requestingUser,
   sorting,
   variable,
 } from '~/core/database/query';
@@ -96,7 +95,6 @@ export class FundingAccountRepository extends DtoRepository(FundingAccount) {
   async list(input: FundingAccountListInput, session: Session) {
     const result = await this.db
       .query()
-      .match(requestingUser(session))
       .match(node('node', 'FundingAccount'))
       .apply(sorting(FundingAccount, input))
       .apply(paginate(input, this.hydrate()))

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -184,7 +184,7 @@ export class LanguageRepository extends DtoRepository<
           relation('out', '', 'engagement'),
           node('node'),
         ])
-        .apply(matchProjectScopedRoles({ session }))
+        .apply(matchProjectScopedRoles())
         .with([
           'node',
           'collect(project) as projList',

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -38,6 +38,7 @@ import {
   merge,
   oncePerProject,
   paginate,
+  pinned,
   propSorter,
   rankSens,
   requestingUser,
@@ -225,7 +226,7 @@ export class LanguageRepository extends DtoRepository<
           merge('props', 'changedProps', {
             __typename: '"Language"',
             ethnologue: 'ethProps',
-            pinned: 'exists((:User { id: $requestingUser })-[:pinned]->(node))',
+            pinned,
             presetInventory: 'presetInventory',
             firstScriptureEngagement: 'firstScriptureEngagement { .id }',
             scope: 'scopedRoles',

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -29,7 +29,6 @@ import {
   createNode,
   createRelationships,
   defineSorters,
-  exp,
   filter,
   FullTextIndex,
   matchChangesetAndChangedProps,
@@ -373,15 +372,11 @@ const isPresetInventory = (query: Query) =>
         ),
       })
       .return(
-        any(
-          'project',
-          collect('project'),
-          exp.path([
-            node('project'),
-            relation('out', '', 'presetInventory', ACTIVE),
-            node('', 'Property', { value: variable('true') }),
-          ]),
-        ).as('presetInventory'),
+        any('project', collect('project'), [
+          node('project'),
+          relation('out', '', 'presetInventory', ACTIVE),
+          node('', 'Property', { value: variable('true') }),
+        ]).as('presetInventory'),
       ),
   );
 

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -41,7 +41,6 @@ import {
   pinned,
   propSorter,
   rankSens,
-  requestingUser,
   sortWith,
   variable,
 } from '~/core/database/query';
@@ -246,8 +245,6 @@ export class LanguageRepository extends DtoRepository<
         relation('out', '', 'language'),
         node('node'),
       ])
-      // match requesting user once (instead of once per row)
-      .match(requestingUser(session))
       .apply(languageFilters(input.filter))
       .apply(
         this.privileges.forUser(session).filterToReadable({

--- a/src/components/organization/organization.repository.ts
+++ b/src/components/organization/organization.repository.ts
@@ -91,7 +91,7 @@ export class OrganizationRepository extends DtoRepository<
           relation('out', 'organization'),
           node('node'),
         ])
-        .apply(matchProjectScopedRoles({ session }))
+        .apply(matchProjectScopedRoles())
         .with([
           'node',
           'collect(project) as projList',

--- a/src/components/organization/organization.repository.ts
+++ b/src/components/organization/organization.repository.ts
@@ -23,7 +23,6 @@ import {
   oncePerProject,
   paginate,
   rankSens,
-  requestingUser,
   sortWith,
 } from '~/core/database/query';
 import {
@@ -125,7 +124,6 @@ export class OrganizationRepository extends DtoRepository<
     const query = this.db
       .query()
       .matchNode('node', 'Organization')
-      .match(requestingUser(session))
       .apply(organizationFilters(input.filter))
       .apply(
         this.privileges.forUser(session).filterToReadable({

--- a/src/components/partner/partner.repository.ts
+++ b/src/components/partner/partner.repository.ts
@@ -210,7 +210,7 @@ export class PartnerRepository extends DtoRepository<
           relation('out', '', 'partner'),
           node('node'),
         ])
-        .apply(matchProjectScopedRoles({ session }))
+        .apply(matchProjectScopedRoles())
         .with([
           'node',
           'collect(project) as projList',

--- a/src/components/partner/partner.repository.ts
+++ b/src/components/partner/partner.repository.ts
@@ -29,7 +29,6 @@ import {
   paginate,
   pinned,
   rankSens,
-  requestingUser,
   sortWith,
 } from '~/core/database/query';
 import * as departmentIdBlockUtils from '../finance/department/neo4j.utils';
@@ -301,7 +300,6 @@ export class PartnerRepository extends DtoRepository<
     const result = await this.db
       .query()
       .matchNode('node', 'Partner')
-      .match(requestingUser(session))
       .apply(partnerFilters(input.filter))
       .apply(
         this.privileges.forUser(session).filterToReadable({

--- a/src/components/partner/partner.repository.ts
+++ b/src/components/partner/partner.repository.ts
@@ -27,6 +27,7 @@ import {
   merge,
   oncePerProject,
   paginate,
+  pinned,
   rankSens,
   requestingUser,
   sortWith,
@@ -291,7 +292,7 @@ export class PartnerRepository extends DtoRepository<
             languagesOfConsulting: 'languagesOfConsulting',
             departmentIdBlock: 'departmentIdBlock',
             scope: 'scopedRoles',
-            pinned: 'exists((:User { id: $requestingUser })-[:pinned]->(node))',
+            pinned,
           }).as('dto'),
         );
   }

--- a/src/components/partnership/partnership.repository.ts
+++ b/src/components/partnership/partnership.repository.ts
@@ -208,7 +208,7 @@ export class PartnershipRepository extends DtoRepository<
           relation('out', '', 'organization', ACTIVE),
           node('org', 'Organization'),
         ])
-        .apply(matchPropsAndProjectSensAndScopedRoles(session, { view }))
+        .apply(matchPropsAndProjectSensAndScopedRoles({ view }))
         .apply(matchChangesetAndChangedProps(view?.changeset))
         .apply(matchProps({ nodeName: 'project', outputVar: 'projectProps' }))
         .apply(

--- a/src/components/partnership/partnership.repository.ts
+++ b/src/components/partnership/partnership.repository.ts
@@ -29,7 +29,6 @@ import {
   merge,
   oncePerProject,
   paginate,
-  requestingUser,
   sortWith,
   variable,
   whereNotDeletedInChangeset,
@@ -270,7 +269,7 @@ export class PartnershipRepository extends DtoRepository<
               : q,
           ),
       )
-      .match(requestingUser(session))
+      .with('*') // needed between call & where
       .apply(partnershipFilters(input.filter))
       .apply(
         this.privileges.forUser(session).filterToReadable({

--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -23,6 +23,7 @@ import {
   ACTIVE,
   createNode,
   createRelationships,
+  currentUser,
   defineSorters,
   deleteBaseNode,
   filter,
@@ -161,7 +162,7 @@ export class PeriodicReportRepository extends DtoRepository<
       .apply(
         createRelationships(File, {
           in: { reportFileNode: variable('report') },
-          out: { createdBy: ['User', input.session.userId] },
+          out: { createdBy: currentUser },
         }),
       )
       .return<{ id: ID; interval: Range<CalendarDate> }>(

--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -416,7 +416,7 @@ export class PeriodicReportRepository extends DtoRepository<
           relation('out', '', 'report', ACTIVE),
           node('node'),
         ])
-        .apply(matchPropsAndProjectSensAndScopedRoles(session))
+        .apply(matchPropsAndProjectSensAndScopedRoles())
         .return<{ dto: UnsecuredDto<PeriodicReport> }>(
           merge('props', { parent: 'parent' }, 'extra').as('dto'),
         );

--- a/src/components/pin/pin.repository.ts
+++ b/src/components/pin/pin.repository.ts
@@ -3,7 +3,7 @@ import { node, relation } from 'cypher-query-builder';
 import { DateTime } from 'luxon';
 import { type ID, type Session } from '~/common';
 import { DatabaseService, DbTraceLayer } from '~/core/database';
-import { requestingUser } from '~/core/database/query';
+import { currentUser } from '~/core/database/query';
 
 @Injectable()
 @DbTraceLayer.applyToClass()
@@ -14,7 +14,7 @@ export class PinRepository {
     const result = await this.db
       .query()
       .match([
-        requestingUser(session),
+        currentUser,
         relation('out', '', 'pinned'),
         node('node', 'BaseNode', { id }),
       ])
@@ -28,9 +28,9 @@ export class PinRepository {
     await this.db
       .query()
       .match(node('node', 'BaseNode', { id }))
-      .match(requestingUser(session))
+      .match(currentUser.as('currentUser'))
       .merge([
-        node('requestingUser'),
+        node('currentUser'),
         relation('out', 'rel', 'pinned'),
         node('node'),
       ])
@@ -44,7 +44,7 @@ export class PinRepository {
     await this.db
       .query()
       .match([
-        requestingUser(session),
+        currentUser,
         relation('out', 'rel', 'pinned'),
         node('node', 'BaseNode', { id }),
       ])

--- a/src/components/post/post.repository.ts
+++ b/src/components/post/post.repository.ts
@@ -102,10 +102,9 @@ export class PostRepository extends DtoRepository<typeof Post, [Session] | []>(
             ) OR (
               shareability.value = '${PostShareability.Membership}'
               AND
-              (node)<-[:post]-(:BaseNode)-[:member]-(:BaseNode)-[:user]->(:User { id: $requestingUser })
+              (node)<-[:post]-(:BaseNode)-[:member]-(:BaseNode)-[:user]->(:User { id: $currentUser })
             )
           `,
-          { requestingUser: session.userId },
         );
   }
 

--- a/src/components/post/post.repository.ts
+++ b/src/components/post/post.repository.ts
@@ -8,6 +8,7 @@ import {
   ACTIVE,
   createNode,
   createRelationships,
+  currentUser,
   matchProps,
   merge,
   paginate,
@@ -37,7 +38,7 @@ export class PostRepository extends DtoRepository<typeof Post, [Session] | []>(
             post: ['BaseNode', input.parentId],
           },
           out: {
-            creator: ['User', session.userId],
+            creator: currentUser,
           },
         }),
       )

--- a/src/components/product-progress/product-progress.repository.ts
+++ b/src/components/product-progress/product-progress.repository.ts
@@ -351,7 +351,7 @@ export class ProductProgressRepository {
         relation('in', '', 'engagement'),
         node('project', 'Project'),
       ])
-      .apply(matchProjectScopedRoles({ session, outputVar: 'scope' }))
+      .apply(matchProjectScopedRoles({ outputVar: 'scope' }))
       .apply(matchProjectSens())
       .subQuery('product', (sub) =>
         sub

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -193,7 +193,7 @@ export class ProductRepository extends CommonRepository {
           relation('out', '', 'product', ACTIVE),
           node('node'),
         ])
-        .apply(matchPropsAndProjectSensAndScopedRoles(session))
+        .apply(matchPropsAndProjectSensAndScopedRoles())
         .optionalMatch([
           node('node'),
           relation('out', '', 'unspecifiedScripture', ACTIVE),

--- a/src/components/progress-report/media/progress-report-media.repository.ts
+++ b/src/components/progress-report/media/progress-report-media.repository.ts
@@ -14,6 +14,7 @@ import {
   ACTIVE,
   createNode,
   createRelationships,
+  currentUser,
   deleteBaseNode,
   filter,
   matchProjectScopedRoles,
@@ -161,7 +162,7 @@ export class ProgressReportMediaRepository extends DtoRepository<
       )
       .apply(
         createRelationships(this.resource, 'out', {
-          creator: ['User', session.userId],
+          creator: currentUser,
         }),
       )
       .apply(

--- a/src/components/progress-report/media/progress-report-media.repository.ts
+++ b/src/components/progress-report/media/progress-report-media.repository.ts
@@ -240,7 +240,7 @@ export class ProgressReportMediaRepository extends DtoRepository<
       query
         .apply(projectFromProgressReportChild)
         .apply(matchProjectSens())
-        .apply(matchProjectScopedRoles({ session, outputVar: 'scope' }))
+        .apply(matchProjectScopedRoles({ outputVar: 'scope' }))
         .match([
           [
             node('node'),

--- a/src/components/progress-report/media/progress-report-media.repository.ts
+++ b/src/components/progress-report/media/progress-report-media.repository.ts
@@ -22,7 +22,6 @@ import {
   oncePerProject,
   paginate,
   path,
-  requestingUser,
   sorting,
   variable,
 } from '~/core/database/query';
@@ -49,7 +48,6 @@ export class ProgressReportMediaRepository extends DtoRepository<
         node('node', this.resource.dbLabel),
       ])
       .apply(progressReportMediaFilters({ variants: args.variants }))
-      .match(requestingUser(session))
       .apply(projectFromProgressReportChild)
       .apply(
         this.privileges.forUser(session).filterToReadable({
@@ -79,7 +77,6 @@ export class ProgressReportMediaRepository extends DtoRepository<
       .matchNode('node', this.resource.dbLabel)
       .where({ 'node.id': inArray(ids) })
       .apply(projectFromProgressReportChild)
-      .match(requestingUser(session))
       .apply(
         this.privileges.forUser(session).filterToReadable({
           wrapContext: oncePerProject,
@@ -112,7 +109,6 @@ export class ProgressReportMediaRepository extends DtoRepository<
           .raw('LIMIT 1'),
       )
       .apply(projectFromProgressReportChild)
-      .match(requestingUser(session))
       .apply(
         this.privileges.forUser(session).filterToReadable({
           wrapContext: oncePerProject,

--- a/src/components/progress-report/progress-report.repository.ts
+++ b/src/components/progress-report/progress-report.repository.ts
@@ -69,7 +69,7 @@ export class ProgressReportRepository extends DtoRepository<
           relation('in', '', 'engagement', ACTIVE),
           node('project', 'Project'),
         ])
-        .apply(matchPropsAndProjectSensAndScopedRoles(session))
+        .apply(matchPropsAndProjectSensAndScopedRoles())
         .subQuery('node', this.extraRepo.extraHydrate())
         .return<{ dto: UnsecuredDto<ProgressReport> }>(
           merge('props', { parent: 'parent' }, 'extra').as('dto'),

--- a/src/components/progress-report/progress-report.repository.ts
+++ b/src/components/progress-report/progress-report.repository.ts
@@ -9,7 +9,6 @@ import {
   merge,
   oncePerProject,
   paginate,
-  requestingUser,
   sortWith,
   variable,
 } from '~/core/database/query';
@@ -46,7 +45,6 @@ export class ProgressReportRepository extends DtoRepository<
         relation('in', '', 'engagement'),
         node('project', 'Project'),
       ])
-      .match(requestingUser(session))
       .apply(progressReportFilters(input.filter))
       .apply(
         this.privileges.forUser(session).filterToReadable({
@@ -100,10 +98,7 @@ export const progressReportFilters = filter.define(
         // needed in conjunction with `optionalMatch`
         .with('outer, node'),
     ),
-    engagement: filter.sub(
-      () => engagementFilters,
-      'requestingUser',
-    )((sub) =>
+    engagement: filter.sub(() => engagementFilters)((sub) =>
       sub.match([
         node('outer'),
         relation('in', '', 'report'),

--- a/src/components/progress-report/workflow/progress-report-workflow.repository.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.repository.ts
@@ -16,7 +16,6 @@ import {
   createNode,
   createRelationships,
   merge,
-  requestingUser,
   sorting,
 } from '~/core/database/query';
 import { ProgressReport, type ProgressReportStatus as Status } from '../dto';
@@ -44,7 +43,7 @@ export class ProgressReportWorkflowRepository extends DtoRepository(
       .query()
       .apply(this.matchEvent())
       .where({ 'report.id': reportId })
-      .match(requestingUser(session))
+      .with('*') // needed between where & where
       .apply(this.privileges.forUser(session).filterToReadable())
       .apply(sorting(WorkflowEvent, { sort: 'createdAt', order: Order.ASC }))
       .apply(this.hydrate())

--- a/src/components/progress-report/workflow/progress-report-workflow.repository.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.repository.ts
@@ -15,6 +15,7 @@ import {
   ACTIVE,
   createNode,
   createRelationships,
+  currentUser,
   merge,
   sorting,
 } from '~/core/database/query';
@@ -97,7 +98,7 @@ export class ProgressReportWorkflowRepository extends DtoRepository(
       .apply(
         createRelationships(WorkflowEvent, {
           in: { workflowEvent: ['ProgressReport', report] },
-          out: { who: ['User', session.userId] },
+          out: { who: currentUser },
         }),
       )
       .apply(this.hydrate())

--- a/src/components/project-change-request/project-change-request.repository.ts
+++ b/src/components/project-change-request/project-change-request.repository.ts
@@ -63,7 +63,7 @@ export class ProjectChangeRequestRepository extends DtoRepository<
           relation('in', '', 'changeset', ACTIVE),
           node('project', 'Project'),
         ])
-        .apply(matchPropsAndProjectSensAndScopedRoles(session))
+        .apply(matchPropsAndProjectSensAndScopedRoles())
         .return<{ dto: UnsecuredDto<ProjectChangeRequest> }>(
           merge('props', {
             canEdit: `props.status = "${Status.Pending}"`,

--- a/src/components/project/project-filters.query.ts
+++ b/src/components/project/project-filters.query.ts
@@ -7,6 +7,7 @@ import {
 } from 'cypher-query-builder';
 import {
   ACTIVE,
+  currentUser,
   filter,
   matchProjectSens,
   path,
@@ -28,7 +29,7 @@ export const projectFilters = filter.define(() => ProjectFilters, {
   mouStart: filter.dateTimeProp(),
   mouEnd: filter.dateTimeProp(),
   mine: filter.pathExistsWhenTrue([
-    node('requestingUser'),
+    currentUser,
     relation('in', '', 'user'),
     node('', 'ProjectMember'),
     relation('in', '', 'member'),
@@ -49,7 +50,7 @@ export const projectFilters = filter.define(() => ProjectFilters, {
     node('', 'Partner', { id }),
   ]),
   isMember: filter.pathExistsWhenTrue([
-    node('requestingUser'),
+    currentUser,
     relation('in', '', 'user'),
     node('', 'ProjectMember'),
     relation('in', '', 'member'),

--- a/src/components/project/project-member/project-member.repository.ts
+++ b/src/components/project/project-member/project-member.repository.ts
@@ -125,7 +125,7 @@ export class ProjectMemberRepository extends DtoRepository<
           relation('out', '', 'member', ACTIVE),
           node('node'),
         ])
-        .apply(matchPropsAndProjectSensAndScopedRoles(session))
+        .apply(matchPropsAndProjectSensAndScopedRoles())
         .match([
           node('node'),
           relation('out', '', 'user'),

--- a/src/components/project/project-member/project-member.repository.ts
+++ b/src/components/project/project-member/project-member.repository.ts
@@ -20,7 +20,6 @@ import {
   merge,
   oncePerProject,
   paginate,
-  requestingUser,
   sorting,
 } from '~/core/database/query';
 import { UserRepository } from '../../user/user.repository';
@@ -167,7 +166,7 @@ export class ProjectMemberRepository extends DtoRepository<
               )
           : q,
       )
-      .match(requestingUser(session))
+      .with('*') // needed between where & where
       .apply(
         this.privileges.forUser(session).filterToReadable({
           wrapContext: oncePerProject,

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -26,6 +26,7 @@ import {
   merge,
   paginate,
   path,
+  pinned,
   requestingUser,
   type SortCol,
   sortWith,
@@ -134,7 +135,7 @@ export class ProjectRepository extends CommonRepository {
         .return<{ dto: UnsecuredDto<Project> }>(
           merge('props', 'changedProps', {
             type: 'node.type',
-            pinned: 'exists((:User { id: $requestingUser })-[:pinned]->(node))',
+            pinned,
             isMember: '"member:true" in props.scope',
             rootDirectory: 'rootDirectory { .id }',
             primaryPartnership: 'primaryPartnership { .id }',

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -27,7 +27,6 @@ import {
   paginate,
   path,
   pinned,
-  requestingUser,
   type SortCol,
   sortWith,
   variable,
@@ -336,7 +335,6 @@ export class ProjectRepository extends CommonRepository {
       .query()
       .matchNode('node', 'Project')
       .with('distinct(node) as node, node as project')
-      .match(requestingUser(session))
       .apply(projectFilters(input.filter))
       .apply(this.privileges.for(session, IProject).filterToReadable())
       .apply(sortWith(projectSorters, input))

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -83,7 +83,7 @@ export class ProjectRepository extends CommonRepository {
     return (query: Query) =>
       query
         .with(['node', 'node as project'])
-        .apply(matchPropsAndProjectSensAndScopedRoles(userId))
+        .apply(matchPropsAndProjectSensAndScopedRoles())
         .apply(matchChangesetAndChangedProps(changeset))
         // optional because not defined until right after creation
         .optionalMatch([

--- a/src/components/project/workflow/project-workflow.neo4j.repository.ts
+++ b/src/components/project/workflow/project-workflow.neo4j.repository.ts
@@ -12,6 +12,7 @@ import {
   ACTIVE,
   createNode,
   createRelationships,
+  currentUser,
   INACTIVE,
   merge,
   sorting,
@@ -109,7 +110,7 @@ export class ProjectWorkflowNeo4jRepository
       .apply(
         createRelationships(WorkflowEvent, {
           in: { workflowEvent: ['Project', project] },
-          out: { who: ['Actor', session.userId] },
+          out: { who: currentUser },
         }),
       )
       .apply(this.hydrate())

--- a/src/components/project/workflow/project-workflow.neo4j.repository.ts
+++ b/src/components/project/workflow/project-workflow.neo4j.repository.ts
@@ -14,7 +14,6 @@ import {
   createRelationships,
   INACTIVE,
   merge,
-  requestingUser,
   sorting,
 } from '~/core/database/query';
 import { IProject, type ProjectStep, stepToStatus } from '../dto';
@@ -46,7 +45,7 @@ export class ProjectWorkflowNeo4jRepository
       .query()
       .apply(this.matchEvent())
       .where({ 'project.id': projectId })
-      .match(requestingUser(session))
+      .with('*') // needed between where & where
       .apply(this.privileges.forUser(session).filterToReadable())
       .apply(sorting(WorkflowEvent, { sort: 'createdAt', order: Order.ASC }))
       .apply(this.hydrate())

--- a/src/components/prompts/prompt-variant-response.repository.ts
+++ b/src/components/prompts/prompt-variant-response.repository.ts
@@ -25,7 +25,6 @@ import {
   paginate,
   prefixNodeLabelsWithDeleted,
   type QueryFragment,
-  requestingUser,
   sorting,
   updateProperty,
   variable,
@@ -94,7 +93,6 @@ export const PromptVariantResponseRepository = <
     protected hydrate(session: Session) {
       return (query: Query) =>
         query
-          .match(requestingUser(session))
           .apply(this.filterToReadable(session))
           .match([
             node('parent', 'BaseNode'),

--- a/src/components/prompts/prompt-variant-response.repository.ts
+++ b/src/components/prompts/prompt-variant-response.repository.ts
@@ -20,6 +20,7 @@ import {
   ACTIVE,
   createNode,
   createRelationships,
+  currentUser,
   defaultPermanentAfter,
   merge,
   paginate,
@@ -163,7 +164,7 @@ export const PromptVariantResponseRepository = <
               child: ['BaseNode', input.resource],
             },
             out: {
-              creator: ['User', session.userId],
+              creator: currentUser,
             },
           }),
         )
@@ -222,7 +223,7 @@ export const PromptVariantResponseRepository = <
                       child: variable('parent'),
                     },
                     out: {
-                      creator: ['User', session.userId],
+                      creator: currentUser,
                     },
                   }),
                 )

--- a/src/components/user/user.repository.ts
+++ b/src/components/user/user.repository.ts
@@ -27,7 +27,6 @@ import {
   path,
   pinned,
   property,
-  requestingUser,
   type SortCol,
   sortWith,
 } from '~/core/database/query';
@@ -128,7 +127,7 @@ export class UserRepository extends DtoRepository<typeof User, [Session | ID]>(
     return await this.readOne(id, id);
   }
 
-  protected hydrate(requestingUserId: Session | ID) {
+  protected hydrate(_: Session | ID) {
     return (query: Query) =>
       query
         .subQuery('node', (sub) =>
@@ -141,7 +140,6 @@ export class UserRepository extends DtoRepository<typeof User, [Session | ID]>(
             .return('collect(role.value) as roles'),
         )
         .apply(matchProps())
-        .match(requestingUser(requestingUserId))
         .return<{ dto: UnsecuredDto<User> }>(
           merge({ email: null }, 'props', {
             __typename: '"User"',
@@ -230,7 +228,6 @@ export class UserRepository extends DtoRepository<typeof User, [Session | ID]>(
     const result = await this.db
       .query()
       .matchNode('node', 'User')
-      .match(requestingUser(session))
       .apply(userFilters(input.filter))
       .apply(this.privileges.forUser(session).filterToReadable())
       .apply(sortWith(userSorters, input))

--- a/src/components/user/user.repository.ts
+++ b/src/components/user/user.repository.ts
@@ -25,6 +25,7 @@ import {
   multiPropsAsSortString,
   paginate,
   path,
+  pinned,
   property,
   requestingUser,
   type SortCol,
@@ -145,7 +146,7 @@ export class UserRepository extends DtoRepository<typeof User, [Session | ID]>(
           merge({ email: null }, 'props', {
             __typename: '"User"',
             roles: 'roles',
-            pinned: 'exists((requestingUser)-[:pinned]->(node))',
+            pinned,
           }).as('dto'),
         );
   }

--- a/src/core/database/query/create-relationships.ts
+++ b/src/core/database/query/create-relationships.ts
@@ -107,6 +107,8 @@ export function createRelationships<TResourceStatic extends ResourceShape<any>>(
             variable: !Array.isArray(varOrTuple)
               ? varOrTuple instanceof Variable
                 ? varOrTuple.value
+                : currentUser.is(varOrTuple)
+                ? relLabel
                 : undefined
               : Array.isArray(varOrTuple[1])
               ? `${relLabel}${i}`
@@ -156,8 +158,8 @@ export function createRelationships<TResourceStatic extends ResourceShape<any>>(
             flattened.map(({ variable, nodeLabel, id }) =>
               id instanceof Variable
                 ? []
-                : id === currentUser
-                ? [currentUser]
+                : currentUser.is(id)
+                ? [id.as(variable!)]
                 : [node(variable, nodeLabel, { id })],
             ),
           )

--- a/src/core/database/query/cypher-functions.ts
+++ b/src/core/database/query/cypher-functions.ts
@@ -46,6 +46,8 @@ export const count = fn1('count');
  */
 export const coalesce = fn('coalesce');
 
+export const exists = fn1('exists');
+
 /**
  * Merges maps together.
  * Note: If one expression is given, it is assumed to be a list.

--- a/src/core/database/query/filters.test.ts
+++ b/src/core/database/query/filters.test.ts
@@ -1,4 +1,6 @@
-import { comparisonOfDateTimeFilter } from './filters';
+import { filter } from './index';
+
+const { comparisonOfDateTimeFilter } = filter;
 
 describe('filters', () => {
   describe('comparisonOfDateTimeFilter', () => {

--- a/src/core/database/query/filters.ts
+++ b/src/core/database/query/filters.ts
@@ -25,7 +25,7 @@ import { variable } from '../query-augmentation/condition-variables';
 import { intersects } from './comparators';
 import { collect } from './cypher-functions';
 import { escapeLuceneSyntax, type FullTextIndex } from './full-text';
-import { ACTIVE } from './matching';
+import { ACTIVE, currentUser } from './matching';
 import { path as pathPattern } from './where-path';
 
 export type Builder<T, K extends keyof T = keyof T> = (
@@ -175,7 +175,7 @@ export const pathExistsWhenTrue: typeof pathExists = (pattern) => (args) =>
   args.value ? pathExists(pattern)(args) : null;
 
 export const isPinned = pathExists<{ pinned?: boolean }, 'pinned'>([
-  node('requestingUser'),
+  currentUser,
   relation('out', '', 'pinned'),
   node('node'),
 ]);

--- a/src/core/database/query/match-project-based-props.ts
+++ b/src/core/database/query/match-project-based-props.ts
@@ -172,7 +172,7 @@ export const oncePerProject =
   (logic: QueryFragment): QueryFragment =>
   (query) =>
     query
-      .with(['project', 'collect(node) as nodeList', 'requestingUser'])
+      .with(['project', 'collect(node) as nodeList'])
       .apply(logic)
       .raw('UNWIND nodeList as node');
 

--- a/src/core/database/query/match-project-based-props.ts
+++ b/src/core/database/query/match-project-based-props.ts
@@ -1,11 +1,7 @@
 import { oneLine } from 'common-tags';
 import { node, type Query, relation } from 'cypher-query-builder';
-import { type ID, type Sensitivity, type Session } from '~/common';
-import {
-  type QueryFragment,
-  requestingUser,
-  Variable,
-} from '~/core/database/query';
+import { type Sensitivity } from '~/common';
+import { type QueryFragment } from '~/core/database/query';
 import {
   type GlobalScopedRole,
   type ScopedRole,
@@ -19,20 +15,21 @@ import {
   merge,
   reduce,
 } from './cypher-functions';
-import { ACTIVE, matchProps, type MatchPropsOptions } from './matching';
+import {
+  ACTIVE,
+  currentUser,
+  matchProps,
+  type MatchPropsOptions,
+} from './matching';
 
 export const matchPropsAndProjectSensAndScopedRoles =
-  (session?: Session | ID | Variable, propsOptions?: MatchPropsOptions) =>
+  (propsOptions?: MatchPropsOptions) =>
   <R>(query: Query<R>) =>
     query.comment`
       matchPropsAndProjectSensAndScopedRoles()
     `.subQuery((sub) =>
       sub
-        .with([
-          'node',
-          'project',
-          ...(session instanceof Variable ? [session.name] : []),
-        ])
+        .with(['node', 'project'])
         .apply(matchProjectSens('project'))
         .apply(
           matchProps(
@@ -41,66 +38,58 @@ export const matchPropsAndProjectSensAndScopedRoles =
               : { ...propsOptions, view: { active: true } },
           ),
         )
-        .apply((q) =>
-          !session ? q : q.apply(matchProjectScopedRoles({ session })),
-        )
+        .apply(matchProjectScopedRoles())
         .return([
           merge(propsOptions?.outputVar ?? 'props', {
             sensitivity: 'sensitivity',
-            scope: session ? `scopedRoles` : null,
+            scope: 'scopedRoles',
           }).as(propsOptions?.outputVar ?? 'props'),
         ]),
     );
 
 export const matchProjectScopedRoles =
   <Output extends string = 'scopedRoles'>({
-    session,
     projectVar = 'project',
     outputVar = 'scopedRoles' as Output,
   }: {
-    session: Session | ID | Variable;
     projectVar?: string;
     outputVar?: Output;
-  }) =>
+  } = {}) =>
   <R>(query: Query<R>) =>
-    query.comment`matchProjectScopedRoles()`.subQuery(
-      [projectVar, session instanceof Variable ? session : null],
-      (sub) =>
-        sub
-          .match([
-            [
-              node(projectVar),
-              relation('out', '', 'member'),
-              node('projectMember'),
-              relation('out', '', 'user'),
-              session instanceof Variable
-                ? node(session.name)
-                : requestingUser(session),
-            ],
-            [
-              node('projectMember'),
-              relation('out', '', 'roles', ACTIVE),
-              node('rolesProp', 'Property'),
-            ],
-          ])
-          .with(collect('rolesProp.value').as('memberRoleProps'))
-          .return<{ [K in Output]: ScopedRole[] }>(
-            listConcat(
-              'case size(memberRoleProps) > 0 when true then ["member:true"] else [] end',
-              reduce(
-                'scopedRoles',
-                [],
-                apoc.coll.flatten('memberRoleProps'),
-                'role',
-                listConcat('scopedRoles', [`"project:" + role`]),
-              ),
-            ).as(outputVar),
-          )
-          .union()
-          .with('project')
-          .with('project')
-          .raw('WHERE project IS NULL')
-          .return(`[] as ${outputVar}`),
+    query.comment`matchProjectScopedRoles()`.subQuery([projectVar], (sub) =>
+      sub
+        .match([
+          [
+            node(projectVar),
+            relation('out', '', 'member'),
+            node('projectMember'),
+            relation('out', '', 'user'),
+            currentUser,
+          ],
+          [
+            node('projectMember'),
+            relation('out', '', 'roles', ACTIVE),
+            node('rolesProp', 'Property'),
+          ],
+        ])
+        .with(collect('rolesProp.value').as('memberRoleProps'))
+        .return<{ [K in Output]: ScopedRole[] }>(
+          listConcat(
+            'case size(memberRoleProps) > 0 when true then ["member:true"] else [] end',
+            reduce(
+              'scopedRoles',
+              [],
+              apoc.coll.flatten('memberRoleProps'),
+              'role',
+              listConcat('scopedRoles', [`"project:" + role`]),
+            ),
+          ).as(outputVar),
+        )
+        .union()
+        .with('project')
+        .with('project')
+        .raw('WHERE project IS NULL')
+        .return(`[] as ${outputVar}`),
     );
 
 export const matchProjectSens =
@@ -155,7 +144,7 @@ export const matchProjectSens =
 
 export const matchUserGloballyScopedRoles =
   <Output extends string = 'scopedRoles'>(
-    userVar = 'requestingUser',
+    userVar: string,
     outputVar = 'globalRoles' as Output,
   ) =>
   <R>(query: Query<R>) =>

--- a/src/core/database/query/matching.ts
+++ b/src/core/database/query/matching.ts
@@ -7,15 +7,7 @@ import {
 import { uniq } from 'lodash';
 import { DateTime } from 'luxon';
 import { type Tagged } from 'type-fest';
-import {
-  type ID,
-  isIdLike,
-  labelForView,
-  many,
-  type Many,
-  type ObjectView,
-  type Session,
-} from '~/common';
+import { labelForView, many, type Many, type ObjectView } from '~/common';
 import { variable } from '../query-augmentation/condition-variables';
 import { apoc, collect, exists, listConcat, merge } from './cypher-functions';
 
@@ -34,16 +26,6 @@ const makeCurrentUser = (name: string) =>
     },
   );
 export const currentUser = makeCurrentUser('');
-
-export const requestingUser = (session?: Session | ID) => {
-  const n = node('requestingUser', 'User', {
-    id: variable(session ? '$requestingUser' : '$currentUser'),
-  });
-  if (session) {
-    n.addParam(isIdLike(session) ? session : session.userId, 'requestingUser');
-  }
-  return n;
-};
 
 /**
  * Same as `{ active: true }` but it doesn't create a bound parameter

--- a/src/core/database/query/matching.ts
+++ b/src/core/database/query/matching.ts
@@ -19,9 +19,21 @@ import {
 import { variable } from '../query-augmentation/condition-variables';
 import { apoc, collect, listConcat, merge } from './cypher-functions';
 
-export const currentUser = node('currentUser', 'User', {
-  id: variable('$currentUser'),
-}) as Tagged<NodePattern, 'CurrentUser'>;
+const currentUserFlag = Symbol();
+const makeCurrentUser = (name: string) =>
+  Object.assign(
+    Object.defineProperty(
+      node(name, 'User', { id: variable('$currentUser') }),
+      currentUserFlag,
+      {},
+    ) as Tagged<NodePattern, 'CurrentUser'>,
+    {
+      as: makeCurrentUser,
+      is: (obj: object): obj is typeof currentUser =>
+        Object.hasOwn(obj, currentUserFlag),
+    },
+  );
+export const currentUser = makeCurrentUser('');
 
 export const requestingUser = (session?: Session | ID) => {
   const n = node('requestingUser', 'User', {

--- a/src/core/database/query/matching.ts
+++ b/src/core/database/query/matching.ts
@@ -17,7 +17,7 @@ import {
   type Session,
 } from '~/common';
 import { variable } from '../query-augmentation/condition-variables';
-import { apoc, collect, listConcat, merge } from './cypher-functions';
+import { apoc, collect, exists, listConcat, merge } from './cypher-functions';
 
 const currentUserFlag = Symbol();
 const makeCurrentUser = (name: string) =>
@@ -146,3 +146,9 @@ export const property = (
     }),
   ],
 ];
+
+export const pinned = exists([
+  currentUser,
+  relation('out', '', 'pinned'),
+  node('node'),
+]);


### PR DESCRIPTION
Following up on #3427

This replaces all cypher queries to use the currentUser global, and not reference session directly.