### PR TITLE
Add link to view current DBL entries and simplify form link styling

### DIFF
--- a/src/components/dbl-upload-notification/emails/dbl-upload.email.tsx
+++ b/src/components/dbl-upload-notification/emails/dbl-upload.email.tsx
@@ -65,6 +65,13 @@ function DBLUploadTemplate(props: Props) {
             Digital Bible Library (DBL).
           </Mjml.Text>
           <Mjml.Text>
+            To see what is currently in the DBL for this project,{' '}
+            <a href="https://seedcompany.domo.com/page/1075686824/kpis/details/947814451">
+              click here
+            </a>
+            . You can filter these entries by FPM and/or Eth Code.
+          </Mjml.Text>
+          <Mjml.Text>
             To move forward, we need a few details from you. Please have your
             field partner complete this short form to provide the necessary
             information indicated below:
@@ -156,7 +163,7 @@ function DBLUploadTemplate(props: Props) {
         <Mjml.Column>
           <Mjml.Text>
             🔗{' '}
-            <a href={config.formUrl} style={{ backgroundColor: 'yellow' }}>
+            <a href={config.formUrl}>
               Seed Company DBL Publication Request Form
             </a>
           </Mjml.Text>


### PR DESCRIPTION
## Reason for this PR
Request to add a link to view current DBL entries and simplifying the styling of the form link.

## Description
Added a link in the DBL upload email template to allow users to view current entries in the Digital Bible Library. Simplified the styling of the form link for better consistency. 

