### PR TITLE
Enhance MarketingPolicy with additional GTL field permissions

### DIFF
--- a/src/components/authorization/policies/by-role/marketing.policy.ts
+++ b/src/components/authorization/policies/by-role/marketing.policy.ts
@@ -1,4 +1,5 @@
 import {
+  isIntern,
   member,
   Policy,
   Role,
@@ -46,7 +47,7 @@ import {
     p.webId.edit,
     p.description.edit,
   ]),
-  r.User.specifically((p) => [
+  r.User.when(isIntern).specifically((p) => [
     p.photo.edit,
     p.displayFirstName.edit,
     p.displayLastName.edit,

--- a/src/components/authorization/policies/by-role/marketing.policy.ts
+++ b/src/components/authorization/policies/by-role/marketing.policy.ts
@@ -41,5 +41,16 @@ import {
     ])
     .children((c) => c.posts.edit),
   r.Language.specifically((p) => p.displayNamePronunciation.edit),
+  r.InternshipEngagement.specifically((p) => [
+    p.marketable.edit,
+    p.webId.edit,
+    p.description.edit,
+  ]),
+  r.User.specifically((p) => [
+    p.photo.edit,
+    p.displayFirstName.edit,
+    p.displayLastName.edit,
+    p.gender.edit,
+  ]),
 ])
 export class MarketingPolicy {}

--- a/src/components/authorization/policies/conditions/index.ts
+++ b/src/components/authorization/policies/conditions/index.ts
@@ -5,3 +5,4 @@ export * from './enum-field.condition';
 export * from './variant.condition';
 export * from './role.condition';
 export * from './self.condition';
+export * from './is-intern.condition';

--- a/src/components/authorization/policies/conditions/is-intern.condition.ts
+++ b/src/components/authorization/policies/conditions/is-intern.condition.ts
@@ -1,0 +1,58 @@
+import { type NonEmptyArray } from '@seedcompany/common';
+import { inspect, type InspectOptionsStylized } from 'util';
+import { type User } from '../../../user/dto';
+import {
+  type AsEdgeQLParams,
+  type Condition,
+  fqnRelativeTo,
+  type IsAllowedParams,
+  MissingContextException,
+} from '../../policy/conditions';
+
+class IsInternCondition<
+  TResourceStatic extends typeof User,
+> implements Condition<TResourceStatic> {
+  isAllowed({ object }: IsAllowedParams<TResourceStatic>) {
+    if (!object) {
+      throw new MissingContextException();
+    }
+    return Boolean(Reflect.get(object, 'isIntern'));
+  }
+
+  asCypherCondition() {
+    return 'exists((node)<-[:intern { active: true }]-(:InternshipEngagement))';
+  }
+
+  asEdgeQLCondition({ namespace }: AsEdgeQLParams<TResourceStatic>) {
+    const InternshipEngagement = fqnRelativeTo(
+      'default::InternshipEngagement',
+      namespace,
+    );
+    return `exists .<intern[is ${InternshipEngagement}]`;
+  }
+
+  // migration-todo: add asDrizzleCondition when User is ported to Postgres —
+  // subquery on internship_engagements where intern_id = users.id.
+
+  union(this: void, conditions: NonEmptyArray<this>) {
+    return conditions[0];
+  }
+
+  intersect(this: void, conditions: NonEmptyArray<this>) {
+    return conditions[0];
+  }
+
+  [inspect.custom](_depth: number, _options: InspectOptionsStylized) {
+    return 'IsIntern';
+  }
+}
+
+/**
+ * The following actions only apply if this User is the `intern` on at least one
+ * InternshipEngagement — i.e. a participant in the GTL (Global Translation
+ * Leader) program.
+ *
+ * Backed by the `isIntern` property on `User`, which the repository hydrate
+ * computes alongside other derived fields.
+ */
+export const isIntern = new IsInternCondition();

--- a/src/components/user/dto/user.dto.ts
+++ b/src/components/user/dto/user.dto.ts
@@ -93,6 +93,10 @@ export class User extends Interfaces {
   gender: SecuredGenderNullable;
 
   readonly photo: Secured<LinkTo<'File'> | null>;
+
+  // Used by MarketingPolicy via the `isIntern` policy condition.
+  // True iff this user is the `intern` on at least one InternshipEngagement.
+  readonly isIntern?: boolean;
 }
 
 @ObjectType({

--- a/src/components/user/user.drizzle.repository.ts
+++ b/src/components/user/user.drizzle.repository.ts
@@ -59,6 +59,9 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
     super(db, users, User);
   }
 
+  // migration-todo: populate `isIntern` on toDto() (subquery against the
+  // internship_engagements table where intern_id = users.id), and add an
+  // `asDrizzleCondition` to IsInternCondition for the DB-level filter.
   override async readMany(
     ids: readonly ID[],
   ): Promise<Array<UnsecuredDto<User>>> {

--- a/src/components/user/user.gel.repository.ts
+++ b/src/components/user/user.gel.repository.ts
@@ -21,6 +21,9 @@ const hydrateSystemAgent = e.shape(e.SystemAgent, (agent) => ({
   __typename: e.str('SystemAgent'),
 }));
 
+// migration-todo: hydrate `isIntern` on the User shape (mirror of the Neo4j
+// hydrate) so MarketingPolicy's `isIntern` condition resolves in-memory.
+// Expression: exists .<intern[is default::InternshipEngagement].
 @Injectable()
 export class UserGelRepository
   extends RepoFor(User, {

--- a/src/components/user/user.repository.ts
+++ b/src/components/user/user.repository.ts
@@ -19,6 +19,7 @@ import {
   createProperty,
   deactivateProperty,
   defineSorters,
+  exists,
   filter,
   FullTextIndex,
   matchProps,
@@ -185,6 +186,7 @@ export class UserRepository extends DtoRepository(User) {
             photo: { id: 'props.photo' },
             roles: 'roles',
             pinned,
+            isIntern,
           }).as('dto'),
         );
   }
@@ -475,6 +477,12 @@ export const userSorters = defineSorters(User, {
       ])
       .return<SortCol>(multiPropsAsSortString('firstName', 'lastName')),
 });
+
+const isIntern = exists([
+  node('node'),
+  relation('in', '', 'intern', ACTIVE),
+  node('', 'InternshipEngagement'),
+]);
 
 const NameIndex = FullTextIndex({
   indexName: 'UserName',


### PR DESCRIPTION
Enhance the MarketingPolicy to include additional permissions for editing GTL fields on InternshipEngagement and User entities. This update allows for users with the Marketing role to manage the data fields specifically used for marketing Global Translation Leaders.
