### PR TITLE
Enhance GQL introspection by automatically returning all new features

### DIFF
--- a/src/core/graphql/better-introspection.plugin.ts
+++ b/src/core/graphql/better-introspection.plugin.ts
@@ -1,0 +1,22 @@
+import { getIntrospectionQuery } from 'graphql/index';
+import { Plugin } from './plugin.decorator';
+
+@Plugin()
+export class BetterIntrospectionPlugin {
+  onParams: Plugin['onParams'] = ({ params, setParams }) => {
+    if (params.operationName !== 'IntrospectionQuery') {
+      return;
+    }
+    // Help out by replacing the introspection query with all the
+    // additional options (new features) that we support.
+    const query = getIntrospectionQuery({
+      descriptions: true,
+      specifiedByUrl: true,
+      directiveIsRepeatable: true,
+      schemaDescription: true,
+      inputValueDeprecation: true,
+      oneOf: true,
+    });
+    setParams({ ...params, query });
+  };
+}

--- a/src/core/graphql/graphql.module.ts
+++ b/src/core/graphql/graphql.module.ts
@@ -2,6 +2,7 @@ import { Module, type Provider } from '@nestjs/common';
 import { GraphQLModule as NestGraphqlModule } from '@nestjs/graphql';
 import { mapValues } from '@seedcompany/common';
 import { TracingModule } from '../tracing';
+import { BetterIntrospectionPlugin } from './better-introspection.plugin';
 import { CleanUpLongLivedConnectionsOnShutdownPlugin } from './clean-up-long-lived-connections-on-shutdown.plugin';
 import { DataLoadersInSubscriptionPlugin } from './data-loaders-in-subscription.plugin';
 import { Driver } from './driver';
@@ -32,6 +33,7 @@ class SharedPluginsModule {}
     GraphqlLoggingPlugin,
     GraphqlTracingPlugin,
     DataLoadersInSubscriptionPlugin,
+    BetterIntrospectionPlugin,
   ],
   exports: [GraphqlOptions],
 })


### PR DESCRIPTION
Sometimes we get `IntrospectQuery`s but they are not requesting all of the latest GQL features, because they are not enabled by default because older GQL servers do not support them.

This checks for that doc name, and completely replaces their query with our own introspection query that enables all the new features.

Idk if this is a good idea. It shouldn't be breaking for any clients in practice.