### PR TITLE
Improve null handling for special cases

### DIFF
--- a/src/common/list-field.ts
+++ b/src/common/list-field.ts
@@ -1,6 +1,10 @@
 import { applyDecorators } from '@nestjs/common';
 import { ArrayNotEmpty } from 'class-validator';
-import { OptionalField, type OptionalFieldOptions } from './optional-field';
+import {
+  OptionalField,
+  type OptionalFieldOptions,
+  withDefaultTransform,
+} from './optional-field';
 
 export type ListFieldOptions = OptionalFieldOptions & {
   /**
@@ -14,11 +18,12 @@ export const ListField = (typeFn: () => any, options: ListFieldOptions) =>
     OptionalField(() => [typeFn()], {
       optional: false,
       ...options,
-      transform: (value) => {
+      transform: withDefaultTransform(options.transform, (prev) => (raw) => {
+        const value = prev(raw);
         let out = value ? [...new Set(value)] : value;
         out = options.empty === 'omit' && out.length === 0 ? undefined : out;
-        return options.transform ? options.transform(out) : out;
-      },
+        return out;
+      }),
     }),
     ...(options.empty === 'deny' ? [ArrayNotEmpty()] : []),
   );

--- a/src/common/optional-field.ts
+++ b/src/common/optional-field.ts
@@ -42,8 +42,11 @@ export function OptionalField(...args: any) {
     typeof args[0] === 'function' ? (args[0] as () => any) : undefined;
   const options: OptionalFieldOptions =
     (typeof args[0] === 'function' ? args[1] : args[0]) ?? {};
-  const nilIn = options.nullable ?? options.optional ?? true;
-  const nullOut = !!options.nullable;
+  const nilIn =
+    options.nullable === 'items' && options.optional
+      ? 'itemsAndList'
+      : options.nullable ?? options.optional ?? true;
+  const nullOut = !!options.nullable && options.nullable !== 'items';
   const schemaOptions = {
     ...options,
     nullable: nilIn,

--- a/src/common/optional-field.ts
+++ b/src/common/optional-field.ts
@@ -30,19 +30,21 @@ export function OptionalField(
 export function OptionalField(...args: any) {
   const typeFn: (() => any) | undefined =
     typeof args[0] === 'function' ? (args[0] as () => any) : undefined;
-  const options: OptionalFieldOptions | undefined =
-    typeof args[0] === 'function' ? args[1] : args[0];
-  const opts = {
+  const options: OptionalFieldOptions =
+    (typeof args[0] === 'function' ? args[1] : args[0]) ?? {};
+  const nilIn = options.nullable ?? options.optional ?? true;
+  const nullOut = !!options.nullable;
+  const schemaOptions = {
     ...options,
-    nullable: options?.nullable ?? options?.optional ?? true,
+    nullable: nilIn,
   };
   return applyDecorators(
-    typeFn ? Field(typeFn, opts) : Field(opts),
+    typeFn ? Field(typeFn, schemaOptions) : Field(schemaOptions),
     Transform(({ value }) => {
-      if (!options?.nullable && (options?.optional ?? true) && value == null) {
+      if (value === null && !nullOut) {
         return undefined;
       }
-      return options?.transform ? options.transform(value) : value;
+      return options.transform ? options.transform(value) : value;
     }),
   );
 }

--- a/src/common/sensitivity.enum.ts
+++ b/src/common/sensitivity.enum.ts
@@ -27,7 +27,11 @@ export const SensitivitiesFilterField = (options?: ListFieldOptions) =>
     ...options,
     optional: true,
     empty: 'omit',
-    transform: (value) =>
+    transform: (prev) => (raw) => {
+      const value = prev(raw);
       // If given all options, there is no need to filter
-      !value || value.length === Sensitivity.values.size ? undefined : value,
+      return !value || value.length === Sensitivity.values.size
+        ? undefined
+        : value;
+    },
   });

--- a/src/components/changeset/dto/changeset.args.ts
+++ b/src/components/changeset/dto/changeset.args.ts
@@ -11,8 +11,8 @@ export class ChangesetIds {
   @IdField()
   id: ID;
 
-  @IdField({ nullable: true })
-  changeset: ID;
+  @IdField({ optional: true })
+  changeset?: ID;
 }
 
 export type IdsAndView = ChangesetIds & { view: ObjectView };
@@ -25,10 +25,10 @@ export class ObjectViewPipe implements PipeTransform {
   constructor(private readonly validator: ValidationPipe) {}
 
   async transform(input: ChangesetIds) {
-    const { id, changeset } = await this.validator.transform(input, {
+    const { id, changeset } = (await this.validator.transform(input, {
       metatype: ChangesetIds,
       type: 'body',
-    });
+    })) as ChangesetIds;
     const view: ObjectView = changeset ? { changeset } : { active: true };
     return { id, changeset, view };
   }

--- a/src/components/partnership/dto/list-partnership.dto.ts
+++ b/src/components/partnership/dto/list-partnership.dto.ts
@@ -20,9 +20,13 @@ export abstract class PartnershipFilters {
   @ListField(() => PartnerType, {
     optional: true,
     empty: 'omit',
-    transform: (value) =>
+    transform: (prev) => (raw) => {
+      const value = prev(raw);
       // If given all options, there is no need to filter
-      !value || value.length === PartnerType.values.size ? undefined : value,
+      return !value || value.length === PartnerType.values.size
+        ? undefined
+        : value;
+    },
   })
   readonly types?: readonly PartnerType[];
 }

--- a/src/components/progress-report/variance-explanation/variance-explanation.dto.ts
+++ b/src/components/progress-report/variance-explanation/variance-explanation.dto.ts
@@ -3,6 +3,7 @@ import { ArrayMaxSize, IsIn } from 'class-validator';
 import {
   type ID,
   IdField,
+  ListField,
   type RichTextDocument,
   RichTextField,
   SecuredRichTextNullable,
@@ -36,7 +37,10 @@ export abstract class ProgressReportVarianceExplanationInput {
   })
   readonly report: ID;
 
-  @Field(() => [String], { nullable: true })
+  @ListField(() => String, {
+    optional: true,
+    transform: (prev) => (value) => value === null ? [] : prev(value),
+  })
   @IsIn([...ReasonOptions.instance.all], {
     each: true,
     message: 'Reason is not one of our available choices',

--- a/src/components/progress-report/variance-explanation/variance-explanation.service.ts
+++ b/src/components/progress-report/variance-explanation/variance-explanation.service.ts
@@ -37,12 +37,7 @@ export class ProgressReportVarianceExplanationService {
     }
 
     const changes = this.repo.getActualChanges(existing, {
-      reasons:
-        input.reasons === undefined
-          ? existing.reasons.value
-          : input.reasons === null
-          ? []
-          : input.reasons,
+      reasons: input.reasons,
       comments: input.comments,
     });
     if (Object.keys(changes).length === 0) {

--- a/src/components/progress-summary/dto/progress-summary-filters.dto.ts
+++ b/src/components/progress-summary/dto/progress-summary-filters.dto.ts
@@ -6,7 +6,8 @@ import { ScheduleStatus } from './schedule-status.enum';
 @InputType()
 export abstract class ProgressSummaryFilters {
   @ListField(() => ScheduleStatus, {
-    nullable: 'itemsAndList',
+    optional: true,
+    nullable: 'items',
     description: stripIndent`
       Filter by schedule status.
       - \`[X, Y]\` will allow summaries with either X or Y status.

--- a/src/components/progress-summary/dto/progress-summary-filters.dto.ts
+++ b/src/components/progress-summary/dto/progress-summary-filters.dto.ts
@@ -15,6 +15,7 @@ export abstract class ProgressSummaryFilters {
       - \`[null]\` will filter to only missing summaries.
       - \`null\` and \`[]\` will be ignored.
     `,
+    empty: 'omit',
   })
   readonly scheduleStatus?: ReadonlyArray<ScheduleStatus | null>;
 }

--- a/src/components/progress-summary/progress-summary.repository.ts
+++ b/src/components/progress-summary/progress-summary.repository.ts
@@ -108,9 +108,6 @@ export const progressSummaryFilters = filter.define(
   {
     scheduleStatus: ({ value, query }) => {
       const status = setOf(value);
-      if (status.size === 0) {
-        return undefined;
-      }
       if (status.size === 1 && status.has(null)) {
         return query.where(new WhereExp('node IS NULL'));
       }


### PR DESCRIPTION
- `ProgressSummaryFilters.scheduleStatus` wants to allow `null` as items in list, but the overall fields should be `optional` aka `null` should not be allowed.
   It was previously allowed, even though it was un-typed. Now `null` is converted to `undefined`.
  An empty list also is converted to `undefined` via the pre-existing, now-enabled `empty: 'omit'` option.

- `ProgressReportVarianceExplanationInput.reasons` now converts `null` to an `empty` array in the declaration instead of the service layer. This `null` was also incorrectly un-typed previously.

- `ChangesetIds.changeset` now correctly conveys that it can be `undefined`. And converts `null` to `undefined`.