### PR TITLE
#10 [pg] Tool Migration

### DIFF
--- a/src/components/tools/tool/tool.drizzle.repository.ts
+++ b/src/components/tools/tool/tool.drizzle.repository.ts
@@ -1,0 +1,156 @@
+import { Injectable } from '@nestjs/common';
+import { and, eq, ilike, isNull, type SQL } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  generateId,
+  type ID,
+  NotFoundException,
+  type PaginatedListType,
+  type UnsecuredDto,
+} from '~/common';
+import {
+  catchUniqueViolation,
+  DrizzleDtoRepository,
+  EMPTY_PAGE,
+  escapeLikePattern,
+  resolveOrderBy,
+  type SortMap,
+} from '~/core/drizzle';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
+import { tools } from '~/core/drizzle/schema';
+import { PolicyExecutor } from '../../authorization/policy/executor/policy-executor';
+import {
+  type CreateTool,
+  Tool,
+  type ToolFilters,
+  type ToolListInput,
+  type UpdateTool,
+} from './dto';
+import { type ToolKey } from './dto/tool-key.enum';
+
+const catchNameUnique = catchUniqueViolation(
+  'tools_name',
+  'name',
+  'Tool with this name already exists.',
+);
+const catchKeyUnique = catchUniqueViolation(
+  'tools_key_unique',
+  'key',
+  'Key is already assigned to another tool.',
+);
+
+@Injectable()
+export class ToolDrizzleRepository extends DrizzleDtoRepository<
+  typeof tools,
+  Tool
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+  ) {
+    super(db, tools, Tool);
+  }
+
+  async create(input: CreateTool): Promise<UnsecuredDto<Tool>> {
+    const id = await generateId();
+    await this.db
+      .insert(tools)
+      .values({
+        id,
+        name: input.name,
+        description: input.description,
+        aiBased: input.aiBased,
+        key: input.key,
+      })
+      .catch(catchKeyUnique)
+      .catch(catchNameUnique);
+    return await this.readOne(id);
+  }
+
+  async update(changes: UpdateTool): Promise<UnsecuredDto<Tool>> {
+    const { id, ...fields } = changes;
+    await this.updateColumns(id, {
+      name: fields.name,
+      description: fields.description,
+      aiBased: fields.aiBased,
+      key: fields.key,
+    })
+      .catch(catchKeyUnique)
+      .catch(catchNameUnique);
+    return await this.readOne(id);
+  }
+
+  async delete(id: ID): Promise<void> {
+    await this.softDelete(id);
+  }
+
+  async list(
+    input: ToolListInput,
+  ): Promise<PaginatedListType<UnsecuredDto<Tool>>> {
+    const conditions: SQL[] = [
+      isNull(tools.deletedAt),
+      ...toolFilterClauses(this.db, input.filter),
+    ];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+
+    const sortColumns = {
+      name: tools.name,
+      createdAt: tools.createdAt,
+    } satisfies SortMap<keyof Tool>;
+
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: and(...conditions),
+      orderBy: resolveOrderBy(input, sortColumns, tools.name),
+      page: input.page,
+      count: input.count,
+    });
+    return {
+      total,
+      items: rows.map((row) => this.toDto(row)),
+      hasMore,
+    };
+  }
+
+  async idByKey(key: ToolKey): Promise<ID<'Tool'>> {
+    const rows = await this.db
+      .select({ id: tools.id })
+      .from(tools)
+      .where(and(eq(tools.key, key), isNull(tools.deletedAt)))
+      .limit(1);
+    const row = rows[0];
+    if (!row) throw new NotFoundException('Tool not found', 'key');
+    return row.id;
+  }
+
+  protected toDto(row: typeof tools.$inferSelect): UnsecuredDto<Tool> {
+    return {
+      id: row.id,
+      __typename: 'Tool',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      name: row.name,
+      description: row.description,
+      aiBased: row.aiBased,
+      key: row.key,
+    };
+  }
+}
+
+/**
+ * Build the column-level WHERE clauses for a `ToolFilters` input against the
+ * `tools` table. Reusable from sub-filters in other domains (e.g. ToolUsage's
+ * `tool` filter once it is migrated).
+ */
+export const toolFilterClauses = (
+  _db: DrizzleDb,
+  filter: ToolFilters | undefined,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+  if (filter.id) conditions.push(eq(tools.id, filter.id));
+  if (filter.name) {
+    conditions.push(ilike(tools.name, `%${escapeLikePattern(filter.name)}%`));
+  }
+  return conditions;
+};

