### PR TITLE
fixes the hyrdation for file nodes

### DIFF
--- a/src/components/file/file.repository.ts
+++ b/src/components/file/file.repository.ts
@@ -326,6 +326,13 @@ export class FileRepository extends CommonRepository {
     return (query: Query) =>
       query
         .apply(matchProps())
+        .optionalMatch([
+          node('node'),
+          relation('out', '', 'parent', ACTIVE),
+          node('', 'FileNode'),
+          relation('out', '', 'public', ACTIVE),
+          node('parentPublicProp', 'Property'),
+        ])
         .match([
           node('node'),
           relation('out', '', 'createdBy', ACTIVE),
@@ -336,6 +343,7 @@ export class FileRepository extends CommonRepository {
             type: `"${FileNodeType.FileVersion}"`,
             createdById: 'createdBy.id',
             canDelete: true,
+            public: 'coalesce(props.public, parentPublicProp.value, false)',
           }).as('dto'),
         );
   }


### PR DESCRIPTION
## Fix: FileVersion not inheriting public flag from parent File


## Description
`hydrateFileVersion()` only read properties on the FileVersion node itself, but the public flag lives on the parent File node — so public files always resolved to false and returned 401. 


## Ready for review checklist
- [ ] Add/update tests if needed
- [ ] Add reviewers to this PR
