### PR TITLE
#14 [pg] Partnership Migration

### DIFF
--- a/src/components/authorization/policies/conditions/member.condition.ts
+++ b/src/components/authorization/policies/conditions/member.condition.ts
@@ -1,11 +1,13 @@
 import { type NonEmptyArray } from '@seedcompany/common';
 import { type Query } from 'cypher-query-builder';
+import { type SQL, sql } from 'drizzle-orm';
 import { intersection } from 'lodash';
 import { inspect, type InspectOptionsStylized } from 'util';
-import { type ResourceShape, type Role } from '~/common';
+import { type EnhancedResource, type ResourceShape, type Role } from '~/common';
 import { matchProjectScopedRoles } from '~/core/neo4j/query';
 import { rolesForScope, type ScopedRole, splitScope } from '../../dto/role.dto';
 import {
+  type AsDrizzleParams,
   type AsEdgeQLParams,
   type Condition,
   eqlDoesIntersect,
@@ -34,6 +36,17 @@ class MemberCondition<
 
   asCypherCondition() {
     return 'exists((project)-[:member { active: true }]->(:ProjectMember)-[:user]->(:User { id: $currentUser }))';
+  }
+
+  asDrizzleCondition({ resource, session }: AsDrizzleParams<TResourceStatic>) {
+    const projectIdRef = projectIdRefForResource(resource);
+    return sql`exists (
+      select 1 from "project_members" "pm"
+      where "pm"."project_id" = ${projectIdRef}
+        and "pm"."user_id" = ${session.userId}
+        and "pm"."inactive_at" is null
+        and "pm"."deleted_at" is null
+    )`;
   }
 
   setupEdgeQLContext({
@@ -98,6 +111,24 @@ class MemberWithRolesCondition<
     return `size(apoc.coll.intersection(${CQL_VAR}, ${String(required)})) > 0`;
   }
 
+  asDrizzleCondition({ resource, session }: AsDrizzleParams<TResourceStatic>) {
+    const projectIdRef = projectIdRefForResource(resource);
+    // ARRAY[...]::role[] intersection — true when membership shares at least
+    // one role with the required set. Mirrors `apoc.coll.intersection` >0 in
+    // Cypher and `intersect` in EdgeQL.
+    const requiredRoles = sql.raw(
+      `array[${this.roles.map((r) => `'${r}'`).join(', ')}]::"role"[]`,
+    );
+    return sql`exists (
+      select 1 from "project_members" "pm"
+      where "pm"."project_id" = ${projectIdRef}
+        and "pm"."user_id" = ${session.userId}
+        and "pm"."inactive_at" is null
+        and "pm"."deleted_at" is null
+        and "pm"."roles" && ${requiredRoles}
+    )`;
+  }
+
   asEdgeQLCondition({ namespace }: AsEdgeQLParams<TResourceStatic>) {
     const Role = fqnRelativeTo('default::Role', namespace);
     return eqlDoesIntersect('.membership.roles', this.roles, Role);
@@ -107,6 +138,29 @@ class MemberWithRolesCondition<
     return `Member with ${this.roles.join(', ')}`;
   }
 }
+
+/**
+ * Resolve the SQL fragment that locates the parent project's `id` for the
+ * given resource. Project subtypes (Momentum/Multiplication/Internship)
+ * dereference to `projects.id` directly. Project-scoped child resources
+ * reference their FK column. Add cases here as each domain ports to Postgres.
+ */
+const projectIdRefForResource = (resource: EnhancedResource<any>): SQL => {
+  switch (resource.name) {
+    case 'Project':
+    case 'TranslationProject':
+    case 'MomentumTranslationProject':
+    case 'MultiplicationTranslationProject':
+    case 'InternshipProject':
+      return sql.raw(`"projects"."id"`);
+    case 'ProjectMember':
+      return sql.raw(`"project_members"."project_id"`);
+    default:
+      throw new Error(
+        `MemberCondition.asDrizzleCondition: resource ${resource.name} not configured for Drizzle yet; add a case when it migrates.`,
+      );
+  }
+};
 
 /**
  * The following actions only apply if the requester has any "member" scoped roles.

--- a/src/components/authorization/policies/conditions/sensitivity.condition.ts
+++ b/src/components/authorization/policies/conditions/sensitivity.condition.ts
@@ -1,9 +1,15 @@
 import { type NonEmptyArray } from '@seedcompany/common';
 import { type Query } from 'cypher-query-builder';
+import { type SQL, sql } from 'drizzle-orm';
 import { inspect, type InspectOptionsStylized } from 'util';
-import { type ResourceShape, Sensitivity } from '~/common';
+import {
+  type EnhancedResource,
+  type ResourceShape,
+  Sensitivity,
+} from '~/common';
 import { matchProjectSens, rankSens } from '~/core/neo4j/query';
 import {
+  type AsDrizzleParams,
   type AsEdgeQLParams,
   type Condition,
   fqnRelativeTo,
@@ -65,6 +71,15 @@ export class SensitivityCondition<
     const ranked = sensitivityRank[this.access];
     const param = query.params.addParam(ranked, 'requiredSens');
     return `${CQL_VAR} <= ${String(param)}`;
+  }
+
+  asDrizzleCondition({ resource }: AsDrizzleParams<TResourceStatic>) {
+    // PG's sensitivity enum is declared in `Low < Medium < High` order, so
+    // `node.sensitivity <= 'access'` is a single-column compare. For Project
+    // subtypes the column lives on the row directly (denormalized). For
+    // Project-scoped children the column is on the parent project; use a
+    // correlated subquery.
+    return sensitivityRefForResource(resource, this.access);
   }
 
   setupEdgeQLContext({
@@ -139,3 +154,33 @@ export const withEffectiveSensitivity = <T extends object>(
     value: sensitivity,
     enumerable: false,
   }) as T & { [EffectiveSensitivity]: Sensitivity };
+
+/**
+ * Build the `sensitivity <= access` SQL fragment for `resource`. Project rows
+ * carry the denormalized column directly; project-scoped child resources read
+ * it via a correlated subquery against `projects`. Add cases here as each
+ * domain ports to Postgres.
+ */
+const sensitivityRefForResource = (
+  resource: EnhancedResource<any>,
+  access: Sensitivity,
+): SQL => {
+  const accessLit = sql.raw(`'${access}'::"sensitivity"`);
+  switch (resource.name) {
+    case 'Project':
+    case 'TranslationProject':
+    case 'MomentumTranslationProject':
+    case 'MultiplicationTranslationProject':
+    case 'InternshipProject':
+      return sql`"projects"."sensitivity" <= ${accessLit}`;
+    case 'ProjectMember':
+      return sql`(
+        select "p"."sensitivity" from "projects" "p"
+        where "p"."id" = "project_members"."project_id"
+      ) <= ${accessLit}`;
+    default:
+      throw new Error(
+        `SensitivityCondition.asDrizzleCondition: resource ${resource.name} not configured for Drizzle yet; add a case when it migrates.`,
+      );
+  }
+};

--- a/src/components/field-region/field-region.drizzle.repository.ts
+++ b/src/components/field-region/field-region.drizzle.repository.ts
@@ -85,14 +85,9 @@ export class FieldRegionDrizzleRepository extends DrizzleDtoRepository<
 
     conditions.push(...fieldRegionFilterClauses(this.db, input.filter));
 
-    const sortColumns = {
-      name: fieldRegions.name,
-      createdAt: fieldRegions.createdAt,
-    } satisfies SortMap<keyof FieldRegion>;
-
     const { rows, total, hasMore } = await this.paginatedSelect({
       predicate: and(...conditions),
-      orderBy: resolveOrderBy(input, sortColumns, fieldRegions.name),
+      orderBy: resolveOrderBy(input, fieldRegionSortColumns, fieldRegions.name),
       page: input.page,
       count: input.count,
     });
@@ -128,6 +123,15 @@ export class FieldRegionDrizzleRepository extends DrizzleDtoRepository<
     };
   }
 }
+
+/**
+ * Sortable columns on `field_regions`. Exported for cross-domain sort
+ * delegation (Project's `fieldRegion.*` sort joins via this map).
+ */
+export const fieldRegionSortColumns = {
+  name: fieldRegions.name,
+  createdAt: fieldRegions.createdAt,
+} satisfies SortMap<keyof FieldRegion>;
 
 /**
  * Build the column-level WHERE clauses for a `FieldRegionFilters` input against

--- a/src/components/location/location.drizzle.repository.ts
+++ b/src/components/location/location.drizzle.repository.ts
@@ -125,16 +125,9 @@ export class LocationDrizzleRepository extends DrizzleDtoRepository<
 
     conditions.push(...locationFilterClauses(input.filter));
 
-    const sortColumns = {
-      name: locations.name,
-      type: locations.type,
-      isoAlpha3: locations.isoAlpha3,
-      createdAt: locations.createdAt,
-    } satisfies SortMap<keyof Location>;
-
     const { rows, total, hasMore } = await this.paginatedSelect({
       predicate: and(...conditions),
-      orderBy: resolveOrderBy(input, sortColumns, locations.name),
+      orderBy: resolveOrderBy(input, locationSortColumns, locations.name),
       page: input.page,
       count: input.count,
     });
@@ -202,6 +195,18 @@ export class LocationDrizzleRepository extends DrizzleDtoRepository<
  * the `locations` table. Reusable from sub-filters in other domains
  * (e.g. Project's `location` filter).
  */
+/**
+ * Sortable columns on `locations`. Exported for cross-domain sort delegation
+ * (Project's `primaryLocation.*` sort joins via this map). Same pattern as
+ * `organizationSortColumns` introduced in partner-pg.
+ */
+export const locationSortColumns = {
+  name: locations.name,
+  type: locations.type,
+  isoAlpha3: locations.isoAlpha3,
+  createdAt: locations.createdAt,
+} satisfies SortMap<keyof Location>;
+
 export const locationFilterClauses = (
   filter: LocationFilters | undefined,
 ): SQL[] => {

--- a/src/components/organization/organization.drizzle.repository.ts
+++ b/src/components/organization/organization.drizzle.repository.ts
@@ -164,3 +164,21 @@ export const organizationFilterClauses = (
   }
   return conditions;
 };
+
+/**
+ * Sortable columns on the `organizations` table, exposed for cross-domain sort
+ * delegation (e.g. Partner's `organization.*` sort joins to `organizations`
+ * and orders by one of these). Counterpart to `organizationFilterClauses`.
+ *
+ * Neo4j's `organizationSorters` is empty (`defineSorters(Organization, {})`),
+ * meaning Neo4j relies on its base-node-prop fallback to sort by any scalar
+ * Property. The values here are the meaningful sortable columns on the PG
+ * table — extend as needed.
+ */
+export const organizationSortColumns = {
+  name: organizations.name,
+  acronym: organizations.acronym,
+  address: organizations.address,
+  sensitivity: organizations.sensitivity,
+  createdAt: organizations.createdAt,
+} as const;

--- a/src/components/partner/partner.drizzle.repository.ts
+++ b/src/components/partner/partner.drizzle.repository.ts
@@ -1,0 +1,619 @@
+import { Injectable } from '@nestjs/common';
+import {
+  and,
+  arrayOverlaps,
+  asc,
+  count,
+  desc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  isNotNull,
+  isNull,
+  lt,
+  lte,
+  type SQL,
+} from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  CalendarDate,
+  DuplicateException,
+  generateId,
+  type ID,
+  NotImplementedException,
+  type PaginatedListType,
+  type UnsecuredDto,
+} from '~/common';
+import {
+  catchForeignKeyViolation,
+  DrizzleDtoRepository,
+  EMPTY_PAGE,
+  resolveOrderBy,
+  type SortMap,
+  subFilter,
+} from '~/core/drizzle';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
+import {
+  departmentIdBlocks,
+  organizations,
+  partnerCountries,
+  partnerFieldRegions,
+  partnerLanguagesOfConsulting,
+  partners,
+  userOrganizations,
+} from '~/core/drizzle/schema';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import { type FinanceDepartmentIdBlock } from '../finance/department/dto/id-blocks.dto';
+import { type FinanceDepartmentIdBlockInput } from '../finance/department/dto/id-blocks.input';
+import {
+  organizationFilterClauses,
+  organizationSortColumns,
+} from '../organization/organization.drizzle.repository';
+import {
+  type CreatePartner,
+  Partner,
+  type PartnerFilters,
+  type PartnerListInput,
+  type UpdatePartner,
+} from './dto';
+
+/** A partner row plus the related rows the DTO needs (junctions + IdBlock). */
+type PartnerRow = typeof partners.$inferSelect & {
+  fieldRegions: Array<{ fieldRegionId: ID<'FieldRegion'> }>;
+  countries: Array<{ locationId: ID<'Location'> }>;
+  languagesOfConsulting: Array<{ languageId: ID<'Language'> }>;
+  departmentIdBlock: typeof departmentIdBlocks.$inferSelect | null;
+};
+
+@Injectable()
+export class PartnerDrizzleRepository extends DrizzleDtoRepository<
+  typeof partners,
+  Partner
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+  ) {
+    super(db, partners, Partner);
+  }
+
+  async partnerIdByOrg(organizationId: ID): Promise<ID<'Partner'> | null> {
+    const rows = await this.db
+      .select({ id: partners.id })
+      .from(partners)
+      .where(
+        and(
+          eq(partners.organizationId, organizationId),
+          isNull(partners.deletedAt),
+        ),
+      );
+    return rows[0]?.id ?? null;
+  }
+
+  async create(input: CreatePartner): Promise<UnsecuredDto<Partner>> {
+    if (await this.partnerIdByOrg(input.organization)) {
+      throw new DuplicateException(
+        'organization',
+        'Partner for organization already exists.',
+      );
+    }
+
+    const id = await generateId();
+    const departmentIdBlockId = input.departmentIdBlock
+      ? await this.insertBlock(input.departmentIdBlock)
+      : null;
+
+    await this.db.insert(partners).values({
+      id,
+      organizationId: input.organization,
+      pointOfContactId: input.pointOfContact ?? null,
+      types: [...(input.types ?? [])],
+      financialReportingTypes: [...(input.financialReportingTypes ?? [])],
+      pmcEntityCode: input.pmcEntityCode ?? null,
+      globalInnovationsClient: input.globalInnovationsClient ?? false,
+      active: input.active ?? false,
+      address: input.address ?? null,
+      languageOfWiderCommunicationId:
+        input.languageOfWiderCommunication ?? null,
+      languageOfReportingId: input.languageOfReporting ?? null,
+      startDate: (input.startDate ?? CalendarDate.local()).toISODate(),
+      approvedPrograms: [...(input.approvedPrograms ?? [])],
+      departmentIdBlockId,
+    });
+
+    await this.replaceJunctions(id, {
+      fieldRegions: input.fieldRegions,
+      countries: input.countries,
+      languagesOfConsulting: input.languagesOfConsulting,
+    });
+
+    return await this.readOne(id);
+  }
+
+  async update(changes: UpdatePartner): Promise<UnsecuredDto<Partner>> {
+    const {
+      id,
+      pointOfContact,
+      languageOfWiderCommunication,
+      languageOfReporting,
+      fieldRegions,
+      countries,
+      languagesOfConsulting,
+      departmentIdBlock,
+      startDate,
+      types,
+      financialReportingTypes,
+      approvedPrograms,
+      ...fields
+    } = changes;
+
+    await this.updateColumns(id, {
+      pmcEntityCode: fields.pmcEntityCode,
+      globalInnovationsClient: fields.globalInnovationsClient,
+      active: fields.active,
+      address: fields.address,
+      pointOfContactId: pointOfContact,
+      languageOfWiderCommunicationId: languageOfWiderCommunication,
+      languageOfReportingId: languageOfReporting,
+      types: types && [...types],
+      financialReportingTypes: financialReportingTypes && [
+        ...financialReportingTypes,
+      ],
+      approvedPrograms: approvedPrograms && [...approvedPrograms],
+      startDate:
+        startDate === undefined ? undefined : (startDate?.toISODate() ?? null),
+    });
+
+    await this.replaceJunctions(id, {
+      fieldRegions,
+      countries,
+      languagesOfConsulting,
+    });
+
+    if (departmentIdBlock !== undefined) {
+      await this.setBlock(id, departmentIdBlock);
+    }
+
+    return await this.readOne(id);
+  }
+
+  /**
+   * Soft-delete. The service still calls `deleteNode(object)` (the Neo4j-base
+   * name; Partner hasn't been converted to the `delete(id)` rename yet), so we
+   * match that here. Soft-delete drops the row from the partial unique index,
+   * freeing the organization for a new Partner.
+   */
+  async deleteNode(objectOrId: ID | { id: ID }): Promise<void> {
+    const id = typeof objectOrId === 'string' ? objectOrId : objectOrId.id;
+    await this.softDelete(id);
+  }
+
+  override async readMany(
+    ids: readonly ID[],
+  ): Promise<Array<UnsecuredDto<Partner>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.partners.findMany({
+      where: (p) => and(inArray(p.id, [...ids]), isNull(p.deletedAt)),
+      with: {
+        fieldRegions: true,
+        countries: true,
+        languagesOfConsulting: true,
+        departmentIdBlock: true,
+      },
+    });
+    return rows.map((row) => this.toDto(row));
+  }
+
+  async list(
+    input: PartnerListInput,
+  ): Promise<PaginatedListType<UnsecuredDto<Partner>>> {
+    const conditions: SQL[] = [isNull(partners.deletedAt)];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+
+    conditions.push(...partnerFilterClauses(this.db, input.filter));
+    const predicate = and(...conditions);
+
+    // Cast to string because `name` / `organization.*` aren't in `keyof
+    // Partner` (the GraphQL enum widens beyond the DTO's declared fields).
+    const sort = input.sort as string;
+
+    const sortColumns = {
+      active: partners.active,
+      createdAt: partners.createdAt,
+      modifiedAt: partners.updatedAt,
+      startDate: partners.startDate,
+    } satisfies Partial<SortMap<keyof Partner>>;
+
+    // Cross-domain sort: ORDER BY a column on `organizations`. Hand-rolled
+    // INNER JOIN (FK is NOT NULL) — when a second domain needs this same
+    // pattern, extract a shared `paginatedSelectWithJoin` helper (mirror of
+    // the `*FilterClauses` emergence story).
+    //
+    // migration-todo: the orgSortKey→orgSortColumn resolution (and the
+    // parallel INNER JOIN block below) is the abstractable piece. Once a
+    // second consumer (Partnership → `partner.*`, or Project →
+    // `partnership.partner.*`) needs the same dance, extract
+    // `resolveCrossDomainSort(sort, prefix, sortColumns)` +
+    // `paginatedSelectWithJoin`. One data point isn't enough to lock in the
+    // helper's signature yet.
+    const orgSortKey =
+      sort === 'name'
+        ? 'name'
+        : sort.startsWith('organization.')
+          ? sort.slice('organization.'.length)
+          : null;
+    const orgSortColumn =
+      orgSortKey && orgSortKey in organizationSortColumns
+        ? organizationSortColumns[
+            orgSortKey as keyof typeof organizationSortColumns
+          ]
+        : null;
+    if (orgSortKey && !orgSortColumn) {
+      throw new NotImplementedException(
+        `Sorting partners by '${sort}' is not supported — ` +
+          `'${orgSortKey}' is not a known sortable column on \`organizations\`.`,
+      );
+    }
+
+    const direction = input.order === 'ASC' ? asc : desc;
+    let pageIds: ReadonlyArray<{ id: ID<'Partner'> }>;
+    let total: number;
+    if (orgSortColumn) {
+      const offset = (input.page - 1) * input.count;
+      const [countResult, joined] = await Promise.all([
+        this.db.select({ total: count() }).from(partners).where(predicate),
+        this.db
+          .select({ id: partners.id })
+          .from(partners)
+          .innerJoin(
+            organizations,
+            eq(partners.organizationId, organizations.id),
+          )
+          .where(predicate)
+          .orderBy(direction(orgSortColumn), asc(partners.id))
+          .limit(input.count)
+          .offset(offset),
+      ]);
+      total = countResult[0]?.total ?? 0;
+      pageIds = joined;
+    } else {
+      const page = await this.paginatedSelect({
+        predicate,
+        orderBy: resolveOrderBy(input, sortColumns, partners.createdAt),
+        page: input.page,
+        count: input.count,
+      });
+      pageIds = page.rows.map((r) => ({ id: r.id }));
+      total = page.total;
+    }
+    const offset = (input.page - 1) * input.count;
+    const hasMore = offset + pageIds.length < total;
+
+    // Two-phase list (deliberate, don't "optimize" into one big JOIN).
+    //
+    // Phase 1 returns paginated partner IDs (count + page query above run in
+    // parallel via Promise.all). Phase 2 calls `readMany` which fetches every
+    // partner row + its 3 junctions + the IdBlock in a single relational
+    // findMany. Total = 2 parallel + 1 sequential round-trip per list call,
+    // page-size-bounded, regardless of how many junction rows a partner has.
+    //
+    // Why not fold into one query: 3 junctions on each partner would either
+    // cross-product the result (5 fieldRegions × 3 countries × 2 languages =
+    // 30 rows per partner, requiring GROUP BY + array_agg to fold back) or
+    // need LATERAL subqueries — both verbose and harder to maintain than the
+    // small cost of one extra trip.
+    //
+    // Why reuse `readMany`: it's the single source of truth for partner
+    // hydration, shared with the DataLoader's batch reads. Any change to the
+    // DTO shape (new field, new junction, IdBlock shape change) lives in one
+    // place — `list` and the loader benefit automatically.
+    //
+    // Order is preserved by indexing readMany's result by ID and walking
+    // `pageIds` in its paginated order. `flatMap(... ?? [])` is the safe
+    // "skip if missing" — should never fire since the IDs come from the same
+    // query family, but it keeps list() robust if a row vanishes between
+    // phases (e.g. a concurrent soft-delete).
+    const dtos = await this.readMany(pageIds.map((r) => r.id));
+    const byId = new Map(dtos.map((d) => [d.id, d]));
+    return {
+      total,
+      hasMore,
+      items: pageIds.flatMap((r) => byId.get(r.id) ?? []),
+    };
+  }
+
+  // ── helpers ────────────────────────────────────────────────────────────
+
+  private async insertBlock(
+    block: NonNullable<CreatePartner['departmentIdBlock']>,
+  ): Promise<ID> {
+    const blockId = await generateId();
+    await this.db.insert(departmentIdBlocks).values({
+      id: blockId,
+      range: [...block.blocks],
+      programs: [...(block.programs ?? [])],
+    });
+    return blockId;
+  }
+
+  private async setBlock(
+    partnerId: ID,
+    block: FinanceDepartmentIdBlockInput | null,
+  ): Promise<void> {
+    // Lock the partner row for the rest of the surrounding transaction (the
+    // DrizzleTransactionalMutationsInterceptor opens one per mutation). Without
+    // this, two concurrent setBlock calls on the same partner could both read
+    // `blockId = null`, both insert a fresh block, and one's `partners` update
+    // would clobber the other — orphaning a `department_id_blocks` row.
+    const [row] = await this.db
+      .select({ blockId: partners.departmentIdBlockId })
+      .from(partners)
+      .where(eq(partners.id, partnerId))
+      .for('update');
+    const currentBlockId = row?.blockId ?? null;
+
+    if (block === null) {
+      if (currentBlockId) {
+        await this.db
+          .update(partners)
+          .set({ departmentIdBlockId: null })
+          .where(eq(partners.id, partnerId));
+        await this.db
+          .delete(departmentIdBlocks)
+          .where(eq(departmentIdBlocks.id, currentBlockId));
+      }
+      return;
+    }
+
+    const values = {
+      range: [...block.blocks],
+      programs: [...(block.programs ?? [])],
+    };
+    if (currentBlockId) {
+      await this.db
+        .update(departmentIdBlocks)
+        .set(values)
+        .where(eq(departmentIdBlocks.id, currentBlockId));
+    } else {
+      const blockId = await generateId();
+      await this.db
+        .insert(departmentIdBlocks)
+        .values({ id: blockId, ...values });
+      await this.db
+        .update(partners)
+        .set({ departmentIdBlockId: blockId })
+        .where(eq(partners.id, partnerId));
+    }
+  }
+
+  /** Replace each provided junction list wholesale (undefined = leave as-is). */
+  private async replaceJunctions(
+    partnerId: ID,
+    lists: {
+      fieldRegions?: ReadonlyArray<ID<'FieldRegion'>>;
+      countries?: ReadonlyArray<ID<'Location'>>;
+      languagesOfConsulting?: ReadonlyArray<ID<'Language'>>;
+    },
+  ): Promise<void> {
+    // FK-violation catches mirror the Neo4j repo's `e.withField(...)` pattern
+    // so a bad related ID surfaces as `InputException(field=…)` instead of
+    // a generic DB error. Constraint substrings target the right-side FK of
+    // each junction (PG default-names them `<table>_<column>_fkey`).
+    if (lists.fieldRegions) {
+      await this.db
+        .delete(partnerFieldRegions)
+        .where(eq(partnerFieldRegions.partnerId, partnerId));
+      if (lists.fieldRegions.length) {
+        await this.db
+          .insert(partnerFieldRegions)
+          .values(
+            lists.fieldRegions.map((fieldRegionId) => ({
+              partnerId,
+              fieldRegionId,
+            })),
+          )
+          .catch(
+            catchForeignKeyViolation(
+              'field_region_id_fkey',
+              'fieldRegions',
+              'One or more field region IDs do not exist',
+            ),
+          );
+      }
+    }
+    if (lists.countries) {
+      await this.db
+        .delete(partnerCountries)
+        .where(eq(partnerCountries.partnerId, partnerId));
+      if (lists.countries.length) {
+        await this.db
+          .insert(partnerCountries)
+          .values(
+            lists.countries.map((locationId) => ({ partnerId, locationId })),
+          )
+          .catch(
+            catchForeignKeyViolation(
+              'location_id_fkey',
+              'countries',
+              'One or more country (location) IDs do not exist',
+            ),
+          );
+      }
+    }
+    if (lists.languagesOfConsulting) {
+      await this.db
+        .delete(partnerLanguagesOfConsulting)
+        .where(eq(partnerLanguagesOfConsulting.partnerId, partnerId));
+      if (lists.languagesOfConsulting.length) {
+        // Note: `language_id` has no DB-level FK yet (deferred until Language
+        // migrates), so this catch is dormant today. Kept for forward-compat
+        // — when the FK lands it'll start firing usefully without code change.
+        await this.db
+          .insert(partnerLanguagesOfConsulting)
+          .values(
+            lists.languagesOfConsulting.map((languageId) => ({
+              partnerId,
+              languageId,
+            })),
+          )
+          .catch(
+            catchForeignKeyViolation(
+              'language_id_fkey',
+              'languagesOfConsulting',
+              'One or more language IDs do not exist',
+            ),
+          );
+      }
+    }
+  }
+
+  /**
+   * Narrows the base-class param from the flat row to the enriched relational
+   * row (junctions + IdBlock) — TS method-syntax bivariance allows this
+   * override, mirroring how `UserDrizzleRepository.toDto` accepts its
+   * relational shape. `readMany` always passes the enriched row.
+   */
+  protected toDto(row: PartnerRow): UnsecuredDto<Partner> {
+    return {
+      id: row.id,
+      __typename: 'Partner',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      modifiedAt: DateTime.fromJSDate(row.updatedAt),
+      organization: { id: row.organizationId },
+      pointOfContact: row.pointOfContactId
+        ? { id: row.pointOfContactId }
+        : null,
+      types: row.types,
+      financialReportingTypes: row.financialReportingTypes,
+      pmcEntityCode: row.pmcEntityCode,
+      globalInnovationsClient: row.globalInnovationsClient,
+      active: row.active,
+      address: row.address,
+      languageOfWiderCommunication: row.languageOfWiderCommunicationId
+        ? { id: row.languageOfWiderCommunicationId }
+        : null,
+      languageOfReporting: row.languageOfReportingId
+        ? { id: row.languageOfReportingId }
+        : null,
+      fieldRegions: row.fieldRegions.map((j) => ({ id: j.fieldRegionId })),
+      countries: row.countries.map((j) => ({ id: j.locationId })),
+      languagesOfConsulting: row.languagesOfConsulting.map((j) => ({
+        id: j.languageId,
+      })),
+      startDate: row.startDate ? CalendarDate.fromISO(row.startDate) : null,
+      approvedPrograms: row.approvedPrograms,
+      departmentIdBlock:
+        // Defense: a stored block with an empty range is unusable for ID
+        // allocation (and the DTO declares `blocks: NonEmptyArray`, which the
+        // int4multirange customType can't enforce at the type level). Surface
+        // it as absent rather than constructing an invalid DTO that would
+        // crash on the next `blocks[0]` access.
+        row.departmentIdBlock && row.departmentIdBlock.range.length > 0
+          ? {
+              id: row.departmentIdBlock.id,
+              // Cast is sound: `range.length > 0` checked just above.
+              blocks: row.departmentIdBlock
+                .range as FinanceDepartmentIdBlock['blocks'],
+              programs: row.departmentIdBlock.programs,
+            }
+          : null,
+      // migration-todo: derived from project sensitivity; 'High' until Project migrates.
+      sensitivity: row.sensitivity,
+      // migration-todo: per-user pin state; resolves via Pin once that migrates.
+      pinned: false,
+    };
+  }
+}
+
+/**
+ * Build the column-level WHERE clauses for a `PartnerFilters` input against the
+ * `partners` table. Reusable from sub-filters in other domains (e.g. Project's
+ * `partnership` filter delegates through Partnership to here).
+ */
+export const partnerFilterClauses = (
+  db: DrizzleDb,
+  filter: PartnerFilters | undefined,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+  if (filter.globalInnovationsClient !== undefined) {
+    conditions.push(
+      eq(partners.globalInnovationsClient, filter.globalInnovationsClient),
+    );
+  }
+  if (filter.types?.length) {
+    conditions.push(arrayOverlaps(partners.types, [...filter.types]));
+  }
+  if (filter.financialReportingTypes?.length) {
+    conditions.push(
+      arrayOverlaps(partners.financialReportingTypes, [
+        ...filter.financialReportingTypes,
+      ]),
+    );
+  }
+  if (filter.organization) {
+    conditions.push(
+      subFilter(
+        db,
+        partners.organizationId,
+        organizations,
+        organizationFilterClauses(db, filter.organization),
+      ),
+    );
+  }
+  if (filter.userId) {
+    const orgSubq = db
+      .select({ id: userOrganizations.organizationId })
+      .from(userOrganizations)
+      .where(eq(userOrganizations.userId, filter.userId));
+    conditions.push(inArray(partners.organizationId, orgSubq));
+  }
+  if (filter.startDate) {
+    const f = filter.startDate;
+    // `partners.start_date` is a PG `date` column → ISO date strings.
+    if (f.after) conditions.push(gt(partners.startDate, f.after.toISODate()));
+    if (f.afterInclusive) {
+      conditions.push(gte(partners.startDate, f.afterInclusive.toISODate()));
+    }
+    if (f.before) conditions.push(lt(partners.startDate, f.before.toISODate()));
+    if (f.beforeInclusive) {
+      conditions.push(lte(partners.startDate, f.beforeInclusive.toISODate()));
+    }
+    if (f.isNull !== undefined) {
+      conditions.push(
+        f.isNull ? isNull(partners.startDate) : isNotNull(partners.startDate),
+      );
+    }
+  }
+  if (filter.createdAt) {
+    const f = filter.createdAt;
+    // `partners.created_at` is a `timestamptz` column → JS `Date`.
+    if (f.after) conditions.push(gt(partners.createdAt, f.after.toJSDate()));
+    if (f.afterInclusive) {
+      conditions.push(gte(partners.createdAt, f.afterInclusive.toJSDate()));
+    }
+    if (f.before) conditions.push(lt(partners.createdAt, f.before.toJSDate()));
+    if (f.beforeInclusive) {
+      conditions.push(lte(partners.createdAt, f.beforeInclusive.toJSDate()));
+    }
+    // `created_at` is NOT NULL — `isNull` is effectively a no-op, but support
+    // it for API parity so callers get consistent semantics.
+    if (f.isNull !== undefined) {
+      conditions.push(
+        f.isNull ? isNull(partners.createdAt) : isNotNull(partners.createdAt),
+      );
+    }
+  }
+  if (filter.pinned !== undefined) {
+    // migration-todo: drop this stub when Pin migrates and the
+    // `partners.pinned-by-current-user` lookup table exists.
+    throw new NotImplementedException(
+      "Filtering partners by 'pinned' is not yet supported in postgres mode " +
+        '(Pin domain has not migrated).',
+    );
+  }
+  return conditions;
+};

