### PR TITLE
#7 [pg] Organization Migration

### DIFF
--- a/src/components/organization/organization.drizzle.repository.ts
+++ b/src/components/organization/organization.drizzle.repository.ts
@@ -1,0 +1,143 @@
+import { Injectable } from '@nestjs/common';
+import { and, eq, ilike, inArray, isNull, type SQL } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  EnhancedResource,
+  generateId,
+  type ID,
+  type PaginatedListType,
+  type UnsecuredDto,
+} from '~/common';
+import {
+  catchUniqueViolation,
+  DrizzleDtoRepository,
+  escapeLikePattern,
+  resolveOrderBy,
+  type SortMap,
+} from '~/core/drizzle';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { organizations, userOrganizations } from '~/core/drizzle/schema';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import {
+  type CreateOrganization,
+  Organization,
+  type OrganizationListInput,
+  type UpdateOrganization,
+} from './dto';
+
+const catchNameUnique = catchUniqueViolation(
+  'name',
+  'name',
+  'Organization with this name already exists',
+);
+
+@Injectable()
+export class OrganizationDrizzleRepository extends DrizzleDtoRepository<
+  typeof organizations,
+  Organization
+> {
+  private readonly resource = EnhancedResource.of(Organization);
+
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+  ) {
+    super(db, organizations);
+  }
+
+  async create(input: CreateOrganization): Promise<UnsecuredDto<Organization>> {
+    const id = await generateId();
+    await this.db
+      .insert(organizations)
+      .values({
+        id,
+        name: input.name,
+        acronym: input.acronym ?? null,
+        address: input.address ?? null,
+        types: [...(input.types ?? [])],
+        reach: [...(input.reach ?? [])],
+      })
+      .catch(catchNameUnique);
+    return await this.readOne(id);
+  }
+
+  async update(
+    changes: UpdateOrganization,
+  ): Promise<UnsecuredDto<Organization>> {
+    const { id, ...fields } = changes;
+    await this.updateColumns(id, {
+      name: fields.name,
+      acronym: fields.acronym,
+      address: fields.address,
+      types: fields.types && [...fields.types],
+      reach: fields.reach && [...fields.reach],
+    }).catch(catchNameUnique);
+    return await this.readOne(id);
+  }
+
+  async delete(id: ID): Promise<void> {
+    await this.softDelete(id);
+  }
+
+  async list(
+    input: OrganizationListInput,
+  ): Promise<PaginatedListType<UnsecuredDto<Organization>>> {
+    const filter = this.executor.drizzleFilter({
+      action: 'read',
+      resource: this.resource,
+    });
+    if (filter === false) return { items: [], total: 0, hasMore: false };
+
+    const conditions: SQL[] = [isNull(organizations.deletedAt)];
+    if (filter !== true) conditions.push(filter);
+
+    if (input.filter?.name) {
+      conditions.push(
+        ilike(organizations.name, `%${escapeLikePattern(input.filter.name)}%`),
+      );
+    }
+    if (input.filter?.userId) {
+      const userOrgSubq = this.db
+        .select({ orgId: userOrganizations.organizationId })
+        .from(userOrganizations)
+        .where(eq(userOrganizations.userId, input.filter.userId));
+      conditions.push(inArray(organizations.id, userOrgSubq));
+    }
+
+    const sortColumns = {
+      name: organizations.name,
+      acronym: organizations.acronym,
+      address: organizations.address,
+      sensitivity: organizations.sensitivity,
+      createdAt: organizations.createdAt,
+    } satisfies SortMap<keyof Organization>;
+
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: and(...conditions),
+      orderBy: resolveOrderBy(input, sortColumns, organizations.name),
+      page: input.page,
+      count: input.count,
+    });
+    return {
+      total,
+      items: rows.map((row) => this.toDto(row)),
+      hasMore,
+    };
+  }
+
+  protected toDto(
+    row: typeof organizations.$inferSelect,
+  ): UnsecuredDto<Organization> {
+    return {
+      id: row.id,
+      __typename: 'Organization',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      name: row.name,
+      acronym: row.acronym ?? null,
+      address: row.address ?? null,
+      types: row.types,
+      reach: row.reach,
+      sensitivity: row.sensitivity,
+    };
+  }
+}

--- a/src/components/organization/organization.drizzle.repository.ts
+++ b/src/components/organization/organization.drizzle.repository.ts
@@ -16,7 +16,11 @@ import {
   type SortMap,
 } from '~/core/drizzle';
 import { DrizzleService } from '~/core/drizzle/drizzle.service';
