### PR TITLE
Add Tool filter to ProjectFilters & EngagementFilters, create ToolContainerType

### DIFF
--- a/src/components/engagement/dto/list-engagements.dto.ts
+++ b/src/components/engagement/dto/list-engagements.dto.ts
@@ -17,6 +17,7 @@ import {
   LanguageMilestone,
 } from '../../language/dto';
 import { ProjectFilters } from '../../project/dto';
+import { ToolFilters } from '../../tools/tool/dto';
 import { UserFilters } from '../../user/dto';
 import {
   type Engagement,
@@ -90,6 +91,9 @@ export abstract class EngagementFilters {
     empty: 'omit',
   })
   readonly usingAIAssistedTranslation?: readonly AIAssistedTranslation[];
+
+  @FilterField(() => ToolFilters)
+  readonly tool?: ToolFilters & {};
 }
 
 @InputType()

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -67,6 +67,7 @@ import {
 import { IProject, ProjectType } from '../project/dto';
 import { projectFilters } from '../project/project-filters.query';
 import { projectSorters } from '../project/project.repository';
+import { toolFilters } from '../tools/tool/tool.neo4j.repository';
 import { userFilters } from '../user';
 import { User } from '../user/dto';
 import {
@@ -850,6 +851,15 @@ export const engagementFilters = filter.define(() => EngagementFilters, {
   milestonePlanned: filter.stringListProp(),
   milestoneReached: filter.propVal(),
   usingAIAssistedTranslation: filter.stringListProp(),
+  tool: filter.sub(() => toolFilters)((sub) =>
+    sub.match([
+      node('outer'),
+      relation('out', '', 'uses', ACTIVE),
+      node('', 'ToolUsage'),
+      relation('out', '', 'tool', ACTIVE),
+      node('node', 'Tool'),
+    ]),
+  ),
 });
 
 export const engagementSorters = defineSorters(IEngagement, {

--- a/src/components/project/dto/list-projects.dto.ts
+++ b/src/components/project/dto/list-projects.dto.ts
@@ -18,6 +18,7 @@ import {
 import { FieldRegionFilters } from '../../field-region/dto';
 import { LocationFilters } from '../../location/dto';
 import { PartnershipFilters } from '../../partnership/dto';
+import { ToolFilters } from '../../tools/tool/dto';
 import { ProjectMemberFilters } from '../project-member/dto';
 import { ProjectStatus } from './project-status.enum';
 import { ProjectStep } from './project-step.enum';
@@ -142,6 +143,9 @@ export abstract class ProjectFilters {
 
   @FilterField(() => FieldRegionFilters)
   readonly fieldRegion?: FieldRegionFilters & {};
+
+  @FilterField(() => ToolFilters)
+  readonly tool?: ToolFilters & {};
 }
 
 Object.defineProperty(ProjectFilters.prototype, 'mine', {

--- a/src/components/project/project-filters.query.ts
+++ b/src/components/project/project-filters.query.ts
@@ -18,6 +18,7 @@ import { fieldRegionFilters } from '../field-region/field-region.repository';
 import { locationFilters } from '../location/location.repository';
 import { partnershipFilters } from '../partnership/partnership.repository';
 import { ToolKey } from '../tools/tool/dto/tool-key.enum';
+import { toolFilters } from '../tools/tool/tool.neo4j.repository';
 import { ProjectFilters } from './dto';
 import { projectMemberFilters } from './project-member/project-member.repository';
 import { ProjectNameIndex } from './project.repository';
@@ -148,6 +149,15 @@ export const projectFilters = filter.define(() => ProjectFilters, {
       node('outer'),
       relation('out', '', 'partnership', ACTIVE),
       node('node', 'Partnership'),
+    ]),
+  ),
+  tool: filter.sub(() => toolFilters)((sub) =>
+    sub.match([
+      node('outer'),
+      relation('out', '', 'uses', ACTIVE),
+      node('', 'ToolUsage'),
+      relation('out', '', 'tool', ACTIVE),
+      node('node', 'Tool'),
     ]),
   ),
 });

--- a/src/components/tools/tool-usage/dto/list-tool-usages.dto.ts
+++ b/src/components/tools/tool-usage/dto/list-tool-usages.dto.ts
@@ -1,6 +1,9 @@
-import { InputType, ObjectType } from '@nestjs/graphql';
+import { Field, InputType, Int, ObjectType } from '@nestjs/graphql';
 import {
+  type EnumType,
   FilterField,
+  makeEnum,
+  OptionalField,
   PaginatedList,
   SecuredList,
   SortablePaginationInput,
@@ -8,10 +11,28 @@ import {
 import { ToolFilters } from '../../tool/dto';
 import { ToolUsage } from './tool-usage.dto';
 
+export type ToolContainerType = EnumType<typeof ToolContainerType>;
+export const ToolContainerType = makeEnum({
+  name: 'ToolContainerType',
+  values: ['Engagement', 'Project'],
+});
+
+@ObjectType()
+export class ToolContainerSummary {
+  @Field(() => ToolContainerType)
+  readonly containerType: ToolContainerType;
+
+  @Field(() => Int)
+  readonly total: number;
+}
+
 @InputType()
 export abstract class ToolUsageFilters {
   @FilterField(() => ToolFilters)
   readonly tool?: ToolFilters & {};
+
+  @OptionalField(() => ToolContainerType)
+  readonly containerType?: ToolContainerType;
 }
 
 @InputType()

--- a/src/components/tools/tool-usage/tool-container-summary.loader.ts
+++ b/src/components/tools/tool-usage/tool-container-summary.loader.ts
@@ -1,0 +1,38 @@
+import { type ID } from '~/common';
+import {
+  type DataLoaderStrategy,
+  type LoaderContextType,
+  LoaderFactory,
+  type LoaderOptionsOf,
+} from '~/core/data-loader';
+import { type Tool } from '../tool/dto';
+import { type ToolContainerSummary } from './dto';
+import { ToolUsageService } from './tool-usage.service';
+
+export interface SummaryByTool {
+  tool: Tool;
+  summary: ToolContainerSummary[];
+}
+
+@LoaderFactory()
+export class ToolContainerSummaryLoader implements DataLoaderStrategy<
+  SummaryByTool,
+  Tool,
+  ID
+> {
+  constructor(private readonly usages: ToolUsageService) {}
+
+  getOptions() {
+    return {
+      propertyKey: ({ tool }) => tool,
+      cacheKeyFn: (tool) => tool.id,
+    } satisfies LoaderOptionsOf<ToolContainerSummaryLoader>;
+  }
+
+  async loadMany(
+    tools: readonly Tool[],
+    _ctx: LoaderContextType,
+  ): Promise<readonly SummaryByTool[]> {
+    return await this.usages.readContainerSummaryForTools(tools);
+  }
+}

--- a/src/components/tools/tool-usage/tool-usage.gel.repository.ts
+++ b/src/components/tools/tool-usage/tool-usage.gel.repository.ts
@@ -4,6 +4,16 @@ import { e, RepoFor } from '~/core/gel';
 import { type ToolContainerType, ToolUsage } from './dto';
 import { type ToolUsageRepository as Neo4jRepository } from './tool-usage.neo4j.repository';
 
+const engagementSubtypes = new Set([
+  'LanguageEngagement',
+  'InternshipEngagement',
+]);
+const projectSubtypes = new Set([
+  'MomentumTranslationProject',
+  'MultiplicationTranslationProject',
+  'InternshipProject',
+]);
+
 const resAsBaseNode = e.shape(e.Resource, (res) => ({
   identity: res.id,
   labels: e.array_agg(e.set(res.__type__.name)),
@@ -62,25 +72,23 @@ export class ToolUsageRepository
   private makeListForToolsWithTypeFilter(containerType: ToolContainerType) {
     const fqns =
       containerType === 'Engagement'
-        ? ([
-            'default::LanguageEngagement',
-            'default::InternshipEngagement',
-          ] as const)
-        : ([`default::${containerType}`] as const);
+        ? ['default::LanguageEngagement', 'default::InternshipEngagement']
+        : [
+            'default::MomentumTranslationProject',
+            'default::MultiplicationTranslationProject',
+            'default::InternshipProject',
+          ];
     return e.params({ tools: e.array(e.uuid) }, ($) => {
       const tools = e.cast(e.Tool, e.array_unpack($.tools));
       return e.select(tools, (tool) => ({
         tool: e.select(tool, (c) => ({ id: c.id })),
         usages: e.select(tool.usages, (usage) => ({
           ...this.hydrate(usage),
-          filter:
-            fqns.length === 1
-              ? e.op(usage.container.__type__.name, '=', e.str(fqns[0]))
-              : e.op(
-                  e.op(usage.container.__type__.name, '=', e.str(fqns[0])),
-                  'or',
-                  e.op(usage.container.__type__.name, '=', e.str(fqns[1])),
-                ),
+          filter: e.op(
+            usage.container.__type__.name,
+            'in',
+            e.array_unpack(e.literal(e.array(e.str), fqns)),
+          ),
         })),
       }));
     });
@@ -88,17 +96,30 @@ export class ToolUsageRepository
 
   async containerSummaryForTools(tools: readonly ID[]) {
     const raw = await this.db.run(this.containerSummaryQuery, { tools });
-    // e.group returns { key: { containerType }, grouping, elements }[] — flatten to match Neo4j shape
-    return raw.flatMap(({ tool, summary }) =>
-      summary.map(({ key, elements }) => {
+    // e.group returns { key: { containerType }, grouping, elements }[] per tool.
+    // Normalize concrete Gel subtypes to enum values and merge totals so grouping
+    // uses the normalized type (avoids duplicate rows when multiple concrete subtypes
+    // map to the same enum value, e.g. LanguageEngagement + InternshipEngagement → Engagement).
+    return raw.flatMap(({ tool, summary }) => {
+      const totals = new Map<string, number>();
+      for (const { key, elements } of summary) {
         const rawType = (key.containerType as string).replace(/^default::/, '');
-        const containerType =
-          rawType === 'LanguageEngagement' || rawType === 'InternshipEngagement'
-            ? 'Engagement'
+        const containerType = engagementSubtypes.has(rawType)
+          ? 'Engagement'
+          : projectSubtypes.has(rawType)
+            ? 'Project'
             : rawType;
-        return { tool, containerType, total: elements.length };
-      }),
-    );
+        totals.set(
+          containerType,
+          (totals.get(containerType) ?? 0) + elements.length,
+        );
+      }
+      return [...totals.entries()].map(([containerType, total]) => ({
+        tool,
+        containerType,
+        total,
+      }));
+    });
   }
   private readonly containerSummaryQuery = e.params(
     { tools: e.array(e.uuid) },

--- a/src/components/tools/tool-usage/tool-usage.gel.repository.ts
+++ b/src/components/tools/tool-usage/tool-usage.gel.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { type ID, type PublicOf } from '~/common';
 import { e, RepoFor } from '~/core/gel';
-import { ToolUsage } from './dto';
+import { type ToolContainerType, ToolUsage } from './dto';
 import { type ToolUsageRepository as Neo4jRepository } from './tool-usage.neo4j.repository';
 
 const resAsBaseNode = e.shape(e.Resource, (res) => ({
@@ -39,7 +39,13 @@ export class ToolUsageRepository
     },
   );
 
-  async listForTools(tools: readonly ID[]) {
+  async listForTools(tools: readonly ID[], containerType?: ToolContainerType) {
+    if (containerType) {
+      return await this.db.run(
+        this.makeListForToolsWithTypeFilter(containerType),
+        { tools },
+      );
+    }
     return await this.db.run(this.listForToolsQuery, { tools });
   }
   private readonly listForToolsQuery = e.params(
@@ -49,6 +55,60 @@ export class ToolUsageRepository
       return e.select(tools, (tool) => ({
         tool: e.select(tool, (c) => ({ id: c.id })),
         usages: e.select(tool.usages, this.hydrate),
+      }));
+    },
+  );
+
+  private makeListForToolsWithTypeFilter(containerType: ToolContainerType) {
+    const fqns =
+      containerType === 'Engagement'
+        ? ([
+            'default::LanguageEngagement',
+            'default::InternshipEngagement',
+          ] as const)
+        : ([`default::${containerType}`] as const);
+    return e.params({ tools: e.array(e.uuid) }, ($) => {
+      const tools = e.cast(e.Tool, e.array_unpack($.tools));
+      return e.select(tools, (tool) => ({
+        tool: e.select(tool, (c) => ({ id: c.id })),
+        usages: e.select(tool.usages, (usage) => ({
+          ...this.hydrate(usage),
+          filter:
+            fqns.length === 1
+              ? e.op(usage.container.__type__.name, '=', e.str(fqns[0]))
+              : e.op(
+                  e.op(usage.container.__type__.name, '=', e.str(fqns[0])),
+                  'or',
+                  e.op(usage.container.__type__.name, '=', e.str(fqns[1])),
+                ),
+        })),
+      }));
+    });
+  }
+
+  async containerSummaryForTools(tools: readonly ID[]) {
+    const raw = await this.db.run(this.containerSummaryQuery, { tools });
+    // e.group returns { key: { containerType }, grouping, elements }[] — flatten to match Neo4j shape
+    return raw.flatMap(({ tool, summary }) =>
+      summary.map(({ key, elements }) => {
+        const rawType = (key.containerType as string).replace(/^default::/, '');
+        const containerType =
+          rawType === 'LanguageEngagement' || rawType === 'InternshipEngagement'
+            ? 'Engagement'
+            : rawType;
+        return { tool, containerType, total: elements.length };
+      }),
+    );
+  }
+  private readonly containerSummaryQuery = e.params(
+    { tools: e.array(e.uuid) },
+    ($) => {
+      const tools = e.cast(e.Tool, e.array_unpack($.tools));
+      return e.select(tools, (tool) => ({
+        tool: e.select(tool, (t) => ({ id: t.id })),
+        summary: e.group(tool.usages, (usage) => ({
+          by: { containerType: usage.container.__type__.name },
+        })),
       }));
     },
   );

--- a/src/components/tools/tool-usage/tool-usage.module.ts
+++ b/src/components/tools/tool-usage/tool-usage.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { splitDb } from '~/core/database';
 import { ToolCoreModule } from '../tool/tool.module';
 import { ResourceToolsResolver } from './resource-tools.resolver';
+import { ToolContainerSummaryLoader } from './tool-container-summary.loader';
 import { ToolUsageByContainerLoader } from './tool-usage-by-container.loader';
 import { ToolUsageByToolLoader } from './tool-usage-by-tool.loader';
 import { ToolUsageRepository as GelRepository } from './tool-usage.gel.repository';
@@ -20,6 +21,7 @@ import { ToolUsagesResolver } from './tool-usages.resolver';
     ToolUsageLoader,
     ToolUsageByContainerLoader,
     ToolUsageByToolLoader,
+    ToolContainerSummaryLoader,
     ToolUsageService,
     splitDb(Neo4jRepository, { gel: GelRepository }),
   ],

--- a/src/components/tools/tool-usage/tool-usage.neo4j.repository.ts
+++ b/src/components/tools/tool-usage/tool-usage.neo4j.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { node, type Query, relation } from 'cypher-query-builder';
+import { hasLabel, node, type Query, relation } from 'cypher-query-builder';
 import { CreationFailed, type ID, type UnsecuredDto } from '~/common';
 import { DtoRepository } from '~/core/neo4j';
 import {
@@ -17,6 +17,7 @@ import { type BaseNode } from '~/core/neo4j/results';
 import { toolFilters } from '../tool/tool.neo4j.repository';
 import {
   type CreateToolUsage,
+  type ToolContainerType,
   ToolUsage,
   ToolUsageFilters,
   type UpdateToolUsage,
@@ -76,7 +77,39 @@ export class ToolUsageRepository extends DtoRepository(ToolUsage) {
     return result;
   }
 
-  async listForTools(tools: readonly ID[]) {
+  async listForTools(tools: readonly ID[], containerType?: ToolContainerType) {
+    const result = await this.db
+      .query()
+      .unwind([...tools], 'toolId')
+      .match(node('tool', 'Tool', { id: variable('toolId') }))
+      .subQuery('tool', (sub) => {
+        let q = sub.match([
+          node('node', 'ToolUsage'),
+          relation('out', '', 'tool', ACTIVE),
+          node('tool'),
+        ]);
+        if (containerType) {
+          q = q
+            .match([
+              node('container', 'BaseNode'),
+              relation('out', '', 'uses', ACTIVE),
+              node('node'),
+            ])
+            .where({ container: hasLabel(containerType) });
+        }
+        return q
+          .subQuery('node', this.hydrate())
+          .return(collect('dto').as('usages'));
+      })
+      .return<{
+        tool: { id: ID };
+        usages: ReadonlyArray<UnsecuredDto<ToolUsage>>;
+      }>(['tool { .id }', 'usages'])
+      .run();
+    return result;
+  }
+
+  async containerSummaryForTools(tools: readonly ID[]) {
     const result = await this.db
       .query()
       .unwind([...tools], 'toolId')
@@ -84,17 +117,24 @@ export class ToolUsageRepository extends DtoRepository(ToolUsage) {
       .subQuery('tool', (sub) =>
         sub
           .match([
+            node('container', 'BaseNode'),
+            relation('out', '', 'uses', ACTIVE),
             node('node', 'ToolUsage'),
             relation('out', '', 'tool', ACTIVE),
             node('tool'),
           ])
-          .subQuery('node', this.hydrate())
-          .return(collect('dto').as('usages')),
+          // Normalize engagement subtypes to 'Engagement'; keep in sync with ToolContainerType enum
+          .with([
+            "CASE WHEN 'Project' IN labels(container) THEN 'Project' WHEN any(l IN labels(container) WHERE l IN ['LanguageEngagement', 'InternshipEngagement']) THEN 'Engagement' ELSE null END as containerType",
+          ])
+          .raw('WHERE containerType IS NOT NULL')
+          .return(['containerType', 'count(*) as total']),
       )
       .return<{
         tool: { id: ID };
-        usages: ReadonlyArray<UnsecuredDto<ToolUsage>>;
-      }>(['tool { .id }', 'usages'])
+        containerType: string;
+        total: number;
+      }>(['tool { .id }', 'containerType', 'total'])
       .run();
     return result;
   }
@@ -157,4 +197,12 @@ export const toolUsageFilters = filter.define(() => ToolUsageFilters, {
       node('node', 'Tool'),
     ]),
   ),
+  containerType: ({ value, query }) =>
+    query
+      .match([
+        node('container', 'BaseNode'),
+        relation('out', '', 'uses', ACTIVE),
+        node('outer'),
+      ])
+      .where({ container: hasLabel(value) }),
 });

--- a/src/components/tools/tool-usage/tool-usage.service.ts
+++ b/src/components/tools/tool-usage/tool-usage.service.ts
@@ -23,7 +23,15 @@ import { Privileges } from '../../authorization';
 import { Tool } from '../tool/dto';
 import { type ToolKey } from '../tool/dto/tool-key.enum';
 import { ToolRepository } from '../tool/tool.neo4j.repository';
-import { type CreateToolUsage, ToolUsage, type UpdateToolUsage } from './dto';
+import {
+  type CreateToolUsage,
+  type SecuredToolUsageList,
+  type ToolContainerSummary,
+  type ToolContainerType,
+  ToolUsage,
+  type ToolUsageFilters,
+  type UpdateToolUsage,
+} from './dto';
 import { type UsagesByContainer } from './tool-usage-by-container.loader';
 import { type UsagesByTool } from './tool-usage-by-tool.loader';
 import { ToolUsageRepository } from './tool-usage.neo4j.repository';
@@ -122,6 +130,65 @@ export class ToolUsageService {
         };
       }),
     );
+  }
+
+  async readForTool(
+    tool: Tool,
+    filters?: ToolUsageFilters,
+  ): Promise<SecuredToolUsageList> {
+    const rows = await this.repo.listForTools(
+      [tool.id],
+      filters?.containerType,
+    );
+    const row = rows[0];
+    if (!row) {
+      return {
+        items: [],
+        total: 0,
+        hasMore: false,
+        canRead: true,
+        canCreate: false,
+      };
+    }
+    const usagesRaw = await Promise.all(
+      row.usages.map(async (dto) => {
+        const container = await this.loadContainer(dto.container);
+        return this.secure(dto, container) ?? [];
+      }),
+    );
+    const usages = usagesRaw.flat();
+    return {
+      items: usages,
+      total: usages.length,
+      hasMore: false,
+      canRead: true,
+      canCreate: false,
+    };
+  }
+
+  async readContainerSummaryForTools(
+    tools: readonly Tool[],
+  ): Promise<Array<{ tool: Tool; summary: ToolContainerSummary[] }>> {
+    const toolsById = mapKeys.fromList(tools, (t) => t.id).asMap;
+    const rows = await this.repo.containerSummaryForTools(
+      tools.map((t) => t.id),
+    );
+    // Group rows by tool id and filter out types not in the ToolContainerType enum
+    const validTypes = new Set<string>(['Engagement', 'Project']);
+    const byToolId = new Map<ID, ToolContainerSummary[]>();
+    for (const row of rows) {
+      if (!validTypes.has(row.containerType)) continue;
+      const entries = byToolId.get(row.tool.id) ?? [];
+      entries.push({
+        containerType: row.containerType as ToolContainerType,
+        total: Number(row.total),
+      });
+      byToolId.set(row.tool.id, entries);
+    }
+    return tools.map((tool) => ({
+      tool: toolsById.get(tool.id)!,
+      summary: byToolId.get(tool.id) ?? [],
+    }));
   }
 
   private secure(

--- a/src/components/tools/tool-usage/tool-usage.service.ts
+++ b/src/components/tools/tool-usage/tool-usage.service.ts
@@ -64,13 +64,7 @@ export class ToolUsageService {
 
   async readMany(ids: ReadonlyArray<ID<ToolUsage>>) {
     const dtos = await this.repo.readMany(ids);
-    const secured = await Promise.all(
-      dtos.map(async (dto) => {
-        const container = await this.loadContainer(dto.container);
-        return this.secure(dto, container) ?? [];
-      }),
-    );
-    return secured.flat();
+    return await this.secureAll(dtos);
   }
 
   async readManyForContainers(containers: readonly Resource[]) {
@@ -111,13 +105,7 @@ export class ToolUsageService {
     return await Promise.all(
       rows.map(async (row): Promise<UsagesByTool> => {
         const tool = toolsById.get(row.tool.id)!;
-        const usagesRaw = await Promise.all(
-          row.usages.map(async (dto) => {
-            const container = await this.loadContainer(dto.container);
-            return this.secure(dto, container) ?? [];
-          }),
-        );
-        const usages = usagesRaw.flat();
+        const usages = await this.secureAll(row.usages);
         return {
           tool,
           usages: {
@@ -150,13 +138,7 @@ export class ToolUsageService {
         canCreate: false,
       };
     }
-    const usagesRaw = await Promise.all(
-      row.usages.map(async (dto) => {
-        const container = await this.loadContainer(dto.container);
-        return this.secure(dto, container) ?? [];
-      }),
-    );
-    const usages = usagesRaw.flat();
+    const usages = await this.secureAll(row.usages);
     return {
       items: usages,
       total: usages.length,
@@ -169,26 +151,48 @@ export class ToolUsageService {
   async readContainerSummaryForTools(
     tools: readonly Tool[],
   ): Promise<Array<{ tool: Tool; summary: ToolContainerSummary[] }>> {
-    const toolsById = mapKeys.fromList(tools, (t) => t.id).asMap;
-    const rows = await this.repo.containerSummaryForTools(
-      tools.map((t) => t.id),
-    );
-    // Group rows by tool id and filter out types not in the ToolContainerType enum
-    const validTypes = new Set<string>(['Engagement', 'Project']);
-    const byToolId = new Map<ID, ToolContainerSummary[]>();
-    for (const row of rows) {
-      if (!validTypes.has(row.containerType)) continue;
-      const entries = byToolId.get(row.tool.id) ?? [];
-      entries.push({
-        containerType: row.containerType as ToolContainerType,
-        total: Number(row.total),
-      });
-      byToolId.set(row.tool.id, entries);
-    }
-    return tools.map((tool) => ({
-      tool: toolsById.get(tool.id)!,
-      summary: byToolId.get(tool.id) ?? [],
-    }));
+    // readManyForTools loads full container resources to evaluate privileges —
+    // counts are derived from the secured results so only accessible containers
+    // are reflected in the summary.
+    const rows = await this.readManyForTools(tools);
+    return rows.map(({ tool, usages }) => {
+      const totals = new Map<ToolContainerType, number>();
+      for (const usage of usages.items) {
+        const labels: readonly string[] = usage.container.value?.labels ?? [];
+        // labels may be Neo4j node labels or Gel FQN type names; both contain
+        // the substring 'Engagement' or 'Project' for the relevant subtypes
+        const containerType: ToolContainerType | null = labels.some((l) =>
+          l.includes('Engagement'),
+        )
+          ? 'Engagement'
+          : labels.some((l) => l.includes('Project'))
+            ? 'Project'
+            : null;
+        if (containerType) {
+          totals.set(containerType, (totals.get(containerType) ?? 0) + 1);
+        }
+      }
+      return {
+        tool,
+        summary: [...totals.entries()].map(([containerType, total]) => ({
+          containerType,
+          total,
+        })),
+      };
+    });
+  }
+
+  private async secureAll(
+    dtos: ReadonlyArray<UnsecuredDto<ToolUsage>>,
+  ): Promise<ToolUsage[]> {
+    return (
+      await Promise.all(
+        dtos.map(async (dto) => {
+          const container = await this.loadContainer(dto.container);
+          return this.secure(dto, container) ?? [];
+        }),
+      )
+    ).flat();
   }
 
   private secure(

--- a/src/components/tools/tool-usage/tool-usages.resolver.ts
+++ b/src/components/tools/tool-usage/tool-usages.resolver.ts
@@ -1,11 +1,20 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { ListArg } from '~/common';
 import { Loader, type LoaderOf } from '~/core/data-loader';
 import { Tool } from '../tool/dto';
-import { SecuredToolUsageList } from './dto';
+import {
+  SecuredToolUsageList,
+  ToolContainerSummary,
+  ToolUsageListInput,
+} from './dto';
+import { ToolContainerSummaryLoader } from './tool-container-summary.loader';
 import { ToolUsageByToolLoader } from './tool-usage-by-tool.loader';
+import { ToolUsageService } from './tool-usage.service';
 
 @Resolver(() => Tool)
 export class ToolUsagesResolver {
+  constructor(private readonly service: ToolUsageService) {}
+
   @ResolveField(() => SecuredToolUsageList, {
     description: 'The usages of this tool',
   })
@@ -16,5 +25,28 @@ export class ToolUsagesResolver {
   ): Promise<SecuredToolUsageList> {
     const { usages } = await loader.load(tool);
     return usages;
+  }
+
+  @ResolveField(() => SecuredToolUsageList, {
+    description: 'Tool usages with optional filtering by container type',
+  })
+  async filteredUsages(
+    @Parent() tool: Tool,
+    @ListArg(ToolUsageListInput) input: ToolUsageListInput,
+  ): Promise<SecuredToolUsageList> {
+    return await this.service.readForTool(tool, input.filter);
+  }
+
+  @ResolveField(() => [ToolContainerSummary], {
+    description:
+      'Distinct container types in use and their counts — for tab display',
+  })
+  async containerSummary(
+    @Parent() tool: Tool,
+    @Loader(() => ToolContainerSummaryLoader)
+    loader: LoaderOf<ToolContainerSummaryLoader>,
+  ): Promise<ToolContainerSummary[]> {
+    const { summary } = await loader.load(tool);
+    return summary;
   }
 }

--- a/src/components/tools/tool-usage/tool-usages.resolver.ts
+++ b/src/components/tools/tool-usage/tool-usages.resolver.ts
@@ -46,7 +46,6 @@ export class ToolUsagesResolver {
     @Loader(() => ToolContainerSummaryLoader)
     loader: LoaderOf<ToolContainerSummaryLoader>,
   ): Promise<ToolContainerSummary[]> {
-    const { summary } = await loader.load(tool);
-    return summary;
+    return (await loader.load(tool)).summary;
   }
 }

--- a/src/components/tools/tool/dto/list-tool.dto.ts
+++ b/src/components/tools/tool/dto/list-tool.dto.ts
@@ -1,6 +1,8 @@
 import { InputType, ObjectType } from '@nestjs/graphql';
 import {
   FilterField,
+  type ID,
+  IdField,
   OptionalField,
   PaginatedList,
   SortablePaginationInput,
@@ -9,6 +11,9 @@ import { Tool } from './tool.dto';
 
 @InputType()
 export abstract class ToolFilters {
+  @IdField({ optional: true })
+  readonly id?: ID<'Tool'>;
+
   @OptionalField()
   readonly name?: string;
 }

--- a/src/components/tools/tool/tool.neo4j.repository.ts
+++ b/src/components/tools/tool/tool.neo4j.repository.ts
@@ -123,6 +123,7 @@ export class ToolRepository extends DtoRepository(Tool) {
 }
 
 export const toolFilters = filter.define(() => ToolFilters, {
+  id: filter.baseNodeProp(),
   name: filter.fullText({
     index: () => ToolNameIndex,
     matchToNode: (q) =>


### PR DESCRIPTION
Adds `tool: ToolFilters` (with `id` and `name`) to both ProjectFilters and
EngagementFilters so the frontend can drive project/engagement lists with
full server-side sort, filter, and pagination by tool — replacing the current
client-side approach.

ToolContainerType enum is simplified from separate LanguageEngagement /
InternshipEngagement values to a single Engagement value. Both Neo4j (via
CASE WHEN in Cypher) and Gel (via post-processing) normalize the concrete
subtypes before returning.

Also wires up the previously-unregistered ToolContainerSummaryLoader and
adds the filteredUsages / containerSummary resolver fields on Tool that the
frontend was already expecting.
