### PR TITLE
Add Claude Code tooling for the PG migration (skills + PR-review workflow)

### DIFF
--- a/.claude/skills/pr-handoff/SKILL.md
+++ b/.claude/skills/pr-handoff/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: pr-handoff
+description: >-
+  Generate a review handoff / PR description for a migration PR in Rob's
+  preferred format — H3 headers + bullets (no tables), wrapped in a 4-backtick
+  fence for clean paste, with a schema/DDL section. Use when asked for a
+  "handoff", "PR description", "review doc", or "something another AI can review".
+---
+
+# PR handoff / description generator
+
+Produce a review handoff for the current PR. Format rules (non-negotiable):
+- **H3 (`###`) headers + bullets. NO tables.**
+- **Wrap the entire doc in a 4-backtick fence** so it pastes as one markdown block.
+- Include a **schema/DDL section** whenever the PR touches the database.
+
+## Sections (in order)
+1. **Title + one-paragraph context** — what the PR is, where it sits in the
+   stack/migration, its branch + base. For a recut, state that mono
+   (`pg-e2e-harness`) is the already-validated source of truth, so the review
+   standard is "parity with mono + the intentional deltas below."
+2. **Files** — path · one-line purpose · insertions.
+3. **What's added** — the substantive changes, grouped logically.
+4. **Intentional deltas vs mono** — anything that deviates from the source of
+   truth, with the reason (drift fixes, decisions, strips). Tell the reviewer
+   to focus their attention here.
+5. **Validation performed** — the exact gates that passed: type-check, lint,
+   fresh-DB migration apply, smoke tests, dual-engine e2e counts.
+6. **Reviewer cross-checks** — specific things to verify independently
+   (enum↔DTO parity, schema↔SQL, generated-CASE↔app-source, journal idx).
+7. **Explicitly out of scope** — deferred work, so the reviewer doesn't flag it
+   as missing.
+
+## Notes
+- Be precise and concrete (file:line, exact commands, counts) — the reader is
+  another AI that will verify claims.
+- Distinguish what was verified by **testing** vs by **reasoning/reading** —
+  never imply test coverage that doesn't exist.

