### PR TITLE
More File Url options & some fixes

### DIFF
--- a/src/common/file-upload.scalar.ts
+++ b/src/common/file-upload.scalar.ts
@@ -1,3 +1,4 @@
+import { File } from '@whatwg-node/fetch';
 import { GraphQLError, GraphQLScalarType } from 'graphql';
 
 export const FileUploadScalar = new GraphQLScalarType({

--- a/src/components/file/file-url.controller.ts
+++ b/src/components/file/file-url.controller.ts
@@ -29,6 +29,7 @@ export class FileUrlController {
   @Get([':fileId', ':fileId/*'])
   async download(
     @Param('fileId') fileId: ID,
+    @Param('*') fileName: string | undefined,
     @Query('download') download: '' | undefined,
     @Request() request: IRequest,
     @Response() res: IResponse,
@@ -42,7 +43,10 @@ export class FileUrlController {
 
     // TODO authorization using session
 
-    const url = await this.files.getDownloadUrl(node, download != null);
+    const url = await this.files.getDownloadUrl(node, {
+      name: fileName || undefined,
+      download: download != null,
+    });
     const cacheControl = this.files.determineCacheHeader(node);
 
     this.http.setHeader(res, 'Cache-Control', cacheControl);

--- a/src/components/file/file-url.resolver-util.ts
+++ b/src/components/file/file-url.resolver-util.ts
@@ -1,4 +1,4 @@
-import { Args, ResolveField } from '@nestjs/graphql';
+import { ArgsType, Field, Args as IArgs, ResolveField } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { URL } from 'url';
 
@@ -11,13 +11,19 @@ export const Resolver = () =>
     `,
   });
 
-export const DownloadArg = () =>
-  Args('download', {
+@ArgsType()
+export class FileUrlArgs {
+  @Field({
     description: stripIndent`
       Whether the browser should download this file if opened directly
 
       This sets the \`Content-Disposition\` header to \`attachment\` instead of \`inline\`.
       https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition
     `,
-    defaultValue: false,
-  });
+  })
+  download?: boolean = false;
+}
+
+export const Args = () => IArgs({ type: () => FileUrlArgs });
+
+export { FileUrlArgs as Options };

--- a/src/components/file/file-url.resolver-util.ts
+++ b/src/components/file/file-url.resolver-util.ts
@@ -2,6 +2,7 @@ import { ArgsType, Field, Args as IArgs, ResolveField } from '@nestjs/graphql';
 import { type EnumType, makeEnum } from '@seedcompany/nest';
 import { stripIndent } from 'common-tags';
 import { URL } from 'url';
