### PR TITLE
Fix organization assignment checks for non-admin users

### DIFF
--- a/src/components/authorization/policies/by-feature/user-can-edit-self.policy.ts
+++ b/src/components/authorization/policies/by-feature/user-can-edit-self.policy.ts
@@ -1,6 +1,10 @@
 import { Policy, self } from '../util';
 
 @Policy('all', (r) =>
-  r.User.when(self).edit.specifically((p) => [p.status.none, p.roles.none]),
+  r.User.when(self).edit.specifically((p) => [
+    p.status.none,
+    p.roles.none,
+    p.organizations.none,
+  ]),
 )
 export class UserCanEditSelfPolicy {}

--- a/src/components/authorization/policies/by-feature/user-can-edit-self.policy.ts
+++ b/src/components/authorization/policies/by-feature/user-can-edit-self.policy.ts
@@ -4,7 +4,7 @@ import { Policy, self } from '../util';
   r.User.when(self).edit.specifically((p) => [
     p.status.none,
     p.roles.none,
-    p.organizations.none,
+    p.organization.none,
   ]),
 )
 export class UserCanEditSelfPolicy {}

--- a/src/components/user/user.service.spec.ts
+++ b/src/components/user/user.service.spec.ts
@@ -21,7 +21,7 @@ jest.unstable_mockModule('~/core/logger', () => ({
 }));
 
 jest.unstable_mockModule('~/core/resources', () => ({
-  HandleIdLookup: () => (_target: any, _key: string, descriptor: PropertyDescriptor) =>
+  HandleIdLookup: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
     descriptor,
 }));
 
@@ -88,12 +88,35 @@ const makeMockUser = (id: ID<'User'> = USER_ID) => ({
   __typename: 'User' as const,
 });
 
+interface MockUserRepository {
+  readOne: jest.Mock<Promise<ReturnType<typeof makeMockUser>>>;
+  assignOrganizationToUser: jest.Mock<Promise<void>>;
+  removeOrganizationFromUser: jest.Mock<Promise<void>>;
+  getActualChanges: jest.Mock;
+  update: jest.Mock;
+  create: jest.Mock;
+  delete: jest.Mock;
+  list: jest.Mock;
+}
+
+interface MockResourcePrivileges {
+  verifyCan: jest.Mock<void>;
+}
+
+interface MockPrivileges {
+  for: jest.Mock<MockResourcePrivileges>;
+}
+
+interface MockLogger {
+  debug: jest.Mock;
+}
+
 describe('UserService — assignOrganizationToUser', () => {
   let UserService: typeof UserServiceClass;
   let service: UserServiceClass;
-  let userRepo: any;
-  let privilegesMock: any;
-  let resourcePrivilegesMock: any;
+  let userRepo: MockUserRepository;
+  let privilegesMock: MockPrivileges;
+  let resourcePrivilegesMock: MockResourcePrivileges;
 
   beforeAll(async () => {
     ({ UserService } = await import('./user.service'));
@@ -122,18 +145,20 @@ describe('UserService — assignOrganizationToUser', () => {
     userRepo.readOne.mockResolvedValue(makeMockUser());
     userRepo.assignOrganizationToUser.mockResolvedValue(undefined);
 
+    const mockLogger: MockLogger = { debug: jest.fn() };
+
     service = new UserService(
-      {} as any, // educations
-      {} as any, // organizations
-      {} as any, // partners
-      {} as any, // unavailabilities
-      privilegesMock as any, // privileges
-      {} as any, // locationService
-      {} as any, // knownLanguages
-      {} as any, // identity
-      {} as any, // hooks
-      userRepo as any, // userRepo
-      { debug: jest.fn() } as any, // logger
+      {} as never, // educations
+      {} as never, // organizations
+      {} as never, // partners
+      {} as never, // unavailabilities
+      privilegesMock as never, // privileges
+      {} as never, // locationService
+      {} as never, // knownLanguages
+      {} as never, // identity
+      {} as never, // hooks
+      userRepo as never, // userRepo
+      mockLogger as never, // logger
     );
   });
 
@@ -213,9 +238,9 @@ describe('UserService — assignOrganizationToUser', () => {
 describe('UserService — removeOrganizationFromUser', () => {
   let UserService: typeof UserServiceClass;
   let service: UserServiceClass;
-  let userRepo: any;
-  let privilegesMock: any;
-  let resourcePrivilegesMock: any;
+  let userRepo: MockUserRepository;
+  let privilegesMock: MockPrivileges;
+  let resourcePrivilegesMock: MockResourcePrivileges;
 
   beforeAll(async () => {
     ({ UserService } = await import('./user.service'));
@@ -244,18 +269,20 @@ describe('UserService — removeOrganizationFromUser', () => {
     userRepo.readOne.mockResolvedValue(makeMockUser());
     userRepo.removeOrganizationFromUser.mockResolvedValue(undefined);
 
+    const mockLogger: MockLogger = { debug: jest.fn() };
+
     service = new UserService(
-      {} as any, // educations
-      {} as any, // organizations
-      {} as any, // partners
-      {} as any, // unavailabilities
-      privilegesMock as any, // privileges
-      {} as any, // locationService
-      {} as any, // knownLanguages
-      {} as any, // identity
-      {} as any, // hooks
-      userRepo as any, // userRepo
-      { debug: jest.fn() } as any, // logger
+      {} as never, // educations
+      {} as never, // organizations
+      {} as never, // partners
+      {} as never, // unavailabilities
+      privilegesMock as never, // privileges
+      {} as never, // locationService
+      {} as never, // knownLanguages
+      {} as never, // identity
+      {} as never, // hooks
+      userRepo as never, // userRepo
+      mockLogger as never, // logger
     );
   });
 

--- a/src/components/user/user.service.spec.ts
+++ b/src/components/user/user.service.spec.ts
@@ -7,74 +7,82 @@ import {
   it,
   jest,
 } from '@jest/globals';
+import { type ID } from '~/common';
 import type { UserService as UserServiceClass } from './user.service';
 
-// ESM mode requires unstable_mockModule + dynamic import.
-// jest.mock() is not hoisted in ESM and cannot intercept ES module imports.
-
+// In ESM mode (ts-jest/presets/default-esm), jest.mock() is NOT hoisted and
+// cannot intercept ES module imports. unstable_mockModule + dynamic import is
+// required.
 jest.unstable_mockModule('~/core/logger', () => ({
   // eslint-disable-next-line @typescript-eslint/naming-convention
   Logger: () => () => undefined,
   // eslint-disable-next-line @typescript-eslint/naming-convention
   ILogger: class {},
 }));
-
+jest.unstable_mockModule('~/core/hooks', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  Hooks: class {},
+}));
+jest.unstable_mockModule('~/core/authentication', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  Identity: class {},
+}));
+jest.unstable_mockModule('~/core/resources', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  HandleIdLookup: () => (_target: any, _key: any, descriptor: any) =>
+    descriptor,
+}));
+jest.unstable_mockModule('../authorization', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  Privileges: class {},
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  AssignableRoles: class {},
+}));
+jest.unstable_mockModule('../location', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  LocationService: class {},
+}));
+jest.unstable_mockModule('../organization', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  OrganizationService: class {},
+}));
+jest.unstable_mockModule('../partner', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  PartnerService: class {},
+}));
+jest.unstable_mockModule('./education', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  EducationService: class {},
+}));
+jest.unstable_mockModule('./unavailability', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  UnavailabilityService: class {},
+}));
+jest.unstable_mockModule('./known-language.repository', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  KnownLanguageRepository: class {},
+}));
 jest.unstable_mockModule('./user.repository', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   UserRepository: class {},
 }));
 
-jest.unstable_mockModule('../authorization/policy/executor/privileges', () => ({
-  Privileges: class {},
-}));
+const USER_ID = 'user-uuid-1' as ID<'User'>;
+const ORG_ID = 'org-uuid-1' as ID<'Organization'>;
 
