### PR TITLE
Refactor splitDb

### DIFF
--- a/src/components/admin/admin.module.ts
+++ b/src/components/admin/admin.module.ts
@@ -12,13 +12,12 @@ import { NormalizeCreatorMigration } from './migrations/normalize-creator.migrat
 @Module({
   imports: [AuthorizationModule, UserModule],
   providers: [
-    splitDb(AdminService, AdminGelService),
-    splitDb(
-      AdminRepository,
+    splitDb(AdminService, { gel: AdminGelService }),
+    splitDb(AdminRepository, {
       // @ts-expect-error types don't have to match since the service is split
       // and each will only use their own.
-      AdminGelRepository,
-    ),
+      gel: AdminGelRepository,
+    }),
     NormalizeCreatorMigration,
     NormalizeCreatorBaseNodeMigration,
   ],

--- a/src/components/ceremony/ceremony.module.ts
+++ b/src/components/ceremony/ceremony.module.ts
@@ -13,7 +13,9 @@ import * as handlers from './handlers';
   providers: [
     CeremonyResolver,
     CeremonyService,
-    splitDb(CeremonyRepository, CeremonyGelRepository),
+    splitDb(CeremonyRepository, {
+      gel: CeremonyGelRepository,
+    }),
     CeremonyLoader,
     ...Object.values(handlers),
   ],

--- a/src/components/engagement/engagement.module.ts
+++ b/src/components/engagement/engagement.module.ts
@@ -57,7 +57,9 @@ import { EngagementProductConnectionResolver } from './product-connection.resolv
     EngagementRules,
     EngagementService,
     EngagementChannels,
-    splitDb(EngagementRepository, EngagementGelRepository),
+    splitDb(EngagementRepository, {
+      gel: EngagementGelRepository,
+    }),
     EngagementLoader,
     ...Object.values(handlers),
     FixNullMethodologiesMigration,

--- a/src/components/ethno-art/ethno-art.module.ts
+++ b/src/components/ethno-art/ethno-art.module.ts
@@ -13,7 +13,9 @@ import { EthnoArtService } from './ethno-art.service';
   providers: [
     EthnoArtLoader,
     EthnoArtResolver,
-    splitDb(EthnoArtRepository, EthnoArtGelRepository),
+    splitDb(EthnoArtRepository, {
+      gel: EthnoArtGelRepository,
+    }),
     EthnoArtService,
   ],
   exports: [EthnoArtService],

--- a/src/components/field-region/field-region.module.ts
+++ b/src/components/field-region/field-region.module.ts
@@ -19,7 +19,9 @@ import { RestrictRegionDirectorRemovalHandler } from './handlers/restrict-region
   providers: [
     FieldRegionResolver,
     FieldRegionService,
-    splitDb(FieldRegionRepository, FieldRegionGelRepository),
+    splitDb(FieldRegionRepository, {
+      gel: FieldRegionGelRepository,
+    }),
     FieldRegionLoader,
     RestrictRegionDirectorRemovalHandler,
   ],

--- a/src/components/field-zone/field-zone.module.ts
+++ b/src/components/field-zone/field-zone.module.ts
@@ -17,7 +17,9 @@ import { RestrictZoneDirectorRemovalHandler } from './handlers/restrict-zone-dir
   providers: [
     FieldZoneResolver,
     FieldZoneService,
-    splitDb(FieldZoneRepository, FieldZoneGelRepository),
+    splitDb(FieldZoneRepository, {
+      gel: FieldZoneGelRepository,
+    }),
     FieldZoneLoader,
     RestrictZoneDirectorRemovalHandler,
   ],

--- a/src/components/film/film.module.ts
+++ b/src/components/film/film.module.ts
@@ -13,7 +13,9 @@ import { FilmService } from './film.service';
   providers: [
     FilmResolver,
     FilmService,
-    splitDb(FilmRepository, FilmGelRepository),
+    splitDb(FilmRepository, {
+      gel: FilmGelRepository,
+    }),
     FilmLoader,
   ],
   exports: [FilmService],

--- a/src/components/funding-account/funding-account.module.ts
+++ b/src/components/funding-account/funding-account.module.ts
@@ -13,7 +13,9 @@ import { FundingAccountAddDeptIdBlockMigration } from './migrations/funding-acco
   providers: [
     FundingAccountResolver,
     FundingAccountService,
-    splitDb(FundingAccountRepository, FundingAccountGelRepository),
+    splitDb(FundingAccountRepository, {
+      gel: FundingAccountGelRepository,
+    }),
     FundingAccountLoader,
     FundingAccountAddDeptIdBlockMigration,
   ],

--- a/src/components/language/language.module.ts
+++ b/src/components/language/language.module.ts
@@ -37,8 +37,12 @@ import { RegistryOfDialectToRegistryOfLanguageVarietiesMigration } from './migra
     LanguageService,
     LanguageChannels,
     EthnologueLanguageService,
-    splitDb(EthnologueLanguageRepository, EthnologueLanguageGelRepository),
-    splitDb(LanguageRepository, LanguageGelRepository),
+    splitDb(EthnologueLanguageRepository, {
+      gel: EthnologueLanguageGelRepository,
+    }),
+    splitDb(LanguageRepository, {
+      gel: LanguageGelRepository,
+    }),
     LanguageLoader,
     InternalFirstScriptureResolver,
     RegistryOfDialectToRegistryOfLanguageVarietiesMigration,

--- a/src/components/location/location.module.ts
+++ b/src/components/location/location.module.ts
@@ -21,7 +21,9 @@ import { DefaultMarketingRegionMigration } from './migrations/default-marketing-
   providers: [
     LocationResolver,
     LocationService,
-    splitDb(LocationRepository, LocationGelRepository),
+    splitDb(LocationRepository, {
+      gel: LocationGelRepository,
+    }),
     LocationLoader,
     DefaultMarketingRegionMigration,
   ],

--- a/src/components/notifications/notification.module.ts
+++ b/src/components/notifications/notification.module.ts
@@ -13,7 +13,7 @@ import {
     NotificationResolver,
     { provide: NotificationService, useExisting: NotificationServiceImpl },
     NotificationServiceImpl,
-    splitDb(Neo4jRepository, GelRepository),
+    splitDb(Neo4jRepository, { gel: GelRepository }),
   ],
   exports: [NotificationService],
 })