-import { organizations, userOrganizations } from '~/core/drizzle/schema';
+import {
+  organizationLocations,
+  organizations,
+  userOrganizations,
+} from '~/core/drizzle/schema';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import {
   type CreateOrganization,
@@ -76,6 +80,15 @@ export class OrganizationDrizzleRepository extends DrizzleDtoRepository<
   }
 
   async delete(id: ID): Promise<void> {
+    // Soft-delete bypasses FK cascade, so clear joins explicitly — otherwise
+    // a stale primary=true row would block future primary-org reassignment
+    // via the user_organizations_one_primary_per_user partial unique index.
+    await this.db
+      .delete(organizationLocations)
+      .where(eq(organizationLocations.organizationId, id));
+    await this.db
+      .delete(userOrganizations)
+      .where(eq(userOrganizations.organizationId, id));
     await this.softDelete(id);
   }
 

--- a/src/components/organization/organization.module.ts
+++ b/src/components/organization/organization.module.ts
@@ -4,6 +4,7 @@ import { AuthorizationModule } from '../authorization/authorization.module';
 import { LocationModule } from '../location/location.module';
 import { AddOrganizationReachMigration } from './migrations/add-reach.migration';
 import { AddOrganizationTypeMigration } from './migrations/add-type.migration';
+import { OrganizationDrizzleRepository } from './organization.drizzle.repository';
 import { OrganizationGelRepository } from './organization.gel.repository';
 import { OrganizationLoader } from './organization.loader';
 import { OrganizationRepository } from './organization.repository';
@@ -20,6 +21,8 @@ import { OrganizationService } from './organization.service';
     OrganizationService,
     splitDb(OrganizationRepository, {
       gel: OrganizationGelRepository,
+      // migration-todo: remove `as any` once splitDb types accept drizzle repos directly
+      postgres: OrganizationDrizzleRepository as any,
     }),
     OrganizationLoader,
     AddOrganizationReachMigration,

--- a/src/components/organization/organization.repository.ts
+++ b/src/components/organization/organization.repository.ts
@@ -142,6 +142,10 @@ export class OrganizationRepository extends DtoRepository(Organization) {
     return (await query.first())!; // result from paginate() will always have 1 row.
   }
 
