### PR TITLE
Authentication `Identity` facade service

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -49,7 +49,7 @@ export * from './secured-mapper';
 export * from './sensitivity.enum';
 export * from './trace-layer';
 export * from './util';
-export { type Session, LoggedInSession, AnonSession } from './session';
+export { type Session } from './session';
 export * from './types';
 export * from './validators';
 export * from './name-field';

--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -6,7 +6,6 @@ import {
 } from '@nestjs/common';
 import { CONTROLLER_WATERMARK } from '@nestjs/common/constants.js';
 import { Context } from '@nestjs/graphql';
-import { uniq } from 'lodash';
 import { type DateTime } from 'luxon';
 import { Identity } from '~/core/authentication';
 import { type ScopedRole } from '../components/authorization/dto';
@@ -70,11 +69,3 @@ export const AnonSession =
 
 const SessionWatermark: ParameterDecorator = (target, key) =>
   Reflect.defineMetadata('SESSION_WATERMARK', true, target.constructor, key!);
-
-export const addScope = (session: Session, scope?: ScopedRole[]) => ({
-  ...session,
-  roles: uniq([...session.roles, ...(scope ?? [])]),
-});
-
-export const isAdmin = (session: Session) =>
-  session.roles.includes('global:Administrator');

--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -8,7 +8,7 @@ import { CONTROLLER_WATERMARK } from '@nestjs/common/constants.js';
 import { Context } from '@nestjs/graphql';
 import { uniq } from 'lodash';
 import { type DateTime } from 'luxon';
-import { SessionHost } from '../components/authentication/session.host';
+import { Identity } from '~/core/authentication';
 import { type ScopedRole } from '../components/authorization/dto';
 import { UnauthenticatedException } from './exceptions';
 import { type ID } from './id-field';
@@ -42,10 +42,10 @@ export function loggedInSession(session: Session): Session {
 
 @Injectable()
 export class SessionPipe implements PipeTransform {
-  constructor(private readonly sessionHost: SessionHost) {}
+  constructor(private readonly identity: Identity) {}
 
   transform() {
-    return this.sessionHost.currentMaybe;
+    return this.identity.currentMaybe;
   }
 }
 

--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -1,13 +1,4 @@
-import {
-  Injectable,
-  Param,
-  type PipeTransform,
-  type Type,
-} from '@nestjs/common';
-import { CONTROLLER_WATERMARK } from '@nestjs/common/constants.js';
-import { Context } from '@nestjs/graphql';
 import { type DateTime } from 'luxon';
-import { Identity } from '~/core/authentication';
 import { type ScopedRole } from '../components/authorization/dto';
 import { type ID } from './id-field';
 
@@ -30,33 +21,3 @@ export interface Session {
     roles: readonly ScopedRole[];
   };
 }
-
-@Injectable()
-export class SessionPipe implements PipeTransform {
-  constructor(private readonly identity: Identity) {}
-
-  transform() {
-    return this.identity.currentMaybe;
-  }
-}
-
-/** @deprecated */
-export const LoggedInSession = () => AnonSession();
-
-/** @deprecated */
-export const AnonSession =
-  (...pipes: Array<Type<PipeTransform> | PipeTransform>): ParameterDecorator =>
-  (...args) => {
-    Context(SessionPipe, ...pipes)(...args);
-    process.nextTick(() => {
-      // Only set this metadata if it's a controller method.
-      // Waiting for the next tick as class decorators execute after methods.
-      if (Reflect.getMetadata(CONTROLLER_WATERMARK, args[0].constructor)) {
-        Param(SessionPipe, ...pipes)(...args);
-        SessionWatermark(...args);
-      }
-    });
-  };
-
-const SessionWatermark: ParameterDecorator = (target, key) =>
-  Reflect.defineMetadata('SESSION_WATERMARK', true, target.constructor, key!);

--- a/src/common/session.ts
+++ b/src/common/session.ts
@@ -9,7 +9,6 @@ import { Context } from '@nestjs/graphql';
 import { type DateTime } from 'luxon';
 import { Identity } from '~/core/authentication';
 import { type ScopedRole } from '../components/authorization/dto';
-import { UnauthenticatedException } from './exceptions';
 import { type ID } from './id-field';
 
 export interface Session {
@@ -32,13 +31,6 @@ export interface Session {
   };
 }
 