--- a/src/components/organization/organization.module.ts
+++ b/src/components/organization/organization.module.ts
@@ -15,7 +15,9 @@ import { OrganizationService } from './organization.service';
   providers: [
     OrganizationResolver,
     OrganizationService,
-    splitDb(OrganizationRepository, OrganizationGelRepository),
+    splitDb(OrganizationRepository, {
+      gel: OrganizationGelRepository,
+    }),
     OrganizationLoader,
     AddOrganizationReachMigration,
     AddOrganizationTypeMigration,

--- a/src/components/partner/partner.module.ts
+++ b/src/components/partner/partner.module.ts
@@ -26,7 +26,9 @@ import { PartnerService } from './partner.service';
   providers: [
     PartnerResolver,
     PartnerService,
-    splitDb(PartnerRepository, PartnerGelRepository),
+    splitDb(PartnerRepository, {
+      gel: PartnerGelRepository,
+    }),
     PartnerLoader,
     AddPartnerApprovedProgramsMigration,
     AddPartnerStartDateMigration,

--- a/src/components/partnership/partnership.module.ts
+++ b/src/components/partnership/partnership.module.ts
@@ -24,7 +24,9 @@ import { PartnershipService } from './partnership.service';
   providers: [
     PartnershipResolver,
     PartnershipService,
-    splitDb(PartnershipRepository, PartnershipGelRepository),
+    splitDb(PartnershipRepository, {
+      gel: PartnershipGelRepository,
+    }),
     PartnershipLoader,
     PartnershipByProjectAndPartnerLoader,
     ...Object.values(handlers),

--- a/src/components/pin/pin.module.ts
+++ b/src/components/pin/pin.module.ts
@@ -9,7 +9,7 @@ import { PinService } from './pin.service';
   providers: [
     PinResolver,
     PinService,
-    splitDb(PinRepository, PinGelRepository),
+    splitDb(PinRepository, { gel: PinGelRepository }),
   ],
   exports: [PinService],
 })

--- a/src/components/pnp/extraction-result/pnp-extraction-result.module.ts
+++ b/src/components/pnp/extraction-result/pnp-extraction-result.module.ts
@@ -1,5 +1,5 @@
 import { forwardRef, Module } from '@nestjs/common';
-import { splitDb2 } from '~/core/database';
+import { splitDb } from '~/core/database';
 import { ProductModule } from '../../product/product.module';
 import { PlanningExtractionResultSaver } from './planning-extraction-result-saver';
 import { PnpExtractionResultLanguageEngagementConnectionResolver } from './pnp-extraction-result-language-engagement-connection.resolver';
@@ -19,8 +19,7 @@ import { SaveProgressExtractionResultHandler } from './save-progress-extraction-
     PnpExtractionResultLoader,
     PlanningExtractionResultSaver,
     SaveProgressExtractionResultHandler,
-    splitDb2(PnpExtractionResultRepository, {
-      gel: PnpExtractionResultRepository,
+    splitDb(PnpExtractionResultRepository, {
       neo4j: PnpExtractionResultNeo4jRepository,
     }),
   ],

--- a/src/components/progress-report/variance-explanation/variance-explanation.module.ts
+++ b/src/components/progress-report/variance-explanation/variance-explanation.module.ts
@@ -16,10 +16,9 @@ import { ProgressReportVarianceExplanationService } from './variance-explanation
     ProgressReportVarianceExplanationReasonOptionsResolver,
     ProgressReportVarianceExplanationLoader,
     ProgressReportVarianceExplanationService,
-    splitDb(
-      ProgressReportVarianceExplanationRepository,
-      VarianceExplanationGelRepository,
-    ),
+    splitDb(ProgressReportVarianceExplanationRepository, {
+      gel: VarianceExplanationGelRepository,
+    }),
     RenameReasonOptionMigration,
   ],
 })

