### PR TITLE
#9 [pg] Funding Account Migration

### DIFF
--- a/src/components/funding-account/dto/list-funding-account.dto.ts
+++ b/src/components/funding-account/dto/list-funding-account.dto.ts
@@ -2,6 +2,10 @@ import { InputType, ObjectType } from '@nestjs/graphql';
 import { PaginatedList, SortablePaginationInput } from '~/common';
 import { FundingAccount } from './funding-account.dto';
 
+// migration-todo: no filter input (parity with the Neo4j repo, which also has
+// none). Add FundingAccountFilters + a `filter` field here if a consumer needs
+// to filter by name/accountNumber; the Drizzle repo's list() already composes
+// conditions and is ready to accept them.
 @InputType()
 export class FundingAccountListInput extends SortablePaginationInput<
   keyof FundingAccount

--- a/src/components/funding-account/funding-account.drizzle.repository.ts
+++ b/src/components/funding-account/funding-account.drizzle.repository.ts
@@ -102,6 +102,14 @@ export class FundingAccountDrizzleRepository extends DrizzleDtoRepository<
   protected toDto(
     row: typeof fundingAccounts.$inferSelect,
   ): UnsecuredDto<FundingAccount> {
+    // migration-todo: departmentIdBlock is deferred to the Project-domain
+    // migration. The Neo4j repo links a DepartmentIdBlock node and the Gel
+    // schema requires one, but the shared IdBlock representation (and its
+    // ProjectType enum) belongs with Project. Nothing reads it in PG mode yet:
+    // its only consumer, SetDepartmentId, is Neo4j-only. When ported, the block
+    // is deterministic from accountNumber:
+    //   range(accountNumber * 10000 + 11 .. (accountNumber + 1) * 10000 - 1)
+    //   programs: [MomentumTranslation, Internship]
     return {
       id: row.id,
       __typename: 'FundingAccount',

--- a/src/components/funding-account/funding-account.drizzle.repository.ts
+++ b/src/components/funding-account/funding-account.drizzle.repository.ts
@@ -1,0 +1,113 @@
+import { Injectable } from '@nestjs/common';
+import { and, isNull, type SQL } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  generateId,
+  type ID,
+  type PaginatedListType,
+  type UnsecuredDto,
+} from '~/common';
+import {
+  catchUniqueViolation,
+  DrizzleDtoRepository,
+  EMPTY_PAGE,
+  resolveOrderBy,
+  type SortMap,
+} from '~/core/drizzle';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { fundingAccounts } from '~/core/drizzle/schema';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import {
+  type CreateFundingAccount,
+  FundingAccount,
+  type FundingAccountListInput,
+  type UpdateFundingAccount,
+} from './dto';
+
+const catchNameUnique = catchUniqueViolation(
+  'name',
+  'name',
+  'FundingAccount with this name already exists.',
+);
+
+@Injectable()
+export class FundingAccountDrizzleRepository extends DrizzleDtoRepository<
+  typeof fundingAccounts,
+  FundingAccount
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+  ) {
+    super(db, fundingAccounts, FundingAccount);
+  }
+
+  async create(
+    input: CreateFundingAccount,
+  ): Promise<UnsecuredDto<FundingAccount>> {
+    const id = await generateId();
+    await this.db
+      .insert(fundingAccounts)
+      .values({
+        id,
+        name: input.name,
+        accountNumber: input.accountNumber,
+      })
+      .catch(catchNameUnique);
+    return await this.readOne(id);
+  }
+
+  async update(
+    changes: UpdateFundingAccount,
+  ): Promise<UnsecuredDto<FundingAccount>> {
+    const { id, ...fields } = changes;
+    await this.updateColumns(id, {
+      name: fields.name,
+      accountNumber: fields.accountNumber,
+    }).catch(catchNameUnique);
+    return await this.readOne(id);
+  }
+
+  async delete(id: ID): Promise<void> {
+    await this.softDelete(id);
+  }
+
+  async list(
+    input: FundingAccountListInput,
+  ): Promise<PaginatedListType<UnsecuredDto<FundingAccount>>> {
+    const conditions: SQL[] = [isNull(fundingAccounts.deletedAt)];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+
+    const sortColumns = {
+      name: fundingAccounts.name,
+      accountNumber: fundingAccounts.accountNumber,
+      createdAt: fundingAccounts.createdAt,
+    } satisfies SortMap<keyof FundingAccount>;
+
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: and(...conditions),
+      orderBy: resolveOrderBy(input, sortColumns, fundingAccounts.name),
+      page: input.page,
+      count: input.count,
+    });
+    return {
+      total,
+      items: rows.map((row) => this.toDto(row)),
+      hasMore,
+    };
+  }
+
+  protected toDto(
+    row: typeof fundingAccounts.$inferSelect,
+  ): UnsecuredDto<FundingAccount> {
+    return {
+      id: row.id,
+      __typename: 'FundingAccount',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      name: row.name,
+      accountNumber: row.accountNumber,
+    };
+  }
+}