-export function loggedInSession(session: Session): Session {
-  if (session.anonymous) {
-    throw new UnauthenticatedException('User is not logged in');
-  }
-  return session;
-}
-
 @Injectable()
 export class SessionPipe implements PipeTransform {
   constructor(private readonly identity: Identity) {}
@@ -49,8 +41,7 @@ export class SessionPipe implements PipeTransform {
 }
 
 /** @deprecated */
-export const LoggedInSession = () =>
-  AnonSession({ transform: loggedInSession });
+export const LoggedInSession = () => AnonSession();
 
 /** @deprecated */
 export const AnonSession =

--- a/src/components/authentication/authentication.module.ts
+++ b/src/components/authentication/authentication.module.ts
@@ -2,6 +2,7 @@ import { forwardRef, Global, Module } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { SessionPipe } from '~/common/session';
 import { splitDb } from '~/core';
+import { Identity } from '~/core/authentication';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { UserModule } from '../user/user.module';
 import { AuthenticationGelRepository } from './authentication.gel.repository';
@@ -34,6 +35,7 @@ import { SessionResolver } from './session.resolver';
     SessionExtraInfoResolver,
     LoginExtraInfoResolver,
     RegisterExtraInfoResolver,
+    Identity,
     AuthenticationService,
     splitDb(AuthenticationRepository, AuthenticationGelRepository),
     { provide: 'AUTHENTICATION', useExisting: AuthenticationService },
@@ -44,6 +46,7 @@ import { SessionResolver } from './session.resolver';
     SessionPipe,
   ],
   exports: [
+    Identity,
     SessionHost,
     SessionInterceptor,
     AuthenticationService,

--- a/src/components/authentication/authentication.module.ts
+++ b/src/components/authentication/authentication.module.ts
@@ -1,6 +1,5 @@
 import { forwardRef, Global, Module } from '@nestjs/common';
 import { APP_INTERCEPTOR } from '@nestjs/core';
-import { SessionPipe } from '~/common/session';
 import { splitDb } from '~/core';
 import { Identity } from '~/core/authentication';
 import { AuthorizationModule } from '../authorization/authorization.module';
@@ -43,7 +42,6 @@ import { SessionResolver } from './session.resolver';
     SessionInterceptor,
     { provide: APP_INTERCEPTOR, useExisting: SessionInterceptor },
     { provide: SessionHost, useClass: SessionHostImpl },
-    SessionPipe,
   ],
   exports: [
     Identity,

--- a/src/components/authentication/authentication.service.ts
+++ b/src/components/authentication/authentication.service.ts
@@ -256,6 +256,17 @@ export class AuthenticationService {
     return session;
   }
 
+  asRole<R>(role: Role, fn: () => R): R {
+    const session: Session = {
+      token: 'system',
+      issuedAt: DateTime.now(),
+      userId: 'anonymous' as ID,
+      anonymous: false,
+      roles: [`global:${role}`],
+    };
+    return this.sessionHost.withSession(session, fn);
+  }
+
   async changePassword(
     oldPassword: string,
     newPassword: string,

--- a/src/components/authentication/extra-info.resolver.ts
+++ b/src/components/authentication/extra-info.resolver.ts
@@ -1,11 +1,6 @@
 import { ResolveField, Resolver } from '@nestjs/graphql';
 import { mapValues } from '@seedcompany/common';
-import {
-  type AbstractClassType,
-  AnonSession,
-  EnhancedResource,
-  type Session,
-} from '~/common';
+import { type AbstractClassType, EnhancedResource } from '~/common';
 import { Privileges } from '../authorization';
 import { BetaFeatures } from '../authorization/dto/beta-features.dto';
 import { LoginOutput, RegisterOutput, SessionOutput } from './dto';
@@ -16,7 +11,7 @@ function AuthExtraInfoResolver(concreteClass: AbstractClassType<any>) {
     constructor(private readonly privileges: Privileges) {}
 
     @ResolveField(() => BetaFeatures)
-    betaFeatures(@AnonSession() session: Session): BetaFeatures {
+    betaFeatures(): BetaFeatures {
       const privileges = this.privileges.for(BetaFeatures);
       const { props } = EnhancedResource.of(BetaFeatures);
       return mapValues.fromList([...props], (prop) =>

--- a/src/components/authentication/login.resolver.ts
+++ b/src/components/authentication/login.resolver.ts
@@ -6,7 +6,6 @@ import {
   Resolver,
 } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
-import { AnonSession, type Session } from '~/common';
 import { Loader, type LoaderOf } from '~/core';
 import { Privileges } from '../authorization';
 import { Power } from '../authorization/dto';
@@ -15,11 +14,13 @@ import { User } from '../user/dto';
 import { Anonymous } from './anonymous.decorator';
 import { AuthenticationService } from './authentication.service';
 import { LoginInput, LoginOutput, LogoutOutput } from './dto';
+import { SessionHost } from './session.host';
 
 @Resolver(LoginOutput)
 export class LoginResolver {
   constructor(
     private readonly authentication: AuthenticationService,
+    private readonly sessionHost: SessionHost,
     private readonly privileges: Privileges,
   ) {}
 
@@ -43,7 +44,8 @@ export class LoginResolver {
     `,
   })
   @Anonymous()
-  async logout(@AnonSession() session: Session): Promise<LogoutOutput> {
+  async logout(): Promise<LogoutOutput> {
+    const session = this.sessionHost.current;
     await this.authentication.logout(session.token);
     await this.authentication.refreshCurrentSession(); // ensure session data is fresh
     return { success: true };

--- a/src/components/authentication/session.interceptor.ts
+++ b/src/components/authentication/session.interceptor.ts
@@ -21,8 +21,8 @@ import {
   type Session,
   UnauthenticatedException,
 } from '~/common';
-import { loggedInSession as verifyLoggedIn } from '~/common/session';
 import { ConfigService } from '~/core';
+import { Identity } from '~/core/authentication';
 import { GlobalHttpHook, type IRequest } from '~/core/http';
 import { rolesForScope } from '../authorization/dto';
 import { Anonymous } from './anonymous.decorator';
@@ -36,6 +36,7 @@ export class SessionInterceptor implements NestInterceptor {
     private readonly auth: AuthenticationService & {},
     private readonly config: ConfigService,
     private readonly sessionHost: SessionHost,
+    private readonly identity: Identity,
   ) {}
 
   private readonly sessionByRequest = new AsyncLocalStorage<
@@ -85,7 +86,7 @@ export class SessionInterceptor implements NestInterceptor {
       Anonymous.get(executionContext.getClass()) ??
       !isMutation;
     if (!allowAnonymous && session) {
-      verifyLoggedIn(session);
+      this.identity.verifyLoggedIn();
     }
 
     return next.handle();

--- a/src/components/authorization/policy/executor/edge-privileges.ts
+++ b/src/components/authorization/policy/executor/edge-privileges.ts
@@ -57,7 +57,7 @@ export class EdgePrivileges<
       : perm.isAllowed({
           object: this.object,
           resource: this.resource,
-          session: this.policyExecutor.sessionHost.current,
+          session: this.policyExecutor.identity.current,
         });
   }
 

--- a/src/components/authorization/policy/executor/policy-dumper.ts
+++ b/src/components/authorization/policy/executor/policy-dumper.ts
@@ -28,7 +28,8 @@ import {
   type Session,
 } from '~/common';
 import { searchCamelCase } from '~/common/search-camel-case';
-import { InjectableCommand, type ResourceLike, ResourcesHost } from '~/core';
+import { InjectableCommand } from '~/core/cli';
+import { type ResourceLike, ResourcesHost } from '~/core/resources';
 import {
   ChildListAction,
   ChildSingleAction,

--- a/src/components/authorization/policy/executor/policy-executor.ts
+++ b/src/components/authorization/policy/executor/policy-executor.ts
@@ -2,8 +2,8 @@ import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { CachedByArg } from '@seedcompany/common';
 import { identity, intersection } from 'lodash';
 import { type EnhancedResource, type Session } from '~/common';
+import { Identity } from '~/core/authentication';
 import { type QueryFragment } from '~/core/database/query';
-import { SessionHost } from '../../../authentication/session.host';
 import { withoutScope } from '../../dto';
 import { RoleCondition } from '../../policies/conditions/role.condition';
 import { type Permission } from '../builder/perm-granter';
@@ -40,7 +40,7 @@ export interface FilterOptions {
 @Injectable()
 export class PolicyExecutor {
   constructor(
-    readonly sessionHost: SessionHost,
+    readonly identity: Identity,
     private readonly policyFactory: PolicyFactory,
     @Inject(forwardRef(() => ConditionOptimizer))
     private readonly conditionOptimizer: ConditionOptimizer & {},
@@ -64,7 +64,7 @@ export class PolicyExecutor {
       }
     }
 
-    const session = this.sessionHost.current;
+    const session = this.identity.current;
     const policies = this.getPolicies(session);
     const isChildRelation = prop && resource.childKeys.has(prop);
 
@@ -187,7 +187,7 @@ export class PolicyExecutor {
 
       const other = {
         resource: params.resource,
-        session: this.sessionHost.current,
+        session: this.identity.current,
       };
       return query
         .comment("Loading policy condition's context")

--- a/src/components/authorization/policy/executor/privileges.ts
+++ b/src/components/authorization/policy/executor/privileges.ts
@@ -6,7 +6,7 @@ import {
   type ResourceShape,
   type SecuredPropsPlusExtraKey,
 } from '~/common';
-import { SessionHost } from '../../../authentication/session.host';
+import { Identity } from '~/core/authentication';
 import type { Power } from '../../dto';
 import { MissingPowerException } from '../../missing-power.exception';
 import {
@@ -23,7 +23,7 @@ import { ResourcePrivileges } from './resource-privileges';
 export class Privileges {
   constructor(
     private readonly policyExecutor: PolicyExecutor,
-    private readonly sessionHost: SessionHost,
+    private readonly identity: Identity,
   ) {}
 
   forResource<TResourceStatic extends ResourceShape<any>>(
@@ -90,7 +90,7 @@ export class Privileges {
    * I think this should be replaced in-app code with `.for(X).verifyCan('create')`
    */
   verifyPower(power: Power) {
-    const session = this.sessionHost.current;
+    const session = this.identity.current;
     if (!this.powers.has(power)) {
       throw new MissingPowerException(
         power,
@@ -102,7 +102,7 @@ export class Privileges {
   }
 
   get powers(): Set<Power> {
-    const session = this.sessionHost.current;
+    const session = this.identity.current;
     const policies = this.policyExecutor.getPolicies(session);
     return new Set(policies.flatMap((policy) => [...policy.powers]));
   }

--- a/src/components/authorization/policy/executor/resource-privileges.ts
+++ b/src/components/authorization/policy/executor/resource-privileges.ts
@@ -106,7 +106,7 @@ export class ResourcePrivileges<TResourceStatic extends ResourceShape<any>> {
       : perm.isAllowed({
           object: this.object,
           resource: this.resource,
-          session: this.policyExecutor.sessionHost.current,
+          session: this.policyExecutor.identity.current,
         });
   }
 

--- a/src/components/changeset/changeset.resolver.ts
+++ b/src/components/changeset/changeset.resolver.ts
@@ -1,12 +1,7 @@
 import { Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
-import {
-  AnonSession,
-  type ID,
-  IdArg,
-  type ObjectView,
-  type Session,
-} from '~/common';
+import { type ID, IdArg, type ObjectView } from '~/common';
 import { ResourceLoader } from '~/core';
+import { Identity } from '~/core/authentication';
 import { type BaseNode } from '~/core/database/results';
 import { ChangesetRepository } from './changeset.repository';
 import { Changeset, ChangesetDiff, type ResourceChange } from './dto';
@@ -16,6 +11,7 @@ export class ChangesetResolver {
   constructor(
     private readonly repo: ChangesetRepository,
     private readonly resources: ResourceLoader,
+    private readonly identity: Identity,
   ) {}
 
   @Query(() => Changeset)
@@ -28,7 +24,6 @@ export class ChangesetResolver {
   })
   async difference(
     @Parent() changeset: Changeset,
-    @AnonSession() session: Session,
     @IdArg({
       name: 'resource',
       nullable: true,
@@ -38,7 +33,7 @@ export class ChangesetResolver {
     parent?: ID,
   ): Promise<ChangesetDiff> {
     // TODO move to auth policy
-    if (session.anonymous) {
+    if (this.identity.isAnonymous) {
       return { added: [], removed: [], changed: [] };
     }
 

--- a/src/components/comments/comment.service.ts
+++ b/src/components/comments/comment.service.ts
@@ -11,7 +11,6 @@ import {
   ServerException,
   type UnsecuredDto,
 } from '~/common';
-import { isAdmin } from '~/common/session';
 import { ResourceLoader, ResourcesHost } from '~/core';
 import { Identity } from '~/core/authentication';
 import { type BaseNode, isBaseNode } from '~/core/database/results';
@@ -118,12 +117,11 @@ export class CommentService {
   }
 
   secureThread(thread: UnsecuredDto<CommentThread>): CommentThread {
-    const session = this.identity.current;
     return {
       ...thread,
       firstComment: this.secureComment(thread.firstComment),
       latestComment: this.secureComment(thread.latestComment),
-      canDelete: thread.creator === session.userId || isAdmin(session),
+      canDelete: this.identity.isSelf(thread.creator) || this.identity.isAdmin,
     };
   }
 

--- a/src/components/comments/comment.service.ts
+++ b/src/components/comments/comment.service.ts
@@ -13,8 +13,8 @@ import {
 } from '~/common';
 import { isAdmin } from '~/common/session';
 import { ResourceLoader, ResourcesHost } from '~/core';
+import { Identity } from '~/core/authentication';
 import { type BaseNode, isBaseNode } from '~/core/database/results';
-import { SessionHost } from '../authentication';
 import { Privileges } from '../authorization';
 import { CommentRepository } from './comment.repository';
 import {
@@ -39,7 +39,7 @@ export class CommentService {
     private readonly privileges: Privileges,
     private readonly resources: ResourceLoader,
     private readonly resourcesHost: ResourcesHost,
-    private readonly sessionHost: SessionHost,
+    private readonly identity: Identity,
     private readonly mentionNotificationService: CommentViaMentionNotificationService,
   ) {}
 
@@ -118,7 +118,7 @@ export class CommentService {
   }
 
   secureThread(thread: UnsecuredDto<CommentThread>): CommentThread {
-    const session = this.sessionHost.current;
+    const session = this.identity.current;
     return {
       ...thread,
       firstComment: this.secureComment(thread.firstComment),

--- a/src/components/comments/commentable.resolver.ts
+++ b/src/components/comments/commentable.resolver.ts
@@ -1,6 +1,5 @@
 import { Info, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import {
-  AnonSession,
   Fields,
   type ID,
   IdArg,
@@ -8,16 +7,19 @@ import {
   ListArg,
   type Resource,
   SecuredList,
-  type Session,
 } from '~/common';
 import { Loader, type LoaderOf } from '~/core';
+import { Identity } from '~/core/authentication';
 import { CommentThreadLoader } from './comment-thread.loader';
 import { CommentService } from './comment.service';
 import { Commentable, CommentThreadList, CommentThreadListInput } from './dto';
 
 @Resolver(Commentable)
 export class CommentableResolver {
-  constructor(private readonly service: CommentService) {}
+  constructor(
+    private readonly service: CommentService,
+    private readonly identity: Identity,
+  ) {}
 
   @Query(() => Commentable, {
     description: 'Load a commentable resource by ID',
@@ -32,12 +34,11 @@ export class CommentableResolver {
   async commentThreads(
     @Parent() parent: Commentable & Resource,
     @ListArg(CommentThreadListInput) input: CommentThreadListInput,
-    @AnonSession() session: Session,
     @Loader(CommentThreadLoader) commentThreads: LoaderOf<CommentThreadLoader>,
     @Info(Fields, IsOnly(['total'])) onlyTotal: boolean,
   ) {
     // TODO move to auth policy
-    if (session.anonymous) {
+    if (this.identity.isAnonymous) {
       return { parent, ...SecuredList.Redacted };
     }
     if (onlyTotal) {

--- a/src/components/engagement/engagement.rules.ts
+++ b/src/components/engagement/engagement.rules.ts
@@ -9,9 +9,9 @@ import {
   UnauthorizedException,
 } from '~/common';
 import { ILogger, Logger } from '~/core';
+import { Identity } from '~/core/authentication';
 import { DatabaseService } from '~/core/database';
 import { ACTIVE, INACTIVE } from '~/core/database/query';
-import { SessionHost } from '../authentication';
 import { withoutScope } from '../authorization/dto';
 import { ProjectStep } from '../project/dto';
 import {
@@ -35,7 +35,7 @@ const rolesThatCanBypassWorkflow: Role[] = [Role.Administrator];
 export class EngagementRules {
   constructor(
     private readonly db: DatabaseService,
-    private readonly sessionHost: SessionHost,
+    private readonly identity: Identity,
     // eslint-disable-next-line @seedcompany/no-unused-vars
     @Logger('engagement:rules') private readonly logger: ILogger,
   ) {}
@@ -317,7 +317,7 @@ export class EngagementRules {
     currentUserRoles?: Role[],
     changeset?: ID,
   ): Promise<EngagementStatusTransition[]> {
-    const session = this.sessionHost.current;
+    const session = this.identity.current;
     if (session.anonymous) {
       return [];
     }
@@ -357,7 +357,7 @@ export class EngagementRules {
   }
 
   async canBypassWorkflow() {
-    const session = this.sessionHost.current;
+    const session = this.identity.current;
     const roles = session.roles.map(withoutScope);
     return intersection(rolesThatCanBypassWorkflow, roles).length > 0;
   }
@@ -369,7 +369,7 @@ export class EngagementRules {
   ) {
     // If current user's roles include a role that can bypass workflow
     // stop the check here.
-    const session = this.sessionHost.current;
+    const session = this.identity.current;
     const currentUserRoles = session.roles.map(withoutScope);
     if (intersection(rolesThatCanBypassWorkflow, currentUserRoles).length > 0) {
       return;

--- a/src/components/file/file-node.resolver.ts
+++ b/src/components/file/file-node.resolver.ts
@@ -1,6 +1,5 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
-import { AnonSession, type Session } from '~/common';
 import { Loader, type LoaderOf } from '~/core';
 import { UserLoader } from '../user';
 import { User } from '../user/dto';
@@ -33,10 +32,7 @@ export class FileNodeResolver {
         without having to fetch each parent serially.
       `,
   })
-  async parents(
-    @Parent() node: FileNode,
-    @AnonSession() _session: Session,
-  ): Promise<readonly FileNode[]> {
+  async parents(@Parent() node: FileNode): Promise<readonly FileNode[]> {
     return await this.service.getParents(node.id);
   }
 

--- a/src/components/file/file-url.controller.ts
+++ b/src/components/file/file-url.controller.ts
@@ -10,7 +10,7 @@ import {
   Response,
 } from '@nestjs/common';
 import { type ID } from '~/common';
-import { loggedInSession as verifyLoggedIn } from '~/common/session';
+import { Identity } from '~/core/authentication';
 import { HttpAdapter, type IRequest, type IResponse } from '~/core/http';
 import { SessionInterceptor } from '../authentication/session.interceptor';
 import { FileService } from './file.service';
@@ -23,6 +23,7 @@ export class FileUrlController {
     @Inject(forwardRef(() => FileService))
     private readonly files: FileService & {},
     private readonly sessionHost: SessionInterceptor,
+    private readonly identity: Identity,
     private readonly http: HttpAdapter,
   ) {}
 
@@ -37,7 +38,7 @@ export class FileUrlController {
 
     if (!node.public) {
       const session = await this.sessionHost.hydrateSession({ request });
-      verifyLoggedIn(session);
+      this.identity.verifyLoggedIn(session);
     }
 
     // TODO authorization using session

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -2,7 +2,7 @@ import {
   GetObjectCommand as GetObject,
   PutObjectCommand as PutObject,
 } from '@aws-sdk/client-s3';
-import { Injectable } from '@nestjs/common';
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { bufferFromStream, cleanJoin, type Nil } from '@seedcompany/common';
 import { fileTypeFromBuffer } from 'file-type';
 import { intersection } from 'lodash';
@@ -60,6 +60,7 @@ export class FileService {
     private readonly repo: FileRepository,
     private readonly rollbacks: RollbackManager,
     private readonly config: ConfigService,
+    @Inject(forwardRef(() => MediaService))
     private readonly mediaService: MediaService,
     private readonly eventBus: IEventBus,
     @Logger('file:service') private readonly logger: ILogger,

--- a/src/components/file/media/media.service.ts
+++ b/src/components/file/media/media.service.ts
@@ -9,7 +9,7 @@ import {
   ServerException,
   UnauthorizedException,
 } from '~/common';
-import { IEventBus } from '~/core';
+import { IEventBus } from '~/core/events';
 import { type FileVersion } from '../dto';
 import { CanUpdateMediaUserMetadataEvent } from './events/can-update-event';
 import { MediaDetector } from './media-detector.service';

--- a/src/components/notifications/notification.resolver.ts
+++ b/src/components/notifications/notification.resolver.ts
@@ -1,5 +1,6 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { AnonSession, ListArg, type Session } from '~/common';
+import { ListArg } from '~/common';
+import { Identity } from '~/core/authentication';
 import {
   MarkNotificationReadArgs,
   Notification,
@@ -10,15 +11,17 @@ import { NotificationServiceImpl } from './notification.service';
 
 @Resolver()
 export class NotificationResolver {
-  constructor(private readonly service: NotificationServiceImpl) {}
+  constructor(
+    private readonly service: NotificationServiceImpl,
+    private readonly identity: Identity,
+  ) {}
 
   @Query(() => NotificationList)
   async notifications(
-    @AnonSession() session: Session,
     @ListArg(NotificationListInput) input: NotificationListInput,
   ): Promise<NotificationList> {
     // TODO move to DB layer?
-    if (session.anonymous) {
+    if (this.identity.isAnonymous) {
       return { items: [], total: 0, totalUnread: 0, hasMore: false };
     }
     return await this.service.list(input);

--- a/src/components/periodic-report/periodic-report.resolver.ts
+++ b/src/components/periodic-report/periodic-report.resolver.ts
@@ -6,15 +6,9 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
-import {
-  AnonSession,
-  CalendarDate,
-  ListArg,
-  type Session,
-  UnauthorizedException,
-} from '~/common';
-import { isAdmin } from '~/common/session';
+import { CalendarDate, ListArg, UnauthorizedException } from '~/common';
 import { Loader, type LoaderOf } from '~/core';
+import { Identity } from '~/core/authentication';
 import { type IdsAndView, IdsAndViewArg } from '../changeset/dto';
 import { FileNodeLoader, resolveDefinedFile } from '../file';
 import { SecuredFile } from '../file/dto';
@@ -30,7 +24,10 @@ import { PeriodicReportService } from './periodic-report.service';
 
 @Resolver(IPeriodicReport)
 export class PeriodicReportResolver {
-  constructor(private readonly service: PeriodicReportService) {}
+  constructor(
+    private readonly identity: Identity,
+    private readonly service: PeriodicReportService,
+  ) {}
 
   @Query(() => IPeriodicReport, {
     description: 'Read a periodic report by id.',
@@ -46,14 +43,16 @@ export class PeriodicReportResolver {
     description: 'List of periodic reports',
   })
   async periodicReports(
-    @AnonSession() session: Session,
     @ListArg(PeriodicReportListInput) input: PeriodicReportListInput,
     @Loader(ReportLoader) loader: LoaderOf<ReportLoader>,
   ): Promise<PeriodicReportListOutput> {
-    // Only let admins do this for now.
-    if (!isAdmin(session)) {
+    // Only let admins do this for now, since it spans across projects,
+    // and the db query may not be filtering correctly.
+    // TODO update list query to filter by auth
+    if (!this.identity.isAdmin) {
       throw new UnauthorizedException();
     }
+
     const list = await this.service.list(input);
     loader.primeAll(list.items);
     return list;

--- a/src/components/periodic-report/periodic-report.service.ts
+++ b/src/components/periodic-report/periodic-report.service.ts
@@ -10,6 +10,7 @@ import {
   type UnsecuredDto,
 } from '~/common';
 import { HandleIdLookup, IEventBus, ILogger, Logger } from '~/core';
+import { Identity } from '~/core/authentication';
 import { type Variable } from '~/core/database/query';
 import { Privileges } from '../authorization';
 import { FileService } from '../file';
@@ -35,6 +36,7 @@ export class PeriodicReportService {
     private readonly files: FileService,
     @Logger('periodic:report:service') private readonly logger: ILogger,
     private readonly eventBus: IEventBus,
+    private readonly identity: Identity,
     private readonly privileges: Privileges,
     private readonly repo: PeriodicReportRepository,
   ) {}

--- a/src/components/pin/pin.resolver.ts
+++ b/src/components/pin/pin.resolver.ts
@@ -1,32 +1,28 @@
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import {
-  AnonSession,
-  type ID,
-  IdArg,
-  ListArg,
-  NotImplementedException,
-  type Session,
-} from '~/common';
+import { type ID, IdArg, ListArg, NotImplementedException } from '~/common';
+import { Identity } from '~/core/authentication';
 import { PinnedListInput, type PinnedListOutput } from './dto';
 import { PinService } from './pin.service';
 
 @Resolver()
 export class PinResolver {
-  constructor(readonly pins: PinService) {}
+  constructor(
+    private readonly pins: PinService,
+    private readonly identity: Identity,
+  ) {}
 
   @Query(() => Boolean, {
     description:
       'Returns whether or not the requesting user has pinned the resource ID',
   })
   async isPinned(
-    @AnonSession() session: Session,
     @IdArg({
       description: 'A resource ID',
     })
     id: ID,
   ): Promise<boolean> {
     // TODO move to DB layer?
-    if (session.anonymous) {
+    if (this.identity.isAnonymous) {
       return false;
     }
     return await this.pins.isPinned(id);

--- a/src/components/post/postable.resolver.ts
+++ b/src/components/post/postable.resolver.ts
@@ -1,12 +1,6 @@
 import { Info, Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { type GraphQLResolveInfo } from 'graphql';
-import {
-  AnonSession,
-  ListArg,
-  type Resource,
-  SecuredList,
-  type Session,
-} from '~/common';
+import { ListArg, type Resource } from '~/common';
 import { Loader, type LoaderOf } from '~/core';
 import { Postable } from './dto';
 import { PostListInput, SecuredPostList } from './dto/list-posts.dto';
@@ -24,14 +18,8 @@ export class PostableResolver {
     @Info() info: GraphQLResolveInfo & {},
     @Parent() parent: Postable & Resource,
     @ListArg(PostListInput) input: PostListInput,
-    @AnonSession() session: Session,
     @Loader(PostLoader) posts: LoaderOf<PostLoader>,
   ): Promise<SecuredPostList> {
-    // TODO move to auth policy
-    if (session.anonymous) {
-      return SecuredList.Redacted;
-    }
-
     const list = await this.service.securedList(
       {
         ...parent,

--- a/src/components/product-progress/create-product-connection.resolver.ts
+++ b/src/components/product-progress/create-product-connection.resolver.ts
@@ -1,21 +1,24 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
-import { AnonSession, type Session, Variant } from '~/common';
+import { Variant } from '~/common';
+import { Identity } from '~/core/authentication';
 import { CreateProductOutput } from '../product/dto';
 import { ProductProgressService } from './product-progress.service';
 
 @Resolver(() => CreateProductOutput)
 export class ProgressReportCreateProductConnectionResolver {
-  constructor(private readonly service: ProductProgressService) {}
+  constructor(
+    private readonly service: ProductProgressService,
+    private readonly identity: Identity,
+  ) {}
 
   @ResolveField(() => [Variant], {
     description: 'All available progress variants for this product',
   })
   async availableVariants(
     @Parent() { product }: CreateProductOutput,
-    @AnonSession() session: Session,
   ): Promise<readonly Variant[]> {
     // TODO move to auth policy
-    if (session.anonymous) {
+    if (this.identity.isAnonymous) {
       return [];
     }
     return await this.service.getAvailableVariantsForProduct(product);

--- a/src/components/progress-report/media/handlers/update-media-metadata-check.handler.ts
+++ b/src/components/progress-report/media/handlers/update-media-metadata-check.handler.ts
@@ -1,5 +1,4 @@
 import { EventsHandler, ResourceLoader } from '~/core';
-import { SessionHost } from '../../../authentication';
 import { Privileges } from '../../../authorization';
 import { CanUpdateMediaUserMetadataEvent } from '../../../file/media/events/can-update-event';
 import { ProgressReportMedia as ReportMedia } from '../dto';
@@ -9,7 +8,6 @@ export class ProgressReportUpdateMediaMetadataCheckHandler {
   constructor(
     private readonly resources: ResourceLoader,
     private readonly privileges: Privileges,
-    private readonly sessionHost: SessionHost,
   ) {}
 
   async handle(event: CanUpdateMediaUserMetadataEvent) {

--- a/src/components/progress-report/workflow/handlers/progress-report-workflow-notification.handler.ts
+++ b/src/components/progress-report/workflow/handlers/progress-report-workflow-notification.handler.ts
@@ -9,11 +9,11 @@ import {
   ILogger,
   Logger,
 } from '~/core';
+import { Identity } from '~/core/authentication';
 import {
   type ProgressReportStatusChangedProps as EmailReportStatusNotification,
   ProgressReportStatusChanged,
 } from '~/core/email/templates/progress-report-status-changed.template';
-import { AuthenticationService } from '../../../authentication';
 import { LanguageService } from '../../../language';
 import { PeriodicReportService } from '../../../periodic-report';
 import { ProjectService } from '../../../project';
@@ -36,7 +36,7 @@ export class ProgressReportWorkflowNotificationHandler
   implements IEventHandler<WorkflowUpdatedEvent>
 {
   constructor(
-    private readonly auth: AuthenticationService,
+    private readonly identity: Identity,
     private readonly repo: ProgressReportWorkflowRepository,
     private readonly configService: ConfigService,
     private readonly userService: UserService,
@@ -113,7 +113,7 @@ export class ProgressReportWorkflowNotificationHandler
     languageId: ID,
   ): Promise<EmailReportStatusNotification> {
     const recipientId = receiver.userId ?? this.configService.rootUser.id;
-    return await this.auth.asUser(recipientId, async () => {
+    return await this.identity.asUser(recipientId, async () => {
       const recipient = receiver.userId
         ? await this.userService.readOne(recipientId)
         : this.fakeUserFromEmailAddress(receiver.email!);

--- a/src/components/project/financial-approver/financial-approver.resolver.ts
+++ b/src/components/project/financial-approver/financial-approver.resolver.ts
@@ -6,8 +6,8 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
-import { AnonSession, type Session } from '~/common';
 import { Loader, type LoaderOf } from '~/core';
+import { Identity } from '~/core/authentication';
 import { Privileges } from '../../authorization';
 import { UserLoader } from '../../user';
 import { User } from '../../user/dto';
@@ -20,6 +20,7 @@ export class FinancialApproverResolver {
   constructor(
     private readonly repo: FinancialApproverRepository,
     private readonly privileges: Privileges,
+    private readonly identity: Identity,
   ) {}
 
   @Query(() => [FinancialApprover])
@@ -30,10 +31,9 @@ export class FinancialApproverResolver {
       nullable: true,
     })
     types: readonly ProjectType[] | undefined,
-    @AnonSession() session: Session,
   ): Promise<readonly FinancialApprover[]> {
     // TODO move to auth policy
-    if (session.anonymous) {
+    if (this.identity.isAnonymous) {
       return [];
     }
     return await this.repo.read(types);

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -22,9 +22,9 @@ import {
 } from '~/common';
 import { isAdmin } from '~/common/session';
 import { HandleIdLookup, IEventBus } from '~/core';
+import { Identity } from '~/core/authentication';
 import { Transactional } from '~/core/database';
 import { type AnyChangesOf } from '~/core/database/changes';
-import { SessionHost } from '../authentication';
 import { Privileges } from '../authorization';
 import { withoutScope } from '../authorization/dto';
 import { BudgetService } from '../budget';
@@ -89,7 +89,7 @@ export class ProjectService {
     @Inject(forwardRef(() => EngagementService))
     private readonly engagementService: EngagementService & {},
     private readonly privileges: Privileges,
-    private readonly sessionHost: SessionHost,
+    private readonly identity: Identity,
     private readonly eventBus: IEventBus,
     private readonly repo: ProjectRepository,
     private readonly projectChangeRequests: ProjectChangeRequestService,
@@ -137,7 +137,7 @@ export class ProjectService {
     );
 
     // Only allow admins to specify department IDs
-    const session = this.sessionHost.current;
+    const session = this.identity.current;
     if (input.departmentId && !isAdmin(session.impersonator ?? session)) {
       throw UnauthorizedException.fromPrivileges(
         'edit',
@@ -252,7 +252,7 @@ export class ProjectService {
       );
 
     // Only allow admins to specify department IDs
-    const session = this.sessionHost.current;
+    const session = this.identity.current;
     if (
       input.departmentId !== undefined &&
       !isAdmin(session.impersonator ?? session)

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -20,7 +20,6 @@ import {
   UnauthorizedException,
   type UnsecuredDto,
 } from '~/common';
-import { isAdmin } from '~/common/session';
 import { HandleIdLookup, IEventBus } from '~/core';
 import { Identity } from '~/core/authentication';
 import { Transactional } from '~/core/database';
@@ -137,8 +136,7 @@ export class ProjectService {
     );
 
     // Only allow admins to specify department IDs
-    const session = this.identity.current;
-    if (input.departmentId && !isAdmin(session.impersonator ?? session)) {
+    if (input.departmentId && !this.identity.isImpersonatorAdmin) {
       throw UnauthorizedException.fromPrivileges(
         'edit',
         undefined,
@@ -158,6 +156,7 @@ export class ProjectService {
       RequiredWhen.verify(IProject, project);
 
       // Add creator to the project team with their global roles
+      const session = this.identity.current;
       await this.projectMembers.create(
         {
           userId: session.userId,
@@ -252,10 +251,9 @@ export class ProjectService {
       );
 
     // Only allow admins to specify department IDs
-    const session = this.identity.current;
     if (
       input.departmentId !== undefined &&
-      !isAdmin(session.impersonator ?? session)
+      !this.identity.isImpersonatorAdmin
     ) {
       throw UnauthorizedException.fromPrivileges(
         'edit',

--- a/src/components/prompts/prompt-variant-response.service.ts
+++ b/src/components/prompts/prompt-variant-response.service.ts
@@ -16,8 +16,8 @@ import {
   type VariantOf,
 } from '~/common';
 import { ResourceLoader } from '~/core';
+import { Identity } from '~/core/authentication';
 import { mapListResults } from '~/core/database/results';
-import { SessionHost } from '../authentication';
 import {
   Privileges,
   type UserResourcePrivileges,
@@ -53,7 +53,7 @@ export const PromptVariantResponseListService = <
   abstract class PromptVariantResponseListServiceClass {
     @Inject(Privileges)
     protected readonly privileges: Privileges;
-    @Inject() protected readonly sessionHost: SessionHost;
+    @Inject() protected readonly identity: Identity;
     @Inject(ResourceLoader)
     protected readonly resources: ResourceLoader;
     @Inject(repo)
@@ -230,7 +230,7 @@ export const PromptVariantResponseListService = <
         await this.repo.submitResponse(input);
       }
 
-      const session = this.sessionHost.current;
+      const session = this.identity.current;
       const responses = mapKeys.fromList(
         response.responses,
         (response) => response.variant,

--- a/src/components/user/assignable-roles.resolver.ts
+++ b/src/components/user/assignable-roles.resolver.ts
@@ -1,5 +1,5 @@
 import { ResolveField, Resolver } from '@nestjs/graphql';
-import { AnonSession, Role, SecuredRoles, type Session } from '~/common';
+import { Role, SecuredRoles } from '~/common';
 import { UserService } from './user.service';
 
 @Resolver(SecuredRoles)
@@ -10,7 +10,7 @@ export class AssignableRolesResolver {
     description:
       'All of the roles that you have permission to assign to this user',
   })
-  async assignableRoles(@AnonSession() session: Session) {
+  async assignableRoles() {
     return [...this.service.getAssignableRoles()];
   }
 }

--- a/src/components/user/education/education.resolver.ts
+++ b/src/components/user/education/education.resolver.ts
@@ -1,5 +1,4 @@
-import { Injectable } from '@nestjs/common';
-import { Args, Mutation, Query } from '@nestjs/graphql';
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { type ID, IdArg, ListArg } from '~/common';
 import { Loader, type LoaderOf } from '~/core';
 import { EducationLoader, EducationService } from '../education';
@@ -14,7 +13,7 @@ import {
   UpdateEducationOutput,
 } from './dto';
 
-@Injectable()
+@Resolver()
 export class EducationResolver {
   constructor(private readonly service: EducationService) {}
 

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -47,8 +47,7 @@ export class EducationService {
     const result = await this.repo.getUserIdByEducation(input.id);
     const changes = this.repo.getActualChanges(ed, input);
     // TODO move this condition into policies
-    const session = this.identity.current;
-    if (result.id !== session.userId) {
+    if (!this.identity.isSelf(result.id)) {
       this.privileges.for(Education, ed).verifyChanges(changes);
     }
 

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { type ID, type ObjectView, type UnsecuredDto } from '~/common';
 import { HandleIdLookup } from '~/core';
-import { SessionHost } from '../../authentication';
+import { Identity } from '~/core/authentication';
 import { Privileges } from '../../authorization';
 import {
   type CreateEducation,
@@ -16,7 +16,7 @@ import { EducationRepository } from './education.repository';
 export class EducationService {
   constructor(
     private readonly privileges: Privileges,
-    private readonly sessionHost: SessionHost,
+    private readonly identity: Identity,
     private readonly repo: EducationRepository,
   ) {}
 
@@ -47,7 +47,7 @@ export class EducationService {
     const result = await this.repo.getUserIdByEducation(input.id);
     const changes = this.repo.getActualChanges(ed, input);
     // TODO move this condition into policies
-    const session = this.sessionHost.current;
+    const session = this.identity.current;
     if (result.id !== session.userId) {
       this.privileges.for(Education, ed).verifyChanges(changes);
     }

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -46,8 +46,7 @@ export class UnavailabilityService {
     const result = await this.repo.getUserIdByUnavailability(input.id);
     const changes = this.repo.getActualChanges(unavailability, input);
     // TODO move this condition into policies
-    const session = this.identity.current;
-    if (result.id !== session.userId) {
+    if (!this.identity.isSelf(result.id)) {
       this.privileges
         .for(Unavailability, unavailability)
         .verifyChanges(changes);

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { type ID, type ObjectView, type UnsecuredDto } from '~/common';
 import { HandleIdLookup } from '~/core';
-import { SessionHost } from '../../authentication';
+import { Identity } from '~/core/authentication';
 import { Privileges } from '../../authorization';
 import {
   type CreateUnavailability,
@@ -16,7 +16,7 @@ import { UnavailabilityRepository } from './unavailability.repository';
 export class UnavailabilityService {
   constructor(
     private readonly privileges: Privileges,
-    private readonly sessionHost: SessionHost,
+    private readonly identity: Identity,
     private readonly repo: UnavailabilityRepository,
   ) {}
 
@@ -46,7 +46,7 @@ export class UnavailabilityService {
     const result = await this.repo.getUserIdByUnavailability(input.id);
     const changes = this.repo.getActualChanges(unavailability, input);
     // TODO move this condition into policies
-    const session = this.sessionHost.current;
+    const session = this.identity.current;
     if (result.id !== session.userId) {
       this.privileges
         .for(Unavailability, unavailability)

--- a/src/components/user/user.resolver.ts
+++ b/src/components/user/user.resolver.ts
@@ -8,7 +8,6 @@ import {
   Resolver,
 } from '@nestjs/graphql';
 import {
-  AnonSession,
   firstLettersOfWords,
   type ID,
   IdArg,
@@ -16,9 +15,9 @@ import {
   ListArg,
   NotFoundException,
   ReadAfterCreationFailed,
-  type Session,
 } from '~/common';
 import { Loader, type LoaderOf } from '~/core';
+import { Identity } from '~/core/authentication';
 import { LocationLoader } from '../location';
 import { LocationListInput, SecuredLocationList } from '../location/dto';
 import { OrganizationLoader } from '../organization';
@@ -72,6 +71,7 @@ export class UserResolver {
   constructor(
     private readonly userService: UserService,
     private readonly timeZoneService: TimeZoneService,
+    private readonly identity: Identity,
   ) {}
 
   @Query(() => User, {
@@ -133,12 +133,9 @@ export class UserResolver {
     description: 'Returns a user for a given email address',
     nullable: true,
   })
-  async userByEmail(
-    @AnonSession() session: Session,
-    @Args() { email }: CheckEmailArgs,
-  ): Promise<User | null> {
+  async userByEmail(@Args() { email }: CheckEmailArgs): Promise<User | null> {
     // TODO move to auth policy?
-    if (session.anonymous) {
+    if (this.identity.isAnonymous) {
       return null;
     }
     return await this.userService.getUserByEmailAddress(email);

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -9,9 +9,9 @@ import {
   type UnsecuredDto,
 } from '~/common';
 import { HandleIdLookup, ILogger, Logger } from '~/core';
+import { Identity } from '~/core/authentication';
 import { Transactional } from '~/core/database';
 import { property } from '~/core/database/query';
-import { SessionHost } from '../authentication/session.host';
 import { Privileges } from '../authorization';
 import { AssignableRoles } from '../authorization/dto/assignable-roles.dto';
 import { LocationService } from '../location';
@@ -61,7 +61,7 @@ export class UserService {
     private readonly privileges: Privileges,
     private readonly locationService: LocationService,
     private readonly knownLanguages: KnownLanguageRepository,
-    private readonly sessionHost: SessionHost,
+    private readonly identity: Identity,
     private readonly userRepo: UserRepository,
     @Logger('user:service') private readonly logger: ILogger,
   ) {}
@@ -77,7 +77,7 @@ export class UserService {
       input.roles &&
       input.roles.length > 0 &&
       // Note: session is only omitted for creating RootUser
-      this.sessionHost.currentIfInCtx
+      this.identity.currentIfInCtx
     ) {
       this.verifyRolesAreAssignable(input.roles);
     }

--- a/src/components/workflow/permission.serializer.ts
+++ b/src/components/workflow/permission.serializer.ts
@@ -1,7 +1,6 @@
 import { setOf } from '@seedcompany/common';
-import { DateTime } from 'luxon';
-import { type ID, Role, type Session } from '~/common';
-import { type SessionHost } from '../authentication';
+import { type ID, Role } from '~/common';
+import { type Identity } from '~/core/authentication';
 import { type Privileges, type UserResourcePrivileges } from '../authorization';
 import { Condition } from '../authorization/policy/conditions';
 import { type Workflow } from './define-workflow';
@@ -12,18 +11,11 @@ export const transitionPermissionSerializer =
   <W extends Workflow>(
     workflow: W,
     privileges: Privileges,
-    sessionHost: SessionHost,
+    identity: Identity,
   ) =>
   (transition: W['transition']): readonly SerializedTransitionPermission[] => {
     const all = [...Role].flatMap((role) => {
-      const session: Session = {
-        token: 'system',
-        issuedAt: DateTime.now(),
-        userId: 'anonymous' as ID,
-        anonymous: false,
-        roles: [`global:${role}`],
-      };
-      return sessionHost.withSession(session, () => {
+      return identity.asRole(role, () => {
         const p = privileges.for(workflow.eventResource);
         const readEvent = resolve(p, 'read', transition.key);
         const execute = resolve(p, 'create', transition.key);

--- a/src/components/workflow/workflow.service.ts
+++ b/src/components/workflow/workflow.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { type Nil } from '@seedcompany/common';
 import { type ID, UnauthorizedException } from '~/common';
-import { SessionHost } from '../authentication';
+import { Identity } from '~/core/authentication';
 import { Privileges } from '../authorization';
 import { MissingContextException } from '../authorization/policy/conditions';
 import { type Workflow } from './define-workflow';
@@ -20,7 +20,7 @@ export const WorkflowService = <W extends Workflow>(workflow: () => W) => {
   @Injectable()
   abstract class WorkflowServiceClass {
     @Inject() protected readonly privileges: Privileges;
-    @Inject() protected readonly sessionHost: SessionHost;
+    @Inject() protected readonly identity: Identity;
     protected readonly workflow: W;
 
     constructor() {
@@ -143,7 +143,7 @@ export const WorkflowService = <W extends Workflow>(workflow: () => W) => {
         transitionPermissionSerializer(
           this.workflow,
           this.privileges,
-          this.sessionHost,
+          this.identity,
         ),
       );
     }

--- a/src/core/authentication/identity.service.ts
+++ b/src/core/authentication/identity.service.ts
@@ -36,4 +36,12 @@ export class Identity {
   asRole<R>(role: Role, fn: () => R): R {
     return this.auth.asRole(role, fn);
   }
+
+  /**
+   * @deprecated probably replace this with something more explicit.
+   */
+  async readyForCli() {
+    // Ensure the default root session is ready to go for data loaders
+    await this.auth.lazySessionForRootUser();
+  }
 }

--- a/src/core/authentication/identity.service.ts
+++ b/src/core/authentication/identity.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import type { ID, Role } from '~/common';
 import { type AuthenticationService } from '../../components/authentication';
 import { SessionHost } from '../../components/authentication/session.host';
@@ -9,7 +9,7 @@ import { SessionHost } from '../../components/authentication/session.host';
 @Injectable()
 export class Identity {
   constructor(
-    @Inject('AUTHENTICATION')
+    @Inject(forwardRef(() => 'AUTHENTICATION'))
     private readonly auth: AuthenticationService & {},
     private readonly sessionHost: SessionHost,
   ) {}

--- a/src/core/authentication/identity.service.ts
+++ b/src/core/authentication/identity.service.ts
@@ -1,0 +1,32 @@
+import { Inject, Injectable } from '@nestjs/common';
+import type { ID } from '~/common';
+import { type AuthenticationService } from '../../components/authentication';
+import { SessionHost } from '../../components/authentication/session.host';
+
+/**
+ * A facade for authentication functionality that is public to the codebase.
+ */
+@Injectable()
+export class Identity {
+  constructor(
+    @Inject('AUTHENTICATION')
+    private readonly auth: AuthenticationService & {},
+    private readonly sessionHost: SessionHost,
+  ) {}
+
+  get current() {
+    return this.sessionHost.current;
+  }
+
+  get currentMaybe() {
+    return this.sessionHost.currentMaybe;
+  }
+
+  get currentIfInCtx() {
+    return this.sessionHost.currentIfInCtx;
+  }
+
+  async asUser<R>(user: ID<'User'>, fn: () => Promise<R>): Promise<R> {
+    return await this.auth.asUser(user, fn);
+  }
+}

--- a/src/core/authentication/identity.service.ts
+++ b/src/core/authentication/identity.service.ts
@@ -27,6 +27,16 @@ export class Identity {
   }
 
   /**
+   * Is the current requestor anonymous (not logged in)?
+   *
+   * Not the best API, use is discouraged.
+   * Prefer using Auth Policies / {@link Privileges}`.for.can()`
+   */
+  get isAnonymous() {
+    return this.current.anonymous;
+  }
+
+  /**
    * Is the current user an admin?
    *
    * Not the best API, use is discouraged.

--- a/src/core/authentication/identity.service.ts
+++ b/src/core/authentication/identity.service.ts
@@ -1,5 +1,5 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
-import type { ID, Role } from '~/common';
+import { type ID, type Role, UnauthenticatedException } from '~/common';
 import { type AuthenticationService } from '../../components/authentication';
 import { SessionHost } from '../../components/authentication/session.host';
 
@@ -34,6 +34,15 @@ export class Identity {
    */
   get isAnonymous() {
     return this.current.anonymous;
+  }
+
+  /**
+   * Manually verify the current requestor is logged in.
+   */
+  verifyLoggedIn(session?: Identity['current']) {
+    if ((session ?? this.current).anonymous) {
+      throw new UnauthenticatedException('User is not logged in');
+    }
   }
 
   /**

--- a/src/core/authentication/identity.service.ts
+++ b/src/core/authentication/identity.service.ts
@@ -26,6 +26,40 @@ export class Identity {
     return this.sessionHost.currentIfInCtx;
   }
 
+  /**
+   * Is the current user an admin?
+   *
+   * Not the best API, use is discouraged.
+   * Prefer using Auth Policies / {@link Privileges}`.for.can()`
+   */
+  get isAdmin() {
+    return this.current.roles.includes('global:Administrator');
+  }
+
+  /**
+   * Is the current user (or impersonator) an admin?
+   * This ignores impersonation.
+   *
+   * Not the best API, use is discouraged.
+   * Prefer using Auth Policies / {@link Privileges}`.for.can()`
+   */
+  get isImpersonatorAdmin() {
+    const session = this.current;
+    return (session.impersonator ?? session).roles.includes(
+      'global:Administrator',
+    );
+  }
+
+  /**
+   * Is this the ID of the current user?
+   *
+   * Not the best API, use is discouraged.
+   * Prefer using Auth Policies / {@link Privileges}`.for.can()`
+   */
+  isSelf(id: ID<'User'>) {
+    return id === this.current.userId;
+  }
+
   async asUser<R>(user: ID<'User'>, fn: () => Promise<R>): Promise<R> {
     return await this.auth.asUser(user, fn);
   }

--- a/src/core/authentication/identity.service.ts
+++ b/src/core/authentication/identity.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import type { ID } from '~/common';
+import type { ID, Role } from '~/common';
 import { type AuthenticationService } from '../../components/authentication';
 import { SessionHost } from '../../components/authentication/session.host';
 
@@ -28,5 +28,12 @@ export class Identity {
 
   async asUser<R>(user: ID<'User'>, fn: () => Promise<R>): Promise<R> {
     return await this.auth.asUser(user, fn);
+  }
+
+  /**
+   * Run this function with the current user as an ephemeral one this role
+   */
+  asRole<R>(role: Role, fn: () => R): R {
+    return this.auth.asRole(role, fn);
   }
 }

--- a/src/core/authentication/index.ts
+++ b/src/core/authentication/index.ts
@@ -1,0 +1,1 @@
+export * from './identity.service';

--- a/src/core/data-loader/data-loader.config.ts
+++ b/src/core/data-loader/data-loader.config.ts
@@ -4,14 +4,14 @@ import {
   lifetimeIdFromExecutionContext,
 } from '@seedcompany/data-loader';
 import { NotFoundException } from '~/common';
-import { SessionHost } from '../../components/authentication';
+import { Identity } from '../authentication';
 import { ConfigService } from '../config/config.service';
 
 @Injectable()
 export class DataLoaderConfig {
   constructor(
     private readonly config: ConfigService,
-    private readonly sessionHost: SessionHost,
+    private readonly identity: Identity,
   ) {}
 
   create(): DataLoaderOptions<any, any> {
@@ -27,7 +27,7 @@ export class DataLoaderConfig {
         // If we have a session, use that as the cache key.
         // It will always be created / scoped within the GQL operation.
         // This ensures the cached data isn't shared between users.
-        const session = this.sessionHost.currentMaybe;
+        const session = this.identity.currentMaybe;
         if (session) return session;
 
         return lifetimeIdFromExecutionContext(context);

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -17,7 +17,7 @@ import {
   type UnwrapSecured,
 } from '~/common';
 import { AbortError, retry, type RetryOptions } from '~/common/retry';
-import { SessionHost } from '../../components/authentication/session.host';
+import { Identity } from '../authentication';
 import { ConfigService } from '../config/config.service';
 import { ILogger, Logger } from '../logger';
 import { ShutdownHook } from '../shutdown.hook';
@@ -64,7 +64,7 @@ export class DatabaseService {
   constructor(
     private readonly db: Connection,
     private readonly config: ConfigService,
-    private readonly sessionHost: SessionHost,
+    private readonly identity: Identity,
     private readonly shutdown$: ShutdownHook,
     @Logger('database:service') private readonly logger: ILogger,
   ) {}
@@ -124,7 +124,7 @@ export class DatabaseService {
     parameters?: Record<string, any>,
   ): Query<Result> {
     const q = this.db.query() as Query<Result>;
-    q.params.addParam(this.sessionHost.currentIfInCtx?.userId, 'currentUser');
+    q.params.addParam(this.identity.currentIfInCtx?.userId, 'currentUser');
     if (query) {
       q.raw(query, parameters);
     }

--- a/src/core/database/database.service.ts
+++ b/src/core/database/database.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { entries, mapKeys } from '@seedcompany/common';
 import { Connection, node, type Query, relation } from 'cypher-query-builder';
 import { LazyGetter } from 'lazy-get-decorator';
@@ -64,6 +64,7 @@ export class DatabaseService {
   constructor(
     private readonly db: Connection,
     private readonly config: ConfigService,
+    @Inject(forwardRef(() => Identity))
     private readonly identity: Identity,
     private readonly shutdown$: ShutdownHook,
     @Logger('database:service') private readonly logger: ILogger,

--- a/src/core/gel/gel.service.ts
+++ b/src/core/gel/gel.service.ts
@@ -6,7 +6,7 @@ import { type QueryArgs } from 'gel/dist/ifaces';
 import { TraceLayer } from '~/common';
 import { retry, type RetryOptions } from '~/common/retry';
 import { TracingService } from '~/core/tracing';
-import { SessionHost } from '../../components/authentication/session.host';
+import { Identity } from '../authentication';
 import { TypedEdgeQL } from './edgeql';
 import { cleanError } from './errors';
 import { InlineQueryRuntimeMap } from './generated-client/inline-queries';
@@ -23,7 +23,7 @@ export class Gel {
     private readonly transactionContext: TransactionContext,
     private readonly optionsContext: OptionsContext,
     private readonly tracing: TracingService,
-    private readonly sessionHost: SessionHost,
+    private readonly identity: Identity,
     @Optional() private readonly childOptions: ApplyOptions[] = [],
     @Optional() private childExecutor?: Executor,
   ) {}
@@ -34,7 +34,7 @@ export class Gel {
       this.transactionContext,
       this.optionsContext,
       this.tracing,
-      this.sessionHost,
+      this.identity,
       [...this.childOptions],
       this.childExecutor,
     );
@@ -115,7 +115,7 @@ export class Gel {
     const queryNames = getCurrentQueryNames();
     const traceName = queryNames?.xray ?? 'Query';
 
-    let currentActorId = this.sessionHost.currentIfInCtx?.userId;
+    let currentActorId = this.identity.currentIfInCtx?.userId;
     // TODO temporarily check if UUID before applying global.
     // Once migration is complete this can be removed.
     currentActorId = isUUID(currentActorId) ? currentActorId : undefined;

--- a/src/core/graphql/graphql-tracing.plugin.ts
+++ b/src/core/graphql/graphql-tracing.plugin.ts
@@ -4,7 +4,7 @@ import {
   type GraphQLResolveInfo as ResolveInfo,
   type ResponsePath,
 } from 'graphql';
-import { SessionHost } from '../../components/authentication/session.host';
+import { Identity } from '../authentication';
 import { type Segment, TracingService } from '../tracing';
 import { Plugin } from './plugin.decorator';
 
@@ -12,7 +12,7 @@ import { Plugin } from './plugin.decorator';
 export class GraphqlTracingPlugin {
   constructor(
     private readonly tracing: TracingService,
-    private readonly sessionHost: SessionHost,
+    private readonly identity: Identity,
   ) {}
 
   onExecute: Plugin['onExecute'] = ({ args }) => {
@@ -47,7 +47,7 @@ export class GraphqlTracingPlugin {
 
     return {
       onExecuteDone: () => {
-        const userId = this.sessionHost.currentMaybe?.userId;
+        const userId = this.identity.currentMaybe?.userId;
         if (userId) {
           segment.setUser?.(userId);
         }


### PR DESCRIPTION
This creates an `Identity` service to be the facade for all authentication functionality that is sanctioned across the codebase.
With the hope that the auth internals can be decoupled and split apart for more sanity.

This also begins the move into `~/core`

I was going for a sibling to `Privileges` with the name `Identity`, but I know the name doesn't feel very service-y.

This consolidates functionality as much as possible into this service usage,
including replacing the `@AnonymousSession()` & `@LoggedInSession()` decorators.