### PR TITLE
Fix: Ignore first scripture engagements from deleted projects

### DIFF
--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -675,6 +675,9 @@ export class EngagementRepository extends CommonRepository {
         relation('out', '', 'firstScripture', ACTIVE),
         node({ value: true }),
       ])
+      .raw(
+        'WHERE exists((otherLanguageEngagements)<-[:engagement { active: true }]-(:Project))',
+      )
       .return('otherLanguageEngagements')
       .first();
     return !!result;

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -237,6 +237,9 @@ export class LanguageRepository extends DtoRepository<
           relation('out', '', 'firstScripture', ACTIVE),
           node('', 'Property', { value: variable('true') }),
         ])
+        .raw(
+          'WHERE firstScriptureEngagement IS NULL OR exists((firstScriptureEngagement)<-[:engagement { active: true }]-(:Project))',
+        )
         .return<{ dto: UnsecuredDto<Language> }>(
           merge('props', 'changedProps', {
             __typename: '"Language"',
@@ -308,6 +311,9 @@ export class LanguageRepository extends DtoRepository<
           value: true,
         },
       })
+      .raw(
+        'AND exists((languageEngagement)<-[:engagement { active: true }]-(:Project))',
+      )
       .return('languageEngagement')
       .first();
     return !!res;


### PR DESCRIPTION
When a project is soft-deleted in Neo4j, its labels are prefixed with Deleted_ but its child engagements are untouched. Three queries for firstScripture on Language only traversed to the engagement level, never verifying the parent project was still live — causing the language page to throw when it tried to resolve an engagement whose project was gone.

Added exists() checks in three places to filter out engagements from deleted projects at query time:

language.repository.ts hydrate() — firstScriptureEngagement optionalMatch
language.repository.ts hasFirstScriptureEngagement() — validation on hasExternalFirstScripture updates
engagement.repository.ts doOtherEngagementsHaveFirstScripture() — duplicate-check on firstScripture=true
Chose query-time filtering over cleanup-on-delete because the project uses soft delete and clearing the property on delete would lose the designation irreversibly if the project is later restored.