### PR TITLE
#4 [pg] Add drizzleFilter to PolicyExecutor and port RoleCondition

### DIFF
--- a/src/components/authorization/policies/conditions/role.condition.ts
+++ b/src/components/authorization/policies/conditions/role.condition.ts
@@ -1,4 +1,5 @@
 import { type NonEmptyArray } from '@seedcompany/common';
+import { sql } from 'drizzle-orm';
 import { inspect } from 'util';
 import { type Role } from '~/common';
 import {
@@ -19,6 +20,10 @@ export class RoleCondition implements Condition {
 
   asCypherCondition() {
     return 'false';
+  }
+
+  asDrizzleCondition() {
+    return sql`false`;
   }
 
   asEdgeQLCondition({ namespace }: AsEdgeQLParams<any>) {

--- a/src/components/authorization/policy/conditions/condition.interface.ts
+++ b/src/components/authorization/policy/conditions/condition.interface.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/method-signature-style */
 import { type Many, type NonEmptyArray } from '@seedcompany/common';
 import { type Query } from 'cypher-query-builder';
+import { type SQL } from 'drizzle-orm';
 import { inspect, type InspectOptionsStylized } from 'util';
 import { type EnhancedResource, type ResourceShape } from '~/common';
 import { type Session } from '~/core/authentication';
@@ -80,6 +81,12 @@ export abstract class Condition<
   ): Record<string, string>;
 
   abstract asEdgeQLCondition(params: AsEdgeQLParams<TResourceStatic>): string;
+
+  /**
+   * Drizzle SQL WHERE clause fragment that represents the condition.
+   * Optional — implement when porting a domain to PostgreSQL.
+   */
+  asDrizzleCondition?(other: AsCypherParams<TResourceStatic>): SQL;
 
   /**
    * Union multiple conditions of this type together to a single one.

--- a/src/components/authorization/policy/executor/policy-executor.ts
+++ b/src/components/authorization/policy/executor/policy-executor.ts
@@ -1,5 +1,6 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { CachedByArg } from '@seedcompany/common';
+import { type SQL } from 'drizzle-orm';
 import { identity } from 'lodash';
 import { type EnhancedResource } from '~/common';
 import { Identity, type Session } from '~/core/authentication';
@@ -164,6 +165,19 @@ export class PolicyExecutor {
       return false;
     }
     return this.conditionOptimizer.optimize(any(...conditions));
+  }
+
+  drizzleFilter(params: ResolveParams): SQL | boolean {
+    const perm = this.resolve(params);
+    if (perm === true || perm === false) return perm;
+
+    const other = { resource: params.resource, session: this.identity.current };
+    if (!perm.asDrizzleCondition) {
+      throw new Error(
+        `Condition ${perm.constructor.name} has not been ported to Drizzle — implement asDrizzleCondition`,
+      );
+    }
+    return perm.asDrizzleCondition(other);
   }
 
   cypherFilter({


### PR DESCRIPTION
## Summary

Extends the policy/authorization layer to produce Drizzle SQL WHERE clauses,
mirroring the existing `cypherFilter` and `edgeqlFilter` paths.

- Adds `asDrizzleCondition?(): SQL` as an optional method on the `Condition`
  abstract base class. Domains implement it when they migrate to PostgreSQL;
  calling `drizzleFilter` on an unported condition throws with a clear message
  pointing to what needs implementing.
- Adds `PolicyExecutor.drizzleFilter()` which resolves permissions and returns
  either a `boolean` (grant/deny all) or a Drizzle `SQL` fragment for use in
  a WHERE clause.
- Ports `RoleCondition.asDrizzleCondition()` as the first implementation
  (returns `sql\`false\`` — role-based access has no row-level SQL equivalent,
  so it denies at the DB level and relies on the session-level role check).

## Context

This is part of the incremental Neo4j → PostgreSQL migration. Repositories
being ported to Drizzle need a way to inject auth-driven WHERE clauses the
same way Neo4j repos use `cypherFilter`. This PR establishes the interface
and wires up the executor so subsequent domain PRs can just implement
`asDrizzleCondition` on whatever conditions they use.

### Usage in domain repos

```ts
const filter = this.executor.drizzleFilter({ action: 'read', resource: ... });
if (filter === false) return [];
await db.select().from(table).where(filter === true ? undefined : filter);
```

**drizzleFilter returns one of three things:**

**false** — the session has no permission to read this resource at all. Skip the DB entirely, return empty.

**true** — the session has unconditional read access (e.g., an admin role with no extra conditions). Run the query with no WHERE clause — undefined tells Drizzle to omit it.

**SQL** — the session's access depends on a condition (e.g., "only resources you created" or "only within your organization"). That condition becomes the WHERE clause, letting the DB do the filtering.

The ternary `filter === true ? undefined : filter` is just collapsing the last two cases into what .where() expects — Drizzle's .where(undefined) means "no filter", and .where(sql\...`)` means "apply this filter".