### PR TITLE
Fix inheritance on ID/ResourceName types

### DIFF
--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -220,7 +220,9 @@ export { Project as IProject, type AnyProject as Project };
   resolveType: resolveProjectType,
   implements: [Project],
 })
-export class TranslationProject extends Project {}
+export class TranslationProject extends Project {
+  declare readonly type: 'MultiplicationTranslation' | 'MomentumTranslation';
+}
 
 @RegisterResource({ db: e.MomentumTranslationProject })
 @ObjectType({

--- a/src/components/user/dto/actor.dto.ts
+++ b/src/components/user/dto/actor.dto.ts
@@ -19,6 +19,8 @@ import { e } from '~/core/gel';
   resolveType: resolveByTypename(Actor.name),
 })
 export class Actor extends DataObject {
+  declare readonly __typename: 'User' | 'SystemAgent';
+
   @IdField()
   readonly id: ID;
 }
@@ -31,7 +33,7 @@ export class Actor extends DataObject {
   implements: [Actor],
 })
 export abstract class SystemAgent extends Actor {
-  __typename?: 'SystemAgent';
+  declare readonly __typename: 'SystemAgent';
 
   @NameField()
   readonly name: string;

--- a/src/components/user/dto/user.dto.ts
+++ b/src/components/user/dto/user.dto.ts
@@ -45,6 +45,8 @@ export class User extends Interfaces {
       ...Commentable.Relations,
     } satisfies ResourceRelationsShape);
 
+  declare readonly __typename: 'User';
+
   @Field()
   @DbUnique('EmailAddress')
   email: SecuredStringNullable;

--- a/src/components/user/system-agent.neo4j.repository.ts
+++ b/src/components/user/system-agent.neo4j.repository.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { node } from 'cypher-query-builder';
-import { type ID, type Role } from '~/common';
+import { type Role } from '~/common';
 import { DatabaseService } from '~/core/database';
+import { merge } from '~/core/database/query';
+import { type SystemAgent } from './dto';
 import { SystemAgentRepository } from './system-agent.repository';
 
 @Injectable()
@@ -22,8 +24,8 @@ export class SystemAgentNeo4jRepository extends SystemAgentRepository {
           'agent.roles': roles ?? [],
         },
       })
-      .return<{ agent: { id: ID; name: string; roles: readonly Role[] } }>(
-        'apoc.convert.toMap(agent) AS agent',
+      .return<{ agent: SystemAgent }>(
+        merge('agent', { __typename: '"SystemAgent"' }).as('agent'),
       )
       .first();
     return res!.agent;

--- a/src/core/resources/resource-name.types.ts
+++ b/src/core/resources/resource-name.types.ts
@@ -65,15 +65,21 @@ type ResourceNameFromStatic<
   IncludeSubclasses extends boolean = false,
 > = ResourceShape<any> extends TResourceStatic
   ? string // short-circuit non-specific types
-  : {
-      [Name in keyof ResourceMap]: ResourceMap[Name] extends TResourceStatic // Only self or subclasses
-        ? IncludeSubclasses extends true
-          ? Name
-          : TResourceStatic extends ResourceMap[Name] // Exclude subclasses
-          ? Name
+  : InstanceType<TResourceStatic> extends infer TResource
+  ? {
+      [Name in keyof ResourceMap]: InstanceType<
+        ResourceMap[Name]
+      > extends infer Other
+        ? Other extends TResource // Only self or subclasses
+          ? IncludeSubclasses extends true
+            ? Name
+            : TResource extends Other // Exclude subclasses
+            ? Name
+            : never
           : never
         : never;
-    }[keyof ResourceMap];
+    }[keyof ResourceMap]
+  : never;
 
 type ResourceNameFromDBName<Name extends AllResourceDBNames> =
   // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
I think this must've changed when we removed the static `Props` declarations.
Previously comparing static types worked, probably because of the static `Props` list.

Now comparing instance types appears to work, which seems more correct anyway.

However, this uses duck typing / shape matching, not actual inheritance.
So we had a problem with `Pinnable` & `Actor`, both of which only require an `id` prop.
I "fixed", worked around this by declaring the `__typename` string literals for `Actor`/`User`/`SystemAgent`.
This is more feasible than enumerating the concrete types of `Pinnable` & doing the same on them.
It's working now, but not the most stable situation to be in. Will continue pondering other ways to address this.