### PR TITLE
Fix: Project mou date policies

### DIFF
--- a/src/components/authorization/policies/by-role/field-operations-director.policy.ts
+++ b/src/components/authorization/policies/by-role/field-operations-director.policy.ts
@@ -1,4 +1,4 @@
-import { Policy, Role } from '../util';
+import { field, Policy, Role } from '../util';
 
 // NOTE: There could be other permissions for this role from other policies
 @Policy(Role.FieldOperationsDirector, (r) => [
@@ -13,7 +13,10 @@ import { Policy, Role } from '../util';
   ]),
   r.Producible.edit.create,
   r.Product.edit.create.delete,
-  r.Project.edit.specifically((p) => [p.departmentId.read]),
+  r.Project.edit.specifically((p) => [
+    p.departmentId.read,
+    p.many('mouStart', 'mouEnd').when(field('status', 'InDevelopment')).edit,
+  ]),
   r.ProjectMember.edit.create.delete,
   r.ProjectWorkflowEvent.read.transitions(
     'Field Ops Approves Proposal',

--- a/src/components/authorization/policies/by-role/field-services.policy.ts
+++ b/src/components/authorization/policies/by-role/field-services.policy.ts
@@ -1,4 +1,4 @@
-import { Policy, Role } from '../util';
+import { field, Policy, Role } from '../util';
 
 @Policy(Role.FieldServices, (r) => [
   r.Budget.edit,
@@ -17,7 +17,9 @@ import { Policy, Role } from '../util';
     p.many('agreement', 'agreementStatus', 'types', 'partner', 'primary').edit,
   ]),
   r.Product.edit.create.delete,
-  r.Project.edit.create.delete,
+  r.Project.edit.create.delete.specifically((p) => [
+    p.many('mouStart', 'mouEnd').when(field('status', 'InDevelopment')).edit,
+  ]),
   r.ProjectMember.edit.create.delete,
   r.PeriodicReport.edit,
   r.ToolUsage.edit.create.delete,

--- a/src/components/authorization/policies/by-role/regional-director.policy.ts
+++ b/src/components/authorization/policies/by-role/regional-director.policy.ts
@@ -1,4 +1,4 @@
-import { member, Policy, Role, sensMediumOrLower } from '../util';
+import { field, member, Policy, Role, sensMediumOrLower } from '../util';
 import * as PM from './project-manager.policy';
 
 // NOTE: There could be other permissions for this role from other policies
@@ -9,6 +9,9 @@ import * as PM from './project-manager.policy';
   r.Project.when(member).edit.specifically((p) => [
     p.rootDirectory.edit.when(sensMediumOrLower).read,
     p.departmentId.read,
+    p
+      .many('mouStart', 'mouEnd')
+      .whenAll(member, field('status', 'InDevelopment')).edit,
   ]),
   r.ProjectWorkflowEvent.transitions(
     PM.projectTransitions,


### PR DESCRIPTION
Prevent non financial service roles from altering active projects mou dates.