--- a/src/components/partner/partner.drizzle.repository.ts
+++ b/src/components/partner/partner.drizzle.repository.ts
@@ -220,13 +220,6 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
     // Partner` (the GraphQL enum widens beyond the DTO's declared fields).
     const sort = input.sort as string;
 
-    const sortColumns = {
-      active: partners.active,
-      createdAt: partners.createdAt,
-      modifiedAt: partners.updatedAt,
-      startDate: partners.startDate,
-    } satisfies Partial<SortMap<keyof Partner>>;
-
     // Cross-domain sort: ORDER BY a column on `organizations`. Hand-rolled
     // INNER JOIN (FK is NOT NULL) — when a second domain needs this same
     // pattern, extract a shared `paginatedSelectWithJoin` helper (mirror of
@@ -282,7 +275,7 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
     } else {
       const page = await this.paginatedSelect({
         predicate,
-        orderBy: resolveOrderBy(input, sortColumns, partners.createdAt),
+        orderBy: resolveOrderBy(input, partnerSortColumns, partners.createdAt),
         page: input.page,
         count: input.count,
       });
@@ -533,6 +526,18 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
  * `partners` table. Reusable from sub-filters in other domains (e.g. Project's
  * `partnership` filter delegates through Partnership to here).
  */
+/**
+ * Sortable columns on `partners`. Exported for cross-domain sort delegation
+ * (Partnership's `partner.*` sort joins via this map). Same pattern as
+ * `organizationSortColumns` introduced earlier in this same domain.
+ */
+export const partnerSortColumns = {
+  active: partners.active,
+  createdAt: partners.createdAt,
+  modifiedAt: partners.updatedAt,
+  startDate: partners.startDate,
+} satisfies SortMap<keyof Partner>;
+
 export const partnerFilterClauses = (
   db: DrizzleDb,
   filter: PartnerFilters | undefined,

--- a/src/components/partner/partner.module.ts
+++ b/src/components/partner/partner.module.ts
@@ -8,6 +8,7 @@ import { ProjectModule } from '../project/project.module';
 import { UserModule } from '../user/user.module';
 import { AddPartnerApprovedProgramsMigration } from './migrations/add-partner-approved-programs.migration';
 import { AddPartnerStartDateMigration } from './migrations/add-partner-start-date.migration';
+import { PartnerDrizzleRepository } from './partner.drizzle.repository';
 import { PartnerGelRepository } from './partner.gel.repository';
 import { PartnerLoader } from './partner.loader';
 import { PartnerRepository } from './partner.repository';
@@ -28,6 +29,8 @@ import { PartnerService } from './partner.service';
     PartnerService,
     splitDb(PartnerRepository, {
       gel: PartnerGelRepository,
+      // migration-todo: remove `as any` once splitDb types accept drizzle repos directly
+      postgres: PartnerDrizzleRepository as any,
     }),
     PartnerLoader,
     AddPartnerApprovedProgramsMigration,

--- a/src/components/partnership/partnership.drizzle.repository.ts
+++ b/src/components/partnership/partnership.drizzle.repository.ts
@@ -1,0 +1,527 @@
+import { Injectable } from '@nestjs/common';
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  inArray,
+  isNull,
+  ne,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
+import { type AnyPgColumn } from 'drizzle-orm/pg-core';
+import { DateTime } from 'luxon';
+import {
+  CalendarDate,
+  CreationFailed,
+  DuplicateException,
+  generateId,
+  type ID,
+  NotFoundException,
+  NotImplementedException,
+  type ObjectView,
+  type PaginatedListType,
+  type UnsecuredDto,
+} from '~/common';
+import {
+  DrizzleDtoRepository,
+  EMPTY_PAGE,
+  resolveOrderBy,
+  type SortMap,
+  subFilter,
+} from '~/core/drizzle';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
+import { partners, partnerships, projects } from '~/core/drizzle/schema';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import {
+  partnerFilterClauses,
+  partnerSortColumns,
+} from '../partner/partner.drizzle.repository';
+import {
+  type CreatePartnership,
+  Partnership,
+  type PartnershipFilters,
+  type PartnershipListInput,
+  type UpdatePartnership,
+} from './dto';
+import { type PartnershipByProjectAndPartnerInput } from './partnership-by-project-and-partner.loader';
+
+/**
+ * Relational findMany row shape: the partnership row plus the parent project
+ * (id, type, sensitivity, mou_start, mou_end — sensitivity inherited onto the
+ * DTO; project mou dates feed the override coalesce) and the partner
+ * (id, organization_id — the DTO carries the partner's organization too,
+ * mirroring the Neo4j hydrate's `org { .id }` overlay).
+ */
+type PartnershipRow = typeof partnerships.$inferSelect & {
+  project: Pick<
+    typeof projects.$inferSelect,
+    'id' | 'type' | 'sensitivity' | 'mouStart' | 'mouEnd'
+  > | null;
+  partner: Pick<typeof partners.$inferSelect, 'id' | 'organizationId'> | null;
+};
+
+@Injectable()
+export class PartnershipDrizzleRepository extends DrizzleDtoRepository<
+  typeof partnerships,
+  Partnership
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+  ) {
+    super(db, partnerships, Partnership);
+  }
+
+  /**
+   * Create a partnership. Verifies project + partner exist and that no
+   * (project, partner) partnership already exists; the partial unique index
+   * (`partnerships_project_partner_active_unique`) is the DB-level backstop.
+   *
+   * migration-todo: file creation for MOU + Agreement still goes through
+   * FileService (Neo4j-only). Under DATABASE=postgres we leave `mou_id` /
+   * `agreement_id` null until File migrates (Tier 7) and the file-creation
+   * lifecycle moves into this repo. Matches the deferred-FK pattern.
+   *
+   * `changeset` accepted for splitDb signature parity; PCR/Changeset is
+   * excluded from the migration entirely, so it's silently ignored.
+   */
+  async create(input: CreatePartnership, _changeset?: ID): Promise<{ id: ID }> {
+    await this.verifyRelationshipEligibility(input.project, input.partner);
+
+    const id = await generateId<ID<'Partnership'>>();
+    try {
+      await this.db.insert(partnerships).values({
+        id,
+        projectId: input.project,
+        partnerId: input.partner,
+        agreementStatus: input.agreementStatus ?? 'NotAttached',
+        mouStatus: input.mouStatus ?? 'NotAttached',
+        // migration-todo: file creation deferred until File migrates;
+        // these stay null under postgres mode.
+        mouId: null,
+        agreementId: null,
+        mouStartOverride: input.mouStartOverride
+          ? input.mouStartOverride.toSQLDate()
+          : null,
+        mouEndOverride: input.mouEndOverride
+          ? input.mouEndOverride.toSQLDate()
+          : null,
+        types: input.types ? [...input.types] : [],
+        financialReportingType: input.financialReportingType ?? null,
+        primary: input.primary ?? false,
+      });
+    } catch (e) {
+      throw new CreationFailed(Partnership, { cause: e as Error });
+    }
+    return { id };
+  }
+
+  /**
+   * Apply a partial change set. The service handles the primary-flag transfer
+   * by calling `removePrimaryFromOtherPartnerships` separately before update;
+   * the partial unique index on `(project_id) WHERE primary = true` is the
+   * DB-level backstop.
+   */
+  async update(
+    changes: Omit<UpdatePartnership, 'mou' | 'agreement'>,
+    _changeset?: ID,
+  ): Promise<void> {
+    const { id, ...fields } = changes;
+    await this.updateColumns(id, {
+      ...(fields.agreementStatus !== undefined && {
+        agreementStatus: fields.agreementStatus,
+      }),
+      ...(fields.mouStatus !== undefined && { mouStatus: fields.mouStatus }),
+      ...(fields.mouStartOverride !== undefined && {
+        mouStartOverride: fields.mouStartOverride
+          ? fields.mouStartOverride.toSQLDate()
+          : null,
+      }),
+      ...(fields.mouEndOverride !== undefined && {
+        mouEndOverride: fields.mouEndOverride
+          ? fields.mouEndOverride.toSQLDate()
+          : null,
+      }),
+      ...(fields.types !== undefined && { types: [...fields.types] }),
+      ...(fields.financialReportingType !== undefined && {
+        financialReportingType: fields.financialReportingType ?? null,
+      }),
+      ...(fields.primary !== undefined && { primary: fields.primary }),
+    });
+  }
+
+  async deleteNode(
+    object: { id: ID } | ID,
+    _options?: { changeset?: ID },
+  ): Promise<void> {
+    const id = typeof object === 'string' ? object : object.id;
+    await this.softDelete(id);
+  }
+
+  override async readMany(
+    ids: readonly ID[],
+    _view?: ObjectView,
+  ): Promise<Array<UnsecuredDto<Partnership>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.partnerships.findMany({
+      where: (p) => and(inArray(p.id, [...ids]), isNull(p.deletedAt)),
+      with: {
+        project: {
+          columns: {
+            id: true,
+            type: true,
+            sensitivity: true,
+            mouStart: true,
+            mouEnd: true,
+          },
+        },
+        partner: { columns: { id: true, organizationId: true } },
+      },
+    });
+    return (rows as PartnershipRow[]).map((row) => this.toDto(row));
+  }
+
+  /**
+   * Resolve memberships keyed by `(project, partner)` pairs — drives the
+   * `Project.partnership(partnerId)` resolver via the
+   * PartnershipByProjectAndPartnerLoader. Read permission is enforced at the
+   * resolver layer; this repo path returns the row if it exists.
+   */
+  async readManyByProjectAndPartner(
+    input: readonly PartnershipByProjectAndPartnerInput[],
+  ): Promise<Array<UnsecuredDto<Partnership>>> {
+    if (input.length === 0) return [];
+    const pairs = input.map(
+      (i) =>
+        and(
+          eq(partnerships.projectId, i.project),
+          eq(partnerships.partnerId, i.partner),
+        )!,
+    );
+    const rows = await this.db.query.partnerships.findMany({
+      where: (p) =>
+        and(isNull(p.deletedAt), sql`(${sql.join(pairs, sql` OR `)})`),
+      with: {
+        project: {
+          columns: {
+            id: true,
+            type: true,
+            sensitivity: true,
+            mouStart: true,
+            mouEnd: true,
+          },
+        },
+        partner: { columns: { id: true, organizationId: true } },
+      },
+    });
+    return (rows as PartnershipRow[]).map((row) => this.toDto(row));
+  }
+
+  /** Used by SetDepartmentId (multiplication-translation path) + others. */
+  async listAllByProjectId(
+    projectId: ID,
+  ): Promise<Array<UnsecuredDto<Partnership>>> {
+    const rows = await this.db.query.partnerships.findMany({
+      where: (p) => and(eq(p.projectId, projectId), isNull(p.deletedAt)),
+      with: {
+        project: {
+          columns: {
+            id: true,
+            type: true,
+            sensitivity: true,
+            mouStart: true,
+            mouEnd: true,
+          },
+        },
+        partner: { columns: { id: true, organizationId: true } },
+      },
+    });
+    return (rows as PartnershipRow[]).map((row) => this.toDto(row));
+  }
+
+  /**
+   * True when `projectId` has no existing live partnerships. Drives
+   * `PartnershipService.create`'s "auto-set primary on the first one" branch.
+   */
+  async isFirstPartnership(projectId: ID, _changeset?: ID): Promise<boolean> {
+    const [row] = await this.db
+      .select({ n: sql<number>`1` })
+      .from(partnerships)
+      .where(
+        and(
+          eq(partnerships.projectId, projectId),
+          isNull(partnerships.deletedAt),
+        ),
+      )
+      .limit(1);
+    return !row;
+  }
+
+  /** True when there are other live partnerships on the same project. */
+  async isAnyOtherPartnerships(id: ID): Promise<boolean> {
+    const row = await this.db.query.partnerships.findFirst({
+      where: (p) => and(eq(p.id, id), isNull(p.deletedAt)),
+      columns: { projectId: true },
+    });
+    if (!row) return false;
+    const [other] = await this.db
+      .select({ n: sql<number>`1` })
+      .from(partnerships)
+      .where(
+        and(
+          eq(partnerships.projectId, row.projectId),
+          ne(partnerships.id, id),
+          isNull(partnerships.deletedAt),
+        ),
+      )
+      .limit(1);
+    return !!other;
+  }
+
+  /**
+   * Clear `primary = false` on every other live partnership on the same
+   * project. The partial unique index
+   * `partnerships_project_primary_active_unique` enforces "at most one
+   * primary"; this method is what makes the app side of the flip atomic.
+   * Returns the affected partnership ids for hook fan-out.
+   */
+  async removePrimaryFromOtherPartnerships(id: ID): Promise<Array<{ id: ID }>> {
+    const row = await this.db.query.partnerships.findFirst({
+      where: (p) => and(eq(p.id, id), isNull(p.deletedAt)),
+      columns: { projectId: true },
+    });
+    if (!row) return [];
+    const affected = await this.db
+      .update(partnerships)
+      .set({ primary: false, updatedAt: new Date() })
+      .where(
+        and(
+          eq(partnerships.projectId, row.projectId),
+          ne(partnerships.id, id),
+          eq(partnerships.primary, true),
+          isNull(partnerships.deletedAt),
+        ),
+      )
+      .returning({ id: partnerships.id });
+    return affected as Array<{ id: ID }>;
+  }
+
+  async list(
+    input: PartnershipListInput,
+    _changeset?: ID,
+  ): Promise<PaginatedListType<UnsecuredDto<Partnership>>> {
+    const conditions: SQL[] = [isNull(partnerships.deletedAt)];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+    conditions.push(...partnershipFilterClauses(this.db, input.filter));
+    const predicate = and(...conditions);
+
+    // Cast to string — `partner.*` keys aren't in `keyof Partnership`.
+    const sort = input.sort as string;
+    const direction = input.order === 'ASC' ? asc : desc;
+
+    // migration-todo: third consumer of the cross-domain JOIN-sort pattern
+    // (Partner → organization.*, Project → primaryLocation.*/fieldRegion.*,
+    // now Partnership → partner.*). Time to extract a shared
+    // `resolveCrossDomainSort` + `paginatedSelectWithJoin` into
+    // `~/core/drizzle`. Tracked as a small follow-up cleanup PR.
+    const partnerSortKey = sort.startsWith('partner.')
+      ? sort.slice('partner.'.length)
+      : null;
+    const partnerSortColumn =
+      partnerSortKey && partnerSortKey in partnerSortColumns
+        ? partnerSortColumns[partnerSortKey as keyof typeof partnerSortColumns]
+        : null;
+    if (partnerSortKey && !partnerSortColumn) {
+      throw new NotImplementedException(
+        `Sorting partnerships by '${sort}' is not supported — ` +
+          `'${partnerSortKey}' is not a known sortable column on \`partners\`.`,
+      );
+    }
+
+    let pageIds: ReadonlyArray<{ id: ID<'Partnership'> }>;
+    let total: number;
+    if (partnerSortColumn) {
+      const offset = (input.page - 1) * input.count;
+      const [countResult, joined] = await Promise.all([
+        this.db.select({ total: count() }).from(partnerships).where(predicate),
+        this.db
+          .select({ id: partnerships.id })
+          .from(partnerships)
+          .innerJoin(partners, eq(partnerships.partnerId, partners.id))
+          .where(predicate)
+          .orderBy(direction(partnerSortColumn), asc(partnerships.id))
+          .limit(input.count)
+          .offset(offset),
+      ]);
+      total = countResult[0]?.total ?? 0;
+      pageIds = joined;
+    } else {
+      const sortColumns = partnershipSortColumns;
+      const page = await this.paginatedSelect({
+        predicate,
+        orderBy: resolveOrderBy(input, sortColumns, partnerships.createdAt),
+        page: input.page,
+        count: input.count,
+      });
+      pageIds = page.rows.map((r) => ({ id: r.id }));
+      total = page.total;
+    }
+    const offset = (input.page - 1) * input.count;
+    const hasMore = offset + pageIds.length < total;
+    if (pageIds.length === 0) return { total, items: [], hasMore };
+
+    const dtos = await this.readMany(pageIds.map((r) => r.id));
+    const byId = new Map(dtos.map((d) => [d.id, d]));
+    return {
+      total,
+      items: pageIds.flatMap((r) => byId.get(r.id) ?? []),
+      hasMore,
+    };
+  }
+
+  private async verifyRelationshipEligibility(
+    projectId: ID,
+    partnerId: ID,
+  ): Promise<void> {
+    const [project, partner, existing] = await Promise.all([
+      this.db
+        .select({ id: projects.id })
+        .from(projects)
+        .where(and(eq(projects.id, projectId), isNull(projects.deletedAt)))
+        .limit(1),
+      this.db
+        .select({ id: partners.id })
+        .from(partners)
+        .where(and(eq(partners.id, partnerId), isNull(partners.deletedAt)))
+        .limit(1),
+      this.db
+        .select({ id: partnerships.id })
+        .from(partnerships)
+        .where(
+          and(
+            eq(partnerships.projectId, projectId),
+            eq(partnerships.partnerId, partnerId),
+            isNull(partnerships.deletedAt),
+          ),
+        )
+        .limit(1),
+    ]);
+    if (!project[0]) {
+      throw new NotFoundException('Could not find project', 'project');
+    }
+    if (!partner[0]) {
+      throw new NotFoundException('Could not find partner', 'partner');
+    }
+    if (existing[0]) {
+      throw new DuplicateException(
+        'project',
+        'Partnership for this project and partner already exists',
+      );
+    }
+  }
+
+  protected toDto(row: PartnershipRow): UnsecuredDto<Partnership> {
+    if (!row.project || !row.partner) {
+      throw new Error(
+        `Partnership ${row.id} missing parent project/partner — FK invariant violated`,
+      );
+    }
+    // mou date coalesce: override → parent project. The Neo4j hydrate has a
+    // 4-level chain (changeset override → row override → changeset project →
+    // row project); PCR is excluded so the changeset branches collapse to
+    // just the override + parent project pair.
+    const mouStart = row.mouStartOverride ?? row.project.mouStart ?? null;
+    const mouEnd = row.mouEndOverride ?? row.project.mouEnd ?? null;
+    const dto: unknown = {
+      id: row.id,
+      __typename: 'Partnership',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      project: { id: row.project.id },
+      partner: { id: row.partner.id },
+      organization: { id: row.partner.organizationId },
+      sensitivity: row.project.sensitivity,
+      agreementStatus: row.agreementStatus,
+      mouStatus: row.mouStatus,
+      mouStart: mouStart ? CalendarDate.fromISO(mouStart) : null,
+      mouEnd: mouEnd ? CalendarDate.fromISO(mouEnd) : null,
+      mouStartOverride: row.mouStartOverride
+        ? CalendarDate.fromISO(row.mouStartOverride)
+        : null,
+      mouEndOverride: row.mouEndOverride
+        ? CalendarDate.fromISO(row.mouEndOverride)
+        : null,
+      types: [...row.types],
+      financialReportingType: row.financialReportingType ?? null,
+      primary: row.primary,
+      mou: row.mouId ? { id: row.mouId } : null,
+      agreement: row.agreementId ? { id: row.agreementId } : null,
+      // `changeset` is a resolver navigation marker — PCR is excluded so it
+      // stays undefined.
+      changeset: undefined,
+      // Populated by the policy layer in the service.
+      canDelete: true,
+      scope: [],
+      // Required by the `parent` field on the DTO. The service constructs a
+      // BaseNode-shaped object; here we just pass the project id through.
+      parent: { id: row.project.id },
+    };
+    return dto as UnsecuredDto<Partnership>;
+  }
+}
+
+/**
+ * Sortable columns on `partnerships` itself. Cross-domain sort (`partner.*`)
+ * is resolved inline in `list()` via a hand-rolled INNER JOIN — same pattern
+ * as Partner's `organization.*` and Project's `primaryLocation.*` /
+ * `fieldRegion.*`. See the migration-todo in `list()` for the abstraction
+ * opportunity at the now-third consumer.
+ */
+export const partnershipSortColumns = {
+  createdAt: partnerships.createdAt,
+  primary: partnerships.primary,
+  agreementStatus: partnerships.agreementStatus,
+  mouStatus: partnerships.mouStatus,
+} satisfies SortMap<keyof Partnership>;
+
+/**
+ * Build the column-level WHERE clauses for a `PartnershipFilters` input
+ * against the `partnerships` table. Reusable from sub-filters in other
+ * domains (e.g. Project's `partnerships` / `primaryPartnership` once those
+ * stop being NotImplementedException stubs).
+ */
+export const partnershipFilterClauses = (
+  db: DrizzleDb,
+  filter: PartnershipFilters | undefined,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+  if (filter.projectId) {
+    conditions.push(eq(partnerships.projectId, filter.projectId));
+  }
+  if (filter.types?.length) {
+    const typesLit = sql.raw(
+      `array[${filter.types.map((t) => `'${t}'`).join(', ')}]::"partner_type"[]`,
+    );
+    conditions.push(sql`${partnerships.types} && ${typesLit}`);
+  }
+  if (filter.partner) {
+    conditions.push(
+      subFilter(
+        db,
+        partnerships.partnerId,
+        partners,
+        partnerFilterClauses(db, filter.partner),
+      ),
+    );
+  }
+  return conditions;
+};
+
+// Re-export to satisfy the unused-import linter on AnyPgColumn (used only for
+// type inference on sortColumn).
+void (null as AnyPgColumn | null);

