### PR TITLE
Bump Org.reach/types migration versions to execute them

### DIFF
--- a/src/components/organization/migrations/add-reach.migration.ts
+++ b/src/components/organization/migrations/add-reach.migration.ts
@@ -1,7 +1,7 @@
 import { BaseMigration, Migration } from '~/core/database';
 import { Organization } from '../dto';
 
-@Migration('2023-08-04T00:00:00')
+@Migration('2025-07-02T18:11:16')
 export class AddOrganizationReachMigration extends BaseMigration {
   async up() {
     await this.addProperty(Organization, 'reach', []);

--- a/src/components/organization/migrations/add-type.migration.ts
+++ b/src/components/organization/migrations/add-type.migration.ts
@@ -1,7 +1,7 @@
 import { BaseMigration, Migration } from '~/core/database';
 import { Organization } from '../dto';
 
-@Migration('2023-08-04T00:00:00')
+@Migration('2025-07-02T18:11:16')
 export class AddOrganizationTypeMigration extends BaseMigration {
   async up() {
     await this.addProperty(Organization, 'types', []);


### PR DESCRIPTION
They were versioned at an early date before the code made it to develop, and other migrations written after were merged first; causing these migrations to never execute.
