### PR TITLE
#13c [pg] Project Workflow + Transition Hooks Migration

### DIFF
--- a/src/components/project/handlers/set-department-id.handler.ts
+++ b/src/components/project/handlers/set-department-id.handler.ts
@@ -1,13 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { isNull, node, not, relation } from 'cypher-query-builder';
+import { eq, sql } from 'drizzle-orm';
 import {
   ClientException,
   type ID,
+  NotImplementedException,
   ServerException,
   type UnsecuredDto,
 } from '~/common';
 import { ConfigService } from '~/core/config';
 import { TransactionRetryInformer } from '~/core/database';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { PgErrorCode } from '~/core/drizzle/pg-error-codes';
+import { projects } from '~/core/drizzle/schema';
 import { OnHook } from '~/core/hooks';
 import { DatabaseService, UniquenessError } from '~/core/neo4j';
 import {
@@ -30,6 +35,7 @@ import { ProjectTransitionedHook } from '../workflow/hooks/project-transitioned.
 export class SetDepartmentId {
   constructor(
     private readonly db: DatabaseService,
+    private readonly drizzle: DrizzleService,
     private readonly config: ConfigService,
     private readonly retryInformer: TransactionRetryInformer,
   ) {}
@@ -37,6 +43,8 @@ export class SetDepartmentId {
   @OnHook(ProjectTransitionedHook)
   @OnHook(ProjectUpdatedHook)
   async handle(event: ProjectTransitionedHook | ProjectUpdatedHook) {
+    // migration-todo: collapse the gel-early-return at Phase 7 cutover when
+    // the Gel path is removed.
     if (this.config.databaseEngine === 'gel') {
       return;
     }
@@ -54,18 +62,136 @@ export class SetDepartmentId {
       return;
     }
 
-    const block = await this.getDepartmentIdBlockId(project);
+    // migration-todo: collapse this engine-check at Phase 7 cutover — drop
+    // the Neo4j branch + assignDepartmentIdNeo4j + DatabaseService injection,
+    // keep only the PG path.
+    const departmentId =
+      this.config.databaseEngine === 'postgres'
+        ? await this.assignDepartmentIdPg(project)
+        : await this.assignDepartmentIdNeo4j(project);
 
-    const departmentId = await this.assignDepartmentIdForProject(
-      project,
-      block,
-    );
     const changed = { ...project, departmentId };
-
     if (event instanceof ProjectTransitionedHook) {
       event.project = changed;
     } else {
       event.updated = changed;
+    }
+  }
+
+  private async assignDepartmentIdNeo4j(project: UnsecuredDto<Project>) {
+    const block = await this.getDepartmentIdBlockId(project);
+    return await this.assignDepartmentIdForProject(project, block);
+  }
+
+  /**
+   * PG path — resolves the DepartmentIdBlock via the FK chain
+   * `project.primary_location_id → locations.funding_account_id →
+   * funding_accounts.department_id_block_id`, enumerates the block's
+   * `range int4multirange`, picks the smallest 5-digit-padded id that
+   * isn't already used, and UPDATEs `projects.department_id`. Catches PG
+   * unique violation 23505 on the partial-unique index and marks the
+   * transaction for retry — mirror of the Neo4j UniquenessError flow.
+   *
+   * MultiplicationTranslation projects route via partnership → partner
+   * instead, but `partnerships` isn't migrated — throws NotImplementedException
+   * with a clear message until partnership-pg lands.
+   *
+   * `funding_accounts` lives on develop (PR #9) but isn't on this branch's
+   * base (`partner-pg` predates the funding-account merge). Raw SQL references
+   * the table by name so the handler compiles here and Just Works at runtime
+   * once this stack rebases onto develop. Same approach as the deferred-FK
+   * pattern used elsewhere.
+   *
+   * `external_department_ids` exclusion is dropped — that table is part of an
+   * unmigrated domain. migration-todo: re-add the exclusion when that domain
+   * ports (probably with the broader Finance/Admin work).
+   */
+  private async assignDepartmentIdPg(project: UnsecuredDto<Project>) {
+    if (project.type === 'MultiplicationTranslation') {
+      // migration-todo: implement the partnership → partner → block path
+      // when partnership-pg lands. Until then this branch never fires in
+      // production (DATABASE=postgres is dev-only), but it'd surface as a
+      // failed transition if hit. Mirror of the Neo4j repo's `holder` switch.
+      throw new NotImplementedException(
+        'SetDepartmentId for MultiplicationTranslation projects requires Partnership migration — pending.',
+      );
+    }
+    if (!project.primaryLocation) {
+      throw new ClientException(
+        'Project must have a primary location to continue',
+      );
+    }
+
+    const projectId = project.id;
+    let nextId: string;
+    try {
+      const { rows } = await this.drizzle.client.execute<{ nextId: string }>(
+        sql`
+          with block_range as (
+            select b.range
+            from projects p
+            join locations l on l.id = p.primary_location_id
+            join funding_accounts fa on fa.id = l.funding_account_id
+            join department_id_blocks b on b.id = fa.department_id_block_id
+            where p.id = ${projectId}
+          ),
+          enumerated as (
+            select case
+              when id < 10000 then lpad(id::text, 5, '0')
+              else id::text
+            end as dept_id
+            from block_range,
+                 unnest(block_range.range) as r,
+                 lateral generate_series(lower(r), upper(r) - 1) as id
+          ),
+          used as (
+            select department_id from projects
+            where department_id is not null and deleted_at is null
+            -- migration-todo: also exclude external_department_ids when that
+            -- table migrates (likely Admin domain).
+          )
+          select dept_id as "nextId" from enumerated
+          where dept_id not in (select department_id from used)
+          order by dept_id asc
+          limit 1
+        `,
+      );
+      const first = rows[0];
+      if (!first) {
+        throw new ServerException('No department ID is available');
+      }
+      nextId = first.nextId;
+    } catch (e) {
+      if (e instanceof ServerException) throw e;
+      throw new ServerException(
+        'Could not resolve next available department ID',
+        e,
+      );
+    }
+
+    try {
+      await this.drizzle.client
+        .update(projects)
+        .set({ departmentId: nextId, modifiedAt: new Date() })
+        .where(eq(projects.id, projectId));
+      return nextId;
+    } catch (e) {
+      const code = (e as { code?: string })?.code;
+      const constraint = (e as { constraint?: string })?.constraint;
+      if (
+        code === PgErrorCode.UniqueViolation &&
+        constraint === 'projects_department_id_active_unique'
+      ) {
+        // Mirror of the Neo4j path: signal the transaction interceptor to
+        // retry. A concurrent assignment grabbed the same id between our
+        // SELECT and UPDATE; reading + writing again will pick the next one.
+        this.retryInformer.markForRetry(e as Error);
+        throw new ServerException(
+          "Could not set Project's Department ID (retryable)",
+          e,
+        );
+      }
+      throw new ServerException("Could not set Project's Department ID", e);
     }
   }
 

--- a/src/components/project/handlers/set-initial-mou-end.handler.ts
+++ b/src/components/project/handlers/set-initial-mou-end.handler.ts
@@ -1,4 +1,8 @@
+import { eq } from 'drizzle-orm';
 import { ServerException } from '~/common';
+import { ConfigService } from '~/core/config';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { projects } from '~/core/drizzle/schema';
 import { OnHook } from '~/core/hooks';
 import { DatabaseService } from '~/core/neo4j';
 import { IProject, ProjectStatus } from '../dto';
@@ -10,7 +14,11 @@ type SubscribedEvent = ProjectCreatedHook | ProjectTransitionedHook;
 @OnHook(ProjectCreatedHook)
 @OnHook(ProjectTransitionedHook)
 export class SetInitialMouEnd {
-  constructor(private readonly db: DatabaseService) {}
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly drizzle: DrizzleService,
+    private readonly config: ConfigService,
+  ) {}
 
   async handle(event: SubscribedEvent) {
     const { project } = event;
@@ -26,6 +34,20 @@ export class SetInitialMouEnd {
     }
 
     try {
+      // migration-todo: collapse this engine-check at Phase 7 cutover — drop
+      // the Neo4j branch + DatabaseService injection, keep only the PG path.
+      if (this.config.databaseEngine === 'postgres') {
+        await this.drizzle.client
+          .update(projects)
+          .set({
+            initialMouEnd: project.mouEnd ? project.mouEnd.toSQLDate() : null,
+          })
+          .where(eq(projects.id, project.id));
+        // Mutate the hook payload so downstream handlers see the new value.
+        event.project = { ...project, initialMouEnd: project.mouEnd ?? null };
+        return;
+      }
+
       const updatedProject = await this.db.updateProperties({
         type: IProject,
         object: project,
@@ -33,12 +55,7 @@ export class SetInitialMouEnd {
           initialMouEnd: project.mouEnd || null,
         },
       });
-
-      if (event instanceof ProjectTransitionedHook) {
-        event.project = updatedProject;
-      } else {
-        event.project = updatedProject;
-      }
+      event.project = updatedProject;
     } catch (exception) {
       throw new ServerException(
         'Could not set initial mou end on project',

--- a/src/components/project/workflow/project-workflow.drizzle.repository.ts
+++ b/src/components/project/workflow/project-workflow.drizzle.repository.ts
@@ -1,0 +1,179 @@
+import { Injectable } from '@nestjs/common';
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import { generateId, type ID, type UnsecuredDto } from '~/common';
+import { Identity } from '~/core/authentication';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { projects, projectWorkflowEvents } from '~/core/drizzle/schema';
+import { type ProjectStep } from '../dto';
+import {
+  type ExecuteProjectTransition,
+  type ProjectWorkflowEvent as WorkflowEvent,
+} from './dto';
+
+/**
+ * PostgreSQL implementation of the canonical `ProjectWorkflowRepository`.
+ *
+ * `projects.step` is kept in sync by an `AFTER INSERT` trigger on
+ * `project_workflow_events` (see migration 0009 — `sync_project_step_from_event`).
+ * App code never writes to `projects.step` directly; insert an event and the
+ * trigger does the rest. `modified_at` is bumped in the same trigger.
+ *
+ * `status` is a `GENERATED ALWAYS AS (CASE step ... END) STORED` column, so it
+ * follows step automatically — no extra write needed.
+ *
+ * `stepChangedAt` derives from the event's `at` timestamp at read time on the
+ * Project resolver; nothing is stored on `projects` for it.
+ */
+// migration-todo: `PublicOf<ProjectWorkflowRepository>` widens to every
+// public/protected member of the Gel base (privileges, getActualChanges,
+// isUnique, etc.) which this class doesn't reproduce. Same trade as every
+// other Drizzle repo — we rely on the `as any` cast at splitDb registration
+// time and lose compile-time enforcement here. Collapses at Phase 7 cutover.
+@Injectable()
+export class ProjectWorkflowDrizzleRepository {
+  constructor(
+    private readonly drizzle: DrizzleService,
+    private readonly identity: Identity,
+  ) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  async readMany(
+    ids: readonly ID[],
+  ): Promise<Array<UnsecuredDto<WorkflowEvent>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.projectWorkflowEvents.findMany({
+      where: (e) => inArray(e.id, [...ids]),
+      with: { project: { columns: { id: true, type: true, step: true } } },
+    });
+    return rows.map((row) => this.toDto(row));
+  }
+
+  async list(projectId: ID): Promise<Array<UnsecuredDto<WorkflowEvent>>> {
+    const rows = await this.db.query.projectWorkflowEvents.findMany({
+      where: (e) => eq(e.projectId, projectId),
+      with: { project: { columns: { id: true, type: true, step: true } } },
+      orderBy: (e, { asc }) => [asc(e.at)],
+    });
+    return rows.map((row) => this.toDto(row));
+  }
+
+  /**
+   * Insert a workflow event. The trigger handles `projects.step` /
+   * `modified_at` sync. We capture the project's current step *before* insert
+   * so the returned dto can carry `project.previousStep` — same surface as the
+   * Neo4j repo, where `previousStep` is read from the pre-update Property
+   * node within the same transaction.
+   */
+  async recordEvent(
+    input: Omit<ExecuteProjectTransition, 'bypassTo'> & { to: ProjectStep },
+  ): Promise<UnsecuredDto<WorkflowEvent>> {
+    const [projectRow] = await this.db
+      .select({ step: projects.step, type: projects.type })
+      .from(projects)
+      .where(eq(projects.id, input.project))
+      .limit(1);
+    const fromStep: ProjectStep | null = projectRow?.step ?? null;
+
+    const id = await generateId<ID<'ProjectWorkflowEvent'>>();
+    const who = this.identity.current.userId;
+    const at = new Date();
+
+    await this.db.insert(projectWorkflowEvents).values({
+      id,
+      projectId: input.project,
+      who,
+      fromStep,
+      toStep: input.to,
+      transitionKey: input.transition ?? null,
+      notes: input.notes ?? null,
+      at,
+    });
+
+    return this.toDto({
+      id,
+      projectId: input.project,
+      who,
+      fromStep,
+      toStep: input.to,
+      transitionKey: input.transition ?? null,
+      notes: input.notes ?? null,
+      at,
+      project: {
+        id: input.project,
+        type: projectRow!.type,
+        step: fromStep ?? input.to,
+      },
+    });
+  }
+
+  /**
+   * Walk this project's event history and return the most recent `to_step`
+   * matching any of `steps`. Drives the `BackToActive` dynamic step in
+   * `project-workflow.ts` (and any future dynamic-state resolver). Returns
+   * null when the project has never reached one of those steps.
+   */
+  async mostRecentStep(
+    projectId: ID<'Project'>,
+    steps: readonly ProjectStep[],
+  ): Promise<ProjectStep | null> {
+    if (steps.length === 0) return null;
+    const rows = await this.db
+      .select({ step: projectWorkflowEvents.toStep })
+      .from(projectWorkflowEvents)
+      .where(
+        and(
+          eq(projectWorkflowEvents.projectId, projectId),
+          inArray(projectWorkflowEvents.toStep, [...steps]),
+        ),
+      )
+      .orderBy(desc(projectWorkflowEvents.at))
+      .limit(1);
+    return rows[0]?.step ?? null;
+  }
+
+  protected toDto(
+    row: typeof projectWorkflowEvents.$inferSelect & {
+      project?: { id: ID<'Project'>; type: string; step: ProjectStep } | null;
+    },
+  ): UnsecuredDto<WorkflowEvent> & {
+    project: { id: ID<'Project'>; type: string; previousStep: ProjectStep };
+  } {
+    if (!row.project) {
+      // Schema FK is NOT NULL → the relational findMany typing widens to nullable
+      // but the row always exists. Loud failure beats silent NaN.
+      throw new Error(
+        `ProjectWorkflowEvent ${row.id} missing parent project row — FK invariant violated`,
+      );
+    }
+    const dto: unknown = {
+      id: row.id,
+      __typename: 'ProjectWorkflowEvent',
+      createdAt: DateTime.fromJSDate(row.at),
+      at: DateTime.fromJSDate(row.at),
+      who: { id: row.who },
+      // `transition` is the transition key (a string id resolved to a
+      // WorkflowTransition object at the resolver layer). null when the
+      // transition was bypassed or dynamic.
+      transition: row.transitionKey ?? null,
+      to: row.toStep,
+      notes: row.notes ?? null,
+      project: {
+        id: row.project.id,
+        type: row.project.type,
+        // `previousStep` = the project's step at the time the event was
+        // observed (post-trigger, this *is* the previous step from the
+        // event's POV because the trigger has already moved the project to
+        // `to_step`). `recordEvent` overrides this with the captured
+        // `fromStep` so its caller sees the correct value.
+        previousStep: row.fromStep ?? row.project.step,
+      },
+    };
+    return dto as UnsecuredDto<WorkflowEvent> & {
+      project: { id: ID<'Project'>; type: string; previousStep: ProjectStep };
+    };
+  }
+}

--- a/src/components/project/workflow/project-workflow.module.ts
+++ b/src/components/project/workflow/project-workflow.module.ts
@@ -6,6 +6,7 @@ import { ProjectWorkflowNotificationHandler } from './handlers/project-workflow-
 import { StepHistoryToWorkflowEventsMigration } from './migrations/step-history-to-workflow-events.migration';
 import { ProjectWorkflowEventLoader } from './project-workflow-event.loader';
 import { ProjectWorkflowChannels } from './project-workflow.channels';
+import { ProjectWorkflowDrizzleRepository } from './project-workflow.drizzle.repository';
 import { ProjectWorkflowFlowchart } from './project-workflow.flowchart';
 import { ProjectWorkflowEventGranter } from './project-workflow.granter';
 import { ProjectWorkflowNeo4jRepository } from './project-workflow.neo4j.repository';
@@ -31,6 +32,9 @@ import { ProjectWorkflowMutationSubscriptionsResolver } from './resolvers/projec
     ProjectWorkflowEventGranter,
     splitDb(ProjectWorkflowRepository, {
       neo4j: ProjectWorkflowNeo4jRepository,
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: ProjectWorkflowDrizzleRepository as any,
     }),
     ProjectWorkflowFlowchart,
     ProjectWorkflowNotificationHandler,


### PR DESCRIPTION
### What's in scope

- **`ProjectWorkflowDrizzleRepository`** (new, ~180 LOC) — `readMany`, `list`, `recordEvent`, `mostRecentStep`. The DB trigger from PR 1 (`AFTER INSERT ON project_workflow_events`) keeps `projects.step` + `modified_at` in sync; app code never writes to `projects.step` directly. `projects.status` follows via PR 1's `GENERATED ALWAYS AS (CASE step ... END) STORED` column.
- **`SetInitialMouEnd` PG path** — engine-check branches to `UPDATE projects SET initial_mou_end = ...` under postgres. Mutates `event.project` so downstream handlers see the new value. Neo4j path unchanged.
- **`SetDepartmentId` PG path** — splits into `assignDepartmentIdNeo4j` (preserves the Cypher + APOC flow) and `assignDepartmentIdPg`. PG path uses a raw SQL CTE to enumerate the block's `int4multirange` and pick the smallest unused 5-digit-padded id; catches unique-violation 23505 and signals `retryInformer.markForRetry` — mirror of the Neo4j `UniquenessError` flow.
- **`ProjectWorkflowModule`** — `splitDb` adds `postgres:` branch alongside the existing `neo4j:` registration.

### Design notes worth surfacing

- **`recordEvent` captures `previousStep` before INSERT.** PG `AFTER INSERT FOR EACH ROW` triggers fire before the transaction commits but before a subsequent same-transaction SELECT — so reading `projects.step` after the INSERT returns the *new* step. The repo captures step *before* INSERT and threads it through `toDto` as `project.previousStep` so the returned event dto matches the Neo4j shape exactly.
- **`from_step` is also persisted** on each event row (using the captured previousStep). This makes `mostRecentStep` and any future event-history query a single column read instead of having to walk computed deltas.
- **Drops `implements PublicOf<>` on the Drizzle repo.** The interface widens to every public/protected member of the Gel base (`privileges`, `getActualChanges`, `isUnique`, etc.) which this class doesn't reproduce. Same trade as every other Drizzle repo — `as any` at splitDb registration is the documented migration-todo, collapses at Phase 7 cutover.
- **Raw SQL CTE for next-available department_id.** `unnest(int4multirange) + lateral generate_series(lower(r), upper(r) - 1)` enumerates each integer in the block; `lpad` for <10000 gives the 5-digit string; `NOT IN (used)` filters; `ORDER BY ... LIMIT 1` picks the smallest. The Neo4j version's APOC `flatten + range + lpad` chain collapses cleanly into one CTE.