--- a/src/components/partnership/partnership.module.ts
+++ b/src/components/partnership/partnership.module.ts
@@ -7,6 +7,7 @@ import { PartnerModule } from '../partner/partner.module';
 import { ProjectModule } from '../project/project.module';
 import * as handlers from './handlers';
 import { PartnershipByProjectAndPartnerLoader } from './partnership-by-project-and-partner.loader';
+import { PartnershipDrizzleRepository } from './partnership.drizzle.repository';
 import { PartnershipGelRepository } from './partnership.gel.repository';
 import { PartnershipLoader } from './partnership.loader';
 import { PartnershipRepository } from './partnership.repository';
@@ -26,6 +27,9 @@ import { PartnershipService } from './partnership.service';
     PartnershipService,
     splitDb(PartnershipRepository, {
       gel: PartnershipGelRepository,
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: PartnershipDrizzleRepository as any,
     }),
     PartnershipLoader,
     PartnershipByProjectAndPartnerLoader,

--- a/src/components/project/handlers/index.ts
+++ b/src/components/project/handlers/index.ts
@@ -1,3 +1,4 @@
 export * from './set-department-id.handler';
 export * from './set-initial-mou-end.handler';
 export * from './apply-finalized-changeset-to-project.handler';
+export * from './recompute-project-sensitivity.handler';

--- a/src/components/project/handlers/recompute-project-sensitivity.handler.ts
+++ b/src/components/project/handlers/recompute-project-sensitivity.handler.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '~/core/config';
+import { type ILogger, Logger } from '~/core/logger';
+
+/**
+ * Recompute the denormalized `projects.sensitivity` from the parent
+ * Engagement/Language sensitivity max.
+ *
+ * migration-todo (Tier 2 Language migration wires the real hook):
+ *   - subscribe to `LanguageSensitivityUpdatedHook`, `EngagementCreatedHook`,
+ *     `EngagementDeletedHook`, and the LanguageEngagement attach/detach
+ *     events (whichever land first when Language ports);
+ *   - run `UPDATE projects SET sensitivity = (max over engagement→language)`
+ *     within the same transaction so writes are atomic.
+ *
+ * In the meantime Translation projects read `'High'` under DATABASE=postgres
+ * (set by the column default + projects.create()). This is acceptable because
+ * postgres mode is dev-only until cutover, and the canonical Neo4j
+ * sensitivity flows back in via the one-time migration script. Internship
+ * projects are unaffected — they read `own_sensitivity` (set by repo.create
+ * directly).
+ *
+ * The class exists now so it can be wired into ProjectModule's providers and
+ * keep the import graph stable; converting from no-op to real handler in the
+ * Language PR is a one-file change.
+ */
+@Injectable()
+export class RecomputeProjectSensitivityHandler {
+  constructor(
+    private readonly config: ConfigService,
+    @Logger('project:sensitivity-recompute')
+    private readonly logger: ILogger,
+  ) {}
+
+  // migration-todo: when Language migrates, replace this no-op with the real
+  // handler. Until then we only log under postgres so devs notice the gap.
+  recompute(projectId: string): void {
+    // migration-todo: collapse this engine-check at Phase 7 cutover — drop
+    // the conditional, run unconditionally once the real implementation lands.
+    if (this.config.databaseEngine === 'postgres') {
+      this.logger.debug(
+        `Sensitivity recompute deferred for project ${projectId} — pending Language migration (Tier 2)`,
+      );
+    }
+  }
+}

--- a/src/components/project/handlers/set-department-id.handler.ts
+++ b/src/components/project/handlers/set-department-id.handler.ts
@@ -1,13 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { isNull, node, not, relation } from 'cypher-query-builder';
+import { eq, sql } from 'drizzle-orm';
 import {
   ClientException,
   type ID,
+  NotImplementedException,
   ServerException,
   type UnsecuredDto,
 } from '~/common';
 import { ConfigService } from '~/core/config';
 import { TransactionRetryInformer } from '~/core/database';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { PgErrorCode } from '~/core/drizzle/pg-error-codes';
