### PR TITLE
Move edit departmentId permission check to policies

### DIFF
--- a/src/components/authorization/policies/by-role/field-operations-director.policy.ts
+++ b/src/components/authorization/policies/by-role/field-operations-director.policy.ts
@@ -13,7 +13,7 @@ import { Policy, Role } from '../util';
   ]),
   r.Producible.edit.create,
   r.Product.edit.create.delete,
-  r.Project.edit,
+  r.Project.edit.specifically((p) => [p.departmentId.read]),
   r.ProjectMember.edit.create.delete,
   r.ProjectWorkflowEvent.read.transitions(
     'Field Ops Approves Proposal',

--- a/src/components/authorization/policies/by-role/project-manager.policy.ts
+++ b/src/components/authorization/policies/by-role/project-manager.policy.ts
@@ -160,6 +160,7 @@ export const momentumProjectsTransitions = () =>
             // Only allow until financial endorsement
             // field('step', stepsUntilFinancialEndorsement),
           ).edit,
+        p.departmentId.read,
       ])
       .children((c) => c.posts.read.create),
     r.ProjectMember.read.when(member).edit.create.delete,

--- a/src/components/authorization/policies/by-role/regional-director.policy.ts
+++ b/src/components/authorization/policies/by-role/regional-director.policy.ts
@@ -6,9 +6,10 @@ import * as PM from './project-manager.policy';
   Role.assignable(r, [Role.ProjectManager]),
 
   r.Partnership.read,
-  r.Project.when(member).edit.specifically(
-    (p) => p.rootDirectory.edit.when(sensMediumOrLower).read,
-  ),
+  r.Project.when(member).edit.specifically((p) => [
+    p.rootDirectory.edit.when(sensMediumOrLower).read,
+    p.departmentId.read,
+  ]),
   r.ProjectWorkflowEvent.transitions(
     PM.projectTransitions,
     PM.momentumProjectsTransitions,

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -250,19 +250,6 @@ export class ProjectService {
         'project.sensitivity',
       );
 
-    // Only allow admins to specify department IDs
-    if (
-      input.departmentId !== undefined &&
-      !this.identity.isImpersonatorAdmin
-    ) {
-      throw UnauthorizedException.fromPrivileges(
-        'edit',
-        undefined,
-        EnhancedResource.of(IProject),
-        'departmentId',
-      );
-    }
-
     const changes = this.repo.getActualChanges(currentProject, input);
     this.privileges
       .for(resolveProjectType(currentProject), currentProject)


### PR DESCRIPTION
This corrects to covey `canEdit` correctly.

This does remove the impersonation introspection (check if the current user is actually an admin impersonating someone else), but that hasn't been needed, and is arguably a bad practice.

FYI the check in create is still the same as this was before. We do actually use that in the monday sync.
We don't actually check edit permission for any properties on create with the permission system. I think it is fine to stay how it is, because we don't expose UI for that.


Related to: #3383