--- a/src/components/progress-report/workflow/progress-report-workflow.module.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.module.ts
@@ -31,10 +31,9 @@ import { ProgressReportWorkflowEventsResolver } from './resolvers/progress-repor
     ProgressReportWorkflowEventLoader,
     ProgressReportWorkflowService,
     ProgressReportWorkflowEventGranter,
-    splitDb(
-      ProgressReportWorkflowRepository,
-      ProgressReportWorkflowGelRepository,
-    ),
+    splitDb(ProgressReportWorkflowRepository, {
+      gel: ProgressReportWorkflowGelRepository,
+    }),
     ProgressReportWorkflowFlowchart,
     ...Object.values(handlers),
   ],

--- a/src/components/progress-summary/progress-summary.module.ts
+++ b/src/components/progress-summary/progress-summary.module.ts
@@ -16,7 +16,9 @@ import { ProgressSummaryResolver } from './progress-summary.resolver';
     ProgressReportConnectionResolver,
     ProgressSummaryResolver,
     ProgressSummaryLoader,
-    splitDb(ProgressSummaryRepository, ProgressSummaryGelRepository),
+    splitDb(ProgressSummaryRepository, {
+      gel: ProgressSummaryGelRepository,
+    }),
     ProgressSummaryExtractor,
     ...Object.values(handlers),
   ],

--- a/src/components/project/financial-approver/financial-approver.module.ts
+++ b/src/components/project/financial-approver/financial-approver.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { splitDb2 } from '~/core/database';
+import { splitDb } from '~/core/database';
 import { FinancialApproverNeo4jRepository } from './financial-approver-neo4j.repository';
 import { FinancialApproverRepository } from './financial-approver.repository';
 import { FinancialApproverResolver } from './financial-approver.resolver';
