### PR TITLE
Fix Language.pinned filter

### DIFF
--- a/src/components/language/language.gel.repository.ts
+++ b/src/components/language/language.gel.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { type ID, type PublicOf } from '~/common';
-import { e, RepoFor } from '~/core/gel';
-import { type CreateLanguage, Language } from './dto';
+import { e, RepoFor, type ScopeOf } from '~/core/gel';
+import { type CreateLanguage, Language, type LanguageListInput } from './dto';
 import { type LanguageRepository } from './language.repository';
 
 @Injectable()
@@ -49,6 +49,17 @@ export class LanguageGelRepository
     const lang = e.cast(e.Language, e.uuid(id));
     const query = e.op('exists', lang.firstScriptureEngagement);
     return await this.db.run(query);
+  }
+
+  protected listFilters(
+    lang: ScopeOf<typeof e.Language>,
+    input: LanguageListInput,
+  ) {
+    if (!input.filter) return [];
+    return [
+      input.filter.pinned != null &&
+        e.op(lang.pinned, '=', input.filter.pinned),
+    ];
   }
 
   async readOneByEth(ethnologueId: ID) {

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -262,6 +262,7 @@ export class LanguageRepository extends DtoRepository<
         relation('out', '', 'language'),
         node('node'),
       ])
+      .with(['node', 'project'])
       .apply(languageFilters(input.filter))
       .apply(
         this.privileges.filterToReadable({


### PR DESCRIPTION
in Cypher, WHERE after OPTIONAL MATCH scopes to the optional match — it only determines whether project is null, not whether node survives. So pinned: true was silently a no-op.

The .with(['node', 'project']) creates a new scope, so the WHERE clauses from languageFilters correctly filter Language nodes out of the result set.