### PR TITLE
#11 [pg] Ethnologue Language Migration

### DIFF
--- a/src/components/language/ethnologue-language/ethnologue-language.drizzle.repository.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.drizzle.repository.ts
@@ -38,6 +38,27 @@ export class EthnologueLanguageDrizzleRepository extends DrizzleDtoRepository<
   async create(
     input: CreateEthnologueLanguage & { languageId: ID },
   ): Promise<UnsecuredDto<EthnologueLanguage>> {
+    // migration-todo: `EthnologueLanguageService.create()` currently passes
+    // `'temp' as ID` for `languageId` because the Language row is created
+    // *after* the EthnologueLanguage in `LanguageRepository.create()` — the
+    // relationship is wired up by the caller via the returned ethnologue
+    // id, so Neo4j never reads `input.languageId`. The Gel repo's `create()`
+    // throws ("Database creates EthnologueLanguages directly. Don't call
+    // this") because Gel creates the row as a side-effect of Language insert.
+    //
+    // Drizzle is the only impl that writes `input.languageId` to a real
+    // column. With `language_id` now nullable (see schema comment), the
+    // 'temp' string still slips through as a non-null bogus id today — the
+    // schema doesn't reject it, but it's still wrong data.
+    //
+    // Resolution lands with the Language migration (Phase 3&4) by flipping
+    // the create flow: insert Language first, then EthnologueLanguage with
+    // the real `languageId`. Or, if the global-pool model is in place by
+    // then, the service `create()` becomes "attach existing pool entry by
+    // code if one matches, else insert a new pool entry" — at which point
+    // `languageId` here is the attaching Language and the call to this
+    // repo's `create()` only fires for genuinely new pool entries.
+    // Dormant until PG mode activates.
     const id = await generateId();
     await this.db
       .insert(ethnologueLanguages)

--- a/src/components/language/ethnologue-language/ethnologue-language.drizzle.repository.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.drizzle.repository.ts
@@ -1,0 +1,127 @@
+import { Injectable } from '@nestjs/common';
+import { ilike, type SQL } from 'drizzle-orm';
+import { generateId, type ID, type UnsecuredDto } from '~/common';
+import {
+  catchUniqueViolation,
+  DrizzleDtoRepository,
+  escapeLikePattern,
+} from '~/core/drizzle';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
+import { ethnologueLanguages } from '~/core/drizzle/schema';
+import {
+  type CreateEthnologueLanguage,
+  EthnologueLanguage,
+  type EthnologueLanguageFilters,
+  type UpdateEthnologueLanguage,
+} from '../dto';
+
+const catchCodeUnique = catchUniqueViolation(
+  'ethnologue_languages_code_unique',
+  'code',
+  'EthnologueLanguage with this code already exists.',
+);
+const catchProvisionalCodeUnique = catchUniqueViolation(
+  'ethnologue_languages_provisional_code_unique',
+  'provisionalCode',
+  'EthnologueLanguage with this provisional code already exists.',
+);
+
+@Injectable()
+export class EthnologueLanguageDrizzleRepository extends DrizzleDtoRepository<
+  typeof ethnologueLanguages,
+  EthnologueLanguage
+> {
+  constructor(db: DrizzleService) {
+    super(db, ethnologueLanguages, EthnologueLanguage);
+  }
+
+  async create(
+    input: CreateEthnologueLanguage & { languageId: ID },
+  ): Promise<UnsecuredDto<EthnologueLanguage>> {
+    const id = await generateId();
+    await this.db
+      .insert(ethnologueLanguages)
+      .values({
+        id,
+        languageId: input.languageId,
+        code: input.code,
+        provisionalCode: input.provisionalCode,
+        name: input.name,
+        population: input.population,
+      })
+      .catch(catchCodeUnique)
+      .catch(catchProvisionalCodeUnique);
+    return await this.readOne(id);
+  }
+
+  async update(
+    changes: UpdateEthnologueLanguage & { id: ID },
+  ): Promise<UnsecuredDto<EthnologueLanguage>> {
+    const { id, ...fields } = changes;
+    await this.updateColumns(id, {
+      code: fields.code,
+      provisionalCode: fields.provisionalCode,
+      name: fields.name,
+      population: fields.population,
+    })
+      .catch(catchCodeUnique)
+      .catch(catchProvisionalCodeUnique);
+    return await this.readOne(id);
+  }
+
+  protected toDto(
+    row: typeof ethnologueLanguages.$inferSelect,
+  ): UnsecuredDto<EthnologueLanguage> {
+    // `sensitivity` is intentionally omitted: the row doesn't carry it
+    // (lives on the parent Language) and `EthnologueLanguageService.secure()`
+    // overlays it via `withEffectiveSensitivity` before any consumer sees
+    // the value. The `as unknown as` cast is the smallest temp patch possible —
+    // populating a placeholder would read as a real default.
+    //
+    // migration-todo: (Phase 3&4) when Language migrates, JOIN
+    // `languages.sensitivity` into readMany and remove this cast.
+    return {
+      id: row.id,
+      __typename: 'EthnologueLanguage',
+      code: row.code,
+      provisionalCode: row.provisionalCode,
+      name: row.name,
+      population: row.population,
+    } as unknown as UnsecuredDto<EthnologueLanguage>;
+  }
+}
+
+/**
+ * Build the column-level WHERE clauses for an `EthnologueLanguageFilters`
+ * input against the `ethnologue_languages` table. Reusable from Language's
+ * `ethnologue` sub-filter when that domain migrates.
+ *
+ * `code`/`provisionalCode`/`name` are partial substring matches to mirror
+ * the Neo4j `filter.propPartialVal()` semantics in `language.repository.ts`.
+ */
+export const ethnologueLanguageFilterClauses = (
+  _db: DrizzleDb,
+  filter: EthnologueLanguageFilters | undefined,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+  if (filter.code) {
+    conditions.push(
+      ilike(ethnologueLanguages.code, `%${escapeLikePattern(filter.code)}%`),
+    );
+  }
+  if (filter.provisionalCode) {
+    conditions.push(
+      ilike(
+        ethnologueLanguages.provisionalCode,
+        `%${escapeLikePattern(filter.provisionalCode)}%`,
+      ),
+    );
+  }
+  if (filter.name) {
+    conditions.push(
+      ilike(ethnologueLanguages.name, `%${escapeLikePattern(filter.name)}%`),
+    );
+  }
+  return conditions;
+};

--- a/src/components/language/language.module.ts
+++ b/src/components/language/language.module.ts
@@ -5,6 +5,7 @@ import { EngagementModule } from '../engagement/engagement.module';
 import { LocationModule } from '../location/location.module';
 import { ProjectModule } from '../project/project.module';
 import { EthnologueLanguageService } from './ethnologue-language';
+import { EthnologueLanguageDrizzleRepository } from './ethnologue-language/ethnologue-language.drizzle.repository';
 import { EthnologueLanguageGelRepository } from './ethnologue-language/ethnologue-language.gel.repository';
 import { EthnologueLanguageRepository } from './ethnologue-language/ethnologue-language.repository';
 import { InternalFirstScriptureResolver } from './internal-first-scripture.resolver';
@@ -39,6 +40,8 @@ import { RegistryOfDialectToRegistryOfLanguageVarietiesMigration } from './migra
     EthnologueLanguageService,
     splitDb(EthnologueLanguageRepository, {
       gel: EthnologueLanguageGelRepository,
+      // migration-todo: remove `as any` once splitDb types accept drizzle repos directly
+      postgres: EthnologueLanguageDrizzleRepository as any,
     }),
     splitDb(LanguageRepository, {
       gel: LanguageGelRepository,

--- a/src/core/drizzle/migrations/0007_add_ethnologue_languages.sql
+++ b/src/core/drizzle/migrations/0007_add_ethnologue_languages.sql
@@ -1,0 +1,41 @@
+-- Migration: add ethnologue_languages table.
+--
+-- EthnologueLanguage is a 1:1 sub-record of Language. The `language_id`
+-- column is a logical FK only until Language migrates in Phase 3&4, at which
+-- point the `REFERENCES languages(id) ON DELETE CASCADE` clause + a btree
+-- index on `language_id` get added in Language's migration.
+
+CREATE TABLE "ethnologue_languages" (
+  "id"               text        PRIMARY KEY,
+  "language_id"      text        NOT NULL,
+  "code"             text,
+  "provisional_code" text,
+  "name"             text,
+  "population"       integer,
+  "created_at"       timestamptz NOT NULL DEFAULT now(),
+  "updated_at"       timestamptz NOT NULL DEFAULT now(),
+  "deleted_at"       timestamptz,
+  CONSTRAINT "ethnologue_languages_code_format_chk"
+    CHECK ("code" IS NULL OR "code" ~ '^[a-z]{3}$'),
+  CONSTRAINT "ethnologue_languages_provisional_code_format_chk"
+    CHECK ("provisional_code" IS NULL OR "provisional_code" ~ '^[a-z]{3}$'),
+  CONSTRAINT "ethnologue_languages_population_non_negative_chk"
+    CHECK ("population" IS NULL OR "population" >= 0)
+);
+--> statement-breakpoint
+
+-- One active EthnologueLanguage row per Language.
+CREATE UNIQUE INDEX "ethnologue_languages_language_id_unique"
+  ON "ethnologue_languages" ("language_id")
+  WHERE "deleted_at" IS NULL;
+--> statement-breakpoint
+
+-- Codes are unique among active rows; null codes don't collide.
+CREATE UNIQUE INDEX "ethnologue_languages_code_unique"
+  ON "ethnologue_languages" ("code")
+  WHERE "code" IS NOT NULL AND "deleted_at" IS NULL;
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX "ethnologue_languages_provisional_code_unique"
+  ON "ethnologue_languages" ("provisional_code")
+  WHERE "provisional_code" IS NOT NULL AND "deleted_at" IS NULL;

--- a/src/core/drizzle/migrations/0007_add_ethnologue_languages.sql
+++ b/src/core/drizzle/migrations/0007_add_ethnologue_languages.sql
@@ -1,13 +1,21 @@
 -- Migration: add ethnologue_languages table.
 --
--- EthnologueLanguage is a 1:1 sub-record of Language. The `language_id`
--- column is a logical FK only until Language migrates in Phase 3&4, at which
--- point the `REFERENCES languages(id) ON DELETE CASCADE` clause + a btree
--- index on `language_id` get added in Language's migration.
+-- EthnologueLanguage is currently created 1:1 alongside a Language, but the
+-- schema preserves the path to the planned future model where these become
+-- a global pool of canonical language records and `language_id` is a soft
+-- attachment (new Languages hook into existing pool entries by code).
+-- Concretely:
+--   - `language_id` is NULLABLE (orphans are valid; pool entries pre-date
+--     their attachment).
+--   - When Language migrates in Phase 3&4 it adds `REFERENCES languages(id)
+--     ON DELETE SET NULL` (not CASCADE — deleting a Language releases the
+--     attachment, doesn't destroy the pool entry) + a btree index.
+--   - `code` / `provisional_code` uniqueness is GLOBAL (not scoped to
+--     attached rows) — the future pool requires globally unique codes.
 
 CREATE TABLE "ethnologue_languages" (
   "id"               text        PRIMARY KEY,
-  "language_id"      text        NOT NULL,
+  "language_id"      text,
   "code"             text,
   "provisional_code" text,
   "name"             text,

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1747267200000,
       "tag": "0006_add_tools",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1747353600000,
+      "tag": "0007_add_ethnologue_languages",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -546,10 +546,32 @@ export const ethnologueLanguages = pgTable(
   'ethnologue_languages',
   {
     id: text('id').$type<ID<'EthnologueLanguage'>>().primaryKey(),
-    // migration-todo: add REFERENCES languages(id) ON DELETE CASCADE when
-    // Language migrates in Phase 3&4. Until then `language_id` is a logical
-    // FK enforced only at the application layer.
-    languageId: text('language_id').$type<ID<'Language'>>().notNull(),
+    // migration-todo: add REFERENCES languages(id) ON DELETE SET NULL when
+    // Language migrates in Phase 3&4. Deliberately NOT `ON DELETE CASCADE`
+    // and `language_id` is nullable — preserves the path to the planned
+    // future model where EthnologueLanguage is a global pool of canonical
+    // language records and `language_id` is a *soft attachment* (a new
+    // Language hooks into an existing pool entry by code, rather than
+    // creating its own Ethnologue). Deleting a Language should release the
+    // attachment, not destroy the pool entry. The Apollo client already
+    // treats EthnologueLanguage as a value object (`typePolicies.base.ts:43`
+    // — `keyFields: false`), and no codepath calls a delete on it.
+    //
+    // The `code` / `provisional_code` partial uniques stay GLOBAL (not
+    // scoped to attached rows) because the future global-pool model
+    // requires codes to be unique across the entire pool — orphaned and
+    // attached alike. Today that means deleting a Language and then
+    // creating a new one with the same code throws on the unique index;
+    // that error path is the seed of the future "attach existing pool
+    // entry by code" logic.
+    //
+    // Separate-ticket cleanup (out of scope here): `EthnologueLanguage.canDelete`
+    // (on the DTO) and the `r.EthnologueLanguage.create.read.edit.delete`
+    // grant in `field-services.policy.ts` are vestigial — `canDelete`
+    // surfaces only because `secure()` injects it as standard Resource
+    // boilerplate, and the `.delete` policy bit is never exercised. Prune
+    // both in a follow-up PR.
+    languageId: text('language_id').$type<ID<'Language'>>(),
     code: text('code'),
     provisionalCode: text('provisional_code'),
     name: text('name'),

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -540,6 +540,58 @@ export const fundingAccounts = pgTable(
 
 export const fundingAccountsRelations = relations(fundingAccounts, () => ({}));
 
+// ─── Ethnologue Languages ──────────────────────────────────────────────────
+
+export const ethnologueLanguages = pgTable(
+  'ethnologue_languages',
+  {
+    id: text('id').$type<ID<'EthnologueLanguage'>>().primaryKey(),
+    // migration-todo: add REFERENCES languages(id) ON DELETE CASCADE when
+    // Language migrates in Phase 3&4. Until then `language_id` is a logical
+    // FK enforced only at the application layer.
+    languageId: text('language_id').$type<ID<'Language'>>().notNull(),
+    code: text('code'),
+    provisionalCode: text('provisional_code'),
+    name: text('name'),
+    population: integer('population'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    check(
+      'ethnologue_languages_code_format_chk',
+      sql`${t.code} IS NULL OR ${t.code} ~ '^[a-z]{3}$'`,
+    ),
+    check(
+      'ethnologue_languages_provisional_code_format_chk',
+      sql`${t.provisionalCode} IS NULL OR ${t.provisionalCode} ~ '^[a-z]{3}$'`,
+    ),
+    check(
+      'ethnologue_languages_population_non_negative_chk',
+      sql`${t.population} IS NULL OR ${t.population} >= 0`,
+    ),
+    uniqueIndex('ethnologue_languages_language_id_unique')
+      .on(t.languageId)
+      .where(sql`${t.deletedAt} IS NULL`),
+    uniqueIndex('ethnologue_languages_code_unique')
+      .on(t.code)
+      .where(sql`${t.code} IS NOT NULL AND ${t.deletedAt} IS NULL`),
+    uniqueIndex('ethnologue_languages_provisional_code_unique')
+      .on(t.provisionalCode)
+      .where(sql`${t.provisionalCode} IS NOT NULL AND ${t.deletedAt} IS NULL`),
+  ],
+);
+
+export const ethnologueLanguagesRelations = relations(
+  ethnologueLanguages,
+  () => ({}),
+);
+
 // ─── Tools ─────────────────────────────────────────────────────────────────
 
 export const toolKeyEnum = pgEnum('tool_key', ['Rev79']);


### PR DESCRIPTION
## Summary

Tier 1 domain port. Adds the \`ethnologue_languages\` table (1:1 with
Language via partial-unique \`language_id\`) and wires
\`EthnologueLanguageDrizzleRepository\` behind \`splitDb()\`. No callers
above the repo layer change.

EthnologueLanguage is an embedded sub-record managed by the Language
flow — no list, no delete, no standalone GraphQL surface. Repo only
implements \`create\` and \`update\`; \`readOne\`/\`readMany\` come from the
base. The Drizzle repo is purely scaffolding until Language migrates
in Phase 3&4 (its only call path runs through LanguageRepository which
is still Neo4j).

Builds on \`tool-pg\`.

## Schema

```sql
CREATE TABLE "ethnologue_languages" (
  "id"               text        PRIMARY KEY,
  "language_id"      text        NOT NULL,
  "code"             text,
  "provisional_code" text,
  "name"             text,
  "population"       integer,
  "created_at"       timestamptz NOT NULL DEFAULT now(),
  "updated_at"       timestamptz NOT NULL DEFAULT now(),
  "deleted_at"       timestamptz,
  CONSTRAINT "ethnologue_languages_code_format_chk"
    CHECK ("code" IS NULL OR "code" ~ '^[a-z]{3}\$'),
  CONSTRAINT "ethnologue_languages_provisional_code_format_chk"
    CHECK ("provisional_code" IS NULL OR "provisional_code" ~ '^[a-z]{3}\$'),
  CONSTRAINT "ethnologue_languages_population_non_negative_chk"
    CHECK ("population" IS NULL OR "population" >= 0)
);

CREATE UNIQUE INDEX "ethnologue_languages_language_id_unique"
  ON "ethnologue_languages" ("language_id")
  WHERE "deleted_at" IS NULL;

CREATE UNIQUE INDEX "ethnologue_languages_code_unique"
  ON "ethnologue_languages" ("code")
  WHERE "code" IS NOT NULL AND "deleted_at" IS NULL;

CREATE UNIQUE INDEX "ethnologue_languages_provisional_code_unique"
  ON "ethnologue_languages" ("provisional_code")
  WHERE "provisional_code" IS NOT NULL AND "deleted_at" IS NULL;
```

## Decisions

| Decision | Choice | Why |
|---|---|---|
| Table shape | Separate \`ethnologue_languages\` table (1:1 with languages) | Mirrors Neo4j and Gel. Preserves \`EthnologueLanguage.id\` as a real resource id (used by \`LanguageRepository.readOneByEth\`). Independent row keeps authorization clean. JOIN cost is 1 hop when Language migrates. |
| FK to \`languages(id)\` | Deferred (migration-todo) | Same pattern as \`locations.funding_account_id\` had. Will be added with \`ON DELETE CASCADE\` in Language's migration in Phase 3&4. |
| \`language_id\` uniqueness | Partial unique on \`(language_id) WHERE deleted_at IS NULL\` | Enforces 1:1 with active Languages; soft-delete + restore cycles don't collide. |
| \`code\` / \`provisional_code\` | \`text\` + regex CHECK + partial unique scoped to non-NULL, non-deleted | Codes are nullable; partial unique excludes NULLs from collision. Soft-deleted rows free their codes for reuse. Regex matches Gel's \`^[a-z]{3}\$\` constraint. |
| \`population\` | \`integer\` + CHECK \`>= 0\` | Matches Gel's \`population extending int32 with __subject__ >= 0\`. |
| \`update\` return value | Returns fresh DTO via \`readOne(id)\` | Consistent with Tool / FieldRegion / FundingAccount. The Neo4j \`return undefined as unknown\` was vestigial; no caller consumes the return. |
| \`sensitivity\` in \`toDto\` | Intentionally omitted; \`as unknown as\` cast carries a migration-todo | Sensitivity lives on the parent Language and is overlaid by \`EthnologueLanguageService.secure()\` via \`withEffectiveSensitivity\`. Populating a placeholder would read as a real security default. Cast resolves at Phase 3&4 by JOINing \`languages.sensitivity\` into readMany. |
| \`list\` / \`delete\` | Not implemented | Domain has no list API; delete cascades from Language. Matches Neo4j's surface. |
| \`ethnologueLanguageFilterClauses\` | Exported | For Language's \`ethnologue\` sub-filter to consume in Phase 3&4. Follows the established \`*FilterClauses\` pattern. |

## Deferred / migration-todo

| Item | Where | Resolves at |
|---|---|---|
| \`as unknown as UnsecuredDto<EthnologueLanguage>\` cast | \`toDto\` | Phase 3&4 — JOIN \`languages.sensitivity\` once Language migrates. |
| FK constraint on \`language_id\` | \`0007_add_ethnologue_languages.sql\` | Phase 3&4 — Language's migration adds \`REFERENCES languages(id) ON DELETE CASCADE\` + btree index. |
| \`splitDb\` \`as any\` cast | \`language.module.ts\` | Phase 7 cutover (same as every prior domain PR). |
| Dead \`EthnologueLanguageService.readOne\` | \`ethnologue-language.service.ts\` | Confirmed no external callers. Likely deletable; leaving alone in this PR. 