### PR TITLE
Find Communities by Rev79ProjectId

### DIFF
--- a/src/components/rev79/dto/index.ts
+++ b/src/components/rev79/dto/index.ts
@@ -1,4 +1,5 @@
 export * from './quarter-period.input';
+export * from './rev79-community';
 export * from './rev79-quarterly-report-context.input';
 export * from './rev79-quarterly-report-context.result';
 export * from './upload-progress-reports.input';

--- a/src/components/rev79/dto/quarter-period.input.ts
+++ b/src/components/rev79/dto/quarter-period.input.ts
@@ -11,7 +11,7 @@ export class QuarterPeriodInput {
 
   @Field(() => Int, {
     description:
-      'Quarter number: 1 = Oct–Dec,2 = Jan–Mar, 3 = Apr–Jun, 4 = Jul–Sep',
+      'Quarter number: 1 = Oct–Dec, 2 = Jan–Mar, 3 = Apr–Jun, 4 = Jul–Sep',
   })
   readonly quarter: number;
 }

--- a/src/components/rev79/dto/quarter-period.input.ts
+++ b/src/components/rev79/dto/quarter-period.input.ts
@@ -1,17 +1,17 @@
 import { Field, InputType, Int } from '@nestjs/graphql';
 
 @InputType({
-  description: 'A fiscal/calendar quarter within a specific year.',
+  description: 'A fiscal quarter within a specific year.',
 })
 export class QuarterPeriodInput {
   @Field(() => Int, {
-    description: 'Calendar year (e.g. 2024)',
+    description: 'Fiscal year (e.g. 2024)',
   })
   readonly year: number;
 
   @Field(() => Int, {
     description:
-      'Quarter number: 1 = Jan–Mar, 2 = Apr–Jun, 3 = Jul–Sep, 4 = Oct–Dec',
+      'Quarter number: 1 = Oct–Dec,2 = Jan–Mar, 3 = Apr–Jun, 4 = Jul–Sep',
   })
   readonly quarter: number;
 }

--- a/src/components/rev79/dto/rev79-community.ts
+++ b/src/components/rev79/dto/rev79-community.ts
@@ -1,0 +1,10 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class Rev79Community {
+  @Field()
+  id: string;
+
+  @Field()
+  name: string;
+}

--- a/src/components/rev79/rev79.gel.repository.ts
+++ b/src/components/rev79/rev79.gel.repository.ts
@@ -34,10 +34,11 @@ export class Rev79GelRepository extends CommonRepository {
         'and',
         e.op('exists', eng.rev79CommunityId),
       ),
-      id: eng.rev79CommunityId,
+      rev79CommunityId: true,
       name: eng.language.displayName,
     }));