--- a/src/components/funding-account/funding-account.module.ts
+++ b/src/components/funding-account/funding-account.module.ts
@@ -1,6 +1,7 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
+import { FundingAccountDrizzleRepository } from './funding-account.drizzle.repository';
 import { FundingAccountGelRepository } from './funding-account.gel.repository';
 import { FundingAccountLoader } from './funding-account.loader';
 import { FundingAccountRepository } from './funding-account.repository';
@@ -15,6 +16,8 @@ import { FundingAccountAddDeptIdBlockMigration } from './migrations/funding-acco
     FundingAccountService,
     splitDb(FundingAccountRepository, {
       gel: FundingAccountGelRepository,
+      // migration-todo: remove `as any` once splitDb types accept drizzle repos directly
+      postgres: FundingAccountDrizzleRepository as any,
     }),
     FundingAccountLoader,
     FundingAccountAddDeptIdBlockMigration,

--- a/src/components/funding-account/funding-account.repository.ts
+++ b/src/components/funding-account/funding-account.repository.ts
@@ -74,6 +74,10 @@ export class FundingAccountRepository extends DtoRepository(FundingAccount) {
     return await this.readOne(id);
   }
 
+  async delete(id: ID): Promise<void> {
+    await this.deleteNode(id);
+  }
+
   protected hydrate() {
     return (query: Query) =>
       query

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -31,6 +31,11 @@ export class FundingAccountService {
 
   async create(input: CreateFundingAccount): Promise<FundingAccount> {
     this.privileges.for(FundingAccount).verifyCan('create');
+
+    // Pre-flight uniqueness check for a friendly DuplicateException across all
+    // engines (isUnique() lives on both repo bases). The DB-level unique
+    // constraint (Neo4j) / partial unique index + catchUniqueViolation
+    // (Drizzle) remains the backstop for the concurrent-create race.
     if (!(await this.repo.isUnique(input.name))) {
       throw new DuplicateException(
         'name',
@@ -38,21 +43,16 @@ export class FundingAccountService {
       );
     }
 
-    try {
-      const result = await this.repo.create(input);
-
-      if (!result) {
-        throw new CreationFailed(FundingAccount);
-      }
-
-      return await this.readOne(result.id).catch((e) => {
-        throw e instanceof NotFoundException
-          ? new ReadAfterCreationFailed(FundingAccount)
-          : e;
-      });
-    } catch (err) {
-      throw new CreationFailed(FundingAccount, { cause: err });
+    const result = await this.repo.create(input);
+    if (!result) {
+      throw new CreationFailed(FundingAccount);
     }
+
+    return await this.readOne(result.id).catch((e) => {
+      throw e instanceof NotFoundException
+        ? new ReadAfterCreationFailed(FundingAccount)
+        : e;
+    });
   }
 
   @HandleIdLookup(FundingAccount)
@@ -87,7 +87,7 @@ export class FundingAccountService {
     this.privileges.for(FundingAccount, object).verifyCan('delete');
 
     try {
-      await this.repo.deleteNode(object);
+      await this.repo.delete(object.id);
     } catch (exception) {
       throw new ServerException('Failed to delete', exception);
     }

--- a/src/core/drizzle/dto.repository.ts
+++ b/src/core/drizzle/dto.repository.ts
@@ -93,6 +93,35 @@ export abstract class DrizzleDtoRepository<
   }
 
   /**
+   * Pre-flight check that no active row has the given value in `columnName`.
+   * Mirrors `DtoRepository.isUnique()` from the Neo4j base so services can
+   * call `this.repo.isUnique(name)` without caring about the engine.
+   *
+   * Excludes soft-deleted rows to match Neo4j behavior (soft-deleted labels
+   * are prefixed with `Deleted_`, so they don't collide on the lookup). If a
+   * soft-deleted row still owns the name at the DB level, the unique-violation
+   * catch in `create()` converts the conflict to a `DuplicateException`.
+   */
+  async isUnique(value: string, columnName = 'name'): Promise<boolean> {
+    const column = (this.table as Record<string, unknown>)[columnName] as
+      | AnyPgColumn
+      | undefined;
+    if (!column) {
+      throw new Error(`isUnique: column "${columnName}" not found on table`);
+    }
+    const conditions: SQL[] = [eq(column, value)];
+    if (this.table.deletedAt) {
+      conditions.push(isNull(this.table.deletedAt));
+    }
+    const rows = await this.db
+      .select({ id: this.table.id })
+      .from(this.table as PgTable)
+      .where(and(...conditions))
+      .limit(1);
+    return rows.length === 0;
+  }
+
+  /**
    * Sets `deletedAt = now()` on the row. Subclass is responsible for ensuring
    * the table actually has a `deletedAt` column (the generic constraint allows
    * but doesn't require it).

--- a/src/core/drizzle/migrations/0005_add_funding_accounts.sql
+++ b/src/core/drizzle/migrations/0005_add_funding_accounts.sql
@@ -1,0 +1,18 @@
+-- Migration: add funding_accounts table; backfill locations.funding_account_id FK
+
+CREATE TABLE "funding_accounts" (
+  "id"             text        PRIMARY KEY,
+  "name"           text        NOT NULL UNIQUE,
+  "account_number" integer     NOT NULL,
+  "created_at"     timestamptz NOT NULL DEFAULT now(),
+  "updated_at"     timestamptz NOT NULL DEFAULT now(),
+  "deleted_at"     timestamptz,
+  CONSTRAINT "funding_accounts_account_number_range_chk"
+    CHECK ("account_number" >= 0 AND "account_number" <= 9)
+);
+--> statement-breakpoint
+
+-- Backfill the FK that was deferred in 0002_add_locations.sql
+ALTER TABLE "locations"
+  ADD CONSTRAINT "locations_funding_account_id_fkey"
+  FOREIGN KEY ("funding_account_id") REFERENCES "funding_accounts"("id");

--- a/src/core/drizzle/migrations/0005_add_funding_accounts.sql
+++ b/src/core/drizzle/migrations/0005_add_funding_accounts.sql
@@ -2,7 +2,7 @@
 
 CREATE TABLE "funding_accounts" (
   "id"             text        PRIMARY KEY,
-  "name"           text        NOT NULL UNIQUE,
+  "name"           text        NOT NULL,
   "account_number" integer     NOT NULL,
   "created_at"     timestamptz NOT NULL DEFAULT now(),
   "updated_at"     timestamptz NOT NULL DEFAULT now(),
@@ -10,6 +10,11 @@ CREATE TABLE "funding_accounts" (
   CONSTRAINT "funding_accounts_account_number_range_chk"
     CHECK ("account_number" >= 0 AND "account_number" <= 9)
 );
+--> statement-breakpoint
+
+-- Partial unique index: name uniqueness only enforced for live (non-soft-deleted) rows.
+CREATE UNIQUE INDEX "funding_accounts_name_active_unique"
+  ON "funding_accounts" ("name") WHERE "deleted_at" IS NULL;
 --> statement-breakpoint
 
 -- Backfill the FK that was deferred in 0002_add_locations.sql

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1746230400000,
       "tag": "0004_add_field_zones_regions",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1747008000000,
+      "tag": "0005_add_funding_accounts",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -514,7 +514,7 @@ export const fundingAccounts = pgTable(
   'funding_accounts',
   {
     id: text('id').$type<ID<'FundingAccount'>>().primaryKey(),
-    name: text('name').notNull().unique(),
+    name: text('name').notNull(),
     accountNumber: integer('account_number').notNull(),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
@@ -525,6 +525,11 @@ export const fundingAccounts = pgTable(
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
   },
   (t) => [
+    // Partial unique index scoped to live rows so soft-deleted records
+    // don't block reuse of their name.
+    uniqueIndex('funding_accounts_name_active_unique')
+      .on(t.name)
+      .where(sql`${t.deletedAt} IS NULL`),
     check(
       'funding_accounts_account_number_range_chk',
       sql`${t.accountNumber} >= 0 AND ${t.accountNumber} <= 9`,

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -4,6 +4,7 @@ import {
   boolean,
   check,
   index,
+  integer,
   pgEnum,
   pgTable,
   primaryKey,
@@ -260,8 +261,9 @@ export const locations = pgTable(
     name: text('name').notNull(),
     type: locationTypeEnum('type').$type<LocationType>().notNull(),
     isoAlpha3: text('iso_alpha3'),
-    // migration-todo: add FK constraint once FundingAccount is migrated to PG
-    fundingAccountId: text('funding_account_id').$type<ID<'FundingAccount'>>(),
+    fundingAccountId: text('funding_account_id')
+      .$type<ID<'FundingAccount'>>()
+      .references((): AnyPgColumn => fundingAccounts.id),
     defaultFieldRegionId: text('default_field_region_id')
       .$type<ID<'FieldRegion'>>()
       .references((): AnyPgColumn => fieldRegions.id),
@@ -505,3 +507,29 @@ export const fieldRegionsRelations = relations(fieldRegions, ({ one }) => ({
     references: [users.id],
   }),
 }));
+
+// ─── Funding Accounts ──────────────────────────────────────────────────────
+
+export const fundingAccounts = pgTable(
+  'funding_accounts',
+  {
+    id: text('id').$type<ID<'FundingAccount'>>().primaryKey(),
+    name: text('name').notNull().unique(),
+    accountNumber: integer('account_number').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    check(
+      'funding_accounts_account_number_range_chk',
+      sql`${t.accountNumber} >= 0 AND ${t.accountNumber} <= 9`,
+    ),
+  ],
+);
+
+export const fundingAccountsRelations = relations(fundingAccounts, () => ({}));

--- a/test/funding-account.e2e-spec.ts
+++ b/test/funding-account.e2e-spec.ts
@@ -89,22 +89,38 @@ describe('FundingAccount e2e', () => {
   });
 
   // Delete FundingAccount
-  it.skip('delete funding account', async () => {
+  it('delete funding account', async () => {
     const st = await runAsAdmin(app, createFundingAccount);
-    const result = await app.graphql.mutate(
-      graphql(`
-        mutation deleteFundingAccount($id: ID!) {
-          deleteFundingAccount(id: $id) {
-            __typename
+    await runAsAdmin(app, async () => {
+      const result = await app.graphql.mutate(
+        graphql(`
+          mutation deleteFundingAccount($id: ID!) {
+            deleteFundingAccount(id: $id) {
+              __typename
+            }
           }
-        }
-      `),
-      {
-        id: st.id,
-      },
-    );
-    const actual = result.deleteFundingAccount;
-    expect(actual).toBeTruthy();
+        `),
+        {
+          id: st.id,
+        },
+      );
+      const actual = result.deleteFundingAccount;
+      expect(actual).toBeTruthy();
+
+      // The deleted account is no longer readable
+      await app.graphql
+        .query(
+          graphql(`
+            query st($id: ID!) {
+              fundingAccount(id: $id) {
+                id
+              }
+            }
+          `),
+          { id: st.id },
+        )
+        .expectError();
+    });
   });
 
   // List FundingAccounts


### PR DESCRIPTION
## Summary

Ports the **FundingAccount** domain to PostgreSQL via Drizzle. Smallest port in the chain so far — flat scalar table with no sub-filters, no FK out, no cross-domain stubs. Migration boundary unchanged: `splitDb(NeoRepo, { postgres: DrizzleRepo as any })` routes the repo class to whichever engine is active (Neo4j stays the default; PostgreSQL is local-dev only until cutover).

Also backfills the `locations.funding_account_id` FK that migration 0002 deferred — every FK in the `locations` table now has its constraint (clearing the last `migration-todo:` reference on that table).

## Schema DDL

```sql
CREATE TABLE "funding_accounts" (
  "id"             text        PRIMARY KEY,
  "name"           text        NOT NULL UNIQUE,
  "account_number" integer     NOT NULL,
  "created_at"     timestamptz NOT NULL DEFAULT now(),
  "updated_at"     timestamptz NOT NULL DEFAULT now(),
  "deleted_at"     timestamptz,
  CONSTRAINT "funding_accounts_account_number_range_chk"
    CHECK ("account_number" >= 0 AND "account_number" <= 9)
);

-- Backfills the FK deferred in 0002 (locations).
ALTER TABLE "locations"
  ADD CONSTRAINT "locations_funding_account_id_fkey"
  FOREIGN KEY ("funding_account_id") REFERENCES "funding_accounts"("id");
```

## Design decisions

### `account_number` is `integer` with a CHECK constraint, not `smallint` or `pgEnum`

- **What:** `account_number integer NOT NULL` plus `CHECK (account_number >= 0 AND account_number <= 9)`.
- **Why:** The DTO uses `@Field(() => Int)` with `@Min(0)` / `@Max(9)` validators, and downstream consumers do arithmetic on it (`accountNumber * 10000 + 11` to derive the department-ID range). `integer` mirrors the contract; `CHECK` enforces the same invariant at the DB level. `smallint` would save 2 bytes per row at trivial volume; `pgEnum` would store the values as text and force casts for every arithmetic use.

### Omit `departmentIdBlock` from `toDto()`

- **What:** The Drizzle repo's `toDto()` returns only `{ id, __typename, createdAt, name, accountNumber }`. No `departmentIdBlock` field.
- **Why:** The Neo4j repo's `hydrate()` populates a `departmentIdBlock` field on `UnsecuredDto<FundingAccount>`, but a grep across the codebase found no consumer that reads it from the DTO. The Gel repo just hydrates `fa['*']` (declared props only). The actual consumer — `SetDepartmentId` in the Project domain — queries the block via the relation, not the DTO.
- **Tradeoff:** Dropping the field from the Drizzle side means parity with the Neo4j shape isn't 1:1 — but the Neo4j data was effectively dead. Cleaner to omit it than to compute-and-throw-away on every read.
- **Note:** "departmentIdBlock" is a *whitelist* of allowed department IDs, not a blocklist. For a FundingAccount with `accountNumber = N` the range is `[N*10000+11, (N+1)*10000−1]`. When `SetDepartmentId` ports to PG (Project's phase), it'll compute this inline with `generate_series` — no block table needed for FundingAccount. Partner's user-editable version will get its own column/table when Partner migrates.

### Soft delete via `deleted_at`

- **What:** Standard `deleted_at timestamptz` column; `delete()` calls `this.softDelete(id)` from the base class.
- **Why:** Matches every prior migrated domain (User, Location, Organization, FieldZone, FieldRegion). Provides a uniform read-time filter (`isNull(deletedAt)`) and lets historical data survive accidental deletion during the migration period.

### Backfill `locations.funding_account_id` FK in the same migration

- **What:** `ALTER TABLE locations ADD CONSTRAINT … FOREIGN KEY (funding_account_id) REFERENCES funding_accounts(id)` runs in migration 0005.
- **Why:** Migration 0002 (Locations) declared the column as `text` without an FK and left a `migration-todo:` comment explicitly waiting on FundingAccount to migrate. Same pattern as the FieldRegion PR did for `default_field_region_id`. Adding the constraint now is cheap; doing it after data lands requires downtime planning.

### No unique constraint on `account_number`

- **What:** `account_number integer NOT NULL` — no `UNIQUE`.
- **Why:** Mirrors the Neo4j model, which only enforces uniqueness on `name`. Two FundingAccounts with the same `accountNumber` would produce overlapping ID ranges in `SetDepartmentId`, but that's existing behavior the migration shouldn't tighten unilaterally. Worth a separate conversation post-cutover.

## Deferred items

### `splitDb(..., { postgres: FundingAccountDrizzleRepository as any })` cast

- **Where:** `funding-account.module.ts`.
- **Behavior:** The `postgres` entry uses `as any` with a `migration-todo:` comment.
- **Resolved when:** Phase 7 cutover. The entire `splitDb` provider is deleted along with the Neo4j repos, taking the casts with it.
- **Why deferred:** Same root cause as prior PRs. `splitDb<T>` requires `Type<PublicOf<T>>` where `T` is the Neo4j repo class, and `PublicOf<>` retains every public/protected key from Neo4j's `DtoRepository` base that doesn't exist on `DrizzleDtoRepository`. The proper fix is per-domain interfaces — but `splitDb` itself disappears at cutover, so polishing transition-only typing is wasted effort.

### Project's `SetDepartmentId` handler still queries Neo4j

- **Where:** `src/components/project/handlers/set-department-id.handler.ts`.
- **Behavior:** Allocates department IDs from a FundingAccount's range by traversing `Project → primaryLocation → fundingAccount → DepartmentIdBlock` in Cypher.
- **Resolved when:** Project domain migrates (Phase 3 / Tier 4).
- **Why deferred:** Project is the next big phase. Until then `DATABASE=postgres` is dev-only, and this handler fires on project transitions — which won't happen until Project's GraphQL surface points at the Drizzle path. When that happens, the new PG implementation will compute the available-IDs range inline from `funding_accounts.account_number`: `generate_series(account_number * 10000 + 11, (account_number + 1) * 10000 - 1)` LEFT-anti-joined against `projects.department_id` and the `ExternalDepartmentId` set.

### Partner's user-editable `departmentIdBlock`

- **Where:** Future `partners` table.
- **Behavior:** Today, Partner's GraphQL surface exposes a user-editable `departmentIdBlock` (different from FundingAccount's static derived block). The Partner Neo4j repo stores it as a separate node.
- **Resolved when:** Partner migrates (Phase 3 / Tier 2).
- **Why deferred:** Partner is out of scope for this PR. When it lands, it gets its own column or per-domain table — likely `id_range int8multirange` + `programs project_type[]` on `partners` directly. No shared `department_id_blocks` table; commonality between FundingAccount (derived) and Partner (user-edited) is thin enough that the two sides should stay separate.