### PR TITLE
Expose FieldRegion.projects & FieldZone.projects

### DIFF
--- a/dbschema/field-region.gel
+++ b/dbschema/field-region.gel
@@ -6,5 +6,7 @@ module default {
     
     required fieldZone: FieldZone;
     required director: User;
+
+    projects := .<fieldRegion[is Project];
   }
 }

--- a/dbschema/field-zone.gel
+++ b/dbschema/field-zone.gel
@@ -7,5 +7,6 @@ module default {
     required director: User;
     
     fieldRegions := .<fieldZone[is FieldRegion];
+    projects := .<fieldZone[is FieldRegion].projects;
   }
 }

--- a/dbschema/migrations/00034-m1qe4pe.edgeql
+++ b/dbschema/migrations/00034-m1qe4pe.edgeql
@@ -1,0 +1,10 @@
+CREATE MIGRATION m1qe4pe3jm66gavbvflww62fdofpp4x7srbpgoeqyo6ojtqydlwxba
+    ONTO m16y5z7zw6smsjr4ikg7i67jsvjlo3qibzblmvnb43smvrnxt57xwa
+{
+  ALTER TYPE default::FieldRegion {
+      CREATE LINK projects := (.<fieldRegion[IS default::Project]);
+  };
+  ALTER TYPE default::FieldZone {
+      CREATE LINK projects := (.<fieldZone[IS default::FieldRegion].projects);
+  };
+};

--- a/src/components/field-region/field-region.module.ts
+++ b/src/components/field-region/field-region.module.ts
@@ -2,6 +2,7 @@ import { forwardRef, Module } from '@nestjs/common';
 import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { FieldZoneModule } from '../field-zone/field-zone.module';
+import { ProjectModule } from '../project/project.module';
 import { UserModule } from '../user/user.module';
 import { FieldRegionGelRepository } from './field-region.gel.repository';
 import { FieldRegionLoader } from './field-region.loader';
