### PR TITLE
Fix search() SDL invalid default argument

### DIFF
--- a/src/components/search/search.resolver.ts
+++ b/src/components/search/search.resolver.ts
@@ -1,5 +1,4 @@
-import { Query, Resolver } from '@nestjs/graphql';
-import { ListArg } from '~/common';
+import { Args, Query, Resolver } from '@nestjs/graphql';
 import { SearchInput, SearchOutput } from './dto';
 import { SearchService } from './search.service';
 
@@ -11,7 +10,7 @@ export class SearchResolver {
     description: 'Perform a search across resources',
   })
   async search(
-    @ListArg(SearchInput, { nullable: false })
+    @Args({ name: 'input', type: () => SearchInput })
     input: SearchInput,
   ): Promise<SearchOutput> {
     return await this.service.search(input);


### PR DESCRIPTION
The `input` arg was incorrectly marked as having a default value even though `input.query` is required.