### PR TITLE
#8 [pg] Field Region/Zone Migration

### DIFF
--- a/src/components/authorization/policy/executor/policy-executor.ts
+++ b/src/components/authorization/policy/executor/policy-executor.ts
@@ -180,6 +180,18 @@ export class PolicyExecutor {
     return perm.asDrizzleCondition(other);
   }
 
+  /**
+   * Resolve the read-policy filter for `resource` and push any resulting
+   * `SQL` clause into `conditions`. Returns `false` when access is denied —
+   * caller should short-circuit (typically by returning an empty page).
+   */
+  applyReadFilter(resource: EnhancedResource<any>, conditions: SQL[]): boolean {
+    const filter = this.drizzleFilter({ action: 'read', resource });
+    if (filter === false) return false;
+    if (filter !== true) conditions.push(filter);
+    return true;
+  }
+
   cypherFilter({
     wrapContext = identity,
     wrapConditions = identity,

--- a/src/components/authorization/policy/policy.module.ts
+++ b/src/components/authorization/policy/policy.module.ts
@@ -26,6 +26,6 @@ import { PolicyFactory } from './policy.factory';
     VariantAndExpUnionOptimizer,
     FlattenAggregateOptimizer,
   ],
-  exports: [Privileges, GelAccessPolicyGenerator],
+  exports: [Privileges, GelAccessPolicyGenerator, PolicyExecutor],
 })
 export class PolicyModule {}

--- a/src/components/field-region/field-region.drizzle.repository.ts
+++ b/src/components/field-region/field-region.drizzle.repository.ts
@@ -1,0 +1,153 @@
+import { Injectable } from '@nestjs/common';
+import { and, eq, ilike, isNull, type SQL } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  generateId,
+  type ID,
+  type PaginatedListType,
+  type UnsecuredDto,
+} from '~/common';
+import {
+  catchUniqueViolation,
+  DrizzleDtoRepository,
+  EMPTY_PAGE,
+  escapeLikePattern,
+  resolveOrderBy,
+  type SortMap,
+  subFilter,
+} from '~/core/drizzle';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { fieldRegions, fieldZones, users } from '~/core/drizzle/schema';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import { fieldZoneFilterClauses } from '../field-zone/field-zone.drizzle.repository';
+import { userFilterClauses } from '../user/user.drizzle.repository';
+import {
+  type CreateFieldRegion,
+  FieldRegion,
+  type FieldRegionListInput,
+  type UpdateFieldRegion,
+} from './dto';
+
+const catchNameUnique = catchUniqueViolation(
+  'name',
+  'name',
+  'FieldRegion with this name already exists.',
+);
+
+@Injectable()
+export class FieldRegionDrizzleRepository extends DrizzleDtoRepository<
+  typeof fieldRegions,
+  FieldRegion
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+  ) {
+    super(db, fieldRegions, FieldRegion);
+  }
+
+  async create(input: CreateFieldRegion): Promise<UnsecuredDto<FieldRegion>> {
+    const id = await generateId();
+    await this.db
+      .insert(fieldRegions)
+      .values({
+        id,
+        name: input.name,
+        fieldZoneId: input.fieldZone,
+        directorId: input.director,
+      })
+      .catch(catchNameUnique);
+    return await this.readOne(id);
+  }
+
+  async update(changes: UpdateFieldRegion): Promise<UnsecuredDto<FieldRegion>> {
+    const { id, fieldZone, director, ...fields } = changes;
+    await this.updateColumns(id, {
+      name: fields.name,
+      fieldZoneId: fieldZone,
+      directorId: director,
+    }).catch(catchNameUnique);
+    return await this.readOne(id);
+  }
+
+  async delete(id: ID): Promise<void> {
+    await this.softDelete(id);
+  }
+
+  async list(
+    input: FieldRegionListInput,
+  ): Promise<PaginatedListType<UnsecuredDto<FieldRegion>>> {
+    const conditions: SQL[] = [isNull(fieldRegions.deletedAt)];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+
+    if (input.filter?.name) {
+      conditions.push(
+        ilike(fieldRegions.name, `%${escapeLikePattern(input.filter.name)}%`),
+      );
+    }
+    if (input.filter?.director) {
+      conditions.push(
+        subFilter(
+          this.db,
+          fieldRegions.directorId,
+          users,
+          userFilterClauses(this.db, input.filter.director),
+        ),
+      );
+    }
+    if (input.filter?.fieldZone) {
+      conditions.push(
+        subFilter(
+          this.db,
+          fieldRegions.fieldZoneId,
+          fieldZones,
+          fieldZoneFilterClauses(this.db, input.filter.fieldZone),
+        ),
+      );
+    }
+
+    const sortColumns = {
+      name: fieldRegions.name,
+      createdAt: fieldRegions.createdAt,
+    } satisfies SortMap<keyof FieldRegion>;
+
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: and(...conditions),
+      orderBy: resolveOrderBy(input, sortColumns, fieldRegions.name),
+      page: input.page,
+      count: input.count,
+    });
+    return {
+      total,
+      items: rows.map((row) => this.toDto(row)),
+      hasMore,
+    };
+  }
+
+  async readAllByDirector(
+    id: ID<'User'>,
+  ): Promise<ReadonlyArray<UnsecuredDto<FieldRegion>>> {
+    const rows = await this.db
+      .select()
+      .from(fieldRegions)
+      .where(
+        and(eq(fieldRegions.directorId, id), isNull(fieldRegions.deletedAt)),
+      );
+    return rows.map((row) => this.toDto(row));
+  }
+
+  protected toDto(
+    row: typeof fieldRegions.$inferSelect,
+  ): UnsecuredDto<FieldRegion> {
+    return {
+      id: row.id,
+      __typename: 'FieldRegion',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      name: row.name,
+      fieldZone: { id: row.fieldZoneId },
+      director: { id: row.directorId },
+    };
+  }
+}

--- a/src/components/field-region/field-region.drizzle.repository.ts
+++ b/src/components/field-region/field-region.drizzle.repository.ts
@@ -16,7 +16,7 @@ import {
   type SortMap,
   subFilter,
 } from '~/core/drizzle';
-import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
 import { fieldRegions, fieldZones, users } from '~/core/drizzle/schema';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import { fieldZoneFilterClauses } from '../field-zone/field-zone.drizzle.repository';
@@ -24,6 +24,7 @@ import { userFilterClauses } from '../user/user.drizzle.repository';
 import {
   type CreateFieldRegion,
   FieldRegion,
+  type FieldRegionFilters,
   type FieldRegionListInput,
   type UpdateFieldRegion,
 } from './dto';
