### PR TITLE
Fix `EngagmentMutation.engagement` specialization

### DIFF
--- a/src/components/engagement/dto/engagement-mutations.dto.ts
+++ b/src/components/engagement/dto/engagement-mutations.dto.ts
@@ -3,6 +3,7 @@ import { Grandparent, type ID, IdField } from '~/common';
 import { AsUpdateType } from '~/common/as-update.type';
 import type { LinkTo } from '~/core/resources';
 import { ProjectMutation } from '../../project/dto/project-mutations.dto';
+import { InternshipEngagement, LanguageEngagement } from './engagement.dto';
 import {
   UpdateEngagement,
   UpdateInternshipEngagement,
@@ -20,10 +21,16 @@ export class EngagementMutationOrDeletion extends ProjectMutation {
 export class EngagementMutation extends EngagementMutationOrDeletion {}
 
 @InterfaceType({ implements: [EngagementMutation] })
-export class LanguageEngagementMutation extends EngagementMutation {}
+export class LanguageEngagementMutation extends EngagementMutation {
+  @Field(() => LanguageEngagement)
+  readonly engagement?: never; // Resolved from EngagementMutation with EngagementMutationLinksResolver
+}
 
 @InterfaceType({ implements: [EngagementMutation] })
-export class InternshipEngagementMutation extends EngagementMutation {}
+export class InternshipEngagementMutation extends EngagementMutation {
+  @Field(() => InternshipEngagement)
+  readonly engagement?: never; // Resolved from EngagementMutation with EngagementMutationLinksResolver
+}
 
 @InterfaceType({ implements: [EngagementMutation] })
 export abstract class EngagementCreated extends EngagementMutation {}
@@ -31,11 +38,17 @@ export abstract class EngagementCreated extends EngagementMutation {}
 @ObjectType({ implements: [LanguageEngagementMutation, EngagementCreated] })
 export class LanguageEngagementCreated extends EngagementCreated {
   declare readonly __typename: 'LanguageEngagementCreated';
+
+  @Field(() => LanguageEngagement)
+  readonly engagement?: never; // Resolved from EngagementMutation with EngagementMutationLinksResolver
 }
 
 @ObjectType({ implements: [InternshipEngagementMutation, EngagementCreated] })
 export class InternshipEngagementCreated extends EngagementCreated {
   declare readonly __typename: 'InternshipEngagementCreated';
+
+  @Field(() => InternshipEngagement)
+  readonly engagement?: never; // Resolved from EngagementMutation with EngagementMutationLinksResolver
 }
 
 @InterfaceType()
@@ -84,6 +97,9 @@ export class LanguageEngagementUpdated extends EngagementUpdated {
 
   @Field({ middleware: [Grandparent.store] })
   declare readonly updated: LanguageEngagementUpdate;
+
+  @Field(() => LanguageEngagement)
+  readonly engagement?: never; // Resolved from EngagementMutation with EngagementMutationLinksResolver
 }
 
 @ObjectType({ implements: [InternshipEngagementMutation, EngagementUpdated] })
@@ -95,6 +111,9 @@ export class InternshipEngagementUpdated extends EngagementUpdated {
 
   @Field({ middleware: [Grandparent.store] })
   declare readonly updated: InternshipEngagementUpdate;
+
+  @Field(() => InternshipEngagement)
+  readonly engagement?: never; // Resolved from EngagementMutation with EngagementMutationLinksResolver
 }
 
 @InterfaceType({ implements: [EngagementMutationOrDeletion] })

--- a/src/components/engagement/engagement-mutation-links.resolver.ts
+++ b/src/components/engagement/engagement-mutation-links.resolver.ts
@@ -1,47 +1,11 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { Loader, type LoaderOf } from '@seedcompany/data-loader';
-import {
-  type Engagement,
-  EngagementMutation,
-  IEngagement,
-  InternshipEngagement,
-  InternshipEngagementMutation,
-  LanguageEngagement,
-  LanguageEngagementMutation,
-} from './dto';
+import { type Engagement, EngagementMutation, IEngagement } from './dto';
 import { EngagementLoader } from './engagement.loader';
 
 @Resolver(EngagementMutation)
 export class EngagementMutationLinksResolver {
   @ResolveField(() => IEngagement)
-  async engagement(
-    @Parent() change: EngagementMutation,
-    @Loader(EngagementLoader) engagements: LoaderOf<EngagementLoader>,
-  ): Promise<Engagement> {
-    return await engagements.load({
-      id: change.engagementId,
-      view: { active: true },
-    });
-  }
-}
-
-@Resolver(LanguageEngagementMutation)
-export class LanguageEngagementMutationLinksResolver {
-  @ResolveField(() => LanguageEngagement)
-  async engagement(
-    @Parent() change: EngagementMutation,
-    @Loader(EngagementLoader) engagements: LoaderOf<EngagementLoader>,
-  ): Promise<Engagement> {
-    return await engagements.load({
-      id: change.engagementId,
-      view: { active: true },
-    });
-  }
-}
-
-@Resolver(InternshipEngagementMutation)
-export class InternshipEngagementMutationLinksResolver {
-  @ResolveField(() => InternshipEngagement)
   async engagement(
     @Parent() change: EngagementMutation,
     @Loader(EngagementLoader) engagements: LoaderOf<EngagementLoader>,

--- a/src/components/engagement/engagement.module.ts
+++ b/src/components/engagement/engagement.module.ts
@@ -7,10 +7,7 @@ import { LanguageModule } from '../language/language.module';
 import { LocationModule } from '../location/location.module';
 import { ProductModule } from '../product/product.module';
 import { ProjectModule } from '../project/project.module';
-import {
-  InternshipEngagementMutationLinksResolver,
-  LanguageEngagementMutationLinksResolver,
-} from './engagement-mutation-links.resolver';
+import { EngagementMutationLinksResolver } from './engagement-mutation-links.resolver';
 import { EngagementMutationSubscriptionsResolver } from './engagement-mutation-subscriptions.resolver';
 import { EngagementStatusResolver } from './engagement-status.resolver';
 import {
@@ -49,10 +46,7 @@ import { EngagementProductConnectionResolver } from './product-connection.resolv
     EngagementResolver,
     EngagementMutationSubscriptionsResolver,
     EngagementUpdatedResolver,
-    LanguageEngagementMutationLinksResolver,
-    InternshipEngagementMutationLinksResolver,
-    // TODO cannot get this to work with without concretes overriding this
-    // EngagementMutationLinksResolver,
+    EngagementMutationLinksResolver,
     LanguageEngagementUpdateLinksResolver,
     InternshipEngagementUpdateLinksResolver,
     LanguageEngagementResolver,

--- a/src/components/engagement/engagement.resolver.ts
+++ b/src/components/engagement/engagement.resolver.ts
@@ -197,20 +197,20 @@ export class EngagementResolver {
   async updateLanguageEngagement(
     @Args('input') { changeset, ...input }: UpdateLanguageEngagement,
   ): Promise<LanguageEngagementUpdated> {
-    const { engagement, payload } = await this.service.updateLanguageEngagement(
-      input,
-      changeset,
-    );
+    const {
+      engagement,
+      payload: { project: _, engagement: __, ...payload } = {
+        previous: {},
+        updated: {},
+        at: DateTime.now(),
+        by: this.identity.current.userId,
+      },
+    } = await this.service.updateLanguageEngagement(input, changeset);
     return {
       __typename: 'LanguageEngagementUpdated',
       projectId: engagement.project.id,
       engagementId: engagement.id,
-      by: this.identity.current.userId,
-      previous: {},
-      updated: {},
-      // if actual changes, then this overrides those empty values.
       ...payload,
-      at: payload?.at ?? DateTime.now(),
     };
   }
 
@@ -220,18 +220,20 @@ export class EngagementResolver {
   async updateInternshipEngagement(
     @Args('input') { changeset, ...input }: UpdateInternshipEngagement,
   ): Promise<InternshipEngagementUpdated> {
-    const { engagement, payload } =
-      await this.service.updateInternshipEngagement(input, changeset);
+    const {
+      engagement,
+      payload: { project: _, engagement: __, ...payload } = {
+        previous: {},
+        updated: {},
+        at: DateTime.now(),
+        by: this.identity.current.userId,
+      },
+    } = await this.service.updateInternshipEngagement(input, changeset);
     return {
       __typename: 'InternshipEngagementUpdated',
       projectId: engagement.project.id,
       engagementId: engagement.id,
-      by: this.identity.current.userId,
-      previous: {},
-      updated: {},
-      // if actual changes, then this overrides those empty values.
       ...payload,
-      at: payload?.at ?? DateTime.now(),
     };
   }
 
@@ -241,14 +243,17 @@ export class EngagementResolver {
   async deleteEngagement(
     @Args() { id, changeset }: ChangesetIds,
   ): Promise<EngagementDeleted> {
-    const { engagement, payload } = await this.service.delete(id, changeset);
+    const {
+      engagement,
+      payload: { project, engagement: _, ...payload },
+    } = await this.service.delete(id, changeset);
     return {
       __typename:
         resolveEngagementType(engagement) === LanguageEngagement
           ? 'LanguageEngagementDeleted'
           : 'InternshipEngagementDeleted',
-      projectId: payload.project,
-      engagementId: payload.engagement,
+      projectId: project,
+      engagementId: engagement.id,
       ...payload,
     };
   }

--- a/src/components/project/dto/update-project.dto.ts
+++ b/src/components/project/dto/update-project.dto.ts
@@ -1,4 +1,4 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { type DateTime } from 'luxon';
 import {
   type CalendarDate,


### PR DESCRIPTION
Now a single interface resolver that handles runtime resolution.
And DTOs declare specialization types, only for schema generation.