+import { projects } from '~/core/drizzle/schema';
 import { OnHook } from '~/core/hooks';
 import { DatabaseService, UniquenessError } from '~/core/neo4j';
 import {
@@ -30,6 +35,7 @@ import { ProjectTransitionedHook } from '../workflow/hooks/project-transitioned.
 export class SetDepartmentId {
   constructor(
     private readonly db: DatabaseService,
+    private readonly drizzle: DrizzleService,
     private readonly config: ConfigService,
     private readonly retryInformer: TransactionRetryInformer,
   ) {}
@@ -37,6 +43,8 @@ export class SetDepartmentId {
   @OnHook(ProjectTransitionedHook)
   @OnHook(ProjectUpdatedHook)
   async handle(event: ProjectTransitionedHook | ProjectUpdatedHook) {
+    // migration-todo: collapse the gel-early-return at Phase 7 cutover when
+    // the Gel path is removed.
     if (this.config.databaseEngine === 'gel') {
       return;
     }
@@ -54,18 +62,136 @@ export class SetDepartmentId {
       return;
     }
 
-    const block = await this.getDepartmentIdBlockId(project);
+    // migration-todo: collapse this engine-check at Phase 7 cutover — drop
+    // the Neo4j branch + assignDepartmentIdNeo4j + DatabaseService injection,
+    // keep only the PG path.
+    const departmentId =
+      this.config.databaseEngine === 'postgres'
+        ? await this.assignDepartmentIdPg(project)
+        : await this.assignDepartmentIdNeo4j(project);
 
-    const departmentId = await this.assignDepartmentIdForProject(
-      project,
-      block,
-    );
     const changed = { ...project, departmentId };
-
     if (event instanceof ProjectTransitionedHook) {
       event.project = changed;
     } else {
       event.updated = changed;
+    }
+  }
+
+  private async assignDepartmentIdNeo4j(project: UnsecuredDto<Project>) {
+    const block = await this.getDepartmentIdBlockId(project);
+    return await this.assignDepartmentIdForProject(project, block);
+  }
+
+  /**
+   * PG path — resolves the DepartmentIdBlock via the FK chain
+   * `project.primary_location_id → locations.funding_account_id →
+   * funding_accounts.department_id_block_id`, enumerates the block's
+   * `range int4multirange`, picks the smallest 5-digit-padded id that
+   * isn't already used, and UPDATEs `projects.department_id`. Catches PG
+   * unique violation 23505 on the partial-unique index and marks the
+   * transaction for retry — mirror of the Neo4j UniquenessError flow.
+   *
+   * MultiplicationTranslation projects route via partnership → partner
+   * instead, but `partnerships` isn't migrated — throws NotImplementedException
+   * with a clear message until partnership-pg lands.
+   *
+   * `funding_accounts` lives on develop (PR #9) but isn't on this branch's
+   * base (`partner-pg` predates the funding-account merge). Raw SQL references
+   * the table by name so the handler compiles here and Just Works at runtime
+   * once this stack rebases onto develop. Same approach as the deferred-FK
+   * pattern used elsewhere.
+   *
+   * `external_department_ids` exclusion is dropped — that table is part of an
+   * unmigrated domain. migration-todo: re-add the exclusion when that domain
+   * ports (probably with the broader Finance/Admin work).
+   */
+  private async assignDepartmentIdPg(project: UnsecuredDto<Project>) {
+    if (project.type === 'MultiplicationTranslation') {
+      // migration-todo: implement the partnership → partner → block path
+      // when partnership-pg lands. Until then this branch never fires in
+      // production (DATABASE=postgres is dev-only), but it'd surface as a
+      // failed transition if hit. Mirror of the Neo4j repo's `holder` switch.
+      throw new NotImplementedException(
+        'SetDepartmentId for MultiplicationTranslation projects requires Partnership migration — pending.',
+      );
+    }
+    if (!project.primaryLocation) {
+      throw new ClientException(
+        'Project must have a primary location to continue',
+      );
+    }
+
+    const projectId = project.id;
+    let nextId: string;
+    try {
+      const { rows } = await this.drizzle.client.execute<{ nextId: string }>(
+        sql`
+          with block_range as (
+            select b.range
+            from projects p
+            join locations l on l.id = p.primary_location_id
+            join funding_accounts fa on fa.id = l.funding_account_id
+            join department_id_blocks b on b.id = fa.department_id_block_id
+            where p.id = ${projectId}
+          ),
+          enumerated as (
+            select case
+              when id < 10000 then lpad(id::text, 5, '0')
+              else id::text
+            end as dept_id
+            from block_range,
+                 unnest(block_range.range) as r,
+                 lateral generate_series(lower(r), upper(r) - 1) as id
+          ),
+          used as (
+            select department_id from projects
+            where department_id is not null and deleted_at is null
+            -- migration-todo: also exclude external_department_ids when that
+            -- table migrates (likely Admin domain).
+          )
+          select dept_id as "nextId" from enumerated
+          where dept_id not in (select department_id from used)
+          order by dept_id asc
+          limit 1
+        `,
+      );
+      const first = rows[0];
+      if (!first) {
+        throw new ServerException('No department ID is available');
+      }
+      nextId = first.nextId;
+    } catch (e) {
+      if (e instanceof ServerException) throw e;
+      throw new ServerException(
+        'Could not resolve next available department ID',
+        e,
+      );
+    }
+
+    try {
+      await this.drizzle.client
+        .update(projects)
+        .set({ departmentId: nextId, modifiedAt: new Date() })
+        .where(eq(projects.id, projectId));
+      return nextId;
+    } catch (e) {
+      const code = (e as { code?: string })?.code;
+      const constraint = (e as { constraint?: string })?.constraint;
+      if (
+        code === PgErrorCode.UniqueViolation &&
+        constraint === 'projects_department_id_active_unique'
+      ) {
+        // Mirror of the Neo4j path: signal the transaction interceptor to
+        // retry. A concurrent assignment grabbed the same id between our
+        // SELECT and UPDATE; reading + writing again will pick the next one.
+        this.retryInformer.markForRetry(e as Error);
+        throw new ServerException(
+          "Could not set Project's Department ID (retryable)",
+          e,
+        );
+      }
+      throw new ServerException("Could not set Project's Department ID", e);
     }
   }
 

--- a/src/components/project/handlers/set-initial-mou-end.handler.ts
+++ b/src/components/project/handlers/set-initial-mou-end.handler.ts
@@ -1,4 +1,8 @@
+import { eq } from 'drizzle-orm';
 import { ServerException } from '~/common';
+import { ConfigService } from '~/core/config';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { projects } from '~/core/drizzle/schema';
 import { OnHook } from '~/core/hooks';
 import { DatabaseService } from '~/core/neo4j';
 import { IProject, ProjectStatus } from '../dto';
@@ -10,7 +14,11 @@ type SubscribedEvent = ProjectCreatedHook | ProjectTransitionedHook;
 @OnHook(ProjectCreatedHook)
 @OnHook(ProjectTransitionedHook)
 export class SetInitialMouEnd {
-  constructor(private readonly db: DatabaseService) {}
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly drizzle: DrizzleService,
+    private readonly config: ConfigService,
+  ) {}
 
   async handle(event: SubscribedEvent) {
     const { project } = event;
@@ -26,6 +34,20 @@ export class SetInitialMouEnd {
     }
 
     try {
+      // migration-todo: collapse this engine-check at Phase 7 cutover — drop
+      // the Neo4j branch + DatabaseService injection, keep only the PG path.
+      if (this.config.databaseEngine === 'postgres') {
+        await this.drizzle.client
+          .update(projects)
+          .set({
+            initialMouEnd: project.mouEnd ? project.mouEnd.toSQLDate() : null,
+          })
+          .where(eq(projects.id, project.id));
+        // Mutate the hook payload so downstream handlers see the new value.
+        event.project = { ...project, initialMouEnd: project.mouEnd ?? null };
+        return;
+      }
+
       const updatedProject = await this.db.updateProperties({
         type: IProject,
         object: project,
@@ -33,12 +55,7 @@ export class SetInitialMouEnd {
           initialMouEnd: project.mouEnd || null,
         },
       });
-
-      if (event instanceof ProjectTransitionedHook) {
-        event.project = updatedProject;
-      } else {
-        event.project = updatedProject;
-      }
+      event.project = updatedProject;
     } catch (exception) {
       throw new ServerException(
         'Could not set initial mou end on project',

--- a/src/components/project/project-member/project-member.drizzle.repository.ts
+++ b/src/components/project/project-member/project-member.drizzle.repository.ts
@@ -1,0 +1,467 @@
+import { Injectable } from '@nestjs/common';
+import {
+  and,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  DuplicateException,
+  generateId,
+  type ID,
+  isIdLike,
+  NotFoundException,
+  type PaginatedListType,
+  type Role,
+  ServerException,
+  type UnsecuredDto,
+} from '~/common';
+import {
+  DrizzleDtoRepository,
+  EMPTY_PAGE,
+  resolveOrderBy,
+  type SortMap,
+} from '~/core/drizzle';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
+import {
+  projectMembers,
+  projects,
+  type userGlobalRoles,
+  users,
+} from '~/core/drizzle/schema';
+import { PolicyExecutor } from '../../authorization/policy/executor/policy-executor';
+import {
+  UserDrizzleRepository,
+  userFilterClauses,
+} from '../../user/user.drizzle.repository';
+import { projectFilterClauses } from '../project.drizzle.repository';
+import {
+  type CreateProjectMember,
+  ProjectMember,
+  type ProjectMemberFilters,
+  type ProjectMemberListInput,
+  type UpdateProjectMember,
+} from './dto';
+import { type MembershipByProjectAndUserInput } from './membership-by-project-and-user.loader';
+
+/**
+ * Relational findMany row shape: the member row plus its parent project's
+ * (`id`, `type`, `sensitivity`) and the full user with global roles. Drives
+ * `toDto` — Project's sensitivity is inherited onto every ProjectMember DTO,
+ * matching the Neo4j repo's `matchPropsAndProjectSensAndScopedRoles()` overlay.
+ */
+type ProjectMemberRow = typeof projectMembers.$inferSelect & {
+  project: Pick<
+    typeof projects.$inferSelect,
+    'id' | 'type' | 'sensitivity'
+  > | null;
+  user: typeof users.$inferSelect & {
+    globalRoles?: Array<typeof userGlobalRoles.$inferSelect>;
+  };
+};
+
+@Injectable()
+export class ProjectMemberDrizzleRepository extends DrizzleDtoRepository<
+  typeof projectMembers,
+  ProjectMember
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+    private readonly userRepo: UserDrizzleRepository,
+  ) {
+    super(db, projectMembers, ProjectMember);
+  }
+
+  override async readMany(
+    ids: readonly ID[],
+  ): Promise<Array<UnsecuredDto<ProjectMember>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.projectMembers.findMany({
+      where: (m) => and(inArray(m.id, [...ids]), isNull(m.deletedAt)),
+      with: {
+        project: { columns: { id: true, type: true, sensitivity: true } },
+        user: { with: { globalRoles: true } },
+      },
+    });
+    return (rows as ProjectMemberRow[]).map((row) => this.toDto(row));
+  }
+
+  async create(
+    input: CreateProjectMember,
+  ): Promise<UnsecuredDto<ProjectMember>> {
+    const projectId = isIdLike(input.project)
+      ? input.project
+      : input.project.id;
+    await this.verifyRelationshipEligibility(projectId, input.user);
+
+    const id = await generateId<ID<'ProjectMember'>>();
+    await this.db.insert(projectMembers).values({
+      id,
+      projectId,
+      userId: input.user,
+      roles: [...(input.roles ?? [])],
+      inactiveAt: input.inactiveAt ? input.inactiveAt.toJSDate() : null,
+    });
+    return await this.readOne(id);
+  }
+
+  async update(
+    input: UpdateProjectMember,
+  ): Promise<UnsecuredDto<ProjectMember>> {
+    const { id, ...changes } = input;
+    await this.updateColumns(id, {
+      ...(changes.roles !== undefined && { roles: [...changes.roles] }),
+      ...(changes.inactiveAt !== undefined && {
+        inactiveAt: changes.inactiveAt ? changes.inactiveAt.toJSDate() : null,
+      }),
+    });
+    return await this.readOne(id);
+  }
+
+  async delete(id: ID): Promise<void> {
+    await this.softDelete(id);
+  }
+
+  async list(
+    input: ProjectMemberListInput,
+  ): Promise<PaginatedListType<UnsecuredDto<ProjectMember>>> {
+    const conditions: SQL[] = [isNull(projectMembers.deletedAt)];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+    conditions.push(...projectMemberFilterClauses(this.db, input.filter));
+
+    const sortColumns = {
+      createdAt: projectMembers.createdAt,
+      modifiedAt: projectMembers.updatedAt,
+    } satisfies SortMap<keyof ProjectMember>;
+
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: and(...conditions),
+      orderBy: resolveOrderBy(input, sortColumns, projectMembers.createdAt),
+      page: input.page,
+      count: input.count,
+    });
+    if (rows.length === 0) return { total, items: [], hasMore };
+
+    // Two-phase: paged IDs → readMany picks up project + user relations.
+    const items = await this.readMany(rows.map((r) => r.id));
+    // Preserve the ordering produced by paginatedSelect.
+    const byId = new Map(items.map((i) => [i.id, i]));
+    return {
+      total,
+      items: rows.map((r) => byId.get(r.id)!).filter(Boolean),
+      hasMore,
+    };
+  }
+
+  /**
+   * Resolve memberships keyed by `(project, user)` pairs — drives the
+   * `Project.membership` resolver, which surfaces the current user's
+   * membership row + roles + inactiveAt. Read permission is assumed (only
+   * called for the requesting user's own row).
+   */
+  async readManyByProjectAndUser(
+    input: readonly MembershipByProjectAndUserInput[],
+  ): Promise<Array<UnsecuredDto<ProjectMember>>> {
+    if (input.length === 0) return [];
+    const pairs = input.map(
+      (i) =>
+        and(
+          eq(projectMembers.projectId, i.project),
+          eq(projectMembers.userId, i.user),
+        )!,
+    );
+    const rows = await this.db.query.projectMembers.findMany({
+      where: (m) =>
+        and(
+          isNull(m.deletedAt),
+          // OR of the (project, user) pairs.
+          sql`(${sql.join(pairs, sql` OR `)})`,
+        ),
+      with: {
+        project: { columns: { id: true, type: true, sensitivity: true } },
+        user: { with: { globalRoles: true } },
+      },
+    });
+    return (rows as ProjectMemberRow[]).map((row) => this.toDto(row));
+  }
+
+  /**
+   * Project-scoped notification recipients — active members on `project`,
+   * optionally filtered by `roles`. Returns minimal user + email pairs (skips
+   * the full hydrate). Used by notifier hooks.
+   */
+  async listAsNotifiers(
+    projectId: ID<'Project'>,
+    roles?: readonly Role[],
+  ): Promise<Array<{ id: ID; email: string | null }>> {
+    const conditions: SQL[] = [
+      eq(projectMembers.projectId, projectId),
+      isNull(projectMembers.inactiveAt),
+      isNull(projectMembers.deletedAt),
+    ];
+    if (roles?.length) {
+      const rolesLit = sql.raw(
+        `array[${roles.map((r) => `'${r}'`).join(', ')}]::"role"[]`,
+      );
+      conditions.push(sql`${projectMembers.roles} && ${rolesLit}`);
+    }
+    return await this.db
+      .select({ id: users.id, email: users.email })
+      .from(projectMembers)
+      .innerJoin(users, eq(users.id, projectMembers.userId))
+      .where(and(...conditions, isNull(users.deletedAt)));
+  }
+
+  /**
+   * Auto-add `user` to `project` with `role` only if no one currently holds
+   * that role on the project. If the user already has any active membership
+   * we union the role onto their existing row; otherwise we create a new row.
+   * Mirrors the Neo4j upsertMember + filter-by-no-existing-role flow.
+   */
+  async addDefaultForRole(
+    role: Role,
+    projectId: ID<'Project'>,
+    userId: ID<'User'>,
+  ): Promise<void> {
+    const roleLit = sql.raw(`array['${role}']::"role"[]`);
+    // Cheap guard: bail if any active member already holds the role.
+    const existing = await this.db
+      .select({ n: sql<number>`1` })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.projectId, projectId),
+          isNull(projectMembers.inactiveAt),
+          isNull(projectMembers.deletedAt),
+          sql`${projectMembers.roles} && ${roleLit}`,
+        ),
+      )
+      .limit(1);
+    if (existing.length > 0) return;
+
+    await this.upsertMemberRole(projectId, userId, role);
+  }
+
+  /**
+   * Bulk-replace director-style memberships when a user leaves a role. Finds
+   * every active project where `oldDirector` holds `role` (optionally scoped
+   * to `region`), removes the role (or marks the membership inactive if it
+   * was the only role), and adds `newDirector` with that role. Used by
+   * field-region director changes.
+   */
+  async replaceMembershipsOnOpenProjects(
+    oldDirector: ID<'User'>,
+    newDirector: ID<'User'>,
+    role: Role,
+    region?: ID<'FieldRegion'>,
+  ): Promise<{ projects: readonly ID[]; timestampId: DateTime }> {
+    const now = DateTime.now();
+    const roleLit = sql.raw(`array['${role}']::"role"[]`);
+
+    // Affected projects: old director is an active member with `role`, project
+    // is in an open status (InDevelopment | Active), optionally on `region`.
+    const conditions: SQL[] = [
+      eq(projectMembers.userId, oldDirector),
+      isNull(projectMembers.inactiveAt),
+      isNull(projectMembers.deletedAt),
+      sql`${projectMembers.roles} && ${roleLit}`,
+      inArray(projects.status, ['InDevelopment', 'Active']),
+      isNull(projects.deletedAt),
+    ];
+    if (region) conditions.push(eq(projects.fieldRegionId, region));
+
+    const targets = await this.db
+      .select({
+        memberId: projectMembers.id,
+        projectId: projectMembers.projectId,
+        roles: projectMembers.roles,
+      })
+      .from(projectMembers)
+      .innerJoin(projects, eq(projects.id, projectMembers.projectId))
+      .where(and(...conditions));
+
+    const affectedProjects: ID[] = [];
+    for (const t of targets) {
+      // Either remove the role (multi-role member) or mark inactive (sole role).
+      if (t.roles.length > 1) {
+        const remaining = t.roles.filter((r) => r !== role);
+        await this.db
+          .update(projectMembers)
+          .set({ roles: remaining, updatedAt: now.toJSDate() })
+          .where(eq(projectMembers.id, t.memberId));
+      } else {
+        await this.db
+          .update(projectMembers)
+          .set({ inactiveAt: now.toJSDate(), updatedAt: now.toJSDate() })
+          .where(eq(projectMembers.id, t.memberId));
+      }
+      await this.upsertMemberRole(t.projectId, newDirector, role);
+      affectedProjects.push(t.projectId);
+    }
+    return { projects: affectedProjects, timestampId: now };
+  }
+
+  /**
+   * Add `role` to the active membership of `(projectId, userId)`; create the
+   * row if it doesn't exist. Re-activates a soft-inactive row in the same
+   * project + user pair. Used by addDefaultForRole and the role-replacement
+   * flow.
+   */
+  private async upsertMemberRole(
+    projectId: ID<'Project'>,
+    userId: ID<'User'>,
+    role: Role,
+  ): Promise<void> {
+    const existing = await this.db
+      .select({ id: projectMembers.id, roles: projectMembers.roles })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.projectId, projectId),
+          eq(projectMembers.userId, userId),
+          isNull(projectMembers.deletedAt),
+        ),
+      )
+      .limit(1);
+    const row = existing[0];
+    if (row) {
+      const next = row.roles.includes(role) ? row.roles : [...row.roles, role];
+      await this.db
+        .update(projectMembers)
+        .set({
+          roles: next,
+          inactiveAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(projectMembers.id, row.id));
+      return;
+    }
+    const id = await generateId<ID<'ProjectMember'>>();
+    await this.db.insert(projectMembers).values({
+      id,
+      projectId,
+      userId,
+      roles: [role],
+    });
+  }
+
+  private async verifyRelationshipEligibility(
+    projectId: ID,
+    userId: ID,
+  ): Promise<void> {
+    const [project, user, existing] = await Promise.all([
+      this.db
+        .select({ id: projects.id })
+        .from(projects)
+        .where(and(eq(projects.id, projectId), isNull(projects.deletedAt)))
+        .limit(1),
+      this.db
+        .select({ id: users.id })
+        .from(users)
+        .where(and(eq(users.id, userId), isNull(users.deletedAt)))
+        .limit(1),
+      this.db
+        .select({ id: projectMembers.id })
+        .from(projectMembers)
+        .where(
+          and(
+            eq(projectMembers.projectId, projectId),
+            eq(projectMembers.userId, userId),
+            isNull(projectMembers.deletedAt),
+          ),
+        )
+        .limit(1),
+    ]);
+    if (!project[0]) {
+      throw new NotFoundException('Could not find project', 'project');
+    }
+    if (!user[0]) {
+      throw new NotFoundException('Could not find person', 'user');
+    }
+    if (existing[0]) {
+      throw new DuplicateException(
+        'user',
+        'Person is already a member of this project',
+      );
+    }
+  }
+
+  protected toDto(row: ProjectMemberRow): UnsecuredDto<ProjectMember> {
+    if (!row.project) {
+      // Schema FK is NOT NULL → can't happen, but the relational findMany
+      // makes it nullable in the type. Loud failure beats silent NaN.
+      throw new ServerException(
+        `ProjectMember ${row.id} has no parent project row — FK invariant violated`,
+      );
+    }
+    return {
+      id: row.id,
+      __typename: 'ProjectMember',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      modifiedAt: DateTime.fromJSDate(row.updatedAt),
+      project: { id: row.project.id, type: row.project.type },
+      user: this.userRepo.mapRowToDto(row.user),
+      roles: [...row.roles],
+      sensitivity: row.project.sensitivity,
+      inactiveAt: row.inactiveAt ? DateTime.fromJSDate(row.inactiveAt) : null,
+    };
+  }
+}
+
+/**
+ * Build the column-level WHERE clauses for a `ProjectMemberFilters` input
+ * against `project_members`. Reusable from sub-filters in other domains
+ * (Project's `members`/`membership` sub-filter calls this, completing the
+ * circular dep between project and project_member filters).
+ */
+export const projectMemberFilterClauses = (
+  db: DrizzleDb,
+  filter: ProjectMemberFilters | undefined,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+  if (filter.roles?.length) {
+    const rolesLit = sql.raw(
+      `array[${filter.roles.map((r) => `'${r}'`).join(', ')}]::"role"[]`,
+    );
+    conditions.push(sql`${projectMembers.roles} && ${rolesLit}`);
+  }
+  if (filter.active === true) {
+    conditions.push(isNull(projectMembers.inactiveAt));
+  } else if (filter.active === false) {
+    conditions.push(isNotNull(projectMembers.inactiveAt));
+  }
+  if (filter.user) {
+    const sub = db
+      .selectDistinct({ id: users.id })
+      .from(users)
+      .where(
+        and(isNull(users.deletedAt), ...userFilterClauses(db, filter.user)),
+      );
+    conditions.push(inArray(projectMembers.userId, sub));
+  }
+  if (filter.project) {
+    // Mirror of projectFilterClauses' `members`/`membership` sub-filter:
+    // restrict to memberships whose parent project matches `filter.project`.
+    // The circular import (project.drizzle.repository ↔ this file) is benign
+    // because each export is a function reference resolved at call time.
+    const sub = db
+      .selectDistinct({ id: projects.id })
+      .from(projects)
+      .where(
+        and(
+          isNull(projects.deletedAt),
+          ...projectFilterClauses(db, filter.project),
+        ),
+      );
+    conditions.push(inArray(projectMembers.projectId, sub));
+  }
+  return conditions;
+};

--- a/src/components/project/project-member/project-member.module.ts
+++ b/src/components/project/project-member/project-member.module.ts
@@ -14,6 +14,7 @@ import { BackfillMissingDirectorsMigration } from './migrations/backfill-missing
 import { ProjectMemberMutationSubscriptionsResolver } from './project-member-mutation-subscriptions.resolver';
 import { ProjectMemberUpdatedResolver } from './project-member-updated.resolver';
 import { ProjectMemberChannels } from './project-member.channels';
+import { ProjectMemberDrizzleRepository } from './project-member.drizzle.repository';
 import { ProjectMemberGelRepository } from './project-member.gel.repository';
 import { ProjectMemberLoader } from './project-member.loader';
 import { ProjectMemberRepository } from './project-member.repository';