-    return (await this.db.run(query)) as Array<{ id: string; name: string }>;
+    const rows = await this.db.run(query);
+    return rows.map((r) => ({ id: r.rev79CommunityId!, name: r.name }));
   }
 
   /**

--- a/src/components/rev79/rev79.gel.repository.ts
+++ b/src/components/rev79/rev79.gel.repository.ts
@@ -21,6 +21,26 @@ export class Rev79GelRepository extends CommonRepository {
   }
 
   /**
+   * Returns all Rev79 community IDs (and their language display names) for
+   * LanguageEngagements that belong to `projectId` and have a rev79CommunityId set.
+   */
+  async findCommunitiesByRev79ProjectId(
+    projectId: ID<'Project'>,
+  ): Promise<ReadonlyArray<{ id: string; name: string }>> {
+    const project = e.cast(e.Project, e.uuid(projectId));
+    const query = e.select(e.LanguageEngagement, (eng) => ({
+      filter: e.op(
+        e.op(eng.project, '=', project),
+        'and',
+        e.op('exists', eng.rev79CommunityId),
+      ),
+      id: eng.rev79CommunityId,
+      name: eng.language.displayName,
+    }));
+    return (await this.db.run(query)) as Array<{ id: string; name: string }>;
+  }
+
+  /**
    * Returns IDs of all LanguageEngagements within `projectId` whose
    * rev79CommunityId matches.
    * The service layer enforces that exactly one result is returned.

--- a/src/components/rev79/rev79.repository.ts
+++ b/src/components/rev79/rev79.repository.ts
@@ -26,6 +26,36 @@ export class Rev79Repository extends CommonRepository {
   }
 
   /**
+   * Returns all Rev79 community IDs (and their language display names) for
+   * LanguageEngagements that belong to `projectId` and have a rev79CommunityId set.
+   */
+  async findCommunitiesByRev79ProjectId(
+    projectId: ID<'Project'>,
+  ): Promise<ReadonlyArray<{ id: string; name: string }>> {
+    return await this.db
+      .query()
+      .match([
+        node('project', 'Project', { id: projectId }),
+        relation('out', '', 'engagement', ACTIVE),
+        node('engagement', 'LanguageEngagement'),
+        relation('out', '', 'rev79CommunityId', ACTIVE),
+        node('communityId', 'Property'),
+      ])
+      .match([
+        node('engagement'),
+        relation('out', '', 'language', ACTIVE),
+        node('language', 'Language'),
+        relation('out', '', 'name', ACTIVE),
+        node('languageName', 'Property'),
+      ])
+      .return<{ id: string; name: string }>([
+        'communityId.value as id',
+        'languageName.value as name',
+      ])
+      .run();
+  }
+
+  /**
    * Returns IDs of all LanguageEngagements within `projectId` whose
    * rev79CommunityId property matches.
    * The service layer enforces that exactly one result is returned.

--- a/src/components/rev79/rev79.resolver.ts
+++ b/src/components/rev79/rev79.resolver.ts
@@ -2,6 +2,7 @@ import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import {
   Rev79BulkUploadProgressReportsInput,
   Rev79BulkUploadResult,
+  Rev79Community,
   Rev79QuarterlyReportContextInput,
   Rev79QuarterlyReportContextResult,
 } from './dto';
@@ -28,6 +29,19 @@ export class Rev79Resolver {
     @Args('input') input: Rev79QuarterlyReportContextInput,
   ): Promise<Rev79QuarterlyReportContextResult> {
     return await this.service.resolveQuarterlyReportContext(input);
+  }
+
+  @Query(() => [Rev79Community], {
+    description: `
+      Returns the Rev79 communities that have language engagements
+      under the Cord project mapped to the given Rev79 project ID.
+      Returns an empty list if no Cord project is found for that Rev79 project ID.
+    `,
+  })
+  async rev79ProjectCommunities(
+    @Args('rev79ProjectId') rev79ProjectId: string,
+  ): Promise<Array<{ id: string; name: string }>> {
+    return await this.service.getProjectCommunities(rev79ProjectId);
   }
 
   @Mutation(() => Rev79BulkUploadResult, {

--- a/src/components/rev79/rev79.resolver.ts
+++ b/src/components/rev79/rev79.resolver.ts
@@ -40,7 +40,7 @@ export class Rev79Resolver {
   })
   async rev79ProjectCommunities(
     @Args('rev79ProjectId') rev79ProjectId: string,
-  ): Promise<Array<{ id: string; name: string }>> {
+  ): Promise<ReadonlyArray<{ id: string; name: string }>> {
     return await this.service.getProjectCommunities(rev79ProjectId);
   }
 

--- a/src/components/rev79/rev79.service.ts
+++ b/src/components/rev79/rev79.service.ts
@@ -100,7 +100,7 @@ export class Rev79Service {
 
   async getProjectCommunities(
     rev79ProjectId: string,
-  ): Promise<Array<{ id: string; name: string }>> {
+  ): Promise<ReadonlyArray<{ id: string; name: string }>> {
     const matches = await this.repo.findProjectsByRev79Id(rev79ProjectId);
     if (matches.length === 0) {
       return [];

--- a/src/components/rev79/rev79.service.ts
+++ b/src/components/rev79/rev79.service.ts
@@ -98,6 +98,25 @@ export class Rev79Service {
     };
   }
 
+  async getProjectCommunities(
+    rev79ProjectId: string,
+  ): Promise<Array<{ id: string; name: string }>> {
+    const matches = await this.repo.findProjectsByRev79Id(rev79ProjectId);
+    if (matches.length !== 1) {
+      return [];
+    }
+    const projectId = matches[0]!.id;
+    try {
+      await this.projectService.readOne(projectId);
+    } catch (e) {
+      if (e instanceof NotFoundException) {
+        return [];
+      }
+      throw e;
+    }
+    return await this.repo.findCommunitiesByRev79ProjectId(projectId);
+  }
+
   async uploadProgressReports(
     input: Rev79BulkUploadProgressReportsInput,
   ): Promise<Rev79BulkUploadResult> {

--- a/src/components/rev79/rev79.service.ts
+++ b/src/components/rev79/rev79.service.ts
@@ -102,8 +102,11 @@ export class Rev79Service {
     rev79ProjectId: string,
   ): Promise<Array<{ id: string; name: string }>> {
     const matches = await this.repo.findProjectsByRev79Id(rev79ProjectId);
-    if (matches.length !== 1) {
+    if (matches.length === 0) {
       return [];
+    }
+    if (matches.length > 1) {
+      throw new AmbiguousRev79ProjectException(rev79ProjectId);
     }
     const projectId = matches[0]!.id;
     try {


### PR DESCRIPTION
### Add rev79ProjectCommunities query

seed-api syncs Rev79 quarterly data by calling rev79QuarterlyReportContext once per community ID. When a Rev79 community ID has no corresponding Cord engagement, this produces a Rev79CommunityNotFound error on every sync for every unmatched community — with no way to pre-filter.

This adds a new query:

**rev79ProjectCommunities(rev79ProjectId: String!): [Rev79Community!]!**

Returns all Rev79 community IDs (with language display names) that have mapped language engagements under the Cord project for the given Rev79 project ID. Returns an empty list if no Cord project is found — never throws.

seed-api can now do one preflight call to get the valid community IDs, then only call rev79QuarterlyReportContext for communities known to exist in Cord, eliminating the spurious errors entirely.