### PR TITLE
Update Ahead threshold to align with Field Ops expectations

### DIFF
--- a/src/components/progress-summary/dto/schedule-status.enum.ts
+++ b/src/components/progress-summary/dto/schedule-status.enum.ts
@@ -10,7 +10,15 @@ export const ScheduleStatus = makeEnum({
       if (variance > 1 || variance < -1) {
         throw new Error('Variance should be a decimal between [-1, 1]');
       }
-      return variance > 0.1
+      // Variance thresholds are based on the
+      // FLD Job Aid in the Field Ops Sharepoint Library
+      // https://seedcompany.sharepoint.com/:b:/s/FieldOpsServices/IQB_9wOt6i_YTZ1ywO1zJArGAVfY-_8KEHR08WaiUKlcZh4?e=kZmwYz
+      // Behind/Delayed: < -10%
+      // On Time: -10% to +30%
+      // Ahead of Schedule: > +30%
+      // The ScheduleStatus determines if an explanation
+      // is required for the IRP progress report.
+      return variance > 0.3
         ? status.Ahead
         : variance < -0.1
         ? status.Behind

--- a/src/components/progress-summary/progress-summary.repository.ts
+++ b/src/components/progress-summary/progress-summary.repository.ts
@@ -114,10 +114,10 @@ export const progressSummaryFilters = filter.define(
 
       const conditions = cleanJoin(' OR ', [
         status.has(null) && `node IS NULL`,
-        status.has('Ahead') && `node.actual - node.planned > 0.1`,
+        status.has('Ahead') && `node.actual - node.planned > 0.3`,
         status.has('Behind') && `node.actual - node.planned < -0.1`,
         status.has('OnTime') &&
-          `node.actual - node.planned <= 0.1 and node.actual - node.planned >= -0.1`,
+          `node.actual - node.planned <= 0.3 and node.actual - node.planned >= -0.1`,
       ]);
       const required = status.has(null) ? undefined : `node IS NOT NULL`;
       const str = [required, conditions]


### PR DESCRIPTION
Adjust the threshold for determining "Ahead of Schedule" from greater than 10% to greater than 30% to reflect current standards in Field Ops and Development. This change ensures consistency with the guidelines outlined in the FLD Job Aid.