+import { OptionalField } from '~/common';
 
 export const Resolver = () =>
   ResolveField(() => URL, {
@@ -44,6 +45,15 @@ export class FileUrlArgs {
     `,
   })
   kind?: EnumType<typeof FileUrlKind> = 'Permanent';
+
+  @OptionalField({
+    description: stripIndent`
+      Override the name of the file.
+
+      The file extension is appended to this.
+    `,
+  })
+  name?: string;
 }
 
 export const Args = () => IArgs({ type: () => FileUrlArgs });

--- a/src/components/file/file-url.resolver-util.ts
+++ b/src/components/file/file-url.resolver-util.ts
@@ -1,4 +1,5 @@
 import { ArgsType, Field, Args as IArgs, ResolveField } from '@nestjs/graphql';
+import { type EnumType, makeEnum } from '@seedcompany/nest';
 import { stripIndent } from 'common-tags';
 import { URL } from 'url';
 
@@ -11,6 +12,20 @@ export const Resolver = () =>
     `,
   });
 
+const FileUrlKind = makeEnum({
+  name: 'FileUrlKind',
+  values: [
+    {
+      value: 'Permanent',
+      description: 'A permanent url whose underlying file will not change',
+    },
+    {
+      value: 'Evergreen',
+      description: 'A url whose underlying file could be updated',
+    },
+  ],
+});
+
 @ArgsType()
 export class FileUrlArgs {
   @Field({
@@ -22,6 +37,13 @@ export class FileUrlArgs {
     `,
   })
   download?: boolean = false;
+
+  @Field(() => FileUrlKind, {
+    description: stripIndent`
+      The kind of url to generate.
+    `,
+  })
+  kind?: EnumType<typeof FileUrlKind> = 'Permanent';
 }
 
 export const Args = () => IArgs({ type: () => FileUrlArgs });

--- a/src/components/file/file-version.resolver.ts
+++ b/src/components/file/file-version.resolver.ts
@@ -10,8 +10,8 @@ export class FileVersionResolver {
   @FileUrl.Resolver()
   async url(
     @Parent() node: FileVersion,
-    @FileUrl.DownloadArg() download: boolean,
+    @FileUrl.Args() options: FileUrl.Options,
   ) {
-    return await this.service.getUrl(node, download);
+    return await this.service.getUrl(node, options);
   }
 }

--- a/src/components/file/file.resolver.ts
+++ b/src/components/file/file.resolver.ts
@@ -69,8 +69,8 @@ export class FileResolver {
   }
 
   @FileUrl.Resolver()
-  async url(@Parent() node: File, @FileUrl.DownloadArg() download: boolean) {
-    return await this.service.getUrl(node, download);
+  async url(@Parent() node: File, @FileUrl.Args() options: FileUrl.Options) {
+    return await this.service.getUrl(node, options);
   }
 
   @Mutation(() => DeleteFileNodeOutput, {

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -148,7 +148,9 @@ export class FileService {
     const url = withAddedPath(
       this.config.hostUrl$.value,
       FileUrl.path,
-      isFile(node) ? node.latestVersionId : node.id,
+      options.kind === 'Permanent' && isFile(node)
+        ? node.latestVersionId
+        : node.id,
       encodeURIComponent(node.name),
     );
     return url.toString() + (options.download ? '?download' : '');

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -48,6 +48,7 @@ import {
 } from './dto';
 import { AfterFileUploadEvent } from './events/after-file-upload.event';
 import { FileUrlController as FileUrl } from './file-url.controller';
+import { type FileUrlArgs } from './file-url.resolver-util';
 import { FileRepository } from './file.repository';
 import { MediaService } from './media/media.service';
 
@@ -143,14 +144,14 @@ export class FileService {
     return data;
   }
 
-  async getUrl(node: FileNode, download: boolean) {
+  async getUrl(node: FileNode, options: FileUrlArgs) {
     const url = withAddedPath(
       this.config.hostUrl$.value,
       FileUrl.path,
       isFile(node) ? node.latestVersionId : node.id,
       encodeURIComponent(node.name),
     );
-    return url.toString() + (download ? '?download' : '');
+    return url.toString() + (options.download ? '?download' : '');
   }
 
   async getDownloadUrl(node: FileNode, download = true): Promise<string> {

--- a/src/components/file/media-url.resolver.ts
+++ b/src/components/file/media-url.resolver.ts
@@ -12,10 +12,10 @@ export class MediaUrlResolver {
   @FileUrl.Resolver()
   async url(
     @Parent() media: Media,
-    @FileUrl.DownloadArg() download: boolean,
+    @FileUrl.Args() options: FileUrl.Options,
     @Loader(FileNodeLoader) files: LoaderOf<FileNodeLoader>,
   ) {
     const node = await files.load(media.file);
-    return await this.service.getUrl(node, download);
+    return await this.service.getUrl(node, options);
   }
 }


### PR DESCRIPTION
- `kind: Evergreen` - Allow generating a url for a `File` that points to that `File` aka the latest version of the file when the url requested, instead of the current version at time of generation.
  This allows the url to live / be referenced longer than the API call for the associated data, which could be useful is some cases.

- Allow overriding the file name in the generated url. Filenames before were are directly from users via rename or the latest version of the actual file uploaded. In some cases, we want a prettier name or maybe more generic name, for displaying.
- This name in the url path now also applies to the filename that is downloaded as well.

- Fixed direct file uploads (in Apollo Explorer) which regressed somewhere around the move to Yoga with its `File` polyfill.