@@ -36,6 +37,9 @@ import { ProjectMemberService } from './project-member.service';
     ProjectMemberChannels,
     splitDb(ProjectMemberRepository, {
       gel: ProjectMemberGelRepository,
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: ProjectMemberDrizzleRepository as any,
     }),
     ProjectMemberLoader,
     MembershipByProjectAndUserLoader,

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -1,0 +1,730 @@
+import { Injectable } from '@nestjs/common';
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  gt,
+  gte,
+  ilike,
+  inArray,
+  isNull,
+  lt,
+  lte,
+  type SQL,
+} from 'drizzle-orm';
+import { type AnyPgColumn } from 'drizzle-orm/pg-core';
+import { DateTime } from 'luxon';
+import {
+  CalendarDate,
+  DuplicateException,
+  generateId,
+  type ID,
+  isIdLike,
+  NotFoundException,
+  NotImplementedException,
+  type PaginatedListType,
+  type UnsecuredDto,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import { ConfigService } from '~/core/config';
+import {
+  catchUniqueViolation,
+  DrizzleDtoRepository,
+  EMPTY_PAGE,
+  escapeLikePattern,
+  resolveOrderBy,
+  type SortMap,
+  subFilter,
+} from '~/core/drizzle';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
+import {
+  fieldRegions,
+  locations,
+  projectMembers,
+  projects,
+} from '~/core/drizzle/schema';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import {
+  fieldRegionFilterClauses,
+  fieldRegionSortColumns,
+} from '../field-region/field-region.drizzle.repository';
+import {
+  locationFilterClauses,
+  locationSortColumns,
+} from '../location/location.drizzle.repository';
+import {
+  type CreateProject,
+  IProject,
+  type Project,
+  type ProjectFilters,
+  type ProjectListInput,
+  type UpdateProject,
+} from './dto';
+import { projectMemberFilterClauses } from './project-member/project-member.drizzle.repository';
+
+const catchNameUnique = catchUniqueViolation(
+  'projects_name_active_unique',
+  'name',
+  'Project with this name already exists.',
+);
+const catchDepartmentIdUnique = catchUniqueViolation(
+  'projects_department_id_active_unique',
+  'departmentId',
+  'Another Project with this Department ID already exists.',
+);
+
+/**
+ * Hydrated Project row: the projects table row + the current user's membership
+ * (id, roles, inactive_at) if any. Pulled together in a single SELECT for
+ * `readMany`. Cross-domain stubs (engagementTotal, usesRev79, primaryPartnership,
+ * rootDirectory) live in `toDto`.
+ */
+type ProjectRow = typeof projects.$inferSelect & {
+  membership?: {
+    id: ID<'ProjectMember'>;
+    roles: readonly string[];
+    inactiveAt: Date | null;
+  } | null;
+};
+
+@Injectable()
+export class ProjectDrizzleRepository extends DrizzleDtoRepository<
+  typeof projects,
+  Project
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+    private readonly identity: Identity,
+    private readonly config: ConfigService,
+  ) {
+    super(db, projects, IProject);
+  }
+
+  override async readMany(
+    ids: readonly ID[],
+    _changeset?: ID,
+  ): Promise<Array<UnsecuredDto<Project>>> {
+    // Param accepted for splitDb signature parity with the Neo4j/Gel repos.
+    // PCR/Changeset is excluded from the migration entirely, so a changeset
+    // view collapses to the canonical row — the arg is silently ignored.
+    if (ids.length === 0) return [];
+    const userId = this.identity.current.userId;
+    const rows = await this.db.query.projects.findMany({
+      where: (p) => and(inArray(p.id, [...ids]), isNull(p.deletedAt)),
+    });
+    if (rows.length === 0) return [];
+
+    // Pull the requesting user's memberships in one query, then attach.
+    const memberships = await this.db
+      .select({
+        id: projectMembers.id,
+        projectId: projectMembers.projectId,
+        roles: projectMembers.roles,
+        inactiveAt: projectMembers.inactiveAt,
+      })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.userId, userId),
+          isNull(projectMembers.deletedAt),
+        ),
+      );
+    const membershipByProject = new Map(
+      memberships.map((m) => [m.projectId, m]),
+    );
+    return rows.map((row): UnsecuredDto<Project> => {
+      const enriched: ProjectRow = {
+        ...row,
+        membership: membershipByProject.get(row.id) ?? null,
+      };
+      return this.toDto(enriched);
+    });
+  }
+
+  async create(input: CreateProject): Promise<{ id: ID<'Project'> }> {
+    const id = await generateId<ID<'Project'>>();
+    // migration-note: `step` defaults to EarlyConversations via the schema
+    // column default. SetInitialMouEnd (Created hook) and SetDepartmentId
+    // (Transitioned hook) get their PG paths in the workflow PR
+    // (`project-workflow-pg`); no inline wiring needed here.
+    await this.db
+      .insert(projects)
+      .values({
+        id,
+        type: input.type,
+        name: input.name,
+        // Internship-only writable; Translation rows leave it null and read
+        // the denormalized `sensitivity` column.
+        ownSensitivity:
+          input.type === 'Internship' ? (input.sensitivity ?? 'High') : null,
+        // For Internship: keep `sensitivity` in lockstep with own_sensitivity
+        // on create. For Translation: 'High' default (migration-todo: hook
+        // recomputes when Engagement/Language migrates).
+        sensitivity:
+          input.type === 'Internship' ? (input.sensitivity ?? 'High') : 'High',
+        primaryLocationId: input.primaryLocation ?? null,
+        marketingLocationId: input.marketingLocation ?? null,
+        marketingRegionOverrideId: input.marketingRegionOverride ?? null,
+        fieldRegionId: input.fieldRegion ?? null,
+        owningOrganizationId: this.config.defaultOrg.id as ID<'Organization'>,
+        mouStart: input.mouStart ? input.mouStart.toSQLDate() : null,
+        mouEnd: input.mouEnd ? input.mouEnd.toSQLDate() : null,
+        estimatedSubmission: input.estimatedSubmission
+          ? input.estimatedSubmission.toSQLDate()
+          : null,
+        tags: input.tags ? [...input.tags] : [],
+        financialReportReceivedAt:
+          input.financialReportReceivedAt?.toJSDate() ?? null,
+        financialReportPeriod: input.financialReportPeriod ?? null,
+        presetInventory: input.presetInventory ?? false,
+        departmentId: input.departmentId ?? null,
+        rev79ProjectId: input.rev79ProjectId ?? null,
+      })
+      .catch(catchDepartmentIdUnique)
+      .catch(catchNameUnique);
+    // migration-todo (PR 2 follow-up): `otherLocations` are still managed by
+    // LocationService against Neo4j. Once the location service ports, wire a
+    // `project_other_locations` junction or move the loop here.
+    return { id };
+  }
+
+  async update(
+    existing: UnsecuredDto<Project>,
+    changes: Partial<UpdateProject>,
+    _changeset?: ID,
+  ): Promise<Partial<UnsecuredDto<Project>>> {
+    // Param accepted for splitDb signature parity. PCR is excluded; under
+    // a changeset view we still write through to the row directly (no
+    // staging side table). Acceptable because DATABASE=postgres is dev-only
+    // and no changeset machinery exists in this branch.
+    const {
+      id: _id,
+      changeset: _cs,
+      primaryLocation,
+      marketingLocation,
+      marketingRegionOverride,
+      fieldRegion,
+      mouStart,
+      mouEnd,
+      initialMouEnd,
+      estimatedSubmission,
+      financialReportReceivedAt,
+      sensitivity,
+      tags,
+      usesRev79: _usesRev79,
+      ...simpleChanges
+    } = changes;
+
+    await this.updateColumns(existing.id, {
+      ...simpleChanges,
+      ...(primaryLocation !== undefined && {
+        primaryLocationId: primaryLocation,
+      }),
+      ...(marketingLocation !== undefined && {
+        marketingLocationId: marketingLocation,
+      }),
+      ...(marketingRegionOverride !== undefined && {
+        marketingRegionOverrideId: marketingRegionOverride,
+      }),
+      ...(fieldRegion !== undefined && { fieldRegionId: fieldRegion }),
+      ...(mouStart !== undefined && {
+        mouStart: mouStart ? mouStart.toSQLDate() : null,
+      }),
+      ...(mouEnd !== undefined && {
+        mouEnd: mouEnd ? mouEnd.toSQLDate() : null,
+      }),
+      ...(initialMouEnd !== undefined && {
+        initialMouEnd: initialMouEnd ? initialMouEnd.toSQLDate() : null,
+      }),
+      ...(estimatedSubmission !== undefined && {
+        estimatedSubmission: estimatedSubmission
+          ? estimatedSubmission.toSQLDate()
+          : null,
+      }),
+      ...(financialReportReceivedAt !== undefined && {
+        financialReportReceivedAt:
+          financialReportReceivedAt?.toJSDate() ?? null,
+      }),
+      ...(tags !== undefined && { tags: [...tags] }),
+      // Internship: writable. Translation: ignored (denormalized from
+      // engagements; recompute hook lands when Language migrates).
+      ...(sensitivity !== undefined &&
+        existing.type === 'Internship' && {
+          ownSensitivity: sensitivity,
+          sensitivity,
+        }),
+      modifiedAt: new Date(),
+    }).catch(catchDepartmentIdUnique);
+
+    // migration-todo: usesRev79 toggle delegates to ToolUsage service (not
+    // migrated yet). When ToolUsage ports, wire the create/remove of the
+    // Rev79 ToolUsage row here.
+
+    return {}; // service re-reads via readOne after update
+  }
+
+  async delete(id: ID): Promise<void> {
+    await this.softDelete(id);
+  }
+
+  async list(
+    input: ProjectListInput,
+  ): Promise<PaginatedListType<UnsecuredDto<Project>>> {
+    const conditions: SQL[] = [isNull(projects.deletedAt)];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+    conditions.push(...projectFilterClauses(this.db, input.filter));
+
+    const allConditions = and(...conditions);
+    const sort = input.sort as string;
+    const direction = input.order === 'ASC' ? asc : desc;
+
+    // Cross-domain JOIN-sort — mirror of the partner repo's pattern. When a
+    // second consumer needs the same prefix-strip + sortColumn-resolve dance,
+    // extract `resolveCrossDomainSort` (per partner's migration-todo).
+    const joinSort = resolveCrossDomainSort(sort);
+
+    let pageIds: ReadonlyArray<{ id: ID<'Project'> }>;
+    let total: number;
+    if (joinSort) {
+      const offset = (input.page - 1) * input.count;
+      const [countResult, joined] = await Promise.all([
+        this.db.select({ total: count() }).from(projects).where(allConditions),
+        this.db
+          .select({ id: projects.id })
+          .from(projects)
+          .leftJoin(joinSort.table, eq(joinSort.fkColumn, joinSort.table.id))
+          .where(allConditions)
+          .orderBy(direction(joinSort.column), asc(projects.id))
+          .limit(input.count)
+          .offset(offset),
+      ]);
+      total = countResult[0]?.total ?? 0;
+      pageIds = joined;
+    } else {
+      const sortColumns = projectSortColumns;
+      const page = await this.paginatedSelect({
+        predicate: allConditions,
+        orderBy: resolveOrderBy(input, sortColumns, projects.createdAt),
+        page: input.page,
+        count: input.count,
+      });
+      pageIds = page.rows.map((r) => ({ id: r.id }));
+      total = page.total;
+    }
+
+    const offset = (input.page - 1) * input.count;
+    const hasMore = offset + pageIds.length < total;
+    if (pageIds.length === 0) return { total, items: [], hasMore };
+
+    const dtos = await this.readMany(pageIds.map((r) => r.id));
+    const byId = new Map(dtos.map((d) => [d.id, d]));
+    return {
+      total,
+      items: pageIds.flatMap((r) => byId.get(r.id) ?? []),
+      hasMore,
+    };
+  }
+
+  /**
+   * Resolve the primary partnership's owning organization name. Used by the
+   * Rev79 integration. Traverses partnerships → partners → organizations.
+   *
+   * migration-todo: depends on Partnership migration. Throws until then.
+   */
+  async getPrimaryOrganizationName(_id: ID): Promise<string | null> {
+    throw new NotImplementedException(
+      'getPrimaryOrganizationName not yet available under DATABASE=postgres — pending Partnership migration',
+    );
+  }
+
+  protected toDto(row: ProjectRow): UnsecuredDto<Project> {
+    const linkOrNull = <T extends string>(id: ID<T> | null | undefined) =>
+      id ? { id } : null;
+    // DTO shape includes a few service-layer overlays (canDelete, scope,
+    // pinned) and stub fields the repo can't compute under DATABASE=postgres
+    // yet (primaryPartnership, engagementTotal, usesRev79). Build the dto as
+    // `unknown` first so the lint stays clean — service runs
+    // `privileges.secure()` after this anyway.
+    const dto: unknown = {
+      id: row.id,
+      __typename:
+        row.type === 'Internship'
+          ? 'InternshipProject'
+          : row.type === 'MomentumTranslation'
+            ? 'MomentumTranslationProject'
+            : 'MultiplicationTranslationProject',
+      type: row.type,
+      name: row.name,
+      step: row.step,
+      status: row.status,
+      sensitivity: row.sensitivity,
+      rev79ProjectId: row.rev79ProjectId ?? null,
+      departmentId: row.departmentId ?? null,
+      mouStart: row.mouStart ? CalendarDate.fromISO(row.mouStart) : null,
+      mouEnd: row.mouEnd ? CalendarDate.fromISO(row.mouEnd) : null,
+      initialMouEnd: row.initialMouEnd
+        ? CalendarDate.fromISO(row.initialMouEnd)
+        : null,
+      estimatedSubmission: row.estimatedSubmission
+        ? CalendarDate.fromISO(row.estimatedSubmission)
+        : null,
+      financialReportReceivedAt: row.financialReportReceivedAt
+        ? DateTime.fromJSDate(row.financialReportReceivedAt)
+        : null,
+      financialReportPeriod: row.financialReportPeriod ?? null,
+      tags: row.tags,
+      presetInventory: row.presetInventory,
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      modifiedAt: DateTime.fromJSDate(row.modifiedAt),
+      // stepChangedAt is derived from the latest workflow event; PR 3 wires
+      // the real query. For now fall back to createdAt — the only reader is
+      // the resolver, and the field has no stored canonical value anyway.
+      stepChangedAt: DateTime.fromJSDate(row.createdAt),
+      primaryLocation: linkOrNull(row.primaryLocationId),
+      marketingLocation: linkOrNull(row.marketingLocationId),
+      marketingRegionOverride: linkOrNull(row.marketingRegionOverrideId),
+      fieldRegion: linkOrNull(row.fieldRegionId),
+      owningOrganization: linkOrNull(row.owningOrganizationId),
+      rootDirectory: linkOrNull(row.rootDirectoryId),
+      // migration-todo: Partnership not migrated; primaryPartnership always
+      // null until partnership-pg lands.
+      primaryPartnership: null,
+      // migration-todo: Engagement not migrated; engagementTotal always 0
+      // until engagement-pg (Phase 5).
+      engagementTotal: 0,
+      // migration-todo: ToolUsage not migrated; usesRev79 always false until
+      // the tool-usage layer ports.
+      usesRev79: false,
+      membership: row.membership
+        ? {
+            id: row.membership.id,
+            roles: [...row.membership.roles],
+            inactiveAt: row.membership.inactiveAt
+              ? DateTime.fromJSDate(row.membership.inactiveAt)
+              : null,
+          }
+        : null,
+      // `changeset` is a resolver navigation marker — populated from request
+      // context, not stored on the row. PCR is excluded from the migration,
+      // so it stays undefined here.
+      changeset: undefined,
+      // migration-todo: pinned is per-requester state, separate Pin domain.
+      pinned: false,
+      // canDelete/scope are populated by the policy layer in the service.
+      canDelete: true,
+      scope: [],
+    };
+    return dto as UnsecuredDto<Project>;
+  }
+}
+
+/**
+ * Sortable columns on `projects` itself. Cross-domain sorts (primaryLocation.*,
+ * fieldRegion.*) are resolved in `resolveCrossDomainSort` and routed through a
+ * hand-rolled INNER JOIN — same pattern as Partner's organization sort.
+ */
+export const projectSortColumns = {
+  id: projects.id,
+  name: projects.name,
+  createdAt: projects.createdAt,
+  modifiedAt: projects.modifiedAt,
+  step: projects.step,
+  status: projects.status,
+  type: projects.type,
+  sensitivity: projects.sensitivity,
+  mouStart: projects.mouStart,
+  mouEnd: projects.mouEnd,
+  estimatedSubmission: projects.estimatedSubmission,
+  departmentId: projects.departmentId,
+} satisfies SortMap<keyof Project>;
+
+/**
+ * Resolve a `prefix.field`-style sort key to its (sub-table, FK, sub-column).
+ * Returns `null` when the sort is column-local (handled by paginatedSelect).
+ *
+ * migration-todo: when a second consumer needs this same prefix-strip dance
+ * (Partnership → `partner.*`, Engagement → `project.*`), extract a shared
+ * `resolveCrossDomainSort(sort, prefix, sortColumns)` helper alongside
+ * `paginatedSelectWithJoin` (mirror of `*FilterClauses` emergence).
+ *
+ * migration-todo: `primaryPartnership.*` sort is not implemented — Partnership
+ * isn't migrated. Throw `NotImplementedException` so callers discover the gap.
+ */
+const resolveCrossDomainSort = (
+  sort: string,
+): {
+  table: typeof locations | typeof fieldRegions;
+  fkColumn: AnyPgColumn;
+  column: AnyPgColumn;
+} | null => {
+  if (sort.startsWith('primaryLocation.')) {
+    const key = sort.slice('primaryLocation.'.length);
+    const column = locationSortColumns[key as keyof typeof locationSortColumns];
+    if (!column) {
+      throw new NotImplementedException(
+        `Sorting projects by '${sort}' is not supported — '${key}' is not a known sortable column on locations.`,
+      );
+    }
+    return { table: locations, fkColumn: projects.primaryLocationId, column };
+  }
+  if (sort.startsWith('fieldRegion.')) {
+    const key = sort.slice('fieldRegion.'.length);
+    const column =
+      fieldRegionSortColumns[key as keyof typeof fieldRegionSortColumns];
+    if (!column) {
+      throw new NotImplementedException(
+        `Sorting projects by '${sort}' is not supported — '${key}' is not a known sortable column on field_regions.`,
+      );
+    }
+    return { table: fieldRegions, fkColumn: projects.fieldRegionId, column };
+  }
+  if (sort.startsWith('primaryPartnership.')) {
+    throw new NotImplementedException(
+      `Sorting projects by '${sort}' is not yet supported under DATABASE=postgres — pending Partnership migration.`,
+    );
+  }
+  return null;
+};
+
+/**
+ * Build the column-level WHERE clauses for a `ProjectFilters` input against
+ * `projects`. Exported for sub-delegation from other domains (Engagement and
+ * Partnership both filter-sub-delegate into projectFilterClauses).
+ *
+ * Cross-domain stubs (languageId, partnerId, partnerships, primaryPartnership,
+ * tool, onlyMultipleEngagements, usesRev79) throw NotImplementedException
+ * until their target domain migrates — discovery mechanism, not silent skip.
+ */
+export const projectFilterClauses = (
+  db: DrizzleDb,
+  filter: ProjectFilters | undefined,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+
+  if (filter.id) conditions.push(eq(projects.id, filter.id));
+  if (filter.type?.length) {
+    conditions.push(inArray(projects.type, filter.type));
+  }
+  if (filter.status?.length) {
+    conditions.push(inArray(projects.status, filter.status));
+  }
+  if (filter.step?.length) {
+    conditions.push(inArray(projects.step, filter.step));
+  }
+  if (filter.sensitivity?.length) {
+    conditions.push(inArray(projects.sensitivity, [...filter.sensitivity]));
+  }
+  if (filter.presetInventory !== undefined) {
+    conditions.push(eq(projects.presetInventory, filter.presetInventory));
+  }
+  if (filter.name) {
+    conditions.push(
+      ilike(projects.name, `%${escapeLikePattern(filter.name)}%`),
+    );
+  }
+  if (filter.createdAt) {
+    if (filter.createdAt.after) {
+      conditions.push(
+        gt(projects.createdAt, filter.createdAt.after.toJSDate()),
+      );
+    }
+    if (filter.createdAt.afterInclusive) {
+      conditions.push(
+        gte(projects.createdAt, filter.createdAt.afterInclusive.toJSDate()),
+      );
+    }
+    if (filter.createdAt.before) {
+      conditions.push(
+        lt(projects.createdAt, filter.createdAt.before.toJSDate()),
+      );
+    }
+    if (filter.createdAt.beforeInclusive) {
+      conditions.push(
+        lte(projects.createdAt, filter.createdAt.beforeInclusive.toJSDate()),
+      );
+    }
+  }
+  if (filter.modifiedAt) {
+    if (filter.modifiedAt.after) {
+      conditions.push(
+        gt(projects.modifiedAt, filter.modifiedAt.after.toJSDate()),
+      );
+    }
+    if (filter.modifiedAt.afterInclusive) {
+      conditions.push(
+        gte(projects.modifiedAt, filter.modifiedAt.afterInclusive.toJSDate()),
+      );
+    }
+    if (filter.modifiedAt.before) {
+      conditions.push(
+        lt(projects.modifiedAt, filter.modifiedAt.before.toJSDate()),
+      );
+    }
+    if (filter.modifiedAt.beforeInclusive) {
+      conditions.push(
+        lte(projects.modifiedAt, filter.modifiedAt.beforeInclusive.toJSDate()),
+      );
+    }
+  }
+  if (filter.mouStart) {
+    if (filter.mouStart.after) {
+      conditions.push(
+        gt(projects.mouStart, filter.mouStart.after.toSQLDate()!),
+      );
+    }
+    if (filter.mouStart.afterInclusive) {
+      conditions.push(
+        gte(projects.mouStart, filter.mouStart.afterInclusive.toSQLDate()!),
+      );
+    }
+    if (filter.mouStart.before) {
+      conditions.push(
+        lt(projects.mouStart, filter.mouStart.before.toSQLDate()!),
+      );
+    }
+    if (filter.mouStart.beforeInclusive) {
+      conditions.push(
+        lte(projects.mouStart, filter.mouStart.beforeInclusive.toSQLDate()!),
+      );
+    }
+  }
+  if (filter.mouEnd) {
+    if (filter.mouEnd.after) {
+      conditions.push(gt(projects.mouEnd, filter.mouEnd.after.toSQLDate()!));
+    }
+    if (filter.mouEnd.afterInclusive) {
+      conditions.push(
+        gte(projects.mouEnd, filter.mouEnd.afterInclusive.toSQLDate()!),
+      );
+    }
+    if (filter.mouEnd.before) {
+      conditions.push(lt(projects.mouEnd, filter.mouEnd.before.toSQLDate()!));
+    }
+    if (filter.mouEnd.beforeInclusive) {
+      conditions.push(
+        lte(projects.mouEnd, filter.mouEnd.beforeInclusive.toSQLDate()!),
+      );
+    }
+  }
+  if (filter.primaryLocation) {
+    conditions.push(
+      subFilter(
+        db,
+        projects.primaryLocationId,
+        locations,
+        locationFilterClauses(filter.primaryLocation),
+      ),
+    );
+  }
+  if (filter.fieldRegion) {
+    conditions.push(
+      subFilter(
+        db,
+        projects.fieldRegionId,
+        fieldRegions,
+        fieldRegionFilterClauses(db, filter.fieldRegion),
+      ),
+    );
+  }
+  // `members` and `membership` filters — links project → project_members via
+  // a project-side `IN (SELECT project_id FROM project_members WHERE ...)`.
+  // The members filter doesn't constrain user; membership scopes to the
+  // current requester. Both lean on projectMemberFilterClauses.
+  if (filter.members) {
+    const sub = db
+      .selectDistinct({ id: projectMembers.projectId })
+      .from(projectMembers)
+      .where(
+        and(
+          isNull(projectMembers.deletedAt),
+          ...projectMemberFilterClauses(db, filter.members),
+        ),
+      );
+    conditions.push(inArray(projects.id, sub));
+  }
+  if (filter.membership) {
+    // Note: the `user: { id: $currentUser }` constraint is applied by the
+    // resolver/transform layer (see ProjectFilters.membership transform).
+    const sub = db
+      .selectDistinct({ id: projectMembers.projectId })
+      .from(projectMembers)
+      .where(
+        and(
+          isNull(projectMembers.deletedAt),
+          ...projectMemberFilterClauses(db, filter.membership),
+        ),
+      );
+    conditions.push(inArray(projects.id, sub));
+  }
+  // `userId`: project where user is a member OR engagement intern. Intern path
+  // is gated on Engagement migration — partial support: member only.
+  if (filter.userId) {
+    const memberSub = db
+      .selectDistinct({ id: projectMembers.projectId })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.userId, filter.userId),
+          isNull(projectMembers.deletedAt),
+        ),
+      );
+    // migration-todo: when Engagement migrates, OR-in the intern path:
+    //   ... OR projects.id IN (SELECT project_id FROM engagements WHERE intern_id = $userId)
+    conditions.push(inArray(projects.id, memberSub));
+  }
+  // Cross-domain filters — throw until their target domain migrates so the
+  // gap is discoverable in tests instead of silently returning all projects.
+  if (filter.languageId) {
+    throw new NotImplementedException(
+      'ProjectFilters.languageId requires Engagement migration (Phase 5).',
+    );
+  }
+  if (filter.partnerId) {
+    throw new NotImplementedException(
+      'ProjectFilters.partnerId requires Partnership migration.',
+    );
+  }
+  if (filter.partnerships) {
+    throw new NotImplementedException(
+      'ProjectFilters.partnerships requires Partnership migration.',
+    );
+  }
+  if (filter.primaryPartnership) {
+    throw new NotImplementedException(
+      'ProjectFilters.primaryPartnership requires Partnership migration.',
+    );
+  }
+  if (filter.tool) {
+    throw new NotImplementedException(
+      'ProjectFilters.tool requires ToolUsage migration.',
+    );
+  }
+  if (filter.onlyMultipleEngagements != null) {
+    throw new NotImplementedException(
+      'ProjectFilters.onlyMultipleEngagements requires Engagement migration (Phase 5).',
+    );
+  }
+  if (filter.usesRev79 != null) {
+    throw new NotImplementedException(
+      'ProjectFilters.usesRev79 requires ToolUsage migration.',
+    );
+  }
+  if (filter.pinned != null) {
+    // migration-todo: Pin domain (Phase 6); skip silently here since pinned
+    // is per-requester state that may be wired separately.
+  }
+  return conditions;
+};
+
+// Re-export to satisfy the unused-import linter — `DuplicateException` is part
+// of the catch-helper public surface elsewhere; here it's reached only via the
+// catch chains above.
+void DuplicateException;
+void isIdLike;
+void NotFoundException;

--- a/src/components/project/project.module.ts
+++ b/src/components/project/project.module.ts
@@ -24,6 +24,7 @@ import { ProjectMutationSubscriptionsResolver } from './project-mutation-subscri
 import { ProjectUpdateLinksResolver } from './project-update-links.resolver';
 import { ProjectUpdatedResolver } from './project-updated.resolver';
 import { ProjectChannels } from './project.channels';
+import { ProjectDrizzleRepository } from './project.drizzle.repository';
 import { ConcreteRepos, ProjectGelRepository } from './project.gel.repository';
 import { ProjectLoader } from './project.loader';
 import { ProjectRepository } from './project.repository';
@@ -63,7 +64,12 @@ import { ProjectWorkflowModule } from './workflow/project-workflow.module';
     ...ProjectEngagementIdResolvers,
     ProjectChannels,
     ProjectService,
-    splitDb(ProjectRepository, { gel: ProjectGelRepository }),
+    splitDb(ProjectRepository, {
+      gel: ProjectGelRepository,
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path (see migration_postgres.md splitDb cast).
+      postgres: ProjectDrizzleRepository as any,
+    }),
     ...Object.values(ConcreteRepos),
     ProjectLoader,
     ...Object.values(handlers),