-jest.unstable_mockModule('../organization', () => ({
-  OrganizationService: class {},
-}));
-
-jest.unstable_mockModule('../partner', () => ({
-  PartnerService: class {},
-}));
-
-jest.unstable_mockModule('../location', () => ({
-  LocationService: class {},
-}));
-
-jest.unstable_mockModule('./education', () => ({
-  EducationService: class {},
-}));
-
-jest.unstable_mockModule('./unavailability', () => ({
-  UnavailabilityService: class {},
-}));
-
-jest.unstable_mockModule('./known-language.repository', () => ({
-  KnownLanguageRepository: class {},
-}));
-
-jest.unstable_mockModule('~/core/authentication', () => ({
-  Identity: class {},
-}));
-
-jest.unstable_mockModule('~/core/hooks', () => ({
-  Hooks: class {},
-}));
-
-jest.unstable_mockModule('./hooks/user-updated.hook', () => ({
-  UserUpdatedHook: class {},
-}));
-
-const FAKE_USER_ID = 'user-uuid-1' as any;
-const FAKE_ORG_ID = 'org-uuid-1' as any;
-
-const makeFakeUser = (id = FAKE_USER_ID) => ({
+const makeFakeUser = (id = USER_ID) => ({
   id,
+  __typename: 'User' as const,
   email: { value: 'test@example.com', canRead: true, canEdit: false },
-  realFirstName: { value: 'Test', canRead: true, canEdit: false },
-  realLastName: { value: 'User', canRead: true, canEdit: false },
+  realFirstName: { value: 'Test', canRead: true, canEdit: true },
+  realLastName: { value: 'User', canRead: true, canEdit: true },
+  displayFirstName: { value: 'Test', canRead: true, canEdit: true },
+  displayLastName: { value: 'User', canRead: true, canEdit: true },
 });
 
-describe('UserService — assignOrganizationToUser', () => {
+describe('UserService', () => {
   let UserService: typeof UserServiceClass;
+  // Typed as `any` to keep mock setup simple.
   let service: UserServiceClass;
   let userRepo: any;
   let privileges: any;
@@ -89,28 +97,44 @@ describe('UserService — assignOrganizationToUser', () => {
       verifyCan: jest.fn(),
     };
 
-    privileges = {
-      for: jest.fn().mockReturnValue(resourcePrivileges),
-    };
-
     userRepo = {
       readOne: jest.fn(),
       assignOrganizationToUser: jest.fn(),
       removeOrganizationFromUser: jest.fn(),
+      readMany: jest.fn(),
+      readManyActors: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      list: jest.fn(),
       getActualChanges: jest.fn(),
+      doesEmailAddressExist: jest.fn(),
+      getUserByEmailAddress: jest.fn(),
     };
+
+    privileges = {
+      for: jest.fn().mockReturnValue(resourcePrivileges),
+    };
+
+    // Default: readOne returns a fake user
+    userRepo.readOne.mockResolvedValue(makeFakeUser());
+    // Default: verifyCan succeeds (no throw)
+    resourcePrivileges.verifyCan.mockReturnValue(undefined);
+    // Default: repo operations succeed
+    userRepo.assignOrganizationToUser.mockResolvedValue(undefined);
+    userRepo.removeOrganizationFromUser.mockResolvedValue(undefined);
 
     service = new (UserService as any)(
       {} as any, // educations
       {} as any, // organizations
       {} as any, // partners
       {} as any, // unavailabilities
-      privileges, // privileges
+      privileges,
       {} as any, // locationService
       {} as any, // knownLanguages
       {} as any, // identity
       {} as any, // hooks
-      userRepo, // userRepo
+      userRepo,
       { debug: jest.fn() } as any, // logger
     );
   });
@@ -119,203 +143,134 @@ describe('UserService — assignOrganizationToUser', () => {
     jest.clearAllMocks();
   });
 
-  it('reads the user from the repository before checking privileges', async () => {
-    const fakeUser = makeFakeUser();
-    userRepo.readOne.mockResolvedValue(fakeUser);
-    userRepo.assignOrganizationToUser.mockResolvedValue(undefined);
+  describe('assignOrganizationToUser', () => {
+    it('reads the user from the repository before checking privileges', async () => {
+      const request = { user: USER_ID, org: ORG_ID };
 
-    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
-    await service.assignOrganizationToUser(request as any);
+      await service.assignOrganizationToUser(request);
 
-    expect(userRepo.readOne).toHaveBeenCalledWith(FAKE_USER_ID);
-  });
-
-  it('checks the organization edit privilege with the fetched user', async () => {
-    const fakeUser = makeFakeUser();
-    userRepo.readOne.mockResolvedValue(fakeUser);
-    userRepo.assignOrganizationToUser.mockResolvedValue(undefined);
-
-    const { User } = await import('./dto');
-    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
-    await service.assignOrganizationToUser(request as any);
-
-    expect(privileges.for).toHaveBeenCalledWith(User, fakeUser);
-    expect(resourcePrivileges.verifyCan).toHaveBeenCalledWith(
-      'edit',
-      'organization',
-    );
-  });
-
-  it('delegates to the repository when the privilege check passes', async () => {
-    const fakeUser = makeFakeUser();
-    userRepo.readOne.mockResolvedValue(fakeUser);
-    userRepo.assignOrganizationToUser.mockResolvedValue(undefined);
-
-    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
-    await service.assignOrganizationToUser(request as any);
-
-    expect(userRepo.assignOrganizationToUser).toHaveBeenCalledWith(request);
-  });
-
-  it('does NOT call the repository when the privilege check throws', async () => {
-    const fakeUser = makeFakeUser();
-    userRepo.readOne.mockResolvedValue(fakeUser);
-    resourcePrivileges.verifyCan.mockImplementation(() => {
-      throw new Error('Unauthorized');
+      expect(userRepo.readOne).toHaveBeenCalledWith(USER_ID);
     });
 
-    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
-    await expect(
-      service.assignOrganizationToUser(request as any),
-    ).rejects.toThrow('Unauthorized');
+    it('verifies the caller can edit the organization field', async () => {
+      const fakeUser = makeFakeUser();
+      userRepo.readOne.mockResolvedValue(fakeUser);
 
-    expect(userRepo.assignOrganizationToUser).not.toHaveBeenCalled();
-  });
+      await service.assignOrganizationToUser({ user: USER_ID, org: ORG_ID });
 
-  it('propagates errors thrown by userRepo.readOne', async () => {
-    userRepo.readOne.mockRejectedValue(new Error('DB connection failed'));
-
-    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
-    await expect(
-      service.assignOrganizationToUser(request as any),
-    ).rejects.toThrow('DB connection failed');
-
-    expect(resourcePrivileges.verifyCan).not.toHaveBeenCalled();
-    expect(userRepo.assignOrganizationToUser).not.toHaveBeenCalled();
-  });
-
-  it('privilege check receives the exact object returned by readOne', async () => {
-    const specificUser = { id: 'specific-uuid' as any, roles: ['Consultant'] };
-    userRepo.readOne.mockResolvedValue(specificUser);
-    userRepo.assignOrganizationToUser.mockResolvedValue(undefined);
-
-    const request = { user: 'specific-uuid' as any, org: FAKE_ORG_ID };
-    await service.assignOrganizationToUser(request as any);
-
-    // The second argument to privileges.for must be the exact object from readOne
-    expect(privileges.for).toHaveBeenCalledWith(expect.anything(), specificUser);
-  });
-});
-
-describe('UserService — removeOrganizationFromUser', () => {
-  let UserService: typeof UserServiceClass;
-  let service: UserServiceClass;
-  let userRepo: any;
-  let privileges: any;
-  let resourcePrivileges: any;
-
-  beforeAll(async () => {
-    ({ UserService } = await import('./user.service'));
-  });
-
-  beforeEach(() => {
-    resourcePrivileges = {
-      verifyCan: jest.fn(),
-    };
-
-    privileges = {
-      for: jest.fn().mockReturnValue(resourcePrivileges),
-    };
-
-    userRepo = {
-      readOne: jest.fn(),
-      assignOrganizationToUser: jest.fn(),
-      removeOrganizationFromUser: jest.fn(),
-      getActualChanges: jest.fn(),
-    };
-
-    service = new (UserService as any)(
-      {} as any,
-      {} as any,
-      {} as any,
-      {} as any,
-      privileges,
-      {} as any,
-      {} as any,
-      {} as any,
-      {} as any,
-      userRepo,
-      { debug: jest.fn() } as any,
-    );
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('reads the user from the repository before checking privileges', async () => {
-    const fakeUser = makeFakeUser();
-    userRepo.readOne.mockResolvedValue(fakeUser);
-    userRepo.removeOrganizationFromUser.mockResolvedValue(undefined);
-
-    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
-    await service.removeOrganizationFromUser(request as any);
-
-    expect(userRepo.readOne).toHaveBeenCalledWith(FAKE_USER_ID);
-  });
-
-  it('checks the organization edit privilege with the fetched user', async () => {
-    const fakeUser = makeFakeUser();
-    userRepo.readOne.mockResolvedValue(fakeUser);
-    userRepo.removeOrganizationFromUser.mockResolvedValue(undefined);
-
-    const { User } = await import('./dto');
-    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
-    await service.removeOrganizationFromUser(request as any);
-
-    expect(privileges.for).toHaveBeenCalledWith(User, fakeUser);
-    expect(resourcePrivileges.verifyCan).toHaveBeenCalledWith(
-      'edit',
-      'organization',
-    );
-  });
-
-  it('delegates to the repository when the privilege check passes', async () => {
-    const fakeUser = makeFakeUser();
-    userRepo.readOne.mockResolvedValue(fakeUser);
-    userRepo.removeOrganizationFromUser.mockResolvedValue(undefined);
-
-    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
-    await service.removeOrganizationFromUser(request as any);
-
-    expect(userRepo.removeOrganizationFromUser).toHaveBeenCalledWith(request);
-  });
-
-  it('does NOT call the repository when the privilege check throws', async () => {
-    const fakeUser = makeFakeUser();
-    userRepo.readOne.mockResolvedValue(fakeUser);
-    resourcePrivileges.verifyCan.mockImplementation(() => {
-      throw new Error('Unauthorized');
+      expect(privileges.for).toHaveBeenCalledWith(
+        expect.anything(), // User resource
+        fakeUser,
+      );
+      expect(resourcePrivileges.verifyCan).toHaveBeenCalledWith(
+        'edit',
+        'organization',
+      );
     });
 
-    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
-    await expect(
-      service.removeOrganizationFromUser(request as any),
-    ).rejects.toThrow('Unauthorized');
+    it('delegates to the repository after successful privilege check', async () => {
+      const request = { user: USER_ID, org: ORG_ID };
 
-    expect(userRepo.removeOrganizationFromUser).not.toHaveBeenCalled();
+      await service.assignOrganizationToUser(request);
+
+      expect(userRepo.assignOrganizationToUser).toHaveBeenCalledWith(request);
+    });
+
+    it('does not call the repository when privilege check throws', async () => {
+      const authError = new Error('Insufficient permission');
+      resourcePrivileges.verifyCan.mockImplementation(() => {
+        throw authError;
+      });
+
+      await expect(
+        service.assignOrganizationToUser({ user: USER_ID, org: ORG_ID }),
+      ).rejects.toThrow(authError);
+
+      expect(userRepo.assignOrganizationToUser).not.toHaveBeenCalled();
+    });
+
+    it('propagates errors thrown by the repository', async () => {
+      const repoError = new Error('Database failure');
+      userRepo.assignOrganizationToUser.mockRejectedValue(repoError);
+
+      await expect(
+        service.assignOrganizationToUser({ user: USER_ID, org: ORG_ID }),
+      ).rejects.toThrow(repoError);
+    });
+
+    it('forwards the full request object including the optional primary flag', async () => {
+      const request = { user: USER_ID, org: ORG_ID, primary: true };
+
+      await service.assignOrganizationToUser(request);
+
+      expect(userRepo.assignOrganizationToUser).toHaveBeenCalledWith(request);
+    });
   });
 
-  it('propagates errors thrown by userRepo.readOne', async () => {
-    userRepo.readOne.mockRejectedValue(new Error('User not found'));
+  describe('removeOrganizationFromUser', () => {
+    it('reads the user from the repository before checking privileges', async () => {
+      await service.removeOrganizationFromUser({ user: USER_ID, org: ORG_ID });
 
-    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
-    await expect(
-      service.removeOrganizationFromUser(request as any),
-    ).rejects.toThrow('User not found');
+      expect(userRepo.readOne).toHaveBeenCalledWith(USER_ID);
+    });
 
-    expect(resourcePrivileges.verifyCan).not.toHaveBeenCalled();
-    expect(userRepo.removeOrganizationFromUser).not.toHaveBeenCalled();
-  });
+    it('verifies the caller can edit the organization field', async () => {
+      const fakeUser = makeFakeUser();
+      userRepo.readOne.mockResolvedValue(fakeUser);
 
-  it('privilege check uses the exact user object returned by readOne', async () => {
-    const specificUser = { id: 'other-uuid' as any, roles: ['FieldPartner'] };
-    userRepo.readOne.mockResolvedValue(specificUser);
-    userRepo.removeOrganizationFromUser.mockResolvedValue(undefined);
+      await service.removeOrganizationFromUser({ user: USER_ID, org: ORG_ID });
 
-    const request = { user: 'other-uuid' as any, org: FAKE_ORG_ID };
-    await service.removeOrganizationFromUser(request as any);
+      expect(privileges.for).toHaveBeenCalledWith(
+        expect.anything(), // User resource
+        fakeUser,
+      );
+      expect(resourcePrivileges.verifyCan).toHaveBeenCalledWith(
+        'edit',
+        'organization',
+      );
+    });
 
-    expect(privileges.for).toHaveBeenCalledWith(expect.anything(), specificUser);
+    it('delegates to the repository after successful privilege check', async () => {
+      const request = { user: USER_ID, org: ORG_ID };
+
+      await service.removeOrganizationFromUser(request);
+
+      expect(userRepo.removeOrganizationFromUser).toHaveBeenCalledWith(request);
+    });
+
+    it('does not call the repository when privilege check throws', async () => {
+      const authError = new Error('Insufficient permission');
+      resourcePrivileges.verifyCan.mockImplementation(() => {
+        throw authError;
+      });
+
+      await expect(
+        service.removeOrganizationFromUser({ user: USER_ID, org: ORG_ID }),
+      ).rejects.toThrow(authError);
+
+      expect(userRepo.removeOrganizationFromUser).not.toHaveBeenCalled();
+    });
+
+    it('propagates errors thrown by the repository', async () => {
+      const repoError = new Error('Database failure');
+      userRepo.removeOrganizationFromUser.mockRejectedValue(repoError);
+
+      await expect(
+        service.removeOrganizationFromUser({ user: USER_ID, org: ORG_ID }),
+      ).rejects.toThrow(repoError);
+    });
+
+    it('privilege check uses the user returned by readOne, not the request id', async () => {
+      const differentUser = makeFakeUser('other-user-id' as ID<'User'>);
+      userRepo.readOne.mockResolvedValue(differentUser);
+
+      await service.removeOrganizationFromUser({ user: USER_ID, org: ORG_ID });
+
+      // Privileges are checked against the actual user object from the DB
+      expect(privileges.for).toHaveBeenCalledWith(
+        expect.anything(),
+        differentUser,
+      );
+    });
   });
 });

--- a/src/components/user/user.service.spec.ts
+++ b/src/components/user/user.service.spec.ts
@@ -8,7 +8,7 @@ import {
   jest,
 } from '@jest/globals';
 import { type ID } from '~/common';
-import type { UserService as UserServiceClass } from './user.service';
+import type { UserService as UserServiceClass } from './user.service.js';
 
 // In ESM mode (ts-jest/presets/default-esm), jest.mock() is NOT hoisted and
 // cannot intercept ES module imports. unstable_mockModule + dynamic import is

--- a/src/components/user/user.service.spec.ts
+++ b/src/components/user/user.service.spec.ts
@@ -1,0 +1,321 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import type { UserService as UserServiceClass } from './user.service';
+
+// ESM mode requires unstable_mockModule + dynamic import.
+// jest.mock() is not hoisted in ESM and cannot intercept ES module imports.
+
+jest.unstable_mockModule('~/core/logger', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  Logger: () => () => undefined,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  ILogger: class {},
+}));
+
+jest.unstable_mockModule('./user.repository', () => ({
+  UserRepository: class {},
+}));
+
+jest.unstable_mockModule('../authorization/policy/executor/privileges', () => ({
+  Privileges: class {},
+}));
+
+jest.unstable_mockModule('../organization', () => ({
+  OrganizationService: class {},
+}));
+
+jest.unstable_mockModule('../partner', () => ({
+  PartnerService: class {},
+}));
+
+jest.unstable_mockModule('../location', () => ({
+  LocationService: class {},
+}));
+
+jest.unstable_mockModule('./education', () => ({
+  EducationService: class {},
+}));
+
+jest.unstable_mockModule('./unavailability', () => ({
+  UnavailabilityService: class {},
+}));
+
+jest.unstable_mockModule('./known-language.repository', () => ({
+  KnownLanguageRepository: class {},
+}));
+
+jest.unstable_mockModule('~/core/authentication', () => ({
+  Identity: class {},
+}));
+
+jest.unstable_mockModule('~/core/hooks', () => ({
+  Hooks: class {},
+}));
+
+jest.unstable_mockModule('./hooks/user-updated.hook', () => ({
+  UserUpdatedHook: class {},
+}));
+
+const FAKE_USER_ID = 'user-uuid-1' as any;
+const FAKE_ORG_ID = 'org-uuid-1' as any;
+
+const makeFakeUser = (id = FAKE_USER_ID) => ({
+  id,
+  email: { value: 'test@example.com', canRead: true, canEdit: false },
+  realFirstName: { value: 'Test', canRead: true, canEdit: false },
+  realLastName: { value: 'User', canRead: true, canEdit: false },
+});
+
+describe('UserService — assignOrganizationToUser', () => {
+  let UserService: typeof UserServiceClass;
+  let service: UserServiceClass;
+  let userRepo: any;
+  let privileges: any;
+  let resourcePrivileges: any;
+
+  beforeAll(async () => {
+    ({ UserService } = await import('./user.service'));
+  });
+
+  beforeEach(() => {
+    resourcePrivileges = {
+      verifyCan: jest.fn(),
+    };
+
+    privileges = {
+      for: jest.fn().mockReturnValue(resourcePrivileges),
+    };
+
+    userRepo = {
+      readOne: jest.fn(),
+      assignOrganizationToUser: jest.fn(),
+      removeOrganizationFromUser: jest.fn(),
+      getActualChanges: jest.fn(),
+    };
+
+    service = new (UserService as any)(
+      {} as any, // educations
+      {} as any, // organizations
+      {} as any, // partners
+      {} as any, // unavailabilities
+      privileges, // privileges
+      {} as any, // locationService
+      {} as any, // knownLanguages
+      {} as any, // identity
+      {} as any, // hooks
+      userRepo, // userRepo
+      { debug: jest.fn() } as any, // logger
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reads the user from the repository before checking privileges', async () => {
+    const fakeUser = makeFakeUser();
+    userRepo.readOne.mockResolvedValue(fakeUser);
+    userRepo.assignOrganizationToUser.mockResolvedValue(undefined);
+
+    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
+    await service.assignOrganizationToUser(request as any);
+
+    expect(userRepo.readOne).toHaveBeenCalledWith(FAKE_USER_ID);
+  });
+
+  it('checks the organization edit privilege with the fetched user', async () => {
+    const fakeUser = makeFakeUser();
+    userRepo.readOne.mockResolvedValue(fakeUser);
+    userRepo.assignOrganizationToUser.mockResolvedValue(undefined);
+
+    const { User } = await import('./dto');
+    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
+    await service.assignOrganizationToUser(request as any);
+
+    expect(privileges.for).toHaveBeenCalledWith(User, fakeUser);
+    expect(resourcePrivileges.verifyCan).toHaveBeenCalledWith(
+      'edit',
+      'organization',
+    );
+  });
+
+  it('delegates to the repository when the privilege check passes', async () => {
+    const fakeUser = makeFakeUser();
+    userRepo.readOne.mockResolvedValue(fakeUser);
+    userRepo.assignOrganizationToUser.mockResolvedValue(undefined);
+
+    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
+    await service.assignOrganizationToUser(request as any);
+
+    expect(userRepo.assignOrganizationToUser).toHaveBeenCalledWith(request);
+  });
+
+  it('does NOT call the repository when the privilege check throws', async () => {
+    const fakeUser = makeFakeUser();
+    userRepo.readOne.mockResolvedValue(fakeUser);
+    resourcePrivileges.verifyCan.mockImplementation(() => {
+      throw new Error('Unauthorized');
+    });
+
+    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
+    await expect(
+      service.assignOrganizationToUser(request as any),
+    ).rejects.toThrow('Unauthorized');
+
+    expect(userRepo.assignOrganizationToUser).not.toHaveBeenCalled();
+  });
+
+  it('propagates errors thrown by userRepo.readOne', async () => {
+    userRepo.readOne.mockRejectedValue(new Error('DB connection failed'));
+
+    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
+    await expect(
+      service.assignOrganizationToUser(request as any),
+    ).rejects.toThrow('DB connection failed');
+
+    expect(resourcePrivileges.verifyCan).not.toHaveBeenCalled();
+    expect(userRepo.assignOrganizationToUser).not.toHaveBeenCalled();
+  });
+
+  it('privilege check receives the exact object returned by readOne', async () => {
+    const specificUser = { id: 'specific-uuid' as any, roles: ['Consultant'] };
+    userRepo.readOne.mockResolvedValue(specificUser);
+    userRepo.assignOrganizationToUser.mockResolvedValue(undefined);
+
+    const request = { user: 'specific-uuid' as any, org: FAKE_ORG_ID };
+    await service.assignOrganizationToUser(request as any);
+
+    // The second argument to privileges.for must be the exact object from readOne
+    expect(privileges.for).toHaveBeenCalledWith(expect.anything(), specificUser);
+  });
+});
+
+describe('UserService — removeOrganizationFromUser', () => {
+  let UserService: typeof UserServiceClass;
+  let service: UserServiceClass;
+  let userRepo: any;
+  let privileges: any;
+  let resourcePrivileges: any;
+
+  beforeAll(async () => {
+    ({ UserService } = await import('./user.service'));
+  });
+
+  beforeEach(() => {
+    resourcePrivileges = {
+      verifyCan: jest.fn(),
+    };
+
+    privileges = {
+      for: jest.fn().mockReturnValue(resourcePrivileges),
+    };
+
+    userRepo = {
+      readOne: jest.fn(),
+      assignOrganizationToUser: jest.fn(),
+      removeOrganizationFromUser: jest.fn(),
+      getActualChanges: jest.fn(),
+    };
+
+    service = new (UserService as any)(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      privileges,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      userRepo,
+      { debug: jest.fn() } as any,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reads the user from the repository before checking privileges', async () => {
+    const fakeUser = makeFakeUser();
+    userRepo.readOne.mockResolvedValue(fakeUser);
+    userRepo.removeOrganizationFromUser.mockResolvedValue(undefined);
+
+    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
+    await service.removeOrganizationFromUser(request as any);
+
+    expect(userRepo.readOne).toHaveBeenCalledWith(FAKE_USER_ID);
+  });
+
+  it('checks the organization edit privilege with the fetched user', async () => {
+    const fakeUser = makeFakeUser();
+    userRepo.readOne.mockResolvedValue(fakeUser);
+    userRepo.removeOrganizationFromUser.mockResolvedValue(undefined);
+
+    const { User } = await import('./dto');
+    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
+    await service.removeOrganizationFromUser(request as any);
+
+    expect(privileges.for).toHaveBeenCalledWith(User, fakeUser);
+    expect(resourcePrivileges.verifyCan).toHaveBeenCalledWith(
+      'edit',
+      'organization',
+    );
+  });
+
+  it('delegates to the repository when the privilege check passes', async () => {
+    const fakeUser = makeFakeUser();
+    userRepo.readOne.mockResolvedValue(fakeUser);
+    userRepo.removeOrganizationFromUser.mockResolvedValue(undefined);
+
+    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
+    await service.removeOrganizationFromUser(request as any);
+
+    expect(userRepo.removeOrganizationFromUser).toHaveBeenCalledWith(request);
+  });
+
+  it('does NOT call the repository when the privilege check throws', async () => {
+    const fakeUser = makeFakeUser();
+    userRepo.readOne.mockResolvedValue(fakeUser);
+    resourcePrivileges.verifyCan.mockImplementation(() => {
+      throw new Error('Unauthorized');
+    });
+
+    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
+    await expect(
+      service.removeOrganizationFromUser(request as any),
+    ).rejects.toThrow('Unauthorized');
+
+    expect(userRepo.removeOrganizationFromUser).not.toHaveBeenCalled();
+  });
+
+  it('propagates errors thrown by userRepo.readOne', async () => {
+    userRepo.readOne.mockRejectedValue(new Error('User not found'));
+
+    const request = { user: FAKE_USER_ID, org: FAKE_ORG_ID };
+    await expect(
+      service.removeOrganizationFromUser(request as any),
+    ).rejects.toThrow('User not found');
+
+    expect(resourcePrivileges.verifyCan).not.toHaveBeenCalled();
+    expect(userRepo.removeOrganizationFromUser).not.toHaveBeenCalled();
+  });
+
+  it('privilege check uses the exact user object returned by readOne', async () => {
+    const specificUser = { id: 'other-uuid' as any, roles: ['FieldPartner'] };
+    userRepo.readOne.mockResolvedValue(specificUser);
+    userRepo.removeOrganizationFromUser.mockResolvedValue(undefined);
+
+    const request = { user: 'other-uuid' as any, org: FAKE_ORG_ID };
+    await service.removeOrganizationFromUser(request as any);
+
+    expect(privileges.for).toHaveBeenCalledWith(expect.anything(), specificUser);
+  });
+});

--- a/src/components/user/user.service.spec.ts
+++ b/src/components/user/user.service.spec.ts
@@ -12,88 +12,95 @@ import type { UserService as UserServiceClass } from './user.service';
 
 // In ESM mode (ts-jest/presets/default-esm), jest.mock() is NOT hoisted and
 // cannot intercept ES module imports. unstable_mockModule + dynamic import is
-// required.
+// required to avoid transitive circular-dep TDZ errors.
 jest.unstable_mockModule('~/core/logger', () => ({
   // eslint-disable-next-line @typescript-eslint/naming-convention
   Logger: () => () => undefined,
   // eslint-disable-next-line @typescript-eslint/naming-convention
   ILogger: class {},
 }));
-jest.unstable_mockModule('~/core/hooks', () => ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  Hooks: class {},
-}));
-jest.unstable_mockModule('~/core/authentication', () => ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  Identity: class {},
-}));
+
 jest.unstable_mockModule('~/core/resources', () => ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  HandleIdLookup: () => (_target: any, _key: any, descriptor: any) =>
+  HandleIdLookup: () => (_target: any, _key: string, descriptor: PropertyDescriptor) =>
     descriptor,
 }));
+
+jest.unstable_mockModule('./user.repository', () => ({
+  UserRepository: class {},
+}));
+
 jest.unstable_mockModule('../authorization', () => ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   Privileges: class {},
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  AssignableRoles: class {},
 }));
-jest.unstable_mockModule('../location', () => ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  LocationService: class {},
-}));
-jest.unstable_mockModule('../organization', () => ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  OrganizationService: class {},
-}));
+
 jest.unstable_mockModule('../partner', () => ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   PartnerService: class {},
 }));
