### PR TITLE
#13a [pg] Project Migration - schema

### DIFF
--- a/src/core/drizzle/migrations/0009_add_projects.sql
+++ b/src/core/drizzle/migrations/0009_add_projects.sql
@@ -1,0 +1,255 @@
+-- Migration: add Project + ProjectMember + ProjectWorkflowEvent.
+-- Plus the supporting enums and the trigger that keeps `projects.step` in
+-- sync with `project_workflow_events`.
+--
+-- Settled design decisions (see migration_postgres.md → Project Domain Notes):
+--   - Single-table inheritance over MomentumTranslation / MultiplicationTranslation /
+--     Internship; `type` discriminator; `own_sensitivity` is meaningful only for
+--     Internship rows.
+--   - `sensitivity` is denormalized — kept current via a hook that wires when
+--     Language migrates (Tier 2). Translation rows read 'High' until then.
+--   - `status` is GENERATED ALWAYS AS (CASE step ... END) STORED — mirrors
+--     stepToStatus() in src/components/project/dto/project-status.enum.ts and
+--     Gel's Project::statusFromStep(.step). Never writable.
+--   - `project_members.roles` is `role[]` (pgEnum array) with a GIN index;
+--     `roles && ARRAY[...]::role[]` powers the intersectsProp filter.
+--   - Workflow → step sync via AFTER INSERT trigger on project_workflow_events.
+
+CREATE TYPE "project_step" AS ENUM (
+  'EarlyConversations',
+  'PendingConceptApproval',
+  'PrepForConsultantEndorsement',
+  'PendingConsultantEndorsement',
+  'PrepForFinancialEndorsement',
+  'PendingFinancialEndorsement',
+  'FinalizingProposal',
+  'PendingRegionalDirectorApproval',
+  'PendingZoneDirectorApproval',
+  'PendingFinanceConfirmation',
+  'OnHoldFinanceConfirmation',
+  'DidNotDevelop',
+  'Rejected',
+  'Active',
+  'ActiveChangedPlan',
+  'DiscussingChangeToPlan',
+  'PendingChangeToPlanApproval',
+  'PendingChangeToPlanConfirmation',
+  'DiscussingSuspension',
+  'PendingSuspensionApproval',
+  'Suspended',
+  'DiscussingReactivation',
+  'PendingReactivationApproval',
+  'DiscussingTermination',
+  'PendingTerminationApproval',
+  'FinalizingCompletion',
+  'Terminated',
+  'Completed'
+);
+--> statement-breakpoint
+
+CREATE TYPE "project_status" AS ENUM (
+  'InDevelopment',
+  'Active',
+  'Terminated',
+  'Completed',
+  'DidNotDevelop'
+);
+--> statement-breakpoint
+
+CREATE TYPE "report_period" AS ENUM ('Monthly', 'Quarterly');
+--> statement-breakpoint
+
+-- First DB-typed role enum. `user_global_roles.role` predates this and is plain
+-- `text` — aligning that column is a separate cleanup PR (out of scope here).
+CREATE TYPE "role" AS ENUM (
+  'Administrator',
+  'BetaTester',
+  'BibleTranslationLiaison',
+  'Consultant',
+  'ConsultantManager',
+  'Controller',
+  'ExperienceOperations',
+  'FieldOperationsDirector',
+  'FieldPartner',
+  'FieldServices',
+  'FinancialAnalyst',
+  'Fundraising',
+  'Intern',
+  'LeadFinancialAnalyst',
+  'Leadership',
+  'Liaison',
+  'Marketing',
+  'Mentor',
+  'MultiplicationFinanceApprover',
+  'ProjectManager',
+  'RegionalCommunicationsCoordinator',
+  'RegionalDirector',
+  'StaffMember',
+  'Translator'
+);
+--> statement-breakpoint
+
+CREATE TABLE "projects" (
+  "id"                             text                PRIMARY KEY,
+  "type"                           "project_type"      NOT NULL,
+  "name"                           text                NOT NULL,
+  "step"                           "project_step"      NOT NULL DEFAULT 'EarlyConversations',
+  -- Mirror of stepToStatus() — never writable.
+  "status"                         "project_status"    NOT NULL GENERATED ALWAYS AS (
+    CASE "step"
+      WHEN 'EarlyConversations'              THEN 'InDevelopment'::project_status
+      WHEN 'PendingConceptApproval'          THEN 'InDevelopment'::project_status
+      WHEN 'PrepForConsultantEndorsement'    THEN 'InDevelopment'::project_status
+      WHEN 'PendingConsultantEndorsement'    THEN 'InDevelopment'::project_status
+      WHEN 'PrepForFinancialEndorsement'     THEN 'InDevelopment'::project_status
+      WHEN 'PendingFinancialEndorsement'     THEN 'InDevelopment'::project_status
+      WHEN 'FinalizingProposal'              THEN 'InDevelopment'::project_status
+      WHEN 'PendingRegionalDirectorApproval' THEN 'InDevelopment'::project_status
+      WHEN 'PendingZoneDirectorApproval'     THEN 'InDevelopment'::project_status
+      WHEN 'PendingFinanceConfirmation'      THEN 'InDevelopment'::project_status
+      WHEN 'OnHoldFinanceConfirmation'       THEN 'InDevelopment'::project_status
+      WHEN 'DidNotDevelop'                   THEN 'DidNotDevelop'::project_status
+      WHEN 'Rejected'                        THEN 'DidNotDevelop'::project_status
+      WHEN 'Active'                          THEN 'Active'::project_status
+      WHEN 'ActiveChangedPlan'               THEN 'Active'::project_status
+      WHEN 'DiscussingChangeToPlan'          THEN 'Active'::project_status
+      WHEN 'PendingChangeToPlanApproval'     THEN 'Active'::project_status
+      WHEN 'PendingChangeToPlanConfirmation' THEN 'Active'::project_status
+      WHEN 'DiscussingSuspension'            THEN 'Active'::project_status
+      WHEN 'PendingSuspensionApproval'       THEN 'Active'::project_status
+      WHEN 'Suspended'                       THEN 'Active'::project_status
+      WHEN 'DiscussingReactivation'          THEN 'Active'::project_status
+      WHEN 'PendingReactivationApproval'     THEN 'Active'::project_status
+      WHEN 'DiscussingTermination'           THEN 'Active'::project_status
+      WHEN 'PendingTerminationApproval'      THEN 'Active'::project_status
+      WHEN 'FinalizingCompletion'            THEN 'Active'::project_status
+      WHEN 'Terminated'                      THEN 'Terminated'::project_status
+      WHEN 'Completed'                       THEN 'Completed'::project_status
+    END
+  ) STORED,
+  -- migration-todo: denormalized — recompute hook fires when Engagement/Language
+  -- sensitivity changes (Tier 2 Language migration wires the hook). Translation
+  -- rows read 'High' until then; Internship reads own_sensitivity.
+  "sensitivity"                    "sensitivity"       NOT NULL DEFAULT 'High',
+  "own_sensitivity"                "sensitivity",
+  "rev79_project_id"               text,
+  "department_id"                  text,
+  "department_id_block_id"         text                REFERENCES "department_id_blocks"("id"),
+  "primary_location_id"            text                REFERENCES "locations"("id"),
+  "marketing_location_id"          text                REFERENCES "locations"("id"),
+  "marketing_region_override_id"   text                REFERENCES "locations"("id"),
+  "field_region_id"                text                REFERENCES "field_regions"("id"),
+  "owning_organization_id"         text                REFERENCES "organizations"("id"),
+  -- migration-todo: deferred FK → directories(id); add REFERENCES when File
+  -- migrates (Tier 7). Plain text until then (same pattern as other deferred FKs).
+  "root_directory_id"              text,
+  "mou_start"                      date,
+  "mou_end"                        date,
+  "initial_mou_end"                date,
+  "estimated_submission"           date,
+  "financial_report_received_at"   timestamptz,
+  "financial_report_period"        "report_period",
+  "tags"                           text[]              NOT NULL DEFAULT '{}',
+  "preset_inventory"               boolean             NOT NULL DEFAULT false,
+  "created_at"                     timestamptz         NOT NULL DEFAULT now(),
+  "modified_at"                    timestamptz         NOT NULL DEFAULT now(),
+  "updated_at"                     timestamptz         NOT NULL DEFAULT now(),
+  "deleted_at"                     timestamptz
+);
+--> statement-breakpoint
+
+-- Partial uniques — only enforced on live (non-soft-deleted) rows.
+CREATE UNIQUE INDEX "projects_name_active_unique"
+  ON "projects" ("name") WHERE "deleted_at" IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "projects_department_id_active_unique"
+  ON "projects" ("department_id")
+  WHERE "department_id" IS NOT NULL AND "deleted_at" IS NULL;
+--> statement-breakpoint
+
+-- FK b-tree indexes — PG doesn't auto-index FKs.
+CREATE INDEX "projects_department_id_block_id_idx"      ON "projects" ("department_id_block_id");
+--> statement-breakpoint
+CREATE INDEX "projects_primary_location_id_idx"         ON "projects" ("primary_location_id");
+--> statement-breakpoint
+CREATE INDEX "projects_marketing_location_id_idx"       ON "projects" ("marketing_location_id");
+--> statement-breakpoint
+CREATE INDEX "projects_marketing_region_override_id_idx" ON "projects" ("marketing_region_override_id");
+--> statement-breakpoint
+CREATE INDEX "projects_field_region_id_idx"             ON "projects" ("field_region_id");
+--> statement-breakpoint
+CREATE INDEX "projects_owning_organization_id_idx"      ON "projects" ("owning_organization_id");
+--> statement-breakpoint
+-- Deferred-FK column — indexed now so we avoid CREATE INDEX CONCURRENTLY later
+-- when File adds the REFERENCES clause.
+CREATE INDEX "projects_root_directory_id_idx"           ON "projects" ("root_directory_id");
+--> statement-breakpoint
+-- Filter-hot columns.
+CREATE INDEX "projects_type_idx"   ON "projects" ("type");
+--> statement-breakpoint
+CREATE INDEX "projects_step_idx"   ON "projects" ("step");
+--> statement-breakpoint
+CREATE INDEX "projects_status_idx" ON "projects" ("status");
+--> statement-breakpoint
+
+CREATE TABLE "project_members" (
+  "id"          text         PRIMARY KEY,
+  "project_id"  text         NOT NULL REFERENCES "projects"("id") ON DELETE CASCADE,
+  "user_id"     text         NOT NULL REFERENCES "users"("id")    ON DELETE CASCADE,
+  "roles"       "role"[]     NOT NULL DEFAULT '{}',
+  "inactive_at" timestamptz,
+  "created_at"  timestamptz  NOT NULL DEFAULT now(),
+  "updated_at"  timestamptz  NOT NULL DEFAULT now(),
+  "deleted_at"  timestamptz
+);
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX "project_members_project_user_active_unique"
+  ON "project_members" ("project_id", "user_id") WHERE "deleted_at" IS NULL;
+--> statement-breakpoint
+CREATE INDEX "project_members_user_id_idx" ON "project_members" ("user_id");
+--> statement-breakpoint
+-- GIN index for `roles && ARRAY[...]::role[]` (intersectsProp filter).
+CREATE INDEX "project_members_roles_gin" ON "project_members" USING gin ("roles");
+--> statement-breakpoint
+
+CREATE TABLE "project_workflow_events" (
+  "id"             text            PRIMARY KEY,
+  "project_id"     text            NOT NULL REFERENCES "projects"("id") ON DELETE CASCADE,
+  "who"            text            NOT NULL REFERENCES "users"("id"),
+  -- Nullable for synthetic/initial events; populated for normal transitions.
+  "from_step"      "project_step",
+  "to_step"        "project_step"  NOT NULL,
+  -- Nullable for dynamic transitions (e.g. BackToActive) — they resolve at
+  -- runtime from event history and don't carry a static key.
+  "transition_key" text,
+  "notes"          jsonb,
+  "at"             timestamptz     NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+
+-- Compound (project_id, at DESC) — every list query is "events for project X,
+-- newest first" (mostRecentStep walks the same path).
+CREATE INDEX "project_workflow_events_project_id_at_idx"
+  ON "project_workflow_events" ("project_id", "at" DESC);
+--> statement-breakpoint
+
+-- Trigger: keep `projects.step` (and modified_at) in sync with the latest
+-- event. App code writes events, never touches `projects.step` directly.
+-- Mirrors Gel's auto-sync trigger on Project::WorkflowEvent.
+CREATE FUNCTION "sync_project_step_from_event"() RETURNS trigger AS $$
+BEGIN
+  UPDATE "projects"
+     SET "step"        = NEW."to_step",
+         "modified_at" = now()
+   WHERE "id" = NEW."project_id";
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+
+CREATE TRIGGER "project_workflow_event_synced"
+  AFTER INSERT ON "project_workflow_events"
+  FOR EACH ROW EXECUTE FUNCTION "sync_project_step_from_event"();
+--> statement-breakpoint
+

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1747526400000,
       "tag": "0008_add_partners",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1747612800000,
+      "tag": "0009_add_projects",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -5,6 +5,7 @@ import {
   check,
   date,
   index,
+  jsonb,
   pgEnum,
   pgTable,
   primaryKey,
@@ -18,6 +19,9 @@ import { type OrganizationReach } from '../../../components/organization/dto/org
 import { type OrganizationType } from '../../../components/organization/dto/organization-type.dto';
 import { type PartnerType } from '../../../components/partner/dto/partner-type.enum';
 import { type FinancialReportingType } from '../../../components/partnership/dto/financial-reporting-type.enum';
+import { type ReportPeriod } from '../../../components/periodic-report/dto/report-period.enum';
+import { type ProjectStatus } from '../../../components/project/dto/project-status.enum';
+import { type ProjectStep } from '../../../components/project/dto/project-step.enum';
 import { type ProjectType } from '../../../components/project/dto/project-type.enum';
 import { type Gender } from '../../../components/user/dto/gender.enum';
 import { int4multirange } from '../int4-multirange';
@@ -720,6 +724,356 @@ export const partnerLanguagesOfConsultingRelations = relations(
     partner: one(partners, {
       fields: [partnerLanguagesOfConsulting.partnerId],
       references: [partners.id],
+    }),
+  }),
+);
+
+// ─── Project ───────────────────────────────────────────────────────────────
+
+export const projectStepEnum = pgEnum('project_step', [
+  'EarlyConversations',
+  'PendingConceptApproval',
+  'PrepForConsultantEndorsement',
+  'PendingConsultantEndorsement',
+  'PrepForFinancialEndorsement',
+  'PendingFinancialEndorsement',
+  'FinalizingProposal',
+  'PendingRegionalDirectorApproval',
+  'PendingZoneDirectorApproval',
+  'PendingFinanceConfirmation',
+  'OnHoldFinanceConfirmation',
+  'DidNotDevelop',
+  'Rejected',
+  'Active',
+  'ActiveChangedPlan',
+  'DiscussingChangeToPlan',
+  'PendingChangeToPlanApproval',
+  'PendingChangeToPlanConfirmation',
+  'DiscussingSuspension',
+  'PendingSuspensionApproval',
+  'Suspended',
+  'DiscussingReactivation',
+  'PendingReactivationApproval',
+  'DiscussingTermination',
+  'PendingTerminationApproval',
+  'FinalizingCompletion',
+  'Terminated',
+  'Completed',
+]);
+
+export const projectStatusEnum = pgEnum('project_status', [
+  'InDevelopment',
+  'Active',
+  'Terminated',
+  'Completed',
+  'DidNotDevelop',
+]);
+
+export const reportPeriodEnum = pgEnum('report_period', [
+  'Monthly',
+  'Quarterly',
+]);
+
+/**
+ * First column to use `role` as a pgEnum (project_members.roles role[]).
+ * `user_global_roles.role` predates this and is plain `text` — aligning it is
+ * tracked as a separate cleanup PR (migration-todo on user_global_roles).
+ */
+export const roleEnum = pgEnum('role', [
+  'Administrator',
+  'BetaTester',
+  'BibleTranslationLiaison',
+  'Consultant',
+  'ConsultantManager',
+  'Controller',
+  'ExperienceOperations',
+  'FieldOperationsDirector',
+  'FieldPartner',
+  'FieldServices',
+  'FinancialAnalyst',
+  'Fundraising',
+  'Intern',
+  'LeadFinancialAnalyst',
+  'Leadership',
+  'Liaison',
+  'Marketing',
+  'Mentor',
+  'MultiplicationFinanceApprover',
+  'ProjectManager',
+  'RegionalCommunicationsCoordinator',
+  'RegionalDirector',
+  'StaffMember',
+  'Translator',
+]);
+
+/**
+ * Project — single-table inheritance over the 3 concrete subtypes
+ * (MomentumTranslation, MultiplicationTranslation, Internship). `type` is the
+ * discriminator; `own_sensitivity` is meaningful only for Internship (Translation
+ * rows ignore it and read the denormalized `sensitivity` column).
+ *
+ * `sensitivity` is denormalized: kept current via a hook that recomputes from
+ * Engagement/Language. The hook is stubbed (`migration-todo:`) until Language
+ * migrates — Translation projects read 'High' in DATABASE=postgres until then.
+ *
+ * `status` is `GENERATED ALWAYS AS (CASE step ... END) STORED` in the raw SQL
+ * migration; mirrors Gel's `Project::statusFromStep(.step)`. Drizzle marks it
+ * as generated so insert/update types omit it.
+ */
+export const projects = pgTable(
+  'projects',
+  {
+    id: text('id').$type<ID<'Project'>>().primaryKey(),
+    type: projectTypeEnum('type').$type<ProjectType>().notNull(),
+    name: text('name').notNull(),
+    step: projectStepEnum('step')
+      .$type<ProjectStep>()
+      .notNull()
+      .default('EarlyConversations'),
+    status: projectStatusEnum('status')
+      .$type<ProjectStatus>()
+      .generatedAlwaysAs(
+        // Mirror of stepToStatus() in src/components/project/dto/project-status.enum.ts
+        sql`CASE step
+          WHEN 'EarlyConversations'              THEN 'InDevelopment'::project_status
+          WHEN 'PendingConceptApproval'          THEN 'InDevelopment'::project_status
+          WHEN 'PrepForConsultantEndorsement'    THEN 'InDevelopment'::project_status
+          WHEN 'PendingConsultantEndorsement'    THEN 'InDevelopment'::project_status
+          WHEN 'PrepForFinancialEndorsement'     THEN 'InDevelopment'::project_status
+          WHEN 'PendingFinancialEndorsement'     THEN 'InDevelopment'::project_status
+          WHEN 'FinalizingProposal'              THEN 'InDevelopment'::project_status
+          WHEN 'PendingRegionalDirectorApproval' THEN 'InDevelopment'::project_status
+          WHEN 'PendingZoneDirectorApproval'     THEN 'InDevelopment'::project_status
+          WHEN 'PendingFinanceConfirmation'      THEN 'InDevelopment'::project_status
+          WHEN 'OnHoldFinanceConfirmation'       THEN 'InDevelopment'::project_status
+          WHEN 'DidNotDevelop'                   THEN 'DidNotDevelop'::project_status
+          WHEN 'Rejected'                        THEN 'DidNotDevelop'::project_status
+          WHEN 'Active'                          THEN 'Active'::project_status
+          WHEN 'ActiveChangedPlan'               THEN 'Active'::project_status
+          WHEN 'DiscussingChangeToPlan'          THEN 'Active'::project_status
+          WHEN 'PendingChangeToPlanApproval'     THEN 'Active'::project_status
+          WHEN 'PendingChangeToPlanConfirmation' THEN 'Active'::project_status
+          WHEN 'DiscussingSuspension'            THEN 'Active'::project_status
+          WHEN 'PendingSuspensionApproval'       THEN 'Active'::project_status
+          WHEN 'Suspended'                       THEN 'Active'::project_status
+          WHEN 'DiscussingReactivation'          THEN 'Active'::project_status
+          WHEN 'PendingReactivationApproval'     THEN 'Active'::project_status
+          WHEN 'DiscussingTermination'           THEN 'Active'::project_status
+          WHEN 'PendingTerminationApproval'      THEN 'Active'::project_status
+          WHEN 'FinalizingCompletion'            THEN 'Active'::project_status
+          WHEN 'Terminated'                      THEN 'Terminated'::project_status
+          WHEN 'Completed'                       THEN 'Completed'::project_status
+        END`,
+      )
+      .notNull(),
+    // migration-todo: denormalized — recompute hook fires when Engagement/Language
+    // sensitivity changes (Tier 2 Language migration wires the hook). Translation
+    // rows read 'High' until then; Internship reads own_sensitivity.
+    sensitivity: sensitivityEnum('sensitivity').notNull().default('High'),
+    // Writable only for Internship projects; Translation rows ignore it.
+    ownSensitivity: sensitivityEnum('own_sensitivity'),
+    rev79ProjectId: text('rev79_project_id'),
+    departmentId: text('department_id'),
+    departmentIdBlockId: text('department_id_block_id')
+      .$type<ID>()
+      .references(() => departmentIdBlocks.id),
+    primaryLocationId: text('primary_location_id')
+      .$type<ID<'Location'>>()
+      .references((): AnyPgColumn => locations.id),
+    marketingLocationId: text('marketing_location_id')
+      .$type<ID<'Location'>>()
+      .references((): AnyPgColumn => locations.id),
+    marketingRegionOverrideId: text('marketing_region_override_id')
+      .$type<ID<'Location'>>()
+      .references((): AnyPgColumn => locations.id),
+    fieldRegionId: text('field_region_id')
+      .$type<ID<'FieldRegion'>>()
+      .references(() => fieldRegions.id),
+    owningOrganizationId: text('owning_organization_id')
+      .$type<ID<'Organization'>>()
+      .references(() => organizations.id),
+    // migration-todo: deferred FK → directories(id); add REFERENCES when File
+    // migrates (Tier 7). Plain text until then.
+    rootDirectoryId: text('root_directory_id').$type<ID<'Directory'>>(),
+    mouStart: date('mou_start'),
+    mouEnd: date('mou_end'),
+    initialMouEnd: date('initial_mou_end'),
+    estimatedSubmission: date('estimated_submission'),
+    financialReportReceivedAt: timestamp('financial_report_received_at', {
+      withTimezone: true,
+    }),
+    financialReportPeriod: reportPeriodEnum(
+      'financial_report_period',
+    ).$type<ReportPeriod>(),
+    tags: text('tags').array().notNull().default([]),
+    presetInventory: boolean('preset_inventory').notNull().default(false),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    modifiedAt: timestamp('modified_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    // Partial uniques — only enforced on live (non-soft-deleted) rows.
+    uniqueIndex('projects_name_active_unique')
+      .on(t.name)
+      .where(sql`${t.deletedAt} IS NULL`),
+    uniqueIndex('projects_department_id_active_unique')
+      .on(t.departmentId)
+      .where(sql`${t.departmentId} IS NOT NULL AND ${t.deletedAt} IS NULL`),
+    // FK b-tree indexes — PG doesn't auto-index FKs.
+    index('projects_department_id_block_id_idx').on(t.departmentIdBlockId),
+    index('projects_primary_location_id_idx').on(t.primaryLocationId),
+    index('projects_marketing_location_id_idx').on(t.marketingLocationId),
+    index('projects_marketing_region_override_id_idx').on(
+      t.marketingRegionOverrideId,
+    ),
+    index('projects_field_region_id_idx').on(t.fieldRegionId),
+    index('projects_owning_organization_id_idx').on(t.owningOrganizationId),
+    // Deferred FK column — indexed now so we avoid CREATE INDEX CONCURRENTLY
+    // later when File adds the REFERENCES clause.
+    index('projects_root_directory_id_idx').on(t.rootDirectoryId),
+    // Filter-hot columns.
+    index('projects_type_idx').on(t.type),
+    index('projects_step_idx').on(t.step),
+    index('projects_status_idx').on(t.status),
+  ],
+);
+
+/**
+ * ProjectMember — composite-unique on (project_id, user_id) for live rows.
+ * `roles role[]` matches Gel's set semantics; GIN index supports the
+ * `roles && ARRAY[...]::role[]` intersectsProp filter.
+ */
+export const projectMembers = pgTable(
+  'project_members',
+  {
+    id: text('id').$type<ID<'ProjectMember'>>().primaryKey(),
+    projectId: text('project_id')
+      .$type<ID<'Project'>>()
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    roles: roleEnum('roles')
+      .array()
+      .$type<readonly Role[]>()
+      .notNull()
+      .default([]),
+    inactiveAt: timestamp('inactive_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    uniqueIndex('project_members_project_user_active_unique')
+      .on(t.projectId, t.userId)
+      .where(sql`${t.deletedAt} IS NULL`),
+    index('project_members_user_id_idx').on(t.userId),
+    // GIN index for `roles && ARRAY[...]::role[]` (intersectsProp filter).
+    index('project_members_roles_gin').using('gin', t.roles),
+  ],
+);
+
+/**
+ * ProjectWorkflowEvent — append-only event stream. A trigger on INSERT keeps
+ * `projects.step` in sync (raw SQL migration). App code writes events, never
+ * touches `projects.step` directly.
+ */
+export const projectWorkflowEvents = pgTable(
+  'project_workflow_events',
+  {
+    id: text('id').$type<ID<'ProjectWorkflowEvent'>>().primaryKey(),
+    projectId: text('project_id')
+      .$type<ID<'Project'>>()
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    who: text('who')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id),
+    // Nullable for synthetic/initial events; populated for normal transitions.
+    fromStep: projectStepEnum('from_step').$type<ProjectStep>(),
+    toStep: projectStepEnum('to_step').$type<ProjectStep>().notNull(),
+    // Nullable for dynamic transitions (e.g. BackToActive) where there's no
+    // single transition key — they resolve at runtime from history.
+    transitionKey: text('transition_key'),
+    notes: jsonb('notes'), // RichText
+    at: timestamp('at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    // Compound index — every list query is "events for project X, newest first".
+    index('project_workflow_events_project_id_at_idx').on(
+      t.projectId,
+      t.at.desc(),
+    ),
+  ],
+);
+
+export const projectsRelations = relations(projects, ({ one, many }) => ({
+  departmentIdBlock: one(departmentIdBlocks, {
+    fields: [projects.departmentIdBlockId],
+    references: [departmentIdBlocks.id],
+  }),
+  primaryLocation: one(locations, {
+    fields: [projects.primaryLocationId],
+    references: [locations.id],
+    relationName: 'projectPrimaryLocation',
+  }),
+  marketingLocation: one(locations, {
+    fields: [projects.marketingLocationId],
+    references: [locations.id],
+    relationName: 'projectMarketingLocation',
+  }),
+  marketingRegionOverride: one(locations, {
+    fields: [projects.marketingRegionOverrideId],
+    references: [locations.id],
+    relationName: 'projectMarketingRegionOverride',
+  }),
+  fieldRegion: one(fieldRegions, {
+    fields: [projects.fieldRegionId],
+    references: [fieldRegions.id],
+  }),
+  owningOrganization: one(organizations, {
+    fields: [projects.owningOrganizationId],
+    references: [organizations.id],
+  }),
+  members: many(projectMembers),
+  workflowEvents: many(projectWorkflowEvents),
+}));
+
+export const projectMembersRelations = relations(projectMembers, ({ one }) => ({
+  project: one(projects, {
+    fields: [projectMembers.projectId],
+    references: [projects.id],
+  }),
+  user: one(users, {
+    fields: [projectMembers.userId],
+    references: [users.id],
+  }),
+}));
+
+export const projectWorkflowEventsRelations = relations(
+  projectWorkflowEvents,
+  ({ one }) => ({
+    project: one(projects, {
+      fields: [projectWorkflowEvents.projectId],
+      references: [projects.id],
+    }),
+    who: one(users, {
+      fields: [projectWorkflowEvents.who],
+      references: [users.id],
     }),
   }),
 );


### PR DESCRIPTION
### What's in scope

- **4 new pgEnums** — `project_step` (28 values), `project_status` (5), `report_period`, `role`
- **3 new tables** — `projects`, `project_members`, `project_workflow_events`
- **1 trigger function** — `sync_project_step_from_event()` keeps `projects.step` in sync with the latest `project_workflow_events` insert; mirrors Gel's auto-sync trigger
- **All FK b-tree indexes** + partial uniques on `name` / `department_id` where `deleted_at IS NULL`
- **GIN index** on `project_members.roles` for the `roles && ARRAY[...]::role[]` intersectsProp filter

### Settled design decisions

- **Subtype storage**: single `projects` table with `type` discriminator. `own_sensitivity` is a nullable column meaningful only for Internship (Translation rows ignore it and read the denormalized `sensitivity`).
- **`status` is GENERATED ALWAYS AS CASE STORED** — 28-branch mapping matches `stepToStatus()` and Gel's `statusFromStep()`. Never writable. Drizzle's `generatedAlwaysAs()` marks it generated so insert/update types omit it.
- **`sensitivity` denormalized** with recompute hook stubbed (migration-todo) until Language migrates. Translation rows read `'High'` in `DATABASE=postgres` until then — acceptable since that mode is dev-only.
- **`roles role[]` + GIN** — single column on `project_members`; closest to Gel's set type and Neo4j's array property. `user_global_roles.role` stays plain text for now; aligning it is a separate cleanup PR.
- **Workflow → step sync via trigger** — `AFTER INSERT ON project_workflow_events`. App code writes events, doesn't touch `projects.step` directly.

### Migration-todo introduced

- `projects.sensitivity` — recompute hook stubbed until Language migrates
- `projects.root_directory_id` — deferred FK to `directories` (Tier 7 File); indexed now so we avoid `CREATE INDEX CONCURRENTLY` later
- `user_global_roles.role` (in `roleEnum` docstring) — flagged for future alignment to use the new `role` pgEnum