@@ -82,31 +83,7 @@ export class FieldRegionDrizzleRepository extends DrizzleDtoRepository<
       return EMPTY_PAGE;
     }
 
-    if (input.filter?.name) {
-      conditions.push(
-        ilike(fieldRegions.name, `%${escapeLikePattern(input.filter.name)}%`),
-      );
-    }
-    if (input.filter?.director) {
-      conditions.push(
-        subFilter(
-          this.db,
-          fieldRegions.directorId,
-          users,
-          userFilterClauses(this.db, input.filter.director),
-        ),
-      );
-    }
-    if (input.filter?.fieldZone) {
-      conditions.push(
-        subFilter(
-          this.db,
-          fieldRegions.fieldZoneId,
-          fieldZones,
-          fieldZoneFilterClauses(this.db, input.filter.fieldZone),
-        ),
-      );
-    }
+    conditions.push(...fieldRegionFilterClauses(this.db, input.filter));
 
     const sortColumns = {
       name: fieldRegions.name,
@@ -151,3 +128,42 @@ export class FieldRegionDrizzleRepository extends DrizzleDtoRepository<
     };
   }
 }
+
+/**
+ * Build the column-level WHERE clauses for a `FieldRegionFilters` input against
+ * the `field_regions` table. Reusable from sub-filters in other domains
+ * (e.g. Project's `fieldRegion` filter).
+ */
+export const fieldRegionFilterClauses = (
+  db: DrizzleDb,
+  filter: FieldRegionFilters | undefined,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+  if (filter.name) {
+    conditions.push(
+      ilike(fieldRegions.name, `%${escapeLikePattern(filter.name)}%`),
+    );
+  }
+  if (filter.director) {
+    conditions.push(
+      subFilter(
+        db,
+        fieldRegions.directorId,
+        users,
+        userFilterClauses(db, filter.director),
+      ),
+    );
+  }
+  if (filter.fieldZone) {
+    conditions.push(
+      subFilter(
+        db,
+        fieldRegions.fieldZoneId,
+        fieldZones,
+        fieldZoneFilterClauses(db, filter.fieldZone),
+      ),
+    );
+  }
+  return conditions;
+};

--- a/src/components/field-region/field-region.module.ts
+++ b/src/components/field-region/field-region.module.ts
@@ -4,6 +4,7 @@ import { AuthorizationModule } from '../authorization/authorization.module';
 import { FieldZoneModule } from '../field-zone/field-zone.module';
 import { ProjectModule } from '../project/project.module';
 import { UserModule } from '../user/user.module';
+import { FieldRegionDrizzleRepository } from './field-region.drizzle.repository';
 import { FieldRegionGelRepository } from './field-region.gel.repository';
 import { FieldRegionLoader } from './field-region.loader';
 import { FieldRegionRepository } from './field-region.repository';
@@ -23,6 +24,8 @@ import { RestrictRegionDirectorRemovalHandler } from './handlers/restrict-region
     FieldRegionService,
     splitDb(FieldRegionRepository, {
       gel: FieldRegionGelRepository,
+      // migration-todo: remove `as any` once splitDb types accept drizzle repos directly
+      postgres: FieldRegionDrizzleRepository as any,
     }),
     FieldRegionLoader,
     RestrictRegionDirectorRemovalHandler,

--- a/src/components/field-zone/field-zone.drizzle.repository.ts
+++ b/src/components/field-zone/field-zone.drizzle.repository.ts
@@ -1,0 +1,149 @@
+import { Injectable } from '@nestjs/common';
+import { and, eq, isNull, type SQL } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  generateId,
+  type ID,
+  type PaginatedListType,
+  type UnsecuredDto,
+} from '~/common';
+import {
+  catchUniqueViolation,
+  DrizzleDtoRepository,
+  EMPTY_PAGE,
+  resolveOrderBy,
+  type SortMap,
+  subFilter,
+} from '~/core/drizzle';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
+import { fieldZones, users } from '~/core/drizzle/schema';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import { userFilterClauses } from '../user/user.drizzle.repository';
+import {
+  type CreateFieldZone,
+  FieldZone,
+  type FieldZoneFilters,
+  type FieldZoneListInput,
+  type UpdateFieldZone,
+} from './dto';
+
+const catchNameUnique = catchUniqueViolation(
+  'name',
+  'name',
+  'FieldZone with this name already exists.',
+);
+
+@Injectable()
+export class FieldZoneDrizzleRepository extends DrizzleDtoRepository<
+  typeof fieldZones,
+  FieldZone
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+  ) {
+    super(db, fieldZones, FieldZone);
+  }
+
+  async create(input: CreateFieldZone): Promise<UnsecuredDto<FieldZone>> {
+    const id = await generateId();
+    await this.db
+      .insert(fieldZones)
+      .values({
+        id,
+        name: input.name,
+        directorId: input.director,
+      })
+      .catch(catchNameUnique);
+    return await this.readOne(id);
+  }
+
+  async update(changes: UpdateFieldZone): Promise<UnsecuredDto<FieldZone>> {
+    const { id, director, ...fields } = changes;
+    await this.updateColumns(id, {
+      name: fields.name,
+      directorId: director,
+    }).catch(catchNameUnique);
+    return await this.readOne(id);
+  }
+
+  async delete(id: ID): Promise<void> {
+    await this.softDelete(id);
+  }
+
+  async list(
+    input: FieldZoneListInput,
+  ): Promise<PaginatedListType<UnsecuredDto<FieldZone>>> {
+    const conditions: SQL[] = [
+      isNull(fieldZones.deletedAt),
+      ...fieldZoneFilterClauses(this.db, input.filter),
+    ];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+
+    const sortColumns = {
+      name: fieldZones.name,
+      createdAt: fieldZones.createdAt,
+    } satisfies SortMap<keyof FieldZone>;
+
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: and(...conditions),
+      orderBy: resolveOrderBy(input, sortColumns, fieldZones.name),
+      page: input.page,
+      count: input.count,
+    });
+    return {
+      total,
+      items: rows.map((row) => this.toDto(row)),
+      hasMore,
+    };
+  }
+
+  async readAllByDirector(
+    id: ID<'User'>,
+  ): Promise<ReadonlyArray<UnsecuredDto<FieldZone>>> {
+    const rows = await this.db
+      .select()
+      .from(fieldZones)
+      .where(and(eq(fieldZones.directorId, id), isNull(fieldZones.deletedAt)));
+    return rows.map((row) => this.toDto(row));
+  }
+
+  protected toDto(
+    row: typeof fieldZones.$inferSelect,
+  ): UnsecuredDto<FieldZone> {
+    return {
+      id: row.id,
+      __typename: 'FieldZone',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      name: row.name,
+      director: { id: row.directorId },
+    };
+  }
+}
+
+/**
+ * Build the column-level WHERE clauses for a `FieldZoneFilters` input against
+ * the `field_zones` table. Reusable from sub-filters in other domains
+ * (e.g. FieldRegion's `fieldZone` filter).
+ */
+export const fieldZoneFilterClauses = (
+  db: DrizzleDb,
+  filter: FieldZoneFilters | undefined,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+  if (filter.id) conditions.push(eq(fieldZones.id, filter.id));
+  if (filter.director) {
+    conditions.push(
+      subFilter(
+        db,
+        fieldZones.directorId,
+        users,
+        userFilterClauses(db, filter.director),
+      ),
+    );
+  }
+  return conditions;
+};