--- a/.claude/skills/recut-domain/SKILL.md
+++ b/.claude/skills/recut-domain/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: recut-domain
+description: >-
+  Recut/port a single domain from the pg-e2e-harness (mono) branch onto develop
+  as a clean, reviewable Drizzle PR during the Neo4j→Postgres migration. Use
+  whenever starting or continuing a domain port — e.g. "recut Language", "port
+  Engagement to PG", "start the Partnership PR", "cut the next spine link".
+  Covers scoping from mono, the schema/repo/handler PR split, the validation
+  gauntlet, decision-surfacing, the PR handoff, and the accumulated gotchas.
+---
+
+# Recut a domain (Neo4j → Postgres, mono → develop)
+
+## Ground truth
+- **mono (`pg-e2e-harness`) is the source of truth** — every domain is already
+  built and e2e-validated there. A recut = strip/stub/renumber mono's code onto
+  develop, NOT a from-scratch build.
+- **develop** is the target (migrations `0000..N`). Branch off the previous
+  spine link (or develop). Harness + File + admin bootstrap are on develop, so
+  PG e2e boots.
+- Consult migration memory first: `migration_postgres.md`,
+  `project_domain_recut_scope.md`, `migration_timeline.md`, and the `feedback_*`
+  entries for domain-specific scope + accumulated findings. Update it after.
+
+## PR split
+- Simple domain → **1 PR**.
+- Circular/large (Project-class) → **schema PR → repos+auth PR → handlers PR**.
+- Cannot split a pair joined by circular `*FilterClauses` imports (e.g.
+  Project+ProjectMember) — build them together.
+
+## 0. Scope from mono
+`git diff develop pg-e2e-harness -- <domain paths>` — take **mono's** version.
+Catalog: schema block · migration + `_journal` entry · Drizzle repo(s) +
+`<domain>.module.ts` splitDb line · service/repo deltas · handlers · auth
+conditions · tests · CI pattern.
+- **STRIP** (absent on develop): audit `ResourceMutatedHook` firing, pin wiring
+  → replace with stubs + `migration-todo:`.
+- **PULL IN** (introduced by this domain, absent on develop): custom pg types,
+  new error matchers, exported `*FilterClauses` / `*SortColumns`.
+
+## 1. Schema + migration
+- Extract mono's schema block verbatim; add type + `pg-core` imports; **REUSE**
+  existing enums (don't redeclare `sensitivity`, `project_type`, etc.).
+- Copy mono's migration SQL; renumber to develop's next free `NNNN`.
+- Append `_journal.json` (idx, tag); **sequence your entry LAST on conflict** —
+  it's the one recurring per-PR merge conflict.
+- **Index every FK column** with a full b-tree index. A partial-unique leading
+  column does NOT count — it excludes soft-deleted rows, so PG can't use it for
+  FK maintenance / `ON DELETE CASCADE`. (Drift class: `who_idx`,
+  `project_members_project_id_idx`.) Verify **schema ↔ SQL index parity**.
+- **Surface schema decisions to Rob BEFORE locking** — pgEnum vs `text[]`;
+  deferred-text FK vs real FK; any enum value set. Never default silently.
+
+## 2. Repos + auth + service
+- Port the Drizzle repo; strip pin/audit; keep engine-agnostic helpers
+  (`getActualChanges`, `isUnique`) — they live on the base class.
+- `splitDb(<Neo4jRepo>, { postgres: <DrizzleRepo> as any })` + `migration-todo:`
+  on the cast (transition-only; deleted at cutover).
+- Guard unknown sort keys: `if (!(sort in sortColumns)) throw NotImplementedException`
+  — `resolveOrderBy`'s `?? fallback` silently mis-sorts otherwise.
+- Port `asDrizzleCondition` only for conditions the repo actually uses via
+  `filterToReadable`.
+- Tag every `if (config.databaseEngine === ...)` branch and every stub with a
+  `migration-todo:` naming what to drop at cutover.
+
+## 3. Validate — run for EVERY PR
+```bash
+yarn type-check          # exit 0
+yarn lint                # exit 0, zero warnings
+```
+Fresh-DB migration apply (proves the hand-written SQL; `--> statement-breakpoint`
+markers are valid SQL comments so psql applies files directly):
+```bash
+PG=cord-api-v3-postgres-1
+docker exec -e PGPASSWORD=postgres -i $PG psql -U postgres -q \
+  -c "DROP DATABASE IF EXISTS recut_check;" -c "CREATE DATABASE recut_check;"
+cat $(ls src/core/drizzle/migrations/*.sql | sort) | \
+  docker exec -e PGPASSWORD=postgres -i $PG psql -U postgres -d recut_check -v ON_ERROR_STOP=1 -q
+# Smoke-test the un-e2e-able DDL: GENERATED columns, triggers (+ order-independence), typed FKs.
+docker exec -e PGPASSWORD=postgres -i $PG psql -U postgres -q -c "DROP DATABASE recut_check;"
+```
+Dual-engine e2e (Neo4j run is the oracle; PG must match — parity IS the test):
+```bash
+docker compose up -d postgres          # + a redis on 6379 (compose has none)
+DATABASE=postgres POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/cord \
+  POSTGRES_POOL_SIZE=3 yarn test:e2e --runInBand <domain> user tool
+```
+`--runInBand` — parallel froze the machine. Add `<domain>` to the postgres
+`--testPathPatterns` alternation in `.github/workflows/test.yml`.
+
+## 4. Handoff + memory
+- **PR handoff**: H3 + bullets (no tables), wrapped in a 4-backtick fence for
+  paste, with a schema-DDL section. Sections: context + recut method · files ·
+  what's added · intentional deltas vs mono · validation performed · reviewer
+  cross-checks · explicitly out-of-scope (so a reviewer doesn't flag deferred
+  work as missing).
+- **Update migration memory**: resolved decisions + any generalizable finding
+  (new drift class, new gotcha).
+
+## Critical gotchas (full set in `migration_postgres.md`)
+- pg-error matchers must unwrap `.cause` via `asDatabaseError` — drizzle wraps
+  execution errors in `DrizzleQueryError` (bare `instanceof DatabaseError` is
+  always false).
+- Raw `db.execute` returns timestamps as SQL strings → `DateTime.fromSQL`, not
+  `fromISO`; `.toMillis()` before any numeric compare.
+- Partial unique index (`... WHERE deleted_at IS NULL`) for soft-delete uniqueness.
+- Domains with time-travel tests: set `createdAt: DateTime.now().toJSDate()`
+  explicitly — `defaultNow()` uses the DB clock and ignores luxon `Settings.now`.
+- `relations()` is required (even empty) or `db.query.<t>.findMany()` returns
+  `undefined`.
+- Drizzle naming: `predicate` (not `where`) for composed conditions;
+  `updateColumns` (not `updateProperties`) for the base partial-update helper.
+- Migration numbers are branch-local bookkeeping; finalize at land, all
+  discarded at the cutover drizzle-kit genesis squash.

--- a/.claude/workflows/review-pr.js
+++ b/.claude/workflows/review-pr.js
@@ -1,0 +1,124 @@
+export const meta = {
+  name: 'review-pr',
+  description:
+    'Multi-lens adversarial review of a migration PR diff. N lenses find issues in parallel, each finding is adversarially verified (default = refute), then confirmed findings are deduped and synthesized into a report. Args: { diffRef, mono, domain, context }.',
+  phases: [{ title: 'Review' }, { title: 'Verify' }, { title: 'Synthesize' }],
+};
+
+// ── Parameters (override via Workflow args) ──────────────────────────────────
+const diffRef = args?.diffRef ?? 'develop'; // base to diff the PR against
+const mono = args?.mono ?? 'pg-e2e-harness'; // validated source-of-truth branch
+const domain = args?.domain ?? 'the changed domain';
+const extra = args?.context ?? '';
+
+// ── Review lenses (migration-specific; add/remove to scale cost) ─────────────
+const LENSES = [
+  {
+    key: 'schema-sql-parity',
+    focus: `schema/index.ts vs the raw migration .sql — every column, enum, index, constraint, default, GENERATED expression, and trigger must agree between the two, AND generated/CASE expressions + triggers must match their app-side source of truth (e.g. stepToStatus()). Flag schema-ahead-of-SQL and SQL-ahead-of-schema drift.`,
+  },
+  {
+    key: 'fk-index-coverage',
+    focus: `every FK column must have a FULL b-tree index. A partial-unique index leading with the FK column does NOT count (it excludes soft-deleted rows, so it can't back ON DELETE CASCADE). Scrutinize junction + soft-delete tables. Check naming (<table>_<col>_idx) and schema↔SQL index parity.`,
+  },
+  {
+    key: 'auth-correctness',
+    focus: `asDrizzleCondition ports (member/sensitivity/aggregate) — generated SQL must match Neo4j/Gel semantics. Check ref-map arms, enum casts (::role[]), EXISTS subqueries, and that unmigrated domains fail loud (default: throw) instead of emitting SQL against non-existent tables.`,
+  },
+  {
+    key: 'mono-drift-logic',
+    focus: `compare the recut against ${mono} (validated source of truth) via 'git diff ${mono} -- <files>' and 'git show ${mono}:<path>'. Flag behavioral divergence that ISN'T an intended strip (pin/audit) or renumber, plus correctness bugs, missing NotImplementedException guards, untagged engine conditionals, and silent sort-key fallbacks.`,
+  },
+];
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['title', 'file', 'severity', 'description'],
+        properties: {
+          title: { type: 'string' },
+          file: { type: 'string' },
+          line: { type: 'string' },
+          severity: { type: 'string', enum: ['P1', 'P2', 'P3', 'P4'] },
+          description: { type: 'string' },
+          suggestedFix: { type: 'string' },
+        },
+      },
+    },
+  },
+};
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['isReal', 'reasoning'],
+  properties: {
+    isReal: { type: 'boolean' },
+    reasoning: { type: 'string' },
+    confidence: { type: 'string', enum: ['low', 'medium', 'high'] },
+  },
+};
+
+const reviewPrompt = (lens) =>
+  `You are reviewing a Postgres/Drizzle migration PR for the cord-api-v3 Neo4j→PG migration.
+Get the PR diff with: git diff ${diffRef}
+Domain: ${domain}. ${extra}
+
+Review ONLY through this lens:
+${lens.focus}
+
+Read whatever you need (changed files, their ${mono} equivalents via 'git show ${mono}:<path>', the app-side sources referenced). Report concrete findings with file + line. No style nits, nothing outside your lens. If clean, return an empty findings array.`;
+
+const verifyPrompt = (f) =>
+  `Adversarially verify this claimed finding from a migration PR review. Default to REFUTE unless evidence is clear.
+Finding: ${f.severity} — ${f.title}
+File: ${f.file}${f.line ? ':' + f.line : ''}
+Claim: ${f.description}
+
+Read the actual code (git diff ${diffRef}, the file, its ${mono} equivalent). Is this a REAL issue to fix/block, or a false positive / already-handled / intended-strip? Set isReal with reasoning.`;
+
+// ── Review → per-finding adversarial verify (pipelined, no barrier) ──────────
+phase('Review');
+const results = await pipeline(
+  LENSES,
+  (lens) =>
+    agent(reviewPrompt(lens), {
+      label: `review:${lens.key}`,
+      phase: 'Review',
+      schema: FINDINGS_SCHEMA,
+    }),
+  (review, lens) =>
+    parallel(
+      (review?.findings ?? []).map((f) => () =>
+        agent(verifyPrompt(f), {
+          label: `verify:${lens.key}`,
+          phase: 'Verify',
+          schema: VERDICT_SCHEMA,
+        }).then((v) => ({ ...f, lens: lens.key, verdict: v })),
+      ),
+    ),
+);
+
+const all = results.flat().filter(Boolean);
+const confirmed = all.filter((f) => f.verdict?.isReal);
+
+// ── Synthesize ───────────────────────────────────────────────────────────────
+phase('Synthesize');
+const report = await agent(
+  `Synthesize a migration-PR review report from these VERIFIED findings (false positives already removed). Dedupe overlaps across lenses. Group by severity (P1→P4); for each give title, file:line, why it matters, suggested fix. End with a one-line verdict (block / fix-then-merge / clean). H3 + bullets, no tables.
+
+Verified findings (JSON):
+${JSON.stringify(confirmed, null, 2)}
+
+Raw findings before verification: ${all.length}; confirmed: ${confirmed.length}.`,
+  { label: 'synthesize', phase: 'Synthesize' },
+);
+
+return report;