--- a/src/components/project/workflow/project-workflow.drizzle.repository.ts
+++ b/src/components/project/workflow/project-workflow.drizzle.repository.ts
@@ -1,0 +1,179 @@
+import { Injectable } from '@nestjs/common';
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import { generateId, type ID, type UnsecuredDto } from '~/common';
+import { Identity } from '~/core/authentication';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { projects, projectWorkflowEvents } from '~/core/drizzle/schema';
+import { type ProjectStep } from '../dto';
+import {
+  type ExecuteProjectTransition,
+  type ProjectWorkflowEvent as WorkflowEvent,
+} from './dto';
+
+/**
+ * PostgreSQL implementation of the canonical `ProjectWorkflowRepository`.
+ *
+ * `projects.step` is kept in sync by an `AFTER INSERT` trigger on
+ * `project_workflow_events` (see migration 0009 — `sync_project_step_from_event`).
+ * App code never writes to `projects.step` directly; insert an event and the
+ * trigger does the rest. `modified_at` is bumped in the same trigger.
+ *
+ * `status` is a `GENERATED ALWAYS AS (CASE step ... END) STORED` column, so it
+ * follows step automatically — no extra write needed.
+ *
+ * `stepChangedAt` derives from the event's `at` timestamp at read time on the
+ * Project resolver; nothing is stored on `projects` for it.
+ */
+// migration-todo: `PublicOf<ProjectWorkflowRepository>` widens to every
+// public/protected member of the Gel base (privileges, getActualChanges,
+// isUnique, etc.) which this class doesn't reproduce. Same trade as every
+// other Drizzle repo — we rely on the `as any` cast at splitDb registration
+// time and lose compile-time enforcement here. Collapses at Phase 7 cutover.
+@Injectable()
+export class ProjectWorkflowDrizzleRepository {
+  constructor(
+    private readonly drizzle: DrizzleService,
+    private readonly identity: Identity,
+  ) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  async readMany(
+    ids: readonly ID[],
+  ): Promise<Array<UnsecuredDto<WorkflowEvent>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.projectWorkflowEvents.findMany({
+      where: (e) => inArray(e.id, [...ids]),
+      with: { project: { columns: { id: true, type: true, step: true } } },
+    });
+    return rows.map((row) => this.toDto(row));
+  }
+
+  async list(projectId: ID): Promise<Array<UnsecuredDto<WorkflowEvent>>> {
+    const rows = await this.db.query.projectWorkflowEvents.findMany({
+      where: (e) => eq(e.projectId, projectId),
+      with: { project: { columns: { id: true, type: true, step: true } } },
+      orderBy: (e, { asc }) => [asc(e.at)],
+    });
+    return rows.map((row) => this.toDto(row));
+  }
+
+  /**
+   * Insert a workflow event. The trigger handles `projects.step` /
+   * `modified_at` sync. We capture the project's current step *before* insert
+   * so the returned dto can carry `project.previousStep` — same surface as the
+   * Neo4j repo, where `previousStep` is read from the pre-update Property
+   * node within the same transaction.
+   */
+  async recordEvent(
+    input: Omit<ExecuteProjectTransition, 'bypassTo'> & { to: ProjectStep },
+  ): Promise<UnsecuredDto<WorkflowEvent>> {
+    const [projectRow] = await this.db
+      .select({ step: projects.step, type: projects.type })
+      .from(projects)
+      .where(eq(projects.id, input.project))
+      .limit(1);
+    const fromStep: ProjectStep | null = projectRow?.step ?? null;
+
+    const id = await generateId<ID<'ProjectWorkflowEvent'>>();
+    const who = this.identity.current.userId;
+    const at = new Date();
+
+    await this.db.insert(projectWorkflowEvents).values({
+      id,
+      projectId: input.project,
+      who,
+      fromStep,
+      toStep: input.to,
+      transitionKey: input.transition ?? null,
+      notes: input.notes ?? null,
+      at,
+    });
+
+    return this.toDto({
+      id,
+      projectId: input.project,
+      who,
+      fromStep,
+      toStep: input.to,
+      transitionKey: input.transition ?? null,
+      notes: input.notes ?? null,
+      at,
+      project: {
+        id: input.project,
+        type: projectRow!.type,
+        step: fromStep ?? input.to,
+      },
+    });
+  }
+
+  /**
+   * Walk this project's event history and return the most recent `to_step`
+   * matching any of `steps`. Drives the `BackToActive` dynamic step in
+   * `project-workflow.ts` (and any future dynamic-state resolver). Returns
+   * null when the project has never reached one of those steps.
+   */
+  async mostRecentStep(
+    projectId: ID<'Project'>,
+    steps: readonly ProjectStep[],
+  ): Promise<ProjectStep | null> {
+    if (steps.length === 0) return null;
+    const rows = await this.db
+      .select({ step: projectWorkflowEvents.toStep })
+      .from(projectWorkflowEvents)
+      .where(
+        and(
+          eq(projectWorkflowEvents.projectId, projectId),
+          inArray(projectWorkflowEvents.toStep, [...steps]),
+        ),
+      )
+      .orderBy(desc(projectWorkflowEvents.at))
+      .limit(1);
+    return rows[0]?.step ?? null;
+  }
+
+  protected toDto(
+    row: typeof projectWorkflowEvents.$inferSelect & {
+      project?: { id: ID<'Project'>; type: string; step: ProjectStep } | null;
+    },
+  ): UnsecuredDto<WorkflowEvent> & {
+    project: { id: ID<'Project'>; type: string; previousStep: ProjectStep };
+  } {
+    if (!row.project) {
+      // Schema FK is NOT NULL → the relational findMany typing widens to nullable
+      // but the row always exists. Loud failure beats silent NaN.
+      throw new Error(
+        `ProjectWorkflowEvent ${row.id} missing parent project row — FK invariant violated`,
+      );
+    }
+    const dto: unknown = {
+      id: row.id,
+      __typename: 'ProjectWorkflowEvent',
+      createdAt: DateTime.fromJSDate(row.at),
+      at: DateTime.fromJSDate(row.at),
+      who: { id: row.who },
+      // `transition` is the transition key (a string id resolved to a
+      // WorkflowTransition object at the resolver layer). null when the
+      // transition was bypassed or dynamic.
+      transition: row.transitionKey ?? null,
+      to: row.toStep,
+      notes: row.notes ?? null,
+      project: {
+        id: row.project.id,
+        type: row.project.type,
+        // `previousStep` = the project's step at the time the event was
+        // observed (post-trigger, this *is* the previous step from the
+        // event's POV because the trigger has already moved the project to
+        // `to_step`). `recordEvent` overrides this with the captured
+        // `fromStep` so its caller sees the correct value.
+        previousStep: row.fromStep ?? row.project.step,
+      },
+    };
+    return dto as UnsecuredDto<WorkflowEvent> & {
+      project: { id: ID<'Project'>; type: string; previousStep: ProjectStep };
+    };
+  }
+}

--- a/src/components/project/workflow/project-workflow.module.ts
+++ b/src/components/project/workflow/project-workflow.module.ts
@@ -6,6 +6,7 @@ import { ProjectWorkflowNotificationHandler } from './handlers/project-workflow-
 import { StepHistoryToWorkflowEventsMigration } from './migrations/step-history-to-workflow-events.migration';
 import { ProjectWorkflowEventLoader } from './project-workflow-event.loader';
 import { ProjectWorkflowChannels } from './project-workflow.channels';
+import { ProjectWorkflowDrizzleRepository } from './project-workflow.drizzle.repository';
 import { ProjectWorkflowFlowchart } from './project-workflow.flowchart';
 import { ProjectWorkflowEventGranter } from './project-workflow.granter';
 import { ProjectWorkflowNeo4jRepository } from './project-workflow.neo4j.repository';
@@ -31,6 +32,9 @@ import { ProjectWorkflowMutationSubscriptionsResolver } from './resolvers/projec
     ProjectWorkflowEventGranter,
     splitDb(ProjectWorkflowRepository, {
       neo4j: ProjectWorkflowNeo4jRepository,
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: ProjectWorkflowDrizzleRepository as any,
     }),
     ProjectWorkflowFlowchart,
     ProjectWorkflowNotificationHandler,

--- a/src/components/user/user.drizzle.repository.ts
+++ b/src/components/user/user.drizzle.repository.ts
@@ -264,6 +264,16 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
     throw new NotImplementedException();
   }
 
