### PR TITLE
Add Project.marketingRegion calculated field

### DIFF
--- a/src/components/location/dto/location-type.enum.ts
+++ b/src/components/location/dto/location-type.enum.ts
@@ -7,7 +7,7 @@ export const LocationType = makeEnum({
     'Country',
     'City',
     'County',
-    'Region',
+    { value: 'Region', label: 'Marketing Region' },
     'State',
     { value: 'CrossBorderArea', label: 'Cross-Border Area' },
   ],

--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -143,6 +143,11 @@ class Project extends Interfaces {
   readonly marketingLocation: Secured<LinkTo<'Location'> | null>;
 
   readonly marketingRegionOverride: Secured<LinkTo<'Location'> | null>;
+
+  // Effective marketing region: marketingRegionOverride if set, else
+  // marketingLocation.defaultMarketingRegion. Derived in the repository.
+  @Calculated()
+  readonly marketingRegion: Secured<LinkTo<'Location'> | null>;
   readonly fieldRegion: Secured<LinkTo<'FieldRegion'> | null>;
 
   readonly owningOrganization: Secured<LinkTo<'Organization'> | null>;

--- a/src/components/project/project.gel.repository.ts
+++ b/src/components/project/project.gel.repository.ts
@@ -51,6 +51,11 @@ const hydrate = e.shape(e.Project, (project) => ({
   primaryLocation: true,
   marketingLocation: true,
   marketingRegionOverride: true,
+  marketingRegion: e.op(
+    project.marketingRegionOverride,
+    '??',
+    project.marketingLocation.defaultMarketingRegion,
+  ),
   fieldRegion: true,
   stepChangedAt: e.op(project.latestWorkflowEvent.at, '??', project.createdAt),
   owningOrganization: e.cast(e.uuid, null), // Not implemented going forward

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -15,6 +15,7 @@ import { type ChangesOf, getChanges } from '~/core/database/changes';
 import { CommonRepository, OnIndex, UniquenessError } from '~/core/neo4j';
 import {
   ACTIVE,
+  coalesce,
   collect,
   createNode,
   createRelationships,
@@ -140,6 +141,11 @@ export class ProjectRepository extends CommonRepository {
           relation('out', '', 'marketingRegionOverride', ACTIVE),
           node('marketingRegionOverride', 'Location'),
         ])
+        .optionalMatch([
+          node('marketingLocation'),
+          relation('out', '', 'defaultMarketingRegion', ACTIVE),
+          node('inheritedMarketingRegion', 'Location'),
+        ])
         .subQuery('node', (sub) =>
           sub
             .match([
@@ -177,6 +183,10 @@ export class ProjectRepository extends CommonRepository {
             usesRev79: 'usesRev79',
             changeset: 'changeset.id',
             marketingRegionOverride: 'marketingRegionOverride { .id }',
+            marketingRegion: coalesce(
+              'marketingRegionOverride { .id }',
+              'inheritedMarketingRegion { .id }',
+            ),
           }).as('dto'),
         );
   }

--- a/src/components/project/project.resolver.ts
+++ b/src/components/project/project.resolver.ts
@@ -361,6 +361,16 @@ export class ProjectResolver {
     );
   }
 
+  @ResolveField(() => SecuredLocation)
+  async marketingRegion(
+    @Parent() project: Project,
+    @Loader(LocationLoader) locations: LoaderOf<LocationLoader>,
+  ): Promise<SecuredLocation> {
+    return await mapSecuredValue(project.marketingRegion, ({ id }) =>
+      locations.load(id),
+    );
+  }
+
   @ResolveField(() => SecuredFieldRegion)
   async fieldRegion(
     @Parent() project: Project,


### PR DESCRIPTION
### Summary

- Add `Project.marketingRegion: SecuredLocation` — the effective marketing region for a project.
- Precedence: `marketingRegionOverride` ► `marketingLocation.defaultMarketingRegion` ► `null`.
- Precedence lives in the repository layer (Cypher `coalesce` for Neo4j, EdgeQL `??` for Gel) with `@Calculated()` on the DTO — same pattern as `Engagement.startDate` / `Partnership.mouStart`.
- Relabel `LocationType.Region` GraphQL display name to `"Marketing Region"`. Enum value (`"Region"`) is unchanged, so existing Neo4j data, the upcoming Postgres `LocationType` enum, and the Cypher `LocationType` migration filter are all unaffected.

### Design decisions

#### Computed in the repo, not the resolver

- **What:** the override-vs-inherited precedence is encoded as `coalesce('marketingRegionOverride { .id }', 'inheritedMarketingRegion { .id }')` in the Neo4j read query and `e.op(override, '??', marketingLocation.defaultMarketingRegion)` in the Gel hydrate. The resolver is a thin `LocationLoader` wrapper identical in shape to `marketingLocation` / `marketingRegionOverride`.
- **Why:** matches the established pattern for derived override fields. Single source of truth for precedence, zero risk of N+1 on list endpoints, and the Gel migration mirrors the Neo4j logic 1:1.
- **Alternative considered:** branching in the resolver with chained `LocationLoader.load()` calls. Rejected — non-idiomatic, more code, and would diverge from how `Engagement.startDate` and `Partnership.mouStart` are wired.

#### `canEdit` is always `false`

- **What:** `marketingRegion.canEdit` resolves to `false` for every caller (enforced by `@Calculated()` in [policy-executor.ts:58-65](src/components/authorization/policy/executor/policy-executor.ts#L58-L65)).
- **Why:** consistent with all other calculated override fields in the codebase. Calculated fields are not directly editable; they're edited by mutating the underlying override.
- **FE impact:** edit affordance for this field should be gated on `marketingRegionOverride.canEdit`, not `marketingRegion.canEdit`. Same as `Engagement.startDate` / `Partnership.mouStart` consumers already do.

#### Changeset behavior is unchanged

- **What:** `marketingRegion` reflects current DB state regardless of `$changeset` view.
- **Why:** both source fields (`marketingRegionOverride` and `marketingLocation`) are read via `ACTIVE` relations only; neither is changeset-aware. The computed field inherits this behavior naturally.
- **Open thread:** if a pending changeset to the override needs to surface on `marketingRegion`, that's a wider change — making `marketingRegionOverride` itself changeset-aware first.

#### Enum value vs label

- **What:** `LocationType.Region` value stays as `"Region"`; only the GraphQL enum display label changes to `"Marketing Region"` (via the existing `{ value, label }` form already used by `CrossBorderArea`).
- **Why:** preserves backward compatibility with stored DB values, the Postgres enum at [drizzle/schema/index.ts:248](src/core/drizzle/schema/index.ts#L248), and the existing Cypher data migration at [default-marketing-region.migration.ts:35](src/components/location/migrations/default-marketing-region.migration.ts#L35).