### PR TITLE
Skip PnP Process for Multiplication File Upload

### DIFF
--- a/src/components/pnp/pnp.ts
+++ b/src/components/pnp/pnp.ts
@@ -25,8 +25,15 @@ export class Pnp {
 
   static fromBuffer(buffer: Buffer, name?: string) {
     const book = Xlsx.WorkBook.fromBuffer(buffer);
-    PlanningSheet.register(book);
-    ProgressSheet.register(book);
+    try {
+      PlanningSheet.register(book);
+      ProgressSheet.register(book);
+    } catch (e) {
+      if (e instanceof NotFoundException) {
+        throw new NotPnPFile(e.message, e);
+      }
+      throw e;
+    }
     return new Pnp(book, name);
   }
 


### PR DESCRIPTION
Before: PDF uploaded → PlanningSheet.register → NotFoundException → propagates up → PnpProductSyncService catch sees it's NOT a NotPnPFile → logs error

After: PDF uploaded → PlanningSheet.register → NotFoundException → caught in fromBuffer → rethrown as NotPnPFile → PnpProductSyncService catch sees it IS a NotPnPFile → silently returns, no error logged

The upload itself always succeeds (the file is stored regardless). The change just ensures PnP extraction is skipped gracefully when the uploaded file isn't a PnP spreadsheet — which is the correct behavior for multiplication reports using PDF uploads.