### PR TITLE
Prettify GQL schema generation errors

### DIFF
--- a/src/core/graphql/driver.ts
+++ b/src/core/graphql/driver.ts
@@ -23,6 +23,7 @@ import { MetadataDiscovery } from '~/core/discovery';
 import { HttpAdapter, type IRequest } from '../http';
 import { type IResponse } from '../http/types';
 import { Plugin } from './plugin.decorator';
+import { prettifySchemaGenerationError } from './schema-errors';
 
 export interface ServerContext {
   /** Cannot be `request` as {@link import('graphql-yoga').YogaInitialContext.request} overrides it */
@@ -244,6 +245,14 @@ export class Driver extends AbstractDriver<DriverConfig> {
 
   async stop() {
     await this.#yoga?.dispose();
+  }
+
+  async generateSchema(options: DriverConfig) {
+    try {
+      return (await super.generateSchema(options))!;
+    } catch (e) {
+      throw prettifySchemaGenerationError(e);
+    }
   }
 }
 

--- a/src/core/graphql/schema-errors.ts
+++ b/src/core/graphql/schema-errors.ts
@@ -1,0 +1,108 @@
+import { GraphQLSchemaBuilder } from '@nestjs/graphql/dist/graphql-schema.builder.js';
+import { SchemaGenerationError } from '@nestjs/graphql/dist/schema-builder/errors/schema-generation.error.js';
+import { patchMethod, setInspect } from '@seedcompany/common';
+import chalk, { Chalk, type ChalkInstance } from 'chalk';
+
+export const prettifySchemaGenerationError = (e: Error) => {
+  if (!(e instanceof SchemaGenerationError)) {
+    return e;
+  }
+
+  const makeMsg = (chalk: ChalkInstance) =>
+    [
+      ...(chalk.level > 0 ? [''] : []),
+      chalk.whiteBright.bgRedBright('Failed to generate GraphQL schema:'),
+      ...(chalk.level > 0 ? [''] : []),
+      ...e.details.map(
+        (detail) =>
+          chalk.dim(' - ') +
+          prettyValidationMessage(detail.message, chalk).replace(/\.$/, ''),
+      ),
+    ].join('\n') + '\n';
+
+  const plain = makeMsg(new Chalk({ level: 0 }));
+  const formatted = new Error(plain);
+  formatted.stack = plain;
+  setInspect(formatted, () => makeMsg(chalk));
+
+  return formatted;
+};
+
+interface Formatters {
+  typeReference: (type: string, ctx: Formatters) => string;
+  fieldReference: (type: string, field: string, ctx: Formatters) => string;
+  argumentReference: (
+    type: string,
+    field: string,
+    arg: string,
+    ctx: Formatters,
+  ) => string;
+}
+const defaultFormatters = (chalk: ChalkInstance): Formatters => ({
+  typeReference: (type) =>
+    chalk.cyan(type.replaceAll(/[![\]]/g, (match) => chalk.dim(match))),
+  fieldReference: (type, field, ctx) =>
+    ctx.typeReference(type, ctx) + chalk.magenta(chalk.dim('.') + field),
+  argumentReference: (type, field, arg, ctx) =>
+    ctx.fieldReference(type, field, ctx) +
+    chalk.cyan(chalk.dim('(') + arg + chalk.dim(':)')),
+});
+
+/**
+ * Regex match messages from graphql/type/validate.js to identity dynamic
+ * strings and add color to help with readability.
+ */
+export const prettyValidationMessage = (
+  message: string,
+  formatter?: Formatters | ChalkInstance,
+) => {
+  const format =
+    formatter && 'typeReference' in formatter
+      ? formatter
+      : defaultFormatters(formatter ?? chalk);
+  return message
+    .replaceAll(
+      /(field|type of|but(?! got:)|argument) (\w+)\.(\w+)(?:\((\w+):\))?/g,
+      (_, prefix: string, type: string, field: string, arg?: string) => {
+        if (arg) {
+          return `${prefix} ${format.argumentReference(type, field, arg, format)}`;
+        }
+        return `${prefix} ${format.fieldReference(type, field, format)}`;
+      },
+    )
+    .replaceAll(
+      /(type(?! (?:of|but got))|implement|implemented by|(?<! includes required )argument) ([\w![\]]+)/gi,
+      (_, prefix: string, type: string) =>
+        `${prefix} ${format.typeReference(type, format)}`,
+    )
+    .replaceAll(
+      /expected but (\w+) does not provide it/g,
+      (match, type: string) =>
+        match.replace(type, format.typeReference(type, format)),
+    );
+};
+
+// Patch GraphQLSchemaBuilder to avoid logging SchemaGenerationErrors.
+// We'll log them ourselves in a nicer format.
+{
+  const caughtTags = new WeakSet();
+  patchMethod(GraphQLSchemaBuilder.prototype, 'build', (base) => {
+    return async (...args) => {
+      const result = await base(...args);
+      // Re-throw the error now that we've avoided the catch block in build().
+      if (caughtTags.has(result)) {
+        throw result;
+      }
+      return result;
+    };
+  });
+  patchMethod(GraphQLSchemaBuilder.prototype, 'generateSchema', (base) => {
+    return async (...args) =>
+      await base(...args).catch((e) => {
+        caughtTags.add(e); // tag error so we know to throw it up the callstack.
+        // return error instead to avoid the log statement the catch block of build()
+        // This only works because build() doesn't inspect the result of generateSchema()
+        return e;
+      });
+  });
+}


### PR DESCRIPTION
Before NestJS would log these errors and then rethrow the wrapper which we would log again in main.ts before exiting the process.
Not only was each error duplicated, but each error also had a stacktrace that was worthless to us - it did not reflect any of our src files pointing out the source of the problems.

I patched NestJS to not log this error.
I catch & rethrow a formatted error now that is much easier to read.


After (8 lines of clarity):
<img width="1351" height="166" alt="Screenshot 2026-02-10 at 11 01 56 AM" src="https://github.com/user-attachments/assets/b34d6cf6-30c8-4ae2-8917-07b3f37e8fb1" />

<details><summary>Before (330 lines of soup):</summary>
<p>

```
[
  GraphQLError: Interface field DirectScriptureProductMutation.product expects type DirectScriptureProduct! but DirectScriptureProductCreated.product is type Product!.
      at SchemaValidationContext.reportError (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:73:7)
      at validateTypeImplementsInterface (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:398:15)
      at validateInterfaces (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:369:5)
      at validateTypes (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:252:7)
      at validateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:43:3)
      at graphqlImpl (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:60:63)
      at /Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:43
      at new Promise (<anonymous>)
      at graphql (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:10)
      at GraphQLSchemaFactory.create (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/schema-builder/graphql-schema.factory.js:50:65)
      at GraphQLSchemaBuilder.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:38:52)
      at GraphQLSchemaBuilder.build (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:22:31)
      at GraphQLFactory.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.factory.js:31:69)
      at Driver.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/drivers/abstract-graphql.driver.js:26:36)
      at GraphQLModule.onModuleInit (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.module.js:112:54)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
      at async callModuleInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/hooks/on-module-init.hook.js:51:9)
      at async NestApplication.callInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application-context.js:242:13)
      at async NestApplication.init (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:100:9)
      at async NestApplication.listen (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:170:13)
      at async bootstrap (/Users/carsonfull/Repos/seedco/cord-api-webhooks/src/main.ts:37:3) {
    path: undefined,
    locations: undefined,
    extensions: [Object: null prototype] {}
  },
  GraphQLError: Interface field DerivativeScriptureProductMutation.product expects type DerivativeScriptureProduct! but DerivativeScriptureProductCreated.product is type Product!.
      at SchemaValidationContext.reportError (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:73:7)
      at validateTypeImplementsInterface (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:398:15)
      at validateInterfaces (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:369:5)
      at validateTypes (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:252:7)
      at validateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:43:3)
      at graphqlImpl (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:60:63)
      at /Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:43
      at new Promise (<anonymous>)
      at graphql (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:10)
      at GraphQLSchemaFactory.create (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/schema-builder/graphql-schema.factory.js:50:65)
      at GraphQLSchemaBuilder.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:38:52)
      at GraphQLSchemaBuilder.build (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:22:31)
      at GraphQLFactory.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.factory.js:31:69)
      at Driver.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/drivers/abstract-graphql.driver.js:26:36)
      at GraphQLModule.onModuleInit (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.module.js:112:54)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
      at async callModuleInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/hooks/on-module-init.hook.js:51:9)
      at async NestApplication.callInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application-context.js:242:13)
      at async NestApplication.init (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:100:9)
      at async NestApplication.listen (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:170:13)
      at async bootstrap (/Users/carsonfull/Repos/seedco/cord-api-webhooks/src/main.ts:37:3) {
    path: undefined,
    locations: undefined,
    extensions: [Object: null prototype] {}
  },
  GraphQLError: Interface field OtherProductMutation.product expects type OtherProduct! but OtherProductCreated.product is type Product!.
      at SchemaValidationContext.reportError (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:73:7)
      at validateTypeImplementsInterface (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:398:15)
      at validateInterfaces (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:369:5)
      at validateTypes (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:252:7)
      at validateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:43:3)
      at graphqlImpl (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:60:63)
      at /Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:43
      at new Promise (<anonymous>)
      at graphql (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:10)
      at GraphQLSchemaFactory.create (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/schema-builder/graphql-schema.factory.js:50:65)
      at GraphQLSchemaBuilder.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:38:52)
      at GraphQLSchemaBuilder.build (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:22:31)
      at GraphQLFactory.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.factory.js:31:69)
      at Driver.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/drivers/abstract-graphql.driver.js:26:36)
      at GraphQLModule.onModuleInit (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.module.js:112:54)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
      at async callModuleInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/hooks/on-module-init.hook.js:51:9)
      at async NestApplication.callInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application-context.js:242:13)
      at async NestApplication.init (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:100:9)
      at async NestApplication.listen (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:170:13)
      at async bootstrap (/Users/carsonfull/Repos/seedco/cord-api-webhooks/src/main.ts:37:3) {
    path: undefined,
    locations: undefined,
    extensions: [Object: null prototype] {}
  },
  GraphQLError: Interface field DirectScriptureProductMutation.product expects type DirectScriptureProduct! but DirectScriptureProductUpdated.product is type Product!.
      at SchemaValidationContext.reportError (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:73:7)
      at validateTypeImplementsInterface (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:398:15)
      at validateInterfaces (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:369:5)
      at validateTypes (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:252:7)
      at validateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:43:3)
      at graphqlImpl (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:60:63)
      at /Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:43
      at new Promise (<anonymous>)
      at graphql (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:10)
      at GraphQLSchemaFactory.create (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/schema-builder/graphql-schema.factory.js:50:65)
      at GraphQLSchemaBuilder.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:38:52)
      at GraphQLSchemaBuilder.build (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:22:31)
      at GraphQLFactory.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.factory.js:31:69)
      at Driver.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/drivers/abstract-graphql.driver.js:26:36)
      at GraphQLModule.onModuleInit (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.module.js:112:54)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
      at async callModuleInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/hooks/on-module-init.hook.js:51:9)
      at async NestApplication.callInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application-context.js:242:13)
      at async NestApplication.init (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:100:9)
      at async NestApplication.listen (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:170:13)
      at async bootstrap (/Users/carsonfull/Repos/seedco/cord-api-webhooks/src/main.ts:37:3) {
    path: undefined,
    locations: undefined,
    extensions: [Object: null prototype] {}
  },
  GraphQLError: Interface field DerivativeScriptureProductMutation.product expects type DerivativeScriptureProduct! but DerivativeScriptureProductUpdated.product is type Product!.
      at SchemaValidationContext.reportError (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:73:7)
      at validateTypeImplementsInterface (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:398:15)
      at validateInterfaces (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:369:5)
      at validateTypes (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:252:7)
      at validateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:43:3)
      at graphqlImpl (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:60:63)
      at /Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:43
      at new Promise (<anonymous>)
      at graphql (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:10)
      at GraphQLSchemaFactory.create (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/schema-builder/graphql-schema.factory.js:50:65)
      at GraphQLSchemaBuilder.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:38:52)
      at GraphQLSchemaBuilder.build (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:22:31)
      at GraphQLFactory.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.factory.js:31:69)
      at Driver.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/drivers/abstract-graphql.driver.js:26:36)
      at GraphQLModule.onModuleInit (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.module.js:112:54)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
      at async callModuleInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/hooks/on-module-init.hook.js:51:9)
      at async NestApplication.callInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application-context.js:242:13)
      at async NestApplication.init (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:100:9)
      at async NestApplication.listen (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:170:13)
      at async bootstrap (/Users/carsonfull/Repos/seedco/cord-api-webhooks/src/main.ts:37:3) {
    path: undefined,
    locations: undefined,
    extensions: [Object: null prototype] {}
  },
  GraphQLError: Interface field OtherProductMutation.product expects type OtherProduct! but OtherProductUpdated.product is type Product!.
      at SchemaValidationContext.reportError (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:73:7)
      at validateTypeImplementsInterface (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:398:15)
      at validateInterfaces (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:369:5)
      at validateTypes (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:252:7)
      at validateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:43:3)
      at graphqlImpl (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:60:63)
      at /Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:43
      at new Promise (<anonymous>)
      at graphql (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:10)
      at GraphQLSchemaFactory.create (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/schema-builder/graphql-schema.factory.js:50:65)
      at GraphQLSchemaBuilder.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:38:52)
      at GraphQLSchemaBuilder.build (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:22:31)
      at GraphQLFactory.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.factory.js:31:69)
      at Driver.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/drivers/abstract-graphql.driver.js:26:36)
      at GraphQLModule.onModuleInit (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.module.js:112:54)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
      at async callModuleInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/hooks/on-module-init.hook.js:51:9)
      at async NestApplication.callInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application-context.js:242:13)
      at async NestApplication.init (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:100:9)
      at async NestApplication.listen (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:170:13)
      at async bootstrap (/Users/carsonfull/Repos/seedco/cord-api-webhooks/src/main.ts:37:3) {
    path: undefined,
    locations: undefined,
    extensions: [Object: null prototype] {}
  }
]
SchemaGenerationError: Schema generation error (code-first approach)
    at GraphQLSchemaFactory.create (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/schema-builder/graphql-schema.factory.js:56:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async GraphQLSchemaBuilder.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:38:24)
    at async GraphQLSchemaBuilder.build (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:22:20)
    at async GraphQLFactory.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.factory.js:31:41)
    at async GraphQLModule.onModuleInit (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.module.js:112:27)
    at async callModuleInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/hooks/on-module-init.hook.js:51:9)
    at async NestApplication.callInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application-context.js:242:13)
    at async NestApplication.init (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:100:9)
    at async NestApplication.listen (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:170:13)
    at async bootstrap (/Users/carsonfull/Repos/seedco/cord-api-webhooks/src/main.ts:37:3) {
  details: [
    GraphQLError: Interface field DirectScriptureProductMutation.product expects type DirectScriptureProduct! but DirectScriptureProductCreated.product is type Product!.
        at SchemaValidationContext.reportError (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:73:7)
        at validateTypeImplementsInterface (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:398:15)
        at validateInterfaces (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:369:5)
        at validateTypes (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:252:7)
        at validateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:43:3)
        at graphqlImpl (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:60:63)
        at /Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:43
        at new Promise (<anonymous>)
        at graphql (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:10)
        at GraphQLSchemaFactory.create (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/schema-builder/graphql-schema.factory.js:50:65)
        at GraphQLSchemaBuilder.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:38:52)
        at GraphQLSchemaBuilder.build (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:22:31)
        at GraphQLFactory.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.factory.js:31:69)
        at Driver.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/drivers/abstract-graphql.driver.js:26:36)
        at GraphQLModule.onModuleInit (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.module.js:112:54)
        at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
        at async callModuleInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/hooks/on-module-init.hook.js:51:9)
        at async NestApplication.callInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application-context.js:242:13)
        at async NestApplication.init (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:100:9)
        at async NestApplication.listen (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:170:13)
        at async bootstrap (/Users/carsonfull/Repos/seedco/cord-api-webhooks/src/main.ts:37:3) {
      path: undefined,
      locations: undefined,
      extensions: [Object: null prototype] {}
    },
    GraphQLError: Interface field DerivativeScriptureProductMutation.product expects type DerivativeScriptureProduct! but DerivativeScriptureProductCreated.product is type Product!.
        at SchemaValidationContext.reportError (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:73:7)
        at validateTypeImplementsInterface (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:398:15)
        at validateInterfaces (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:369:5)
        at validateTypes (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:252:7)
        at validateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:43:3)
        at graphqlImpl (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:60:63)
        at /Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:43
        at new Promise (<anonymous>)
        at graphql (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:10)
        at GraphQLSchemaFactory.create (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/schema-builder/graphql-schema.factory.js:50:65)
        at GraphQLSchemaBuilder.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:38:52)
        at GraphQLSchemaBuilder.build (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:22:31)
        at GraphQLFactory.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.factory.js:31:69)
        at Driver.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/drivers/abstract-graphql.driver.js:26:36)
        at GraphQLModule.onModuleInit (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.module.js:112:54)
        at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
        at async callModuleInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/hooks/on-module-init.hook.js:51:9)
        at async NestApplication.callInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application-context.js:242:13)
        at async NestApplication.init (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:100:9)
        at async NestApplication.listen (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:170:13)
        at async bootstrap (/Users/carsonfull/Repos/seedco/cord-api-webhooks/src/main.ts:37:3) {
      path: undefined,
      locations: undefined,
      extensions: [Object: null prototype] {}
    },
    GraphQLError: Interface field OtherProductMutation.product expects type OtherProduct! but OtherProductCreated.product is type Product!.
        at SchemaValidationContext.reportError (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:73:7)
        at validateTypeImplementsInterface (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:398:15)
        at validateInterfaces (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:369:5)
        at validateTypes (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:252:7)
        at validateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:43:3)
        at graphqlImpl (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:60:63)
        at /Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:43
        at new Promise (<anonymous>)
        at graphql (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:10)
        at GraphQLSchemaFactory.create (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/schema-builder/graphql-schema.factory.js:50:65)
        at GraphQLSchemaBuilder.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:38:52)
        at GraphQLSchemaBuilder.build (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:22:31)
        at GraphQLFactory.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.factory.js:31:69)
        at Driver.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/drivers/abstract-graphql.driver.js:26:36)
        at GraphQLModule.onModuleInit (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.module.js:112:54)
        at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
        at async callModuleInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/hooks/on-module-init.hook.js:51:9)
        at async NestApplication.callInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application-context.js:242:13)
        at async NestApplication.init (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:100:9)
        at async NestApplication.listen (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:170:13)
        at async bootstrap (/Users/carsonfull/Repos/seedco/cord-api-webhooks/src/main.ts:37:3) {
      path: undefined,
      locations: undefined,
      extensions: [Object: null prototype] {}
    },
    GraphQLError: Interface field DirectScriptureProductMutation.product expects type DirectScriptureProduct! but DirectScriptureProductUpdated.product is type Product!.
        at SchemaValidationContext.reportError (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:73:7)
        at validateTypeImplementsInterface (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:398:15)
        at validateInterfaces (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:369:5)
        at validateTypes (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:252:7)
        at validateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:43:3)
        at graphqlImpl (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:60:63)
        at /Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:43
        at new Promise (<anonymous>)
        at graphql (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:10)
        at GraphQLSchemaFactory.create (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/schema-builder/graphql-schema.factory.js:50:65)
        at GraphQLSchemaBuilder.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:38:52)
        at GraphQLSchemaBuilder.build (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:22:31)
        at GraphQLFactory.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.factory.js:31:69)
        at Driver.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/drivers/abstract-graphql.driver.js:26:36)
        at GraphQLModule.onModuleInit (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.module.js:112:54)
        at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
        at async callModuleInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/hooks/on-module-init.hook.js:51:9)
        at async NestApplication.callInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application-context.js:242:13)
        at async NestApplication.init (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:100:9)
        at async NestApplication.listen (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:170:13)
        at async bootstrap (/Users/carsonfull/Repos/seedco/cord-api-webhooks/src/main.ts:37:3) {
      path: undefined,
      locations: undefined,
      extensions: [Object: null prototype] {}
    },
    GraphQLError: Interface field DerivativeScriptureProductMutation.product expects type DerivativeScriptureProduct! but DerivativeScriptureProductUpdated.product is type Product!.
        at SchemaValidationContext.reportError (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:73:7)
        at validateTypeImplementsInterface (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:398:15)
        at validateInterfaces (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:369:5)
        at validateTypes (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:252:7)
        at validateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:43:3)
        at graphqlImpl (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:60:63)
        at /Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:43
        at new Promise (<anonymous>)
        at graphql (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:10)
        at GraphQLSchemaFactory.create (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/schema-builder/graphql-schema.factory.js:50:65)
        at GraphQLSchemaBuilder.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:38:52)
        at GraphQLSchemaBuilder.build (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:22:31)
        at GraphQLFactory.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.factory.js:31:69)
        at Driver.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/drivers/abstract-graphql.driver.js:26:36)
        at GraphQLModule.onModuleInit (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.module.js:112:54)
        at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
        at async callModuleInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/hooks/on-module-init.hook.js:51:9)
        at async NestApplication.callInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application-context.js:242:13)
        at async NestApplication.init (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:100:9)
        at async NestApplication.listen (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:170:13)
        at async bootstrap (/Users/carsonfull/Repos/seedco/cord-api-webhooks/src/main.ts:37:3) {
      path: undefined,
      locations: undefined,
      extensions: [Object: null prototype] {}
    },
    GraphQLError: Interface field OtherProductMutation.product expects type OtherProduct! but OtherProductUpdated.product is type Product!.
        at SchemaValidationContext.reportError (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:73:7)
        at validateTypeImplementsInterface (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:398:15)
        at validateInterfaces (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:369:5)
        at validateTypes (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:252:7)
        at validateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/type/validate.js:43:3)
        at graphqlImpl (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:60:63)
        at /Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:43
        at new Promise (<anonymous>)
        at graphql (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/graphql/graphql.js:23:10)
        at GraphQLSchemaFactory.create (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/schema-builder/graphql-schema.factory.js:50:65)
        at GraphQLSchemaBuilder.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:38:52)
        at GraphQLSchemaBuilder.build (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql-schema.builder.js:22:31)
        at GraphQLFactory.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.factory.js:31:69)
        at Driver.generateSchema (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/drivers/abstract-graphql.driver.js:26:36)
        at GraphQLModule.onModuleInit (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/graphql/dist/graphql.module.js:112:54)
        at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
        at async callModuleInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/hooks/on-module-init.hook.js:51:9)
        at async NestApplication.callInitHook (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application-context.js:242:13)
        at async NestApplication.init (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:100:9)
        at async NestApplication.listen (/Users/carsonfull/Repos/seedco/cord-api-webhooks/node_modules/@nestjs/core/nest-application.js:170:13)
        at async bootstrap (/Users/carsonfull/Repos/seedco/cord-api-webhooks/src/main.ts:37:3) {
      path: undefined,
      locations: undefined,
      extensions: [Object: null prototype] {}
    }
  ]
}

```

</p>
</details>