### PR TITLE
Validate field region/zone director roles

### DIFF
--- a/src/components/field-region/events/field-region-updated.event.ts
+++ b/src/components/field-region/events/field-region-updated.event.ts
@@ -1,0 +1,10 @@
+import { type UnsecuredDto } from '~/common';
+import { type FieldRegion, type UpdateFieldRegion } from '../dto';
+
+export class FieldRegionUpdatedEvent {
+  constructor(
+    readonly updated: UnsecuredDto<FieldRegion>,
+    readonly previous: UnsecuredDto<FieldRegion>,
+    readonly input: UpdateFieldRegion,
+  ) {}
+}

--- a/src/components/field-region/field-region.gel.repository.ts
+++ b/src/components/field-region/field-region.gel.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { type PublicOf } from '~/common';
-import { RepoFor } from '~/core/gel';
+import { type ID, type PublicOf } from '~/common';
+import { e, RepoFor } from '~/core/gel';
 import { FieldRegion } from './dto';
 import { type FieldRegionRepository } from './field-region.repository';
 
@@ -13,4 +13,16 @@ export class FieldRegionGelRepository
       fieldZone: true,
     }),
   })
-  implements PublicOf<FieldRegionRepository> {}
+  implements PublicOf<FieldRegionRepository>
+{
+  async readAllByDirector(id: ID<'User'>) {
+    return await this.db.run(this.readAllByDirectorQuery, { id });
+  }
+  private readonly readAllByDirectorQuery = e.params({ id: e.uuid }, ($) => {
+    const director = e.cast(e.User, $.id);
+    return e.select(e.FieldRegion, (region) => ({
+      filter: e.op(region.director, '=', director),
+      ...this.hydrate(region),
+    }));
+  });
+}

--- a/src/components/field-region/field-region.module.ts
+++ b/src/components/field-region/field-region.module.ts
@@ -8,6 +8,7 @@ import { FieldRegionLoader } from './field-region.loader';
 import { FieldRegionRepository } from './field-region.repository';
 import { FieldRegionResolver } from './field-region.resolver';
 import { FieldRegionService } from './field-region.service';
+import { RestrictRegionDirectorRemovalHandler } from './handlers/restrict-region-director-removal.handler';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { FieldRegionService } from './field-region.service';
     FieldRegionService,
     splitDb(FieldRegionRepository, FieldRegionGelRepository),
     FieldRegionLoader,
+    RestrictRegionDirectorRemovalHandler,
   ],
   exports: [FieldRegionService],
 })

--- a/src/components/field-region/field-region.repository.ts
+++ b/src/components/field-region/field-region.repository.ts
@@ -115,4 +115,17 @@ export class FieldRegionRepository extends DtoRepository(FieldRegion) {
       .first();
     return result!; // result from paginate() will always have 1 row.
   }
+
+  async readAllByDirector(id: ID<'User'>) {
+    return await this.db
+      .query()
+      .match([
+        node('node', 'FieldRegion'),
+        relation('out', '', 'director', ACTIVE),
+        node('', 'User', { id }),
+      ])
+      .apply(this.hydrate())
+      .map('dto')
+      .run();
+  }
 }

--- a/src/components/field-region/handlers/restrict-region-director-removal.handler.ts
+++ b/src/components/field-region/handlers/restrict-region-director-removal.handler.ts
@@ -1,0 +1,29 @@
+import { InputException } from '~/common';
+import { EventsHandler } from '~/core/events';
+import { UserUpdatedEvent } from '../../user/events/user-updated.event';
+import { FieldRegionRepository } from '../field-region.repository';
+
+@EventsHandler(UserUpdatedEvent)
+export class RestrictRegionDirectorRemovalHandler {
+  constructor(private readonly repo: FieldRegionRepository) {}
+
+  async handle(event: UserUpdatedEvent) {
+    if (!event.updated.roles) {
+      return;
+    }
+    const roleRemoved =
+      event.previous.roles.includes('RegionalDirector') &&
+      !event.updated.roles.includes('RegionalDirector');
+    if (!roleRemoved) {
+      return;
+    }
+
+    const regions = await this.repo.readAllByDirector(event.updated.id);
+    if (regions.length > 0) {
+      throw new InputException(
+        'User is still a director for these field regions:\n' +
+          regions.map((z) => `  - ${z.name}`).join('\n'),
+      );
+    }
+  }
+}

