### PR TITLE
Fix empty DBL upload notification emails

### DIFF
--- a/src/components/dbl-upload-notification/emails/dbl-upload.email.tsx
+++ b/src/components/dbl-upload-notification/emails/dbl-upload.email.tsx
@@ -6,27 +6,27 @@ import {
   Headers,
   LanguageRef,
   Mjml,
-  useConfig,
   useFrontendUrl,
-  useResources,
 } from '~/core/email';
+import { type Language } from '../../../components/language/dto';
+import { type Project } from '../../../components/project/dto';
 import { type LanguageEngagement } from '../../engagement/dto';
+
+interface EmailConfig {
+  replyTo?: string;
+  formUrl?: string;
+}
 
 interface Props {
   engagement: LanguageEngagement;
   completedBooks: NonEmptyArray<Range<Verse>>;
+  language: Language;
+  project: Project;
+  config: EmailConfig;
 }
 
 export async function DBLUpload(props: Props) {
-  const { engagement, completedBooks } = props;
-
-  const resources = useResources();
-  const [language, project] = await Promise.all([
-    resources.load('Language', props.engagement.language.value!.id),
-    resources.load('Project', props.engagement.project.id),
-  ]);
-
-  const config = useConfig().email.notifyDblUpload!;
+  const { engagement, completedBooks, language, project, config } = props;
 
   const languageName = language.name.value;
   return (


### PR DESCRIPTION
Users were receiving completely empty DBL upload notification emails due to the email template trying to use NestJS dependency injection hooks `useResources()` and `useConfig()` during server-side rendering, where these hooks are unavailable.

This data is now being loaded in the handler and passed into the email.