### PR TITLE
Integrate redis-semaphore's mutex as Locker/Lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "read-package-up": "^11.0.0",
+    "redis-semaphore": "^5.6.2",
     "reflect-metadata": "^0.2.2",
     "rimraf": "^6.0.1",
     "rxjs": "^7.8.1",

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -323,6 +323,11 @@ export const makeConfig = (env: EnvironmentService) =>
       prefix: env.string('BULL_PREFIX').optional() ?? this.redis.prefix,
     };
 
+    locker = {
+      url: env.string('LOCKER_REDIS_URL').optional() ?? this.redis.url,
+      prefix: env.string('LOCKER_REDIS_PREFIX').optional() ?? this.redis.prefix,
+    };
+
     /**
      * @see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html
      */

--- a/src/core/locker/index.ts
+++ b/src/core/locker/index.ts
@@ -1,0 +1,3 @@
+export { LostLockError, TimeoutError } from 'redis-semaphore';
+export * from './lock';
+export * from './locker.service';

--- a/src/core/locker/lock.ts
+++ b/src/core/locker/lock.ts
@@ -1,0 +1,116 @@
+import { mapValues } from '@seedcompany/common';
+import type { Redis } from 'ioredis';
+import { Duration } from 'luxon';
+import {
+  type LockLostCallback,
+  // eslint-disable-next-line @seedcompany/no-unused-vars
+  type LostLockError,
+  Mutex,
+  type LockOptions as RawOptions,
+} from 'redis-semaphore';
+import type { DurationIn } from '~/common';
+import type { Locker } from './locker.service';
+
+export class Lock extends Mutex implements AsyncDisposable {
+  private readonly releaseOnDispose: boolean;
+
+  /** @internal */
+  constructor(
+    redis: Redis,
+    readonly key: string,
+    lockerOptions: Locker.Options,
+    { releaseOnDispose, ...options }: Lock.Options = {},
+  ) {
+    super(
+      redis,
+      (lockerOptions.prefix ?? '') + key,
+      options ? normalizeOptions(options) : undefined,
+    );
+    this.releaseOnDispose = releaseOnDispose ?? true;
+  }
+
+  // @ts-expect-error yeah changing the return type
+  async acquire() {
+    await super.acquire();
+    return this;
+  }
+
+  async [Symbol.asyncDispose]() {
+    if (this.releaseOnDispose) {
+      await this.release();
+    } else {
+      this.stopRefresh();
+    }
+  }
+
+  /** Helper so the caller doesn't have to mess with the symbol. */
+  async dispose() {
+    await this[Symbol.asyncDispose]();
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Lock {
+  // Redefining these to allow smart durations & to document each property.
+
+  export type Options = Pick<
+    RawOptions,
+    'identifier' | 'acquiredExternally'
+  > & {
+    /**
+     * The duration until the lock will be auto-released (expired).
+     *
+     * @default 10 seconds
+     */
+    lockTimeout?: DurationIn;
+    /**
+     * The max timeout for {@link Lock.acquire} call
+     *
+     * @default 10 seconds
+     */
+    acquireTimeout?: DurationIn;
+    /**
+     * The max number of attempts to be made in {@link Lock.acquire} call
+     *
+     * @default Infinity
+     */
+    acquireAttemptsLimit?: number;
+    /**
+     * Time between acquiring attempts if resource locked
+     *
+     * @default 10 milliseconds
+     */
+    retryInterval?: DurationIn;
+    /**
+     * The auto-refresh interval; to disable behavior set to 0
+     *
+     * @default 80% of {@link lockTimeout}
+     */
+    refreshInterval?: DurationIn;
+    /**
+     * Called when lock loss is detected due refresh cycle.
+     *
+     * @default throws (unhandled) {@link LostLockError}
+     */
+    onLockLost?: LockLostCallback;
+  } & {
+    /**
+     * Whether to release lock on {@link Lock.dispose} call.
+     * If false, the lock will just release as the timeout expires.
+     *
+     * @default true
+     */
+    releaseOnDispose?: boolean;
+  };
+}
+
+const normalizeOptions = (options: Lock.Options): RawOptions =>
+  mapValues(options, (key, value) => {
+    if (
+      value != null &&
+      (key.endsWith('Timeout') || key.endsWith('Interval'))
+    ) {
+      return Duration.from(value as DurationIn).toMillis();
+    }
+    return value;
+  }).asRecord as RawOptions;

--- a/src/core/locker/locker.module.ts
+++ b/src/core/locker/locker.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import Redis from 'ioredis';
+import { ConfigService } from '~/core/config';
+import { Locker } from './locker.service';
+
+@Module({
+  providers: [
+    {
+      provide: Locker,
+      inject: [ConfigService],
+      useFactory: async (config: ConfigService): Promise<Locker> => {
+        const { url, prefix } = config.locker;
+
+        let redis;
+        if (url) {
+          redis = new Redis(url);
+        } else {
+          const { RedisMock } = await import('~/core/redis/redis.mock');
+          redis = new RedisMock();
+        }
+
+        return new Locker(redis, { prefix });
+      },
+    },
+  ],
+  exports: [Locker],
+})
+export class LockerModule {}

--- a/src/core/locker/locker.service.ts
+++ b/src/core/locker/locker.service.ts
@@ -1,0 +1,122 @@
+import type { Redis } from 'ioredis';
+import { Lock } from './lock';
+
+export class Locker {
+  constructor(
+    private readonly redis: Redis,
+    private readonly options: Locker.Options,
+  ) {}
+
+  /**
+   * @example Simple
+   * async function doSomething() {
+   *   await using lock = this.locker.getLock('lockingResource');
+   *   await lock.acquire();
+   *  // or acquire immediately
+   *   await using lock = await this.locker.getLock('lockingResource').acquire();
+   *
+   *   // critical code
+   * }
+   *
+   * @example Lost lock handling
+   * async function doSomething() {
+   *   await using lock = this.locker.getLock('lockingResource', {
+   *     onLockLost(err) {
+   *       this.logger.error(err);
+   *     },
+   *   });
+   *   await lock.acquire();
+   *
+   *   // with each iteration, check if the lock is still acquired
+   *   // and break when it is lost.
+   *   while (lock.isAcquired) {
+   *     // critical cycle iteration
+   *   }
+   * }
+   *
+   * @example Optional lock
+   * async function doSomething() {
+   *   await using lock = this.locker.getLock('lockingResource', {
+   *     acquireAttemptsLimit: 1,
+   *   });
+   *   const lockAcquired = await lock.tryAcquire();
+   *   if (!lockAcquired) {
+   *     return
+   *   }
+   *
+   *   ...
+   * }
+   *
+   * @example Temporary refresh
+   * async function doSomething() {
+   *   await using lock = this.locker.getLock('lockingResource', {
+   *     lockTimeout: '2 mins',
+   *     refreshInterval: '15s',
+   *     // Let the lock expire over time (2 mins) after operation is finished
+   *     releaseOnDispose: false,
+   *   });
+   *
+   *   // acquire
+   *   ...
+   * }
+   *
+   * @example Dynamically adjusting existing lock
+   * // This creates an original lock
+   * await using preMutex = this.locker.getLock('lockingResource', {
+   *   lockTimeout: '10s',
+   *   refreshInterval: 0, // disable refreshing
+   *   releaseOnDispose: false,
+   * });
+   *
+   * // This adapts the lock with a new TTL and starts refresh
+   * await using lock = this.locker.getLock(preMutex.key, {
+   *   identifier: preMutex.identifier,
+   *   acquiredExternally: true, // required in this case
+   *   lockTimeout: '30min',
+   *   refreshInterval: '1min',
+   * });
+   *
+   * @example shared lock between scheduler and handler apps
+   * // scheduler app code
+   * async function every10MinutesCronScheduler() {
+   *   await using lock = this.locker.getLock('lockingResource', {
+   *     lockTimeout: '30 mins',
+   *     refreshInterval: 0, // disable refreshing
+   *     releaseOnDispose: false,
+   *   });
+   *   if (await lock.tryAcquire()) {
+   *     someQueue.publish({ lockIdentifier: lock.identifier })
+   *   } else {
+   *     logger.info('Job already scheduled. Do nothing in current cron cycle')
+   *   }
+   * }
+   *
+   * // handler app code
+   * async function queueHandler(queueMessageData) {
+   *   const { lockIdentifier } = queueMessageData
+   *   await using lock = this.locker.getLock('lockingResource', {
+   *     lockTimeout: '10 secs',
+   *     identifier: lockIdentifier,
+   *     acquiredExternally: true, // required in this case
+   *   })
+   *
+   *   // Since acquired externally, this will do a `refresh` with the new
+   *   // lockTimeout instead of `acquire`.
+   *   // If the lock was locked by another process or the lock was expired,
+   *   // an exception will be thrown (default refresh behavior)
+   *   await lock.acquire();
+   *
+   *   ...
+   * }
+   */
+  getLock(key: string, options?: Lock.Options) {
+    return new Lock(this.redis, key, this.options, options);
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Locker {
+  export interface Options {
+    prefix?: string;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6913,6 +6913,7 @@ __metadata:
     react: "npm:^19.1.0"
     react-dom: "npm:^19.1.0"
     read-package-up: "npm:^11.0.0"
+    redis-semaphore: "npm:^5.6.2"
     reflect-metadata: "npm:^0.2.2"
     rimraf: "npm:^6.0.1"
     rxjs: "npm:^7.8.1"
@@ -13330,6 +13331,20 @@ __metadata:
   dependencies:
     redis-errors: "npm:^1.0.0"
   checksum: 10c0/ee16ac4c7b2a60b1f42a2cdaee22b005bd4453eb2d0588b8a4939718997ae269da717434da5d570fe0b05030466eeb3f902a58cf2e8e1ca058bf6c9c596f632f
+  languageName: node
+  linkType: hard
+
+"redis-semaphore@npm:^5.6.2":
+  version: 5.6.2
+  resolution: "redis-semaphore@npm:5.6.2"
+  dependencies:
+    debug: "npm:^4.4.0"
+  peerDependencies:
+    ioredis: ^4.1.0 || ^5
+  peerDependenciesMeta:
+    ioredis:
+      optional: true
+  checksum: 10c0/63f0fd1a45eb74cac160b041c30a1ecccb19123e41ab17842efcc6e413fffbdeae5091ec07f3e7290809a61ed409939cc36ecdde4bf5a2d1b770d9dc115765e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Instead of porting seed-api's Locker code I'm reimagining it. It was created redis-semaphore existed.

This implementation is really just redis-semaphore's `Mutex` API.
The main difference is that refreshing happens automatically with a nodejs interval instead of having to explicitly call `lock.extend()`. And if Redis is not configured, we use `RedisMock` instead of a bespoke in-memory version.

We thinly wrap the library to:
- Provide dependency injection (`Locker` service)
- I documented configuration options & defaults for DX
- Allow `DurationIn` values in configuration (i.e. `{ lockTimeout: '2 mins' }`)
- Locks have explicit resource management. So usage can just be
  ```ts
  await using lock = this.locker.getLock('key');
  ```
  instead of
  ```ts
  const lock = this.locker.getLock('key');
  try {
    // ...
  } finally {
    await lock.release();
  }
  ```