--- a/src/components/field-zone/events/field-zone-updated.event.ts
+++ b/src/components/field-zone/events/field-zone-updated.event.ts
@@ -1,0 +1,10 @@
+import { type UnsecuredDto } from '~/common';
+import { type FieldZone, type UpdateFieldZone } from '../dto';
+
+export class FieldZoneUpdatedEvent {
+  constructor(
+    readonly updated: UnsecuredDto<FieldZone>,
+    readonly previous: UnsecuredDto<FieldZone>,
+    readonly input: UpdateFieldZone,
+  ) {}
+}

--- a/src/components/field-zone/field-zone.gel.repository.ts
+++ b/src/components/field-zone/field-zone.gel.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { type PublicOf } from '~/common';
-import { RepoFor } from '~/core/gel';
+import { type ID, type PublicOf } from '~/common';
+import { e, RepoFor } from '~/core/gel';
 import { FieldZone } from './dto';
 import { type FieldZoneRepository } from './field-zone.repository';
 
@@ -12,4 +12,16 @@ export class FieldZoneGelRepository
       director: true,
     }),
   })
-  implements PublicOf<FieldZoneRepository> {}
+  implements PublicOf<FieldZoneRepository>
+{
+  async readAllByDirector(id: ID<'User'>) {
+    return await this.db.run(this.readAllByDirectorQuery, { id });
+  }
+  private readonly readAllByDirectorQuery = e.params({ id: e.uuid }, ($) => {
+    const director = e.cast(e.User, $.id);
+    return e.select(e.FieldZone, (zone) => ({
+      filter: e.op(zone.director, '=', director),
+      ...this.hydrate(zone),
+    }));
+  });
+}

--- a/src/components/field-zone/field-zone.module.ts
+++ b/src/components/field-zone/field-zone.module.ts
@@ -7,6 +7,7 @@ import { FieldZoneLoader } from './field-zone.loader';
 import { FieldZoneRepository } from './field-zone.repository';
 import { FieldZoneResolver } from './field-zone.resolver';
 import { FieldZoneService } from './field-zone.service';
+import { RestrictZoneDirectorRemovalHandler } from './handlers/restrict-zone-director-removal.handler';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { FieldZoneService } from './field-zone.service';
     FieldZoneService,
     splitDb(FieldZoneRepository, FieldZoneGelRepository),
     FieldZoneLoader,
+    RestrictZoneDirectorRemovalHandler,
   ],
   exports: [FieldZoneService],
 })

--- a/src/components/field-zone/field-zone.repository.ts
+++ b/src/components/field-zone/field-zone.repository.ts
@@ -133,4 +133,17 @@ export class FieldZoneRepository extends DtoRepository(FieldZone) {
       .first();
     return result!; // result from paginate() will always have 1 row.
   }
+
+  async readAllByDirector(id: ID<'User'>) {
+    return await this.db
+      .query()
+      .match([
+        node('node', 'FieldZone'),
+        relation('out', '', 'director', ACTIVE),
+        node('', 'User', { id }),
+      ])
+      .apply(this.hydrate())
+      .map('dto')
+      .run();
+  }
 }

--- a/src/components/field-zone/handlers/restrict-zone-director-removal.handler.ts
+++ b/src/components/field-zone/handlers/restrict-zone-director-removal.handler.ts
@@ -1,0 +1,29 @@
+import { InputException } from '~/common';
+import { EventsHandler } from '~/core/events';
+import { UserUpdatedEvent } from '../../user/events/user-updated.event';
+import { FieldZoneRepository } from '../field-zone.repository';
+
+@EventsHandler(UserUpdatedEvent)
+export class RestrictZoneDirectorRemovalHandler {
+  constructor(private readonly repo: FieldZoneRepository) {}
+
+  async handle(event: UserUpdatedEvent) {
+    if (!event.updated.roles) {
+      return;
+    }
+    const roleRemoved =
+      event.previous.roles.includes('FieldOperationsDirector') &&
+      !event.updated.roles.includes('FieldOperationsDirector');
+    if (!roleRemoved) {
+      return;
+    }
+
+    const zones = await this.repo.readAllByDirector(event.updated.id);
+    if (zones.length > 0) {
+      throw new InputException(
+        'User is still a director for these field zones:\n' +
+          zones.map((z) => `  - ${z.name}`).join('\n'),
+      );
+    }
+  }
+}