--- a/src/components/tools/tool/tool.drizzle.repository.ts
+++ b/src/components/tools/tool/tool.drizzle.repository.ts
@@ -87,13 +87,11 @@ export class ToolDrizzleRepository extends DrizzleDtoRepository<
   async list(
     input: ToolListInput,
   ): Promise<PaginatedListType<UnsecuredDto<Tool>>> {
-    const conditions: SQL[] = [
-      isNull(tools.deletedAt),
-      ...toolFilterClauses(this.db, input.filter),
-    ];
+    const conditions: SQL[] = [isNull(tools.deletedAt)];
     if (!this.executor.applyReadFilter(this.resource, conditions)) {
       return EMPTY_PAGE;
     }
+    conditions.push(...toolFilterClauses(this.db, input.filter));
 
     const sortColumns = {
       name: tools.name,

--- a/src/components/tools/tool/tool.drizzle.repository.ts
+++ b/src/components/tools/tool/tool.drizzle.repository.ts
@@ -29,7 +29,7 @@ import {
 import { type ToolKey } from './dto/tool-key.enum';
 
 const catchNameUnique = catchUniqueViolation(
-  'tools_name',
+  'tools_name_active_unique',
   'name',
   'Tool with this name already exists.',
 );

--- a/src/components/tools/tool/tool.module.ts
+++ b/src/components/tools/tool/tool.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { splitDb } from '~/core/database';
+import { ToolDrizzleRepository } from './tool.drizzle.repository';
 import { ToolRepository as GelRepository } from './tool.gel.repository';
 import { ToolLoader } from './tool.loader';
 import { ToolRepository as Neo4jRepository } from './tool.neo4j.repository';
@@ -11,7 +12,11 @@ import { ToolService } from './tool.service';
     ToolResolver,
     ToolLoader,
     ToolService,
-    splitDb(Neo4jRepository, { gel: GelRepository }),
+    splitDb(Neo4jRepository, {
+      gel: GelRepository,
+      // migration-todo: remove `as any` once splitDb types accept drizzle repos directly
+      postgres: ToolDrizzleRepository as any,
+    }),
   ],
   exports: [ToolService, Neo4jRepository],
 })

