### PR TITLE
Support specific aliases for PnP step labels

### DIFF
--- a/src/components/pnp/findStepColumns.ts
+++ b/src/components/pnp/findStepColumns.ts
@@ -1,4 +1,4 @@
-import { sortBy } from '@seedcompany/common';
+import { mapOf, sortBy } from '@seedcompany/common';
 import levenshtein from 'fastest-levenshtein';
 import { startCase } from 'lodash';
 import { type Column } from '~/common/xlsx.util';
@@ -7,7 +7,7 @@ import { type PnpExtractionResult, PnpProblemType } from './extraction-result';
 import { type PlanningSheet } from './planning-sheet';
 import { type ProgressSheet } from './progress-sheet';
 
-const ApprovedCustomSteps = new Map<string, Step>([
+const ApprovedAliases = mapOf<string, Step>([
   ['draft & keyboard', Step.ExegesisAndFirstDraft],
   ['first draft', Step.ExegesisAndFirstDraft],
   ['exegesis, 1st draft, keyboard', Step.ExegesisAndFirstDraft],
@@ -38,9 +38,7 @@ export function findStepColumns(
     .walkRight()
     .filter((cell) => !!cell.asString)
     .map((cell) => ({
-      label:
-        ApprovedCustomSteps.get(cell.asString!.trim().toLowerCase()) ??
-        cell.asString!,
+      label: cell.asString!.trim(),
       column: cell.column,
       cell,
     }))
@@ -69,6 +67,11 @@ const chooseStep = (
   label: string,
   available: ReadonlySet<Step>,
 ): Step | undefined => {
+  const alias = ApprovedAliases.get(label.toLowerCase());
+  if (alias) {
+    return alias;
+  }
+
   const distances = available.values().map((step) => {
     const humanLabel = startCase(step).replace(' And ', ' & ');
     const distance = levenshtein.distance(label, humanLabel);

--- a/src/components/pnp/findStepColumns.ts
+++ b/src/components/pnp/findStepColumns.ts
@@ -1,6 +1,6 @@
 import { sortBy } from '@seedcompany/common';
 import levenshtein from 'fastest-levenshtein';
-import { startCase, without } from 'lodash';
+import { startCase } from 'lodash';
 import { type Column } from '~/common/xlsx.util';
 import { ProductStep as Step } from '../product/dto';
 import { type PnpExtractionResult, PnpProblemType } from './extraction-result';
@@ -15,8 +15,8 @@ export function findStepColumns(
   result?: PnpExtractionResult,
   availableSteps: readonly Step[] = [...Step],
 ) {
-  const matchedColumns: Partial<Record<Step, Column>> = {};
-  let remainingSteps = availableSteps;
+  const matchedColumns = new Map<Step, Column>();
+  const remainingSteps = new Set(availableSteps);
   const possibleSteps = sheet.stepLabels
     .walkRight()
     .filter((cell) => !!cell.asString)
@@ -25,32 +25,40 @@ export function findStepColumns(
   possibleSteps.forEach(({ label, column, cell }, index) => {
     if (index === possibleSteps.length - 1) {
       // The last step should always be called Completed in CORD per Seth.
-      // Written PnP already match, but OBS calls it Record. This is mislabeled
-      // depending on the methodology.
-      matchedColumns[Step.Completed] = column;
+      // Written PnP already matches, but OBS calls it Record.
+      // This is mislabeled depending on the methodology.
+      matchedColumns.set(Step.Completed, column);
       return;
     }
-    const distances = remainingSteps.map((step) => {
-      const humanLabel = startCase(step).replace(' And ', ' & ');
-      const distance = levenshtein.distance(label, humanLabel);
-      return [step, distance] as const;
-    });
-    // Pick the step that is the closest fuzzy match
-    const chosen = sortBy(
-      // 5 is too far ignore those
-      distances.filter(([_, distance]) => distance < 5),
-      ([_, distance]) => distance,
-    )[0]?.[0];
+
+    const chosen = chooseStep(label, remainingSteps);
     if (!chosen) {
       result?.addProblem(NonStandardStep, cell, { label });
       return;
     }
-    matchedColumns[chosen] = column;
-
-    remainingSteps = without(remainingSteps, chosen);
+    matchedColumns.set(chosen, column);
+    remainingSteps.delete(chosen);
   });
-  return matchedColumns as Record<Step, Column>;
+  return matchedColumns as ReadonlyMap<Step, Column>;
 }
+
+const chooseStep = (
+  label: string,
+  available: ReadonlySet<Step>,
+): Step | undefined => {
+  const distances = available.values().map((step) => {
+    const humanLabel = startCase(step).replace(' And ', ' & ');
+    const distance = levenshtein.distance(label, humanLabel);
+    return { step, distance };
+  });
+  // Pick the step that is the closest fuzzy match
+  const chosen = sortBy(
+    // 5 is too far ignoring those
+    distances.filter(({ distance }) => distance < 5),
+    ({ distance }) => distance,
+  ).at(0);
+  return chosen?.step;
+};
 
 const NonStandardStep = PnpProblemType.register({
   name: 'NonStandardStep',

--- a/src/components/pnp/findStepColumns.ts
+++ b/src/components/pnp/findStepColumns.ts
@@ -20,7 +20,11 @@ export function findStepColumns(
   const possibleSteps = sheet.stepLabels
     .walkRight()
     .filter((cell) => !!cell.asString)
-    .map((cell) => ({ label: cell.asString!, column: cell.column, cell }))
+    .map((cell) => ({
+      label: cell.asString!.trim(),
+      column: cell.column,
+      cell,
+    }))
     .toArray();
   possibleSteps.forEach(({ label, column, cell }, index) => {
     if (index === possibleSteps.length - 1) {

--- a/src/components/pnp/findStepColumns.ts
+++ b/src/components/pnp/findStepColumns.ts
@@ -7,6 +7,23 @@ import { type PnpExtractionResult, PnpProblemType } from './extraction-result';
 import { type PlanningSheet } from './planning-sheet';
 import { type ProgressSheet } from './progress-sheet';
 
+const ApprovedCustomSteps = new Map<string, Step>([
+  ['draft & keyboard', Step.ExegesisAndFirstDraft],
+  ['first draft', Step.ExegesisAndFirstDraft],
+  ['exegesis, 1st draft, keyboard', Step.ExegesisAndFirstDraft],
+  ['internalization & first draft', Step.ExegesisAndFirstDraft],
+  ['exegesis 1st draft & keybrd', Step.ExegesisAndFirstDraft],
+  ['first draft & keyboard', Step.ExegesisAndFirstDraft],
+  ['exegesis, 1st draft. keyboard', Step.ExegesisAndFirstDraft],
+  ['team check & 1st testing', Step.TeamCheck],
+  ['team check & revision', Step.TeamCheck],
+  ['team check & 1st test', Step.TeamCheck],
+  ['field test', Step.CommunityTesting],
+  ['community check', Step.CommunityTesting],
+  ['community review', Step.CommunityTesting],
+  ['community testing & revision', Step.CommunityTesting],
+]);
+
 /**
  * Fuzzy match available steps to their column address.
  */
@@ -21,7 +38,9 @@ export function findStepColumns(
     .walkRight()
     .filter((cell) => !!cell.asString)
     .map((cell) => ({
-      label: cell.asString!.trim(),
+      label:
+        ApprovedCustomSteps.get(cell.asString!.trim().toLowerCase()) ??
+        cell.asString!,
       column: cell.column,
       cell,
     }))

--- a/src/components/pnp/findStepColumns.ts
+++ b/src/components/pnp/findStepColumns.ts
@@ -69,7 +69,7 @@ const chooseStep = (
 ): Step | undefined => {
   const alias = ApprovedAliases.get(label.toLowerCase());
   if (alias) {
-    return alias;
+    return available.has(alias) ? alias : undefined;
   }
 
   const distances = available.values().map((step) => {

--- a/src/components/product-progress/step-progress-extractor.service.ts
+++ b/src/components/product-progress/step-progress-extractor.service.ts
@@ -66,8 +66,8 @@ export class StepProgressExtractor {
 const parseProgressRow =
   (
     pnp: Pnp,
-    stepColumns: Record<Step, Column>,
-    planningStepColumns: Record<Step, Column>,
+    stepColumns: ReadonlyMap<Step, Column>,
+    planningStepColumns: ReadonlyMap<Step, Column>,
     result: PnpProgressExtractionResult,
   ) =>
   (cell: Cell<ProgressSheet>, index: number): ExtractedRow => {
@@ -81,7 +81,7 @@ const parseProgressRow =
     const steps = entries(stepColumns).flatMap<StepProgressInput>(
       ([step, column]) => {
         const fiscalYear = pnp.planning.cell(
-          planningStepColumns[step],
+          planningStepColumns.get(step)!,
           planningRow,
         );
 

--- a/src/components/product/product.extractor.ts
+++ b/src/components/product/product.extractor.ts
@@ -81,8 +81,8 @@ export class ProductExtractor {
 const parseProductRow =
   (
     pnp: Pnp,
-    stepColumns: Record<Step, Column>,
-    progressStepColumns: Record<Step, Column>,
+    stepColumns: ReadonlyMap<Step, Column>,
+    progressStepColumns: ReadonlyMap<Step, Column>,
     result: PnpPlanningExtractionResult,
   ) =>
   (cell: Cell<PlanningSheet>, index: number): ExtractedRow => {
@@ -94,7 +94,7 @@ const parseProductRow =
     const steps = entries(stepColumns).flatMap(([step, column]) => {
       const plannedCell = sheet.cell(column, row);
       const progressCell = pnp.progress.cell(
-        progressStepColumns[step],
+        progressStepColumns.get(step)!,
         progressRow,
       );
 


### PR DESCRIPTION
This will remedy the custom step header error for a leadership approved list of alternative headers by replacing custom steps with standard ones.