### PR TITLE
Add Partner.people 

### DIFF
--- a/src/components/partner/dto/partner-people-list.dto.ts
+++ b/src/components/partner/dto/partner-people-list.dto.ts
@@ -1,0 +1,13 @@
+import { InputType } from '@nestjs/graphql';
+import { FilterField, SortablePaginationInput } from '~/common';
+import { type User, UserFilters } from '../../user/dto';
+
+@InputType()
+export class PartnerPeopleListInput extends SortablePaginationInput<
+  keyof User | 'fullName'
+>({
+  defaultSort: 'fullName',
+}) {
+  @FilterField(() => UserFilters)
+  readonly filter?: UserFilters & {};
+}

--- a/src/components/partner/partner.resolver.ts
+++ b/src/components/partner/partner.resolver.ts
@@ -34,7 +34,7 @@ import { PartnerLoader, PartnerService } from '../partner';
 import { ProjectLoader } from '../project';
 import { ProjectListInput, SecuredProjectList } from '../project/dto';
 import { UserLoader } from '../user';
-import { SecuredUser } from '../user/dto';
+import { SecuredUser, SecuredUserList } from '../user/dto';
 import {
   CreatePartner,
   Partner,
@@ -45,6 +45,7 @@ import {
   PartnerUpdated,
   UpdatePartner,
 } from './dto';
+import { PartnerPeopleListInput } from './dto/partner-people-list.dto';
 
 @Resolver(Partner)
 export class PartnerResolver {
@@ -184,6 +185,20 @@ export class PartnerResolver {
   ): Promise<EngagementListOutput> {
     const list = await this.partnerService.listEngagements(partner, input);
     loader.primeAll(list.items);
+    return list;
+  }
+
+  @ResolveField(() => SecuredUserList, {
+    description:
+      'Users associated with the partner via organization membership.',
+  })
+  async people(
+    @Parent() partner: Partner,
+    @ListArg(PartnerPeopleListInput) input: PartnerPeopleListInput,
+    @Loader(UserLoader) users: LoaderOf<UserLoader>,
+  ): Promise<SecuredUserList> {
+    const list = await this.partnerService.listPeople(partner, input);
+    users.primeAll(list.items);
     return list;
   }
 

--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -26,6 +26,8 @@ import {
   type ProjectListInput,
   type SecuredProjectList,
 } from '../project/dto';
+import { UserService } from '../user';
+import { type SecuredUserList } from '../user/dto';
 import {
   type CreatePartner,
   Partner,
@@ -34,6 +36,7 @@ import {
   PartnerType,
   type UpdatePartner,
 } from './dto';
+import { type PartnerPeopleListInput } from './dto/partner-people-list.dto';
 import { PartnerRepository } from './partner.repository';
 
 @Injectable()
@@ -46,6 +49,8 @@ export class PartnerService {
     private readonly engagementService: EngagementService & {},
     @Inject(forwardRef(() => LanguageService))
     private readonly languageService: LanguageService & {},
+    @Inject(forwardRef(() => UserService))
+    private readonly userService: UserService & {},
     private readonly repo: PartnerRepository,
     private readonly resourceLoader: ResourceLoader,
   ) {}
@@ -204,6 +209,27 @@ export class PartnerService {
       ...input,
       filter: { ...input.filter, partnerId: partner.id },
     });
+  }
+
+  async listPeople(
+    partner: Partner,
+    input: PartnerPeopleListInput,
+  ): Promise<SecuredUserList> {
+    const partnerPrivileges = this.privileges.for(Partner, partner);
+
+    const users = await this.userService.list({
+      ...input,
+      filter: {
+        ...input.filter,
+        partnerId: partner.id,
+      },
+    });
+
+    return {
+      ...users,
+      canRead: true,
+      canCreate: partnerPrivileges.can('edit', 'pointOfContact'),
+    };
   }
 
   protected verifyFinancialReportingType(

--- a/src/components/user/dto/list-users.dto.ts
+++ b/src/components/user/dto/list-users.dto.ts
@@ -7,6 +7,7 @@ import {
   OptionalField,
   PaginatedList,
   Role,
+  SecuredList,
   SortablePaginationInput,
 } from '~/common';
 import { UserStatus } from './user-status.enum';
@@ -16,6 +17,8 @@ import { User } from './user.dto';
 export abstract class UserFilters {
   @IdField({ optional: true })
   readonly id?: ID<'User'>;
+
+  readonly partnerId?: ID<'Partner'>;
 
   @OptionalField()
   readonly name?: string;
@@ -39,8 +42,10 @@ export abstract class UserFilters {
 }
 
 @InputType()
-export class UserListInput extends SortablePaginationInput<keyof User>({
-  defaultSort: 'id', // TODO How to sort on name?
+export class UserListInput extends SortablePaginationInput<
+  keyof User | 'fullName'
+>({
+  defaultSort: 'id',
 }) {
   @FilterField(() => UserFilters)
   readonly filter?: UserFilters;
@@ -48,3 +53,8 @@ export class UserListInput extends SortablePaginationInput<keyof User>({
 
 @ObjectType()
 export class UserListOutput extends PaginatedList(User) {}
+
+@ObjectType({
+  description: SecuredList.descriptionFor('users'),
+})
+export abstract class SecuredUserList extends SecuredList(User) {}

--- a/src/components/user/user.repository.ts
+++ b/src/components/user/user.repository.ts
@@ -435,6 +435,13 @@ export const userFilters = filter.define(() => UserFilters, {
   id: filter.baseNodeProp(),
   pinned: filter.isPinned,
   status: filter.propVal(),
+  partnerId: filter.pathExists((id) => [
+    node('node'),
+    relation('out', '', 'organization', ACTIVE),
+    node('', 'Organization'),
+    relation('in', '', 'organization', ACTIVE),
+    node('', 'Partner', { id }),
+  ]),
   name: filter.fullText({
     index: () => NameIndex,
     matchToNode: (q) =>

--- a/test/partner.e2e-spec.ts
+++ b/test/partner.e2e-spec.ts
@@ -180,4 +180,64 @@ describe('Partner e2e', () => {
       }),
     );
   });
+
+  it('lists people on a partner via organization membership', async () => {
+    const org = await createOrganization(app);
+    const poc = await createPerson(app);
+    const partner = await createPartner(app, {
+      organization: org.id,
+      pointOfContact: poc.id,
+    });
+
+    const otherUser = await createPerson(app);
+    await runAsAdmin(app, async () => {
+      await app.graphql.mutate(AssignOrgToUserDoc, {
+        org: org.id,
+        user: otherUser.id,
+      });
+      await app.graphql.mutate(AssignOrgToUserDoc, {
+        org: org.id,
+        user: poc.id,
+      });
+    });
+
+    const result = await app.graphql.query(
+      graphql(`
+        query partnerPeople($id: ID!) {
+          partner(id: $id) {
+            pointOfContact {
+              value {
+                id
+              }
+            }
+            people(input: { count: 25 }) {
+              canRead
+              canCreate
+              total
+              hasMore
+              items {
+                id
+              }
+            }
+          }
+        }
+      `),
+      { id: partner.id },
+    );
+
+    const list = result.partner.people;
+    expect(list.canRead).toBe(true);
+    expect(list.total).toBeGreaterThanOrEqual(2);
+    const userIds = list.items.map((u) => u.id);
+    expect(userIds).toEqual(expect.arrayContaining([poc.id, otherUser.id]));
+    expect(result.partner.pointOfContact.value?.id).toBe(poc.id);
+  });
 });
+
+const AssignOrgToUserDoc = graphql(`
+  mutation assignOrgToUserForPartnerPeople($org: ID!, $user: ID!) {
+    assignOrganizationToUser(org: $org, user: $user) {
+      __typename
+    }
+  }
+`);


### PR DESCRIPTION
## Summary

Adds a paginated, sortable, filterable list of users associated with a Partner to back the "People" DataGrid on the cord-field partner detail page. Today the page only shows a single Point-of-Contact card; this exposes the full list. Items are bare `User` (no row wrapper); the POC chip is rendered FE-side by comparing `user.id` against `partner.pointOfContact.value.id` on the same query. POC modeling is unchanged.

## Schema

```graphql
extend type Partner {
  people(input: PartnerPeopleListInput): SecuredUserList!
}

input PartnerPeopleListInput {
  count: Int          # default 25
  page: Int
  sort: String        # default "fullName"
  order: Order
  filter: UserFilters
}

# new — extends SecuredList(User)
type SecuredUserList {
  canRead: Boolean!
  canCreate: Boolean!
  total: Int!
  hasMore: Boolean!
  items: [User!]!
}
```

The resolver delegates to `PartnerService.listPeople()`, which calls `userService.list({ filter: { partnerId } })`. The new `partnerId` filter on `UserFilters` walks `User → Organization ← Partner` via active org-membership edges (symmetric to the existing `userId` filter on `PartnerFilters`).

## Design decisions

### Items are `User`, not a row wrapper

- **What:** `Partner.people` returns `SecuredUserList!` with bare `User` items, not a `PartnerPerson { user, isPointOfContact }` wrapper.
- **Why:** FE wants raw user fields and intuitive sort keys (`sort: "fullName"` works out of the box). Wrapping forces `row.user.field.value` access and breaks nested sorting via Cypher.
- **Tradeoff:** FE does one ID comparison per row to render the POC chip. Negligible cost; POC info is on `Partner.pointOfContact` already.

### Derived from organization membership, not a new join entity

- **What:** The list is computed by walking the existing User↔Organization↔Partner relationship; no new `PartnerMember` table or DTO.
- **Why:** A first-class membership entity would mean new Neo4j/Gel/Drizzle repos, filter sub-delegation, and data-migration work mid PG-migration. The brief doesn't require per-edge metadata (role, title, etc.) yet.
- **Deferred until:** product needs partner-specific role metadata. At that point, the field shape stays the same; the underlying derivation evolves.

### `Partner.pointOfContact` is unchanged

- **What:** Existing single-POC field stays as `SecuredUser`. POC is exposed in `Partner.people` only as a derivable flag (FE-side ID compare).
- **Why:** Folding POC into a role enum requires the membership entity above. Keeping it where it is means zero migration cost and no breaking change to the existing single-POC card.

### No new mutations

- **What:** Add = `assignOrganizationToUser`. Remove = `removeOrganizationFromUser`. Set POC = `updatePartner({ pointOfContactId })`.
- **Why:** New partner-scoped wrappers would imply a new join. The org-level mutations are the right primitive given the derivation rule.

### Default sort is `fullName`

- **What:** `PartnerPeopleListInput` sets `defaultSort: 'fullName'`. FE doesn't need to specify sort for the common case.
- **Why:** The DataGrid renders by name; default should match.
- **Side effect:** Widened `UserListInput` sort space from `keyof User` to `keyof User | 'fullName'`. `userSorters` already supported `fullName` at runtime — the type was just narrower than reality. Any caller of `users(input:)` can now sort by `fullName` without a cast.

### `PartnerPeopleListInput` is not in the `partner/dto` barrel

- **What:** Imported directly from `./dto/partner-people-list.dto` in the resolver and service; not re-exported from `partner/dto/index.ts`.
- **Why:** Adding it to the barrel created a `User`↔`Partner` module cycle. `user.dto` imports `Partner` from `partner/dto`; the barrel re-entering via the new input left `User` in TDZ during `emitDecoratorMetadata`. `ProjectMember.dto` solves the same problem the same way.

### `canCreate` mirrors `Partner.pointOfContact` edit perm

- **What:** `canCreate` on the list is `partnerPrivileges.can('edit', 'pointOfContact')`.
- **Why:** Approximation. The actual Add op is `assignOrganizationToUser`, which has its own perm model. Refine once product confirms which role gates "Add Person."
- **Open thread:** want a real check tied to the org-member-assign perm.

## Deferred

### `partnerId` filter on `UserDrizzleRepository.list()`

- **Where:** `src/components/user/user.drizzle.repository.ts` — `list()` builds `conditions: SQL[]` from `input.filter`. Today it silently ignores `partnerId`.
- **Behavior:** Drizzle path returns all users when `partnerId` is set (no narrowing). Production runs Neo4j until cutover, so this is unreachable in prod.
- **Resolved when:** Partner domain is migrated to Postgres.
- **Why deferred:** Cross-domain filters can't be implemented until both domains are migrated. Consistent with the existing pattern (e.g., `userId` filter on Partner is also Neo4j-only).

### `partnerId` filter on `UserGelRepository.listFilters()`

- **Where:** `src/components/user/user.gel.repository.ts` — `listFilters()` returns an array of filter expressions. Today it has no `partnerId` branch.
- **Behavior:** Gel path silently ignores the filter.
- **Resolved when:** cross-domain filters on Gel are formally supported, or when Partner ports to Gel.
- **Why deferred:** Same pattern as above; no callers in prod since `DATABASE=neo4j`.

### Per-row `canDelete`

- **Where:** Returned `User` items don't carry a per-row Remove perm.
- **Behavior:** FE uses `canCreate` on the list as the heuristic for showing the Remove button. Auth errors on Remove fall through to the existing error-handling path.
- **Resolved when:** product confirms whether Remove should be gated separately from Add (e.g., self-removal vs. admin-removal).
- **Why deferred:** Modeling per-row perms requires a new resolve-field on User that knows about the partner context — non-trivial wiring for a guess at the perm semantics.

### Server-side `isPointOfContact` filter

- **Where:** `PartnerPeopleListInput.filter` is just `UserFilters`; no `isPointOfContact` field.
- **Behavior:** FE renders the chip per row from `user.id === partner.pointOfContact.value?.id`; no server-side toggle.
- **Resolved when:** a "POC only" tab or filter chip ships in the FE.
- **Why deferred:** Implementing `false` (exclude POC) without a "not id" filter on User would break pagination semantics. The flag is per-row; client-side filtering covers v1.
