### PR TITLE
Fix Project.engagements() with input.filter.project usage

### DIFF
--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -355,8 +355,8 @@ export class ProjectService {
         filter: {
           ...input.filter,
           project: {
-            id: project.id,
             ...input.filter?.project,
+            id: project.id,
           },
         },
       },
@@ -383,8 +383,8 @@ export class ProjectService {
       filter: {
         ...input.filter,
         project: {
-          id: project.id,
           ...input.filter?.project,
+          id: project.id,
         },
       },
     });


### PR DESCRIPTION
New ECMA class fields have all properties defined as undefined. Keys are not optional.

So
```ts
{
  id: project.id,
  ...{ id: undefined },
}
```
So undefined overrides our id instead of us forcing it.

This caused queries like
```graphql
query {
  project(id: "") {
    engagements(input: { filter: { project: {} } }) {
      total
      items {
        id
      }
    }
  }
}
```
to return more engagements than the one for the project
