### PR TITLE
Add GQL queries for InternshipEngagements

### DIFF
--- a/src/components/engagement/dto/list-engagements.dto.ts
+++ b/src/components/engagement/dto/list-engagements.dto.ts
@@ -112,6 +112,16 @@ export class LanguageEngagementListOutput extends PaginatedList(
   },
 ) {}
 
+@ObjectType()
+export class InternshipEngagementListOutput extends PaginatedList(
+  InternshipEngagement,
+  {
+    itemsDescription: PaginatedList.itemDescriptionFor(
+      'internship engagements',
+    ),
+  },
+) {}
+
 @ObjectType({
   description: SecuredList.descriptionFor('engagements'),
 })

--- a/src/components/engagement/engagement.resolver.ts
+++ b/src/components/engagement/engagement.resolver.ts
@@ -27,6 +27,8 @@ import {
   EngagementListInput,
   EngagementListOutput,
   IEngagement,
+  InternshipEngagement,
+  InternshipEngagementListOutput,
   LanguageEngagement,
   LanguageEngagementListOutput,
   UpdateInternshipEngagementInput,
@@ -63,6 +65,20 @@ export class EngagementResolver {
     return engagement;
   }
 
+  @Query(() => InternshipEngagement, {
+    description: 'Lookup an InternshipEngagement by ID',
+  })
+  async internshipEngagement(
+    @IdsAndViewArg() key: IdsAndView,
+    @Loader(EngagementLoader) engagements: LoaderOf<EngagementLoader>,
+  ): Promise<Engagement> {
+    const engagement = await engagements.load(key);
+    if (InternshipEngagement.resolve(engagement) !== InternshipEngagement) {
+      throw new InvalidIdForTypeException();
+    }
+    return engagement;
+  }
+
   @Query(() => EngagementListOutput, {
     description: 'Look up engagements',
   })
@@ -85,6 +101,22 @@ export class EngagementResolver {
     const list = await this.service.list({
       ...input,
       filter: { ...input.filter, type: 'language' },
+    });
+    engagements.primeAll(list.items);
+
+    return list;
+  }
+
+  @Query(() => InternshipEngagementListOutput, {
+    description: 'Look up internship engagements',
+  })
+  async internshipEngagements(
+    @ListArg(EngagementListInput) input: EngagementListInput,
+    @Loader(EngagementLoader) engagements: LoaderOf<EngagementLoader>,
+  ): Promise<EngagementListOutput> {
+    const list = await this.service.list({
+      ...input,
+      filter: { ...input.filter, type: 'internship' },
     });
     engagements.primeAll(list.items);
 


### PR DESCRIPTION
Shamelessly reusing @CarsonF's[ previous PR description](https://github.com/SeedCompany/cord-api-v3/pull/3081):

> It's annoying to have to add fragments to narrow type when you all you want is [internship] engagements.
> It's problematic with codegen expecting certain types that only exist on the concrete.

Related to [#860](https://github.com/SeedCompany/seed-api/issues/860)