### PR TITLE
Fix change check on region/zone director role removal

### DIFF
--- a/src/components/engagement/handlers/apply-finalized-changeset-to-engagement.handler.ts
+++ b/src/components/engagement/handlers/apply-finalized-changeset-to-engagement.handler.ts
@@ -106,7 +106,9 @@ export class ApplyFinalizedChangesetToEngagement
               node('node', 'Language'),
             ])
             .apply(
-              changeset.id ? commitChangesetProps() : rejectChangesetProps(),
+              changeset.applied
+                ? commitChangesetProps()
+                : rejectChangesetProps(),
             )
             .return('1 as one'),
         )

--- a/src/components/field-region/handlers/restrict-region-director-removal.handler.ts
+++ b/src/components/field-region/handlers/restrict-region-director-removal.handler.ts
@@ -8,7 +8,7 @@ export class RestrictRegionDirectorRemovalHandler {
   constructor(private readonly repo: FieldRegionRepository) {}
 
   async handle(event: UserUpdatedEvent) {
-    if (!event.updated.roles) {
+    if (!event.input.roles) {
       return;
     }
     const roleRemoved =

--- a/src/components/field-zone/handlers/restrict-zone-director-removal.handler.ts
+++ b/src/components/field-zone/handlers/restrict-zone-director-removal.handler.ts
@@ -8,7 +8,7 @@ export class RestrictZoneDirectorRemovalHandler {
   constructor(private readonly repo: FieldZoneRepository) {}
 
   async handle(event: UserUpdatedEvent) {
-    if (!event.updated.roles) {
+    if (!event.input.roles) {
       return;
     }
     const roleRemoved =


### PR DESCRIPTION
These were found while enabling `no-unnecessary-condition` lint rule, but are actual bugs so I wanted to call them out separately