@@ -7,8 +7,7 @@ import { FinancialApproverResolver } from './financial-approver.resolver';
 @Module({
   providers: [
     FinancialApproverResolver,
-    splitDb2(FinancialApproverRepository, {
-      gel: FinancialApproverRepository,
+    splitDb(FinancialApproverRepository, {
       neo4j: FinancialApproverNeo4jRepository,
     }),
   ],

--- a/src/components/project/project-member/project-member.module.ts
+++ b/src/components/project/project-member/project-member.module.ts
@@ -34,7 +34,9 @@ import { ProjectMemberService } from './project-member.service';
     MemberProjectConnectionResolver,
     ProjectMemberService,
     ProjectMemberChannels,
-    splitDb(ProjectMemberRepository, ProjectMemberGelRepository),
+    splitDb(ProjectMemberRepository, {
+      gel: ProjectMemberGelRepository,
+    }),
     ProjectMemberLoader,
     MembershipByProjectAndUserLoader,
     AddInactiveAtMigration,

--- a/src/components/project/project.module.ts
+++ b/src/components/project/project.module.ts
@@ -61,7 +61,9 @@ import { ProjectWorkflowModule } from './workflow/project-workflow.module';
     ...ProjectEngagementIdResolvers,
     ProjectChannels,
     ProjectService,
-    splitDb(ProjectRepository, ProjectGelRepository),
+    splitDb(ProjectRepository, {
+      gel: ProjectGelRepository,
+    }),
     ...Object.values(ConcreteRepos),
     ProjectLoader,
     ...Object.values(handlers),

--- a/src/components/project/workflow/project-workflow.module.ts
+++ b/src/components/project/workflow/project-workflow.module.ts
@@ -1,5 +1,5 @@
 import { forwardRef, Module } from '@nestjs/common';
-import { splitDb2 } from '~/core/database';
+import { splitDb } from '~/core/database';
 import { UserModule } from '../../user/user.module';
 import { ProjectModule } from '../project.module';
 import { ProjectWorkflowNotificationHandler } from './handlers/project-workflow-notification.handler';
@@ -29,9 +29,8 @@ import { ProjectWorkflowMutationSubscriptionsResolver } from './resolvers/projec
     ProjectWorkflowService,
     ProjectWorkflowChannels,
     ProjectWorkflowEventGranter,
-    splitDb2(ProjectWorkflowRepository, {
+    splitDb(ProjectWorkflowRepository, {
       neo4j: ProjectWorkflowNeo4jRepository,
-      gel: ProjectWorkflowRepository,
     }),
     ProjectWorkflowFlowchart,
     ProjectWorkflowNotificationHandler,

--- a/src/components/story/story.module.ts
+++ b/src/components/story/story.module.ts
@@ -13,7 +13,9 @@ import { StoryService } from './story.service';
   providers: [
     StoryResolver,
     StoryService,
-    splitDb(StoryRepository, StoryGelRepository),
+    splitDb(StoryRepository, {
+      gel: StoryGelRepository,
+    }),
     StoryLoader,
   ],
   exports: [StoryService],

--- a/src/components/tools/tool-usage/tool-usage.module.ts
+++ b/src/components/tools/tool-usage/tool-usage.module.ts
@@ -21,7 +21,7 @@ import { ToolUsagesResolver } from './tool-usages.resolver';
     ToolUsageByContainerLoader,
     ToolUsageByToolLoader,
     ToolUsageService,
-    splitDb(Neo4jRepository, GelRepository),
+    splitDb(Neo4jRepository, { gel: GelRepository }),
   ],
   exports: [ToolUsageService],
 })

--- a/src/components/tools/tool/tool.module.ts
+++ b/src/components/tools/tool/tool.module.ts
@@ -11,7 +11,7 @@ import { ToolService } from './tool.service';
     ToolResolver,
     ToolLoader,
     ToolService,
-    splitDb(Neo4jRepository, GelRepository),
+    splitDb(Neo4jRepository, { gel: GelRepository }),
   ],
   exports: [ToolService],
 })

--- a/src/components/user/education/education.module.ts
+++ b/src/components/user/education/education.module.ts
@@ -12,7 +12,9 @@ import { EducationService } from './education.service';
   providers: [
     EducationResolver,
     EducationService,
-    splitDb(EducationRepository, EducationGelRepository),
+    splitDb(EducationRepository, {
+      gel: EducationGelRepository,
+    }),
     EducationLoader,
   ],
   exports: [EducationService],