### PR DESCRIPTION
### Summary

- Adds project-scoped **Claude Code** tooling that codifies the Neo4j→Postgres migration workflow so each of the remaining domain recuts runs the same way.
- **No application, runtime, build, or CI impact** — everything lives under `.claude/` and only affects Claude Code sessions. `.claude/settings.local.json` is intentionally excluded.

### What's included

- **`.claude/skills/recut-domain/`** — the per-domain recut procedure: scope from the `pg-e2e-harness` mono branch → schema/repo/handler PR split → the validation gauntlet (type-check, lint, fresh-DB migration apply, smoke-tests for the un-e2e-able DDL like GENERATED columns/triggers, dual-engine e2e) → PR handoff → memory. Includes the accumulated gotchas (index every FK column, unwrap `.cause` for pg-error matchers, partial-unique indexes for soft-delete, explicit `createdAt` for time-travel tests, etc.).
- **`.claude/skills/pr-handoff/`** — the review-handoff / PR-description format (H3 + bullets, DDL section, reviewer cross-checks, explicit out-of-scope).
- **`.claude/workflows/review-pr.js`** — a multi-agent PR review: independent lenses (schema↔SQL parity, FK/index coverage, auth-condition correctness, mono-drift) review the diff in parallel, each finding is adversarially verified (default = refute), then deduped and synthesized into a report.