### PR TITLE
[pg] Partner Domain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,4 +97,11 @@ jobs:
           NEO4J_VERSION: ${{ matrix.neo4j-version }}
           DATABASE: ${{ matrix.database }}
           POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/cord
-        continue-on-error: ${{ matrix.database == 'gel' }}
+        # neo4j is the production engine → blocking (required to merge).
+        # postgres is dev-only until the cutover, so keep it running for
+        # migration signal but DON'T gate merges on it — a PG failure on a
+        # migrated domain shouldn't block an unrelated PR. (gel is likewise
+        # advisory.) migration-todo: flip postgres back to a required gate
+        # (narrow this to `== 'gel'`) once the migration is further along /
+        # approaching cutover.
+        continue-on-error: ${{ matrix.database != 'neo4j' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
           # full suite.
           - database: postgres
             test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|tool)\."
+              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|tool)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/src/components/organization/organization.drizzle.repository.ts
+++ b/src/components/organization/organization.drizzle.repository.ts
@@ -164,3 +164,21 @@ export const organizationFilterClauses = (
   }
   return conditions;
 };
+
+/**
+ * Sortable columns on `organizations`, keyed by GraphQL sort field. Exported
+ * for cross-domain sort delegation (e.g. Partner's `organization.*` sort joins
+ * to `organizations` and orders by one of these). Counterpart to
+ * `organizationFilterClauses`.
+ *
+ * Neo4j's `organizationSorters` is empty (`defineSorters(Organization, {})`),
+ * relying on its base-node-prop fallback to sort by any scalar Property. The
+ * values here are the meaningful sortable columns on the PG table.
+ */
+export const organizationSortColumns = {
+  name: organizations.name,
+  acronym: organizations.acronym,
+  address: organizations.address,
+  sensitivity: organizations.sensitivity,
+  createdAt: organizations.createdAt,
+} as const;

--- a/src/components/partner/partner.drizzle.repository.ts
+++ b/src/components/partner/partner.drizzle.repository.ts
@@ -136,6 +136,25 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
           'organization',
           'Partner for organization already exists.',
         ),
