### PR TITLE
`AuthLevel` decorator

### DIFF
--- a/src/components/authentication/anonymous.decorator.ts
+++ b/src/components/authentication/anonymous.decorator.ts
@@ -1,7 +1,0 @@
-import { createMetadataDecorator } from '@seedcompany/nest';
-
-export const LoggedIn = () => Anonymous(false);
-export const Anonymous = createMetadataDecorator({
-  setter: (anonymous = true) => anonymous,
-  types: ['class', 'method'],
-});

--- a/src/components/authentication/auth-level.decorator.ts
+++ b/src/components/authentication/auth-level.decorator.ts
@@ -1,0 +1,6 @@
+import { createMetadataDecorator } from '@seedcompany/nest';
+
+export const AuthLevel = createMetadataDecorator({
+  setter: (level: 'authenticated' | 'anonymous' | 'sessionless') => level,
+  types: ['class', 'method'],
+});

--- a/src/components/authentication/index.ts
+++ b/src/components/authentication/index.ts
@@ -1,3 +1,3 @@
 export * from './authentication.service';
 export { SessionHost } from './session.host';
-export * from './anonymous.decorator';
+export * from './auth-level.decorator';

--- a/src/components/authentication/login.resolver.ts
+++ b/src/components/authentication/login.resolver.ts
@@ -11,12 +11,13 @@ import { Privileges } from '../authorization';
 import { Power } from '../authorization/dto';
 import { UserLoader } from '../user';
 import { User } from '../user/dto';
-import { Anonymous } from './anonymous.decorator';
+import { AuthLevel } from './auth-level.decorator';
 import { AuthenticationService } from './authentication.service';
 import { LoginInput, LoginOutput, LogoutOutput } from './dto';
 import { SessionHost } from './session.host';
 
 @Resolver(LoginOutput)
