### PR TITLE
Org user assignment

### DIFF
--- a/src/components/user/dto/assign-organization-to-user.dto.ts
+++ b/src/components/user/dto/assign-organization-to-user.dto.ts
@@ -1,7 +1,8 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { type ID, IdField, MutationPlaceholderOutput } from '~/common';
+import { type ID, IdField } from '~/common';
+import { User } from './user.dto';
 
 @InputType()
 export class AssignOrganizationToUser {
@@ -20,8 +21,11 @@ export abstract class AssignOrganizationToUserInput {
   @Field()
   @Type(() => AssignOrganizationToUser)
   @ValidateNested()
-  readonly request: AssignOrganizationToUser;
+  readonly assignment: AssignOrganizationToUser;
 }
 
 @ObjectType()
-export abstract class AssignOrganizationToUserOutput extends MutationPlaceholderOutput {}
+export abstract class AssignOrganizationToUserOutput {
+  @Field()
+  readonly assignment: User;
+}

--- a/src/components/user/dto/assign-organization-to-user.dto.ts
+++ b/src/components/user/dto/assign-organization-to-user.dto.ts
@@ -2,7 +2,7 @@ import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { type ID, IdField } from '~/common';
-import { User } from './user.dto';
+import { Partner } from '../../../components/partner/dto';
 
 @InputType()
 export class AssignOrganizationToUser {
@@ -27,5 +27,5 @@ export abstract class AssignOrganizationToUserInput {
 @ObjectType()
 export abstract class AssignOrganizationToUserOutput {
   @Field()
-  readonly assignment: User;
+  readonly partner: Partner;
 }

--- a/src/components/user/dto/remove-organization-from-user.dto.ts
+++ b/src/components/user/dto/remove-organization-from-user.dto.ts
@@ -1,7 +1,8 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
-import { type ID, IdField, MutationPlaceholderOutput } from '~/common';
+import { type ID, IdField } from '~/common';
+import { Partner } from '../../../components/partner/dto';
 
 @InputType()
 export class RemoveOrganizationFromUser {
@@ -21,4 +22,7 @@ export abstract class RemoveOrganizationFromUserInput {
 }
 
 @ObjectType()
-export abstract class RemoveOrganizationFromUserOutput extends MutationPlaceholderOutput {}
+export abstract class RemoveOrganizationFromUserOutput {
+  @Field()
+  readonly partner: Partner;
+}

--- a/src/components/user/dto/remove-organization-from-user.dto.ts
+++ b/src/components/user/dto/remove-organization-from-user.dto.ts
@@ -17,7 +17,7 @@ export abstract class RemoveOrganizationFromUserInput {
   @Field()
   @Type(() => RemoveOrganizationFromUser)
   @ValidateNested()
-  readonly request: RemoveOrganizationFromUser;
+  readonly assignment: RemoveOrganizationFromUser;
 }
 
 @ObjectType()

--- a/src/components/user/user.resolver.ts
+++ b/src/components/user/user.resolver.ts
@@ -31,6 +31,7 @@ import { TimeZoneService } from '../timezone';
 import { SecuredTimeZone } from '../timezone/timezone.dto';
 import {
   AssignOrganizationToUserInput,
+  AssignOrganizationToUserOutput,
   CheckEmailArgs,
   CreatePersonInput,
   CreatePersonOutput,
@@ -38,6 +39,7 @@ import {
   KnownLanguage,
   ModifyKnownLanguageArgs,
   RemoveOrganizationFromUserInput,
+  RemoveOrganizationFromUserOutput,
   UpdateUserInput,
   UpdateUserOutput,
   User,
@@ -264,24 +266,31 @@ export class UserResolver {
     return await this.userService.readOne(userId);
   }
 
-  @Mutation(() => User, {
+  @Mutation(() => AssignOrganizationToUserOutput, {
     description: 'Assign organization OR primaryOrganization to user',
   })
   async assignOrganizationToUser(
     @Args('input') input: AssignOrganizationToUserInput,
-  ): Promise<User> {
+  ): Promise<AssignOrganizationToUserOutput> {
     await this.userService.assignOrganizationToUser(input.assignment);
-    return await this.userService.readOne(input.assignment.userId);
+    const partner = await this.partnerService.readOnePartnerByOrgId(
+      input.assignment.orgId,
+    );
+
+    return { partner };
   }
 
-  @Mutation(() => User, {
+  @Mutation(() => RemoveOrganizationFromUserOutput, {
     description: 'Remove organization OR primaryOrganization from user',
   })
   async removeOrganizationFromUser(
     @Args('input') input: RemoveOrganizationFromUserInput,
-  ): Promise<User> {
+  ): Promise<RemoveOrganizationFromUserOutput> {
     await this.userService.removeOrganizationFromUser(input.assignment);
-    return await this.userService.readOne(input.assignment.userId);
+    const partner = await this.partnerService.readOnePartnerByOrgId(
+      input.assignment.orgId,
+    );
+    return { partner };
   }
 
   @Mutation(() => User, {

--- a/src/components/user/user.resolver.ts
+++ b/src/components/user/user.resolver.ts
@@ -25,8 +25,8 @@ import {
   OrganizationListInput,
   SecuredOrganizationList,
 } from '../organization/dto';
-import { PartnerLoader } from '../partner';
-import { PartnerListInput, SecuredPartnerList } from '../partner/dto';
+import { PartnerLoader, PartnerService } from '../partner';
+import { Partner, PartnerListInput, SecuredPartnerList } from '../partner/dto';
 import { TimeZoneService } from '../timezone';
 import { SecuredTimeZone } from '../timezone/timezone.dto';
 import {
@@ -68,6 +68,7 @@ class ModifyLocationArgs {
 export class UserResolver {
   constructor(
     private readonly userService: UserService,
+    private readonly partnerService: PartnerService,
     private readonly timeZoneService: TimeZoneService,
     private readonly identity: Identity,
   ) {}
@@ -160,6 +161,14 @@ export class UserResolver {
     const list = await this.userService.listOrganizations(id, input);
     organizations.primeAll(list.items);
     return list;
+  }
+
+  @ResolveField(() => Partner, { nullable: true })
+  async primaryOrganization(@Parent() { id }: User): Promise<Partner | null> {
+    const primaryOrgId = await this.userService.getPrimaryOrganizationId(id);
+    return primaryOrgId
+      ? await this.partnerService.readOnePartnerByOrgId(primaryOrgId)
+      : null;
   }
 
   @ResolveField(() => SecuredPartnerList)

--- a/src/components/user/user.resolver.ts
+++ b/src/components/user/user.resolver.ts
@@ -31,7 +31,6 @@ import { TimeZoneService } from '../timezone';
 import { SecuredTimeZone } from '../timezone/timezone.dto';
 import {
   AssignOrganizationToUserInput,
-  AssignOrganizationToUserOutput,
   CheckEmailArgs,
   CreatePersonInput,
   CreatePersonOutput,
@@ -39,7 +38,6 @@ import {
   KnownLanguage,
   ModifyKnownLanguageArgs,
   RemoveOrganizationFromUserInput,
-  RemoveOrganizationFromUserOutput,
   UpdateUserInput,
   UpdateUserOutput,
   User,
@@ -257,24 +255,24 @@ export class UserResolver {
     return await this.userService.readOne(userId);
   }
 
-  @Mutation(() => AssignOrganizationToUserOutput, {
+  @Mutation(() => User, {
     description: 'Assign organization OR primaryOrganization to user',
   })
   async assignOrganizationToUser(
     @Args('input') input: AssignOrganizationToUserInput,
-  ): Promise<AssignOrganizationToUserOutput> {
-    await this.userService.assignOrganizationToUser(input.request);
-    return { success: true };
+  ): Promise<User> {
+    await this.userService.assignOrganizationToUser(input.assignment);
+    return await this.userService.readOne(input.assignment.userId);
   }
 
-  @Mutation(() => RemoveOrganizationFromUserOutput, {
+  @Mutation(() => User, {
     description: 'Remove organization OR primaryOrganization from user',
   })
   async removeOrganizationFromUser(
     @Args('input') input: RemoveOrganizationFromUserInput,
-  ): Promise<RemoveOrganizationFromUserOutput> {
-    await this.userService.removeOrganizationFromUser(input.request);
-    return { success: true };
+  ): Promise<User> {
+    await this.userService.removeOrganizationFromUser(input.assignment);
+    return await this.userService.readOne(input.assignment.userId);
   }
 
   @Mutation(() => User, {

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -333,6 +333,11 @@ export class UserService {
     await this.userRepo.assignOrganizationToUser(request);
   }
 
+  async getPrimaryOrganizationId(userId: ID) {
+    const org = await this.userRepo.getPrimaryOrganizationId(userId);
+    return org ?? null;
+  }
+
   async removeOrganizationFromUser(
     request: RemoveOrganizationFromUser,
   ): Promise<void> {


### PR DESCRIPTION
Added a new GraphQL resolver field `primaryOrganization` to the `User` type that returns the user's primary organization as a `Partner` object. 

Fixed a bug in the organization assignment logic where setting a new primary organization wouldn't properly override the existing one. 

Updated the `assignOrganizationToUser` mutation to use `readOnePartnerByOrgId` and return the related `Partner`.

Updated the `removeOrganizationFromUser` mutation to use `readOnePartnerByOrgId` and return the related `Partner`.