--- a/src/components/user/events/user-updated.event.ts
+++ b/src/components/user/events/user-updated.event.ts
@@ -1,0 +1,10 @@
+import { type UnsecuredDto } from '~/common';
+import { type UpdateUser, type User } from '../dto';
+
+export class UserUpdatedEvent {
+  constructor(
+    readonly updated: UnsecuredDto<User>,
+    readonly previous: UnsecuredDto<User>,
+    readonly input: UpdateUser,
+  ) {}
+}

--- a/test/region.e2e-spec.ts
+++ b/test/region.e2e-spec.ts
@@ -28,9 +28,9 @@ describe('Region e2e', () => {
     await loginAsAdmin(app);
 
     director = await createPerson(app, {
-      roles: [Role.FieldOperationsDirector, Role.ProjectManager],
+      roles: [Role.RegionalDirector],
     });
-    fieldZone = await createZone(app, { directorId: director.id });
+    fieldZone = await createZone(app);
   });
 
   afterAll(async () => {

--- a/test/utility/create-region.ts
+++ b/test/utility/create-region.ts
@@ -5,7 +5,6 @@ import {
 } from '../../src/components/field-region/dto';
 import { type TestApp } from './create-app';
 import { createPerson } from './create-person';
-import { getUserFromSession } from './create-session';
 import { createZone } from './create-zone';
 import { fragments } from './fragments';
 import { gql } from './gql-tag';
@@ -25,9 +24,11 @@ export async function createRegion(
 
     directorId:
       input.directorId ||
-      (await getUserFromSession(app)).id ||
       (await runAsAdmin(app, async () => {
-        return (await createPerson(app)).id;
+        const director = await createPerson(app, {
+          roles: ['RegionalDirector'],
+        });
+        return director.id;
       })),
     ...input,
   };

--- a/test/utility/create-zone.ts
+++ b/test/utility/create-zone.ts
@@ -5,7 +5,6 @@ import {
 } from '../../src/components/field-zone/dto';
 import { type TestApp } from './create-app';
 import { createPerson } from './create-person';
-import { getUserFromSession } from './create-session';
 import { fragments } from './fragments';
 import { gql } from './gql-tag';
 import { runAsAdmin } from './login';
@@ -18,10 +17,12 @@ export async function createZone(
     name: 'Zone' + (await generateId()),
     directorId:
       input.directorId ||
-      (await getUserFromSession(app)).id ||
       // don't want to have to declare the role at the top level. The person part doesn't really matter here.
       (await runAsAdmin(app, async () => {
-        return (await createPerson(app)).id;
+        const director = await createPerson(app, {
+          roles: ['FieldOperationsDirector'],
+        });
+        return director.id;
       })),
     ...input,
   };

--- a/test/zone.e2e-spec.ts
+++ b/test/zone.e2e-spec.ts
@@ -24,8 +24,12 @@ describe('Field Zone e2e', () => {
     // Zones can only be created by admin
     await loginAsAdmin(app);
 
-    director = await createPerson(app);
-    newDirector = await createPerson(app);
+    director = await createPerson(app, {
+      roles: ['FieldOperationsDirector'],
+    });
+    newDirector = await createPerson(app, {
+      roles: ['FieldOperationsDirector'],
+    });
   });
 
   afterAll(async () => {


### PR DESCRIPTION
- Directors of Field Zones need to have the `FieldOperationsDirector` role
- Directors of Field Regions need to have the `RegionalDirector` role
- These users cannot have those roles removed if they are currently a director of any zones/regions