### PR TITLE
Data loader strategies do not need to be request scoped

### DIFF
--- a/src/core/data-loader/loader-factory.decorator.ts
+++ b/src/core/data-loader/loader-factory.decorator.ts
@@ -1,4 +1,4 @@
-import { Injectable, Scope, type Type } from '@nestjs/common';
+import { Injectable, type Type } from '@nestjs/common';
 import { createMetadataDecorator } from '@seedcompany/nest';
 import type { ValueOf } from 'type-fest';
 import type { Many } from '~/common';
@@ -42,7 +42,7 @@ export const LoaderFactory =
     options?: LoaderOptions,
   ): (<LoaderCtor extends DataLoaderCtor>(target: LoaderCtor) => void) =>
   (target) => {
-    Injectable({ scope: Scope.REQUEST })(target);
+    Injectable()(target);
 
     LoaderFactoryMetadata(resource, {
       ...options,

--- a/src/core/resources/loader.registry.ts
+++ b/src/core/resources/loader.registry.ts
@@ -1,9 +1,4 @@
-import {
-  Injectable,
-  type OnModuleInit,
-  Scope,
-  type Type,
-} from '@nestjs/common';
+import { Injectable, type OnModuleInit, type Type } from '@nestjs/common';
 import { ModulesContainer } from '@nestjs/core';
 import { many } from '~/common';
 import { type DataLoaderStrategy } from '~/core/data-loader';
@@ -25,7 +20,6 @@ export class ResourceLoaderRegistry implements OnModuleInit {
   async onModuleInit() {
     const loaderFactories = [...this.modulesContainer.values()]
       .flatMap((nestModule) => [...nestModule.providers.values()])
-      .filter((provider) => provider.scope === Scope.REQUEST)
       .flatMap((provider) => {
         if (!provider.metatype) {
           return [];


### PR DESCRIPTION
Maybe at one point they did need the `REQUEST`/`CONTEXT` injected for session/identity.
But now that's passed around as an async context.