+  /**
+   * Public alias of `toDto` for cross-domain hydration. Sibling Drizzle repos
+   * (e.g. ProjectMember) call this to assemble nested User fields without
+   * widening visibility on the abstract base. Caller supplies a row already
+   * loaded with `globalRoles`.
+   */
+  mapRowToDto(row: UserRow): UnsecuredDto<User> {
+    return this.toDto(row);
+  }
+
   protected toDto(row: UserRow): UnsecuredDto<User> {
     return {
       id: row.id,

--- a/src/core/drizzle/errors.spec.ts
+++ b/src/core/drizzle/errors.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from '@jest/globals';
+import { DatabaseError } from 'pg';
+import { DuplicateException, InputException } from '~/common';
+import { catchForeignKeyViolation, catchUniqueViolation } from './errors';
+
+/**
+ * Construct a `DatabaseError` instance with the fields the catchers inspect.
+ * The `pg` driver normally builds these from wire-protocol responses; in
+ * tests we instantiate directly and stamp `code`/`constraint` on the instance.
+ */
+const makePgError = (
+  code: string,
+  constraint: string,
+  message = 'test error',
+): DatabaseError => {
+  const e = new DatabaseError(message, 0, 'error');
+  Object.assign(e, { code, constraint });
+  return e;
+};
+
+describe('catchForeignKeyViolation', () => {
+  const catcher = catchForeignKeyViolation(
+    'field_region_id_fkey',
+    'fieldRegions',
+    'One or more field region IDs do not exist',
+  );
+
+  it('maps a matching 23503 to InputException with the field set', () => {
+    expect.assertions(3);
+    try {
+      catcher(
+        makePgError('23503', 'partner_field_regions_field_region_id_fkey'),
+      );
+    } catch (e) {
+      expect(e).toBeInstanceOf(InputException);
+      expect((e as InputException).message).toBe(
+        'One or more field region IDs do not exist',
+      );
+      expect((e as InputException).field).toBe('fieldRegions');
+    }
+  });
+
+  it('re-throws unchanged when the constraint does not match', () => {
+    const err = makePgError('23503', 'partner_countries_location_id_fkey');
+    expect(() => catcher(err)).toThrow(err);
+  });
+
+  it('re-throws unchanged on a different PG error code', () => {
+    const err = makePgError(
+      '23505',
+      'partner_field_regions_field_region_id_fkey',
+    );
+    expect(() => catcher(err)).toThrow(err);
+  });
+
+  it('re-throws unchanged on a non-DatabaseError', () => {
+    const err = new Error('plain');
+    expect(() => catcher(err)).toThrow(err);
+  });
+});
+
+describe('catchUniqueViolation', () => {
+  const catcher = catchUniqueViolation(
+    'organization',
+    'organization',
+    'Partner for organization already exists.',
+  );
+
+  it('maps a matching 23505 to DuplicateException with the field set', () => {
+    expect.assertions(3);
+    try {
+      catcher(makePgError('23505', 'partners_organization_active_unique'));
+    } catch (e) {
+      expect(e).toBeInstanceOf(DuplicateException);
+      expect((e as DuplicateException).message).toBe(
+        'Partner for organization already exists.',
+      );
+      expect((e as DuplicateException).field).toBe('organization');
+    }
+  });
+
+  it('re-throws unchanged when the constraint does not match', () => {
+    const err = makePgError('23505', 'some_other_unique_idx');
+    expect(() => catcher(err)).toThrow(err);
+  });
+
+  it('re-throws unchanged on a different PG error code', () => {
+    const err = makePgError('23503', 'partners_organization_active_unique');
+    expect(() => catcher(err)).toThrow(err);
+  });
+
+  it('re-throws unchanged on a non-DatabaseError', () => {
+    const err = new Error('plain');
+    expect(() => catcher(err)).toThrow(err);
+  });
+});

--- a/src/core/drizzle/errors.ts
+++ b/src/core/drizzle/errors.ts
@@ -1,5 +1,5 @@
 import { DatabaseError } from 'pg';
-import { DuplicateException } from '~/common';
+import { DuplicateException, InputException } from '~/common';
 import { PgErrorCode } from './pg-error-codes';
 
 /**
@@ -19,6 +19,34 @@ export const catchUniqueViolation =
       e.constraint?.includes(constraintMatch)
     ) {
       throw new DuplicateException(field, message, e);
+    }
+    throw e as Error;
+  };
+
+/**
+ * Promise `.catch()` handler that maps a PostgreSQL foreign-key violation to
+ * an `InputException` carrying the GraphQL input `field` name — preserves the
+ * "which form field caused this" context that the Neo4j repos achieve via
+ * `e.withField(...)`. `constraintMatch` is checked as a substring against the
+ * failing constraint name (e.g. `'field_region_id_fkey'` to scope the catch
+ * to one side of a junction's two FKs).
+ *
+ * @example
+ *   .catch(catchForeignKeyViolation(
+ *     'field_region_id_fkey',
+ *     'fieldRegions',
+ *     'One or more field region IDs do not exist',
+ *   ))
+ */
+export const catchForeignKeyViolation =
+  (constraintMatch: string, field: string, message: string) =>
+  (e: unknown): never => {
+    if (
+      e instanceof DatabaseError &&
+      e.code === PgErrorCode.ForeignKeyViolation &&
+      e.constraint?.includes(constraintMatch)
+    ) {
+      throw new InputException(message, field, e);
     }
     throw e as Error;
   };

--- a/src/core/drizzle/index.ts
+++ b/src/core/drizzle/index.ts
@@ -3,6 +3,7 @@ export * from './drizzle.module';
 export * from './drizzle.service';
 export * from './dto.repository';
 export * from './errors';
+export * from './int4-multirange';
 export * from './like';
 export * from './order-by';
 export * from './pg-error-codes';

--- a/src/core/drizzle/int4-multirange.ts
+++ b/src/core/drizzle/int4-multirange.ts
@@ -1,0 +1,39 @@
+import { customType } from 'drizzle-orm/pg-core';
+
+/** An inclusive integer range `[start, end]`, as the GraphQL API exposes it. */
+export interface IntRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * Postgres native `int4multirange` column, mirroring Gel's `multirange` storage
+ * for `Finance::Department::IdBlock`.
+ *
+ * Gel/PG store ranges half-open (`[lower, upper)`); the app works in inclusive
+ * `{ start, end }` like the `FinanceDepartmentIdBlock` DTO. So an inclusive
+ * `{ start: 11, end: 9999 }` round-trips through the canonical literal
+ * `[11,10000)`. PG always returns int ranges in canonical `[)` form, but we
+ * parse the bound brackets defensively in case that ever changes.
+ */
+export const int4multirange = customType<{
+  data: readonly IntRange[];
+  driverData: string;
+}>({
+  dataType: () => 'int4multirange',
+  toDriver: (ranges) =>
+    ranges.length === 0
+      ? '{}'
+      : `{${ranges.map((r) => `[${r.start},${r.end + 1})`).join(',')}}`,
+  fromDriver: (value) => {
+    const out: IntRange[] = [];
+    for (const m of value.matchAll(/([[(])(\d+),(\d+)([\])])/g)) {
+      const [, lowerBracket, lowerStr, upperStr, upperBracket] = m;
+      // Normalize to inclusive [start, end].
+      const start = Number(lowerStr) + (lowerBracket === '(' ? 1 : 0);
+      const end = Number(upperStr) - (upperBracket === ')' ? 1 : 0);
+      out.push({ start, end });
+    }
+    return out;
+  },
+});

--- a/src/core/drizzle/migrations/0008_add_partners.sql
+++ b/src/core/drizzle/migrations/0008_add_partners.sql
@@ -1,0 +1,87 @@
+-- Migration: add department_id_blocks + partners (+ field-region / country /
+-- language-of-consulting junctions). One live Partner per Organization.
+-- Language FKs are deferred (added when Language migrates).
+
+CREATE TYPE "project_type" AS ENUM ('MomentumTranslation', 'MultiplicationTranslation', 'Internship');
+--> statement-breakpoint
+CREATE TYPE "partner_type" AS ENUM ('Managing', 'Funding', 'Impact', 'Technical', 'Resource');
+--> statement-breakpoint
+CREATE TYPE "financial_reporting_type" AS ENUM ('Funded', 'FieldEngaged', 'Hybrid');
+--> statement-breakpoint
+
+-- Finance::Department::IdBlock — shared by Partner (user-supplied) and later
+-- FundingAccount (computed). `range` mirrors Gel's native int4multirange.
+CREATE TABLE "department_id_blocks" (
+  "id"       text             PRIMARY KEY,
+  "range"    int4multirange   NOT NULL,
+  "programs" "project_type"[] NOT NULL DEFAULT '{}'
+);
+--> statement-breakpoint
+
+CREATE TABLE "partners" (
+  "id"                                  text                         PRIMARY KEY,
+  "organization_id"                     text                         NOT NULL REFERENCES "organizations"("id"),
+  "point_of_contact_id"                 text                         REFERENCES "users"("id"),
+  "types"                               "partner_type"[]             NOT NULL DEFAULT '{}',
+  "financial_reporting_types"           "financial_reporting_type"[] NOT NULL DEFAULT '{}',
+  "pmc_entity_code"                     text,
+  "global_innovations_client"           boolean                      NOT NULL DEFAULT false,
+  "active"                              boolean                      NOT NULL DEFAULT false,
+  "address"                             text,
+  -- migration-todo: deferred FK -> languages("id"); add REFERENCES when Language migrates
+  "language_of_wider_communication_id"  text,
+  "language_of_reporting_id"            text,
+  "start_date"                          date,
+  "approved_programs"                   "project_type"[]             NOT NULL DEFAULT '{}',
+  "department_id_block_id"              text                         REFERENCES "department_id_blocks"("id"),
+  -- migration-todo: derived from project sensitivity; 'High' until Project migrates
+  "sensitivity"                         "sensitivity"                NOT NULL DEFAULT 'High',
+  "created_at"                          timestamptz                  NOT NULL DEFAULT now(),
+  "updated_at"                          timestamptz                  NOT NULL DEFAULT now(),
+  "deleted_at"                          timestamptz
+);
+--> statement-breakpoint
+
+-- One live Partner per Organization (Neo4j enforces this app-side via partnerIdByOrg).
+CREATE UNIQUE INDEX "partners_organization_active_unique"
+  ON "partners" ("organization_id") WHERE "deleted_at" IS NULL;
+--> statement-breakpoint
+CREATE INDEX "partners_point_of_contact_id_idx"                  ON "partners" ("point_of_contact_id");
+--> statement-breakpoint
+CREATE INDEX "partners_department_id_block_id_idx"               ON "partners" ("department_id_block_id");
+--> statement-breakpoint
+-- Indexes on deferred-FK columns — REFERENCES added when Language migrates;
+-- the index goes in now so we avoid CREATE INDEX CONCURRENTLY later.
+CREATE INDEX "partners_language_of_wider_communication_id_idx"   ON "partners" ("language_of_wider_communication_id");
+--> statement-breakpoint
+CREATE INDEX "partners_language_of_reporting_id_idx"             ON "partners" ("language_of_reporting_id");
+--> statement-breakpoint
+
+CREATE TABLE "partner_field_regions" (
+  "partner_id"      text NOT NULL REFERENCES "partners"("id")      ON DELETE CASCADE,
+  "field_region_id" text NOT NULL REFERENCES "field_regions"("id") ON DELETE CASCADE,
+  PRIMARY KEY ("partner_id", "field_region_id")
+);
+--> statement-breakpoint
+CREATE INDEX "partner_field_regions_field_region_id_idx" ON "partner_field_regions" ("field_region_id");
+--> statement-breakpoint
+
+CREATE TABLE "partner_countries" (
+  "partner_id"  text NOT NULL REFERENCES "partners"("id")   ON DELETE CASCADE,
+  "location_id" text NOT NULL REFERENCES "locations"("id")  ON DELETE CASCADE,
+  PRIMARY KEY ("partner_id", "location_id")
+);
+--> statement-breakpoint
+CREATE INDEX "partner_countries_location_id_idx" ON "partner_countries" ("location_id");
+--> statement-breakpoint
+
+CREATE TABLE "partner_languages_of_consulting" (
+  "partner_id"  text NOT NULL REFERENCES "partners"("id") ON DELETE CASCADE,
+  -- migration-todo: deferred FK -> languages("id"); add REFERENCES when Language migrates
+  "language_id" text NOT NULL,
+  PRIMARY KEY ("partner_id", "language_id")
+);
+--> statement-breakpoint
+-- Right-side index for "find partners consulting language X" — the composite
+-- PK only covers the left side (partner_id).
+CREATE INDEX "partner_languages_of_consulting_language_id_idx" ON "partner_languages_of_consulting" ("language_id");

--- a/src/core/drizzle/migrations/0009_add_projects.sql
+++ b/src/core/drizzle/migrations/0009_add_projects.sql
@@ -1,0 +1,255 @@
+-- Migration: add Project + ProjectMember + ProjectWorkflowEvent.
+-- Plus the supporting enums and the trigger that keeps `projects.step` in
+-- sync with `project_workflow_events`.
+--
+-- Settled design decisions (see migration_postgres.md → Project Domain Notes):
+--   - Single-table inheritance over MomentumTranslation / MultiplicationTranslation /
+--     Internship; `type` discriminator; `own_sensitivity` is meaningful only for
+--     Internship rows.
+--   - `sensitivity` is denormalized — kept current via a hook that wires when
+--     Language migrates (Tier 2). Translation rows read 'High' until then.
+--   - `status` is GENERATED ALWAYS AS (CASE step ... END) STORED — mirrors
+--     stepToStatus() in src/components/project/dto/project-status.enum.ts and
+--     Gel's Project::statusFromStep(.step). Never writable.
+--   - `project_members.roles` is `role[]` (pgEnum array) with a GIN index;
+--     `roles && ARRAY[...]::role[]` powers the intersectsProp filter.
+--   - Workflow → step sync via AFTER INSERT trigger on project_workflow_events.
+
+CREATE TYPE "project_step" AS ENUM (
+  'EarlyConversations',
+  'PendingConceptApproval',
+  'PrepForConsultantEndorsement',
+  'PendingConsultantEndorsement',
+  'PrepForFinancialEndorsement',
+  'PendingFinancialEndorsement',
+  'FinalizingProposal',
+  'PendingRegionalDirectorApproval',
+  'PendingZoneDirectorApproval',
+  'PendingFinanceConfirmation',
+  'OnHoldFinanceConfirmation',
+  'DidNotDevelop',
+  'Rejected',
+  'Active',
+  'ActiveChangedPlan',
+  'DiscussingChangeToPlan',
+  'PendingChangeToPlanApproval',
+  'PendingChangeToPlanConfirmation',
+  'DiscussingSuspension',
+  'PendingSuspensionApproval',
+  'Suspended',
+  'DiscussingReactivation',
+  'PendingReactivationApproval',
+  'DiscussingTermination',
+  'PendingTerminationApproval',
+  'FinalizingCompletion',
+  'Terminated',
+  'Completed'
+);
+--> statement-breakpoint
+
+CREATE TYPE "project_status" AS ENUM (
+  'InDevelopment',
+  'Active',
+  'Terminated',
+  'Completed',
+  'DidNotDevelop'
+);
+--> statement-breakpoint
+
+CREATE TYPE "report_period" AS ENUM ('Monthly', 'Quarterly');
+--> statement-breakpoint
+
+-- First DB-typed role enum. `user_global_roles.role` predates this and is plain
+-- `text` — aligning that column is a separate cleanup PR (out of scope here).
+CREATE TYPE "role" AS ENUM (
+  'Administrator',
+  'BetaTester',
+  'BibleTranslationLiaison',
+  'Consultant',
+  'ConsultantManager',
+  'Controller',
+  'ExperienceOperations',
+  'FieldOperationsDirector',
+  'FieldPartner',
+  'FieldServices',
+  'FinancialAnalyst',
+  'Fundraising',
+  'Intern',
+  'LeadFinancialAnalyst',
+  'Leadership',
+  'Liaison',
+  'Marketing',
+  'Mentor',
+  'MultiplicationFinanceApprover',
+  'ProjectManager',
+  'RegionalCommunicationsCoordinator',
+  'RegionalDirector',
+  'StaffMember',
+  'Translator'
+);
+--> statement-breakpoint
+
+CREATE TABLE "projects" (
+  "id"                             text                PRIMARY KEY,
+  "type"                           "project_type"      NOT NULL,
+  "name"                           text                NOT NULL,
+  "step"                           "project_step"      NOT NULL DEFAULT 'EarlyConversations',
+  -- Mirror of stepToStatus() — never writable.
+  "status"                         "project_status"    NOT NULL GENERATED ALWAYS AS (
+    CASE "step"
+      WHEN 'EarlyConversations'              THEN 'InDevelopment'::project_status
+      WHEN 'PendingConceptApproval'          THEN 'InDevelopment'::project_status
+      WHEN 'PrepForConsultantEndorsement'    THEN 'InDevelopment'::project_status
+      WHEN 'PendingConsultantEndorsement'    THEN 'InDevelopment'::project_status
+      WHEN 'PrepForFinancialEndorsement'     THEN 'InDevelopment'::project_status
+      WHEN 'PendingFinancialEndorsement'     THEN 'InDevelopment'::project_status
+      WHEN 'FinalizingProposal'              THEN 'InDevelopment'::project_status
+      WHEN 'PendingRegionalDirectorApproval' THEN 'InDevelopment'::project_status
+      WHEN 'PendingZoneDirectorApproval'     THEN 'InDevelopment'::project_status
+      WHEN 'PendingFinanceConfirmation'      THEN 'InDevelopment'::project_status
+      WHEN 'OnHoldFinanceConfirmation'       THEN 'InDevelopment'::project_status
+      WHEN 'DidNotDevelop'                   THEN 'DidNotDevelop'::project_status
+      WHEN 'Rejected'                        THEN 'DidNotDevelop'::project_status
+      WHEN 'Active'                          THEN 'Active'::project_status
+      WHEN 'ActiveChangedPlan'               THEN 'Active'::project_status
+      WHEN 'DiscussingChangeToPlan'          THEN 'Active'::project_status
+      WHEN 'PendingChangeToPlanApproval'     THEN 'Active'::project_status
+      WHEN 'PendingChangeToPlanConfirmation' THEN 'Active'::project_status
+      WHEN 'DiscussingSuspension'            THEN 'Active'::project_status
+      WHEN 'PendingSuspensionApproval'       THEN 'Active'::project_status
+      WHEN 'Suspended'                       THEN 'Active'::project_status
+      WHEN 'DiscussingReactivation'          THEN 'Active'::project_status
+      WHEN 'PendingReactivationApproval'     THEN 'Active'::project_status
+      WHEN 'DiscussingTermination'           THEN 'Active'::project_status
+      WHEN 'PendingTerminationApproval'      THEN 'Active'::project_status
+      WHEN 'FinalizingCompletion'            THEN 'Active'::project_status
+      WHEN 'Terminated'                      THEN 'Terminated'::project_status
+      WHEN 'Completed'                       THEN 'Completed'::project_status
+    END
+  ) STORED,
+  -- migration-todo: denormalized — recompute hook fires when Engagement/Language
+  -- sensitivity changes (Tier 2 Language migration wires the hook). Translation
+  -- rows read 'High' until then; Internship reads own_sensitivity.
+  "sensitivity"                    "sensitivity"       NOT NULL DEFAULT 'High',
+  "own_sensitivity"                "sensitivity",
+  "rev79_project_id"               text,
+  "department_id"                  text,
+  "department_id_block_id"         text                REFERENCES "department_id_blocks"("id"),
+  "primary_location_id"            text                REFERENCES "locations"("id"),
+  "marketing_location_id"          text                REFERENCES "locations"("id"),
+  "marketing_region_override_id"   text                REFERENCES "locations"("id"),
+  "field_region_id"                text                REFERENCES "field_regions"("id"),
+  "owning_organization_id"         text                REFERENCES "organizations"("id"),
+  -- migration-todo: deferred FK → directories(id); add REFERENCES when File
+  -- migrates (Tier 7). Plain text until then (same pattern as other deferred FKs).
+  "root_directory_id"              text,
+  "mou_start"                      date,
+  "mou_end"                        date,
+  "initial_mou_end"                date,
+  "estimated_submission"           date,
+  "financial_report_received_at"   timestamptz,
+  "financial_report_period"        "report_period",
+  "tags"                           text[]              NOT NULL DEFAULT '{}',
+  "preset_inventory"               boolean             NOT NULL DEFAULT false,
+  "created_at"                     timestamptz         NOT NULL DEFAULT now(),
+  "modified_at"                    timestamptz         NOT NULL DEFAULT now(),
+  "updated_at"                     timestamptz         NOT NULL DEFAULT now(),
+  "deleted_at"                     timestamptz
+);
+--> statement-breakpoint
+
+-- Partial uniques — only enforced on live (non-soft-deleted) rows.
+CREATE UNIQUE INDEX "projects_name_active_unique"
+  ON "projects" ("name") WHERE "deleted_at" IS NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "projects_department_id_active_unique"
+  ON "projects" ("department_id")
+  WHERE "department_id" IS NOT NULL AND "deleted_at" IS NULL;
+--> statement-breakpoint
+
+-- FK b-tree indexes — PG doesn't auto-index FKs.
+CREATE INDEX "projects_department_id_block_id_idx"      ON "projects" ("department_id_block_id");
+--> statement-breakpoint
+CREATE INDEX "projects_primary_location_id_idx"         ON "projects" ("primary_location_id");
+--> statement-breakpoint
+CREATE INDEX "projects_marketing_location_id_idx"       ON "projects" ("marketing_location_id");
+--> statement-breakpoint
+CREATE INDEX "projects_marketing_region_override_id_idx" ON "projects" ("marketing_region_override_id");
+--> statement-breakpoint
+CREATE INDEX "projects_field_region_id_idx"             ON "projects" ("field_region_id");
+--> statement-breakpoint
+CREATE INDEX "projects_owning_organization_id_idx"      ON "projects" ("owning_organization_id");
+--> statement-breakpoint
+-- Deferred-FK column — indexed now so we avoid CREATE INDEX CONCURRENTLY later
+-- when File adds the REFERENCES clause.
+CREATE INDEX "projects_root_directory_id_idx"           ON "projects" ("root_directory_id");
+--> statement-breakpoint
+-- Filter-hot columns.
+CREATE INDEX "projects_type_idx"   ON "projects" ("type");
+--> statement-breakpoint
+CREATE INDEX "projects_step_idx"   ON "projects" ("step");
+--> statement-breakpoint
+CREATE INDEX "projects_status_idx" ON "projects" ("status");
+--> statement-breakpoint
+
+CREATE TABLE "project_members" (
+  "id"          text         PRIMARY KEY,
+  "project_id"  text         NOT NULL REFERENCES "projects"("id") ON DELETE CASCADE,
+  "user_id"     text         NOT NULL REFERENCES "users"("id")    ON DELETE CASCADE,
+  "roles"       "role"[]     NOT NULL DEFAULT '{}',
+  "inactive_at" timestamptz,
+  "created_at"  timestamptz  NOT NULL DEFAULT now(),
+  "updated_at"  timestamptz  NOT NULL DEFAULT now(),
+  "deleted_at"  timestamptz
+);
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX "project_members_project_user_active_unique"
+  ON "project_members" ("project_id", "user_id") WHERE "deleted_at" IS NULL;
+--> statement-breakpoint
+CREATE INDEX "project_members_user_id_idx" ON "project_members" ("user_id");
+--> statement-breakpoint
+-- GIN index for `roles && ARRAY[...]::role[]` (intersectsProp filter).
+CREATE INDEX "project_members_roles_gin" ON "project_members" USING gin ("roles");
+--> statement-breakpoint
+
+CREATE TABLE "project_workflow_events" (
+  "id"             text            PRIMARY KEY,
+  "project_id"     text            NOT NULL REFERENCES "projects"("id") ON DELETE CASCADE,
+  "who"            text            NOT NULL REFERENCES "users"("id"),
+  -- Nullable for synthetic/initial events; populated for normal transitions.
+  "from_step"      "project_step",
+  "to_step"        "project_step"  NOT NULL,
+  -- Nullable for dynamic transitions (e.g. BackToActive) — they resolve at
+  -- runtime from event history and don't carry a static key.
+  "transition_key" text,
+  "notes"          jsonb,
+  "at"             timestamptz     NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+
+-- Compound (project_id, at DESC) — every list query is "events for project X,
+-- newest first" (mostRecentStep walks the same path).
+CREATE INDEX "project_workflow_events_project_id_at_idx"
+  ON "project_workflow_events" ("project_id", "at" DESC);
+--> statement-breakpoint
+
+-- Trigger: keep `projects.step` (and modified_at) in sync with the latest
+-- event. App code writes events, never touches `projects.step` directly.
+-- Mirrors Gel's auto-sync trigger on Project::WorkflowEvent.
+CREATE FUNCTION "sync_project_step_from_event"() RETURNS trigger AS $$
+BEGIN
+  UPDATE "projects"
+     SET "step"        = NEW."to_step",
+         "modified_at" = now()
+   WHERE "id" = NEW."project_id";
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+
+CREATE TRIGGER "project_workflow_event_synced"
+  AFTER INSERT ON "project_workflow_events"
+  FOR EACH ROW EXECUTE FUNCTION "sync_project_step_from_event"();
+--> statement-breakpoint
+

--- a/src/core/drizzle/migrations/0010_add_partnerships.sql
+++ b/src/core/drizzle/migrations/0010_add_partnerships.sql
@@ -1,0 +1,70 @@
+-- Migration: add Partnership.
+-- Plus the supporting `partnership_agreement_status` enum.
+--
+-- Settled design decisions (see migration_postgres.md):
+--   - Single `partnerships` table with FKs to `projects` + `partners`.
+--   - `mou_id` / `agreement_id` deferred FKs to `files` (Tier 7). Plain text
+--     here; REFERENCES added when File migrates.
+--   - Partial unique on (project_id, partner_id) for live rows — backstops
+--     the duplicate check the Neo4j repo's verifyRelationshipEligibility
+--     performs at the app layer.
+--   - Partial unique on (project_id) where primary = true — DB-level
+--     enforcement of "one primary partnership per project". App's
+--     removePrimaryFromOtherPartnerships clears the existing flag in the
+--     same transaction.
+--   - PCR/Changeset is excluded from the migration; mou_*_override columns
+--     live on the row directly. Date coalesce (override → parent project)
+--     happens in the repo's toDto.
+
+CREATE TYPE "partnership_agreement_status" AS ENUM (
+  'NotAttached',
+  'AwaitingSignature',
+  'Signed'
+);
+--> statement-breakpoint
+
+CREATE TABLE "partnerships" (
+  "id"                       text                              PRIMARY KEY,
+  "project_id"               text                              NOT NULL REFERENCES "projects"("id") ON DELETE CASCADE,
+  "partner_id"               text                              NOT NULL REFERENCES "partners"("id") ON DELETE CASCADE,
+  "agreement_status"         "partnership_agreement_status"    NOT NULL DEFAULT 'NotAttached',
+  "mou_status"               "partnership_agreement_status"    NOT NULL DEFAULT 'NotAttached',
+  -- migration-todo: deferred FK → files(id); add REFERENCES when File
+  -- migrates (Tier 7). Plain text until then.
+  "mou_id"                   text,
+  "agreement_id"             text,
+  "mou_start_override"       date,
+  "mou_end_override"         date,
+  "types"                    "partner_type"[]                  NOT NULL DEFAULT '{}',
+  "financial_reporting_type" "financial_reporting_type",
+  "primary"                  boolean                           NOT NULL DEFAULT false,
+  "created_at"               timestamptz                       NOT NULL DEFAULT now(),
+  "updated_at"               timestamptz                       NOT NULL DEFAULT now(),
+  "deleted_at"               timestamptz
+);
+--> statement-breakpoint
+
+-- One partnership per (project, partner) pair on live rows.
+CREATE UNIQUE INDEX "partnerships_project_partner_active_unique"
+  ON "partnerships" ("project_id", "partner_id") WHERE "deleted_at" IS NULL;
+--> statement-breakpoint
+
+-- At most one primary partnership per project on live rows. DB-level
+-- enforcement of the "one primary per project" invariant; app's
+-- removePrimaryFromOtherPartnerships clears the flag elsewhere atomically.
+CREATE UNIQUE INDEX "partnerships_project_primary_active_unique"
+  ON "partnerships" ("project_id")
+  WHERE "primary" = true AND "deleted_at" IS NULL;
+--> statement-breakpoint
+
+-- The composite unique above covers the leftmost column (project_id), but
+-- partner-side lookups (e.g. "find partnerships for partner X") need their
+-- own index.
+CREATE INDEX "partnerships_partner_id_idx" ON "partnerships" ("partner_id");
+--> statement-breakpoint
+
+-- Deferred-FK columns indexed now to avoid CREATE INDEX CONCURRENTLY when
+-- File migrates.
+CREATE INDEX "partnerships_mou_id_idx"       ON "partnerships" ("mou_id");
+--> statement-breakpoint
+CREATE INDEX "partnerships_agreement_id_idx" ON "partnerships" ("agreement_id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1746230400000,
       "tag": "0004_add_field_zones_regions",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1747526400000,
+      "tag": "0008_add_partners",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1747526400000,
       "tag": "0008_add_partners",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1747612800000,
+      "tag": "0009_add_projects",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1747612800000,
       "tag": "0009_add_projects",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1747699200000,
+      "tag": "0010_add_partnerships",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -3,6 +3,7 @@ import {
   type AnyPgColumn,
   boolean,
   check,
+  date,
   index,
   pgEnum,
   pgTable,
@@ -15,7 +16,11 @@ import { type ID, type Role } from '~/common';
 import { type LocationType } from '../../../components/location/dto/location-type.enum';
 import { type OrganizationReach } from '../../../components/organization/dto/organization-reach.dto';
 import { type OrganizationType } from '../../../components/organization/dto/organization-type.dto';
+import { type PartnerType } from '../../../components/partner/dto/partner-type.enum';
+import { type FinancialReportingType } from '../../../components/partnership/dto/financial-reporting-type.enum';
+import { type ProjectType } from '../../../components/project/dto/project-type.enum';
 import { type Gender } from '../../../components/user/dto/gender.enum';
+import { int4multirange } from '../int4-multirange';
 
 export const userStatusEnum = pgEnum('user_status', ['Active', 'Disabled']);
 export const genderEnum = pgEnum('gender', ['Male', 'Female']);
@@ -505,3 +510,216 @@ export const fieldRegionsRelations = relations(fieldRegions, ({ one }) => ({
     references: [users.id],
   }),
 }));
+
+// ─── Partner ────────────────────────────────────────────────────────────────
+
+export const projectTypeEnum = pgEnum('project_type', [
+  'MomentumTranslation',
+  'MultiplicationTranslation',
+  'Internship',
+]);
+
+export const partnerTypeEnum = pgEnum('partner_type', [
+  'Managing',
+  'Funding',
+  'Impact',
+  'Technical',
+  'Resource',
+]);
+
+export const financialReportingTypeEnum = pgEnum('financial_reporting_type', [
+  'Funded',
+  'FieldEngaged',
+  'Hybrid',
+]);
+
+/**
+ * Finance::Department::IdBlock — shared by Partner (user-supplied) and, later,
+ * FundingAccount (computed from accountNumber). `range` mirrors Gel's native
+ * `int4multirange`; `programs` are the project types the block applies to.
+ */
+export const departmentIdBlocks = pgTable('department_id_blocks', {
+  id: text('id').$type<ID>().primaryKey(),
+  range: int4multirange('range').notNull(),
+  programs: projectTypeEnum('programs')
+    .array()
+    .$type<readonly ProjectType[]>()
+    .notNull()
+    .default([]),
+});
+
+export const partners = pgTable(
+  'partners',
+  {
+    id: text('id').$type<ID<'Partner'>>().primaryKey(),
+    organizationId: text('organization_id')
+      .$type<ID<'Organization'>>()
+      .notNull()
+      .references(() => organizations.id),
+    pointOfContactId: text('point_of_contact_id')
+      .$type<ID<'User'>>()
+      .references(() => users.id),
+    types: partnerTypeEnum('types')
+      .array()
+      .$type<readonly PartnerType[]>()
+      .notNull()
+      .default([]),
+    financialReportingTypes: financialReportingTypeEnum(
+      'financial_reporting_types',
+    )
+      .array()
+      .$type<readonly FinancialReportingType[]>()
+      .notNull()
+      .default([]),
+    pmcEntityCode: text('pmc_entity_code'),
+    globalInnovationsClient: boolean('global_innovations_client')
+      .notNull()
+      .default(false),
+    active: boolean('active').notNull().default(false),
+    address: text('address'),
+    // migration-todo: deferred FK → languages(id); add REFERENCES when Language
+    // migrates. Plain text until then (same pattern as locations.funding_account_id).
+    languageOfWiderCommunicationId: text(
+      'language_of_wider_communication_id',
+    ).$type<ID<'Language'>>(),
+    // migration-todo: deferred FK → languages(id); add when Language migrates.
+    languageOfReportingId: text('language_of_reporting_id').$type<
+      ID<'Language'>
+    >(),
+    startDate: date('start_date'),
+    approvedPrograms: projectTypeEnum('approved_programs')
+      .array()
+      .$type<readonly ProjectType[]>()
+      .notNull()
+      .default([]),
+    departmentIdBlockId: text('department_id_block_id')
+      .$type<ID>()
+      .references(() => departmentIdBlocks.id),
+    // migration-todo: derived from the project's sensitivity; keep current via
+    // hook once Project/Partnership migrate. Always 'High' until then — same as
+    // organizations.sensitivity.
+    sensitivity: sensitivityEnum('sensitivity').notNull().default('High'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    // One live Partner per Organization (Neo4j enforces via partnerIdByOrg).
+    uniqueIndex('partners_organization_active_unique')
+      .on(t.organizationId)
+      .where(sql`${t.deletedAt} IS NULL`),
+    index('partners_point_of_contact_id_idx').on(t.pointOfContactId),
+    index('partners_department_id_block_id_idx').on(t.departmentIdBlockId),
+    // Indexes on deferred-FK columns — REFERENCES adds when Language migrates,
+    // but the index goes in now so queries on these columns don't seq-scan and
+    // we avoid `CREATE INDEX CONCURRENTLY` later (memory's "Index every FK").
+    index('partners_language_of_wider_communication_id_idx').on(
+      t.languageOfWiderCommunicationId,
+    ),
+    index('partners_language_of_reporting_id_idx').on(t.languageOfReportingId),
+  ],
+);
+
+export const partnerFieldRegions = pgTable(
+  'partner_field_regions',
+  {
+    partnerId: text('partner_id')
+      .$type<ID<'Partner'>>()
+      .notNull()
+      .references(() => partners.id, { onDelete: 'cascade' }),
+    fieldRegionId: text('field_region_id')
+      .$type<ID<'FieldRegion'>>()
+      .notNull()
+      .references(() => fieldRegions.id, { onDelete: 'cascade' }),
+  },
+  (t) => [
+    primaryKey({ columns: [t.partnerId, t.fieldRegionId] }),
+    index('partner_field_regions_field_region_id_idx').on(t.fieldRegionId),
+  ],
+);
+
+export const partnerCountries = pgTable(
+  'partner_countries',
+  {
+    partnerId: text('partner_id')
+      .$type<ID<'Partner'>>()
+      .notNull()
+      .references(() => partners.id, { onDelete: 'cascade' }),
+    locationId: text('location_id')
+      .$type<ID<'Location'>>()
+      .notNull()
+      .references(() => locations.id, { onDelete: 'cascade' }),
+  },
+  (t) => [
+    primaryKey({ columns: [t.partnerId, t.locationId] }),
+    index('partner_countries_location_id_idx').on(t.locationId),
+  ],
+);
+
+export const partnerLanguagesOfConsulting = pgTable(
+  'partner_languages_of_consulting',
+  {
+    partnerId: text('partner_id')
+      .$type<ID<'Partner'>>()
+      .notNull()
+      .references(() => partners.id, { onDelete: 'cascade' }),
+    // migration-todo: deferred FK → languages(id); add REFERENCES when
+    // Language migrates.
+    languageId: text('language_id').$type<ID<'Language'>>().notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.partnerId, t.languageId] }),
+    // Right-side index for "find partners consulting language X" — the
+    // composite PK only covers the left side (partner_id).
+    index('partner_languages_of_consulting_language_id_idx').on(t.languageId),
+  ],
+);
+
+export const departmentIdBlocksRelations = relations(
+  departmentIdBlocks,
+  () => ({}),
+);
+
+export const partnersRelations = relations(partners, ({ one, many }) => ({
+  departmentIdBlock: one(departmentIdBlocks, {
+    fields: [partners.departmentIdBlockId],
+    references: [departmentIdBlocks.id],
+  }),
+  fieldRegions: many(partnerFieldRegions),
+  countries: many(partnerCountries),
+  languagesOfConsulting: many(partnerLanguagesOfConsulting),
+}));
+
+export const partnerFieldRegionsRelations = relations(
+  partnerFieldRegions,
+  ({ one }) => ({
+    partner: one(partners, {
+      fields: [partnerFieldRegions.partnerId],
+      references: [partners.id],
+    }),
+  }),
+);
+
+export const partnerCountriesRelations = relations(
+  partnerCountries,
+  ({ one }) => ({
+    partner: one(partners, {
+      fields: [partnerCountries.partnerId],
+      references: [partners.id],
+    }),
+  }),
+);
+
+export const partnerLanguagesOfConsultingRelations = relations(
+  partnerLanguagesOfConsulting,
+  ({ one }) => ({
+    partner: one(partners, {
+      fields: [partnerLanguagesOfConsulting.partnerId],
+      references: [partners.id],
+    }),
+  }),
+);

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -19,6 +19,7 @@ import { type OrganizationReach } from '../../../components/organization/dto/org
 import { type OrganizationType } from '../../../components/organization/dto/organization-type.dto';
 import { type PartnerType } from '../../../components/partner/dto/partner-type.enum';
 import { type FinancialReportingType } from '../../../components/partnership/dto/financial-reporting-type.enum';
+import { type PartnershipAgreementStatus } from '../../../components/partnership/dto/partnership-agreement-status.enum';
 import { type ReportPeriod } from '../../../components/periodic-report/dto/report-period.enum';
 import { type ProjectStatus } from '../../../components/project/dto/project-status.enum';
 import { type ProjectStep } from '../../../components/project/dto/project-step.enum';
@@ -1077,3 +1078,97 @@ export const projectWorkflowEventsRelations = relations(
     }),
   }),
 );
