### PR TITLE
Allow Resource to have Relations

### DIFF
--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -11,6 +11,7 @@ import {
 import { createMetadataDecorator } from '@seedcompany/nest';
 import { LazyGetter as Once } from 'lazy-get-decorator';
 import { DateTime } from 'luxon';
+import { type OmitIndexSignature } from 'type-fest';
 import type {
   ResourceDBMap,
   ResourceLike,
@@ -28,6 +29,12 @@ import { DateTimeField } from './luxon.graphql';
 import { getParentTypes } from './parent-types';
 import { type MaybeSecured, type SecuredProps } from './secured-property';
 import { type AbstractClassType } from './types';
+
+// Merge with this to declare Relations types for Resources.
+// Be sure to patch at runtime too.
+// Don't reference this type directly, other than to declaration merge.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DeclareResourceRelations {}
 
 const GqlClassType = createMetadataDecorator({
   key: CLASS_TYPE_METADATA,
@@ -54,7 +61,12 @@ export const resolveByTypename =
 @DbLabel('BaseNode')
 export abstract class Resource extends DataObject {
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  static readonly Relations = () => ({} satisfies ResourceRelationsShape);
+  static readonly Relations =
+    (): OmitIndexSignature<DeclareResourceRelations> => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore -- runtime needs to be patched in.
+      return {};
+    };
 
   readonly __typename?: string;
 

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -80,7 +80,10 @@ export type ResourceShape<T> = AbstractClassType<T> & {
   // Default should probably be considered the props on Resource class.
   BaseNodeProps?: string[];
   Relations?: Thunk<
-    Record<string, ResourceShape<any> | [ResourceShape<any>] | undefined>
+    Record<
+      string,
+      ResourceShape<any> | readonly [ResourceShape<any>] | undefined
+    >
   >;
   /**
    * Define this resource as being a child of another.
@@ -397,7 +400,7 @@ export type SecuredPropsPlusExtraKey<
 /* eslint-disable @typescript-eslint/ban-types -- {} is used to mean non-nullable, it's not an empty interface */
 
 export type ExtraPropsFromRelationsKey<T extends ResourceShape<any>> = {
-  [R in RelKey<T>]: RelOf<T>[R] extends Array<infer U>
+  [R in RelKey<T>]: RelOf<T>[R] extends ReadonlyArray<infer U>
     ? U extends ResourceShape<any>
       ? U['Parent'] extends {}
         ? never
@@ -411,7 +414,7 @@ export type ExtraPropsFromRelationsKey<T extends ResourceShape<any>> = {
 }[RelKey<T>];
 
 export type ChildSinglesKey<T extends ResourceShape<any>> = {
-  [R in RelKey<T>]: RelOf<T>[R] extends any[]
+  [R in RelKey<T>]: RelOf<T>[R] extends readonly any[]
     ? never
     : RelOf<T>[R] extends ResourceShape<any>
     ? RelOf<T>[R]['Parent'] extends {}
@@ -421,7 +424,7 @@ export type ChildSinglesKey<T extends ResourceShape<any>> = {
 }[RelKey<T>];
 
 export type ChildListsKey<T extends ResourceShape<any>> = {
-  [R in RelKey<T>]: RelOf<T>[R] extends Array<infer U>
+  [R in RelKey<T>]: RelOf<T>[R] extends ReadonlyArray<infer U>
     ? U extends ResourceShape<any>
       ? U['Parent'] extends {}
         ? R

--- a/src/common/resource.dto.ts
+++ b/src/common/resource.dto.ts
@@ -53,6 +53,9 @@ export const resolveByTypename =
 })
 @DbLabel('BaseNode')
 export abstract class Resource extends DataObject {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  static readonly Relations = () => ({} satisfies ResourceRelationsShape);
+
   readonly __typename?: string;
 
   @IdField()

--- a/src/components/budget/dto/budget.dto.ts
+++ b/src/components/budget/dto/budget.dto.ts
@@ -27,6 +27,7 @@ const Interfaces = IntersectTypes(Resource, ChangesetAware);
 })
 export class Budget extends Interfaces {
   static readonly Relations = (() => ({
+    ...Resource.Relations(),
     records: [BudgetRecord],
   })) satisfies ResourceRelationsShape;
   static readonly Parent = () =>

--- a/src/components/comments/dto/comment-thread.dto.ts
+++ b/src/components/comments/dto/comment-thread.dto.ts
@@ -16,9 +16,10 @@ import { Comment } from './comment.dto';
   implements: [Resource],
 })
 export class CommentThread extends Resource {
-  static readonly Relations = {
+  static readonly Relations = (() => ({
+    ...Resource.Relations(),
     comments: [Comment],
-  } satisfies ResourceRelationsShape;
+  })) satisfies ResourceRelationsShape;
   static readonly Parent = 'dynamic';
 
   @Field(() => Comment)

--- a/src/components/comments/dto/commentable.dto.ts
+++ b/src/components/comments/dto/commentable.dto.ts
@@ -15,9 +15,10 @@ import { CommentThread } from './comment-thread.dto';
   resolveType: resolveByTypename(Commentable.name),
 })
 export abstract class Commentable extends Resource {
-  static readonly Relations = {
+  static readonly Relations = (() => ({
+    ...Resource.Relations(),
     commentThreads: [CommentThread],
-  } satisfies ResourceRelationsShape;
+  })) satisfies ResourceRelationsShape;
 
   declare __typename: string;
 }

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -69,9 +69,10 @@ const RequiredWhenNotInDev = RequiredWhen(() => Engagement)({
  * This should be used for GraphQL but never for TypeScript types.
  */
 class Engagement extends Interfaces {
-  static readonly Relations = {
-    ...Commentable.Relations,
-  } satisfies ResourceRelationsShape;
+  static readonly Relations = (() => ({
+    ...Resource.Relations(),
+    ...Commentable.Relations(),
+  })) satisfies ResourceRelationsShape;
   static readonly Parent = () =>
     import('../../project/dto').then((m) => m.IProject);
   static readonly resolve = resolveEngagementType;
@@ -163,11 +164,11 @@ export { Engagement as IEngagement, type AnyEngagement as Engagement };
   implements: [Engagement],
 })
 export class LanguageEngagement extends Engagement {
-  static readonly Relations = {
-    ...Engagement.Relations,
+  static readonly Relations = (() => ({
+    ...Engagement.Relations(),
     // why is this singular?
     product: [Product],
-  } satisfies ResourceRelationsShape;
+  })) satisfies ResourceRelationsShape;
   static readonly Parent = () =>
     import('../../project/dto').then((m) => m.TranslationProject);
 

--- a/src/components/language/dto/language.dto.ts
+++ b/src/components/language/dto/language.dto.ts
@@ -82,12 +82,13 @@ const Interfaces = IntersectTypes(Resource, Pinnable, Postable, Commentable);
   implements: Interfaces.members,
 })
 export class Language extends Interfaces {
-  static readonly Relations = {
+  static readonly Relations = (() => ({
+    ...Resource.Relations(),
     ethnologue: EthnologueLanguage,
     locations: [Location], // a child list but not creating deleting...does it still count?
-    ...Postable.Relations,
-    ...Commentable.Relations,
-  } satisfies ResourceRelationsShape;
+    ...Postable.Relations(),
+    ...Commentable.Relations(),
+  })) satisfies ResourceRelationsShape;
 
   @NameField({
     description: `The real language name`,

--- a/src/components/organization/dto/organization.dto.ts
+++ b/src/components/organization/dto/organization.dto.ts
@@ -21,9 +21,10 @@ import { SecuredOrganizationTypes } from './organization-type.dto';
   implements: Resource,
 })
 export class Organization extends Resource {
-  static readonly Relations = {
+  static readonly Relations = (() => ({
+    ...Resource.Relations(),
     locations: [Location],
-  } satisfies ResourceRelationsShape;
+  })) satisfies ResourceRelationsShape;
 
   @NameField()
   @DbUnique('OrgName')

--- a/src/components/partner/dto/partner.dto.ts
+++ b/src/components/partner/dto/partner.dto.ts
@@ -30,12 +30,12 @@ const Interfaces = IntersectTypes(Resource, Pinnable, Postable, Commentable);
   implements: Interfaces.members,
 })
 export class Partner extends Interfaces {
-  static readonly Relations = () =>
-    ({
-      projects: [IProject],
-      ...Postable.Relations,
-      ...Commentable.Relations,
-    } satisfies ResourceRelationsShape);
+  static readonly Relations = (() => ({
+    ...Resource.Relations(),
+    projects: [IProject],
+    ...Postable.Relations(),
+    ...Commentable.Relations(),
+  })) satisfies ResourceRelationsShape;
 
   readonly organization: Secured<LinkTo<'Organization'>>;
 

--- a/src/components/partnership/dto/partnership.dto.ts
+++ b/src/components/partnership/dto/partnership.dto.ts
@@ -28,10 +28,11 @@ const Interfaces = IntersectTypes(Resource, ChangesetAware);
   implements: Interfaces.members,
 })
 export class Partnership extends Interfaces {
-  static readonly Relations = {
+  static readonly Relations = (() => ({
+    ...Resource.Relations(),
     // why is this here? We have a relation to partner, not org...
     organization: Organization,
-  } satisfies ResourceRelationsShape;
+  })) satisfies ResourceRelationsShape;
   static readonly Parent = () =>
     import('../../project/dto').then((m) => m.IProject);
 

--- a/src/components/post/dto/postable.dto.ts
+++ b/src/components/post/dto/postable.dto.ts
@@ -1,6 +1,11 @@
 import { InterfaceType } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
-import { type ID, IdField, type ResourceRelationsShape } from '~/common';
+import {
+  type ID,
+  IdField,
+  Resource,
+  type ResourceRelationsShape,
+} from '~/common';
 import { e } from '~/core/gel';
 import { RegisterResource } from '~/core/resources';
 import { Post } from './post.dto';
@@ -12,9 +17,10 @@ import { Post } from './post.dto';
   `,
 })
 export abstract class Postable {
-  static readonly Relations = {
+  static readonly Relations = (() => ({
+    ...Resource.Relations(),
     posts: [Post],
-  } satisfies ResourceRelationsShape;
+  })) satisfies ResourceRelationsShape;
   static readonly Parent = 'dynamic';
 
   @IdField({

--- a/src/components/progress-report/dto/progress-report.dto.ts
+++ b/src/components/progress-report/dto/progress-report.dto.ts
@@ -32,12 +32,13 @@ const Interfaces = IntersectTypes(IPeriodicReport, Resource, Commentable);
 export class ProgressReport extends Interfaces {
   static readonly Parent = () =>
     import('../../engagement/dto').then((m) => m.IEngagement);
-  static readonly Relations = {
+  static readonly Relations = (() => ({
+    ...Resource.Relations(),
     highlights: [ProgressReportHighlight],
     teamNews: [ProgressReportTeamNews],
     communityStories: [ProgressReportCommunityStory],
-    ...Commentable.Relations,
-  } satisfies ResourceRelationsShape;
+    ...Commentable.Relations(),
+  })) satisfies ResourceRelationsShape;
 
   declare readonly type: 'Progress';
 

--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -87,20 +87,20 @@ class Project extends Interfaces {
     ...EnhancedResource.of(Resource).props,
     'type',
   ];
-  static readonly Relations = () =>
-    ({
-      rootDirectory: Directory,
-      member: [ProjectMember], // why singular
-      otherLocations: [Location],
-      partnership: [Partnership], // why singular
-      budget: Budget, // currentBudget
-      engagement: [Engagement], // why singular
-      // edge case because it's writable for internships but not secured
-      sensitivity: undefined,
-      ...Postable.Relations,
-      changeRequests: [ProjectChangeRequest],
-      ...Commentable.Relations,
-    } satisfies ResourceRelationsShape);
+  static readonly Relations = (() => ({
+    ...Resource.Relations(),
+    rootDirectory: Directory,
+    member: [ProjectMember], // why singular
+    otherLocations: [Location],
+    partnership: [Partnership], // why singular
+    budget: Budget, // currentBudget
+    engagement: [Engagement], // why singular
+    // edge case because it's writable for internships but not secured
+    sensitivity: undefined,
+    ...Postable.Relations(),
+    changeRequests: [ProjectChangeRequest],
+    ...Commentable.Relations(),
+  })) satisfies ResourceRelationsShape;
 
   @Field(() => ProjectType)
   readonly type: ProjectType;

--- a/src/components/prompts/dto/prompt-response.dto.ts
+++ b/src/components/prompts/dto/prompt-response.dto.ts
@@ -52,10 +52,11 @@ export class PromptVariantResponse<
 > extends Resource {
   static readonly Parent = 'dynamic' as 'dynamic' | (() => Promise<any>);
 
-  static Relations = {
+  static readonly Relations = (() => ({
+    ...Resource.Relations(),
     // So the policies can specify
     responses: [VariantResponse],
-  } satisfies ResourceRelationsShape;
+  })) satisfies ResourceRelationsShape;
 
   readonly creator: Secured<LinkTo<'User'>>;
 

--- a/src/components/user/dto/user.dto.ts
+++ b/src/components/user/dto/user.dto.ts
@@ -34,17 +34,17 @@ const Interfaces = IntersectTypes(Resource, Actor, Pinnable, Commentable);
 })
 @DbLabel('User', 'Actor')
 export class User extends Interfaces {
-  static readonly Relations = () =>
-    ({
-      education: [Education],
-      organization: Organization,
-      partner: Partner,
-      unavailability: [Unavailability],
-      locations: [Location],
-      knownLanguage: [KnownLanguage],
-      projects: [Project],
-      ...Commentable.Relations,
-    } satisfies ResourceRelationsShape);
+  static readonly Relations = (() => ({
+    ...Resource.Relations(),
+    education: [Education],
+    organization: Organization,
+    partner: Partner,
+    unavailability: [Unavailability],
+    locations: [Location],
+    knownLanguage: [KnownLanguage],
+    projects: [Project],
+    ...Commentable.Relations(),
+  })) satisfies ResourceRelationsShape;
 
   declare readonly __typename: 'User';
 


### PR DESCRIPTION
Updated concrete Resources to pull in these Relations.


Added method to "patch in" a relation to the base resource indirectly. Seen here:
```ts
declare module '~/common/resource.dto' {
  export interface DeclareResourceRelations {
    readonly foos: readonly [typeof Foo];
  }
}
patchMethod(Resource, 'Relations', (orig) => () => ({
  ...orig(),
  foos: [Foo] as const,
}));
```