### PR TITLE
Fix engagement duplication when :language or :intern has historical rels

### DIFF
--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -951,13 +951,17 @@ const matchNames = (query: Query) =>
     ])
     .optionalMatch([
       node('node'),
-      relation('out', '', 'language'),
+      relation('out', '', 'language', ACTIVE),
       node('', 'Language'),
       relation('out', '', 'name', ACTIVE),
       node('languageName'),
     ])
     .optionalMatch([
-      [node('node'), relation('out', '', 'intern'), node('intern', 'User')],
+      [
+        node('node'),
+        relation('out', '', 'intern', ACTIVE),
+        node('intern', 'User'),
+      ],
       [
         node('intern'),
         relation('out', '', 'displayFirstName', ACTIVE),


### PR DESCRIPTION
## Summary

- Adds `ACTIVE` filter to the `:language` and `:intern` relationship
  traversals in `matchNames` so they match the active edge only,
  consistent with the rest of the engagement read path.
- Resolves duplicate-row emission to the DOMO sync (`CORD.LanguageEngagements.PROD`)
  that surfaced after a one-off language transfer in prod.

## Root cause

`engagement.repository.ts` reads engagements via `hydrate()`, which uses
two separate `:language` matches:

1. **hydrate, [line 148-152](src/components/engagement/engagement.repository.ts#L148-L152)** — binds the `language` variable; filters by `ACTIVE`. Returns 1 row.
2. **matchNames, [line 952-958](src/components/engagement/engagement.repository.ts#L952-L958)** — binds `languageName` (for the engagement's display label); did **not** filter by active. Returns 1 row per `:language` edge.

When an engagement has been transferred between languages, it has one
active `:language` edge (current target) and one inactive (history). The
unfiltered match in `matchNames` walked both, cross-producting against the
filtered match in `hydrate` and producing two output rows for the same
engagement. Both rows had identical `language.id` (bound from `hydrate`'s
active match), differing only in the internal `label.language` field.

The same omission existed on the `:intern` traversal two lines down. It
hasn't manifested because no intern engagement has ever been transferred
between users — same class of latent bug.

## Why the UI never noticed

- Apollo Client normalizes responses by `__typename + id` and silently
  merged the duplicate items in its cache.
- The per-id `EngagementLoader` path keyed by `{id, view}` collapsed
  duplicates in `ObjectViewAwareLoader.propertyKey`.
- The DOMO seed exporter uses neither Apollo nor DataLoader. It streams
  GraphQL list responses directly to DOMO, which rejects id collisions —
  hence "seen during this stream at indexes: 6094, 6095".

## Change

Two one-keyword additions in `matchNames`:

```ts
relation('out', '', 'language', ACTIVE)   // was: relation('out', '', 'language')
relation('out', '', 'intern',   ACTIVE)   // was: relation('out', '', 'intern')
