### PR TITLE
Adjust GQL type mappers to store field metadata for all GQL field holder types

### DIFF
--- a/src/components/engagement/dto/update-engagement.dto.ts
+++ b/src/components/engagement/dto/update-engagement.dto.ts
@@ -1,4 +1,4 @@
-import { Field, InputType, InterfaceType, ObjectType } from '@nestjs/graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { stripIndent } from 'common-tags';
@@ -19,8 +19,6 @@ import { ProductMethodology } from '../../product/dto';
 import { InternshipPosition } from './intern-position.enum';
 import { EngagementStatus } from './status.enum';
 
-@InterfaceType({ isAbstract: true })
-@ObjectType({ isAbstract: true })
 @InputType({ isAbstract: true })
 export abstract class UpdateEngagement {
   @IdField()
@@ -47,7 +45,6 @@ export abstract class UpdateEngagement {
   readonly description?: RichTextDocument | null;
 }
 
-@ObjectType({ isAbstract: true })
 @InputType()
 export abstract class UpdateLanguageEngagement extends UpdateEngagement {
   @Field({ nullable: true })
@@ -93,7 +90,6 @@ export abstract class UpdateLanguageEngagement extends UpdateEngagement {
   readonly changeset?: ID;
 }
 
-@ObjectType({ isAbstract: true })
 @InputType()
 export abstract class UpdateInternshipEngagement extends UpdateEngagement {
   @IdField({ nullable: true })

--- a/src/components/project/dto/update-project.dto.ts
+++ b/src/components/project/dto/update-project.dto.ts
@@ -15,7 +15,6 @@ import {
 import { ChangesetIdField } from '../../changeset';
 import { ReportPeriod } from '../../periodic-report/dto';
 
-@ObjectType({ isAbstract: true })
 @InputType()
 export abstract class UpdateProject {
   @IdField()

--- a/src/components/project/project-member/dto/update-project-member.dto.ts
+++ b/src/components/project/project-member/dto/update-project-member.dto.ts
@@ -1,8 +1,7 @@
-import { InputType, ObjectType } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
 import { type DateTime } from 'luxon';
 import { DateTimeField, type ID, IdField, ListField, Role } from '~/common';
 
-@ObjectType({ isAbstract: true })
 @InputType()
 export abstract class UpdateProjectMember {
   @IdField()

--- a/src/core/webhooks/dto/webhook.dto.ts
+++ b/src/core/webhooks/dto/webhook.dto.ts
@@ -1,4 +1,4 @@
-import { Field, ID as IDType, InputType, ObjectType } from '@nestjs/graphql';
+import { Field, ID as IDType, ObjectType } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { GraphQLJSONObject } from 'graphql-scalars';
 import { DateTime } from 'luxon';
@@ -7,7 +7,6 @@ import { type LinkTo, RegisterResource } from '~/core/resources';
 import { GraphqlDocumentScalar } from './graphql-document.scalar';
 
 @RegisterResource()
-@InputType({ isAbstract: true })
 @ObjectType({
   description: stripIndent`
     A webhook is a subscription to a GraphQL operation that will POST events to a given URL.


### PR DESCRIPTION
This basically just allows mapping across different types (args, interface, object, input).
This only applies to these 4 type mapper class creators.

Before (default functionality) only forwarded metadata for the outermost type.
So this didn't work:
```ts
@ObjectType()
@InputType({ isAbstract: true })
class A {
  @Field()
  foo: string;
}

@InputType()
class B extends PartialType(A) {}
```
As the fields on `A` for input types would not be forwarded to `B`, since `ObjectType` is the outer type on `A` that is forwarded.

I'm not exactly sure why the field metadata is segmented by type...it doesn't make sense to me.