### PR TITLE
Fix Subscription error handling

### DIFF
--- a/src/core/graphql/driver.ts
+++ b/src/core/graphql/driver.ts
@@ -167,6 +167,24 @@ export class Driver extends AbstractDriver<DriverConfig> {
         }
         return args;
       },
+      onError: (ctx, id, payload, errors) => {
+        // When a subscription iterable throws/emits an error,
+        // 1. Our GraphqlErrorFormatter plugin formats it & flattens aggregate errors.
+        // 2. It wraps it back into a new AggregateError
+        // 3. Yoga throws this error
+        // 3. graphql-ws catches this and wraps it a GraphQLError and
+        //    puts that in a single array and calls onError.
+        // 4. We unwrap all of this so that our array from our formatting plugin
+        //    is what is emitted over the wire.
+        if (
+          errors.length === 1 &&
+          errors[0]!.originalError instanceof AggregateError
+        ) {
+          errors = errors[0]!.originalError.errors;
+        }
+        // default logic:
+        return errors.map((e) => e.toJSON());
+      },
     });
 
     const wsHandler: FastifyRoute['wsHandler'] = function (socket, req) {

--- a/src/core/graphql/graphql-error-formatter.ts
+++ b/src/core/graphql/graphql-error-formatter.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
+import { many } from '@seedcompany/common';
 import { GraphQLError } from 'graphql';
 import {
   handleStreamOrSingleExecutionResult,
@@ -70,7 +71,11 @@ export class GraphqlErrorFormatter {
     // This is called when the iterable stream emits an error
     onSubscribeError: ({ error, setError }) => {
       const formatted = this.formatError(error);
-      setError(formatted);
+      // Wrap the many errors into a single aggregate that can be thrown.
+      // Yoga throws this.
+      // Individual transport protocols should understand to unwrap this
+      // into the error array of the FormattedExecutionResult.
+      setError(new AggregateError(many(formatted)));
     },
   });
 


### PR DESCRIPTION
This fixes driver logic so that both an error thrown while establishing the subscription (thrown from subscription resolver), and an error thrown within the iterable/observable stream are formatted & emitted correctly.
Both of these error paths are unique, and even unique to the transport protocol.