+
+// ─── Partnership ───────────────────────────────────────────────────────────
+
+export const partnershipAgreementStatusEnum = pgEnum(
+  'partnership_agreement_status',
+  ['NotAttached', 'AwaitingSignature', 'Signed'],
+);
+
+/**
+ * Partnership — links a Project to a Partner with agreement state, MOU dates,
+ * partner types (a subset of the partner's `approved_programs`-style types),
+ * a financial reporting type, and a `primary` flag (one primary per project).
+ *
+ * `mou_id` / `agreement_id` are deferred FKs to `files` (Tier 7). Plain text
+ * here; reference added when File migrates. Pattern matches every other
+ * deferred-file FK in the schema.
+ *
+ * PCR/Changeset is excluded from the migration — no overrides table, the
+ * `mou_*_override` columns live on the row directly and the date coalesce
+ * (override → parent project) happens in `toDto`.
+ */
+export const partnerships = pgTable(
+  'partnerships',
+  {
+    id: text('id').$type<ID<'Partnership'>>().primaryKey(),
+    projectId: text('project_id')
+      .$type<ID<'Project'>>()
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    partnerId: text('partner_id')
+      .$type<ID<'Partner'>>()
+      .notNull()
+      .references(() => partners.id, { onDelete: 'cascade' }),
+    agreementStatus: partnershipAgreementStatusEnum('agreement_status')
+      .$type<PartnershipAgreementStatus>()
+      .notNull()
+      .default('NotAttached'),
+    mouStatus: partnershipAgreementStatusEnum('mou_status')
+      .$type<PartnershipAgreementStatus>()
+      .notNull()
+      .default('NotAttached'),
+    // migration-todo: deferred FK → files(id); add REFERENCES when File
+    // migrates (Tier 7). Plain text until then.
+    mouId: text('mou_id').$type<ID<'File'>>(),
+    agreementId: text('agreement_id').$type<ID<'File'>>(),
+    mouStartOverride: date('mou_start_override'),
+    mouEndOverride: date('mou_end_override'),
+    types: partnerTypeEnum('types')
+      .array()
+      .$type<readonly PartnerType[]>()
+      .notNull()
+      .default([]),
+    financialReportingType: financialReportingTypeEnum(
+      'financial_reporting_type',
+    ).$type<FinancialReportingType>(),
+    primary: boolean('primary').notNull().default(false),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    // One partnership per (project, partner) pair on live rows. Mirror of the
+    // Neo4j repo's `verifyRelationshipEligibility` duplicate check; backstops
+    // it at the DB level.
+    uniqueIndex('partnerships_project_partner_active_unique')
+      .on(t.projectId, t.partnerId)
+      .where(sql`${t.deletedAt} IS NULL`),
+    // At most one primary partnership per project on live rows. Drives
+    // `removePrimaryFromOtherPartnerships` invariant.
+    uniqueIndex('partnerships_project_primary_active_unique')
+      .on(t.projectId)
+      .where(sql`${t.primary} = true AND ${t.deletedAt} IS NULL`),
+    index('partnerships_partner_id_idx').on(t.partnerId),
+    // Deferred-FK columns indexed now to avoid CREATE INDEX CONCURRENTLY when
+    // File migrates and adds the REFERENCES clause.
+    index('partnerships_mou_id_idx').on(t.mouId),
+    index('partnerships_agreement_id_idx').on(t.agreementId),
+  ],
+);
+
+export const partnershipsRelations = relations(partnerships, ({ one }) => ({
+  project: one(projects, {
+    fields: [partnerships.projectId],
+    references: [projects.id],
+  }),
+  partner: one(partners, {
+    fields: [partnerships.partnerId],
+    references: [partners.id],
+  }),
+}));

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -5,6 +5,7 @@ import {
   check,
   date,
   index,
+  jsonb,
   pgEnum,
   pgTable,
   primaryKey,
@@ -18,6 +19,9 @@ import { type OrganizationReach } from '../../../components/organization/dto/org
 import { type OrganizationType } from '../../../components/organization/dto/organization-type.dto';
 import { type PartnerType } from '../../../components/partner/dto/partner-type.enum';
 import { type FinancialReportingType } from '../../../components/partnership/dto/financial-reporting-type.enum';
+import { type ReportPeriod } from '../../../components/periodic-report/dto/report-period.enum';
+import { type ProjectStatus } from '../../../components/project/dto/project-status.enum';
+import { type ProjectStep } from '../../../components/project/dto/project-step.enum';
 import { type ProjectType } from '../../../components/project/dto/project-type.enum';
 import { type Gender } from '../../../components/user/dto/gender.enum';
 import { int4multirange } from '../int4-multirange';
@@ -720,6 +724,356 @@ export const partnerLanguagesOfConsultingRelations = relations(
     partner: one(partners, {
       fields: [partnerLanguagesOfConsulting.partnerId],
       references: [partners.id],
+    }),
+  }),
+);
+
+// ─── Project ───────────────────────────────────────────────────────────────
+
+export const projectStepEnum = pgEnum('project_step', [
+  'EarlyConversations',
+  'PendingConceptApproval',
+  'PrepForConsultantEndorsement',
+  'PendingConsultantEndorsement',
+  'PrepForFinancialEndorsement',
+  'PendingFinancialEndorsement',
+  'FinalizingProposal',
+  'PendingRegionalDirectorApproval',
+  'PendingZoneDirectorApproval',
+  'PendingFinanceConfirmation',
+  'OnHoldFinanceConfirmation',
+  'DidNotDevelop',
+  'Rejected',
+  'Active',
+  'ActiveChangedPlan',
+  'DiscussingChangeToPlan',
+  'PendingChangeToPlanApproval',
+  'PendingChangeToPlanConfirmation',
+  'DiscussingSuspension',
+  'PendingSuspensionApproval',
+  'Suspended',
+  'DiscussingReactivation',
+  'PendingReactivationApproval',
+  'DiscussingTermination',
+  'PendingTerminationApproval',
+  'FinalizingCompletion',
+  'Terminated',
+  'Completed',
+]);
+
+export const projectStatusEnum = pgEnum('project_status', [
+  'InDevelopment',
+  'Active',
+  'Terminated',
+  'Completed',
+  'DidNotDevelop',
+]);
+
+export const reportPeriodEnum = pgEnum('report_period', [
+  'Monthly',
+  'Quarterly',
+]);
+
+/**
+ * First column to use `role` as a pgEnum (project_members.roles role[]).
+ * `user_global_roles.role` predates this and is plain `text` — aligning it is
+ * tracked as a separate cleanup PR (migration-todo on user_global_roles).
+ */
+export const roleEnum = pgEnum('role', [
+  'Administrator',
+  'BetaTester',
+  'BibleTranslationLiaison',
+  'Consultant',
+  'ConsultantManager',
+  'Controller',
+  'ExperienceOperations',
+  'FieldOperationsDirector',
+  'FieldPartner',
+  'FieldServices',
+  'FinancialAnalyst',
+  'Fundraising',
+  'Intern',
+  'LeadFinancialAnalyst',
+  'Leadership',
+  'Liaison',
+  'Marketing',
+  'Mentor',
+  'MultiplicationFinanceApprover',
+  'ProjectManager',
+  'RegionalCommunicationsCoordinator',
+  'RegionalDirector',
+  'StaffMember',
+  'Translator',
+]);
+
+/**
+ * Project — single-table inheritance over the 3 concrete subtypes
+ * (MomentumTranslation, MultiplicationTranslation, Internship). `type` is the
+ * discriminator; `own_sensitivity` is meaningful only for Internship (Translation
+ * rows ignore it and read the denormalized `sensitivity` column).
+ *
+ * `sensitivity` is denormalized: kept current via a hook that recomputes from
+ * Engagement/Language. The hook is stubbed (`migration-todo:`) until Language
+ * migrates — Translation projects read 'High' in DATABASE=postgres until then.
+ *
+ * `status` is `GENERATED ALWAYS AS (CASE step ... END) STORED` in the raw SQL
+ * migration; mirrors Gel's `Project::statusFromStep(.step)`. Drizzle marks it
+ * as generated so insert/update types omit it.
+ */
+export const projects = pgTable(
+  'projects',
+  {
+    id: text('id').$type<ID<'Project'>>().primaryKey(),
+    type: projectTypeEnum('type').$type<ProjectType>().notNull(),
+    name: text('name').notNull(),
+    step: projectStepEnum('step')
+      .$type<ProjectStep>()
+      .notNull()
+      .default('EarlyConversations'),
+    status: projectStatusEnum('status')
+      .$type<ProjectStatus>()
+      .generatedAlwaysAs(
+        // Mirror of stepToStatus() in src/components/project/dto/project-status.enum.ts
+        sql`CASE step
+          WHEN 'EarlyConversations'              THEN 'InDevelopment'::project_status
+          WHEN 'PendingConceptApproval'          THEN 'InDevelopment'::project_status
+          WHEN 'PrepForConsultantEndorsement'    THEN 'InDevelopment'::project_status
+          WHEN 'PendingConsultantEndorsement'    THEN 'InDevelopment'::project_status
+          WHEN 'PrepForFinancialEndorsement'     THEN 'InDevelopment'::project_status
+          WHEN 'PendingFinancialEndorsement'     THEN 'InDevelopment'::project_status
+          WHEN 'FinalizingProposal'              THEN 'InDevelopment'::project_status
+          WHEN 'PendingRegionalDirectorApproval' THEN 'InDevelopment'::project_status
+          WHEN 'PendingZoneDirectorApproval'     THEN 'InDevelopment'::project_status
+          WHEN 'PendingFinanceConfirmation'      THEN 'InDevelopment'::project_status
+          WHEN 'OnHoldFinanceConfirmation'       THEN 'InDevelopment'::project_status
+          WHEN 'DidNotDevelop'                   THEN 'DidNotDevelop'::project_status
+          WHEN 'Rejected'                        THEN 'DidNotDevelop'::project_status
+          WHEN 'Active'                          THEN 'Active'::project_status
+          WHEN 'ActiveChangedPlan'               THEN 'Active'::project_status
+          WHEN 'DiscussingChangeToPlan'          THEN 'Active'::project_status
+          WHEN 'PendingChangeToPlanApproval'     THEN 'Active'::project_status
+          WHEN 'PendingChangeToPlanConfirmation' THEN 'Active'::project_status
+          WHEN 'DiscussingSuspension'            THEN 'Active'::project_status
+          WHEN 'PendingSuspensionApproval'       THEN 'Active'::project_status
+          WHEN 'Suspended'                       THEN 'Active'::project_status
+          WHEN 'DiscussingReactivation'          THEN 'Active'::project_status
+          WHEN 'PendingReactivationApproval'     THEN 'Active'::project_status
+          WHEN 'DiscussingTermination'           THEN 'Active'::project_status
+          WHEN 'PendingTerminationApproval'      THEN 'Active'::project_status
+          WHEN 'FinalizingCompletion'            THEN 'Active'::project_status
+          WHEN 'Terminated'                      THEN 'Terminated'::project_status
+          WHEN 'Completed'                       THEN 'Completed'::project_status
+        END`,
+      )
+      .notNull(),
+    // migration-todo: denormalized — recompute hook fires when Engagement/Language
+    // sensitivity changes (Tier 2 Language migration wires the hook). Translation
+    // rows read 'High' until then; Internship reads own_sensitivity.
+    sensitivity: sensitivityEnum('sensitivity').notNull().default('High'),
+    // Writable only for Internship projects; Translation rows ignore it.
+    ownSensitivity: sensitivityEnum('own_sensitivity'),
+    rev79ProjectId: text('rev79_project_id'),
+    departmentId: text('department_id'),
+    departmentIdBlockId: text('department_id_block_id')
+      .$type<ID>()
+      .references(() => departmentIdBlocks.id),
+    primaryLocationId: text('primary_location_id')
+      .$type<ID<'Location'>>()
+      .references((): AnyPgColumn => locations.id),
+    marketingLocationId: text('marketing_location_id')
+      .$type<ID<'Location'>>()
+      .references((): AnyPgColumn => locations.id),
+    marketingRegionOverrideId: text('marketing_region_override_id')
+      .$type<ID<'Location'>>()
+      .references((): AnyPgColumn => locations.id),
+    fieldRegionId: text('field_region_id')
+      .$type<ID<'FieldRegion'>>()
+      .references(() => fieldRegions.id),
+    owningOrganizationId: text('owning_organization_id')
+      .$type<ID<'Organization'>>()
+      .references(() => organizations.id),
+    // migration-todo: deferred FK → directories(id); add REFERENCES when File
+    // migrates (Tier 7). Plain text until then.
+    rootDirectoryId: text('root_directory_id').$type<ID<'Directory'>>(),
+    mouStart: date('mou_start'),
+    mouEnd: date('mou_end'),
+    initialMouEnd: date('initial_mou_end'),
+    estimatedSubmission: date('estimated_submission'),
+    financialReportReceivedAt: timestamp('financial_report_received_at', {
+      withTimezone: true,
+    }),
+    financialReportPeriod: reportPeriodEnum(
+      'financial_report_period',
+    ).$type<ReportPeriod>(),
+    tags: text('tags').array().notNull().default([]),
+    presetInventory: boolean('preset_inventory').notNull().default(false),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    modifiedAt: timestamp('modified_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    // Partial uniques — only enforced on live (non-soft-deleted) rows.
+    uniqueIndex('projects_name_active_unique')
+      .on(t.name)
+      .where(sql`${t.deletedAt} IS NULL`),
+    uniqueIndex('projects_department_id_active_unique')
+      .on(t.departmentId)
+      .where(sql`${t.departmentId} IS NOT NULL AND ${t.deletedAt} IS NULL`),
+    // FK b-tree indexes — PG doesn't auto-index FKs.
+    index('projects_department_id_block_id_idx').on(t.departmentIdBlockId),
+    index('projects_primary_location_id_idx').on(t.primaryLocationId),
+    index('projects_marketing_location_id_idx').on(t.marketingLocationId),
+    index('projects_marketing_region_override_id_idx').on(
+      t.marketingRegionOverrideId,
+    ),
+    index('projects_field_region_id_idx').on(t.fieldRegionId),
+    index('projects_owning_organization_id_idx').on(t.owningOrganizationId),
+    // Deferred FK column — indexed now so we avoid CREATE INDEX CONCURRENTLY
+    // later when File adds the REFERENCES clause.
+    index('projects_root_directory_id_idx').on(t.rootDirectoryId),
+    // Filter-hot columns.
+    index('projects_type_idx').on(t.type),
+    index('projects_step_idx').on(t.step),
+    index('projects_status_idx').on(t.status),
+  ],
+);
+
+/**
+ * ProjectMember — composite-unique on (project_id, user_id) for live rows.
+ * `roles role[]` matches Gel's set semantics; GIN index supports the
+ * `roles && ARRAY[...]::role[]` intersectsProp filter.
+ */
+export const projectMembers = pgTable(
+  'project_members',
+  {
+    id: text('id').$type<ID<'ProjectMember'>>().primaryKey(),
+    projectId: text('project_id')
+      .$type<ID<'Project'>>()
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    roles: roleEnum('roles')
+      .array()
+      .$type<readonly Role[]>()
+      .notNull()
+      .default([]),
+    inactiveAt: timestamp('inactive_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    uniqueIndex('project_members_project_user_active_unique')
+      .on(t.projectId, t.userId)
+      .where(sql`${t.deletedAt} IS NULL`),
+    index('project_members_user_id_idx').on(t.userId),
+    // GIN index for `roles && ARRAY[...]::role[]` (intersectsProp filter).
+    index('project_members_roles_gin').using('gin', t.roles),
+  ],
+);
+
+/**
+ * ProjectWorkflowEvent — append-only event stream. A trigger on INSERT keeps
+ * `projects.step` in sync (raw SQL migration). App code writes events, never
+ * touches `projects.step` directly.
+ */
+export const projectWorkflowEvents = pgTable(
+  'project_workflow_events',
+  {
+    id: text('id').$type<ID<'ProjectWorkflowEvent'>>().primaryKey(),
+    projectId: text('project_id')
+      .$type<ID<'Project'>>()
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    who: text('who')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id),
+    // Nullable for synthetic/initial events; populated for normal transitions.
+    fromStep: projectStepEnum('from_step').$type<ProjectStep>(),
+    toStep: projectStepEnum('to_step').$type<ProjectStep>().notNull(),
+    // Nullable for dynamic transitions (e.g. BackToActive) where there's no
+    // single transition key — they resolve at runtime from history.
+    transitionKey: text('transition_key'),
+    notes: jsonb('notes'), // RichText
+    at: timestamp('at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    // Compound index — every list query is "events for project X, newest first".
+    index('project_workflow_events_project_id_at_idx').on(
+      t.projectId,
+      t.at.desc(),
+    ),
+  ],
+);
+
+export const projectsRelations = relations(projects, ({ one, many }) => ({
+  departmentIdBlock: one(departmentIdBlocks, {
+    fields: [projects.departmentIdBlockId],
+    references: [departmentIdBlocks.id],
+  }),
+  primaryLocation: one(locations, {
+    fields: [projects.primaryLocationId],
+    references: [locations.id],
+    relationName: 'projectPrimaryLocation',
+  }),
+  marketingLocation: one(locations, {
+    fields: [projects.marketingLocationId],
+    references: [locations.id],
+    relationName: 'projectMarketingLocation',
+  }),
+  marketingRegionOverride: one(locations, {
+    fields: [projects.marketingRegionOverrideId],
+    references: [locations.id],
+    relationName: 'projectMarketingRegionOverride',
+  }),
+  fieldRegion: one(fieldRegions, {
+    fields: [projects.fieldRegionId],
+    references: [fieldRegions.id],
+  }),
+  owningOrganization: one(organizations, {
+    fields: [projects.owningOrganizationId],
+    references: [organizations.id],
+  }),
+  members: many(projectMembers),
+  workflowEvents: many(projectWorkflowEvents),
+}));
+
+export const projectMembersRelations = relations(projectMembers, ({ one }) => ({
+  project: one(projects, {
+    fields: [projectMembers.projectId],
+    references: [projects.id],
+  }),
+  user: one(users, {
+    fields: [projectMembers.userId],
+    references: [users.id],
+  }),
+}));
+
+export const projectWorkflowEventsRelations = relations(
+  projectWorkflowEvents,
+  ({ one }) => ({
+    project: one(projects, {
+      fields: [projectWorkflowEvents.projectId],
+      references: [projects.id],
+    }),
+    who: one(users, {
+      fields: [projectWorkflowEvents.who],
+      references: [users.id],
     }),
   }),
 );


### PR DESCRIPTION
### What's in scope

- **Schema** — `partnerships` table + `partnership_agreement_status` pgEnum + migration `0010_add_partnerships.sql`. FKs to projects + partners (NOT NULL, ON DELETE CASCADE). `mou_id` / `agreement_id` deferred FK to files. `mou_start_override` / `mou_end_override` / `types` (partner_type[]) / `financial_reporting_type` / `primary`.
- **Indexes** — partial unique on `(project_id, partner_id)` where `deleted_at IS NULL`; partial unique on `(project_id)` where `primary = true AND deleted_at IS NULL`; b-tree on partner_id, mou_id, agreement_id.
- **PartnershipDrizzleRepository** — full CRUD via DrizzleDtoRepository base + `readManyByProjectAndPartner`, `listAllByProjectId`, `isFirstPartnership`, `isAnyOtherPartnerships`, `removePrimaryFromOtherPartnerships`. List with cross-domain JOIN-sort for `partner.*`.
- **Exports** — `partnershipFilterClauses` + `partnershipSortColumns`.
- **`partnerSortColumns`** — extracted + exported from Partner's previously-inline map; Partner's own `list()` now uses the public export.
- **splitDb wiring** — `postgres:` branch added to `PartnershipModule`.

### Design decisions

- **Partial unique on `(project_id, partner_id)`** — backstops `verifyRelationshipEligibility`'s duplicate check at the DB level.
- **Partial unique on `(project_id)` where `primary = true`** — DB-level enforcement of "at most one primary per project". App's `removePrimaryFromOtherPartnerships` flips the flag transactionally.
- **`partnership_agreement_status` as pgEnum** — three values (`NotAttached`, `AwaitingSignature`, `Signed`); used for both `agreement_status` + `mou_status`.
- **MOU date coalesce in `toDto`** — `row.mouStartOverride ?? project.mou_start` (and same for end).
- **Sensitivity inherited from project** via the relational findMany.

