### PR TITLE
Polls v2

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -39,7 +39,7 @@ export * from './pagination.input';
 export * from './pagination-list';
 export * from './grandparent.middleware';
 export * from './parent-types';
-export * from './poll';
+export * as Polls from './poll';
 export * from './resource.dto';
 export * from './role.dto';
 export * from './secured-list';

--- a/src/components/authorization/handler/can-impersonate-via-privileges.handler.ts
+++ b/src/components/authorization/handler/can-impersonate-via-privileges.handler.ts
@@ -12,6 +12,6 @@ export class CanImpersonateViaPrivilegesHandler {
   canImpersonate({ session, allow }: CanImpersonateHook) {
     const p = this.privileges.for(AssignableRoles);
     const granted = session.roles.values().every((role) => p.can('edit', role));
-    allow.vote(granted);
+    allow.vote(this, granted);
   }
 }

--- a/src/components/file/media/events/can-update-event.ts
+++ b/src/components/file/media/events/can-update-event.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Optional, Scope } from '@nestjs/common';
 import { CachedByArg as Once } from '@seedcompany/common';
-import { PollVoter } from '~/common';
+import { Polls } from '~/common';
 import { ResourceResolver, ResourcesHost } from '~/core';
 import { type AnyMedia, MediaUserMetadata } from '../media.dto';
 
@@ -16,7 +16,7 @@ export class CanUpdateMediaUserMetadataEvent {
   constructor(
     @Optional() readonly media: AnyMedia,
     @Optional() readonly input: MediaUserMetadata,
-    @Optional() readonly allowUpdate: PollVoter<boolean>,
+    @Optional() readonly allowUpdate: Polls.BallotBox<boolean>,
   ) {}
 
   @Once() getAttachedResource() {

--- a/src/components/file/media/media.service.ts
+++ b/src/components/file/media/media.service.ts
@@ -5,7 +5,7 @@ import {
   createAndInject,
   type IdOf,
   NotFoundException,
-  Poll,
+  Polls,
   ServerException,
   UnauthorizedException,
 } from '~/common';
@@ -42,16 +42,17 @@ export class MediaService {
     input: RequireAtLeastOne<Pick<AnyMedia, 'id' | 'file'>> & MediaUserMetadata,
   ) {
     const media = await this.repo.readOne(input);
-    const poll = new Poll();
+    const canUpdatePoll = new Polls.Poll<boolean>();
     const event = await createAndInject(
       this.moduleRef,
       CanUpdateMediaUserMetadataEvent,
       media,
       input,
-      poll,
+      canUpdatePoll,
     );
     await this.eventBus.publish(event);
-    if (!(poll.plurality && !poll.vetoed)) {
+    const canUpdate = canUpdatePoll.close();
+    if (!(canUpdate.winner?.choice && !canUpdate.vetoed)) {
       throw new UnauthorizedException(
         'You do not have permission to update this media metadata',
       );

--- a/src/components/progress-report/media/handlers/update-media-metadata-check.handler.ts
+++ b/src/components/progress-report/media/handlers/update-media-metadata-check.handler.ts
@@ -20,6 +20,6 @@ export class ProgressReportUpdateMediaMetadataCheckHandler {
     const reportMedia = await this.resources.load(ReportMedia, reportMediaId);
     const allowed = this.privileges.for(ReportMedia, reportMedia).can('edit');
 
-    event.allowUpdate.vote(allowed);
+    event.allowUpdate.vote(this, allowed);
   }
 }

--- a/src/core/authentication/hooks/can-impersonate.hook.ts
+++ b/src/core/authentication/hooks/can-impersonate.hook.ts
@@ -1,6 +1,9 @@
-import { type PollVoter } from '~/common';
+import { type Polls } from '~/common';
 import { type Session } from '../session/session.dto';
 
 export class CanImpersonateHook {
-  constructor(readonly session: Session, readonly allow: PollVoter<boolean>) {}
+  constructor(
+    readonly session: Session,
+    readonly allow: Polls.BallotBox<boolean>,
+  ) {}
 }

--- a/src/core/authentication/session/session.manager.ts
+++ b/src/core/authentication/session/session.manager.ts
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon';
 import type { Writable } from 'ts-essentials';
 import {
   type ID,
-  Poll,
+  Polls,
   type Role,
   ServerException,
   UnauthorizedException,
@@ -103,7 +103,7 @@ export class SessionManager {
       : requesterSession;
 
     if (impersonatee) {
-      const allowImpersonation = new Poll();
+      const allowImpersonation = new Polls.Poll<boolean>();
       await this.sessionHost.withSession(requesterSession, async () => {
         const event = new CanImpersonateHook(
           requesterSession,
@@ -111,7 +111,8 @@ export class SessionManager {
         );
         await this.hooks.run(event);
       });
-      if (!(allowImpersonation.plurality && !allowImpersonation.vetoed)) {
+      const res = allowImpersonation.close();
+      if (!(res.winner?.choice && !res.vetoed)) {
         // Don't expose what the requester is unable to do as this could leak
         // private information.
         throw new UnauthorizedException(


### PR DESCRIPTION
## Identified voters
Voters must identify themselves via registration. This info is exposed in the result, and prevents behavior where a single voter can vote multiple times to increase the tally of a certain choice. Not that we don't still expect/need good faith actors.

## Strict workflow
Voters must register themselves, only once. Results can only be viewed once a poll is closed. Voting is blocked after poll is closed.
This is to avoid unexpected silent behavior. For example, it prevents a mistake where some voter logic is run multiple times. Or some voter logic accidentally runs after the results are consumed.

## Renames

In general there are just a lot of renames.

And all classes are exported via a `Polls` namespace now, to prevent global pollution/ambiguity in `~/common` and promote discoverability. 

## Move to library

I will move this to our library now, but I wanted a code diff here for reference.