@@ -14,6 +15,7 @@ import { RestrictRegionDirectorRemovalHandler } from './handlers/restrict-region
   imports: [
     forwardRef(() => AuthorizationModule),
     FieldZoneModule,
+    forwardRef(() => ProjectModule),
     forwardRef(() => UserModule),
   ],
   providers: [

--- a/src/components/field-region/field-region.resolver.ts
+++ b/src/components/field-region/field-region.resolver.ts
@@ -10,6 +10,8 @@ import { type ID, IdArg, ListArg, mapSecuredValue } from '~/common';
 import { Loader, type LoaderOf } from '~/core/data-loader';
 import { FieldZoneLoader } from '../field-zone';
 import { SecuredFieldZone } from '../field-zone/dto';
+import { ProjectListInput, SecuredProjectList } from '../project/dto';
+import { ProjectLoader } from '../project/project.loader';
 import { UserLoader } from '../user';
 import { SecuredUser } from '../user/dto';
 import {
@@ -69,6 +71,19 @@ export class FieldRegionResolver {
     return await mapSecuredValue(fieldRegion.fieldZone, ({ id }) =>
       fieldZones.load(id),
     );
+  }
+
+  @ResolveField(() => SecuredProjectList, {
+    description: 'The list of projects in this field region.',
+  })
+  async projects(
+    @Parent() fieldRegion: FieldRegion,
+    @ListArg(ProjectListInput) input: ProjectListInput,
+    @Loader(ProjectLoader) loader: LoaderOf<ProjectLoader>,
+  ): Promise<SecuredProjectList> {
+    const list = await this.fieldRegionService.listProjects(fieldRegion, input);
+    loader.primeAll(list.items);
+    return list;
   }
 
   @Mutation(() => FieldRegionCreated, {

--- a/src/components/field-region/field-region.service.ts
+++ b/src/components/field-region/field-region.service.ts
@@ -10,6 +10,12 @@ import {
 import { Hooks } from '~/core/hooks';
 import { HandleIdLookup } from '~/core/resources';
 import { Privileges } from '../authorization';
+import {
+  IProject,
+  type ProjectListInput,
+  type SecuredProjectList,
+} from '../project/dto';
+import { ProjectService } from '../project/project.service';
 import { UserService } from '../user';
 import {
   type CreateFieldRegion,
@@ -28,6 +34,7 @@ export class FieldRegionService {
     private readonly hooks: Hooks,
     private readonly users: UserService,
     private readonly repo: FieldRegionRepository,
+    private readonly projects: ProjectService,
   ) {}
 
   async create(input: CreateFieldRegion): Promise<FieldRegion> {
@@ -113,6 +120,21 @@ export class FieldRegionService {
     return {
       ...results,
       items: results.items.map((dto) => this.secure(dto)),
+    };
+  }
+
+  async listProjects(
+    fieldRegion: FieldRegion,
+    input: ProjectListInput,
+  ): Promise<SecuredProjectList> {
+    const result = await this.projects.list({
+      ...input,
+      filter: { ...input.filter, fieldRegion: { id: fieldRegion.id } },
+    });
+    return {
+      ...result,
+      canRead: true,
+      canCreate: this.privileges.for(IProject).can('create'),
     };
   }
 }

--- a/src/components/field-zone/field-zone.module.ts
+++ b/src/components/field-zone/field-zone.module.ts
@@ -1,6 +1,7 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
+import { ProjectModule } from '../project/project.module';
 import { UserModule } from '../user/user.module';
 import { FieldZoneGelRepository } from './field-zone.gel.repository';
 import { FieldZoneLoader } from './field-zone.loader';
@@ -12,6 +13,7 @@ import { RestrictZoneDirectorRemovalHandler } from './handlers/restrict-zone-dir
 @Module({
   imports: [
     forwardRef(() => AuthorizationModule),
+    forwardRef(() => ProjectModule),
     forwardRef(() => UserModule),
   ],
   providers: [

--- a/src/components/field-zone/field-zone.resolver.ts
+++ b/src/components/field-zone/field-zone.resolver.ts
@@ -8,6 +8,8 @@ import {
 } from '@nestjs/graphql';
 import { type ID, IdArg, ListArg, mapSecuredValue } from '~/common';
 import { Loader, type LoaderOf } from '~/core/data-loader';
+import { ProjectListInput, SecuredProjectList } from '../project/dto';
+import { ProjectLoader } from '../project/project.loader';
 import { UserLoader } from '../user';
 import { SecuredUser } from '../user/dto';
 import {
@@ -57,6 +59,19 @@ export class FieldZoneResolver {
     return await mapSecuredValue(fieldZone.director, ({ id }) =>
       users.load(id),
     );
+  }
+
+  @ResolveField(() => SecuredProjectList, {
+    description: 'The list of projects in this field zone.',
+  })
+  async projects(
+    @Parent() fieldZone: FieldZone,
+    @ListArg(ProjectListInput) input: ProjectListInput,
+    @Loader(ProjectLoader) loader: LoaderOf<ProjectLoader>,
+  ): Promise<SecuredProjectList> {
+    const list = await this.fieldZoneService.listProjects(fieldZone, input);
+    loader.primeAll(list.items);
+    return list;
   }
 
   @Mutation(() => FieldZoneCreated, {

--- a/src/components/field-zone/field-zone.service.ts
+++ b/src/components/field-zone/field-zone.service.ts
@@ -10,6 +10,8 @@ import {
 import { Hooks } from '~/core/hooks';
 import { HandleIdLookup } from '~/core/resources';
 import { Privileges } from '../authorization';
+import { type ProjectListInput, type SecuredProjectList } from '../project/dto';
+import { ProjectService } from '../project/project.service';
 import { UserService } from '../user';
 import {
   type CreateFieldZone,
@@ -28,6 +30,7 @@ export class FieldZoneService {
     private readonly hooks: Hooks,
     private readonly users: UserService,
     private readonly repo: FieldZoneRepository,
+    private readonly projects: ProjectService,
   ) {}
 
   async create(input: CreateFieldZone): Promise<FieldZone> {
@@ -113,6 +116,24 @@ export class FieldZoneService {
     return {
       ...results,
       items: results.items.map((dto) => this.secure(dto)),
+    };
+  }
+
+  async listProjects(
+    fieldZone: FieldZone,
+    input: ProjectListInput,
+  ): Promise<SecuredProjectList> {
+    const result = await this.projects.list({
+      ...input,
+      filter: {
+        ...input.filter,
+        fieldRegion: { fieldZone: { id: fieldZone.id } },
+      },
+    });
+    return {
+      ...result,
+      canRead: true,
+      canCreate: false,
     };
   }
 }

--- a/src/components/location/location.module.ts
+++ b/src/components/location/location.module.ts
@@ -15,7 +15,7 @@ import { DefaultMarketingRegionMigration } from './migrations/default-marketing-
   imports: [
     forwardRef(() => AuthorizationModule),
     forwardRef(() => FundingAccountModule),
-    FieldRegionModule,
+    forwardRef(() => FieldRegionModule),
     FileModule,
   ],
   providers: [

--- a/src/components/organization/organization.module.ts
+++ b/src/components/organization/organization.module.ts
@@ -11,7 +11,10 @@ import { OrganizationResolver } from './organization.resolver';
 import { OrganizationService } from './organization.service';
 
 @Module({
-  imports: [forwardRef(() => AuthorizationModule), LocationModule],
+  imports: [
+    forwardRef(() => AuthorizationModule),
+    forwardRef(() => LocationModule),
+  ],
   providers: [
     OrganizationResolver,
     OrganizationService,

--- a/src/components/project/project.gel.repository.ts
+++ b/src/components/project/project.gel.repository.ts
@@ -221,6 +221,14 @@ export class ProjectGelRepository
           '=',
           input.usesRev79,
         ),
+      input.fieldRegion?.id &&
+        e.op(project.fieldRegion.id, '=', e.uuid(input.fieldRegion.id)),
+      input.fieldRegion?.fieldZone?.id &&
+        e.op(
+          project.fieldRegion.fieldZone.id,
+          '=',
+          e.uuid(input.fieldRegion.fieldZone.id),
+        ),
     ];
   }
 


### PR DESCRIPTION
BE for https://github.com/SeedCompany/cord-field/issues/1709

### Expose FieldRegion.projects and FieldZone.projects in GraphQL API

Adds a paginated, filterable projects relationship to both FieldRegion and FieldZone so the UI can display project tables on each detail page.

### Changes:

**Schema** — added computed links to both types:

FieldRegion.projects → direct back-reference via .<fieldRegion[is Project]
FieldZone.projects → aggregated through regions via .<fieldZone[is FieldRegion].projects
Project gel repository — added fieldRegion.id and fieldRegion.fieldZone.id filter handling to listFilters (these were already supported in the Neo4j path but missing from the Gel implementation)

**Services** — listProjects() added to both FieldRegionService and FieldZoneService, delegating to ProjectService.list() with the appropriate filter. FieldZone sets canCreate: false since zones don't own projects directly.

**Resolvers** — @ResolveField projects added inline to FieldRegionResolver and FieldZoneResolver, supporting full ProjectListInput pagination and filtering.

**Circular dependency fixes** — introducing ProjectModule into FieldRegionModule and FieldZoneModule created new cycles through LocationModule and OrganizationModule; wrapped those imports with forwardRef.