### PR TITLE
Add project.rev79Communities field via Seed API

### DIFF
--- a/src/components/rev79/dto/index.ts
+++ b/src/components/rev79/dto/index.ts
@@ -1,4 +1,5 @@
 export * from './quarter-period.input';
+export * from './rev79-community.dto';
 export * from './rev79-quarterly-report-context.input';
 export * from './rev79-quarterly-report-context.result';
 export * from './upload-progress-reports.input';

--- a/src/components/rev79/dto/rev79-community.dto.ts
+++ b/src/components/rev79/dto/rev79-community.dto.ts
@@ -1,0 +1,10 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class Rev79Community {
+  @Field()
+  id: string;
+
+  @Field()
+  name: string;
+}

--- a/src/components/rev79/rev79-project.resolver.ts
+++ b/src/components/rev79/rev79-project.resolver.ts
@@ -1,0 +1,35 @@
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { SeedApiService } from '~/core/seed-api';
+import { IProject, type Project } from '../project/dto';
+import { Rev79Community } from './dto/rev79-community.dto';
+
+const rev79CommunitiesQuery = /* GraphQL */ `
+  query Rev79Projects($filter: JSONObject) {
+    rev79Projects(filter: $filter) {
+      id
+      communitiesInUse {
+        id
+        name
+      }
+    }
+  }
+`;
+
+@Resolver(IProject)
+export class Rev79ProjectResolver {
+  constructor(private readonly seedApi: SeedApiService) {}
+
+  @ResolveField(() => [Rev79Community])
+  async rev79Communities(
+    @Parent() project: Project,
+  ): Promise<Rev79Community[]> {
+    const rev79ProjectId = project.rev79ProjectId.value;
+    if (!rev79ProjectId) return [];
+
+    const data = await this.seedApi.query<{
+      rev79Projects: Array<{ id: string; communitiesInUse: Rev79Community[] }>;
+    }>(rev79CommunitiesQuery, { filter: { id: rev79ProjectId } });
+
+    return data?.rev79Projects[0]?.communitiesInUse ?? [];
+  }
+}

--- a/src/components/rev79/rev79.module.ts
+++ b/src/components/rev79/rev79.module.ts
@@ -5,6 +5,7 @@ import { ProductProgressModule } from '../product-progress/product-progress.modu
 import { ProgressReportModule } from '../progress-report/progress-report.module';
 import { ProjectModule } from '../project/project.module';
 import { FixRev79ActiveFlagMigration } from './migrations/fix-rev79-active-flag.migration';
+import { Rev79ProjectResolver } from './rev79-project.resolver';
 import { Rev79GelRepository } from './rev79.gel.repository';
 import { Rev79Repository } from './rev79.repository';
 import { Rev79Resolver } from './rev79.resolver';
@@ -19,6 +20,7 @@ import { Rev79Service } from './rev79.service';
   ],
   providers: [
     Rev79Resolver,
+    Rev79ProjectResolver,
     Rev79Service,
     splitDb(Rev79Repository, { gel: Rev79GelRepository }),
     FixRev79ActiveFlagMigration,

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -341,6 +341,11 @@ export const makeConfig = (env: EnvironmentService) =>
     webhooks = {
       requestTimeout: env.duration('WEBHOOK_REQUEST_TIMEOUT').optional('5m'),
     };
+
+    seedApi = {
+      url: env.url('SEED_API_URL').optional('http://localhost:8367'),
+      secret: env.string('SEED_API_SECRET').optional(''),
+    };
   };
 
 // @ts-expect-error We will call makeConfig to create this shape.

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -27,6 +27,7 @@ import { QueueModule } from './queue/queue.module';
 import { ResourceModule } from './resources/resource.module';
 import { ScalarProviders } from './scalars.resolver';
 import { ScheduleModule } from './schedule/schedule.module';
+import { SeedApiModule } from './seed-api/seed-api.module';
 import { ShutdownHookProvider } from './shutdown.hook';
 import { TimeoutInterceptor } from './timeout.interceptor';
 import { TracingModule } from './tracing';
@@ -58,6 +59,7 @@ import { WebhooksModule } from './webhooks/webhooks.module';
     QueueModule,
     LockerModule,
     ScheduleModule,
+    SeedApiModule,
   ],
   providers: [
     AwsS3Factory,

--- a/src/core/seed-api/index.ts
+++ b/src/core/seed-api/index.ts
@@ -1,0 +1,2 @@
+export * from './seed-api.module';
+export * from './seed-api.service';

--- a/src/core/seed-api/seed-api.module.ts
+++ b/src/core/seed-api/seed-api.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { SeedApiService } from './seed-api.service';
+
+@Global()
+@Module({
+  providers: [SeedApiService],
+  exports: [SeedApiService],
+})
+export class SeedApiModule {}

--- a/src/core/seed-api/seed-api.service.ts
+++ b/src/core/seed-api/seed-api.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import got, { type ExtendOptions, type Got } from 'got';
+import { ConfigService } from '~/core/config';
+
+@Injectable()
+export class SeedApiService {
+  private readonly http: Got;
+
+  constructor(config: ConfigService) {
+    this.http = got.extend({
+      prefixUrl: config.seedApi.url,
+      headers: {
+        'user-agent': 'cord-api',
+        authorization: config.seedApi.secret,
+      },
+    } satisfies ExtendOptions);
+  }
+
+  async query<T>(
+    document: string,
+    variables?: Record<string, unknown>,
+  ): Promise<T | null> {
+    const response = await this.http
+      .post('graphql', { json: { query: document, variables } })
+      .json<{ data: T | null }>();
+    return response.data;
+  }
+}


### PR DESCRIPTION
Adds a rev79Communities field on Project that fetches community IDs and names from Seed API given a project's rev79ProjectId. Enables the FE to populate a dropdown for selecting rev79CommunityId on a LanguageEngagement instead of free text input.

Also introduces a generic SeedApiService in src/core/seed-api/ as the foundation for future Cord → Seed API calls.