### PR TITLE
#6 [pg] Location Migration

### DIFF
--- a/src/components/location/location.drizzle.repository.ts
+++ b/src/components/location/location.drizzle.repository.ts
@@ -1,0 +1,215 @@
+import { Injectable } from '@nestjs/common';
+import { and, eq, ilike, inArray, isNull, type SQL } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  EnhancedResource,
+  generateId,
+  type ID,
+  NotImplementedException,
+  type PaginatedListType,
+  ServerException,
+  type UnsecuredDto,
+} from '~/common';
+import {
+  catchUniqueViolation,
+  DrizzleDtoRepository,
+  escapeLikePattern,
+  resolveOrderBy,
+  type SortMap,
+} from '~/core/drizzle';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { locations } from '~/core/drizzle/schema';
+import { type ResourceNameLike } from '~/core/resources';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import { FileService } from '../file';
+import { type FileId } from '../file/dto';
+import {
+  type CreateLocation,
+  Location,
+  type LocationListInput,
+  type LocationListOutput,
+  type UpdateLocation,
+} from './dto';
+
+const catchNameUnique = catchUniqueViolation(
+  'name',
+  'name',
+  'Location with this name already exists.',
+);
+
+@Injectable()
+export class LocationDrizzleRepository extends DrizzleDtoRepository<
+  typeof locations,
+  Location
+> {
+  private readonly resource = EnhancedResource.of(Location);
+
+  constructor(
+    db: DrizzleService,
+    private readonly files: FileService,
+    private readonly executor: PolicyExecutor,
+  ) {
+    super(db, locations);
+  }
+
+  async create(input: CreateLocation): Promise<UnsecuredDto<Location>> {
+    const id = await generateId();
+    const mapImageId = await generateId<FileId>();
+
+    await this.db
+      .insert(locations)
+      .values({
+        id,
+        name: input.name,
+        type: input.type,
+        isoAlpha3: input.isoAlpha3 ?? null,
+        fundingAccountId: input.fundingAccount ?? null,
+        defaultFieldRegionId: input.defaultFieldRegion ?? null,
+        defaultMarketingRegionId: input.defaultMarketingRegion ?? null,
+        mapImageId,
+      })
+      .catch(catchNameUnique);
+
+    const dto = await this.readOne(id);
+
+    await this.files.createDefinedFile(
+      mapImageId,
+      input.name,
+      id,
+      'mapImage',
+      input.mapImage,
+      true,
+    );
+
+    return dto;
+  }
+
+  async update(changes: UpdateLocation): Promise<UnsecuredDto<Location>> {
+    const { id, mapImage, ...fields } = changes;
+
+    await this.updateColumns(id, {
+      name: fields.name,
+      type: fields.type,
+      isoAlpha3: fields.isoAlpha3,
+      fundingAccountId: fields.fundingAccount,
+      defaultFieldRegionId: fields.defaultFieldRegion,
+      defaultMarketingRegionId: fields.defaultMarketingRegion,
+    }).catch(catchNameUnique);
+
+    if (mapImage !== undefined) {
+      const location = await this.readOne(id);
+      if (!location.mapImage) {
+        throw new ServerException(
+          'Expected map image file to be updated with the location',
+        );
+      }
+      await this.files.createFileVersion({
+        ...mapImage,
+        parent: location.mapImage.id,
+      });
+    }
+
+    return await this.readOne(id);
+  }
+
+  async delete(id: ID): Promise<void> {
+    await this.softDelete(id);
+  }
+
+  async list(
+    input: LocationListInput,
+  ): Promise<PaginatedListType<UnsecuredDto<Location>>> {
+    const filter = this.executor.drizzleFilter({
+      action: 'read',
+      resource: this.resource,
+    });
+    if (filter === false) return { items: [], total: 0, hasMore: false };
+
+    const conditions: SQL[] = [isNull(locations.deletedAt)];
+    if (filter !== true) conditions.push(filter);
+
+    if (input.filter?.name) {
+      conditions.push(
+        ilike(locations.name, `%${escapeLikePattern(input.filter.name)}%`),
+      );
+    }
+    if (input.filter?.type?.length) {
+      conditions.push(inArray(locations.type, [...input.filter.type]));
+    }
+    if (input.filter?.fundingAccountId) {
+      conditions.push(
+        eq(locations.fundingAccountId, input.filter.fundingAccountId),
+      );
+    }
+
+    const sortColumns = {
+      name: locations.name,
+      type: locations.type,
+      isoAlpha3: locations.isoAlpha3,
+      createdAt: locations.createdAt,
+    } satisfies SortMap<keyof Location>;
+
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: and(...conditions),
+      orderBy: resolveOrderBy(input, sortColumns, locations.name),
+      page: input.page,
+      count: input.count,
+    });
+    return {
+      total,
+      items: rows.map((row) => this.toDto(row)),
+      hasMore,
+    };
+  }
+
+  // migration-todo: implement when location-node relationships are migrated to PG
+  addLocationToNode(
+    _label: ResourceNameLike,
+    _id: ID,
+    _rel: string,
+    _locationId: ID<'Location'>,
+  ): Promise<DateTime | null> {
+    throw new NotImplementedException();
+  }
+
+  // migration-todo: implement when location-node relationships are migrated to PG
+  removeLocationFromNode(
+    _label: ResourceNameLike,
+    _id: ID,
+    _rel: string,
+    _locationId: ID<'Location'>,
+  ): Promise<DateTime | null> {
+    throw new NotImplementedException();
+  }
+
+  // migration-todo: implement when location-node relationships are migrated to PG
+  listLocationsFromNodeNoSecGroups(
+    _label: string,
+    _rel: string,
+    _id: ID,
+    _input: LocationListInput,
+  ): Promise<LocationListOutput> {
+    throw new NotImplementedException();
+  }
+
+  protected toDto(row: typeof locations.$inferSelect): UnsecuredDto<Location> {
+    return {
+      id: row.id,
+      __typename: 'Location',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      name: row.name,
+      type: row.type,
+      isoAlpha3: row.isoAlpha3 ?? null,
+      fundingAccount: row.fundingAccountId
+        ? { id: row.fundingAccountId }
+        : null,
+      defaultFieldRegion: row.defaultFieldRegionId
+        ? { id: row.defaultFieldRegionId }
+        : null,
+      defaultMarketingRegion: row.defaultMarketingRegionId
+        ? { id: row.defaultMarketingRegionId }
+        : null,
+      mapImage: row.mapImageId ? { id: row.mapImageId } : null,
+    };
+  }
+}