--- a/src/components/field-zone/field-zone.drizzle.repository.ts
+++ b/src/components/field-zone/field-zone.drizzle.repository.ts
@@ -74,13 +74,11 @@ export class FieldZoneDrizzleRepository extends DrizzleDtoRepository<
   async list(
     input: FieldZoneListInput,
   ): Promise<PaginatedListType<UnsecuredDto<FieldZone>>> {
-    const conditions: SQL[] = [
-      isNull(fieldZones.deletedAt),
-      ...fieldZoneFilterClauses(this.db, input.filter),
-    ];
+    const conditions: SQL[] = [isNull(fieldZones.deletedAt)];
     if (!this.executor.applyReadFilter(this.resource, conditions)) {
       return EMPTY_PAGE;
     }
+    conditions.push(...fieldZoneFilterClauses(this.db, input.filter));
 
     const sortColumns = {
       name: fieldZones.name,

--- a/src/components/field-zone/field-zone.module.ts
+++ b/src/components/field-zone/field-zone.module.ts
@@ -3,6 +3,7 @@ import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { ProjectModule } from '../project/project.module';
 import { UserModule } from '../user/user.module';
+import { FieldZoneDrizzleRepository } from './field-zone.drizzle.repository';
 import { FieldZoneGelRepository } from './field-zone.gel.repository';
 import { FieldZoneLoader } from './field-zone.loader';
 import { FieldZoneRepository } from './field-zone.repository';
@@ -21,6 +22,8 @@ import { RestrictZoneDirectorRemovalHandler } from './handlers/restrict-zone-dir
     FieldZoneService,
     splitDb(FieldZoneRepository, {
       gel: FieldZoneGelRepository,
+      // migration-todo: remove `as any` once splitDb types accept drizzle repos directly
+      postgres: FieldZoneDrizzleRepository as any,
     }),
     FieldZoneLoader,
     RestrictZoneDirectorRemovalHandler,

--- a/src/components/location/location.drizzle.repository.ts
+++ b/src/components/location/location.drizzle.repository.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { and, eq, ilike, inArray, isNull, type SQL } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import {
-  EnhancedResource,
   generateId,
   type ID,
   NotImplementedException,
@@ -13,6 +12,7 @@ import {
 import {
   catchUniqueViolation,
   DrizzleDtoRepository,
+  EMPTY_PAGE,
   escapeLikePattern,
   resolveOrderBy,
   type SortMap,
@@ -42,14 +42,12 @@ export class LocationDrizzleRepository extends DrizzleDtoRepository<
   typeof locations,
   Location
 > {
-  private readonly resource = EnhancedResource.of(Location);
-
   constructor(
     db: DrizzleService,
     private readonly files: FileService,
     private readonly executor: PolicyExecutor,
   ) {
-    super(db, locations);
+    super(db, locations, Location);
   }
 
   async create(input: CreateLocation): Promise<UnsecuredDto<Location>> {
@@ -119,14 +117,10 @@ export class LocationDrizzleRepository extends DrizzleDtoRepository<
   async list(
     input: LocationListInput,
   ): Promise<PaginatedListType<UnsecuredDto<Location>>> {
-    const filter = this.executor.drizzleFilter({
-      action: 'read',
-      resource: this.resource,
-    });
-    if (filter === false) return { items: [], total: 0, hasMore: false };
-
     const conditions: SQL[] = [isNull(locations.deletedAt)];
-    if (filter !== true) conditions.push(filter);
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
 
     if (input.filter?.name) {
       conditions.push(

--- a/src/components/location/location.drizzle.repository.ts
+++ b/src/components/location/location.drizzle.repository.ts
@@ -26,6 +26,7 @@ import { type FileId } from '../file/dto';
 import {
   type CreateLocation,
   Location,
+  type LocationFilters,
   type LocationListInput,
   type LocationListOutput,
   type UpdateLocation,
@@ -122,19 +123,7 @@ export class LocationDrizzleRepository extends DrizzleDtoRepository<
       return EMPTY_PAGE;
     }
 
-    if (input.filter?.name) {
-      conditions.push(
-        ilike(locations.name, `%${escapeLikePattern(input.filter.name)}%`),
-      );
-    }
-    if (input.filter?.type?.length) {
-      conditions.push(inArray(locations.type, [...input.filter.type]));
-    }
-    if (input.filter?.fundingAccountId) {
-      conditions.push(
-        eq(locations.fundingAccountId, input.filter.fundingAccountId),
-      );
-    }
+    conditions.push(...locationFilterClauses(input.filter));
 
     const sortColumns = {
       name: locations.name,
@@ -207,3 +196,27 @@ export class LocationDrizzleRepository extends DrizzleDtoRepository<
     };
   }
 }
+
+/**
+ * Build the column-level WHERE clauses for a `LocationFilters` input against
+ * the `locations` table. Reusable from sub-filters in other domains
+ * (e.g. Project's `location` filter).
+ */
+export const locationFilterClauses = (
+  filter: LocationFilters | undefined,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+  if (filter.name) {
+    conditions.push(
+      ilike(locations.name, `%${escapeLikePattern(filter.name)}%`),
+    );
+  }
+  if (filter.type?.length) {
+    conditions.push(inArray(locations.type, [...filter.type]));
+  }
+  if (filter.fundingAccountId) {
+    conditions.push(eq(locations.fundingAccountId, filter.fundingAccountId));
+  }
+  return conditions;
+};

--- a/src/components/organization/organization.drizzle.repository.ts
+++ b/src/components/organization/organization.drizzle.repository.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { and, eq, ilike, inArray, isNull, type SQL } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import {
-  EnhancedResource,
   generateId,
   type ID,
   type PaginatedListType,
@@ -11,6 +10,7 @@ import {
 import {
   catchUniqueViolation,
   DrizzleDtoRepository,
+  EMPTY_PAGE,
   escapeLikePattern,
   resolveOrderBy,
   type SortMap,
@@ -40,13 +40,11 @@ export class OrganizationDrizzleRepository extends DrizzleDtoRepository<
   typeof organizations,
   Organization
 > {
-  private readonly resource = EnhancedResource.of(Organization);
-
   constructor(
     db: DrizzleService,
     private readonly executor: PolicyExecutor,
   ) {
-    super(db, organizations);
+    super(db, organizations, Organization);
   }
 
   async create(input: CreateOrganization): Promise<UnsecuredDto<Organization>> {
@@ -95,14 +93,10 @@ export class OrganizationDrizzleRepository extends DrizzleDtoRepository<
   async list(
     input: OrganizationListInput,
   ): Promise<PaginatedListType<UnsecuredDto<Organization>>> {
-    const filter = this.executor.drizzleFilter({
-      action: 'read',
-      resource: this.resource,
-    });
-    if (filter === false) return { items: [], total: 0, hasMore: false };
-
     const conditions: SQL[] = [isNull(organizations.deletedAt)];
-    if (filter !== true) conditions.push(filter);
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
 
     if (input.filter?.name) {
       conditions.push(

--- a/src/components/organization/organization.drizzle.repository.ts
+++ b/src/components/organization/organization.drizzle.repository.ts
@@ -15,7 +15,7 @@ import {
   resolveOrderBy,
   type SortMap,
 } from '~/core/drizzle';
-import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
 import {
   organizationLocations,
   organizations,
@@ -25,6 +25,7 @@ import { PolicyExecutor } from '../authorization/policy/executor/policy-executor
 import {
   type CreateOrganization,
   Organization,
+  type OrganizationFilters,
   type OrganizationListInput,
   type UpdateOrganization,
 } from './dto';
@@ -98,18 +99,7 @@ export class OrganizationDrizzleRepository extends DrizzleDtoRepository<
       return EMPTY_PAGE;
     }
 
-    if (input.filter?.name) {
-      conditions.push(
-        ilike(organizations.name, `%${escapeLikePattern(input.filter.name)}%`),
-      );
-    }
-    if (input.filter?.userId) {
-      const userOrgSubq = this.db
-        .select({ orgId: userOrganizations.organizationId })
-        .from(userOrganizations)
-        .where(eq(userOrganizations.userId, input.filter.userId));
-      conditions.push(inArray(organizations.id, userOrgSubq));
-    }
+    conditions.push(...organizationFilterClauses(this.db, input.filter));
 
     const sortColumns = {
       name: organizations.name,
@@ -148,3 +138,29 @@ export class OrganizationDrizzleRepository extends DrizzleDtoRepository<
     };
   }
 }
+
+/**
+ * Build the column-level WHERE clauses for an `OrganizationFilters` input
+ * against the `organizations` table. Reusable from sub-filters in other
+ * domains (e.g. Partner's `organization` filter).
+ */
+export const organizationFilterClauses = (
+  db: DrizzleDb,
+  filter: OrganizationFilters | undefined,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+  if (filter.name) {
+    conditions.push(
+      ilike(organizations.name, `%${escapeLikePattern(filter.name)}%`),
+    );
+  }
+  if (filter.userId) {
+    const userOrgSubq = db
+      .select({ orgId: userOrganizations.organizationId })
+      .from(userOrganizations)
+      .where(eq(userOrganizations.userId, filter.userId));
+    conditions.push(inArray(organizations.id, userOrgSubq));
+  }
+  return conditions;
+};

--- a/src/components/user/education/education.drizzle.repository.ts
+++ b/src/components/user/education/education.drizzle.repository.ts
@@ -13,7 +13,7 @@ import { DrizzleDtoRepository } from '~/core/drizzle/dto.repository';
 import { educations } from '~/core/drizzle/schema';
 import {
   type CreateEducation,
-  type Education,
+  Education,
   type EducationListInput,
   type UpdateEducation,
 } from './dto';
@@ -24,7 +24,7 @@ export class EducationDrizzleRepository extends DrizzleDtoRepository<
   Education
 > {
   constructor(db: DrizzleService) {
-    super(db, educations);
+    super(db, educations, Education);
   }
 
   async create(input: CreateEducation): Promise<UnsecuredDto<Education>> {

--- a/src/components/user/unavailability/unavailability.drizzle.repository.ts
+++ b/src/components/user/unavailability/unavailability.drizzle.repository.ts
@@ -13,7 +13,7 @@ import { DrizzleDtoRepository } from '~/core/drizzle/dto.repository';
 import { unavailabilities } from '~/core/drizzle/schema';
 import {
   type CreateUnavailability,
-  type Unavailability,
+  Unavailability,
   type UnavailabilityListInput,
   type UpdateUnavailability,
 } from './dto';
@@ -24,7 +24,7 @@ export class UnavailabilityDrizzleRepository extends DrizzleDtoRepository<
   Unavailability
 > {
   constructor(db: DrizzleService) {
-    super(db, unavailabilities);
+    super(db, unavailabilities, Unavailability);
   }
 
   async create(

--- a/src/components/user/user.drizzle.repository.ts
+++ b/src/components/user/user.drizzle.repository.ts
@@ -3,7 +3,6 @@ import { and, eq, ilike, inArray, isNull, or, type SQL } from 'drizzle-orm';
 import { groupBy } from 'lodash';
 import { DateTime } from 'luxon';
 import {
-  EnhancedResource,
   generateId,
   type ID,
   NotImplementedException,
@@ -15,11 +14,12 @@ import { Identity } from '~/core/authentication';
 import {
   catchUniqueViolation,
   DrizzleDtoRepository,
+  EMPTY_PAGE,
   escapeLikePattern,
   resolveOrderBy,
   type SortMap,
 } from '~/core/drizzle';
-import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
 import { userGlobalRoles, users } from '~/core/drizzle/schema';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import { FileService } from '../file';
@@ -31,6 +31,7 @@ import {
   type SystemAgent,
   type UpdateUser,
   User,
+  type UserFilters,
   type UserListInput,
 } from './dto';
 
@@ -49,15 +50,13 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
   typeof users,
   User
 > {
-  private readonly resource = EnhancedResource.of(User);
-
   constructor(
     db: DrizzleService,
     private readonly executor: PolicyExecutor,
     private readonly files: FileService,
     private readonly identity: Identity,
   ) {
-    super(db, users);
+    super(db, users, User);
   }
 
   override async readMany(
@@ -190,39 +189,12 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
   async list(
     input: UserListInput,
   ): Promise<PaginatedListType<UnsecuredDto<User>>> {
-    const filter = this.executor.drizzleFilter({
-      action: 'read',
-      resource: this.resource,
-    });
-    if (filter === false) return { items: [], total: 0, hasMore: false };
-
-    const conditions: SQL[] = [isNull(users.deletedAt)];
-    if (filter !== true) conditions.push(filter);
-    if (input.filter?.id) conditions.push(eq(users.id, input.filter.id));
-    if (input.filter?.status)
-      conditions.push(eq(users.status, input.filter.status));
-    if (input.filter?.name) {
-      const term = `%${escapeLikePattern(input.filter.name)}%`;
-      conditions.push(
-        or(
-          ilike(users.realFirstName, term),
-          ilike(users.realLastName, term),
-          ilike(users.displayFirstName, term),
-          ilike(users.displayLastName, term),
-        )!,
-      );
-    }
-    if (input.filter?.title) {
-      conditions.push(
-        ilike(users.title, `%${escapeLikePattern(input.filter.title)}%`),
-      );
-    }
-    if (input.filter?.roles?.length) {
-      const roleSubq = this.db
-        .selectDistinct({ userId: userGlobalRoles.userId })
-        .from(userGlobalRoles)
-        .where(inArray(userGlobalRoles.role, input.filter.roles));
-      conditions.push(inArray(users.id, roleSubq));
+    const conditions: SQL[] = [
+      isNull(users.deletedAt),
+      ...userFilterClauses(this.db, input.filter),
+    ];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
     }
 
     const sortColumns = {
@@ -269,14 +241,8 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
   async getUserByEmailAddress(
     email: string,
   ): Promise<UnsecuredDto<User> | null> {
-    const filter = this.executor.drizzleFilter({
-      action: 'read',
-      resource: this.resource,
-    });
-    if (filter === false) return null;
-
     const conditions: SQL[] = [eq(users.email, email), isNull(users.deletedAt)];
-    if (filter !== true) conditions.push(filter);
+    if (!this.executor.applyReadFilter(this.resource, conditions)) return null;
 
     const row = await this.db.query.users.findFirst({
       where: and(...conditions),
@@ -323,3 +289,43 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
     };
   }
 }
+
+/**
+ * Build the column-level WHERE clauses for a `UserFilters` input against the
+ * `users` table. Reusable from sub-filters in other domains (e.g. FieldZone's
+ * `director` filter) — the caller composes these with their own join/lookup.
+ *
+ * Note: `pinned` is not stored on the user row (per-requester state), so it is
+ * intentionally not handled here — same migration-todo as the user list itself.
+ */
+export const userFilterClauses = (
+  db: DrizzleDb,
+  filter: UserFilters | undefined,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+  if (filter.id) conditions.push(eq(users.id, filter.id));
+  if (filter.status) conditions.push(eq(users.status, filter.status));
+  if (filter.name) {
+    const term = `%${escapeLikePattern(filter.name)}%`;
+    conditions.push(
+      or(
+        ilike(users.realFirstName, term),
+        ilike(users.realLastName, term),
+        ilike(users.displayFirstName, term),
+        ilike(users.displayLastName, term),
+      )!,
+    );
+  }
+  if (filter.title) {
+    conditions.push(ilike(users.title, `%${escapeLikePattern(filter.title)}%`));
+  }
+  if (filter.roles?.length) {
+    const roleSubq = db
+      .selectDistinct({ userId: userGlobalRoles.userId })
+      .from(userGlobalRoles)
+      .where(inArray(userGlobalRoles.role, filter.roles));
+    conditions.push(inArray(users.id, roleSubq));
+  }
+  return conditions;
+};

--- a/src/components/user/user.drizzle.repository.ts
+++ b/src/components/user/user.drizzle.repository.ts
@@ -189,13 +189,11 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
   async list(
     input: UserListInput,
   ): Promise<PaginatedListType<UnsecuredDto<User>>> {
-    const conditions: SQL[] = [
-      isNull(users.deletedAt),
-      ...userFilterClauses(this.db, input.filter),
-    ];
+    const conditions: SQL[] = [isNull(users.deletedAt)];
     if (!this.executor.applyReadFilter(this.resource, conditions)) {
       return EMPTY_PAGE;
     }
+    conditions.push(...userFilterClauses(this.db, input.filter));
 
     const sortColumns = {
       realLastName: [users.realLastName, users.realFirstName],

--- a/src/core/drizzle/dto.repository.ts
+++ b/src/core/drizzle/dto.repository.ts
@@ -1,7 +1,24 @@
 import { and, asc, count, eq, inArray, isNull, type SQL } from 'drizzle-orm';
 import { type AnyPgColumn, type PgTable } from 'drizzle-orm/pg-core';
-import { type ID, NotFoundException, type UnsecuredDto } from '~/common';
+import {
+  EnhancedResource,
+  type ID,
+  NotFoundException,
+  type ResourceShape,
+  type UnsecuredDto,
+} from '~/common';
+import { getChanges } from '../database/changes';
 import { type DrizzleService } from './drizzle.service';
+
+/**
+ * The shape `list()` returns when policy denies read access — caller bails
+ * out before touching the DB. Use with `PolicyExecutor.applyReadFilter()`.
+ */
+export const EMPTY_PAGE = {
+  items: [] as never[],
+  total: 0,
+  hasMore: false,
+} as const;
 
 /**
  * Common machinery for CRUD repositories on a single Drizzle table.
@@ -22,10 +39,26 @@ export abstract class DrizzleDtoRepository<
   },
   TDto extends { id: ID },
 > {
+  protected readonly resource: EnhancedResource<ResourceShape<TDto>>;
+
+  /**
+   * Diff an existing DTO against an `Update*` input and return only fields
+   * whose values actually changed. Mirrors the helper on the Neo4j and Gel
+   * bases — services call `repo.getActualChanges(existing, input)` regardless
+   * of which engine `splitDb` resolves to.
+   */
+  readonly getActualChanges!: ReturnType<
+    typeof getChanges<ResourceShape<TDto>>
+  >;
+
   constructor(
     private readonly drizzle: DrizzleService,
     protected readonly table: TTable,
-  ) {}
+    dto: ResourceShape<TDto>,
+  ) {
+    this.resource = EnhancedResource.of(dto);
+    this.getActualChanges = getChanges(dto);
+  }
 
   /**
    * Drizzle client. A getter (not a captured value) so AsyncLocalStorage-bound

--- a/src/core/drizzle/index.ts
+++ b/src/core/drizzle/index.ts
@@ -7,3 +7,4 @@ export * from './like';
 export * from './order-by';
 export * from './pg-error-codes';
 export * from './schema/index';
+export * from './sub-filter';

--- a/src/core/drizzle/migrations/0004_add_field_zones_regions.sql
+++ b/src/core/drizzle/migrations/0004_add_field_zones_regions.sql
@@ -2,7 +2,7 @@
 
 CREATE TABLE "field_zones" (
   "id"          text        PRIMARY KEY,
-  "name"        text        NOT NULL UNIQUE,
+  "name"        text        NOT NULL,
   "director_id" text        NOT NULL REFERENCES "users"("id"),
   "created_at"  timestamptz NOT NULL DEFAULT now(),
   "updated_at"  timestamptz NOT NULL DEFAULT now(),
@@ -12,7 +12,7 @@ CREATE TABLE "field_zones" (
 
 CREATE TABLE "field_regions" (
   "id"            text        PRIMARY KEY,
-  "name"          text        NOT NULL UNIQUE,
+  "name"          text        NOT NULL,
   "field_zone_id" text        NOT NULL REFERENCES "field_zones"("id"),
   "director_id"   text        NOT NULL REFERENCES "users"("id"),
   "created_at"    timestamptz NOT NULL DEFAULT now(),
@@ -20,6 +20,13 @@ CREATE TABLE "field_regions" (
   "deleted_at"    timestamptz
 );
 --> statement-breakpoint
+
+-- Partial unique indexes: name uniqueness only enforced for live (non-soft-deleted) rows.
+CREATE UNIQUE INDEX "field_zones_name_active_unique"
+  ON "field_zones" ("name") WHERE "deleted_at" IS NULL;
+
+CREATE UNIQUE INDEX "field_regions_name_active_unique"
+  ON "field_regions" ("name") WHERE "deleted_at" IS NULL;
 
 CREATE INDEX "field_zones_director_id_idx"     ON "field_zones"   ("director_id");
 CREATE INDEX "field_regions_field_zone_id_idx" ON "field_regions" ("field_zone_id");

--- a/src/core/drizzle/migrations/0004_add_field_zones_regions.sql
+++ b/src/core/drizzle/migrations/0004_add_field_zones_regions.sql
@@ -1,0 +1,32 @@
+-- Migration: add field_zones + field_regions tables; backfill locations.default_field_region_id FK
+
+CREATE TABLE "field_zones" (
+  "id"          text        PRIMARY KEY,
+  "name"        text        NOT NULL UNIQUE,
+  "director_id" text        NOT NULL REFERENCES "users"("id"),
+  "created_at"  timestamptz NOT NULL DEFAULT now(),
+  "updated_at"  timestamptz NOT NULL DEFAULT now(),
+  "deleted_at"  timestamptz
+);
+--> statement-breakpoint
+
+CREATE TABLE "field_regions" (
+  "id"            text        PRIMARY KEY,
+  "name"          text        NOT NULL UNIQUE,
+  "field_zone_id" text        NOT NULL REFERENCES "field_zones"("id"),
+  "director_id"   text        NOT NULL REFERENCES "users"("id"),
+  "created_at"    timestamptz NOT NULL DEFAULT now(),
+  "updated_at"    timestamptz NOT NULL DEFAULT now(),
+  "deleted_at"    timestamptz
+);
+--> statement-breakpoint
+
+CREATE INDEX "field_zones_director_id_idx"     ON "field_zones"   ("director_id");
+CREATE INDEX "field_regions_field_zone_id_idx" ON "field_regions" ("field_zone_id");
+CREATE INDEX "field_regions_director_id_idx"   ON "field_regions" ("director_id");
+--> statement-breakpoint
+
+-- Backfill the FK that was deferred in 0002_add_locations.sql
+ALTER TABLE "locations"
+  ADD CONSTRAINT "locations_default_field_region_id_fkey"
+  FOREIGN KEY ("default_field_region_id") REFERENCES "field_regions"("id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1746144000000,
       "tag": "0003_add_organizations",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1746230400000,
+      "tag": "0004_add_field_zones_regions",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -432,7 +432,7 @@ export const fieldZones = pgTable(
   'field_zones',
   {
     id: text('id').$type<ID<'FieldZone'>>().primaryKey(),
-    name: text('name').notNull().unique(),
+    name: text('name').notNull(),
     directorId: text('director_id')
       .$type<ID<'User'>>()
       .notNull()
@@ -445,7 +445,14 @@ export const fieldZones = pgTable(
       .defaultNow(),
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
   },
-  (t) => [index('field_zones_director_id_idx').on(t.directorId)],
+  (t) => [
+    // Partial unique index scoped to live rows so soft-deleted records
+    // don't block reuse of their name.
+    uniqueIndex('field_zones_name_active_unique')
+      .on(t.name)
+      .where(sql`${t.deletedAt} IS NULL`),
+    index('field_zones_director_id_idx').on(t.directorId),
+  ],
 );
 
 export const fieldZonesRelations = relations(fieldZones, ({ one, many }) => ({
@@ -460,7 +467,7 @@ export const fieldRegions = pgTable(
   'field_regions',
   {
     id: text('id').$type<ID<'FieldRegion'>>().primaryKey(),
-    name: text('name').notNull().unique(),
+    name: text('name').notNull(),
     fieldZoneId: text('field_zone_id')
       .$type<ID<'FieldZone'>>()
       .notNull()
@@ -478,6 +485,11 @@ export const fieldRegions = pgTable(
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
   },
   (t) => [
+    // Partial unique index scoped to live rows so soft-deleted records
+    // don't block reuse of their name.
+    uniqueIndex('field_regions_name_active_unique')
+      .on(t.name)
+      .where(sql`${t.deletedAt} IS NULL`),
     index('field_regions_field_zone_id_idx').on(t.fieldZoneId),
     index('field_regions_director_id_idx').on(t.directorId),
   ],

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -260,11 +260,11 @@ export const locations = pgTable(
     name: text('name').notNull(),
     type: locationTypeEnum('type').$type<LocationType>().notNull(),
     isoAlpha3: text('iso_alpha3'),
-    // migration-todo: add FK constraints once FundingAccount and FieldRegion are migrated to PG
+    // migration-todo: add FK constraint once FundingAccount is migrated to PG
     fundingAccountId: text('funding_account_id').$type<ID<'FundingAccount'>>(),
-    defaultFieldRegionId: text('default_field_region_id').$type<
-      ID<'FieldRegion'>
-    >(),
+    defaultFieldRegionId: text('default_field_region_id')
+      .$type<ID<'FieldRegion'>>()
+      .references((): AnyPgColumn => fieldRegions.id),
     defaultMarketingRegionId: text('default_marketing_region_id')
       .$type<ID<'Location'>>()
       .references((): AnyPgColumn => locations.id),
@@ -425,3 +425,71 @@ export const userOrganizationsRelations = relations(
     }),
   }),
 );
+
+// ─── Field Zones / Regions ─────────────────────────────────────────────────
+
+export const fieldZones = pgTable(
+  'field_zones',
+  {
+    id: text('id').$type<ID<'FieldZone'>>().primaryKey(),
+    name: text('name').notNull().unique(),
+    directorId: text('director_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [index('field_zones_director_id_idx').on(t.directorId)],
+);
+
+export const fieldZonesRelations = relations(fieldZones, ({ one, many }) => ({
+  director: one(users, {
+    fields: [fieldZones.directorId],
+    references: [users.id],
+  }),
+  regions: many(fieldRegions),
+}));
+
+export const fieldRegions = pgTable(
+  'field_regions',
+  {
+    id: text('id').$type<ID<'FieldRegion'>>().primaryKey(),
+    name: text('name').notNull().unique(),
+    fieldZoneId: text('field_zone_id')
+      .$type<ID<'FieldZone'>>()
+      .notNull()
+      .references(() => fieldZones.id),
+    directorId: text('director_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    index('field_regions_field_zone_id_idx').on(t.fieldZoneId),
+    index('field_regions_director_id_idx').on(t.directorId),
+  ],
+);
+
+export const fieldRegionsRelations = relations(fieldRegions, ({ one }) => ({
+  fieldZone: one(fieldZones, {
+    fields: [fieldRegions.fieldZoneId],
+    references: [fieldZones.id],
+  }),
+  director: one(users, {
+    fields: [fieldRegions.directorId],
+    references: [users.id],
+  }),
+}));

--- a/src/core/drizzle/sub-filter.ts
+++ b/src/core/drizzle/sub-filter.ts
@@ -1,0 +1,37 @@
+import { and, inArray, isNull, type SQL } from 'drizzle-orm';
+import { type AnyPgColumn, type PgTable } from 'drizzle-orm/pg-core';
+import { type DrizzleDb } from './drizzle.service';
+
+/**
+ * Build a sub-filter that restricts an outer query to rows whose FK column
+ * references a row in `subTable` matching the given clauses. Pairs with the
+ * `*FilterClauses(...)` helpers each repo exports.
+ *
+ * Soft-deleted rows in the sub-table are automatically excluded when the
+ * sub-table has a `deletedAt` column.
+ *
+ * @example
+ *   if (input.filter?.director) {
+ *     conditions.push(subFilter(
+ *       this.db,
+ *       fieldRegions.directorId,
+ *       users,
+ *       userFilterClauses(this.db, input.filter.director),
+ *     ));
+ *   }
+ */
+export const subFilter = (
+  db: DrizzleDb,
+  linkedColumn: AnyPgColumn,
+  subTable: PgTable & { id: AnyPgColumn; deletedAt?: AnyPgColumn },
+  clauses: SQL[],
+): SQL => {
+  const conditions: SQL[] = subTable.deletedAt
+    ? [isNull(subTable.deletedAt), ...clauses]
+    : [...clauses];
+  const subq = db
+    .select({ id: subTable.id })
+    .from(subTable)
+    .where(and(...conditions));
+  return inArray(linkedColumn, subq);
+};


### PR DESCRIPTION
## Summary

Ports the **FieldZone** and **FieldRegion** domains to PostgreSQL via Drizzle as the next step in the Neo4j → PostgreSQL migration. Both land in one PR because FieldRegion's filter sub-delegates to FieldZone (Tier 3 → Tier 2 dependency) and they share the director-on-user pattern — committing them together keeps the sub-filter graph internally consistent.

Also includes a cross-cutting refactor of `DrizzleDtoRepository` and `PolicyExecutor` that introduces shared helpers (`applyReadFilter`, `EMPTY_PAGE`, `subFilter`, `resource`/`getActualChanges` on the base class), simplifies the four already-migrated domain repos (User, Location, Organization, Education, Unavailability), and unblocks update paths under `DATABASE=postgres`. Plus a one-line DI fix that exposes `PolicyExecutor` to Drizzle consumer modules.

Migration boundary unchanged: `splitDb(NeoRepo, { postgres: DrizzleRepo as any })` routes the repo class to whichever engine is active — Neo4j stays the default; PostgreSQL is local-dev only until cutover.

## Schema DDL

```sql
CREATE TABLE "field_zones" (
  "id"          text        PRIMARY KEY,
  "name"        text        NOT NULL UNIQUE,
  "director_id" text        NOT NULL REFERENCES "users"("id"),
  "created_at"  timestamptz NOT NULL DEFAULT now(),
  "updated_at"  timestamptz NOT NULL DEFAULT now(),
  "deleted_at"  timestamptz
);

CREATE TABLE "field_regions" (
  "id"            text        PRIMARY KEY,
  "name"          text        NOT NULL UNIQUE,
  "field_zone_id" text        NOT NULL REFERENCES "field_zones"("id"),
  "director_id"   text        NOT NULL REFERENCES "users"("id"),
  "created_at"    timestamptz NOT NULL DEFAULT now(),
  "updated_at"    timestamptz NOT NULL DEFAULT now(),
  "deleted_at"    timestamptz
);

CREATE INDEX "field_zones_director_id_idx"     ON "field_zones"   ("director_id");
CREATE INDEX "field_regions_field_zone_id_idx" ON "field_regions" ("field_zone_id");
CREATE INDEX "field_regions_director_id_idx"   ON "field_regions" ("director_id");

-- Backfills the FK deferred in migration 0002 (locations).
ALTER TABLE "locations"
  ADD CONSTRAINT "locations_default_field_region_id_fkey"
  FOREIGN KEY ("default_field_region_id") REFERENCES "field_regions"("id");
```

## Design decisions

### director_id is NOT NULL on both tables

- **What:** Both `field_zones.director_id` and `field_regions.director_id` are `text NOT NULL REFERENCES users(id)`.
- **Why:** The GraphQL `CreateFieldZone` and `CreateFieldRegion` inputs already require `director: ID<'User'>!`, and the service validates the user has the correct role (`FieldOperationsDirector` / `RegionalDirector`) before insert. The DB constraint mirrors the application invariant.
- **Tradeoff:** Gel and Neo4j model director as a relationship that can technically be missing — we've never observed that in prod and the create path can't produce it. NOT NULL eliminates the nullable-direct or branch in `toDto()` and gives us referential integrity for free.

### Backfill `locations.default_field_region_id` FK in the same migration

- **What:** `ALTER TABLE locations ADD CONSTRAINT … FOREIGN KEY (default_field_region_id) REFERENCES field_regions(id)` runs in migration 0004, simultaneously with the `field_regions` table creation.
- **Why:** Migration 0002 (Locations) declared the column as `text` without an FK and left a `migration-todo:` comment explicitly waiting on FieldRegion to migrate. Now that it has, the cleanup belongs in the same change set — and adding the constraint after data lands would require `ALTER TABLE` downtime planning later.

### Sub-filter helper + per-domain `*FilterClauses` functions

- **What:** Each Drizzle repo exports a `<domain>FilterClauses(db, filter)` function that returns `SQL[]` of WHERE conditions on its own table. A shared `subFilter(db, linkedColumn, subTable, clauses)` helper composes them into `inArray(linkedCol, db.select(...).from(subTable).where(...))` subqueries with automatic soft-delete handling on the sub-table.
- **Why:** The FE explicitly uses `filter.director: UserFilters` and `filter.fieldZone: FieldZoneFilters` on FieldRegion. The Neo4j side handles this via `filter.sub()`; we needed a Drizzle equivalent. Composable clause functions + a tiny `subFilter` wrapper give us the same shape without per-repo boilerplate.
- **Example call site:**
  ```ts
  if (input.filter?.director) {
    conditions.push(subFilter(
      this.db, fieldRegions.directorId, users,
      userFilterClauses(this.db, input.filter.director),
    ));
  }
  ```
- **Refactor scope:** `userFilterClauses` was lifted out of `user.drizzle.repository.ts` (where it was inline in `list()`) into an exported helper, then re-consumed by `users.list()` itself. Net result: zero behavior change in User, plus a reusable export.

### `applyReadFilter` + `EMPTY_PAGE` collapse the read-auth short-circuit

- **What:** New method on `PolicyExecutor`: `applyReadFilter(resource, conditions): boolean`. Resolves the read-policy filter, mutates `conditions` in place, returns `false` when access is denied. Paired with an exported `EMPTY_PAGE` constant for the `{ items: [], total: 0, hasMore: false }` literal.
- **Why:** Every `list()` in the migrated repos had the same 6-line block: call `drizzleFilter`, check for `false` → return empty, check for `true` vs `SQL` → push. (For context: `drizzleFilter` returns `false`/`true`/`SQL` — denied / unconditional / conditional access.) Five repos, identical boilerplate. Helper collapses it to one line: `if (!this.executor.applyReadFilter(this.resource, conditions)) return EMPTY_PAGE;`
- **Tradeoff:** In-place mutation of `conditions: SQL[]` instead of returning a value. Worth it; alternative API shapes were uglier.

### `resource` and `getActualChanges` live on the base class

- **What:** `DrizzleDtoRepository`'s constructor now takes a third argument — the DTO class — and the base owns `protected readonly resource: EnhancedResource<...>` and `readonly getActualChanges = getChanges(dto)`. Subclasses pass `super(db, table, Dto)` and drop their local declarations.
- **Why for `resource`:** Every Drizzle repo had `private readonly resource = EnhancedResource.of(Dto)`. Lifting it deduplicates and matches the Neo4j and Gel bases.
- **Why for `getActualChanges`:** Services call `this.repo.getActualChanges(existing, input)` regardless of engine — `getChanges()` is a pure DTO diff helper, not Neo4j-specific. The Neo4j and Gel bases already expose it. Without it on the Drizzle base, every service's `update*` mutation threw `this.repo.getActualChanges is not a function` at runtime under `DATABASE=postgres`. Type system can't catch this because services type their `repo` field against the Neo4j repo class (see splitDb cast in Deferred items).
- **Gotcha:** Declaring `private readonly resource = ...` locally in a subclass now triggers a TypeScript variance error on `childKeys` / `securedPropsPlusExtra` (narrow `EnhancedResource<typeof Foo>` vs base's `EnhancedResource<ResourceShape<Foo>>`). The fix is to delete the subclass declaration, which is the point.

### Export `PolicyExecutor` from `PolicyModule`

- **What:** `policy.module.ts` adds `PolicyExecutor` to its `exports` array.
- **Why:** Drizzle repos inject `PolicyExecutor` directly for `drizzleFilter` / `applyReadFilter`. Neo4j repos never did — they use the higher-level `Privileges` wrapper — so the missing export was invisible until the app booted under `DATABASE=postgres` and Nest tried to instantiate the Drizzle repo, producing `UnknownDependenciesException`.

## Deferred items

### `splitDb(..., { postgres: XDrizzleRepository as any })` cast

- **Where:** `field-zone.module.ts`, `field-region.module.ts`, and prior migrated modules.
- **Behavior:** Each Drizzle repo registration uses `as any` with a `migration-todo:` comment.
- **Resolved when:** Phase 7 cutover. The entire `splitDb` provider is deleted along with the Neo4j-side repos, taking the casts with it.
- **Why deferred:** `splitDb<T>` requires `Type<PublicOf<T>>` where `T` is the Neo4j repo class. `PublicOf<>` retains every public/protected key from Neo4j's `DtoRepository` base (`getActualChanges`, `db: DatabaseService`, `privileges`, `getBaseNode`, etc.) that doesn't exist on `DrizzleDtoRepository`. The proper fix is per-domain interfaces (`IFieldRegionRepository`, etc.) — but since splitDb itself disappears at cutover, polishing transition-only typing is wasted effort.

### Cross-domain stubs in `LocationDrizzleRepository`

- **Where:** `location.drizzle.repository.ts` — `addLocationToNode`, `removeLocationFromNode`, `listLocationsFromNodeNoSecGroups`.
- **Behavior:** All throw `NotImplementedException` with `migration-todo:` comments.
- **Resolved when:** the domains owning those node-relationship calls (Organization's `locations` resolver, Partner, Project, etc.) port to PostgreSQL.
- **Why deferred:** These methods bridge to Neo4j-style node-anchored location lists that haven't been ported yet. Not introduced by this PR — flagging because the GraphQL `organization.locations` resolver does hit these stubs, so a UI smoke test against `DATABASE=postgres` will see the error there.

### Unused `UserFilters` sub-filter fields

- **Where:** `userFilterClauses` in `user.drizzle.repository.ts`.
- **Behavior:** Handles `id`, `name`, `title`, `status`, `roles`. Does NOT handle `pinned` (per-requester state, not stored on the user row) — `pinned: false` is hardcoded in `toDto`.
- **Resolved when:** the `pinned` mechanism is reintroduced post-cutover as per-requester state (audit log or join).
- **Why deferred:** Same gap as before this PR; `userFilterClauses` just inherited it. Not a regression.

### `locations.funding_account_id` FK

- **Where:** `locations` table.
- **Behavior:** Column is `text`, no FK constraint.
- **Resolved when:** the `FundingAccount` domain migrates to PostgreSQL.
- **Why deferred:** Same pattern as `default_field_region_id` before this PR — wait for the referenced table to exist, then `ALTER TABLE ADD CONSTRAINT` in that domain's migration.