--- a/src/components/user/unavailability/unavailability.module.ts
+++ b/src/components/user/unavailability/unavailability.module.ts
@@ -12,7 +12,9 @@ import { UnavailabilityService } from './unavailability.service';
   providers: [
     UnavailabilityResolver,
     UnavailabilityService,
-    splitDb(UnavailabilityRepository, UnavailabilityGelRepository),
+    splitDb(UnavailabilityRepository, {
+      gel: UnavailabilityGelRepository,
+    }),
     UnavailabilityLoader,
   ],
   exports: [UnavailabilityService],

--- a/src/components/user/user.module.ts
+++ b/src/components/user/user.module.ts
@@ -45,10 +45,13 @@ import { UserService } from './user.service';
     UserLoader,
     ActorLoader,
     UserService,
-    splitDb(UserRepository, UserGelRepository),
+    splitDb(UserRepository, { gel: UserGelRepository }),
     KnownLanguageRepository,
     {
-      ...splitDb(SystemAgentNeo4jRepository, SystemAgentGelRepository),
+      ...splitDb(SystemAgentNeo4jRepository, {
+        neo4j: SystemAgentNeo4jRepository,
+        gel: SystemAgentGelRepository,
+      }),
       provide: SystemAgentRepository,
     },
     AddActorLabelMigration,

--- a/src/core/authentication/authentication.module.ts
+++ b/src/core/authentication/authentication.module.ts
@@ -36,7 +36,9 @@ import { SessionManager } from './session/session.manager';
     SessionHost,
 
     AuthenticationService,
-    splitDb(AuthenticationRepository, AuthenticationGelRepository),
+    splitDb(AuthenticationRepository, {
+      gel: AuthenticationGelRepository,
+    }),
     JwtService,
     CryptoService,
 

--- a/src/core/database/split-db.provider.ts
+++ b/src/core/database/split-db.provider.ts
@@ -3,29 +3,18 @@ import { ModuleRef } from '@nestjs/core';
 import type { PublicOf } from '~/common';
 import { ConfigService } from '~/core/config';
 
+type DatabaseEngines = 'gel' | 'neo4j';
+
 export const splitDb = <T>(
-  neo4jRepository: Type<T>,
-  gelRepository: Type<PublicOf<T>>,
+  canonical: Type<T>,
+  engineOverrides: Partial<Record<DatabaseEngines, Type<PublicOf<T>>>>,
 ) =>
   ({
-    provide: neo4jRepository,
+    provide: canonical,
     inject: [ModuleRef, ConfigService],
     useFactory: async (moduleRef: ModuleRef, config: ConfigService) => {
       const cls =
-        config.databaseEngine === 'gel' ? gelRepository : neo4jRepository;
-      return await moduleRef.create<T>(cls);
-    },
-  }) satisfies Provider;
-
-export const splitDb2 = <T>(
-  token: Type<T>,
-  repos: { gel: Type<PublicOf<T>>; neo4j: Type<PublicOf<T>> },
-) =>
-  ({
-    provide: token,
-    inject: [ModuleRef, ConfigService],
-    useFactory: async (moduleRef: ModuleRef, config: ConfigService) => {
-      const cls = config.databaseEngine === 'gel' ? repos.gel : repos.neo4j;
+        engineOverrides[config.databaseEngine as DatabaseEngines] ?? canonical;
       return await moduleRef.create<T>(cls);
     },
   }) satisfies Provider;

--- a/src/core/gel/gel.module.ts
+++ b/src/core/gel/gel.module.ts
@@ -61,7 +61,7 @@ import './errors';
       provide: APP_INTERCEPTOR,
       useClass: GelTransactionalMutationsInterceptor,
     },
-    splitDb(IdResolver, AliasIdResolver),
+    splitDb(IdResolver, { gel: AliasIdResolver }),
     GelWarningHandler,
   ],
   exports: [Gel, Client, IdResolver],


### PR DESCRIPTION
Now the canonical type is first, and any engine specifics can be given after. This lets the canonical one be for any engine, and the specifics explicitly named after.

Like for example, in some repos the gel version is the canonical, so the override is for gel and the override is for neo4j. This was awkward before and needed splitDb2 to support. Now both ways (neo4j -> gel) & (gel <- neo4j) make sense.

This also opens the door for a 3rd engine, if Postgres ever comes.