### PR TITLE
Fixes bugs in webhook validator

### DIFF
--- a/src/core/webhooks/webhook.validator.ts
+++ b/src/core/webhooks/webhook.validator.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { JsonSet } from '@seedcompany/common';
 import {
+  assertName,
   type DocumentNode,
   GraphQLError,
   Kind,
@@ -16,6 +17,7 @@ export class WebhookValidator {
 
   async validate(documentStr: string, key?: ID) {
     const { schema, parse, validate } = this.yoga.getEnveloped();
+
     let doc: DocumentNode;
     try {
       doc = parse(documentStr);
@@ -32,37 +34,69 @@ export class WebhookValidator {
       }
       throw e;
     }
+
     const errors: readonly GraphQLError[] = validate(schema, doc);
     if (errors.length > 0) {
       throw Object.assign(new AggregateError(errors), { [SkipLogging]: true });
     }
-    if (doc.definitions[0]?.kind !== 'OperationDefinition') {
+
+    const operationDefinitionNodes = doc.definitions.filter(
+      (definition): definition is OperationDefinitionNode =>
+        definition.kind === 'OperationDefinition',
+    );
+
+    if (operationDefinitionNodes.length === 0) {
       throw new InputException(
-        'Given subscription operation is invalid',
+        'No subscription operation found in the provided document',
         'subscription',
       );
     }
-    if (doc.definitions[0].operation !== 'subscription') {
+
+    if (operationDefinitionNodes.length > 1) {
+      throw new InputException(
+        'Only a single operation of type subscription is allowed per document',
+        'subscription',
+      );
+    }
+
+    const operationDefinitionNode = operationDefinitionNodes[0]!;
+    if (operationDefinitionNode.operation !== 'subscription') {
       throw new InputException(
         'Only subscription operations are valid here',
         'subscription',
       );
     }
 
-    let name = doc.definitions[0].name?.value;
-    if (!name) {
-      if (!key) {
-        throw new InputException(
-          'Webhooks are identified by their subscription operation name or a key. Please provide one.',
-          'subscription',
-        );
-      }
-      name = key;
-      Object.assign(doc.definitions[0], {
-        name: { kind: Kind.NAME, value: key },
+    const name =
+      operationDefinitionNode.name?.value ??
+      this.validateAndGetNodeNameFromKey(key);
+
+    if (!operationDefinitionNode.name) {
+      Object.assign(operationDefinitionNode, {
+        name: { kind: Kind.NAME, value: name },
       } satisfies Pick<OperationDefinitionNode, 'name'>);
     }
 
     return { name, document: doc };
+  }
+
+  private validateAndGetNodeNameFromKey(key: ID | undefined): string {
+    if (!key) {
+      throw new InputException(
+        'Webhooks are identified by their subscription operation name or a key; please provide one.',
+        'subscription',
+      );
+    }
+
+    try {
+      assertName(key);
+    } catch {
+      throw new InputException(
+        'Key must be a valid GraphQL name (letters, digits, underscores; cannot start with a digit)',
+        'key',
+      );
+    }
+
+    return key;
   }
 }

--- a/test/__snapshots__/webhooks.e2e-spec.ts.snap
+++ b/test/__snapshots__/webhooks.e2e-spec.ts.snap
@@ -116,7 +116,39 @@ exports[`Webhooks Management Saving / Creation Subscription Validation should re
     ],
     "field": "subscription",
   },
-  "message": "Webhooks are identified by their subscription operation name or a key. Please provide one.",
+  "message": "Webhooks are identified by their subscription operation name or a key; please provide one.",
+  "path": [
+    "saveWebhook",
+  ],
+}
+`;
+
+exports[`Webhooks Management Saving / Creation Subscription Validation should return validation error when document contains multiple operations 1`] = `
+{
+  "extensions": {
+    "codes": [
+      "Input",
+      "Client",
+    ],
+    "field": "subscription",
+  },
+  "message": "Only a single operation of type subscription is allowed per document",
+  "path": [
+    "saveWebhook",
+  ],
+}
+`;
+
+exports[`Webhooks Management Saving / Creation Subscription Validation should return validation error when key is not a valid GraphQL name 1`] = `
+{
+  "extensions": {
+    "codes": [
+      "Input",
+      "Client",
+    ],
+    "field": "key",
+  },
+  "message": "Key must be a valid GraphQL name (letters, digits, underscores; cannot start with a digit)",
   "path": [
     "saveWebhook",
   ],

--- a/test/webhooks.e2e-spec.ts
+++ b/test/webhooks.e2e-spec.ts
@@ -346,6 +346,72 @@ describe('Webhooks', () => {
           await expect(op).rejects.toMatchSnapshot();
         });
 
+        it('should accept a subscription document with a fragment defined before the operation', async () => {
+          const webhook = await tester.apply(
+            webhooks.save({
+              url: receiver.url,
+              subscription: `
+                fragment projectFields on Project {
+                  id
+                  name { value }
+                }
+                subscription FragmentBeforeOperation {
+                  projectCreated {
+                    project { ...projectFields }
+                  }
+                }
+              `,
+            }),
+          );
+          expect(webhook).toBeDefined();
+        });
+
+        it('should return validation error when document contains multiple operations', async () => {
+          const op = tester.apply(
+            webhooks.save({
+              url: receiver.url,
+              subscription: `
+                subscription FirstSub {
+                  projectCreated {
+                    project { id }
+                  }
+                }
+                subscription SecondSub {
+                  projectDeleted {
+                    projectId
+                  }
+                }
+              `,
+            }),
+          );
+          await expect(op).rejects.toThrowGqlError({
+            code: 'Input',
+            field: 'subscription',
+          });
+          await expect(op).rejects.toMatchSnapshot();
+        });
+
+        it('should return validation error when key is not a valid GraphQL name', async () => {
+          const op = tester.apply(
+            webhooks.save({
+              url: receiver.url,
+              key: 'invalid-key-with-hyphens' as ID,
+              subscription: `
+                subscription {
+                  projectCreated {
+                    project { id }
+                  }
+                }
+              `,
+            }),
+          );
+          await expect(op).rejects.toThrowGqlError({
+            code: 'Input',
+            field: 'key',
+          });
+          await expect(op).rejects.toMatchSnapshot();
+        });
+
         it('should not create webhook when validation fails', async () => {
           const listBefore = await tester.apply(webhooks.list());
           const countBefore = listBefore.items.length;
@@ -368,6 +434,27 @@ describe('Webhooks', () => {
 
           const listAfter = await tester.apply(webhooks.list());
           expect(listAfter.items).toHaveLength(countBefore);
+        });
+
+        it('should inject key as operation name for anonymous subscription, even with preceding fragment', async () => {
+          const webhook = await tester.apply(
+            webhooks.save({
+              url: receiver.url,
+              key: 'SomeKey' as ID,
+              subscription: `
+                fragment projectFields on Project {
+                  id
+                }
+                subscription {
+                  projectCreated {
+                    project { ...projectFields }
+                  }
+                }
+              `,
+            }),
+          );
+          expect(webhook.key).toBe('SomeKey');
+          expect(webhook.subscription).toContain('subscription SomeKey');
         });
       });
 


### PR DESCRIPTION
This pull request enhances the validation logic for webhook subscription documents to ensure stricter adherence to GraphQL standards and clearer error handling. The main improvements include enforcing that only a single subscription operation is allowed per document, validating that the provided key (if used) is a valid GraphQL name, and improving error messages for invalid cases. Additional tests have been added to cover these scenarios.

**Validation logic improvements:**

* Updated `WebhookValidator` to ensure that only a single `subscription` operation is present in the document, and to provide specific error messages when this is not the case.
* Added validation to check that the `key` provided for anonymous subscription operations is a valid GraphQL name, with clear error reporting if it is not.
* Improved error messages for missing or invalid operation names and keys to be more descriptive and actionable. [[1]](diffhunk://#diff-ac51acffe77e5566fdc58d5dc6c3eee591cef6c9402106e90e3358b7b819c186R37-R101) [[2]](diffhunk://#diff-bcdca960ea97800af92ae74d7b45d796e7207e19ff41f34cb5a240b0541c020aL119-R151)

**Testing enhancements:**

* Added new tests to verify that multiple operations in a document, invalid keys, and fragments preceding operations are all handled correctly by the validator. [[1]](diffhunk://#diff-15375bbb9c320ea87ea556af32e87efcafe14cc2b3ed192bb36557407f68c2e6R349-R414) [[2]](diffhunk://#diff-15375bbb9c320ea87ea556af32e87efcafe14cc2b3ed192bb36557407f68c2e6R438-R458)
* Updated test snapshots to reflect the improved error messages and validation logic.

**Dependency and code organization:**

* Imported `assertName` to assist with validating GraphQL names for keys.