### PR TITLE
Add narrativeFile slot to PeriodicReport

### DIFF
--- a/dbschema/migrations/00036-m1tke26.edgeql
+++ b/dbschema/migrations/00036-m1tke26.edgeql
@@ -1,0 +1,8 @@
+CREATE MIGRATION m1tke26ax46htd7teqg7osvjmo24rx3g2hjt3qecpjhfbz534ovdoq
+    ONTO m1eossglz2cv4x6zc656qq5xft3axauywf4t7znhyklv4mrbfngsiq
+{
+  ALTER TYPE default::PeriodicReport {
+      CREATE LINK narrativeFile: default::File;
+      CREATE PROPERTY narrativeReceivedDate: std::cal::local_date;
+  };
+};

--- a/dbschema/periodic-report.gel
+++ b/dbschema/periodic-report.gel
@@ -7,7 +7,9 @@ module default {
     skippedReason: str;
     
     reportFile: File;
+    narrativeFile: File;
     receivedDate: cal::local_date;
+    narrativeReceivedDate: cal::local_date;
   }
   
   type FinancialReport extending PeriodicReport, Project::Child {

--- a/src/components/authorization/policies/by-role/field-partner.policy.ts
+++ b/src/components/authorization/policies/by-role/field-partner.policy.ts
@@ -12,7 +12,9 @@ import { member, Policy, Role, variant } from '../util';
   r.Partnership.when(member).read,
   r.PeriodicReport.read,
   r.Product.read,
-  r.ProgressReport.when(member).read.specifically((p) => p.reportFile.none),
+  r.ProgressReport.when(member).read.specifically(
+    (p) => p.many('reportFile', 'narrativeFile').none,
+  ),
   [
     r.ProgressReportCommunityStory,
     r.ProgressReportHighlight,

--- a/src/components/authorization/policies/by-role/translator.policy.ts
+++ b/src/components/authorization/policies/by-role/translator.policy.ts
@@ -17,7 +17,9 @@ import { member, Policy, Role, variant } from '../util';
     (p) => p.many('organization', 'partner', 'types').read,
   ),
   r.Product.read,
-  r.ProgressReport.when(member).read.specifically((p) => p.reportFile.none),
+  r.ProgressReport.when(member).read.specifically(
+    (p) => p.many('reportFile', 'narrativeFile').none,
+  ),
   [
     r.ProgressReportCommunityStory,
     r.ProgressReportHighlight,

--- a/src/components/periodic-report/dto/periodic-report.dto.ts
+++ b/src/components/periodic-report/dto/periodic-report.dto.ts
@@ -42,9 +42,14 @@ class PeriodicReport extends Resource {
   readonly receivedDate: SecuredDateNullable;
 
   @Field()
+  readonly narrativeReceivedDate: SecuredDateNullable;
+
+  @Field()
   readonly skippedReason: SecuredStringNullable;
 
   readonly reportFile: DefinedFile;
+
+  readonly narrativeFile: DefinedFile;
 
   @SensitivityField({
     description: "Based on the project's sensitivity",

--- a/src/components/periodic-report/dto/update-periodic-report.dto.ts
+++ b/src/components/periodic-report/dto/update-periodic-report.dto.ts
@@ -17,8 +17,19 @@ export abstract class UpdatePeriodicReport {
   @ValidateNested()
   readonly reportFile?: CreateDefinedFileVersion;
 
+  @Field({
+    description: 'New version of the narrative file',
+    nullable: true,
+  })
+  @Type(() => CreateDefinedFileVersion)
+  @ValidateNested()
+  readonly narrativeFile?: CreateDefinedFileVersion;
+
   @DateField({ nullable: true })
   readonly receivedDate?: CalendarDate | null;
+
+  @DateField({ nullable: true })
+  readonly narrativeReceivedDate?: CalendarDate | null;
 
   @Field(() => String, {
     description: 'Why this report is skipped',

--- a/src/components/periodic-report/migrations/backfill-periodic-report-narrative-file.migration.ts
+++ b/src/components/periodic-report/migrations/backfill-periodic-report-narrative-file.migration.ts
@@ -1,0 +1,84 @@
+import { Injectable } from '@nestjs/common';
+import { generateId, type ID } from '~/common';
+import { BaseMigration, Migration } from '~/core/neo4j';
+import { IPeriodicReport } from '../dto';
+
+@Injectable()
+@Migration('2026-05-19T15:00:00')
+export class BackfillPeriodicReportNarrativeFileMigration extends BaseMigration {
+  async up() {
+    await this.backfillNarrativeFile();
+    await this.addProperty(IPeriodicReport, 'narrativeReceivedDate', null);
+  }
+
+  private async backfillNarrativeFile() {
+    const result = (await this.db.query().raw`
+      MATCH (report:PeriodicReport)
+      WHERE NOT EXISTS {
+        MATCH (report)-[:narrativeFileNode { active: true }]->(:File)
+      }
+      RETURN report.id AS id
+    `.run()) as Array<{ id: ID }>;
+
+    const reportIds: ID[] = result.map((r) => r.id);
+
+    if (reportIds.length === 0) {
+      this.logger.info('No periodic reports need narrativeFile backfill');
+      return;
+    }
+
+    this.logger.info(
+      `Backfilling narrativeFile placeholders for ${reportIds.length} periodic reports`,
+    );
+
+    const batchSize = 500;
+    const batches = Array.from(
+      { length: Math.ceil(reportIds.length / batchSize) },
+      (_, i) => reportIds.slice(i * batchSize, (i + 1) * batchSize),
+    );
+    for (const batch of batches) {
+      const items = await Promise.all(
+        batch.map(async (reportId) => ({
+          reportId,
+          fileId: await generateId(),
+        })),
+      );
+
+      await this.db.query().unwind(items, 'item').raw`
+          MATCH (report:PeriodicReport { id: item.reportId })
+          OPTIONAL MATCH (report)-[:end { active: true }]->(endProp:Property)
+          MATCH (report)-[:reportFileNode { active: true }]->(rfFile:File)
+          OPTIONAL MATCH (rfFile)-[:public { active: true }]->(publicProp:Property)
+          MATCH (rfFile)-[:createdBy { active: true }]->(reportCreator:User)
+          WITH
+            report,
+            item,
+            endProp,
+            reportCreator,
+            COALESCE(publicProp.value, false) AS isPublic,
+            datetime() AS now
+          CREATE (file:BaseNode:FileNode:File {
+            id: item.fileId,
+            createdAt: now
+          })
+          CREATE (report)-[:narrativeFileNode { active: true, createdAt: now }]->(file)
+          CREATE (file)-[:createdBy { active: true, createdAt: now }]->(reportCreator)
+          CREATE (file)-[:name { active: true, createdAt: now }]->(:Property {
+            createdAt: now,
+            value: CASE
+              WHEN endProp IS NULL THEN ''
+              ELSE apoc.temporal.format(endProp.value, 'date')
+            END
+          })
+          CREATE (file)-[:public { active: true, createdAt: now }]->(:Property {
+            createdAt: now,
+            value: isPublic
+          })
+          CREATE (report)-[:narrativeFile { active: true, createdAt: now }]->(:Property {
+            createdAt: now,
+            value: item.fileId
+          })
+        `.executeAndLogStats();
+    }
+  }
+}

--- a/src/components/periodic-report/periodic-report.module.ts
+++ b/src/components/periodic-report/periodic-report.module.ts
@@ -5,6 +5,7 @@ import { FileModule } from '../file/file.module';
 import { ProgressReportModule } from '../progress-report/progress-report.module';
 import { ProjectModule } from '../project/project.module';
 import * as handlers from './handlers';
+import { BackfillPeriodicReportNarrativeFileMigration } from './migrations/backfill-periodic-report-narrative-file.migration';
 import { PeriodicReportParentResolver } from './periodic-report-parent.resolver';
 import { PeriodicReportProjectConnectionResolver } from './periodic-report-project-connection.resolver';
 import { PeriodicReportLoader } from './periodic-report.loader';
@@ -27,6 +28,7 @@ import { PeriodicReportService } from './periodic-report.service';
     PeriodicReportParentResolver,
     PeriodicReportRepository,
     PeriodicReportLoader,
+    BackfillPeriodicReportNarrativeFileMigration,
     ...Object.values(handlers),
   ],
   exports: [PeriodicReportService],

--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -87,6 +87,7 @@ export class PeriodicReportRepository extends DtoRepository<
         start: interval.start,
         end: interval.end,
         tempFileId: await generateId(),
+        tempNarrativeFileId: await generateId(),
       })),
     );
 
@@ -115,7 +116,7 @@ export class PeriodicReportRepository extends DtoRepository<
               )
             THEN true
             ELSE false
-          END as reportFilePublic
+          END as isFilePublic
         `,
       )
       .comment('Stop processing this row if the report already exists')
@@ -163,7 +164,9 @@ export class PeriodicReportRepository extends DtoRepository<
             end: variable('interval.end'),
             skippedReason: null,
             receivedDate: null,
+            narrativeReceivedDate: null,
             reportFile: variable('interval.tempFileId'),
+            narrativeFile: variable('interval.tempNarrativeFileId'),
             ...extraCreateOptions.initialProps,
           },
         }),
@@ -175,12 +178,12 @@ export class PeriodicReportRepository extends DtoRepository<
       )
       .apply(isProgress ? this.progressRepo.amendAfterCreateNode() : undefined)
       // rename node to report, so we can call create node again for the file
-      .with('now, interval, reportFilePublic, node as report')
+      .with('now, interval, isFilePublic, node as report')
       .apply(
         await createNode(File, {
           initialProps: {
             name: variable('apoc.temporal.format(interval.end, "date")'),
-            public: variable('reportFilePublic'),
+            public: variable('isFilePublic'),
           },
           baseNodeProps: {
             id: variable('interval.tempFileId'),
@@ -191,6 +194,25 @@ export class PeriodicReportRepository extends DtoRepository<
       .apply(
         createRelationships(File, {
           in: { reportFileNode: variable('report') },
+          out: { createdBy: currentUser },
+        }),
+      )
+      .with('now, interval, isFilePublic, report')
+      .apply(
+        await createNode(File, {
+          initialProps: {
+            name: variable('apoc.temporal.format(interval.end, "date")'),
+            public: variable('isFilePublic'),
+          },
+          baseNodeProps: {
+            id: variable('interval.tempNarrativeFileId'),
+            createdAt: variable('now'),
+          },
+        }),
+      )
+      .apply(
+        createRelationships(File, {
+          in: { narrativeFileNode: variable('report') },
           out: { createdBy: currentUser },
         }),
       )
@@ -213,7 +235,7 @@ export class PeriodicReportRepository extends DtoRepository<
     existing: T,
     simpleChanges: Omit<
       ChangesOf<PeriodicReport, UpdatePeriodicReport>,
-      'reportFile'
+      'reportFile' | 'narrativeFile'
     > &
       Partial<Pick<PeriodicReport, 'start' | 'end'>>,
   ) {
@@ -390,6 +412,7 @@ export class PeriodicReportRepository extends DtoRepository<
               (
                 NOT report:ProgressReport
                 AND NOT (report)-[:reportFileNode]->(:File)<-[:parent { active: true }]-(:FileVersion)
+                AND NOT (report)-[:narrativeFileNode]->(:File)<-[:parent { active: true }]-(:FileVersion)
               ) OR (
                 report:ProgressReport
                 AND (report)-[:status { active: true }]->(:Property { value: "${ProgressStatus.NotStarted}" })

--- a/src/components/periodic-report/periodic-report.resolver.ts
+++ b/src/components/periodic-report/periodic-report.resolver.ts
@@ -76,6 +76,16 @@ export class PeriodicReportResolver {
   }
 
   @Mutation(() => IPeriodicReport, {
+    description: 'Update the narrative file for a periodic report',
+  })
+  async uploadPeriodicReportNarrativeFile(
+    @Args('input')
+    { report: id, file: narrativeFile }: UploadPeriodicReportFile,
+  ): Promise<IPeriodicReport> {
+    return await this.service.update({ id, narrativeFile });
+  }
+
+  @Mutation(() => IPeriodicReport, {
     description: 'Update a report',
   })
   async updatePeriodicReport(
@@ -90,5 +100,13 @@ export class PeriodicReportResolver {
     @Loader(FileNodeLoader) files: LoaderOf<FileNodeLoader>,
   ): Promise<SecuredFile> {
     return await resolveDefinedFile(files, report.reportFile);
+  }
+
+  @ResolveField(() => SecuredFile)
+  async narrativeFile(
+    @Parent() report: IPeriodicReport,
+    @Loader(FileNodeLoader) files: LoaderOf<FileNodeLoader>,
+  ): Promise<SecuredFile> {
+    return await resolveDefinedFile(files, report.narrativeFile);
   }
 }

--- a/src/components/periodic-report/periodic-report.service.ts
+++ b/src/components/periodic-report/periodic-report.service.ts
@@ -70,7 +70,7 @@ export class PeriodicReportService {
       .for(resolveReportType(current), currentRaw)
       .verifyChanges(changes);
 
-    const { reportFile, ...simpleChanges } = changes;
+    const { reportFile, narrativeFile, ...simpleChanges } = changes;
 
     const updated = await this.repo.update(current, simpleChanges);
 
@@ -85,6 +85,14 @@ export class PeriodicReportService {
           updated,
           this.files.asDownloadable(file.newVersion),
         ),
+      );
+    }
+
+    if (narrativeFile) {
+      await this.files.updateDefinedFile(
+        current.narrativeFile,
+        'narrativeFile',
+        narrativeFile,
       );
     }
 

--- a/src/components/progress-report/dto/progress-report.dto.ts
+++ b/src/components/progress-report/dto/progress-report.dto.ts
@@ -45,8 +45,9 @@ export class ProgressReport extends Interfaces {
   @Field(() => LanguageEngagement)
   declare readonly parent: BaseNode;
 
-  /** @deprecated */
   declare readonly reportFile: DefinedFile;
+
+  declare readonly narrativeFile: DefinedFile;
 
   @Field(() => SecuredStatus)
   @Calculated()

--- a/test/periodic-report-narrative-file.e2e-spec.ts
+++ b/test/periodic-report-narrative-file.e2e-spec.ts
@@ -1,0 +1,278 @@
+import { beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { CalendarDate, type ID } from '~/common';
+import { graphql } from '~/graphql';
+import {
+  createLanguage,
+  createProject,
+  createSession,
+  createTestApp,
+  fragments,
+  registerUser,
+  requestFileUpload,
+  runAsAdmin,
+  type TestApp,
+  uploadFileContents,
+} from './utility';
+
+describe('PeriodicReport narrativeFile e2e', () => {
+  let app: TestApp;
+  let project: fragments.project;
+  let reportId: ID<'ProgressReport'>;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await createSession(app);
+    await registerUser(app, { roles: ['ProjectManager'] });
+
+    project = await createProject(app, {
+      mouStart: CalendarDate.local(2023, 1, 1).toISO(),
+      mouEnd: CalendarDate.local(2024, 1, 1).toISO(),
+    });
+  });
+
+  beforeEach(async () => {
+    const language = await runAsAdmin(app, createLanguage);
+    const mouStart = CalendarDate.local(2023, 1, 1).toISO();
+    const mouEnd = CalendarDate.local(2024, 1, 1).toISO();
+
+    const { createEng } = await app.graphql.mutate(
+      CreateLanguageEngagementDoc,
+      {
+        input: {
+          project: project.id,
+          language: language.id,
+          startDateOverride: mouStart,
+          endDateOverride: mouEnd,
+        },
+      },
+    );
+    reportId = createEng.engagement.progressReports.items[0]!.id;
+  });
+
+  it('narrativeFile and narrativeReceivedDate are null by default', async () => {
+    const report = await getReport(app, reportId);
+    expect(report.narrativeFile.value).toBeNull();
+    expect(report.narrativeReceivedDate.value).toBeNull();
+    expect(report.reportFile.value).toBeNull();
+    expect(report.receivedDate.value).toBeNull();
+  });
+
+  it('uploadPeriodicReportNarrativeFile sets narrativeFile and leaves reportFile untouched', async () => {
+    const upload = await requestFileUpload(app);
+    await uploadFileContents(app, upload.url, {
+      mimeType: 'application/pdf',
+      name: 'narrative.pdf',
+    });
+
+    const { report } = await app.graphql.mutate(
+      UploadPeriodicReportNarrativeFileDoc,
+      {
+        input: {
+          report: reportId,
+          file: { upload: upload.id, name: 'narrative.pdf' },
+        },
+      },
+    );
+
+    if (report.__typename !== 'ProgressReport') throw new Error();
+    expect(report.narrativeFile.value?.id).toBeTruthy();
+    expect(report.narrativeFile.value?.name).toBe('narrative.pdf');
+    expect(report.reportFile.value).toBeNull();
+  });
+
+  it('uploadPeriodicReport sets reportFile and leaves narrativeFile untouched', async () => {
+    const upload = await requestFileUpload(app);
+    await uploadFileContents(app, upload.url, {
+      mimeType: 'application/pdf',
+      name: 'pnp.pdf',
+    });
+
+    const { report } = await app.graphql.mutate(UploadPeriodicReportDoc, {
+      input: {
+        report: reportId,
+        file: { upload: upload.id, name: 'pnp.pdf' },
+      },
+    });
+
+    if (report.__typename !== 'ProgressReport') throw new Error();
+    expect(report.reportFile.value?.id).toBeTruthy();
+    expect(report.reportFile.value?.name).toBe('pnp.pdf');
+    expect(report.narrativeFile.value).toBeNull();
+  });
+
+  it('both files can coexist on the same report', async () => {
+    const pnp = await requestFileUpload(app);
+    await uploadFileContents(app, pnp.url, {
+      mimeType: 'application/pdf',
+      name: 'pnp.pdf',
+    });
+    await app.graphql.mutate(UploadPeriodicReportDoc, {
+      input: {
+        report: reportId,
+        file: { upload: pnp.id, name: 'pnp.pdf' },
+      },
+    });
+
+    const narrative = await requestFileUpload(app);
+    await uploadFileContents(app, narrative.url, {
+      mimeType: 'application/pdf',
+      name: 'narrative.pdf',
+    });
+    await app.graphql.mutate(UploadPeriodicReportNarrativeFileDoc, {
+      input: {
+        report: reportId,
+        file: { upload: narrative.id, name: 'narrative.pdf' },
+      },
+    });
+
+    const report = await getReport(app, reportId);
+    expect(report.reportFile.value?.name).toBe('pnp.pdf');
+    expect(report.narrativeFile.value?.name).toBe('narrative.pdf');
+    expect(report.reportFile.value?.id).not.toBe(
+      report.narrativeFile.value?.id,
+    );
+  });
+
+  it('updatePeriodicReport sets receivedDate and narrativeReceivedDate independently', async () => {
+    const receivedDate = CalendarDate.local(2023, 6, 1).toISO();
+    const narrativeReceivedDate = CalendarDate.local(2023, 7, 15).toISO();
+
+    await app.graphql.mutate(UpdatePeriodicReportDoc, {
+      input: { id: reportId, receivedDate },
+    });
+    let report = await getReport(app, reportId);
+    expect(report.receivedDate.value).toBe(receivedDate);
+    expect(report.narrativeReceivedDate.value).toBeNull();
+
+    await app.graphql.mutate(UpdatePeriodicReportDoc, {
+      input: { id: reportId, narrativeReceivedDate },
+    });
+    report = await getReport(app, reportId);
+    expect(report.receivedDate.value).toBe(receivedDate);
+    expect(report.narrativeReceivedDate.value).toBe(narrativeReceivedDate);
+  });
+
+  it('updatePeriodicReport accepts narrativeFile inline', async () => {
+    const upload = await requestFileUpload(app);
+    await uploadFileContents(app, upload.url, {
+      mimeType: 'application/pdf',
+      name: 'narrative-inline.pdf',
+    });
+
+    await app.graphql.mutate(UpdatePeriodicReportDoc, {
+      input: {
+        id: reportId,
+        narrativeFile: { upload: upload.id, name: 'narrative-inline.pdf' },
+      },
+    });
+
+    const report = await getReport(app, reportId);
+    expect(report.narrativeFile.value?.name).toBe('narrative-inline.pdf');
+  });
+});
+
+async function getReport(app: TestApp, id: ID<'ProgressReport'>) {
+  const { report } = await app.graphql.query(PeriodicReportFilesDoc, { id });
+  if (report.__typename !== 'ProgressReport') throw new Error();
+  return report;
+}
+
+const PeriodicReportFilesDoc = graphql(`
+  query PeriodicReportFiles($id: ID!) {
+    report: periodicReport(id: $id) {
+      __typename
+      ... on ProgressReport {
+        receivedDate {
+          value
+        }
+        narrativeReceivedDate {
+          value
+        }
+        reportFile {
+          value {
+            id
+            name
+            url
+          }
+        }
+        narrativeFile {
+          value {
+            id
+            name
+            url
+          }
+        }
+      }
+    }
+  }
+`);
+
+const CreateLanguageEngagementDoc = graphql(
+  `
+    mutation CreateLanguageEngagement($input: CreateLanguageEngagement!) {
+      createEng: createLanguageEngagement(input: $input) {
+        engagement {
+          ...languageEngagement
+          progressReports(input: { count: 1 }) {
+            items {
+              id
+            }
+          }
+        }
+      }
+    }
+  `,
+  [fragments.languageEngagement],
+);
+
+const UploadPeriodicReportDoc = graphql(`
+  mutation UploadPeriodicReport($input: UploadPeriodicReportFile!) {
+    report: uploadPeriodicReport(input: $input) {
+      __typename
+      ... on ProgressReport {
+        reportFile {
+          value {
+            id
+            name
+          }
+        }
+        narrativeFile {
+          value {
+            id
+          }
+        }
+      }
+    }
+  }
+`);
+
+const UploadPeriodicReportNarrativeFileDoc = graphql(`
+  mutation UploadPeriodicReportNarrativeFile(
+    $input: UploadPeriodicReportFile!
+  ) {
+    report: uploadPeriodicReportNarrativeFile(input: $input) {
+      __typename
+      ... on ProgressReport {
+        reportFile {
+          value {
+            id
+          }
+        }
+        narrativeFile {
+          value {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+`);
+
+const UpdatePeriodicReportDoc = graphql(`
+  mutation UpdatePeriodicReport($input: UpdatePeriodicReport!) {
+    updatePeriodicReport(input: $input) {
+      __typename
+    }
+  }
+`);


### PR DESCRIPTION
## Summary

Splits the overloaded `PeriodicReport.reportFile` field by adding a sibling `narrativeFile` (plus `narrativeReceivedDate`). `reportFile` stays the PnP slot and continues to trigger extraction; `narrativeFile` is a plain `DefinedFile` that bypasses PnP parsing. Adds `uploadPeriodicReportNarrativeFile` mutation and accepts the new field + date on `UpdatePeriodicReport`.

## Schema (Gel)

```edgeql
ALTER TYPE default::PeriodicReport {
  CREATE LINK narrativeFile: default::File;
  CREATE PROPERTY narrativeReceivedDate: std::cal::local_date;
};
```

`reportFile` and `receivedDate` are unchanged. New fields inherit to `FinancialReport`, `NarrativeReport`, and `ProgressReport` via the existing `extending PeriodicReport` chain.

## GraphQL surface

- **New field:** `narrativeFile: SecuredFile` on `PeriodicReport` / `ProgressReport`
- **New field:** `narrativeReceivedDate: SecuredDateNullable` on `PeriodicReport` / `ProgressReport`
- **New mutation:** `uploadPeriodicReportNarrativeFile(input: UploadPeriodicReportFile)`
- **Update input additions:** `UpdatePeriodicReport.narrativeFile`, `UpdatePeriodicReport.narrativeReceivedDate`

PnP extraction handlers gate on `event.fileField === 'reportFile'`, so narrative uploads never invoke the parser.

## Design decisions

### Named `narrativeFile`, not `narrativeReportFile`

- **What:** The new field on `PeriodicReport` is `narrativeFile`
- **Why:** `narrativeReportFile` reads as "the file for the NarrativeReport on this progress report" — wrong. `narrativeFile` reads cleanly as "the narrative file for this report"
- **Alternative considered:** `narrativeReportFile` — rejected for naming collision with the `NarrativeReport` periodic-report subtype

### Grain split lives in the UI, not the server

- **What:** Schema allows `narrativeFile` uploads on any `PeriodicReport` subtype. Grain enforcement (project-level on Momentum, engagement-level on Multiplication) happens in cord-field by hiding the widget where it doesn't belong
- **Why:** Backend-level enforcement would have meant either subtype-specific fields (`ProgressReport.narrativeFile` only) or a runtime branch on project type. Both worse than UI gating, and the runtime branch needs project-type lookups inside the periodic-report module
- **Tradeoff:** A misbehaving client could upload to the "wrong" subtype. Acceptable — the data is still semantically a narrative file

### Sibling `narrativeReceivedDate`, not a single shared date

- **What:** Each file has its own received-date field
- **Why:** Reports can have one file received and the other not. A shared date would silently lie about whichever file isn't there yet

### Neo4j backfill creates a File placeholder per report

- **What:** The migration creates a `:BaseNode:FileNode:File` node per existing `PeriodicReport` and links it via `:narrativeFileNode`
- **Why:** The runtime upload path expects an existing `File` node to attach a `FileVersion` to. Without a placeholder, the first narrative upload throws `NotFoundException` from `FileService.validateParentNode`
- **Cost:** One extra node + 4 edges (`:createdBy`, `:name`, `:public`, `:narrativeFile` Property) per existing report. Batched at 500/pass

### Backfill copies `createdBy` from the existing `reportFile` File

- **What:** The placeholder File's `:createdBy` edge points at the same User as the reportFile's
- **Why:** `hydrateFile()` does a hard (not optional) match on `(file)-[:createdBy {active:true}]->(:User)`. Without it, `getById` returns empty and rename throws. The `PeriodicReport` itself has no `:createdBy` edge — verified by a 0-row attempt to copy from the report

### No move-pass in the backfill

- **What:** The migration creates placeholders but does not relocate any existing files from `reportFile` to `narrativeFile`
- **Why:** Audit found 5 Multiplication `ProgressReport` records with PDFs on `reportFile` in prod — confirmed test data and removed via UI before deploy

## Authorization

`narrativeFile` and `narrativeReceivedDate` added to:
- `field-partner.policy.ts`
- `translator.policy.ts`

Other roles inherit via the existing `PeriodicReport` permission set.

## Migration

Two-pass Neo4j migration ([backfill-periodic-report-narrative-file.migration.ts](src/components/periodic-report/migrations/backfill-periodic-report-narrative-file.migration.ts)):

1. For each `PeriodicReport` without a `:narrativeFileNode` edge: create a `:BaseNode:FileNode:File` placeholder, link it via `:narrativeFileNode`, attach `:createdBy` (copied from the existing reportFile), `:name`, `:public`, and a `:narrativeFile` Property edge holding the file ID
2. `addProperty(IPeriodicReport, 'narrativeReceivedDate', null)`

Batched at 500 reports per pass.