+      )
+      // Map main-table FK violations to field-level input errors — parity with
+      // the Neo4j repo's relationship-creation errors and the junction catches
+      // in `replaceJunctions`. `department_id_block_id` is internally generated
+      // (see `insertBlock`), so it can't be a bad user input; only the
+      // user-supplied `organization` and `pointOfContact` FKs need mapping.
+      .catch(
+        catchForeignKeyViolation(
+          'partners_organization_id_fkey',
+          'organization',
+          'Organization does not exist',
+        ),
+      )
+      .catch(
+        catchForeignKeyViolation(
+          'partners_point_of_contact_id_fkey',
+          'pointOfContact',
+          'Point of contact (user) does not exist',
+        ),
       );
 
     await this.replaceJunctions(id, {
@@ -164,7 +183,7 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
       ...fields
     } = changes;
 
-    await this.updateColumns(id, {
+    const scalarChanges = {
       pmcEntityCode: fields.pmcEntityCode,
       globalInnovationsClient: fields.globalInnovationsClient,
       active: fields.active,
@@ -179,7 +198,8 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
       approvedPrograms: approvedPrograms && [...approvedPrograms],
       startDate:
         startDate === undefined ? undefined : (startDate?.toISODate() ?? null),
-    });
+    };
+    await this.updateColumns(id, scalarChanges);
 
     await this.replaceJunctions(id, {
       fieldRegions,
@@ -189,6 +209,27 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
 
     if (departmentIdBlock !== undefined) {
       await this.setBlock(id, departmentIdBlock);
+    }
+
+    // `updateColumns` auto-stamps `updatedAt` whenever a scalar/link column
+    // changes, but a junction-list-only update bypasses it (the lists live in
+    // separate tables). Bump `updatedAt` so `modifiedAt` advances, mirroring
+    // Neo4j — `getChanges` injects `modifiedAt` on any real change and
+    // `updateProperties` persists it. Skip when a scalar already changed (to
+    // avoid a redundant write) and when only `departmentIdBlock` changed (which
+    // doesn't bump `modifiedAt` in Neo4j either).
+    const scalarChanged = Object.values(scalarChanges).some(
+      (v) => v !== undefined,
+    );
+    const junctionsChanged =
+      fieldRegions !== undefined ||
+      countries !== undefined ||
+      languagesOfConsulting !== undefined;
+    if (junctionsChanged && !scalarChanged) {
+      await this.db
+        .update(partners)
+        .set({ updatedAt: new Date() })
+        .where(eq(partners.id, id));
     }
 
     return await this.readOne(id);
@@ -289,6 +330,15 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
       total = countResult[0]?.total ?? 0;
       pageIds = joined;
     } else {
+      // Own-table sort. Reject keys we have no column for instead of silently
+      // sorting by `createdAt` (resolveOrderBy's `?? fallback`), mirroring the
+      // `organization.*` NotImplementedException branch above — a bad sort key
+      // should be discoverable, not quietly ignored.
+      if (!(sort in partnerSortColumns)) {
+        throw new NotImplementedException(
+          `Sorting partners by '${sort}' is not supported.`,
+        );
+      }
       const page = await this.paginatedSelect({
         predicate,
         orderBy: resolveOrderBy(input, partnerSortColumns, partners.createdAt),
@@ -546,8 +596,12 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
  */
 export const partnerSortColumns = {
   active: partners.active,
+  address: partners.address,
   createdAt: partners.createdAt,
+  globalInnovationsClient: partners.globalInnovationsClient,
   modifiedAt: partners.updatedAt,
+  pmcEntityCode: partners.pmcEntityCode,
+  sensitivity: partners.sensitivity,
   startDate: partners.startDate,
 } satisfies SortMap<keyof Partner>;
 

--- a/src/components/partner/partner.drizzle.repository.ts
+++ b/src/components/partner/partner.drizzle.repository.ts
@@ -199,7 +199,17 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
       startDate:
         startDate === undefined ? undefined : (startDate?.toISODate() ?? null),
     };
-    await this.updateColumns(id, scalarChanges);
+    await this.updateColumns(id, scalarChanges).catch(
+      // Map the point-of-contact FK violation to a field-level input error —
+      // parity with create(). `pointOfContact` is the only user-supplied live FK
+      // in the update path (`organization` isn't updatable; the language FKs are
+      // still deferred-text with no constraint).
+      catchForeignKeyViolation(
+        'partners_point_of_contact_id_fkey',
+        'pointOfContact',
+        'Point of contact (user) does not exist',
+      ),
+    );
 
     await this.replaceJunctions(id, {
       fieldRegions,

--- a/src/components/partner/partner.drizzle.repository.ts
+++ b/src/components/partner/partner.drizzle.repository.ts
@@ -1,0 +1,637 @@
+import { Injectable } from '@nestjs/common';
+import {
+  and,
+  arrayOverlaps,
+  asc,
+  count,
+  desc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  isNotNull,
+  isNull,
+  lt,
+  lte,
+  type SQL,
+} from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  CalendarDate,
+  DuplicateException,
+  generateId,
+  type ID,
+  NotImplementedException,
+  type PaginatedListType,
+  type UnsecuredDto,
+} from '~/common';
+import {
+  catchForeignKeyViolation,
+  catchUniqueViolation,
+  DrizzleDtoRepository,
+  EMPTY_PAGE,
+  resolveOrderBy,
+  type SortMap,
+  subFilter,
+} from '~/core/drizzle';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
+import {
+  departmentIdBlocks,
+  organizations,
+  partnerCountries,
+  partnerFieldRegions,
+  partnerLanguagesOfConsulting,
+  partners,
+  userOrganizations,
+} from '~/core/drizzle/schema';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import { type FinanceDepartmentIdBlock } from '../finance/department/dto/id-blocks.dto';
+import { type FinanceDepartmentIdBlockInput } from '../finance/department/dto/id-blocks.input';
+import {
+  organizationFilterClauses,
+  organizationSortColumns,
+} from '../organization/organization.drizzle.repository';
+import {
+  type CreatePartner,
+  Partner,
+  type PartnerFilters,
+  type PartnerListInput,
+  type UpdatePartner,
+} from './dto';
+
+/** A partner row plus the related rows the DTO needs (junctions + IdBlock). */
+type PartnerRow = typeof partners.$inferSelect & {
+  fieldRegions: Array<{ fieldRegionId: ID<'FieldRegion'> }>;
+  countries: Array<{ locationId: ID<'Location'> }>;
+  languagesOfConsulting: Array<{ languageId: ID<'Language'> }>;
+  departmentIdBlock: typeof departmentIdBlocks.$inferSelect | null;
+};
+
+@Injectable()
+export class PartnerDrizzleRepository extends DrizzleDtoRepository<
+  typeof partners,
+  Partner
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+  ) {
+    super(db, partners, Partner);
+  }
+
+  async partnerIdByOrg(organizationId: ID): Promise<ID<'Partner'> | null> {
+    const rows = await this.db
+      .select({ id: partners.id })
+      .from(partners)
+      .where(
+        and(
+          eq(partners.organizationId, organizationId),
+          isNull(partners.deletedAt),
+        ),
+      );
+    return rows[0]?.id ?? null;
+  }
+
+  async create(input: CreatePartner): Promise<UnsecuredDto<Partner>> {
+    if (await this.partnerIdByOrg(input.organization)) {
+      throw new DuplicateException(
+        'organization',
+        'Partner for organization already exists.',
+      );
+    }
+
+    const id = await generateId();
+    const departmentIdBlockId = input.departmentIdBlock
+      ? await this.insertBlock(input.departmentIdBlock)
+      : null;
+
+    // The `partnerIdByOrg` pre-check above gives the friendly error in the
+    // common case, but it's TOCTOU-racey — two concurrent creates for the same
+    // org both pass it, then the partial unique index rejects the loser. Catch
+    // that here so the race surfaces the same DuplicateException, not a raw DB
+    // error. (Both inserts run in the mutation's transaction, so the loser's
+    // department_id_block insert rolls back too — no orphan.)
+    await this.db
+      .insert(partners)
+      .values({
+        id,
+        organizationId: input.organization,
+        pointOfContactId: input.pointOfContact ?? null,
+        types: [...(input.types ?? [])],
+        financialReportingTypes: [...(input.financialReportingTypes ?? [])],
+        pmcEntityCode: input.pmcEntityCode ?? null,
+        globalInnovationsClient: input.globalInnovationsClient ?? false,
+        active: input.active ?? false,
+        address: input.address ?? null,
+        languageOfWiderCommunicationId:
+          input.languageOfWiderCommunication ?? null,
+        languageOfReportingId: input.languageOfReporting ?? null,
+        startDate: (input.startDate ?? CalendarDate.local()).toISODate(),
+        approvedPrograms: [...(input.approvedPrograms ?? [])],
+        departmentIdBlockId,
+      })
+      .catch(
+        catchUniqueViolation(
+          'partners_organization_active_unique',
+          'organization',
+          'Partner for organization already exists.',
+        ),
+      );
+
+    await this.replaceJunctions(id, {
+      fieldRegions: input.fieldRegions,
+      countries: input.countries,
+      languagesOfConsulting: input.languagesOfConsulting,
+    });
+
+    return await this.readOne(id);
+  }
+
+  async update(changes: UpdatePartner): Promise<UnsecuredDto<Partner>> {
+    const {
+      id,
+      pointOfContact,
+      languageOfWiderCommunication,
+      languageOfReporting,
+      fieldRegions,
+      countries,
+      languagesOfConsulting,
+      departmentIdBlock,
+      startDate,
+      types,
+      financialReportingTypes,
+      approvedPrograms,
+      ...fields
+    } = changes;
+
+    await this.updateColumns(id, {
+      pmcEntityCode: fields.pmcEntityCode,
+      globalInnovationsClient: fields.globalInnovationsClient,
+      active: fields.active,
+      address: fields.address,
+      pointOfContactId: pointOfContact,
+      languageOfWiderCommunicationId: languageOfWiderCommunication,
+      languageOfReportingId: languageOfReporting,
+      types: types && [...types],
+      financialReportingTypes: financialReportingTypes && [
+        ...financialReportingTypes,
+      ],
+      approvedPrograms: approvedPrograms && [...approvedPrograms],
+      startDate:
+        startDate === undefined ? undefined : (startDate?.toISODate() ?? null),
+    });
+
+    await this.replaceJunctions(id, {
+      fieldRegions,
+      countries,
+      languagesOfConsulting,
+    });
+
+    if (departmentIdBlock !== undefined) {
+      await this.setBlock(id, departmentIdBlock);
+    }
+
+    return await this.readOne(id);
+  }
+
+  /**
+   * Soft-delete. The service still calls `deleteNode(object)` (the Neo4j-base
+   * name; Partner hasn't been converted to the `delete(id)` rename yet), so we
+   * match that here. Soft-delete drops the row from the partial unique index,
+   * freeing the organization for a new Partner.
+   */
+  async deleteNode(objectOrId: ID | { id: ID }): Promise<void> {
+    const id = typeof objectOrId === 'string' ? objectOrId : objectOrId.id;
+    await this.softDelete(id);
+  }
+
+  override async readMany(
+    ids: readonly ID[],
+  ): Promise<Array<UnsecuredDto<Partner>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.partners.findMany({
+      where: (p) => and(inArray(p.id, [...ids]), isNull(p.deletedAt)),
+      with: {
+        fieldRegions: true,
+        countries: true,
+        languagesOfConsulting: true,
+        departmentIdBlock: true,
+      },
+    });
+    return rows.map((row) => this.toDto(row));
+  }
+
+  async list(
+    input: PartnerListInput,
+  ): Promise<PaginatedListType<UnsecuredDto<Partner>>> {
+    const conditions: SQL[] = [isNull(partners.deletedAt)];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+
+    conditions.push(...partnerFilterClauses(this.db, input.filter));
+    const predicate = and(...conditions);
+
+    // Cast to string because `name` / `organization.*` aren't in `keyof
+    // Partner` (the GraphQL enum widens beyond the DTO's declared fields).
+    const sort = input.sort as string;
+
+    // Cross-domain sort: ORDER BY a column on `organizations`. Hand-rolled
+    // INNER JOIN (FK is NOT NULL) — when a second domain needs this same
+    // pattern, extract a shared `paginatedSelectWithJoin` helper (mirror of
+    // the `*FilterClauses` emergence story).
+    //
+    // migration-todo: the orgSortKey→orgSortColumn resolution (and the
+    // parallel INNER JOIN block below) is the abstractable piece. Once a
+    // second consumer (Partnership → `partner.*`, or Project →
+    // `partnership.partner.*`) needs the same dance, extract
+    // `resolveCrossDomainSort(sort, prefix, sortColumns)` +
+    // `paginatedSelectWithJoin`. One data point isn't enough to lock in the
+    // helper's signature yet.
+    const orgSortKey =
+      sort === 'name'
+        ? 'name'
+        : sort.startsWith('organization.')
+          ? sort.slice('organization.'.length)
+          : null;
+    const orgSortColumn =
+      orgSortKey && orgSortKey in organizationSortColumns
+        ? organizationSortColumns[
+            orgSortKey as keyof typeof organizationSortColumns
+          ]
+        : null;
+    if (orgSortKey && !orgSortColumn) {
+      throw new NotImplementedException(
+        `Sorting partners by '${sort}' is not supported — ` +
+          `'${orgSortKey}' is not a known sortable column on \`organizations\`.`,
+      );
+    }
+
+    const direction = input.order === 'ASC' ? asc : desc;
+    let pageIds: ReadonlyArray<{ id: ID<'Partner'> }>;
+    let total: number;
+    if (orgSortColumn) {
+      const offset = (input.page - 1) * input.count;
+      const [countResult, joined] = await Promise.all([
+        this.db.select({ total: count() }).from(partners).where(predicate),
+        this.db
+          .select({ id: partners.id })
+          .from(partners)
+          .innerJoin(
+            organizations,
+            eq(partners.organizationId, organizations.id),
+          )
+          .where(predicate)
+          .orderBy(direction(orgSortColumn), asc(partners.id))
+          .limit(input.count)
+          .offset(offset),
+      ]);
+      total = countResult[0]?.total ?? 0;
+      pageIds = joined;
+    } else {
+      const page = await this.paginatedSelect({
+        predicate,
+        orderBy: resolveOrderBy(input, partnerSortColumns, partners.createdAt),
+        page: input.page,
+        count: input.count,
+      });
+      pageIds = page.rows.map((r) => ({ id: r.id }));
+      total = page.total;
+    }
+    const offset = (input.page - 1) * input.count;
+    const hasMore = offset + pageIds.length < total;
+
+    // Two-phase list (deliberate, don't "optimize" into one big JOIN).
+    //
+    // Phase 1 returns paginated partner IDs (count + page query above run in
+    // parallel via Promise.all). Phase 2 calls `readMany` which fetches every
+    // partner row + its 3 junctions + the IdBlock in a single relational
+    // findMany. Total = 2 parallel + 1 sequential round-trip per list call,
+    // page-size-bounded, regardless of how many junction rows a partner has.
+    //
+    // Why not fold into one query: 3 junctions on each partner would either
+    // cross-product the result (5 fieldRegions × 3 countries × 2 languages =
+    // 30 rows per partner, requiring GROUP BY + array_agg to fold back) or
+    // need LATERAL subqueries — both verbose and harder to maintain than the
+    // small cost of one extra trip.
+    //
+    // Why reuse `readMany`: it's the single source of truth for partner
+    // hydration, shared with the DataLoader's batch reads. Any change to the
+    // DTO shape (new field, new junction, IdBlock shape change) lives in one
+    // place — `list` and the loader benefit automatically.
+    //
+    // Order is preserved by indexing readMany's result by ID and walking
+    // `pageIds` in its paginated order. `flatMap(... ?? [])` is the safe
+    // "skip if missing" — should never fire since the IDs come from the same
+    // query family, but it keeps list() robust if a row vanishes between
+    // phases (e.g. a concurrent soft-delete).
+    const dtos = await this.readMany(pageIds.map((r) => r.id));
+    const byId = new Map(dtos.map((d) => [d.id, d]));
+    return {
+      total,
+      hasMore,
+      items: pageIds.flatMap((r) => byId.get(r.id) ?? []),
+    };
+  }
+
+  // ── helpers ────────────────────────────────────────────────────────────
+
+  private async insertBlock(
+    block: NonNullable<CreatePartner['departmentIdBlock']>,
+  ): Promise<ID> {
+    const blockId = await generateId();
+    await this.db.insert(departmentIdBlocks).values({
+      id: blockId,
+      range: [...block.blocks],
+      programs: [...(block.programs ?? [])],
+    });
+    return blockId;
+  }
+
+  private async setBlock(
+    partnerId: ID,
+    block: FinanceDepartmentIdBlockInput | null,
+  ): Promise<void> {
+    // Lock the partner row for the rest of the surrounding transaction (the
+    // DrizzleTransactionalMutationsInterceptor opens one per mutation). Without
+    // this, two concurrent setBlock calls on the same partner could both read
+    // `blockId = null`, both insert a fresh block, and one's `partners` update
+    // would clobber the other — orphaning a `department_id_blocks` row.
+    const [row] = await this.db
+      .select({ blockId: partners.departmentIdBlockId })
+      .from(partners)
+      .where(eq(partners.id, partnerId))
+      .for('update');
+    const currentBlockId = row?.blockId ?? null;
+
+    if (block === null) {
+      if (currentBlockId) {
+        await this.db
+          .update(partners)
+          .set({ departmentIdBlockId: null })
+          .where(eq(partners.id, partnerId));
+        await this.db
+          .delete(departmentIdBlocks)
+          .where(eq(departmentIdBlocks.id, currentBlockId));
+      }
+      return;
+    }
+
+    const values = {
+      range: [...block.blocks],
+      programs: [...(block.programs ?? [])],
+    };
+    if (currentBlockId) {
+      await this.db
+        .update(departmentIdBlocks)
+        .set(values)
+        .where(eq(departmentIdBlocks.id, currentBlockId));
+    } else {
+      const blockId = await generateId();
+      await this.db
+        .insert(departmentIdBlocks)
+        .values({ id: blockId, ...values });
+      await this.db
+        .update(partners)
+        .set({ departmentIdBlockId: blockId })
+        .where(eq(partners.id, partnerId));
+    }
+  }
+
+  /** Replace each provided junction list wholesale (undefined = leave as-is). */
+  private async replaceJunctions(
+    partnerId: ID,
+    lists: {
+      fieldRegions?: ReadonlyArray<ID<'FieldRegion'>>;
+      countries?: ReadonlyArray<ID<'Location'>>;
+      languagesOfConsulting?: ReadonlyArray<ID<'Language'>>;
+    },
+  ): Promise<void> {
+    // FK-violation catches mirror the Neo4j repo's `e.withField(...)` pattern
+    // so a bad related ID surfaces as `InputException(field=…)` instead of
+    // a generic DB error. Constraint substrings target the right-side FK of
+    // each junction (PG default-names them `<table>_<column>_fkey`).
+    if (lists.fieldRegions) {
+      await this.db
+        .delete(partnerFieldRegions)
+        .where(eq(partnerFieldRegions.partnerId, partnerId));
+      if (lists.fieldRegions.length) {
+        await this.db
+          .insert(partnerFieldRegions)
+          .values(
+            lists.fieldRegions.map((fieldRegionId) => ({
+              partnerId,
+              fieldRegionId,
+            })),
+          )
+          .catch(
+            catchForeignKeyViolation(
+              'field_region_id_fkey',
+              'fieldRegions',
+              'One or more field region IDs do not exist',
+            ),
+          );
+      }
+    }
+    if (lists.countries) {
+      await this.db
+        .delete(partnerCountries)
+        .where(eq(partnerCountries.partnerId, partnerId));
+      if (lists.countries.length) {
+        await this.db
+          .insert(partnerCountries)
+          .values(
+            lists.countries.map((locationId) => ({ partnerId, locationId })),
+          )
+          .catch(
+            catchForeignKeyViolation(
+              'location_id_fkey',
+              'countries',
+              'One or more country (location) IDs do not exist',
+            ),
+          );
+      }
+    }
+    if (lists.languagesOfConsulting) {
+      await this.db
+        .delete(partnerLanguagesOfConsulting)
+        .where(eq(partnerLanguagesOfConsulting.partnerId, partnerId));
+      if (lists.languagesOfConsulting.length) {
+        // Note: `language_id` has no DB-level FK yet (deferred until Language
+        // migrates), so this catch is dormant today. Kept for forward-compat
+        // — when the FK lands it'll start firing usefully without code change.
+        await this.db
+          .insert(partnerLanguagesOfConsulting)
+          .values(
+            lists.languagesOfConsulting.map((languageId) => ({
+              partnerId,
+              languageId,
+            })),
+          )
+          .catch(
+            catchForeignKeyViolation(
+              'language_id_fkey',
+              'languagesOfConsulting',
+              'One or more language IDs do not exist',
+            ),
+          );
+      }
+    }
+  }
+
+  /**
+   * Narrows the base-class param from the flat row to the enriched relational
+   * row (junctions + IdBlock) — TS method-syntax bivariance allows this
+   * override, mirroring how `UserDrizzleRepository.toDto` accepts its
+   * relational shape. `readMany` always passes the enriched row.
+   */
+  protected toDto(row: PartnerRow): UnsecuredDto<Partner> {
+    return {
+      id: row.id,
+      __typename: 'Partner',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      modifiedAt: DateTime.fromJSDate(row.updatedAt),
+      organization: { id: row.organizationId },
+      pointOfContact: row.pointOfContactId
+        ? { id: row.pointOfContactId }
+        : null,
+      types: row.types,
+      financialReportingTypes: row.financialReportingTypes,
+      pmcEntityCode: row.pmcEntityCode,
+      globalInnovationsClient: row.globalInnovationsClient,
+      active: row.active,
+      address: row.address,
+      languageOfWiderCommunication: row.languageOfWiderCommunicationId
+        ? { id: row.languageOfWiderCommunicationId }
+        : null,
+      languageOfReporting: row.languageOfReportingId
+        ? { id: row.languageOfReportingId }
+        : null,
+      fieldRegions: row.fieldRegions.map((j) => ({ id: j.fieldRegionId })),
+      countries: row.countries.map((j) => ({ id: j.locationId })),
+      languagesOfConsulting: row.languagesOfConsulting.map((j) => ({
+        id: j.languageId,
+      })),
+      startDate: row.startDate ? CalendarDate.fromISO(row.startDate) : null,
+      approvedPrograms: row.approvedPrograms,
+      departmentIdBlock:
+        // Defense: a stored block with an empty range is unusable for ID
+        // allocation (and the DTO declares `blocks: NonEmptyArray`, which the
+        // int4multirange customType can't enforce at the type level). Surface
+        // it as absent rather than constructing an invalid DTO that would
+        // crash on the next `blocks[0]` access.
+        row.departmentIdBlock && row.departmentIdBlock.range.length > 0
+          ? {
+              id: row.departmentIdBlock.id,
+              // Cast is sound: `range.length > 0` checked just above.
+              blocks: row.departmentIdBlock
+                .range as FinanceDepartmentIdBlock['blocks'],
+              programs: row.departmentIdBlock.programs,
+            }
+          : null,
+      // migration-todo: derived from project sensitivity; 'High' until Project migrates.
+      sensitivity: row.sensitivity,
+      // migration-todo: pinned is per-requesting-user state, not stored on the
+      // partner row. Re-add the requesterId param + pinnedByRequester batch
+      // when the Pin domain migrates to Postgres.
+      pinned: false,
+    };
+  }
+}
+
+/**
+ * Sortable columns on `partners`. Exported for cross-domain sort delegation
+ * (Partnership's `partner.*` sort joins via this map). Same pattern as
+ * `organizationSortColumns` introduced earlier in this same domain.
+ */
+export const partnerSortColumns = {
+  active: partners.active,
+  createdAt: partners.createdAt,
+  modifiedAt: partners.updatedAt,
+  startDate: partners.startDate,
+} satisfies SortMap<keyof Partner>;
+
+/**
+ * Build the column-level WHERE clauses for a `PartnerFilters` input against the
+ * `partners` table. Reusable from sub-filters in other domains (e.g. Project's
+ * `partnership` filter delegates through Partnership to here).
+ */
+export const partnerFilterClauses = (
+  db: DrizzleDb,
+  filter: PartnerFilters | undefined,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+  if (filter.globalInnovationsClient !== undefined) {
+    conditions.push(
+      eq(partners.globalInnovationsClient, filter.globalInnovationsClient),
+    );
+  }
+  if (filter.types?.length) {
+    conditions.push(arrayOverlaps(partners.types, [...filter.types]));
+  }
+  if (filter.financialReportingTypes?.length) {
+    conditions.push(
+      arrayOverlaps(partners.financialReportingTypes, [
+        ...filter.financialReportingTypes,
+      ]),
+    );
+  }
+  if (filter.organization) {
+    conditions.push(
+      subFilter(
+        db,
+        partners.organizationId,
+        organizations,
+        organizationFilterClauses(db, filter.organization),
+      ),
+    );
+  }
+  if (filter.userId) {
+    const orgSubq = db
+      .select({ id: userOrganizations.organizationId })
+      .from(userOrganizations)
+      .where(eq(userOrganizations.userId, filter.userId));
+    conditions.push(inArray(partners.organizationId, orgSubq));
+  }
+  if (filter.startDate) {
+    const f = filter.startDate;
+    // `partners.start_date` is a PG `date` column → ISO date strings.
+    if (f.after) conditions.push(gt(partners.startDate, f.after.toISODate()));
+    if (f.afterInclusive) {
+      conditions.push(gte(partners.startDate, f.afterInclusive.toISODate()));
+    }
+    if (f.before) conditions.push(lt(partners.startDate, f.before.toISODate()));
+    if (f.beforeInclusive) {
+      conditions.push(lte(partners.startDate, f.beforeInclusive.toISODate()));
+    }
+    if (f.isNull !== undefined) {
+      conditions.push(
+        f.isNull ? isNull(partners.startDate) : isNotNull(partners.startDate),
+      );
+    }
+  }
+  if (filter.createdAt) {
+    const f = filter.createdAt;
+    // `partners.created_at` is a `timestamptz` column → JS `Date`.
+    if (f.after) conditions.push(gt(partners.createdAt, f.after.toJSDate()));
+    if (f.afterInclusive) {
+      conditions.push(gte(partners.createdAt, f.afterInclusive.toJSDate()));
+    }
+    if (f.before) conditions.push(lt(partners.createdAt, f.before.toJSDate()));
+    if (f.beforeInclusive) {
+      conditions.push(lte(partners.createdAt, f.beforeInclusive.toJSDate()));
+    }
+    // `created_at` is NOT NULL — `isNull` is effectively a no-op, but support
+    // it for API parity so callers get consistent semantics.
+    if (f.isNull !== undefined) {
+      conditions.push(
+        f.isNull ? isNull(partners.createdAt) : isNotNull(partners.createdAt),
+      );
+    }
+  }
+  // migration-todo: `filter.pinned` is unsupported until the Pin domain
+  // migrates to Postgres (it needs the per-requester `pinnedFilter` helper).
+  // Re-add the `requesterId` param + the `pinnedFilter` branch then.
+  return conditions;
+};

--- a/src/components/partner/partner.module.ts
+++ b/src/components/partner/partner.module.ts
@@ -8,6 +8,7 @@ import { ProjectModule } from '../project/project.module';
 import { UserModule } from '../user/user.module';
 import { AddPartnerApprovedProgramsMigration } from './migrations/add-partner-approved-programs.migration';
 import { AddPartnerStartDateMigration } from './migrations/add-partner-start-date.migration';
+import { PartnerDrizzleRepository } from './partner.drizzle.repository';
 import { PartnerGelRepository } from './partner.gel.repository';
 import { PartnerLoader } from './partner.loader';
 import { PartnerRepository } from './partner.repository';
@@ -28,6 +29,8 @@ import { PartnerService } from './partner.service';
     PartnerService,
     splitDb(PartnerRepository, {
       gel: PartnerGelRepository,
+      // migration-todo: drop the `as any` + the Neo4j/Gel paths at Phase 7 cutover.
+      postgres: PartnerDrizzleRepository as any,
     }),
     PartnerLoader,
     AddPartnerApprovedProgramsMigration,

--- a/src/core/drizzle/errors.ts
+++ b/src/core/drizzle/errors.ts
@@ -1,21 +1,22 @@
 import { DatabaseError } from 'pg';
-import { DuplicateException } from '~/common';
+import { DuplicateException, InputException } from '~/common';
 import { PgErrorCode } from './pg-error-codes';
 
 /**
- * Resolve the underlying pg `DatabaseError` from a thrown value. drizzle-orm
- * rethrows query-execution failures wrapped in a `DrizzleQueryError`
- * ("Failed query: ...") with the original pg error on `.cause`, so a bare
- * `instanceof DatabaseError` check no longer matches. Unwrap one level so the
- * constraint-mapping helpers keep working. Reuse for any future pg-error
- * matcher (FK violation, check constraint, etc.).
+ * Drizzle wraps driver failures (`DrizzleQueryError: Failed query: ...`) with
+ * the underlying `pg.DatabaseError` on `cause`, so walk the cause chain to
+ * find it. A bare `instanceof DatabaseError` check no longer matches.
  */
-const asDatabaseError = (e: unknown): DatabaseError | undefined =>
-  e instanceof DatabaseError
-    ? e
-    : e instanceof Error && e.cause instanceof DatabaseError
-      ? e.cause
-      : undefined;
+const findDatabaseError = (e: unknown): DatabaseError | undefined => {
+  let current = e;
+  while (current != null) {
+    if (current instanceof DatabaseError) {
+      return current;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return undefined;
+};
 
 /**
  * Promise `.catch()` handler that maps a PostgreSQL unique-constraint
@@ -28,12 +29,42 @@ const asDatabaseError = (e: unknown): DatabaseError | undefined =>
 export const catchUniqueViolation =
   (constraintMatch: string, field: string, message: string) =>
   (e: unknown): never => {
-    const dbError = asDatabaseError(e);
+    const dbError = findDatabaseError(e);
     if (
-      dbError?.code === PgErrorCode.UniqueViolation &&
+      dbError &&
+      dbError.code === PgErrorCode.UniqueViolation &&
       dbError.constraint?.includes(constraintMatch)
     ) {
-      throw new DuplicateException(field, message, dbError);
+      throw new DuplicateException(field, message, e as Error);
+    }
+    throw e as Error;
+  };
+
+/**
+ * Promise `.catch()` handler that maps a PostgreSQL foreign-key violation to
+ * an `InputException` carrying the GraphQL input `field` name — preserves the
+ * "which form field caused this" context that the Neo4j repos achieve via
+ * `e.withField(...)`. `constraintMatch` is checked as a substring against the
+ * failing constraint name (e.g. `'field_region_id_fkey'` to scope the catch
+ * to one side of a junction's two FKs).
+ *
+ * @example
+ *   .catch(catchForeignKeyViolation(
+ *     'field_region_id_fkey',
+ *     'fieldRegions',
+ *     'One or more field region IDs do not exist',
+ *   ))
+ */
+export const catchForeignKeyViolation =
+  (constraintMatch: string, field: string, message: string) =>
+  (e: unknown): never => {
+    const dbError = findDatabaseError(e);
+    if (
+      dbError &&
+      dbError.code === PgErrorCode.ForeignKeyViolation &&
+      dbError.constraint?.includes(constraintMatch)
+    ) {
+      throw new InputException(message, field, e as Error);
     }
     throw e as Error;
   };

--- a/src/core/drizzle/index.ts
+++ b/src/core/drizzle/index.ts
@@ -3,6 +3,7 @@ export * from './drizzle.module';
 export * from './drizzle.service';
 export * from './dto.repository';
 export * from './errors';
+export * from './int4-multirange';
 export * from './like';
 export * from './order-by';
 export * from './pg-error-codes';

--- a/src/core/drizzle/int4-multirange.ts
+++ b/src/core/drizzle/int4-multirange.ts
@@ -1,0 +1,39 @@
+import { customType } from 'drizzle-orm/pg-core';
+
+/** An inclusive integer range `[start, end]`, as the GraphQL API exposes it. */
+export interface IntRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * Postgres native `int4multirange` column, mirroring Gel's `multirange` storage
+ * for `Finance::Department::IdBlock`.
+ *
+ * Gel/PG store ranges half-open (`[lower, upper)`); the app works in inclusive
+ * `{ start, end }` like the `FinanceDepartmentIdBlock` DTO. So an inclusive
+ * `{ start: 11, end: 9999 }` round-trips through the canonical literal
+ * `[11,10000)`. PG always returns int ranges in canonical `[)` form, but we
+ * parse the bound brackets defensively in case that ever changes.
+ */
+export const int4multirange = customType<{
+  data: readonly IntRange[];
+  driverData: string;
+}>({
+  dataType: () => 'int4multirange',
+  toDriver: (ranges) =>
+    ranges.length === 0
+      ? '{}'
+      : `{${ranges.map((r) => `[${r.start},${r.end + 1})`).join(',')}}`,
+  fromDriver: (value) => {
+    const out: IntRange[] = [];
+    for (const m of value.matchAll(/([[(])(\d+),(\d+)([\])])/g)) {
+      const [, lowerBracket, lowerStr, upperStr, upperBracket] = m;
+      // Normalize to inclusive [start, end].
+      const start = Number(lowerStr) + (lowerBracket === '(' ? 1 : 0);
+      const end = Number(upperStr) - (upperBracket === ')' ? 1 : 0);
+      out.push({ start, end });
+    }
+    return out;
+  },
+});

--- a/src/core/drizzle/migrations/0009_add_partners.sql
+++ b/src/core/drizzle/migrations/0009_add_partners.sql
@@ -1,0 +1,91 @@
+-- Migration: add department_id_blocks + partners (+ field-region / country /
+-- language-of-consulting junctions). One live Partner per Organization.
+-- Language FKs are deferred (added when Language migrates).
+
+CREATE TYPE "project_type" AS ENUM ('MomentumTranslation', 'MultiplicationTranslation', 'Internship');
+--> statement-breakpoint
+CREATE TYPE "partner_type" AS ENUM ('Managing', 'Funding', 'Impact', 'Technical', 'Resource');
+--> statement-breakpoint
+CREATE TYPE "financial_reporting_type" AS ENUM ('Funded', 'FieldEngaged', 'Hybrid');
+--> statement-breakpoint
+
+-- Finance::Department::IdBlock — shared by Partner (user-supplied) and later
+-- FundingAccount (computed). `range` mirrors Gel's native int4multirange.
+CREATE TABLE "department_id_blocks" (
+  "id"       text             PRIMARY KEY,
+  "range"    int4multirange   NOT NULL,
+  "programs" "project_type"[] NOT NULL DEFAULT '{}'
+);
+--> statement-breakpoint
+
+CREATE TABLE "partners" (
+  "id"                                  text                         PRIMARY KEY,
+  "organization_id"                     text                         NOT NULL REFERENCES "organizations"("id"),
+  "point_of_contact_id"                 text                         REFERENCES "users"("id"),
+  "types"                               "partner_type"[]             NOT NULL DEFAULT '{}',
+  "financial_reporting_types"           "financial_reporting_type"[] NOT NULL DEFAULT '{}',
+  "pmc_entity_code"                     text,
+  "global_innovations_client"           boolean                      NOT NULL DEFAULT false,
+  "active"                              boolean                      NOT NULL DEFAULT false,
+  "address"                             text,
+  -- migration-todo: deferred FK -> languages("id"); add REFERENCES when Language migrates
+  "language_of_wider_communication_id"  text,
+  "language_of_reporting_id"            text,
+  "start_date"                          date,
+  "approved_programs"                   "project_type"[]             NOT NULL DEFAULT '{}',
+  "department_id_block_id"              text                         REFERENCES "department_id_blocks"("id"),
+  -- migration-todo: derived from project sensitivity; 'High' until Project migrates
+  "sensitivity"                         "sensitivity"                NOT NULL DEFAULT 'High',
+  "created_at"                          timestamptz                  NOT NULL DEFAULT now(),
+  "updated_at"                          timestamptz                  NOT NULL DEFAULT now(),
+  "deleted_at"                          timestamptz
+);
+--> statement-breakpoint
+
+-- One live Partner per Organization (Neo4j enforces this app-side via partnerIdByOrg).
+CREATE UNIQUE INDEX "partners_organization_active_unique"
+  ON "partners" ("organization_id") WHERE "deleted_at" IS NULL;
+--> statement-breakpoint
+-- Full FK index — the partial unique above doesn't cover FK-maintenance scans
+-- (parent org update/delete checks all rows, not just deleted_at IS NULL).
+CREATE INDEX "partners_organization_id_idx"                      ON "partners" ("organization_id");
+--> statement-breakpoint
+CREATE INDEX "partners_point_of_contact_id_idx"                  ON "partners" ("point_of_contact_id");
+--> statement-breakpoint
+CREATE INDEX "partners_department_id_block_id_idx"               ON "partners" ("department_id_block_id");
+--> statement-breakpoint
+-- Indexes on deferred-FK columns — REFERENCES added when Language migrates;
+-- the index goes in now so we avoid CREATE INDEX CONCURRENTLY later.
+CREATE INDEX "partners_language_of_wider_communication_id_idx"   ON "partners" ("language_of_wider_communication_id");
+--> statement-breakpoint
+CREATE INDEX "partners_language_of_reporting_id_idx"             ON "partners" ("language_of_reporting_id");
+--> statement-breakpoint
+
+CREATE TABLE "partner_field_regions" (
+  "partner_id"      text NOT NULL REFERENCES "partners"("id")      ON DELETE CASCADE,
+  "field_region_id" text NOT NULL REFERENCES "field_regions"("id") ON DELETE CASCADE,
+  PRIMARY KEY ("partner_id", "field_region_id")
+);
+--> statement-breakpoint
+CREATE INDEX "partner_field_regions_field_region_id_idx" ON "partner_field_regions" ("field_region_id");
+--> statement-breakpoint
+
+CREATE TABLE "partner_countries" (
+  "partner_id"  text NOT NULL REFERENCES "partners"("id")   ON DELETE CASCADE,
+  "location_id" text NOT NULL REFERENCES "locations"("id")  ON DELETE CASCADE,
+  PRIMARY KEY ("partner_id", "location_id")
+);
+--> statement-breakpoint
+CREATE INDEX "partner_countries_location_id_idx" ON "partner_countries" ("location_id");
+--> statement-breakpoint
+
+CREATE TABLE "partner_languages_of_consulting" (
+  "partner_id"  text NOT NULL REFERENCES "partners"("id") ON DELETE CASCADE,
+  -- migration-todo: deferred FK -> languages("id"); add REFERENCES when Language migrates
+  "language_id" text NOT NULL,
+  PRIMARY KEY ("partner_id", "language_id")
+);
+--> statement-breakpoint
+-- Right-side index for "find partners consulting language X" — the composite
+-- PK only covers the left side (partner_id).
+CREATE INDEX "partner_languages_of_consulting_language_id_idx" ON "partner_languages_of_consulting" ("language_id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1747526400000,
       "tag": "0008_add_files",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1747612800000,
+      "tag": "0009_add_partners",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -4,6 +4,7 @@ import {
   bigint,
   boolean,
   check,
+  date,
   doublePrecision,
   index,
   integer,
@@ -19,8 +20,12 @@ import { type FileNodeType } from '../../../components/file/dto/file-node-type.e
 import { type LocationType } from '../../../components/location/dto/location-type.enum';
 import { type OrganizationReach } from '../../../components/organization/dto/organization-reach.dto';
 import { type OrganizationType } from '../../../components/organization/dto/organization-type.dto';
+import { type PartnerType } from '../../../components/partner/dto/partner-type.enum';
+import { type FinancialReportingType } from '../../../components/partnership/dto/financial-reporting-type.enum';
+import { type ProjectType } from '../../../components/project/dto/project-type.enum';
 import { type ToolKey } from '../../../components/tools/tool/dto/tool-key.enum';
 import { type Gender } from '../../../components/user/dto/gender.enum';
+import { int4multirange } from '../int4-multirange';
 
 export const userStatusEnum = pgEnum('user_status', ['Active', 'Disabled']);
 export const genderEnum = pgEnum('gender', ['Male', 'Female']);
@@ -743,3 +748,220 @@ export const mediaRelations = relations(media, ({ one }) => ({
     references: [fileNodes.id],
   }),
 }));
+
+// ─── Partner ─────────────────────────────────────────────────────────────────
+
+export const projectTypeEnum = pgEnum('project_type', [
+  'MomentumTranslation',
+  'MultiplicationTranslation',
+  'Internship',
+]);
+
+export const partnerTypeEnum = pgEnum('partner_type', [
+  'Managing',
+  'Funding',
+  'Impact',
+  'Technical',
+  'Resource',
+]);
+
+export const financialReportingTypeEnum = pgEnum('financial_reporting_type', [
+  'Funded',
+  'FieldEngaged',
+  'Hybrid',
+]);
+
+/**
+ * Finance::Department::IdBlock — shared by Partner (user-supplied) and, later,
+ * FundingAccount (computed from accountNumber). `range` mirrors Gel's native
+ * `int4multirange`; `programs` are the project types the block applies to.
+ */
+export const departmentIdBlocks = pgTable('department_id_blocks', {
+  id: text('id').$type<ID>().primaryKey(),
+  range: int4multirange('range').notNull(),
+  programs: projectTypeEnum('programs')
+    .array()
+    .$type<readonly ProjectType[]>()
+    .notNull()
+    .default([]),
+});
+
+export const partners = pgTable(
+  'partners',
+  {
+    id: text('id').$type<ID<'Partner'>>().primaryKey(),
+    organizationId: text('organization_id')
+      .$type<ID<'Organization'>>()
+      .notNull()
+      .references(() => organizations.id),
+    pointOfContactId: text('point_of_contact_id')
+      .$type<ID<'User'>>()
+      .references(() => users.id),
+    types: partnerTypeEnum('types')
+      .array()
+      .$type<readonly PartnerType[]>()
+      .notNull()
+      .default([]),
+    financialReportingTypes: financialReportingTypeEnum(
+      'financial_reporting_types',
+    )
+      .array()
+      .$type<readonly FinancialReportingType[]>()
+      .notNull()
+      .default([]),
+    pmcEntityCode: text('pmc_entity_code'),
+    globalInnovationsClient: boolean('global_innovations_client')
+      .notNull()
+      .default(false),
+    active: boolean('active').notNull().default(false),
+    address: text('address'),
+    // migration-todo: deferred FK → languages(id); add REFERENCES when Language
+    // migrates. Plain text until then (same pattern as locations.funding_account_id).
+    languageOfWiderCommunicationId: text(
+      'language_of_wider_communication_id',
+    ).$type<ID<'Language'>>(),
+    // migration-todo: deferred FK → languages(id); add when Language migrates.
+    languageOfReportingId: text('language_of_reporting_id').$type<
+      ID<'Language'>
+    >(),
+    startDate: date('start_date'),
+    approvedPrograms: projectTypeEnum('approved_programs')
+      .array()
+      .$type<readonly ProjectType[]>()
+      .notNull()
+      .default([]),
+    departmentIdBlockId: text('department_id_block_id')
+      .$type<ID>()
+      .references(() => departmentIdBlocks.id),
+    // migration-todo: derived from the project's sensitivity; keep current via
+    // hook once Project/Partnership migrate. Always 'High' until then — same as
+    // organizations.sensitivity.
+    sensitivity: sensitivityEnum('sensitivity').notNull().default('High'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    // One live Partner per Organization (Neo4j enforces via partnerIdByOrg).
+    uniqueIndex('partners_organization_active_unique')
+      .on(t.organizationId)
+      .where(sql`${t.deletedAt} IS NULL`),
+    // Full FK index in addition to the partial unique above: that one only
+    // covers deleted_at IS NULL rows, so PG can't use it for FK-maintenance
+    // scans on organization parent updates/deletes (which check all rows).
+    index('partners_organization_id_idx').on(t.organizationId),
+    index('partners_point_of_contact_id_idx').on(t.pointOfContactId),
+    index('partners_department_id_block_id_idx').on(t.departmentIdBlockId),
+    // Indexes on deferred-FK columns — REFERENCES adds when Language migrates,
+    // but the index goes in now so queries on these columns don't seq-scan and
+    // we avoid `CREATE INDEX CONCURRENTLY` later (memory's "Index every FK").
+    index('partners_language_of_wider_communication_id_idx').on(
+      t.languageOfWiderCommunicationId,
+    ),
+    index('partners_language_of_reporting_id_idx').on(t.languageOfReportingId),
+  ],
+);
+
+export const partnerFieldRegions = pgTable(
+  'partner_field_regions',
+  {
+    partnerId: text('partner_id')
+      .$type<ID<'Partner'>>()
+      .notNull()
+      .references(() => partners.id, { onDelete: 'cascade' }),
+    fieldRegionId: text('field_region_id')
+      .$type<ID<'FieldRegion'>>()
+      .notNull()
+      .references(() => fieldRegions.id, { onDelete: 'cascade' }),
+  },
+  (t) => [
+    primaryKey({ columns: [t.partnerId, t.fieldRegionId] }),
+    index('partner_field_regions_field_region_id_idx').on(t.fieldRegionId),
+  ],
+);
+
+export const partnerCountries = pgTable(
+  'partner_countries',
+  {
+    partnerId: text('partner_id')
+      .$type<ID<'Partner'>>()
+      .notNull()
+      .references(() => partners.id, { onDelete: 'cascade' }),
+    locationId: text('location_id')
+      .$type<ID<'Location'>>()
+      .notNull()
+      .references(() => locations.id, { onDelete: 'cascade' }),
+  },
+  (t) => [
+    primaryKey({ columns: [t.partnerId, t.locationId] }),
+    index('partner_countries_location_id_idx').on(t.locationId),
+  ],
+);
+
+export const partnerLanguagesOfConsulting = pgTable(
+  'partner_languages_of_consulting',
+  {
+    partnerId: text('partner_id')
+      .$type<ID<'Partner'>>()
+      .notNull()
+      .references(() => partners.id, { onDelete: 'cascade' }),
+    // migration-todo: deferred FK → languages(id); add REFERENCES when
+    // Language migrates.
+    languageId: text('language_id').$type<ID<'Language'>>().notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.partnerId, t.languageId] }),
+    // Right-side index for "find partners consulting language X" — the
+    // composite PK only covers the left side (partner_id).
+    index('partner_languages_of_consulting_language_id_idx').on(t.languageId),
+  ],
+);
+
+export const departmentIdBlocksRelations = relations(
+  departmentIdBlocks,
+  () => ({}),
+);
+
+export const partnersRelations = relations(partners, ({ one, many }) => ({
+  departmentIdBlock: one(departmentIdBlocks, {
+    fields: [partners.departmentIdBlockId],
+    references: [departmentIdBlocks.id],
+  }),
+  fieldRegions: many(partnerFieldRegions),
+  countries: many(partnerCountries),
+  languagesOfConsulting: many(partnerLanguagesOfConsulting),
+}));
+
+export const partnerFieldRegionsRelations = relations(
+  partnerFieldRegions,
+  ({ one }) => ({
+    partner: one(partners, {
+      fields: [partnerFieldRegions.partnerId],
+      references: [partners.id],
+    }),
+  }),
+);
+
+export const partnerCountriesRelations = relations(
+  partnerCountries,
+  ({ one }) => ({
+    partner: one(partners, {
+      fields: [partnerCountries.partnerId],
+      references: [partners.id],
+    }),
+  }),
+);
+
+export const partnerLanguagesOfConsultingRelations = relations(
+  partnerLanguagesOfConsulting,
+  ({ one }) => ({
+    partner: one(partners, {
+      fields: [partnerLanguagesOfConsulting.partnerId],
+      references: [partners.id],
+    }),
+  }),
+);


### PR DESCRIPTION
### What
Migrates the **Partner** domain to Postgres (Drizzle) behind `splitDb`. Neo4j/Gel paths untouched; only active under `DATABASE=postgres` (dev-only until cutover).

### Schema — migration `0009_add_partners`
- `partners` + `department_id_blocks` + 3 junctions (`partner_field_regions`, `partner_countries`, `partner_languages_of_consulting`)
- enums `project_type`, `partner_type`, `financial_reporting_type`
- **one live Partner per Organization** via partial unique index `WHERE deleted_at IS NULL`
- custom `int4multirange` type for `department_id_blocks.range` (mirrors Gel's multirange)
- explicit index on every FK column; Language FKs deferred (plain `text` + index) until Language migrates

### Repository
- two-phase `list()` (paginated IDs → `readMany` hydrate); cross-domain sort by `organization.*` via INNER JOIN (`organizationSortColumns` added to the org repo)
- exports `partnerFilterClauses` / `partnerSortColumns` for future consumers (Partnership)
- adds `catchForeignKeyViolation` + `findDatabaseError` cause-chain unwrap to `errors.ts`

### Review fixes (2nd commit)
- reject unknown Partner sort keys (previously silently sorted by `createdAt`)
- map main-table FK violations (`organization` / `pointOfContact`) to field-level input errors
- bump `modifiedAt` on junction-list-only updates (Neo4j parity)
