### PR TITLE
Adds e2e tests against language population updates & `LanguageUpdatedResolver` comments

### DIFF
--- a/src/components/language/language-updated.resolver.ts
+++ b/src/components/language/language-updated.resolver.ts
@@ -11,6 +11,21 @@ export class LanguageUpdatedResolver {
 
       This can be used to determine which fields have been updated, since
       GQL cannot distinguish between omitted fields and explicit nulls.
+
+      Note: these are the *input* fields that were written, not the computed
+      fields they affect. In particular the derived \`Language.population\`
+      field — which is \`populationOverride\`, falling back to the ethnologue
+      population when the override is null — is never listed here.
+
+      To detect a change to the effective \`population\`:
+      - if \`populationOverride\` is in this list, it changed; or
+      - if \`population\` appears in the nested \`ethnologue\` update AND the
+        language's \`populationOverride\` is currently null, the fallback moved.
+
+      The override-is-null check matters: when an override is set, an ethnologue
+      population change is reported (under \`ethnologue\`) but does NOT change the
+      effective population, since the override still wins. If in doubt, just
+      re-read \`Language.population\` — it always reflects the current value.
     `,
   })
   updatedKeys(

--- a/test/language.e2e-spec.ts
+++ b/test/language.e2e-spec.ts
@@ -95,6 +95,72 @@ describe('Language e2e', () => {
     });
   });
 
+  // `Language.population` is a computed field (`populationOverride`, falling
+  // back to the ethnologue population). `updatedKeys` reports *input* fields,
+  // not computed ones, so `population` itself never appears. These tests lock
+  // in the two signals a client uses to detect an effective-population change,
+  // as documented on the `updatedKeys` field.
+  describe('population change signals in updatedKeys', () => {
+    it('changing the override surfaces `populationOverride`', async () => {
+      const language = await createLanguageMinimal(app, {
+        populationOverride: 100,
+      });
+
+      const { updatedKeys } = await updateLanguageReturning(app, {
+        id: language.id,
+        populationOverride: 200,
+      });
+
+      expect(updatedKeys).toContain('populationOverride');
+      // The computed field is never reported directly.
+      expect(updatedKeys).not.toContain('population');
+    });
+
+    it('changing the ethnologue population surfaces it in the nested update', async () => {
+      const language = await createLanguageMinimal(app, {
+        ethnologue: { population: 100 },
+      });
+
+      const { updatedKeys, updated } = await updateLanguageReturning(app, {
+        id: language.id,
+        ethnologue: { population: 200 },
+      });
+
+      // With no override, the fallback path is what moves the effective
+      // population — the client detects it via the nested ethnologue update.
+      expect(updatedKeys).toContain('ethnologue');
+      expect(updated.ethnologue?.population).toBe(200);
+      // The computed field is never reported directly, even via the fallback.
+      expect(updatedKeys).not.toContain('population');
+    });
+
+    it('keeps the override result when a masked ethnologue population changes', async () => {
+      const language = await createLanguageMinimal(app, {
+        populationOverride: 500,
+        ethnologue: { population: 100 },
+      });
+
+      const {
+        updatedKeys,
+        updated,
+        language: result,
+      } = await updateLanguageReturning(app, {
+        id: language.id,
+        ethnologue: { population: 200 },
+      });
+
+      // The ethnologue update is real and reported in the nested update...
+      expect(updatedKeys).toContain('ethnologue');
+      expect(updated.ethnologue?.population).toBe(200);
+      // ...but the override still wins, so the effective population is unchanged.
+      expect(result.population.value).toBe(500);
+      // The override was untouched and the computed field is never reported,
+      // so no effective-population signal leaks into updatedKeys.
+      expect(updatedKeys).not.toContain('populationOverride');
+      expect(updatedKeys).not.toContain('population');
+    });
+  });
+
   // DELETE LANGUAGE
   it('delete language', async () => {
     const language = await createLanguage(app);
@@ -397,3 +463,31 @@ const UpdateLanguageDoc = graphql(
   `,
   [fragments.language],
 );
+
+async function updateLanguageReturning(
+  app: TestApp,
+  input: InputOf<typeof UpdateLanguageReturningDoc>,
+) {
+  const result = await app.graphql.mutate(UpdateLanguageReturningDoc, {
+    input,
+  });
+  return result.updateLanguage;
+}
+const UpdateLanguageReturningDoc = graphql(`
+  mutation updateLanguageReturning($input: UpdateLanguage!) {
+    updateLanguage(input: $input) {
+      updatedKeys
+      updated {
+        populationOverride
+        ethnologue {
+          population
+        }
+      }
+      language {
+        population {
+          value
+        }
+      }
+    }
+  }
+`);


### PR DESCRIPTION
This pull request clarifies how the `updatedKeys` field reports changes to the `Language.population` computed field and adds tests to ensure this behavior is well-documented and locked in. The main focus is on ensuring clients can reliably detect changes to the effective population value, even though it is a computed field.

**Documentation improvements:**

* Added detailed explanation to the `updatedKeys` field in `LanguageUpdatedResolver` to clarify that only input fields are reported, not computed fields like `population`. The documentation now explains how to detect changes to the effective population via `populationOverride` or nested `ethnologue.population` updates.

**Testing enhancements:**

* Added a new test suite to `language.e2e-spec.ts` that verifies the two supported signals for population changes are correctly surfaced in `updatedKeys`:
  * Changing `populationOverride` is reflected in `updatedKeys`.
  * Changing `ethnologue.population` (when no override is set) is reflected in the nested update.
* Introduced a helper mutation and function (`UpdateLanguageReturningDoc` and `updateLanguageReturning`) to support these tests by returning both `updatedKeys` and the updated population values.