+
+jest.unstable_mockModule('../location', () => ({
+  LocationService: class {},
+}));
+
+jest.unstable_mockModule('../organization', () => ({
+  OrganizationService: class {},
+}));
+
 jest.unstable_mockModule('./education', () => ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   EducationService: class {},
 }));
+
 jest.unstable_mockModule('./unavailability', () => ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   UnavailabilityService: class {},
 }));
+
+jest.unstable_mockModule('~/core/authentication', () => ({
+  Identity: class {},
+}));
+
+jest.unstable_mockModule('~/core/hooks', () => ({
+  Hooks: class {},
+}));
+
 jest.unstable_mockModule('./known-language.repository', () => ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   KnownLanguageRepository: class {},
 }));
-jest.unstable_mockModule('./user.repository', () => ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  UserRepository: class {},
+
+jest.unstable_mockModule('./hooks/user-updated.hook', () => ({
+  UserUpdatedHook: class {},
+}));
+
+jest.unstable_mockModule('../authorization/dto/assignable-roles.dto', () => ({
+  AssignableRoles: class {},
 }));
 
 const USER_ID = 'user-uuid-1' as ID<'User'>;
 const ORG_ID = 'org-uuid-1' as ID<'Organization'>;
 
-const makeFakeUser = (id = USER_ID) => ({
+const makeMockUser = (id: ID<'User'> = USER_ID) => ({
   id,
-  __typename: 'User' as const,
   email: { value: 'test@example.com', canRead: true, canEdit: false },
   realFirstName: { value: 'Test', canRead: true, canEdit: true },
   realLastName: { value: 'User', canRead: true, canEdit: true },
   displayFirstName: { value: 'Test', canRead: true, canEdit: true },
   displayLastName: { value: 'User', canRead: true, canEdit: true },
+  roles: { value: [], canRead: true, canEdit: false },
+  status: { value: 'Active', canRead: true, canEdit: false },
+  __typename: 'User' as const,
 });
 
-describe('UserService', () => {
+describe('UserService — assignOrganizationToUser', () => {
   let UserService: typeof UserServiceClass;
-  // Typed as `any` to keep mock setup simple.
   let service: UserServiceClass;
   let userRepo: any;
-  let privileges: any;
-  let resourcePrivileges: any;
+  let privilegesMock: any;
+  let resourcePrivilegesMock: any;
 
   beforeAll(async () => {
     ({ UserService } = await import('./user.service'));
   });
 
   beforeEach(() => {
-    resourcePrivileges = {
+    resourcePrivilegesMock = {
       verifyCan: jest.fn(),
     };
 
@@ -101,40 +108,31 @@ describe('UserService', () => {
       readOne: jest.fn(),
       assignOrganizationToUser: jest.fn(),
       removeOrganizationFromUser: jest.fn(),
-      readMany: jest.fn(),
-      readManyActors: jest.fn(),
-      create: jest.fn(),
+      getActualChanges: jest.fn(),
       update: jest.fn(),
+      create: jest.fn(),
       delete: jest.fn(),
       list: jest.fn(),
-      getActualChanges: jest.fn(),
-      doesEmailAddressExist: jest.fn(),
-      getUserByEmailAddress: jest.fn(),
     };
 
-    privileges = {
-      for: jest.fn().mockReturnValue(resourcePrivileges),
+    privilegesMock = {
+      for: jest.fn().mockReturnValue(resourcePrivilegesMock),
     };
 
-    // Default: readOne returns a fake user
-    userRepo.readOne.mockResolvedValue(makeFakeUser());
-    // Default: verifyCan succeeds (no throw)
-    resourcePrivileges.verifyCan.mockReturnValue(undefined);
-    // Default: repo operations succeed
+    userRepo.readOne.mockResolvedValue(makeMockUser());
     userRepo.assignOrganizationToUser.mockResolvedValue(undefined);
-    userRepo.removeOrganizationFromUser.mockResolvedValue(undefined);
 
-    service = new (UserService as any)(
+    service = new UserService(
       {} as any, // educations
       {} as any, // organizations
       {} as any, // partners
       {} as any, // unavailabilities
-      privileges,
+      privilegesMock as any, // privileges
       {} as any, // locationService
       {} as any, // knownLanguages
       {} as any, // identity
       {} as any, // hooks
-      userRepo,
+      userRepo as any, // userRepo
       { debug: jest.fn() } as any, // logger
     );
   });
@@ -143,134 +141,212 @@ describe('UserService', () => {
     jest.clearAllMocks();
   });
 
-  describe('assignOrganizationToUser', () => {
-    it('reads the user from the repository before checking privileges', async () => {
-      const request = { user: USER_ID, org: ORG_ID };
+  it('reads the user before checking privileges', async () => {
+    await service.assignOrganizationToUser({ org: ORG_ID, user: USER_ID });
 
-      await service.assignOrganizationToUser(request);
-
-      expect(userRepo.readOne).toHaveBeenCalledWith(USER_ID);
-    });
-
-    it('verifies the caller can edit the organization field', async () => {
-      const fakeUser = makeFakeUser();
-      userRepo.readOne.mockResolvedValue(fakeUser);
-
-      await service.assignOrganizationToUser({ user: USER_ID, org: ORG_ID });
-
-      expect(privileges.for).toHaveBeenCalledWith(
-        expect.anything(), // User resource
-        fakeUser,
-      );
-      expect(resourcePrivileges.verifyCan).toHaveBeenCalledWith(
-        'edit',
-        'organization',
-      );
-    });
-
-    it('delegates to the repository after successful privilege check', async () => {
-      const request = { user: USER_ID, org: ORG_ID };
-
-      await service.assignOrganizationToUser(request);
-
-      expect(userRepo.assignOrganizationToUser).toHaveBeenCalledWith(request);
-    });
-
-    it('does not call the repository when privilege check throws', async () => {
-      const authError = new Error('Insufficient permission');
-      resourcePrivileges.verifyCan.mockImplementation(() => {
-        throw authError;
-      });
-
-      await expect(
-        service.assignOrganizationToUser({ user: USER_ID, org: ORG_ID }),
-      ).rejects.toThrow(authError);
-
-      expect(userRepo.assignOrganizationToUser).not.toHaveBeenCalled();
-    });
-
-    it('propagates errors thrown by the repository', async () => {
-      const repoError = new Error('Database failure');
-      userRepo.assignOrganizationToUser.mockRejectedValue(repoError);
-
-      await expect(
-        service.assignOrganizationToUser({ user: USER_ID, org: ORG_ID }),
-      ).rejects.toThrow(repoError);
-    });
-
-    it('forwards the full request object including the optional primary flag', async () => {
-      const request = { user: USER_ID, org: ORG_ID, primary: true };
-
-      await service.assignOrganizationToUser(request);
-
-      expect(userRepo.assignOrganizationToUser).toHaveBeenCalledWith(request);
-    });
+    expect(userRepo.readOne).toHaveBeenCalledWith(USER_ID);
   });
 
-  describe('removeOrganizationFromUser', () => {
-    it('reads the user from the repository before checking privileges', async () => {
-      await service.removeOrganizationFromUser({ user: USER_ID, org: ORG_ID });
+  it('checks edit privilege on organization property', async () => {
+    const mockUser = makeMockUser();
+    userRepo.readOne.mockResolvedValue(mockUser);
 
-      expect(userRepo.readOne).toHaveBeenCalledWith(USER_ID);
+    await service.assignOrganizationToUser({ org: ORG_ID, user: USER_ID });
+
+    expect(privilegesMock.for).toHaveBeenCalledWith(
+      expect.anything(), // User class
+      mockUser,
+    );
+    expect(resourcePrivilegesMock.verifyCan).toHaveBeenCalledWith(
+      'edit',
+      'organization',
+    );
+  });
+
+  it('delegates to repository when privilege check passes', async () => {
+    const request = { org: ORG_ID, user: USER_ID, primary: true };
+
+    await service.assignOrganizationToUser(request);
+
+    expect(userRepo.assignOrganizationToUser).toHaveBeenCalledWith(request);
+  });
+
+  it('does not call repository when privilege check throws', async () => {
+    resourcePrivilegesMock.verifyCan.mockImplementation(() => {
+      throw new Error('Unauthorized');
     });
 
-    it('verifies the caller can edit the organization field', async () => {
-      const fakeUser = makeFakeUser();
-      userRepo.readOne.mockResolvedValue(fakeUser);
+    await expect(
+      service.assignOrganizationToUser({ org: ORG_ID, user: USER_ID }),
+    ).rejects.toThrow('Unauthorized');
 
-      await service.removeOrganizationFromUser({ user: USER_ID, org: ORG_ID });
+    expect(userRepo.assignOrganizationToUser).not.toHaveBeenCalled();
+  });
 
-      expect(privileges.for).toHaveBeenCalledWith(
-        expect.anything(), // User resource
-        fakeUser,
-      );
-      expect(resourcePrivileges.verifyCan).toHaveBeenCalledWith(
-        'edit',
-        'organization',
-      );
+  it('propagates the error thrown by verifyCan', async () => {
+    const authError = new Error('You do not have permission to edit organization');
+    resourcePrivilegesMock.verifyCan.mockImplementation(() => {
+      throw authError;
     });
 
-    it('delegates to the repository after successful privilege check', async () => {
-      const request = { user: USER_ID, org: ORG_ID };
+    await expect(
+      service.assignOrganizationToUser({ org: ORG_ID, user: USER_ID }),
+    ).rejects.toBe(authError);
+  });
 
-      await service.removeOrganizationFromUser(request);
+  it('privilege check uses the user object returned by readOne', async () => {
+    const specificUser = makeMockUser('other-user-id' as ID<'User'>);
+    userRepo.readOne.mockResolvedValue(specificUser);
 
-      expect(userRepo.removeOrganizationFromUser).toHaveBeenCalledWith(request);
+    await service.assignOrganizationToUser({
+      org: ORG_ID,
+      user: 'other-user-id' as ID<'User'>,
     });
 
-    it('does not call the repository when privilege check throws', async () => {
-      const authError = new Error('Insufficient permission');
-      resourcePrivileges.verifyCan.mockImplementation(() => {
-        throw authError;
-      });
+    expect(privilegesMock.for).toHaveBeenCalledWith(
+      expect.anything(),
+      specificUser,
+    );
+  });
+});
 
-      await expect(
-        service.removeOrganizationFromUser({ user: USER_ID, org: ORG_ID }),
-      ).rejects.toThrow(authError);
+describe('UserService — removeOrganizationFromUser', () => {
+  let UserService: typeof UserServiceClass;
+  let service: UserServiceClass;
+  let userRepo: any;
+  let privilegesMock: any;
+  let resourcePrivilegesMock: any;
 
-      expect(userRepo.removeOrganizationFromUser).not.toHaveBeenCalled();
+  beforeAll(async () => {
+    ({ UserService } = await import('./user.service'));
+  });
+
+  beforeEach(() => {
+    resourcePrivilegesMock = {
+      verifyCan: jest.fn(),
+    };
+
+    userRepo = {
+      readOne: jest.fn(),
+      assignOrganizationToUser: jest.fn(),
+      removeOrganizationFromUser: jest.fn(),
+      getActualChanges: jest.fn(),
+      update: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      list: jest.fn(),
+    };
+
+    privilegesMock = {
+      for: jest.fn().mockReturnValue(resourcePrivilegesMock),
+    };
+
+    userRepo.readOne.mockResolvedValue(makeMockUser());
+    userRepo.removeOrganizationFromUser.mockResolvedValue(undefined);
+
+    service = new UserService(
+      {} as any, // educations
+      {} as any, // organizations
+      {} as any, // partners
+      {} as any, // unavailabilities
+      privilegesMock as any, // privileges
+      {} as any, // locationService
+      {} as any, // knownLanguages
+      {} as any, // identity
+      {} as any, // hooks
+      userRepo as any, // userRepo
+      { debug: jest.fn() } as any, // logger
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reads the user before checking privileges', async () => {
+    await service.removeOrganizationFromUser({ org: ORG_ID, user: USER_ID });
+
+    expect(userRepo.readOne).toHaveBeenCalledWith(USER_ID);
+  });
+
+  it('checks edit privilege on organization property', async () => {
+    const mockUser = makeMockUser();
+    userRepo.readOne.mockResolvedValue(mockUser);
+
+    await service.removeOrganizationFromUser({ org: ORG_ID, user: USER_ID });
+
+    expect(privilegesMock.for).toHaveBeenCalledWith(
+      expect.anything(), // User class
+      mockUser,
+    );
+    expect(resourcePrivilegesMock.verifyCan).toHaveBeenCalledWith(
+      'edit',
+      'organization',
+    );
+  });
+
+  it('delegates to repository when privilege check passes', async () => {
+    const request = { org: ORG_ID, user: USER_ID };
+
+    await service.removeOrganizationFromUser(request);
+
+    expect(userRepo.removeOrganizationFromUser).toHaveBeenCalledWith(request);
+  });
+
+  it('does not call repository when privilege check throws', async () => {
+    resourcePrivilegesMock.verifyCan.mockImplementation(() => {
+      throw new Error('Unauthorized');
     });
 
-    it('propagates errors thrown by the repository', async () => {
-      const repoError = new Error('Database failure');
-      userRepo.removeOrganizationFromUser.mockRejectedValue(repoError);
+    await expect(
+      service.removeOrganizationFromUser({ org: ORG_ID, user: USER_ID }),
+    ).rejects.toThrow('Unauthorized');
 
-      await expect(
-        service.removeOrganizationFromUser({ user: USER_ID, org: ORG_ID }),
-      ).rejects.toThrow(repoError);
+    expect(userRepo.removeOrganizationFromUser).not.toHaveBeenCalled();
+  });
+
+  it('propagates the error thrown by verifyCan', async () => {
+    const authError = new Error('You do not have permission to edit organization');
+    resourcePrivilegesMock.verifyCan.mockImplementation(() => {
+      throw authError;
     });
 
-    it('privilege check uses the user returned by readOne, not the request id', async () => {
-      const differentUser = makeFakeUser('other-user-id' as ID<'User'>);
-      userRepo.readOne.mockResolvedValue(differentUser);
+    await expect(
+      service.removeOrganizationFromUser({ org: ORG_ID, user: USER_ID }),
+    ).rejects.toBe(authError);
+  });
 
-      await service.removeOrganizationFromUser({ user: USER_ID, org: ORG_ID });
+  it('privilege check uses the user object returned by readOne', async () => {
+    const specificUser = makeMockUser('other-user-id' as ID<'User'>);
+    userRepo.readOne.mockResolvedValue(specificUser);
 
-      // Privileges are checked against the actual user object from the DB
-      expect(privileges.for).toHaveBeenCalledWith(
-        expect.anything(),
-        differentUser,
-      );
+    await service.removeOrganizationFromUser({
+      org: ORG_ID,
+      user: 'other-user-id' as ID<'User'>,
     });
+
+    expect(privilegesMock.for).toHaveBeenCalledWith(
+      expect.anything(),
+      specificUser,
+    );
+  });
+
+  it('privilege check happens before repository call (read then verify then remove)', async () => {
+    const callOrder: string[] = [];
+
+    userRepo.readOne.mockImplementation(async () => {
+      callOrder.push('readOne');
+      return makeMockUser();
+    });
+    resourcePrivilegesMock.verifyCan.mockImplementation(() => {
+      callOrder.push('verifyCan');
+    });
+    userRepo.removeOrganizationFromUser.mockImplementation(async () => {
+      callOrder.push('removeOrganizationFromUser');
+    });
+
+    await service.removeOrganizationFromUser({ org: ORG_ID, user: USER_ID });
+
+    expect(callOrder).toEqual(['readOne', 'verifyCan', 'removeOrganizationFromUser']);
   });
 });

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -320,12 +320,16 @@ export class UserService {
   }
 
   async assignOrganizationToUser(request: AssignOrganizationToUser) {
+    const user = await this.userRepo.readOne(request.user);
+    this.privileges.for(User, user).verifyCan('edit', 'organization');
     await this.userRepo.assignOrganizationToUser(request);
   }
 
   async removeOrganizationFromUser(
     request: RemoveOrganizationFromUser,
   ): Promise<void> {
+    const user = await this.userRepo.readOne(request.user);
+    this.privileges.for(User, user).verifyCan('edit', 'organization');
     await this.userRepo.removeOrganizationFromUser(request);
   }
 }

--- a/test/progress-report-media.e2e-spec.ts
+++ b/test/progress-report-media.e2e-spec.ts
@@ -202,7 +202,7 @@ describe('ProgressReport Media e2e', () => {
     expect(reportUpdated.media.total).toBe(2);
 
     const [m1, m2] = reportUpdated.media.items;
-    expect(m1!.variantGroup).toBe(m2!.variantGroup);
+    expect(m1.variantGroup).toBe(m2.variantGroup);
   });
 
   it('Only one variant per group', async () => {

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -1139,9 +1139,7 @@ describe('Project e2e', () => {
         ),
       );
 
-      expect(project1!.departmentId.value).not.toBe(
-        project2!.departmentId.value,
-      );
+      expect(project1.departmentId.value).not.toBe(project2.departmentId.value);
     });
   });
 });

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -10,6 +10,7 @@ import {
   createSession,
   createTestApp,
   createUnavailability,
+  errors,
   fragments,
   generateRegisterInput,
   generateRequireFieldsRegisterInput,
@@ -242,6 +243,32 @@ describe('User e2e', () => {
       org: org.id,
       user: newUser.id,
       primary: true,
+    });
+  });
+
+  it('non-admin cannot assign organization to self', async () => {
+    const user = await registerUser(app);
+
+    await user.runAs(async () => {
+      await expect(
+        assignOrganizationToUser(app, {
+          org: org.id,
+          user: user.id,
+        }),
+      ).rejects.toThrowGqlError(errors.unauthorized());
+    });
+  });
+
+  it('non-admin cannot remove organization from self', async () => {
+    const user = await registerUser(app);
+
+    await user.runAs(async () => {
+      await expect(
+        removeOrganizationFromUser(app, {
+          org: org.id,
+          user: user.id,
+        }),
+      ).rejects.toThrowGqlError(errors.unauthorized());
     });
   });
 

--- a/test/utility/create-partnership.ts
+++ b/test/utility/create-partnership.ts
@@ -6,6 +6,17 @@ import { createPartner } from './create-partner';
 import { createProject } from './create-project';
 import * as fragments from './fragments';
 
+/**
+ * Creates a partnership via the GraphQL mutation and asserts key fields on the returned entity.
+ *
+ * The function builds a full `CreatePartnership` input (filling defaults and creating dependent
+ * project/partner records when not provided), performs the mutation, and asserts that the
+ * returned partnership exists, has a valid id, and that agreement status, MOU status, and
+ * types match the requested input.
+ *
+ * @param input - Optional overrides for the mutation input; partial fields will replace defaults.
+ * @returns The created partnership object returned by the mutation.
+ */
 export async function createPartnership(
   app: TestApp,
   input: Partial<InputOf<typeof CreatePartnershipDoc>> = {},

--- a/test/utility/create-partnership.ts
+++ b/test/utility/create-partnership.ts
@@ -32,9 +32,7 @@ export async function createPartnership(
   expect(isValidId(actual.id)).toBe(true);
   expect(actual.agreementStatus.value).toBe(partnership.agreementStatus);
   expect(actual.mouStatus.value).toBe(partnership.mouStatus);
-  expect(actual.types.value).toEqual(
-    expect.arrayContaining(partnership.types!),
-  );
+  expect(actual.types.value).toEqual(expect.arrayContaining(partnership.types));
 
   return actual;
 }

--- a/test/utility/create-session.e2e-spec.ts
+++ b/test/utility/create-session.e2e-spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit-style tests for the test utilities in create-session.ts.
+ *
+ * These tests exercise the changed logic in getUserFromSession without
+ * spinning up the full NestJS application. The TestApp is mocked with a
+ * minimal stub of app.graphql.query.
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+import { CurrentUserDoc, getUserFromSession } from './create-session';
+
+// ---------------------------------------------------------------------------
+// Minimal TestApp stub
+// ---------------------------------------------------------------------------
+
+function makeApp(queryResult: Record<string, any>) {
+  return {
+    graphql: {
+      authToken: undefined as string | undefined,
+      query: jest.fn<() => Promise<any>>().mockResolvedValue(queryResult),
+    },
+  } as any;
+}
+
+// ---------------------------------------------------------------------------
+// getUserFromSession
+// ---------------------------------------------------------------------------
+
+describe('getUserFromSession', () => {
+  it('returns an object with the session user id when authenticated', async () => {
+    const app = makeApp({ session: { user: { id: 'user-abc-123' } } });
+
+    const result = await getUserFromSession(app);
+
+    expect(result).toEqual({ id: 'user-abc-123' });
+  });
+
+  it('throws an error when session user is null', async () => {
+    const app = makeApp({ session: { user: null } });
+
+    await expect(getUserFromSession(app)).rejects.toThrow(
+      'Expected session user to be present',
+    );
+  });
+
+  it('throws an error when session user is undefined', async () => {
+    const app = makeApp({ session: { user: undefined } });
+
+    await expect(getUserFromSession(app)).rejects.toThrow(
+      'Expected session user to be present',
+    );
+  });
+
+  it('throws an error when session user exists but has no id', async () => {
+    const app = makeApp({ session: { user: { id: undefined } } });
+
+    await expect(getUserFromSession(app)).rejects.toThrow(
+      'Expected session user to be present',
+    );
+  });
+
+  it('throws an error when session user id is an empty string', async () => {
+    const app = makeApp({ session: { user: { id: '' } } });
+
+    await expect(getUserFromSession(app)).rejects.toThrow(
+      'Expected session user to be present',
+    );
+  });
+
+  it('queries using the CurrentUserDoc document', async () => {
+    const app = makeApp({ session: { user: { id: 'user-xyz' } } });
+
+    await getUserFromSession(app);
+
+    expect(app.graphql.query).toHaveBeenCalledWith(
+      CurrentUserDoc,
+      expect.anything(),
+    );
+  });
+
+  it('returns only the id, not any additional fields from the session', async () => {
+    // Even if the server returns extra fields, the function strips them.
+    const app = makeApp({
+      session: { user: { id: 'user-123', email: 'x@y.com', roles: ['Admin'] } },
+    });
+
+    const result = await getUserFromSession(app);
+
+    expect(result).toEqual({ id: 'user-123' });
+    expect(result).not.toHaveProperty('email');
+    expect(result).not.toHaveProperty('roles');
+  });
+});

--- a/test/utility/create-session.e2e-spec.ts
+++ b/test/utility/create-session.e2e-spec.ts
@@ -1,92 +1,88 @@
 /**
- * Unit-style tests for the test utilities in create-session.ts.
+ * Unit-style tests for the create-session utility helpers.
  *
- * These tests exercise the changed logic in getUserFromSession without
- * spinning up the full NestJS application. The TestApp is mocked with a
- * minimal stub of app.graphql.query.
+ * These tests run under the E2E Jest project (roots=['test']) but use only
+ * mocked objects so no real database or application is needed.
  */
-import { describe, expect, it, jest } from '@jest/globals';
-import { CurrentUserDoc, getUserFromSession } from './create-session';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { getUserFromSession } from './create-session';
 
-// ---------------------------------------------------------------------------
-// Minimal TestApp stub
-// ---------------------------------------------------------------------------
-
-function makeApp(queryResult: Record<string, any>) {
-  return {
+const makeApp = (sessionUserPayload: unknown) =>
+  ({
     graphql: {
-      authToken: undefined as string | undefined,
-      query: jest.fn<() => Promise<any>>().mockResolvedValue(queryResult),
+      query: jest.fn<() => Promise<any>>().mockResolvedValue({
+        session: sessionUserPayload,
+      }),
     },
-  } as any;
-}
-
-// ---------------------------------------------------------------------------
-// getUserFromSession
-// ---------------------------------------------------------------------------
+  }) as any;
 
 describe('getUserFromSession', () => {
-  it('returns an object with the session user id when authenticated', async () => {
-    const app = makeApp({ session: { user: { id: 'user-abc-123' } } });
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an object with the user id when the session has a logged-in user', async () => {
+    const app = makeApp({ user: { id: 'user-abc-123' } });
 
     const result = await getUserFromSession(app);
 
     expect(result).toEqual({ id: 'user-abc-123' });
   });
 
-  it('throws an error when session user is null', async () => {
-    const app = makeApp({ session: { user: null } });
+  it('throws when the session user is null (unauthenticated session)', async () => {
+    const app = makeApp({ user: null });
 
     await expect(getUserFromSession(app)).rejects.toThrow(
       'Expected session user to be present',
     );
   });
 
-  it('throws an error when session user is undefined', async () => {
-    const app = makeApp({ session: { user: undefined } });
+  it('throws when the session user object is missing an id', async () => {
+    const app = makeApp({ user: {} });
 
     await expect(getUserFromSession(app)).rejects.toThrow(
       'Expected session user to be present',
     );
   });
 
-  it('throws an error when session user exists but has no id', async () => {
-    const app = makeApp({ session: { user: { id: undefined } } });
+  it('throws when the session user id is an empty string', async () => {
+    const app = makeApp({ user: { id: '' } });
 
     await expect(getUserFromSession(app)).rejects.toThrow(
       'Expected session user to be present',
     );
   });
 
-  it('throws an error when session user id is an empty string', async () => {
-    const app = makeApp({ session: { user: { id: '' } } });
+  it('throws when the session user is undefined', async () => {
+    const app = makeApp({ user: undefined });
 
     await expect(getUserFromSession(app)).rejects.toThrow(
       'Expected session user to be present',
     );
   });
 
-  it('queries using the CurrentUserDoc document', async () => {
-    const app = makeApp({ session: { user: { id: 'user-xyz' } } });
-
-    await getUserFromSession(app);
-
-    expect(app.graphql.query).toHaveBeenCalledWith(
-      CurrentUserDoc,
-      expect.anything(),
-    );
-  });
-
-  it('returns only the id, not any additional fields from the session', async () => {
-    // Even if the server returns extra fields, the function strips them.
+  it('returns only id regardless of extra properties on the session user', async () => {
     const app = makeApp({
-      session: { user: { id: 'user-123', email: 'x@y.com', roles: ['Admin'] } },
+      user: { id: 'user-xyz', email: 'user@example.com', roles: ['Admin'] },
     });
 
     const result = await getUserFromSession(app);
 
-    expect(result).toEqual({ id: 'user-123' });
-    expect(result).not.toHaveProperty('email');
-    expect(result).not.toHaveProperty('roles');
+    // Result is shaped as SessionUser, which only has id.
+    expect(result).toEqual({ id: 'user-xyz' });
+    expect(Object.keys(result)).toEqual(['id']);
+  });
+
+  it('passes an empty-object variables argument to app.graphql.query', async () => {
+    const app = makeApp({ user: { id: 'user-abc' } });
+
+    await getUserFromSession(app);
+
+    // The second argument to query() must be {} (not undefined) so the
+    // typed GraphQL client does not complain about missing variables.
+    expect(app.graphql.query).toHaveBeenCalledWith(
+      expect.anything(),
+      {},
+    );
   });
 });

--- a/test/utility/create-session.ts
+++ b/test/utility/create-session.ts
@@ -22,7 +22,7 @@ export async function getUserFromSession(app: TestApp) {
   const result = await app.graphql.query(CurrentUserDoc);
   const user = result.session.user;
   expect(user).toBeTruthy();
-  return user!;
+  return user;
 }
 export const CurrentUserDoc = graphql(`
   query SessionUser {

--- a/test/utility/create-session.ts
+++ b/test/utility/create-session.ts
@@ -1,6 +1,11 @@
 import { expect } from '@jest/globals';
+import { type ID } from '~/common';
 import { graphql } from '~/graphql';
 import { type TestApp } from './create-app';
+
+interface SessionUser {
+  id: ID;
+}
 
 export async function createSession(app: TestApp) {
   const result = await app.graphql.query(
@@ -11,6 +16,7 @@ export async function createSession(app: TestApp) {
         }
       }
     `),
+    {},
   );
   const token = result.session.token;
   expect(token).toBeTruthy();
@@ -18,11 +24,16 @@ export async function createSession(app: TestApp) {
   return token;
 }
 
-export async function getUserFromSession(app: TestApp) {
-  const result = await app.graphql.query(CurrentUserDoc);
+/**
+ * Return the current session user and fail fast if the session is unauthenticated.
+ */
+export async function getUserFromSession(app: TestApp): Promise<SessionUser> {
+  const result = await app.graphql.query(CurrentUserDoc, {});
   const user = result.session.user;
-  expect(user).toBeTruthy();
-  return user;
+  if (!user?.id) {
+    throw new Error('Expected session user to be present');
+  }
+  return { id: user.id };
 }
 export const CurrentUserDoc = graphql(`
   query SessionUser {

--- a/test/utility/create-session.ts
+++ b/test/utility/create-session.ts
@@ -7,6 +7,14 @@ interface SessionUser {
   id: ID;
 }
 
+/**
+ * Creates a test session and stores the returned token on the app's GraphQL client.
+ *
+ * This performs the SessionToken query, assigns the returned token to `app.graphql.authToken`,
+ * and verifies a token was received.
+ *
+ * @returns The session token string
+ */
 export async function createSession(app: TestApp) {
   const result = await app.graphql.query(
     graphql(`
@@ -25,7 +33,10 @@ export async function createSession(app: TestApp) {
 }
 
 /**
- * Return the current session user and fail fast if the session is unauthenticated.
+ * Return the current session user or throw if the session is unauthenticated.
+ *
+ * @returns An object with the session user's `id`.
+ * @throws Error if no authenticated session user is present.
  */
 export async function getUserFromSession(app: TestApp): Promise<SessionUser> {
   const result = await app.graphql.query(CurrentUserDoc, {});


### PR DESCRIPTION
## Description
Enhance user permissions by updating the `UserCanEditSelfPolicy` to include organization checks. Implement privilege checks in the `UserService` for organization assignments. Improve test coverage by adding checks for non-admin users attempting to assign or remove organizations. Clean up code by removing unnecessary null assertions and streamlining type checks in various utilities. Refactor session management with added type definitions and improved query handling.

Front-end PR: SeedCompany/cord-field/pull/1829