--- a/src/components/location/location.module.ts
+++ b/src/components/location/location.module.ts
@@ -4,6 +4,7 @@ import { AuthorizationModule } from '../authorization/authorization.module';
 import { FieldRegionModule } from '../field-region/field-region.module';
 import { FileModule } from '../file/file.module';
 import { FundingAccountModule } from '../funding-account/funding-account.module';
+import { LocationDrizzleRepository } from './location.drizzle.repository';
 import { LocationGelRepository } from './location.gel.repository';
 import { LocationLoader } from './location.loader';
 import { LocationRepository } from './location.repository';
@@ -23,6 +24,8 @@ import { DefaultMarketingRegionMigration } from './migrations/default-marketing-
     LocationService,
     splitDb(LocationRepository, {
       gel: LocationGelRepository,
+      // migration-todo: remove `as any` once splitDb types accept drizzle repos directly
+      postgres: LocationDrizzleRepository as any,
     }),
     LocationLoader,
     DefaultMarketingRegionMigration,

--- a/src/components/location/location.repository.ts
+++ b/src/components/location/location.repository.ts
@@ -194,6 +194,10 @@ export class LocationRepository extends DtoRepository(Location) {
     return result!; // result from paginate() will always have 1 row.
   }
 
+  async delete(id: ID): Promise<void> {
+    await this.deleteNode(id);
+  }
+
   async addLocationToNode(
     label: ResourceNameLike,
     id: ID,

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -67,7 +67,7 @@ export class LocationService {
     this.privileges.for(Location, object).verifyCan('delete');
 
     try {
-      await this.repo.deleteNode(object);
+      await this.repo.delete(id);
     } catch (exception) {
       throw new ServerException('Failed to delete', exception);
     }

--- a/src/core/drizzle/migrations/0002_add_locations.sql
+++ b/src/core/drizzle/migrations/0002_add_locations.sql
@@ -1,0 +1,25 @@
+CREATE TYPE location_type AS ENUM (
+  'Country',
+  'City',
+  'County',
+  'Region',
+  'State',
+  'CrossBorderArea'
+);
+
+CREATE TABLE locations (
+  id                          text PRIMARY KEY,
+  name                        text NOT NULL UNIQUE,
+  type                        location_type NOT NULL,
+  iso_alpha3                  text UNIQUE,
+  funding_account_id          text,
+  default_field_region_id     text,
+  default_marketing_region_id text REFERENCES locations(id),
+  map_image_id                text,
+  created_at                  timestamptz NOT NULL DEFAULT now(),
+  updated_at                  timestamptz NOT NULL DEFAULT now(),
+  deleted_at                  timestamptz
+);
+
+CREATE INDEX "locations_default_marketing_region_id_idx"
+  ON "locations" ("default_marketing_region_id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1745712000000,
       "tag": "0001_add_user_profile",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1746057600000,
+      "tag": "0002_add_locations",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -1,5 +1,6 @@
 import { relations, sql } from 'drizzle-orm';
 import {
+  type AnyPgColumn,
   boolean,
   check,
   index,
@@ -10,6 +11,7 @@ import {
   timestamp,
 } from 'drizzle-orm/pg-core';
 import { type ID, type Role } from '~/common';
+import { type LocationType } from '../../../components/location/dto/location-type.enum';
 import { type Gender } from '../../../components/user/dto/gender.enum';
 
 export const userStatusEnum = pgEnum('user_status', ['Active', 'Disabled']);
@@ -236,3 +238,47 @@ export const authPasswordResetTokensRelations = relations(
     }),
   }),
 );
