### PR TITLE
Fix handling null scriptureReferences, treat as empty array

### DIFF
--- a/src/components/product/dto/create-product.dto.ts
+++ b/src/components/product/dto/create-product.dto.ts
@@ -81,7 +81,7 @@ export abstract class CreateDirectScriptureProduct extends CreateBaseProduct {
   @ScriptureField({
     nullable: true,
   })
-  readonly scriptureReferences?: readonly ScriptureRangeInput[];
+  readonly scriptureReferences?: readonly ScriptureRangeInput[] | null;
 
   @Field(() => UnspecifiedScripturePortionInput, {
     nullable: true,

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -324,7 +324,7 @@ export class ProductService {
         compareNullable(UnspecifiedScripturePortion.isEqual),
       )(input.unspecifiedScripture, current.unspecifiedScripture),
       scriptureReferences: ifDiff(isScriptureEqual)(
-        input.scriptureReferences,
+        input.scriptureReferences === null ? [] : input.scriptureReferences,
         current.scriptureReferences,
       ),
     };


### PR DESCRIPTION
This has been a long-standing bug, since at least Nov 2022; probably existed since the feature was created.

I've known about it for awhile, but I think my perspective on null inputs has changed over the years.
Now my stance is that GraphQL allows them per spec, so the API should be able to handle it.
And now we also convert nulls to empty arrays in a lot of cases.
See #3403