+  async delete(id: ID): Promise<void> {
+    await this.deleteNode(id);
+  }
+
   @OnIndex('schema')
   private async createSchemaIndexes() {
     await this.db.query().apply(OrgNameIndex.create()).run();

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -70,7 +70,7 @@ export class OrganizationService {
     this.privileges.for(Organization, object).verifyCan('delete');
 
     try {
-      await this.repo.deleteNode(object);
+      await this.repo.delete(id);
     } catch (exception) {
       throw new ServerException('Failed to delete', exception);
     }

--- a/src/core/drizzle/migrations/0002_add_locations.sql
+++ b/src/core/drizzle/migrations/0002_add_locations.sql
@@ -9,9 +9,9 @@ CREATE TYPE location_type AS ENUM (
 
 CREATE TABLE locations (
   id                          text PRIMARY KEY,
-  name                        text NOT NULL UNIQUE,
+  name                        text NOT NULL,
   type                        location_type NOT NULL,
-  iso_alpha3                  text UNIQUE,
+  iso_alpha3                  text,
   funding_account_id          text,
   default_field_region_id     text,
   default_marketing_region_id text REFERENCES locations(id),
@@ -20,6 +20,14 @@ CREATE TABLE locations (
   updated_at                  timestamptz NOT NULL DEFAULT now(),
   deleted_at                  timestamptz
 );
+
+-- Partial unique indexes: uniqueness only enforced for live (non-soft-deleted) rows,
+-- so a soft-deleted record does not block reuse of its name/iso_alpha3.
+CREATE UNIQUE INDEX "locations_name_active_unique"
+  ON "locations" ("name") WHERE "deleted_at" IS NULL;
+
+CREATE UNIQUE INDEX "locations_iso_alpha3_active_unique"
+  ON "locations" ("iso_alpha3") WHERE "deleted_at" IS NULL;
 
 CREATE INDEX "locations_default_marketing_region_id_idx"
   ON "locations" ("default_marketing_region_id");

--- a/src/core/drizzle/migrations/0003_add_organizations.sql
+++ b/src/core/drizzle/migrations/0003_add_organizations.sql
@@ -7,7 +7,7 @@ CREATE TYPE "sensitivity" AS ENUM ('Low', 'Medium', 'High');
 
 CREATE TABLE "organizations" (
   "id" text PRIMARY KEY,
-  "name" text NOT NULL UNIQUE,
+  "name" text NOT NULL,
   "acronym" text,
   "address" text,
   "types" "organization_type"[] NOT NULL DEFAULT '{}',
@@ -34,6 +34,10 @@ CREATE TABLE "user_organizations" (
   PRIMARY KEY ("user_id", "organization_id")
 );
 --> statement-breakpoint
+
+-- Partial unique index: name uniqueness only enforced for live (non-soft-deleted) rows.
+CREATE UNIQUE INDEX "organizations_name_active_unique"
+  ON "organizations" ("name") WHERE "deleted_at" IS NULL;
 
 -- At most one primary org per user
 CREATE UNIQUE INDEX "user_organizations_one_primary_per_user"

--- a/src/core/drizzle/migrations/0003_add_organizations.sql
+++ b/src/core/drizzle/migrations/0003_add_organizations.sql
@@ -1,0 +1,45 @@
+-- Migration: add organizations, organization_locations, and user_organizations tables
+
+CREATE TYPE "organization_type" AS ENUM ('Church', 'Parachurch', 'Mission', 'Translation', 'Alliance');
+CREATE TYPE "organization_reach" AS ENUM ('Local', 'Regional', 'National', 'Global');
+CREATE TYPE "sensitivity" AS ENUM ('Low', 'Medium', 'High');
+--> statement-breakpoint
+
+CREATE TABLE "organizations" (
+  "id" text PRIMARY KEY,
+  "name" text NOT NULL UNIQUE,
+  "acronym" text,
+  "address" text,
+  "types" "organization_type"[] NOT NULL DEFAULT '{}',
+  "reach" "organization_reach"[] NOT NULL DEFAULT '{}',
+  "sensitivity" "sensitivity" NOT NULL DEFAULT 'High',
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  "deleted_at" timestamptz
+);
+--> statement-breakpoint
+
+CREATE TABLE "organization_locations" (
+  "organization_id" text NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+  "location_id" text NOT NULL REFERENCES "locations"("id") ON DELETE CASCADE,
+  PRIMARY KEY ("organization_id", "location_id")
+);
+--> statement-breakpoint
+
+CREATE TABLE "user_organizations" (
+  "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "organization_id" text NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+  "primary" boolean NOT NULL DEFAULT false,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("user_id", "organization_id")
+);
+--> statement-breakpoint
+
+-- At most one primary org per user
+CREATE UNIQUE INDEX "user_organizations_one_primary_per_user"
+  ON "user_organizations" ("user_id")
+  WHERE "primary" = true;
+
+-- FK indexes on the right side of composite PKs (the leftmost column is already covered)
+CREATE INDEX "organization_locations_location_id_idx" ON "organization_locations" ("location_id");
+CREATE INDEX "user_organizations_organization_id_idx" ON "user_organizations" ("organization_id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1746057600000,
       "tag": "0002_add_locations",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1746144000000,
+      "tag": "0003_add_organizations",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -257,9 +257,9 @@ export const locations = pgTable(
   'locations',
   {
     id: text('id').$type<ID<'Location'>>().primaryKey(),
-    name: text('name').notNull().unique(),
+    name: text('name').notNull(),
     type: locationTypeEnum('type').$type<LocationType>().notNull(),
-    isoAlpha3: text('iso_alpha3').unique(),
+    isoAlpha3: text('iso_alpha3'),
     // migration-todo: add FK constraints once FundingAccount and FieldRegion are migrated to PG
     fundingAccountId: text('funding_account_id').$type<ID<'FundingAccount'>>(),
     defaultFieldRegionId: text('default_field_region_id').$type<
@@ -278,6 +278,14 @@ export const locations = pgTable(
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
   },
   (t) => [
+    // Partial unique indexes scoped to live rows so soft-deleted records
+    // don't block reuse of their name / iso_alpha3.
+    uniqueIndex('locations_name_active_unique')
+      .on(t.name)
+      .where(sql`${t.deletedAt} IS NULL`),
+    uniqueIndex('locations_iso_alpha3_active_unique')
+      .on(t.isoAlpha3)
+      .where(sql`${t.deletedAt} IS NULL`),
     index('locations_default_marketing_region_id_idx').on(
       t.defaultMarketingRegionId,
     ),
@@ -305,32 +313,42 @@ export const organizationReachEnum = pgEnum('organization_reach', [
 
 export const sensitivityEnum = pgEnum('sensitivity', ['Low', 'Medium', 'High']);
 
-export const organizations = pgTable('organizations', {
-  id: text('id').$type<ID<'Organization'>>().primaryKey(),
-  name: text('name').notNull().unique(),
-  acronym: text('acronym'),
-  address: text('address'),
-  types: organizationTypeEnum('types')
-    .array()
-    .$type<readonly OrganizationType[]>()
-    .notNull()
-    .default([]),
-  reach: organizationReachEnum('reach')
-    .array()
-    .$type<readonly OrganizationReach[]>()
-    .notNull()
-    .default([]),
-  // migration-todo: keep current via hooks once Project/Partnership migrate;
-  // currently always 'High' since no project linkage exists in PG yet.
-  sensitivity: sensitivityEnum('sensitivity').notNull().default('High'),
-  createdAt: timestamp('created_at', { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  updatedAt: timestamp('updated_at', { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  deletedAt: timestamp('deleted_at', { withTimezone: true }),
-});
+export const organizations = pgTable(
+  'organizations',
+  {
+    id: text('id').$type<ID<'Organization'>>().primaryKey(),
+    name: text('name').notNull(),
+    acronym: text('acronym'),
+    address: text('address'),
+    types: organizationTypeEnum('types')
+      .array()
+      .$type<readonly OrganizationType[]>()
+      .notNull()
+      .default([]),
+    reach: organizationReachEnum('reach')
+      .array()
+      .$type<readonly OrganizationReach[]>()
+      .notNull()
+      .default([]),
+    // migration-todo: keep current via hooks once Project/Partnership migrate;
+    // currently always 'High' since no project linkage exists in PG yet.
+    sensitivity: sensitivityEnum('sensitivity').notNull().default('High'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    // Partial unique index scoped to live rows so soft-deleted records
+    // don't block reuse of their name.
+    uniqueIndex('organizations_name_active_unique')
+      .on(t.name)
+      .where(sql`${t.deletedAt} IS NULL`),
+  ],
+);
 
 export const organizationLocations = pgTable(
   'organization_locations',

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -9,9 +9,12 @@ import {
   primaryKey,
   text,
   timestamp,
+  uniqueIndex,
 } from 'drizzle-orm/pg-core';
 import { type ID, type Role } from '~/common';
 import { type LocationType } from '../../../components/location/dto/location-type.enum';
+import { type OrganizationReach } from '../../../components/organization/dto/organization-reach.dto';
+import { type OrganizationType } from '../../../components/organization/dto/organization-type.dto';
 import { type Gender } from '../../../components/user/dto/gender.enum';
 
 export const userStatusEnum = pgEnum('user_status', ['Active', 'Disabled']);
@@ -282,3 +285,125 @@ export const locations = pgTable(
 );
 
 export const locationsRelations = relations(locations, () => ({}));
+
+// ─── Organizations ─────────────────────────────────────────────────────────
+
+export const organizationTypeEnum = pgEnum('organization_type', [
+  'Church',
+  'Parachurch',
+  'Mission',
+  'Translation',
+  'Alliance',
+]);
+
+export const organizationReachEnum = pgEnum('organization_reach', [
+  'Local',
+  'Regional',
+  'National',
+  'Global',
+]);
+
+export const sensitivityEnum = pgEnum('sensitivity', ['Low', 'Medium', 'High']);
+
+export const organizations = pgTable('organizations', {
+  id: text('id').$type<ID<'Organization'>>().primaryKey(),
+  name: text('name').notNull().unique(),
+  acronym: text('acronym'),
+  address: text('address'),
+  types: organizationTypeEnum('types')
+    .array()
+    .$type<readonly OrganizationType[]>()
+    .notNull()
+    .default([]),
+  reach: organizationReachEnum('reach')
+    .array()
+    .$type<readonly OrganizationReach[]>()
+    .notNull()
+    .default([]),
+  // migration-todo: keep current via hooks once Project/Partnership migrate;
+  // currently always 'High' since no project linkage exists in PG yet.
+  sensitivity: sensitivityEnum('sensitivity').notNull().default('High'),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  deletedAt: timestamp('deleted_at', { withTimezone: true }),
+});
+
+export const organizationLocations = pgTable(
+  'organization_locations',
+  {
+    organizationId: text('organization_id')
+      .$type<ID<'Organization'>>()
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    locationId: text('location_id')
+      .$type<ID<'Location'>>()
+      .notNull()
+      .references(() => locations.id, { onDelete: 'cascade' }),
+  },
+  (t) => [
+    primaryKey({ columns: [t.organizationId, t.locationId] }),
+    index('organization_locations_location_id_idx').on(t.locationId),
+  ],
+);
+
+export const userOrganizations = pgTable(
+  'user_organizations',
+  {
+    userId: text('user_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    organizationId: text('organization_id')
+      .$type<ID<'Organization'>>()
+      .notNull()
+      .references(() => organizations.id, { onDelete: 'cascade' }),
+    primary: boolean('primary').notNull().default(false),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.userId, t.organizationId] }),
+    index('user_organizations_organization_id_idx').on(t.organizationId),
+    uniqueIndex('user_organizations_one_primary_per_user')
+      .on(t.userId)
+      .where(sql`${t.primary} = true`),
+  ],
+);
+
+export const organizationsRelations = relations(organizations, ({ many }) => ({
+  locations: many(organizationLocations),
+  users: many(userOrganizations),
+}));
+
+export const organizationLocationsRelations = relations(
+  organizationLocations,
+  ({ one }) => ({
+    organization: one(organizations, {
+      fields: [organizationLocations.organizationId],
+      references: [organizations.id],
+    }),
+    location: one(locations, {
+      fields: [organizationLocations.locationId],
+      references: [locations.id],
+    }),
+  }),
+);
+
+export const userOrganizationsRelations = relations(
+  userOrganizations,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [userOrganizations.userId],
+      references: [users.id],
+    }),
+    organization: one(organizations, {
+      fields: [userOrganizations.organizationId],
+      references: [organizations.id],
+    }),
+  }),
+);


### PR DESCRIPTION
## Summary

Third PostgreSQL port. Adds the `organizations` table plus its M:N join tables (`organization_locations`, `user_organizations`) and ports `OrganizationRepository` to Drizzle. Stacks on `location-pg` (which itself stacks on the merged `users-pg`).

Engine routing via `splitDb()`; Neo4j and Gel paths unchanged.

## Schema (DDL)

```sql
CREATE TYPE "organization_type" AS ENUM ('Church', 'Parachurch', 'Mission', 'Translation', 'Alliance');
CREATE TYPE "organization_reach" AS ENUM ('Local', 'Regional', 'National', 'Global');
CREATE TYPE "sensitivity"        AS ENUM ('Low', 'Medium', 'High');

CREATE TABLE "organizations" (
  "id"          text PRIMARY KEY,
  "name"        text NOT NULL UNIQUE,
  "acronym"     text,
  "address"     text,
  "types"       "organization_type"[]  NOT NULL DEFAULT '{}',
  "reach"       "organization_reach"[] NOT NULL DEFAULT '{}',
  "sensitivity" "sensitivity"          NOT NULL DEFAULT 'High',
  "created_at"  timestamptz NOT NULL DEFAULT now(),
  "updated_at"  timestamptz NOT NULL DEFAULT now(),
  "deleted_at"  timestamptz
);

CREATE TABLE "organization_locations" (
  "organization_id" text NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
  "location_id"     text NOT NULL REFERENCES "locations"("id")     ON DELETE CASCADE,
  PRIMARY KEY ("organization_id", "location_id")
);
CREATE INDEX "organization_locations_location_id_idx"
  ON "organization_locations" ("location_id");

CREATE TABLE "user_organizations" (
  "user_id"         text NOT NULL REFERENCES "users"("id")         ON DELETE CASCADE,
  "organization_id" text NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
  "primary"         boolean NOT NULL DEFAULT false,
  "created_at"      timestamptz NOT NULL DEFAULT now(),
  PRIMARY KEY ("user_id", "organization_id")
);
CREATE INDEX "user_organizations_organization_id_idx"
  ON "user_organizations" ("organization_id");

-- At most one primary org per user
CREATE UNIQUE INDEX "user_organizations_one_primary_per_user"
  ON "user_organizations" ("user_id")
  WHERE "primary" = true;
```

## Design decisions

### `organization_type`, `organization_reach`, `sensitivity` are `pgEnum`

All three are closed sets owned by application code that don't change frequently. pgEnum gives DB-side validity and pairs with `$type<OrganizationType>()` / `$type<OrganizationReach>()` branding so reads come back already typed. (Same call as `location_type` and `gender` on prior PRs; same call as `roles` going the other way — `roles` is `text[]` because the Role set evolves often.)

### `types` and `reach` are `pgEnum[]` arrays

An organization can simultaneously be e.g. both Church and Parachurch, and have Local + Regional reach. Kept as denormalized arrays on the row instead of join tables — the cardinality is tiny and we never query "which orgs have type X" through a join.

### `sensitivity` defaults to `'High'`

In Neo4j, sensitivity is derived from the highest-sensitivity Project the org is linked to. Project hasn't ported to PG yet, so there's no linkage to derive from. Defaulting to `'High'` is conservative — if we don't know, treat it as restricted. A `migration-todo` flags the column to be hook-driven once Project lands.

### M:N join tables instead of array columns for relationships

`organization_locations` and `user_organizations` are first-class tables with a composite primary key. Reasons:
- They carry side data (`primary`, `created_at` on `user_organizations`).
- They support symmetric queries from both sides ("orgs for user X" and "users for org Y").
- `ON DELETE CASCADE` cleanly cleans up join rows when either parent is deleted.

### Partial unique index for "one primary org per user"

```sql
CREATE UNIQUE INDEX user_organizations_one_primary_per_user
  ON user_organizations (user_id) WHERE primary = true;
```

A row-level CHECK can't enforce this (it's a cross-row constraint). A regular UNIQUE on `(user_id, primary)` would only prevent two rows where `primary = true` AND would block multiple `primary = false` rows. The partial index does exactly the right thing — at most one row matching `primary = true` per `user_id`, no constraint on the false rows.

### FK indexes on the right-hand-side of composite PKs

A composite PK `(a, b)` already indexes `a` (and any prefix), but **not** `b` alone. So queries like `WHERE location_id = $1` against `organization_locations` would seq-scan without `organization_locations_location_id_idx`. Same for `WHERE organization_id = $1` against `user_organizations`. Postgres won't auto-create these.

### `list()` filter for `userId` uses a `selectDistinct` subquery

```ts
const userOrgSubq = this.db
  .select({ orgId: userOrganizations.organizationId })
  .from(userOrganizations)
  .where(eq(userOrganizations.userId, input.filter.userId));
conditions.push(inArray(organizations.id, userOrgSubq));
```

Drizzle's filter DSL doesn't yet express "row exists in M:N join" cleanly. The subquery is straightforward, planner-friendly, and matches what the Neo4j path does.

### Schema columns branded with `$type<>()`

- `id: text('id').$type<ID<'Organization'>>().primaryKey()`
- `types: organizationTypeEnum('types').array().$type<readonly OrganizationType[]>()`
- Same for `reach`, FK columns, etc.

`toDto` has zero `as ID` casts; row data lands as the domain shape directly.

### Reuses cleanup helpers from `users-pg`

- `escapeLikePattern(value)` for the name ILIKE filter
- `resolveOrderBy(input, sortMap, fallback)` + `SortMap<keyof Organization>`
- `EnhancedResource.of(Organization)` cached as a `private readonly resource` field

### `splitDb` Drizzle slot uses `as any`

Same pattern as the prior ports. Gel repos satisfy `PublicOf<XRepository>` because `RepoFor` extends `CommonRepository` which mirrors the Neo4j surface; `DrizzleDtoRepository` deliberately omits all that. Cast at module wiring is the line; tracked with `migration-todo`.

### Service-repo boundary: `deleteNode` → `delete`

Drizzle repo defines `delete(id: ID)` (calls `softDelete`). Neo4j repo gets a `delete(id)` shim that forwards to `deleteNode(id)`. Service updated to call `repo.delete(id)`. Matches the rename already landed for User, Unavailability, and Location.

### Soft-delete-safe uniqueness

- Dropped inline `UNIQUE` on `locations.name`, `locations.iso_alpha3`, and `organizations.name` in migrations `0002` / `0003` and in the Drizzle schema.
- Added partial unique indexes — `locations_name_active_unique`, `locations_iso_alpha3_active_unique`, `organizations_name_active_unique` — each scoped to `WHERE deleted_at IS NULL`. Soft-deleted rows no longer block reuse of their name / ISO code.
- Index names keep the column as a substring so `catchUniqueViolation('name', …)` / `catchUniqueViolation('iso_alpha3', …)` still translate PG 23505 errors into `DuplicateException` correctly.


## Deferred items

- `sensitivity` derivation from Project — currently always `'High'`. Hook-driven once Project ports to PG.
- Hooks-driven recomputation of `sensitivity` on Partnership / Project linkage changes — same reason.
- `splitDb` `as any` cast — until `PublicOf` accepts Drizzle repos cleanly (separate cleanup PR).


Fixes #3731 