### PR TITLE
CI GQL diff with Hive only

### DIFF
--- a/.github/workflows/api-schema.yml
+++ b/.github/workflows/api-schema.yml
@@ -13,7 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ref: [base, head]
+        ref:
+#          not used ATM
+#          - base
+          - head
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,10 +44,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v4
-        with:
-          name: base-gql-schema
-          path: base
+#      - uses: actions/download-artifact@v4
+#        with:
+#          name: base-gql-schema
+#          path: base
       - uses: actions/download-artifact@v4
         with:
           name: head-gql-schema


### PR DESCRIPTION
Dropping the two graphql diff actions, as they are old and not working with the latest graphql spec.
Hive checks seem nice, so its being promoted from an experimental path to the main one.
The only down side here is that nested branches (develop -> feat1 -> feat2), cannot isolate their (feat2) schema changes from the non-develop base branch (feat1).
It is not that common of a use case we have, so I'm moving forward without it.