--- a/src/core/drizzle/migrations/0006_add_tools.sql
+++ b/src/core/drizzle/migrations/0006_add_tools.sql
@@ -5,7 +5,7 @@ CREATE TYPE "tool_key" AS ENUM ('Rev79');
 
 CREATE TABLE "tools" (
   "id"          text        PRIMARY KEY,
-  "name"        text        NOT NULL UNIQUE,
+  "name"        text        NOT NULL,
   "description" text,
   "ai_based"    boolean     NOT NULL DEFAULT false,
   "key"         "tool_key",
@@ -13,6 +13,11 @@ CREATE TABLE "tools" (
   "updated_at"  timestamptz NOT NULL DEFAULT now(),
   "deleted_at"  timestamptz
 );
+--> statement-breakpoint
+
+-- Partial unique index: name uniqueness only enforced for live (non-soft-deleted) rows.
+CREATE UNIQUE INDEX "tools_name_active_unique"
+  ON "tools" ("name") WHERE "deleted_at" IS NULL;
 --> statement-breakpoint
 
 -- Partial unique: one active tool per machine identifier; NULLs allowed.

--- a/src/core/drizzle/migrations/0006_add_tools.sql
+++ b/src/core/drizzle/migrations/0006_add_tools.sql
@@ -1,0 +1,21 @@
+-- Migration: add tools table + tool_key enum.
+
+CREATE TYPE "tool_key" AS ENUM ('Rev79');
+--> statement-breakpoint
+
+CREATE TABLE "tools" (
+  "id"          text        PRIMARY KEY,
+  "name"        text        NOT NULL UNIQUE,
+  "description" text,
+  "ai_based"    boolean     NOT NULL DEFAULT false,
+  "key"         "tool_key",
+  "created_at"  timestamptz NOT NULL DEFAULT now(),
+  "updated_at"  timestamptz NOT NULL DEFAULT now(),
+  "deleted_at"  timestamptz
+);
+--> statement-breakpoint
+
+-- Partial unique: one active tool per machine identifier; NULLs allowed.
+CREATE UNIQUE INDEX "tools_key_unique"
+  ON "tools" ("key")
+  WHERE "key" IS NOT NULL AND "deleted_at" IS NULL;

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1747008000000,
       "tag": "0005_add_funding_accounts",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1747267200000,
+      "tag": "0006_add_tools",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -16,6 +16,7 @@ import { type ID, type Role } from '~/common';
 import { type LocationType } from '../../../components/location/dto/location-type.enum';
 import { type OrganizationReach } from '../../../components/organization/dto/organization-reach.dto';
 import { type OrganizationType } from '../../../components/organization/dto/organization-type.dto';
+import { type ToolKey } from '../../../components/tools/tool/dto/tool-key.enum';
 import { type Gender } from '../../../components/user/dto/gender.enum';
 
 export const userStatusEnum = pgEnum('user_status', ['Active', 'Disabled']);
@@ -538,3 +539,35 @@ export const fundingAccounts = pgTable(
 );
 
 export const fundingAccountsRelations = relations(fundingAccounts, () => ({}));
+
+// ─── Tools ─────────────────────────────────────────────────────────────────
+
+export const toolKeyEnum = pgEnum('tool_key', ['Rev79']);
+
+export const tools = pgTable(
+  'tools',
+  {
+    id: text('id').$type<ID<'Tool'>>().primaryKey(),
+    name: text('name').notNull().unique(),
+    description: text('description'),
+    aiBased: boolean('ai_based').notNull().default(false),
+    key: toolKeyEnum('key').$type<ToolKey>(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    // Partial unique on `key`: enforce one tool per machine identifier among
+    // active (non-deleted) rows. NULLs are excluded by the WHERE clause so
+    // tools without a key never collide.
+    uniqueIndex('tools_key_unique')
+      .on(t.key)
+      .where(sql`${t.key} IS NOT NULL AND ${t.deletedAt} IS NULL`),
+  ],
+);
+
+export const toolsRelations = relations(tools, () => ({}));

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -548,7 +548,7 @@ export const tools = pgTable(
   'tools',
   {
     id: text('id').$type<ID<'Tool'>>().primaryKey(),
-    name: text('name').notNull().unique(),
+    name: text('name').notNull(),
     description: text('description'),
     aiBased: boolean('ai_based').notNull().default(false),
     key: toolKeyEnum('key').$type<ToolKey>(),
@@ -561,6 +561,11 @@ export const tools = pgTable(
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
   },
   (t) => [
+    // Partial unique index scoped to live rows so soft-deleted records
+    // don't block reuse of their name.
+    uniqueIndex('tools_name_active_unique')
+      .on(t.name)
+      .where(sql`${t.deletedAt} IS NULL`),
     // Partial unique on `key`: enforce one tool per machine identifier among
     // active (non-deleted) rows. NULLs are excluded by the WHERE clause so
     // tools without a key never collide.


### PR DESCRIPTION
## Summary

Tier 1 domain port. Adds the `tools` table + `tool_key` pgEnum, then
wires `ToolDrizzleRepository` behind `splitDb()` so DATABASE=postgres
exercises the new path. No callers above the repo layer change.

## Schema

```sql
CREATE TYPE "tool_key" AS ENUM ('Rev79');

CREATE TABLE "tools" (
  "id"          text        PRIMARY KEY,
  "name"        text        NOT NULL UNIQUE,
  "description" text,
  "ai_based"    boolean     NOT NULL DEFAULT false,
  "key"         "tool_key",
  "created_at"  timestamptz NOT NULL DEFAULT now(),
  "updated_at"  timestamptz NOT NULL DEFAULT now(),
  "deleted_at"  timestamptz
);

CREATE UNIQUE INDEX "tools_key_unique"
  ON "tools" ("key")
  WHERE "key" IS NOT NULL AND "deleted_at" IS NULL;
```

## Decisions

| Decision | Choice | Why |
|---|---|---|
| \`key\` column type | \`pgEnum('tool_key', ['Rev79'])\` | Closed set today (only \`Rev79\`); matches the established pattern for closed enums (gender, degree, location_type, etc.). Adding values later costs one \`ALTER TYPE\` line in a future migration — fine since enum additions are rare. |
| Uniqueness on \`key\` | Partial unique index | \`key\` is nullable (most tools don't have a machine identifier). Partial unique scoped to \`key IS NOT NULL AND deleted_at IS NULL\` enforces exactly the invariant we want: at most one *active* tool per machine identifier. |
| Pre-flight uniqueness checks | None | Drizzle pattern is \`catchUniqueViolation\` on insert/update, not \`isUnique()\` pre-flight. Both name and key violations convert to \`DuplicateException\` with the right field tag. |
| \`assertKeyUnassigned\` ported? | No | It was \`private\` on the Neo4j repo and only used internally before insert. The unique-violation catch on the Drizzle side covers the same surface. |
| \`idByKey\` ported? | Yes | Consumed by \`tool-usage.service.ts:253\` — \`this.toolRepo.idByKey(key)\`. Public method on both Neo4j and Gel repos. |
| FullText index on name | Dropped | Neo4j had \`ToolName\` full-text index for the name filter. PG uses \`ilike\` with \`escapeLikePattern\` — same pattern as FieldZone/FieldRegion/FundingAccount. |
| \`toolFilterClauses\` export | Added | ToolUsage's filter sub-delegates to \`ToolFilters\`. Following the \`*FilterClauses\` helper pattern established in PR #8 (FieldZone/FieldRegion). |

## Deferred / migration-todo

| Item | Where | Resolves at |
|---|---|---|
| \`splitDb\` \`as any\` cast | \`tool.module.ts\` | Phase 7 cutover, when \`splitDb\` is deleted entirely (same as every prior domain PR). |
| \`tool.service.delete()\` calls \`repo.deleteNode(tool)\` | \`tool.service.ts:63\` | Tracked separately under the codebase-wide \`deleteNode → delete(id)\` rename. Not blocking — DATABASE=postgres is dev-only until cutover. |