+@AuthLevel('anonymous')
 export class LoginResolver {
   constructor(
     private readonly authentication: AuthenticationService,
@@ -30,7 +31,6 @@ export class LoginResolver {
       @sensitive-secrets
     `,
   })
-  @Anonymous()
   async login(@Args('input') input: LoginInput): Promise<LoginOutput> {
     const user = await this.authentication.login(input);
     await this.authentication.refreshCurrentSession();
@@ -43,7 +43,6 @@ export class LoginResolver {
       @sensitive-secrets
     `,
   })
-  @Anonymous()
   async logout(): Promise<LogoutOutput> {
     const session = this.sessionHost.current;
     await this.authentication.logout(session.token);

--- a/src/components/authentication/password.resolver.ts
+++ b/src/components/authentication/password.resolver.ts
@@ -1,6 +1,6 @@
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
-import { Anonymous } from './anonymous.decorator';
+import { AuthLevel } from './auth-level.decorator';
 import { AuthenticationService } from './authentication.service';
 import {
   ChangePasswordArgs,
@@ -31,6 +31,7 @@ export class PasswordResolver {
   @Mutation(() => ForgotPasswordOutput, {
     description: 'Forgot password; send password reset email',
   })
+  @AuthLevel('anonymous')
   async forgotPassword(
     @Args() { email }: ForgotPasswordArgs,
   ): Promise<ForgotPasswordOutput> {
@@ -44,7 +45,7 @@ export class PasswordResolver {
       @sensitive-secrets
     `,
   })
-  @Anonymous()
+  @AuthLevel('anonymous')
   async resetPassword(
     @Args('input') input: ResetPasswordInput,
   ): Promise<ResetPasswordOutput> {

--- a/src/components/authentication/register.resolver.ts
+++ b/src/components/authentication/register.resolver.ts
@@ -11,11 +11,12 @@ import { Privileges } from '../authorization';
 import { Power } from '../authorization/dto';
 import { UserLoader } from '../user';
 import { User } from '../user/dto';
-import { Anonymous } from './anonymous.decorator';
+import { AuthLevel } from './auth-level.decorator';
 import { AuthenticationService } from './authentication.service';
 import { RegisterInput, RegisterOutput } from './dto';
 
 @Resolver(RegisterOutput)
+@AuthLevel('anonymous')
 export class RegisterResolver {
   constructor(
     private readonly authentication: AuthenticationService,
@@ -28,7 +29,6 @@ export class RegisterResolver {
       @sensitive-secrets
     `,
   })
-  @Anonymous()
   async register(@Args('input') input: RegisterInput): Promise<RegisterOutput> {
     const user = await this.authentication.register(input);
     await this.authentication.login(input);

--- a/src/components/authentication/session.resolver.ts
+++ b/src/components/authentication/session.resolver.ts
@@ -18,12 +18,14 @@ import { Privileges } from '../authorization';
 import { Power } from '../authorization/dto';
 import { UserLoader, UserService } from '../user';
 import { User } from '../user/dto';
+import { AuthLevel } from './auth-level.decorator';
 import { AuthenticationService } from './authentication.service';
 import { SessionOutput } from './dto';
 import { SessionHost } from './session.host';
 import { SessionInterceptor } from './session.interceptor';
 
 @Resolver(SessionOutput)
+@AuthLevel('sessionless')
 export class SessionResolver {
   constructor(
     private readonly authentication: AuthenticationService,

--- a/src/components/file/file-url.controller.ts
+++ b/src/components/file/file-url.controller.ts
@@ -10,12 +10,13 @@ import {
   Response,
 } from '@nestjs/common';
 import { type ID } from '~/common';
-import { Identity } from '~/core/authentication';
+import { AuthLevel, Identity } from '~/core/authentication';
 import { HttpAdapter, type IRequest, type IResponse } from '~/core/http';
 import { SessionInterceptor } from '../authentication/session.interceptor';
 import { FileService } from './file.service';
 
 @Controller(FileUrlController.path)
+@AuthLevel('sessionless')
 export class FileUrlController {
   static path = '/file';
 

--- a/src/components/file/local-bucket.controller.ts
+++ b/src/components/file/local-bucket.controller.ts
@@ -11,6 +11,7 @@ import {
 import { DateTime } from 'luxon';
 import { URL } from 'node:url';
 import { InputException } from '~/common';
+import { AuthLevel } from '~/core/authentication';
 import {
   HttpAdapter,
   type IRequest,
@@ -23,6 +24,7 @@ import { FileBucket, InvalidSignedUrlException } from './bucket';
  * This fakes S3 web hosting for use with LocalBuckets.
  */
 @Controller(LocalBucketController.path)
+@AuthLevel('sessionless')
 export class LocalBucketController {
   static path = '/local-bucket';
 

--- a/src/core/authentication/index.ts
+++ b/src/core/authentication/index.ts
@@ -1,1 +1,2 @@
+export * from '../../components/authentication/auth-level.decorator';
 export * from './identity.service';

--- a/src/core/core.controller.ts
+++ b/src/core/core.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Get, HttpStatus, Redirect } from '@nestjs/common';
+import { AuthLevel } from '~/core/authentication';
 import { ConfigService } from './config/config.service';
 
 @Controller()
+@AuthLevel('sessionless')
 export class CoreController {
   constructor(private readonly config: ConfigService) {}
 


### PR DESCRIPTION
Replacing `Anonymous/LoggedIn` decorators with an expanded `AuthLevel`.

This new one allows declaring that a session should not even be tried to be resumed, which is  needed with our HTTP routes.

So the 3 levels:
- `sessionless` - do not attempt a credential gathering from the request
- `anonymous` - gather credential info & validate token is in db & resume session
- `authenticated` - assert that the session is tied to a user aka "logged in"

Now `SessionInterceptor` doesn't have to make assumptions about the codebase.
It doesn't have to know to avoid starting a session for the `session` gql query.
It doesn't have to know to avoid starting a session for http requests unless
it has the session watermark/(session decorator).

This is a smaller PR but distinct with its business logic change, so I wanted to give it its own PR.