+
+// ─── Locations ─────────────────────────────────────────────────────────────
+
+export const locationTypeEnum = pgEnum('location_type', [
+  'Country',
+  'City',
+  'County',
+  'Region',
+  'State',
+  'CrossBorderArea',
+]);
+
+export const locations = pgTable(
+  'locations',
+  {
+    id: text('id').$type<ID<'Location'>>().primaryKey(),
+    name: text('name').notNull().unique(),
+    type: locationTypeEnum('type').$type<LocationType>().notNull(),
+    isoAlpha3: text('iso_alpha3').unique(),
+    // migration-todo: add FK constraints once FundingAccount and FieldRegion are migrated to PG
+    fundingAccountId: text('funding_account_id').$type<ID<'FundingAccount'>>(),
+    defaultFieldRegionId: text('default_field_region_id').$type<
+      ID<'FieldRegion'>
+    >(),
+    defaultMarketingRegionId: text('default_marketing_region_id')
+      .$type<ID<'Location'>>()
+      .references((): AnyPgColumn => locations.id),
+    mapImageId: text('map_image_id').$type<ID<'File'>>(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    index('locations_default_marketing_region_id_idx').on(
+      t.defaultMarketingRegionId,
+    ),
+  ],
+);
+
+export const locationsRelations = relations(locations, () => ({}));


### PR DESCRIPTION
## Summary

Second PostgreSQL port. Adds the `locations` table and ports `LocationRepository` to Drizzle. Builds on `users-pg` (base infrastructure + User/Education/Unavailability/SystemAgent/Auth) — that PR must merge first.

Engine routing via `splitDb()`; Neo4j and Gel paths unchanged.

## Schema (DDL)

```sql
CREATE TYPE location_type AS ENUM (
  'Country', 'City', 'County', 'Region', 'State', 'CrossBorderArea'
);

CREATE TABLE locations (
  id                          text PRIMARY KEY,
  name                        text NOT NULL UNIQUE,
  type                        location_type NOT NULL,
  iso_alpha3                  text UNIQUE,
  funding_account_id          text,
  default_field_region_id     text,
  default_marketing_region_id text REFERENCES locations(id),
  map_image_id                text,
  created_at                  timestamptz NOT NULL DEFAULT now(),
  updated_at                  timestamptz NOT NULL DEFAULT now(),
  deleted_at                  timestamptz
);

CREATE INDEX "locations_default_marketing_region_id_idx"
  ON "locations" ("default_marketing_region_id");
```

## Design decisions

### `location_type` is `pgEnum`, not `text`

Closed set of six values, owned by application code but rarely changes. pgEnum gives DB-side validity and pairs with `$type<LocationType>()` in the schema for end-to-end type narrowing on read.

### FK constraints deferred for cross-domain references

- `funding_account_id` and `default_field_region_id` are plain `text` columns, not `REFERENCES`. The FundingAccount and FieldRegion domains haven't been ported to PG yet — adding the constraint would prevent writes against PG since those parent rows don't exist. Marked with a `migration-todo` to add the constraint when those domains land.
- `default_marketing_region_id` is a self-FK (Location → Location), so the constraint is added now.

### FK index on `default_marketing_region_id`

Postgres doesn't auto-index FK columns. Without this, `WHERE default_marketing_region_id = $1` queries seq-scan, and `ON DELETE` triggers on `locations` would fan out unindexed lookups.

### Soft delete via `deleted_at`

Matches the User domain pattern: nullable `deleted_at`, reads filtered with `IS NULL`. `DrizzleDtoRepository.readMany` and `softDelete` honor it automatically.

### `name` and `iso_alpha3` are `UNIQUE`

`catchUniqueViolation('name', 'name', 'Location with this name already exists.')` maps Postgres `23505` → `DuplicateException` on conflict. ISO alpha-3 codes are world-unique by definition, so the constraint is appropriate even though no business logic enforces it.

### Schema columns branded with `$type<>()`

- `id: text('id').$type<ID<'Location'>>().primaryKey()`
- `type: locationTypeEnum('type').$type<LocationType>().notNull()`
- `fundingAccountId: text('funding_account_id').$type<ID<'FundingAccount'>>()`, etc.

Result: query rows come back already typed as the domain shape; `toDto` has no `as ID` / `as FileId` casts.

### `list()` returns `PaginatedListType<UnsecuredDto<Location>>`

The repo produces unsecured DTOs; the service secures them with `privileges.for(Location).secure(dto)` before returning. Earlier WIP typed `list()` as `LocationListOutput` (secured items) and used an `as unknown as Location[]` cast to satisfy the compiler. That cast is removed and the type now matches reality — same pattern as User/Education/Unavailability list methods.

### Reuses cleanup helpers from `users-pg`

- `escapeLikePattern(value)` for the name ILIKE filter (escapes `%`, `_`, `\\`).
- `resolveOrderBy(input, sortMap, fallback)` + `SortMap<keyof Location>` for sort resolution.
- `EnhancedResource.of(Location)` cached as a `private readonly resource` field instead of constructed twice.

### `splitDb` Drizzle slot uses `as any`

Same pattern as User/Education/Unavailability: Gel repos satisfy `PublicOf<XRepository>` because `RepoFor` extends `CommonRepository` which mirrors the Neo4j surface (`privileges`, `getActualChanges`, etc.); `DrizzleDtoRepository` deliberately omits all that. The cast is the line; tracked with `migration-todo`.

## Deferred items

- `addLocationToNode`, `removeLocationFromNode`, `listLocationsFromNodeNoSecGroups` — stubs that throw `NotImplementedException`. These manage relationships between Locations and other resources (Project, Organization, etc.) and need their parent domains ported before they can be implemented.
- FK constraints for `funding_account_id` and `default_field_region_id` — added when FundingAccount / FieldRegion port to PG.
- FK indexes for the same two columns — deferred with the constraints (no point indexing a column we don't yet query through joins).
- `splitDb` `as any` cast — see decisions above.
