### PR TITLE
Consider role hierarchies in project membership

### DIFF
--- a/src/common/role.dto.ts
+++ b/src/common/role.dto.ts
@@ -50,6 +50,18 @@ export const Role = makeEnum({
         'RegionalDirector',
         'FieldOperationsDirector',
       ]),
+
+      /**
+       * Named hierarchies of roles, ordered ascending.
+       */
+      Hierarchies: {
+        Finance: ['FinancialAnalyst', 'LeadFinancialAnalyst', 'Controller'],
+        Field: [
+          'ProjectManager',
+          'RegionalDirector',
+          'FieldOperationsDirector',
+        ],
+      } satisfies Record<string, Role[]>,
     };
   },
 });

--- a/src/components/authorization/policies/by-feature/engagements-create-delete.policy.ts
+++ b/src/components/authorization/policies/by-feature/engagements-create-delete.policy.ts
@@ -1,6 +1,6 @@
-import { any, field, Hierarchies, member, Policy } from '../util';
+import { any, field, member, Policy, Role } from '../util';
 
-@Policy([...Hierarchies.Field, ...Hierarchies.Finance], (r) => [
+@Policy([...Role.Hierarchies.Field, ...Role.Hierarchies.Finance], (r) => [
   r.Project,
   r.Engagement.read,
   r.Engagement.whenAll(

--- a/src/components/authorization/policies/util.ts
+++ b/src/components/authorization/policies/util.ts
@@ -1,5 +1,3 @@
-import { Role } from '~/common';
-
 // File exists to simplify imports for policy definitions.
 export { Role } from '~/common';
 export { Policy, inherit, allowAll, allowActions } from '../policy';
@@ -7,12 +5,3 @@ export { action } from '../policy/builder/perm-granter';
 export type { Policy as BuiltPolicy } from '../policy/policy.factory';
 export { any, all } from '../policy/conditions';
 export * from './conditions';
-
-export const Hierarchies = {
-  Finance: [Role.FinancialAnalyst, Role.LeadFinancialAnalyst, Role.Controller],
-  Field: [
-    Role.ProjectManager,
-    Role.RegionalDirector,
-    Role.FieldOperationsDirector,
-  ],
-};

--- a/src/components/project/project-member/available-roles-to-project.resolver.ts
+++ b/src/components/project/project-member/available-roles-to-project.resolver.ts
@@ -1,0 +1,20 @@
+import { ResolveField, Resolver } from '@nestjs/graphql';
+import { Grandparent, Role, SecuredRoles } from '~/common';
+import { type User } from '../../user/dto';
+import { ProjectMemberService } from './project-member.service';
+
+@Resolver(SecuredRoles)
+export class AvailableRolesToProjectResolver {
+  constructor(private readonly service: ProjectMemberService) {}
+
+  @ResolveField(() => [Role], {
+    description:
+      'All of the roles this user could serve in project memberships',
+  })
+  async availableForProjects(
+    @Grandparent() user: User,
+  ): Promise<readonly Role[]> {
+    const roles = this.service.getAvailableRoles(user);
+    return [...roles];
+  }
+}

--- a/src/components/project/project-member/project-member.module.ts
+++ b/src/components/project/project-member/project-member.module.ts
@@ -3,6 +3,7 @@ import { splitDb } from '~/core';
 import { AuthorizationModule } from '../../authorization/authorization.module';
 import { UserModule } from '../../user/user.module';
 import { ProjectModule } from '../project.module';
+import { AvailableRolesToProjectResolver } from './available-roles-to-project.resolver';
 import { ProjectMemberGelRepository } from './project-member.gel.repository';
 import { ProjectMemberLoader } from './project-member.loader';
 import { ProjectMemberRepository } from './project-member.repository';
@@ -17,6 +18,7 @@ import { ProjectMemberService } from './project-member.service';
   ],
   providers: [
     ProjectMemberResolver,
+    AvailableRolesToProjectResolver,
     ProjectMemberService,
     splitDb(ProjectMemberRepository, ProjectMemberGelRepository),
     ProjectMemberLoader,

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -5,7 +5,7 @@ import {
   InputException,
   NotFoundException,
   type ObjectView,
-  type Role,
+  Role,
   ServerException,
   UnauthorizedException,
   type UnsecuredDto,
@@ -105,7 +105,14 @@ export class ProjectMemberService {
   }
 
   getAvailableRoles(user: User) {
-    const availableRoles = user.roles.value ?? [];
+    const availableRoles = (user.roles.value ?? []).flatMap((role: Role) =>
+      Object.values(Role.Hierarchies)
+        .flatMap((hierarchy: Role[]) => {
+          const idx = hierarchy.indexOf(role);
+          return idx > -1 ? hierarchy.slice(0, idx) : [];
+        })
+        .concat(role),
+    );
     return setOf(availableRoles);
   }
 

--- a/src/components/user/assignable-roles.resolver.ts
+++ b/src/components/user/assignable-roles.resolver.ts
@@ -8,7 +8,7 @@ export class AssignableRolesResolver {
 
   @ResolveField(() => [Role], {
     description:
-      'All of the roles that you have permission to assign to this user',
+      'All of the roles that _you_ have permission to assign to this user',
   })
   async assignableRoles() {
     return [...this.service.getAssignableRoles()];

--- a/src/components/user/dto/user.dto.ts
+++ b/src/components/user/dto/user.dto.ts
@@ -2,6 +2,7 @@ import { Field, ObjectType } from '@nestjs/graphql';
 import {
   DbLabel,
   DbUnique,
+  Grandparent,
   IntersectTypes,
   NameField,
   Resource,
@@ -78,7 +79,9 @@ export class User extends Interfaces {
   @Field()
   status: SecuredUserStatus;
 
-  @Field()
+  @Field({
+    middleware: [Grandparent.store],
+  })
   roles: SecuredRoles;
 
   @Field()


### PR DESCRIPTION
Aka allow RD/FOD to be FPMs _on projects_, etc.

Expose this new list via `User.roles.availableForProjects`
This list should be favored instead of assuming the User's current roles
