### PR TITLE
Dedupe Migration Script for Progress Reports

### DIFF
--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -9,6 +9,7 @@ import {
   type Query,
   relation,
 } from 'cypher-query-builder';
+import { createHash } from 'node:crypto';
 import {
   type CalendarDate,
   generateId,
@@ -17,7 +18,7 @@ import {
   type UnsecuredDto,
 } from '~/common';
 import { type ChangesOf } from '~/core/database/changes';
-import { DtoRepository } from '~/core/neo4j';
+import { DtoRepository, UniquenessError } from '~/core/neo4j';
 import {
   ACTIVE,
   createNode,
@@ -69,9 +70,20 @@ export class PeriodicReportRepository extends DtoRepository<
 
     // Create IDs here that will feed into the reports that are new.
     // If only neo4j had a nanoid generator natively.
+    //
+    // tempId is derived deterministically from (parent, type, start, end) so
+    // that concurrent transactions computing IDs for the same interval always
+    // land on the same value.  The existing BaseNode.id uniqueness constraint
+    // then guarantees at most one node is created: the second writer gets a
+    // UniquenessError (caught below) and returns [] instead of a duplicate.
     const intervals = await Promise.all(
       input.intervals.map(async (interval) => ({
-        tempId: await generateId(),
+        tempId: deterministicReportId(
+          input.parent,
+          input.type,
+          interval.start,
+          interval.end,
+        ),
         start: interval.start,
         end: interval.end,
         tempFileId: await generateId(),
@@ -185,7 +197,16 @@ export class PeriodicReportRepository extends DtoRepository<
       .return<{ id: ID; interval: Range<CalendarDate> }>(
         'report.id as id, interval',
       );
-    return await query.run();
+    try {
+      return await query.run();
+    } catch (e) {
+      // A concurrent transaction created these same reports (same deterministic
+      // IDs) and committed first.  Treat this as a no-op: the reports exist.
+      if (e instanceof UniquenessError && e.property === 'id') {
+        return [];
+      }
+      throw e;
+    }
   }
 
   async update<T extends PeriodicReport | UnsecuredDto<PeriodicReport>>(
@@ -431,6 +452,25 @@ export class PeriodicReportRepository extends DtoRepository<
         );
   }
 }
+
+/**
+ * Produces a stable ID for a periodic report given its identifying dimensions.
+ * Two calls with the same arguments always return the same 11-character
+ * base64url string (66 bits of SHA-256), which is enough to avoid accidental
+ * collisions while being deterministic enough to detect intentional duplicates.
+ */
+const deterministicReportId = (
+  parentId: ID,
+  type: string,
+  start: CalendarDate,
+  end: CalendarDate,
+): ID => {
+  const key = `${parentId}:${type}:${start.toISODate()}:${end.toISODate()}`;
+  return createHash('sha256')
+    .update(key)
+    .digest('base64url')
+    .slice(0, 11) as ID;
+};
 
 export const matchCurrentDue =
   (parentId: ID | Variable | undefined, reportType: ReportType) =>

--- a/src/components/progress-report/migrations/drop-duplicate-multiplication-progress-reports.migration.ts
+++ b/src/components/progress-report/migrations/drop-duplicate-multiplication-progress-reports.migration.ts
@@ -1,0 +1,34 @@
+import { BaseMigration, Migration } from '~/core/neo4j';
+
+/**
+ * Removes duplicate ProgressReport nodes for multiplication project engagements.
+ *
+ * These duplicates share the same parent (LanguageEngagement) and the same
+ * start/end dates. They were created by a race condition when engagements were
+ * first set up (two concurrent merge() calls both passed the dedup check before
+ * either committed). All duplicates are NotStarted with no uploaded file.
+ *
+ * Strategy: for each (parent, start, end) group with more than one report,
+ * keep the first (by sort order) and detach-delete the rest along with their
+ * empty placeholder File nodes.
+ */
+@Migration('2026-03-30T12:00:00')
+export class DropDuplicateMultiplicationProgressReportsMigration extends BaseMigration {
+  async up() {
+    await this.db.query().raw`
+      MATCH (parent:BaseNode)-[:report { active: true }]->(report:ProgressReport)
+      WHERE
+        EXISTS {
+          MATCH (:Project { type: "MultiplicationTranslation" })-[:engagement { active: true }]->(parent)
+        }
+      MATCH (report)-[:start { active: true }]->(startProp:Property)
+      MATCH (report)-[:end { active: true }]->(endProp:Property)
+      WITH parent, startProp.value AS start, endProp.value AS end, collect(report) AS reports
+      WHERE size(reports) > 1
+      UNWIND reports[1..] AS duplicate
+      OPTIONAL MATCH (duplicate)-[:reportFileNode]->(file:File)
+      DETACH DELETE duplicate, file
+      RETURN count(duplicate) AS deleted
+    `.executeAndLogStats();
+  }
+}

--- a/src/components/progress-report/progress-report.module.ts
+++ b/src/components/progress-report/progress-report.module.ts
@@ -9,6 +9,7 @@ import { ProgressReportHighlightsResolver } from './highlights/progress-report-h
 import { ProgressReportHighlightsService } from './highlights/progress-report-highlights.service';
 import { ProgressReportMediaModule } from './media/progress-report-media.module';
 import { BackfillMultiplicationProgressReportFilePublicMigration } from './migrations/backfill-multiplication-progress-report-file-public.migration';
+import { DropDuplicateMultiplicationProgressReportsMigration } from './migrations/drop-duplicate-multiplication-progress-reports.migration';
 import { DropInternshipProgressReportsMigration } from './migrations/drop-internship-progress-reports.migration';
 import { ReextractPnpProgressReportsMigration } from './migrations/reextract-all-progress-reports.migration';
 import { ProgressReportExtraForPeriodicInterfaceRepository } from './progress-report-extra-for-periodic-interface.repository';
@@ -50,6 +51,7 @@ import { ProgressReportWorkflowModule } from './workflow/progress-report-workflo
     ProgressReportRepository,
     ProgressReportExtraForPeriodicInterfaceRepository,
     BackfillMultiplicationProgressReportFilePublicMigration,
+    DropDuplicateMultiplicationProgressReportsMigration,
     DropInternshipProgressReportsMigration,
     ReextractPnpProgressReportsMigration,
   ],


### PR DESCRIPTION
### **Fix duplicate progress reports on multiplication engagements**

### Problem
Multiplication project engagements were accumulating duplicate quarterly ProgressReport nodes — multiple nodes with the same parent engagement, start date, and end date but different IDs.

The root cause is a race condition in PeriodicReportRepository.merge(). The dedup logic uses a check-then-create pattern: a subquery counts existing reports for a given (parent, start, end) interval and only proceeds to CREATE if the count is zero. Two concurrent transactions (e.g. two event handlers firing for the same engagement simultaneously) both pass this check before either commits, and both create a node — leaving duplicates in the DB.

### Fix 1 — Migration: drop existing duplicates
DropDuplicateMultiplicationProgressReportsMigration cleans up all existing duplicates for multiplication projects:

Matches all ProgressReport nodes whose parent engagement belongs to a MultiplicationTranslation project
Groups them by (parent, start, end)
For any group with more than one report, keeps the first (by internal order) and DETACH DELETEs the rest along with their empty placeholder File nodes
All duplicates were NotStarted with no uploaded file, so no data is lost.

### Fix 2 — Prevent recurrence: atomic dedup via deterministic IDs
PeriodicReportRepository.merge() now computes a deterministic report ID from sha256(parentId:type:start:end) (11-char base64url, 66 bits) instead of a random nanoid.

Because the ID is deterministic, two concurrent transactions computing IDs for the same interval always land on the same value. The existing BaseNode.id uniqueness constraint (already enforced in the DB) then becomes the race guard: exactly one transaction wins, and the second receives a UniquenessError at commit time instead of creating a duplicate. That error is caught in merge() and treated as a no-op — the reports already exist.

This requires no schema changes and no Cypher restructuring; it turns the constraint that was already there into the synchronization primitive.