### PR TITLE
[pg] Project + ProjectMember → Postgres (Drizzle) (PR 2 of 3)

### DIFF
--- a/src/components/authorization/policies/conditions/member.condition.ts
+++ b/src/components/authorization/policies/conditions/member.condition.ts
@@ -1,11 +1,13 @@
 import { type NonEmptyArray } from '@seedcompany/common';
 import { type Query } from 'cypher-query-builder';
+import { type SQL, sql } from 'drizzle-orm';
 import { intersection } from 'lodash';
 import { inspect, type InspectOptionsStylized } from 'util';
-import { type ResourceShape, type Role } from '~/common';
+import { type EnhancedResource, type ResourceShape, type Role } from '~/common';
 import { matchProjectScopedRoles } from '~/core/neo4j/query';
 import { rolesForScope, type ScopedRole, splitScope } from '../../dto/role.dto';
 import {
+  type AsDrizzleParams,
   type AsEdgeQLParams,
   type Condition,
   eqlDoesIntersect,
@@ -34,6 +36,17 @@ class MemberCondition<
 
   asCypherCondition() {
     return 'exists((project)-[:member { active: true }]->(:ProjectMember)-[:user]->(:User { id: $currentUser }))';
+  }
+
+  asDrizzleCondition({ resource, session }: AsDrizzleParams<TResourceStatic>) {
+    const projectIdRef = projectIdRefForResource(resource);
+    return sql`exists (
+      select 1 from "project_members" "pm"
+      where "pm"."project_id" = ${projectIdRef}
+        and "pm"."user_id" = ${session.userId}
+        and "pm"."inactive_at" is null
+        and "pm"."deleted_at" is null
+    )`;
   }
 
   setupEdgeQLContext({
@@ -98,6 +111,24 @@ class MemberWithRolesCondition<
     return `size(apoc.coll.intersection(${CQL_VAR}, ${String(required)})) > 0`;
   }
 
+  asDrizzleCondition({ resource, session }: AsDrizzleParams<TResourceStatic>) {
+    const projectIdRef = projectIdRefForResource(resource);
+    // ARRAY[...]::role[] intersection — true when membership shares at least
+    // one role with the required set. Mirrors `apoc.coll.intersection` >0 in
+    // Cypher and `intersect` in EdgeQL.
+    const requiredRoles = sql.raw(
+      `array[${this.roles.map((r) => `'${r}'`).join(', ')}]::"role"[]`,
+    );
+    return sql`exists (
+      select 1 from "project_members" "pm"
+      where "pm"."project_id" = ${projectIdRef}
+        and "pm"."user_id" = ${session.userId}
+        and "pm"."inactive_at" is null
+        and "pm"."deleted_at" is null
+        and "pm"."roles" && ${requiredRoles}
+    )`;
+  }
+
   asEdgeQLCondition({ namespace }: AsEdgeQLParams<TResourceStatic>) {
     const Role = fqnRelativeTo('default::Role', namespace);
     return eqlDoesIntersect('.membership.roles', this.roles, Role);
@@ -107,6 +138,42 @@ class MemberWithRolesCondition<
     return `Member with ${this.roles.join(', ')}`;
   }
 }
+
+/**
+ * Resolve the SQL fragment that locates the parent project's `id` for the
+ * given resource. Project subtypes (Momentum/Multiplication/Internship)
+ * dereference to `projects.id` directly. Project-scoped child resources
+ * reference their FK column. Add cases here as each domain ports to Postgres.
+ */
+const projectIdRefForResource = (resource: EnhancedResource<any>): SQL => {
+  switch (resource.name) {
+    case 'Project':
+    case 'TranslationProject':
+    case 'MomentumTranslationProject':
+    case 'MultiplicationTranslationProject':
+    case 'InternshipProject':
+      return sql.raw(`"projects"."id"`);
+    case 'ProjectMember':
+      return sql.raw(`"project_members"."project_id"`);
+    // migration-todo: re-add a case per domain as it ports to Postgres
+    // (Partnership/Budget/Engagement/Ceremony/Language/BudgetRecord each
+    // dereference to their `project_id` FK — mono has the arms). Kept stripped
+    // so an unmigrated domain routed through Drizzle fails loud here instead of
+    // emitting SQL against a non-existent table.
+    //
+    // Partner is on develop and member-gated (field-partner.policy
+    // `r.Partner.when(member).read`), but it intentionally has NO arm: its
+    // member check must traverse partner→partnership→project→project_members,
+    // and `partnerships` isn't on develop, so it can't be expressed in SQL yet.
+    // It therefore hits `default: throw` — a pre-existing dev-only gap (a
+    // FieldPartner reading Partners under DATABASE=postgres; the admin-run e2e
+    // never exercises it). Add the Partner arm when Partnership migrates.
+    default:
+      throw new Error(
+        `MemberCondition.asDrizzleCondition: resource ${resource.name} not configured for Drizzle yet; add a case when it migrates.`,
+      );
+  }
+};
 
 /**
  * The following actions only apply if the requester has any "member" scoped roles.

--- a/src/components/authorization/policies/conditions/sensitivity.condition.ts
+++ b/src/components/authorization/policies/conditions/sensitivity.condition.ts
@@ -165,19 +165,19 @@ const sensitivityRefForResource = (
   resource: EnhancedResource<any>,
   access: Sensitivity,
 ): SQL => {
-  const accessLit = sql.raw(`'${access}'::"sensitivity"`);
+  const accessLiteral = sql.raw(`'${access}'::"sensitivity"`);
   switch (resource.name) {
     case 'Project':
     case 'TranslationProject':
     case 'MomentumTranslationProject':
     case 'MultiplicationTranslationProject':
     case 'InternshipProject':
-      return sql`"projects"."sensitivity" <= ${accessLit}`;
+      return sql`"projects"."sensitivity" <= ${accessLiteral}`;
     case 'ProjectMember':
       return sql`(
         select "p"."sensitivity" from "projects" "p"
         where "p"."id" = "project_members"."project_id"
-      ) <= ${accessLit}`;
+      ) <= ${accessLiteral}`;
     // migration-todo: re-add a case per domain as it ports to Postgres
     // (Partnership/Budget/Engagement/Ceremony/Language/BudgetRecord read
     // sensitivity via their parent project; Partner has its own derived column —

--- a/src/components/authorization/policies/conditions/sensitivity.condition.ts
+++ b/src/components/authorization/policies/conditions/sensitivity.condition.ts
@@ -1,9 +1,15 @@
 import { type NonEmptyArray } from '@seedcompany/common';
 import { type Query } from 'cypher-query-builder';
+import { type SQL, sql } from 'drizzle-orm';
 import { inspect, type InspectOptionsStylized } from 'util';
-import { type ResourceShape, Sensitivity } from '~/common';
+import {
+  type EnhancedResource,
+  type ResourceShape,
+  Sensitivity,
+} from '~/common';
 import { matchProjectSens, rankSens } from '~/core/neo4j/query';
 import {
+  type AsDrizzleParams,
   type AsEdgeQLParams,
   type Condition,
   fqnRelativeTo,
@@ -65,6 +71,15 @@ export class SensitivityCondition<
     const ranked = sensitivityRank[this.access];
     const param = query.params.addParam(ranked, 'requiredSens');
     return `${CQL_VAR} <= ${String(param)}`;
+  }
+
+  asDrizzleCondition({ resource }: AsDrizzleParams<TResourceStatic>) {
+    // PG's sensitivity enum is declared in `Low < Medium < High` order, so
+    // `node.sensitivity <= 'access'` is a single-column compare. For Project
+    // subtypes the column lives on the row directly (denormalized). For
+    // Project-scoped children the column is on the parent project; use a
+    // correlated subquery.
+    return sensitivityRefForResource(resource, this.access);
   }
 
   setupEdgeQLContext({
@@ -139,3 +154,38 @@ export const withEffectiveSensitivity = <T extends object>(
     value: sensitivity,
     enumerable: false,
   }) as T & { [EffectiveSensitivity]: Sensitivity };
+
+/**
+ * Build the `sensitivity <= access` SQL fragment for `resource`. Project rows
+ * carry the denormalized column directly; project-scoped child resources read
+ * it via a correlated subquery against `projects`. Add cases here as each
+ * domain ports to Postgres.
+ */
+const sensitivityRefForResource = (
+  resource: EnhancedResource<any>,
+  access: Sensitivity,
+): SQL => {
+  const accessLit = sql.raw(`'${access}'::"sensitivity"`);
+  switch (resource.name) {
+    case 'Project':
+    case 'TranslationProject':
+    case 'MomentumTranslationProject':
+    case 'MultiplicationTranslationProject':
+    case 'InternshipProject':
+      return sql`"projects"."sensitivity" <= ${accessLit}`;
+    case 'ProjectMember':
+      return sql`(
+        select "p"."sensitivity" from "projects" "p"
+        where "p"."id" = "project_members"."project_id"
+      ) <= ${accessLit}`;
+    // migration-todo: re-add a case per domain as it ports to Postgres
+    // (Partnership/Budget/Engagement/Ceremony/Language/BudgetRecord read
+    // sensitivity via their parent project; Partner has its own derived column —
+    // mono has the arms). Kept stripped so an unmigrated domain routed through
+    // Drizzle fails loud here instead of emitting SQL against a missing table.
+    default:
+      throw new Error(
+        `SensitivityCondition.asDrizzleCondition: resource ${resource.name} not configured for Drizzle yet; add a case when it migrates.`,
+      );
+  }
+};

--- a/src/components/authorization/policy/conditions/aggregate.condition.ts
+++ b/src/components/authorization/policy/conditions/aggregate.condition.ts
@@ -5,6 +5,7 @@ import {
   type Nil,
 } from '@seedcompany/common';
 import { type Query } from 'cypher-query-builder';
+import { and, or, type SQL } from 'drizzle-orm';
 import addIndent from 'indent-string';
 import { type Class, type Constructor } from 'type-fest';
 import { inspect, type InspectOptionsStylized } from 'util';
@@ -12,6 +13,7 @@ import { type ResourceShape } from '~/common';
 import { type Policy } from '../policy.factory';
 import type {
   AsCypherParams,
+  AsDrizzleParams,
   AsEdgeQLParams,
   Condition,
   IsAllowedParams,
@@ -62,6 +64,21 @@ export abstract class AggregateConditions<
       .map((c) => c.asCypherCondition(query, other))
       .join(separator);
     return `(${inner})`;
+  }
+
+  asDrizzleCondition(params: AsDrizzleParams<TResourceStatic>): SQL {
+    const inner = this.conditions.map((c) => {
+      if (!c.asDrizzleCondition) {
+        throw new Error(
+          `Condition ${c.constructor.name} has not been ported to Drizzle — implement asDrizzleCondition`,
+        );
+      }
+      return c.asDrizzleCondition(params);
+    });
+    const combined =
+      this instanceof AndConditions ? and(...inner) : or(...inner);
+    // and()/or() only return undefined for zero inputs; from() guarantees 1+.
+    return combined!;
   }
 
   setupEdgeQLContext(params: AsEdgeQLParams<TResourceStatic>) {

--- a/src/components/authorization/policy/conditions/aggregate.condition.ts
+++ b/src/components/authorization/policy/conditions/aggregate.condition.ts
@@ -61,19 +61,19 @@ export abstract class AggregateConditions<
     }
     const separator = this instanceof AndConditions ? ' AND ' : ' OR ';
     const inner = this.conditions
-      .map((c) => c.asCypherCondition(query, other))
+      .map((condition) => condition.asCypherCondition(query, other))
       .join(separator);
     return `(${inner})`;
   }
 
   asDrizzleCondition(params: AsDrizzleParams<TResourceStatic>): SQL {
-    const inner = this.conditions.map((c) => {
-      if (!c.asDrizzleCondition) {
+    const inner = this.conditions.map((condition) => {
+      if (!condition.asDrizzleCondition) {
         throw new Error(
-          `Condition ${c.constructor.name} has not been ported to Drizzle — implement asDrizzleCondition`,
+          `Condition ${condition.constructor.name} has not been ported to Drizzle — implement asDrizzleCondition`,
         );
       }
-      return c.asDrizzleCondition(params);
+      return condition.asDrizzleCondition(params);
     });
     const combined =
       this instanceof AndConditions ? and(...inner) : or(...inner);
@@ -95,16 +95,16 @@ export abstract class AggregateConditions<
     }
     const separator = this instanceof AndConditions ? '\nand ' : '\nor ';
     const inner = this.conditions
-      .map((c) => c.asEdgeQLCondition(params))
+      .map((condition) => condition.asEdgeQLCondition(params))
       .join(separator);
     return `(${addIndent('\n' + inner, 2)}\n)`;
   }
 
   [inspect.custom](_depth: number, _options: InspectOptionsStylized) {
     const name = this instanceof AndConditions ? ' AND ' : ' OR ';
-    const asStrings = this.conditions.map((c) => {
-      const l = inspect(c);
-      return c instanceof AggregateConditions ? `(${l})` : l;
+    const asStrings = this.conditions.map((condition) => {
+      const label = inspect(condition);
+      return condition instanceof AggregateConditions ? `(${label})` : label;
     });
     return [...new Set(asStrings)].join(name);
   }
@@ -156,8 +156,8 @@ export class OrConditions<
       throw new Error('OrConditions requires at least one condition');
     }
 
-    const flattened = conditions.flatMap((c) =>
-      c instanceof OrConditions ? c.conditions : c,
+    const flattened = conditions.flatMap((condition) =>
+      condition instanceof OrConditions ? condition.conditions : condition,
     );
 
     if (!optimize) {

--- a/src/components/field-region/field-region.drizzle.repository.ts
+++ b/src/components/field-region/field-region.drizzle.repository.ts
@@ -130,6 +130,15 @@ export class FieldRegionDrizzleRepository extends DrizzleDtoRepository<
 }
 
 /**
+ * Sortable columns on `field_regions`. Exported for cross-domain sort
+ * (Project sorts by `fieldRegion.*`), parallel to `*FilterClauses`.
+ */
+export const fieldRegionSortColumns = {
+  name: fieldRegions.name,
+  createdAt: fieldRegions.createdAt,
+} satisfies SortMap<keyof FieldRegion>;
+
+/**
  * Build the column-level WHERE clauses for a `FieldRegionFilters` input against
  * the `field_regions` table. Reusable from sub-filters in other domains
  * (e.g. Project's `fieldRegion` filter).

--- a/src/components/location/location.drizzle.repository.ts
+++ b/src/components/location/location.drizzle.repository.ts
@@ -201,6 +201,17 @@ export class LocationDrizzleRepository extends DrizzleDtoRepository<
 }
 
 /**
+ * Sortable columns on `locations`. Exported for cross-domain sort
+ * (Project sorts by `primaryLocation.*`), parallel to `*FilterClauses`.
+ */
+export const locationSortColumns = {
+  name: locations.name,
+  type: locations.type,
+  isoAlpha3: locations.isoAlpha3,
+  createdAt: locations.createdAt,
+} satisfies SortMap<keyof Location>;
+
+/**
  * Build the column-level WHERE clauses for a `LocationFilters` input against
  * the `locations` table. Reusable from sub-filters in other domains
  * (e.g. Project's `location` filter).

--- a/src/components/project/project-member/membership-scope.ts
+++ b/src/components/project/project-member/membership-scope.ts
@@ -1,0 +1,45 @@
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { type ID } from '~/common';
+import { type DrizzleDb } from '~/core/drizzle/drizzle.service';
+import { projectMembers } from '~/core/drizzle/schema';
+import {
+  rolesForScope,
+  type ScopedRole,
+} from '../../authorization/dto/role.dto';
+
+/**
+ * The requesting user's scoped roles per project — `member` policy conditions
+ * read these off each DTO's `scope` property (mirror of Neo4j's
+ * matchProjectScopedRoles): the `'member:true'` marker plus the membership
+ * roles project-scoped. Every project-scoped domain's drizzle repo attaches
+ * this in its read paths.
+ */
+export const requesterScopeByProject = async (
+  db: DrizzleDb,
+  userId: ID<'User'>,
+  projectIds: ReadonlyArray<ID<'Project'>>,
+): Promise<Map<ID<'Project'>, ScopedRole[]>> => {
+  if (projectIds.length === 0) {
+    return new Map();
+  }
+  const memberships = await db
+    .select({
+      projectId: projectMembers.projectId,
+      roles: projectMembers.roles,
+    })
+    .from(projectMembers)
+    .where(
+      and(
+        eq(projectMembers.userId, userId),
+        inArray(projectMembers.projectId, [...new Set(projectIds)]),
+        isNull(projectMembers.inactiveAt),
+        isNull(projectMembers.deletedAt),
+      ),
+    );
+  return new Map(
+    memberships.map((m) => [
+      m.projectId,
+      ['member:true' as const, ...m.roles.map(rolesForScope('project'))],
+    ]),
+  );
+};

--- a/src/components/project/project-member/project-member.drizzle.repository.ts
+++ b/src/components/project/project-member/project-member.drizzle.repository.ts
@@ -1,0 +1,502 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  and,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  DuplicateException,
+  generateId,
+  type ID,
+  isIdLike,
+  NotFoundException,
+  NotImplementedException,
+  type PaginatedListType,
+  type Role,
+  ServerException,
+  type UnsecuredDto,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import {
+  DrizzleDtoRepository,
+  EMPTY_PAGE,
+  resolveOrderBy,
+  type SortMap,
+} from '~/core/drizzle';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
+import {
+  projectMembers,
+  projects,
+  type userGlobalRoles,
+  users,
+} from '~/core/drizzle/schema';
+import { type ScopedRole } from '../../authorization/dto/role.dto';
+import { PolicyExecutor } from '../../authorization/policy/executor/policy-executor';
+import {
+  type UserDrizzleRepository,
+  userFilterClauses,
+} from '../../user/user.drizzle.repository';
+import { UserRepository } from '../../user/user.repository';
+import { projectFilterClauses } from '../project.drizzle.repository';
+import {
+  type CreateProjectMember,
+  ProjectMember,
+  type ProjectMemberFilters,
+  type ProjectMemberListInput,
+  type UpdateProjectMember,
+} from './dto';
+import { type MembershipByProjectAndUserInput } from './membership-by-project-and-user.loader';
+import { requesterScopeByProject } from './membership-scope';
+
+/**
+ * Relational findMany row shape: the member row plus its parent project's
+ * (`id`, `type`, `sensitivity`) and the full user with global roles. Drives
+ * `toDto` — Project's sensitivity is inherited onto every ProjectMember DTO,
+ * matching the Neo4j repo's `matchPropsAndProjectSensAndScopedRoles()` overlay.
+ */
+type ProjectMemberRow = typeof projectMembers.$inferSelect & {
+  project: Pick<
+    typeof projects.$inferSelect,
+    'id' | 'type' | 'sensitivity'
+  > | null;
+  user: typeof users.$inferSelect & {
+    globalRoles?: Array<typeof userGlobalRoles.$inferSelect>;
+  };
+};
+
+@Injectable()
+export class ProjectMemberDrizzleRepository extends DrizzleDtoRepository<
+  typeof projectMembers,
+  ProjectMember
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+    private readonly identity: Identity,
+    // Resolves to the Drizzle implementation under DATABASE=postgres, which
+    // is the only engine this repository is instantiated for.
+    @Inject(UserRepository) private readonly userRepo: UserDrizzleRepository,
+  ) {
+    super(db, projectMembers, ProjectMember);
+  }
+
+  override async readMany(
+    ids: readonly ID[],
+  ): Promise<Array<UnsecuredDto<ProjectMember>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.projectMembers.findMany({
+      where: (m) => and(inArray(m.id, [...ids]), isNull(m.deletedAt)),
+      with: {
+        project: { columns: { id: true, type: true, sensitivity: true } },
+        user: { with: { globalRoles: true } },
+      },
+    });
+    const scopeByProject = await requesterScopeByProject(
+      this.db,
+      this.identity.current.userId,
+      rows.map((r) => r.projectId),
+    );
+    return (rows as ProjectMemberRow[]).map((row) =>
+      this.toDto(row, scopeByProject.get(row.projectId) ?? []),
+    );
+  }
+
+  async create(
+    input: CreateProjectMember,
+  ): Promise<UnsecuredDto<ProjectMember>> {
+    const projectId = isIdLike(input.project)
+      ? input.project
+      : input.project.id;
+    await this.verifyRelationshipEligibility(projectId, input.user);
+
+    const id = await generateId<ID<'ProjectMember'>>();
+    await this.db.insert(projectMembers).values({
+      id,
+      projectId,
+      userId: input.user,
+      roles: [...(input.roles ?? [])],
+      inactiveAt: input.inactiveAt ? input.inactiveAt.toJSDate() : null,
+    });
+    return await this.readOne(id);
+  }
+
+  async update(
+    input: UpdateProjectMember,
+  ): Promise<UnsecuredDto<ProjectMember>> {
+    const { id, ...changes } = input;
+    await this.updateColumns(id, {
+      ...(changes.roles !== undefined && { roles: [...changes.roles] }),
+      ...(changes.inactiveAt !== undefined && {
+        inactiveAt: changes.inactiveAt ? changes.inactiveAt.toJSDate() : null,
+      }),
+    });
+    return await this.readOne(id);
+  }
+
+  async delete(id: ID): Promise<void> {
+    await this.softDelete(id);
+  }
+
+  async list(
+    input: ProjectMemberListInput,
+  ): Promise<PaginatedListType<UnsecuredDto<ProjectMember>>> {
+    const conditions: SQL[] = [isNull(projectMembers.deletedAt)];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+    conditions.push(...projectMemberFilterClauses(this.db, input.filter));
+
+    const sortColumns = {
+      createdAt: projectMembers.createdAt,
+      modifiedAt: projectMembers.updatedAt,
+    } satisfies SortMap<keyof ProjectMember>;
+
+    // Reject unknown/unmapped sort keys instead of silently falling back to
+    // createdAt (resolveOrderBy's `map[sort] ?? fallback`). Partner-parity.
+    const sort = input.sort as string;
+    if (!(sort in sortColumns)) {
+      throw new NotImplementedException(
+        `Sorting project members by '${sort}' is not supported.`,
+      );
+    }
+
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: and(...conditions),
+      orderBy: resolveOrderBy(input, sortColumns, projectMembers.createdAt),
+      page: input.page,
+      count: input.count,
+    });
+    if (rows.length === 0) return { total, items: [], hasMore };
+
+    // Two-phase: paged IDs → readMany picks up project + user relations.
+    const items = await this.readMany(rows.map((r) => r.id));
+    // Preserve the ordering produced by paginatedSelect.
+    const byId = new Map(items.map((i) => [i.id, i]));
+    return {
+      total,
+      items: rows.map((r) => byId.get(r.id)!).filter(Boolean),
+      hasMore,
+    };
+  }
+
+  /**
+   * Resolve memberships keyed by `(project, user)` pairs — drives the
+   * `Project.membership` resolver, which surfaces the current user's
+   * membership row + roles + inactiveAt. Read permission is assumed (only
+   * called for the requesting user's own row).
+   */
+  async readManyByProjectAndUser(
+    input: readonly MembershipByProjectAndUserInput[],
+  ): Promise<Array<UnsecuredDto<ProjectMember>>> {
+    if (input.length === 0) return [];
+    const pairs = input.map(
+      (i) =>
+        and(
+          eq(projectMembers.projectId, i.project),
+          eq(projectMembers.userId, i.user),
+        )!,
+    );
+    const rows = await this.db.query.projectMembers.findMany({
+      where: (m) =>
+        and(
+          isNull(m.deletedAt),
+          // OR of the (project, user) pairs.
+          sql`(${sql.join(pairs, sql` OR `)})`,
+        ),
+      with: {
+        project: { columns: { id: true, type: true, sensitivity: true } },
+        user: { with: { globalRoles: true } },
+      },
+    });
+    const scopeByProject = await requesterScopeByProject(
+      this.db,
+      this.identity.current.userId,
+      rows.map((r) => r.projectId),
+    );
+    return (rows as ProjectMemberRow[]).map((row) =>
+      this.toDto(row, scopeByProject.get(row.projectId) ?? []),
+    );
+  }
+
+  /**
+   * Project-scoped notification recipients — active members on `project`,
+   * optionally filtered by `roles`. Returns minimal user + email pairs (skips
+   * the full hydrate). Used by notifier hooks.
+   */
+  async listAsNotifiers(
+    projectId: ID<'Project'>,
+    roles?: readonly Role[],
+  ): Promise<Array<{ id: ID; email: string | null }>> {
+    const conditions: SQL[] = [
+      eq(projectMembers.projectId, projectId),
+      isNull(projectMembers.inactiveAt),
+      isNull(projectMembers.deletedAt),
+    ];
+    if (roles?.length) {
+      const rolesLit = sql.raw(
+        `array[${roles.map((r) => `'${r}'`).join(', ')}]::"role"[]`,
+      );
+      conditions.push(sql`${projectMembers.roles} && ${rolesLit}`);
+    }
+    return await this.db
+      .select({ id: users.id, email: users.email })
+      .from(projectMembers)
+      .innerJoin(users, eq(users.id, projectMembers.userId))
+      .where(and(...conditions, isNull(users.deletedAt)));
+  }
+
+  /**
+   * Auto-add `user` to `project` with `role` only if no one currently holds
+   * that role on the project. If the user already has any active membership
+   * we union the role onto their existing row; otherwise we create a new row.
+   * Mirrors the Neo4j upsertMember + filter-by-no-existing-role flow.
+   */
+  async addDefaultForRole(
+    role: Role,
+    projectId: ID<'Project'>,
+    userId: ID<'User'>,
+  ): Promise<void> {
+    const roleLit = sql.raw(`array['${role}']::"role"[]`);
+    // Cheap guard: bail if any active member already holds the role.
+    const existing = await this.db
+      .select({ n: sql<number>`1` })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.projectId, projectId),
+          isNull(projectMembers.inactiveAt),
+          isNull(projectMembers.deletedAt),
+          sql`${projectMembers.roles} && ${roleLit}`,
+        ),
+      )
+      .limit(1);
+    if (existing.length > 0) return;
+
+    await this.upsertMemberRole(projectId, userId, role);
+  }
+
+  /**
+   * Bulk-replace director-style memberships when a user leaves a role. Finds
+   * every active project where `oldDirector` holds `role` (optionally scoped
+   * to `region`), removes the role (or marks the membership inactive if it
+   * was the only role), and adds `newDirector` with that role. Used by
+   * field-region director changes.
+   */
+  async replaceMembershipsOnOpenProjects(
+    oldDirector: ID<'User'>,
+    newDirector: ID<'User'>,
+    role: Role,
+    region?: ID<'FieldRegion'>,
+  ): Promise<{ projects: readonly ID[]; timestampId: DateTime }> {
+    const now = DateTime.now();
+    const roleLit = sql.raw(`array['${role}']::"role"[]`);
+
+    // Affected projects: old director is an active member with `role`, project
+    // is in an open status (InDevelopment | Active), optionally on `region`.
+    const conditions: SQL[] = [
+      eq(projectMembers.userId, oldDirector),
+      isNull(projectMembers.inactiveAt),
+      isNull(projectMembers.deletedAt),
+      sql`${projectMembers.roles} && ${roleLit}`,
+      inArray(projects.status, ['InDevelopment', 'Active']),
+      isNull(projects.deletedAt),
+    ];
+    if (region) conditions.push(eq(projects.fieldRegionId, region));
+
+    const targets = await this.db
+      .select({
+        memberId: projectMembers.id,
+        projectId: projectMembers.projectId,
+        roles: projectMembers.roles,
+      })
+      .from(projectMembers)
+      .innerJoin(projects, eq(projects.id, projectMembers.projectId))
+      .where(and(...conditions));
+
+    const affectedProjects: ID[] = [];
+    for (const t of targets) {
+      // Either remove the role (multi-role member) or mark inactive (sole role).
+      if (t.roles.length > 1) {
+        const remaining = t.roles.filter((r) => r !== role);
+        await this.db
+          .update(projectMembers)
+          .set({ roles: remaining, updatedAt: now.toJSDate() })
+          .where(eq(projectMembers.id, t.memberId));
+      } else {
+        await this.db
+          .update(projectMembers)
+          .set({ inactiveAt: now.toJSDate(), updatedAt: now.toJSDate() })
+          .where(eq(projectMembers.id, t.memberId));
+      }
+      await this.upsertMemberRole(t.projectId, newDirector, role);
+      affectedProjects.push(t.projectId);
+    }
+    return { projects: affectedProjects, timestampId: now };
+  }
+
+  /**
+   * Add `role` to the active membership of `(projectId, userId)`; create the
+   * row if it doesn't exist. Re-activates a soft-inactive row in the same
+   * project + user pair. Used by addDefaultForRole and the role-replacement
+   * flow.
+   */
+  private async upsertMemberRole(
+    projectId: ID<'Project'>,
+    userId: ID<'User'>,
+    role: Role,
+  ): Promise<void> {
+    const existing = await this.db
+      .select({ id: projectMembers.id, roles: projectMembers.roles })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.projectId, projectId),
+          eq(projectMembers.userId, userId),
+          isNull(projectMembers.deletedAt),
+        ),
+      )
+      .limit(1);
+    const row = existing[0];
+    if (row) {
+      const next = row.roles.includes(role) ? row.roles : [...row.roles, role];
+      await this.db
+        .update(projectMembers)
+        .set({
+          roles: next,
+          inactiveAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(projectMembers.id, row.id));
+      return;
+    }
+    const id = await generateId<ID<'ProjectMember'>>();
+    await this.db.insert(projectMembers).values({
+      id,
+      projectId,
+      userId,
+      roles: [role],
+    });
+  }
+
+  private async verifyRelationshipEligibility(
+    projectId: ID,
+    userId: ID,
+  ): Promise<void> {
+    const [project, user, existing] = await Promise.all([
+      this.db
+        .select({ id: projects.id })
+        .from(projects)
+        .where(and(eq(projects.id, projectId), isNull(projects.deletedAt)))
+        .limit(1),
+      this.db
+        .select({ id: users.id })
+        .from(users)
+        .where(and(eq(users.id, userId), isNull(users.deletedAt)))
+        .limit(1),
+      this.db
+        .select({ id: projectMembers.id })
+        .from(projectMembers)
+        .where(
+          and(
+            eq(projectMembers.projectId, projectId),
+            eq(projectMembers.userId, userId),
+            isNull(projectMembers.deletedAt),
+          ),
+        )
+        .limit(1),
+    ]);
+    if (!project[0]) {
+      throw new NotFoundException('Could not find project', 'project');
+    }
+    if (!user[0]) {
+      throw new NotFoundException('Could not find person', 'user');
+    }
+    if (existing[0]) {
+      throw new DuplicateException(
+        'user',
+        'Person is already a member of this project',
+      );
+    }
+  }
+
+  protected toDto(
+    row: ProjectMemberRow,
+    scope: ScopedRole[] = [],
+  ): UnsecuredDto<ProjectMember> {
+    if (!row.project) {
+      // Schema FK is NOT NULL → can't happen, but the relational findMany
+      // makes it nullable in the type. Loud failure beats silent NaN.
+      throw new ServerException(
+        `ProjectMember ${row.id} has no parent project row — FK invariant violated`,
+      );
+    }
+    return {
+      id: row.id,
+      __typename: 'ProjectMember',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      modifiedAt: DateTime.fromJSDate(row.updatedAt),
+      project: { id: row.project.id, type: row.project.type },
+      user: this.userRepo.mapRowToDto(row.user),
+      roles: [...row.roles],
+      sensitivity: row.project.sensitivity,
+      inactiveAt: row.inactiveAt ? DateTime.fromJSDate(row.inactiveAt) : null,
+      scope,
+    };
+  }
+}
+
+/**
+ * Build the column-level WHERE clauses for a `ProjectMemberFilters` input
+ * against `project_members`. Reusable from sub-filters in other domains
+ * (Project's `members`/`membership` sub-filter calls this, completing the
+ * circular dep between project and project_member filters).
+ */
+export const projectMemberFilterClauses = (
+  db: DrizzleDb,
+  filter: ProjectMemberFilters | undefined,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+  if (filter.roles?.length) {
+    const rolesLit = sql.raw(
+      `array[${filter.roles.map((r) => `'${r}'`).join(', ')}]::"role"[]`,
+    );
+    conditions.push(sql`${projectMembers.roles} && ${rolesLit}`);
+  }
+  if (filter.active === true) {
+    conditions.push(isNull(projectMembers.inactiveAt));
+  } else if (filter.active === false) {
+    conditions.push(isNotNull(projectMembers.inactiveAt));
+  }
+  if (filter.user) {
+    const sub = db
+      .selectDistinct({ id: users.id })
+      .from(users)
+      .where(
+        and(isNull(users.deletedAt), ...userFilterClauses(db, filter.user)),
+      );
+    conditions.push(inArray(projectMembers.userId, sub));
+  }
+  if (filter.project) {
+    // Mirror of projectFilterClauses' `members`/`membership` sub-filter:
+    // restrict to memberships whose parent project matches `filter.project`.
+    // The circular import (project.drizzle.repository ↔ this file) is benign
+    // because each export is a function reference resolved at call time.
+    const sub = db
+      .selectDistinct({ id: projects.id })
+      .from(projects)
+      .where(
+        and(
+          isNull(projects.deletedAt),
+          ...projectFilterClauses(db, filter.project),
+        ),
+      );
+    conditions.push(inArray(projectMembers.projectId, sub));
+  }
+  return conditions;
+};

--- a/src/components/project/project-member/project-member.drizzle.repository.ts
+++ b/src/components/project/project-member/project-member.drizzle.repository.ts
@@ -238,10 +238,10 @@ export class ProjectMemberDrizzleRepository extends DrizzleDtoRepository<
       isNull(projectMembers.deletedAt),
     ];
     if (roles?.length) {
-      const rolesLit = sql.raw(
+      const rolesLiteral = sql.raw(
         `array[${roles.map((r) => `'${r}'`).join(', ')}]::"role"[]`,
       );
-      conditions.push(sql`${projectMembers.roles} && ${rolesLit}`);
+      conditions.push(sql`${projectMembers.roles} && ${rolesLiteral}`);
     }
     return await this.db
       .select({ id: users.id, email: users.email })
@@ -261,7 +261,7 @@ export class ProjectMemberDrizzleRepository extends DrizzleDtoRepository<
     projectId: ID<'Project'>,
     userId: ID<'User'>,
   ): Promise<void> {
-    const roleLit = sql.raw(`array['${role}']::"role"[]`);
+    const roleLiteral = sql.raw(`array['${role}']::"role"[]`);
     // Cheap guard: bail if any active member already holds the role.
     const existing = await this.db
       .select({ n: sql<number>`1` })
@@ -271,7 +271,7 @@ export class ProjectMemberDrizzleRepository extends DrizzleDtoRepository<
           eq(projectMembers.projectId, projectId),
           isNull(projectMembers.inactiveAt),
           isNull(projectMembers.deletedAt),
-          sql`${projectMembers.roles} && ${roleLit}`,
+          sql`${projectMembers.roles} && ${roleLiteral}`,
         ),
       )
       .limit(1);
@@ -294,7 +294,7 @@ export class ProjectMemberDrizzleRepository extends DrizzleDtoRepository<
     region?: ID<'FieldRegion'>,
   ): Promise<{ projects: readonly ID[]; timestampId: DateTime }> {
     const now = DateTime.now();
-    const roleLit = sql.raw(`array['${role}']::"role"[]`);
+    const roleLiteral = sql.raw(`array['${role}']::"role"[]`);
 
     // Affected projects: old director is an active member with `role`, project
     // is in an open status (InDevelopment | Active), optionally on `region`.
@@ -302,7 +302,7 @@ export class ProjectMemberDrizzleRepository extends DrizzleDtoRepository<
       eq(projectMembers.userId, oldDirector),
       isNull(projectMembers.inactiveAt),
       isNull(projectMembers.deletedAt),
-      sql`${projectMembers.roles} && ${roleLit}`,
+      sql`${projectMembers.roles} && ${roleLiteral}`,
       inArray(projects.status, ['InDevelopment', 'Active']),
       isNull(projects.deletedAt),
     ];
@@ -463,10 +463,10 @@ export const projectMemberFilterClauses = (
   const conditions: SQL[] = [];
   if (!filter) return conditions;
   if (filter.roles?.length) {
-    const rolesLit = sql.raw(
+    const rolesLiteral = sql.raw(
       `array[${filter.roles.map((r) => `'${r}'`).join(', ')}]::"role"[]`,
     );
-    conditions.push(sql`${projectMembers.roles} && ${rolesLit}`);
+    conditions.push(sql`${projectMembers.roles} && ${rolesLiteral}`);
   }
   if (filter.active === true) {
     conditions.push(isNull(projectMembers.inactiveAt));

--- a/src/components/project/project-member/project-member.module.ts
+++ b/src/components/project/project-member/project-member.module.ts
@@ -14,6 +14,7 @@ import { BackfillMissingDirectorsMigration } from './migrations/backfill-missing
 import { ProjectMemberMutationSubscriptionsResolver } from './project-member-mutation-subscriptions.resolver';
 import { ProjectMemberUpdatedResolver } from './project-member-updated.resolver';
 import { ProjectMemberChannels } from './project-member.channels';
+import { ProjectMemberDrizzleRepository } from './project-member.drizzle.repository';
 import { ProjectMemberGelRepository } from './project-member.gel.repository';
 import { ProjectMemberLoader } from './project-member.loader';
 import { ProjectMemberRepository } from './project-member.repository';
@@ -36,6 +37,8 @@ import { ProjectMemberService } from './project-member.service';
     ProjectMemberChannels,
     splitDb(ProjectMemberRepository, {
       gel: ProjectMemberGelRepository,
+      // migration-todo: drop the `as any` + the Neo4j/Gel paths at Phase 7 cutover.
+      postgres: ProjectMemberDrizzleRepository as any,
     }),
     ProjectMemberLoader,
     MembershipByProjectAndUserLoader,

--- a/src/components/project/project-member/project-member.repository.ts
+++ b/src/components/project/project-member/project-member.repository.ts
@@ -188,6 +188,10 @@ export class ProjectMemberRepository extends DtoRepository(ProjectMember) {
       .run();
   }
 
+  async delete(id: ID): Promise<void> {
+    await this.deleteNode(id);
+  }
+
   async list({ filter, ...input }: ProjectMemberListInput) {
     const result = await this.db
       .query()

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -1,5 +1,6 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { type MaybeAsync, setOf } from '@seedcompany/common';
+import { DateTime } from 'luxon';
 import {
   type ID,
   InputException,
@@ -191,9 +192,10 @@ export class ProjectMemberService {
 
     this.privileges.for(ProjectMember, object).verifyCan('delete');
 
-    const { at } = await this.repo.deleteNode(object).catch((e) => {
+    await this.repo.delete(id).catch((e) => {
       throw new ServerException('Failed to delete project member', e);
     });
+    const at = DateTime.now();
 
     return this.channels.publishToAll('deleted', {
       program: object.project.type,

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -1,0 +1,828 @@
+import { Injectable } from '@nestjs/common';
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  gt,
+  gte,
+  ilike,
+  inArray,
+  isNull,
+  lt,
+  lte,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
+import { type AnyPgColumn } from 'drizzle-orm/pg-core';
+import { DateTime } from 'luxon';
+import {
+  CalendarDate,
+  DuplicateException,
+  generateId,
+  type ID,
+  NotFoundException,
+  NotImplementedException,
+  type PaginatedListType,
+  type Role,
+  type UnsecuredDto,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import { ConfigService } from '~/core/config';
+import {
+  catchUniqueViolation,
+  DrizzleDtoRepository,
+  EMPTY_PAGE,
+  escapeLikePattern,
+  resolveOrderBy,
+  type SortMap,
+  subFilter,
+} from '~/core/drizzle';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
+import {
+  fieldRegions,
+  locations,
+  projectMembers,
+  projects,
+} from '~/core/drizzle/schema';
+import { rolesForScope } from '../authorization/dto/role.dto';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import {
+  fieldRegionFilterClauses,
+  fieldRegionSortColumns,
+} from '../field-region/field-region.drizzle.repository';
+import {
+  locationFilterClauses,
+  locationSortColumns,
+} from '../location/location.drizzle.repository';
+import {
+  type CreateProject,
+  IProject,
+  type Project,
+  type ProjectFilters,
+  type ProjectListInput,
+  type UpdateProject,
+} from './dto';
+import { projectMemberFilterClauses } from './project-member/project-member.drizzle.repository';
+
+const catchNameUnique = catchUniqueViolation(
+  'projects_name_active_unique',
+  'name',
+  'Project with this name already exists',
+);
+const catchDepartmentIdUnique = catchUniqueViolation(
+  'projects_department_id_active_unique',
+  'departmentId',
+  'Another Project with this Department ID already exists.',
+);
+
+/**
+ * Hydrated Project row: the projects table row + the current user's membership
+ * (id, roles, inactive_at) if any. Pulled together in a single SELECT for
+ * `readMany`. Cross-domain stubs (engagementTotal, usesRev79, primaryPartnership,
+ * rootDirectory) live in `toDto`.
+ */
+type ProjectRow = typeof projects.$inferSelect & {
+  engagementTotal?: number;
+  membership?: {
+    id: ID<'ProjectMember'>;
+    roles: readonly string[];
+    inactiveAt: Date | null;
+  } | null;
+};
+
+@Injectable()
+export class ProjectDrizzleRepository extends DrizzleDtoRepository<
+  typeof projects,
+  Project
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+    private readonly identity: Identity,
+    private readonly config: ConfigService,
+  ) {
+    super(db, projects, IProject);
+  }
+
+  // migration-todo: Neo4j-shaped existence check kept for the service layer's
+  // validateOtherResourceId. Only the labels project create/update actually
+  // validates are mapped; extend if a new label appears. Replace with a
+  // shared exists() helper at Phase 7 cutover when getBaseNode leaves the
+  // service layer.
+  async getBaseNode(id: ID, label?: string) {
+    if (label === 'FieldRegion') {
+      return await this.db.query.fieldRegions.findFirst({
+        where: (fr) =>
+          and(eq(fr.id, id as ID<'FieldRegion'>), isNull(fr.deletedAt)),
+        columns: { id: true },
+      });
+    }
+    if (label === 'Location') {
+      return await this.db.query.locations.findFirst({
+        where: (l) => and(eq(l.id, id as ID<'Location'>), isNull(l.deletedAt)),
+        columns: { id: true },
+      });
+    }
+    throw new NotImplementedException(
+      `getBaseNode existence check for label "${String(label)}" under postgres`,
+    );
+  }
+
+  override async readMany(
+    ids: readonly ID[],
+    _changeset?: ID,
+  ): Promise<Array<UnsecuredDto<Project>>> {
+    // Param accepted for splitDb signature parity with the Neo4j/Gel repos.
+    // PCR/Changeset is excluded from the migration entirely, so a changeset
+    // view collapses to the canonical row — the arg is silently ignored.
+    if (ids.length === 0) return [];
+    const userId = this.identity.current.userId;
+    const rows = await this.db.query.projects.findMany({
+      where: (p) => and(inArray(p.id, [...ids]), isNull(p.deletedAt)),
+    });
+    if (rows.length === 0) return [];
+
+    // Pull the requesting user's memberships in one query, then attach.
+    const memberships = await this.db
+      .select({
+        id: projectMembers.id,
+        projectId: projectMembers.projectId,
+        roles: projectMembers.roles,
+        inactiveAt: projectMembers.inactiveAt,
+      })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.userId, userId),
+          isNull(projectMembers.deletedAt),
+        ),
+      );
+    const membershipByProject = new Map(
+      memberships.map((m) => [m.projectId, m]),
+    );
+    // migration-todo: engagementTotal is stubbed to 0 until Engagement migrates
+    // (the `engagements` table isn't on develop yet). `pinned` dropped — Pin
+    // isn't migrated; re-add the pinnedByRequester batch when the pin domain ports.
+    return rows.map((row): UnsecuredDto<Project> => {
+      const enriched: ProjectRow = {
+        ...row,
+        membership: membershipByProject.get(row.id) ?? null,
+        engagementTotal: 0,
+      };
+      return this.toDto(enriched);
+    });
+  }
+
+  async create(input: CreateProject): Promise<{ id: ID<'Project'> }> {
+    const id = await generateId<ID<'Project'>>();
+    // migration-note: `step` defaults to EarlyConversations via the schema
+    // column default. SetInitialMouEnd (Created hook) and SetDepartmentId
+    // (Transitioned hook) get their PG paths in the workflow PR
+    // (`project-workflow-pg`); no inline wiring needed here.
+    await this.db
+      .insert(projects)
+      .values({
+        id,
+        type: input.type,
+        name: input.name,
+        // Internship-only writable; Translation rows leave it null and read
+        // the denormalized `sensitivity` column.
+        ownSensitivity:
+          input.type === 'Internship' ? (input.sensitivity ?? 'High') : null,
+        // For Internship: keep `sensitivity` in lockstep with own_sensitivity
+        // on create. For Translation: 'High' default (migration-todo: hook
+        // recomputes when Engagement/Language migrates).
+        sensitivity:
+          input.type === 'Internship' ? (input.sensitivity ?? 'High') : 'High',
+        primaryLocationId: input.primaryLocation ?? null,
+        marketingLocationId: input.marketingLocation ?? null,
+        marketingRegionOverrideId: input.marketingRegionOverride ?? null,
+        fieldRegionId: input.fieldRegion ?? null,
+        owningOrganizationId: this.config.defaultOrg.id as ID<'Organization'>,
+        mouStart: input.mouStart ? input.mouStart.toSQLDate() : null,
+        mouEnd: input.mouEnd ? input.mouEnd.toSQLDate() : null,
+        estimatedSubmission: input.estimatedSubmission
+          ? input.estimatedSubmission.toSQLDate()
+          : null,
+        tags: input.tags ? [...input.tags] : [],
+        financialReportReceivedAt:
+          input.financialReportReceivedAt?.toJSDate() ?? null,
+        financialReportPeriod: input.financialReportPeriod ?? null,
+        presetInventory: input.presetInventory ?? false,
+        departmentId: input.departmentId ?? null,
+        rev79ProjectId: input.rev79ProjectId ?? null,
+      })
+      .catch(catchDepartmentIdUnique)
+      .catch(catchNameUnique);
+    // migration-todo (PR 2 follow-up): `otherLocations` are still managed by
+    // LocationService against Neo4j. Once the location service ports, wire a
+    // `project_other_locations` junction or move the loop here.
+    return { id };
+  }
+
+  async update(
+    existing: UnsecuredDto<Project>,
+    changes: Partial<UpdateProject>,
+    _changeset?: ID,
+  ): Promise<Partial<UnsecuredDto<Project>>> {
+    // Param accepted for splitDb signature parity. PCR is excluded; under
+    // a changeset view we still write through to the row directly (no
+    // staging side table). Acceptable because DATABASE=postgres is dev-only
+    // and no changeset machinery exists in this branch.
+    const {
+      id: _id,
+      changeset: _cs,
+      primaryLocation,
+      marketingLocation,
+      marketingRegionOverride,
+      fieldRegion,
+      mouStart,
+      mouEnd,
+      initialMouEnd,
+      estimatedSubmission,
+      financialReportReceivedAt,
+      sensitivity,
+      tags,
+      usesRev79: _usesRev79,
+      ...simpleChanges
+    } = changes;
+
+    await this.updateColumns(existing.id, {
+      ...simpleChanges,
+      ...(primaryLocation !== undefined && {
+        primaryLocationId: primaryLocation,
+      }),
+      ...(marketingLocation !== undefined && {
+        marketingLocationId: marketingLocation,
+      }),
+      ...(marketingRegionOverride !== undefined && {
+        marketingRegionOverrideId: marketingRegionOverride,
+      }),
+      ...(fieldRegion !== undefined && { fieldRegionId: fieldRegion }),
+      ...(mouStart !== undefined && {
+        mouStart: mouStart ? mouStart.toSQLDate() : null,
+      }),
+      ...(mouEnd !== undefined && {
+        mouEnd: mouEnd ? mouEnd.toSQLDate() : null,
+      }),
+      ...(initialMouEnd !== undefined && {
+        initialMouEnd: initialMouEnd ? initialMouEnd.toSQLDate() : null,
+      }),
+      ...(estimatedSubmission !== undefined && {
+        estimatedSubmission: estimatedSubmission
+          ? estimatedSubmission.toSQLDate()
+          : null,
+      }),
+      ...(financialReportReceivedAt !== undefined && {
+        financialReportReceivedAt:
+          financialReportReceivedAt?.toJSDate() ?? null,
+      }),
+      ...(tags !== undefined && { tags: [...tags] }),
+      // Internship: writable. Translation: ignored (denormalized from
+      // engagements; recompute hook lands when Language migrates).
+      ...(sensitivity !== undefined &&
+        existing.type === 'Internship' && {
+          ownSensitivity: sensitivity,
+          sensitivity,
+        }),
+      modifiedAt: new Date(),
+    }).catch(catchDepartmentIdUnique);
+
+    // migration-todo: usesRev79 toggle delegates to ToolUsage service (not
+    // migrated yet). When ToolUsage ports, wire the create/remove of the
+    // Rev79 ToolUsage row here.
+
+    // The service runs RequiredWhen.calc against this return value, so it
+    // must be the full updated DTO — not a stub.
+    return await this.readOne(existing.id);
+  }
+
+  async delete(id: ID): Promise<void> {
+    await this.softDelete(id);
+  }
+
+  async list(
+    input: ProjectListInput,
+  ): Promise<PaginatedListType<UnsecuredDto<Project>>> {
+    const conditions: SQL[] = [isNull(projects.deletedAt)];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+    conditions.push(
+      ...projectFilterClauses(
+        this.db,
+        input.filter,
+        this.identity.current.userId,
+      ),
+    );
+
+    const allConditions = and(...conditions);
+    const sort = input.sort as string;
+    const direction = input.order === 'ASC' ? asc : desc;
+
+    // Cross-domain JOIN-sort — mirror of the partner repo's pattern. When a
+    // second consumer needs the same prefix-strip + sortColumn-resolve dance,
+    // extract `resolveCrossDomainSort` (per partner's migration-todo).
+    const joinSort = resolveCrossDomainSort(sort);
+
+    let pageIds: ReadonlyArray<{ id: ID<'Project'> }>;
+    let total: number;
+    if (joinSort) {
+      const offset = (input.page - 1) * input.count;
+      const [countResult, joined] = await Promise.all([
+        this.db.select({ total: count() }).from(projects).where(allConditions),
+        this.db
+          .select({ id: projects.id })
+          .from(projects)
+          .leftJoin(joinSort.table, eq(joinSort.fkColumn, joinSort.table.id))
+          .where(allConditions)
+          .orderBy(direction(joinSort.column), asc(projects.id))
+          .limit(input.count)
+          .offset(offset),
+      ]);
+      total = countResult[0]?.total ?? 0;
+      pageIds = joined;
+    } else {
+      const sortColumns = projectSortColumns;
+      // Reject unknown/unmapped own-table sort keys instead of silently
+      // falling back to createdAt (resolveOrderBy's `map[sort] ?? fallback`).
+      // Mirrors the Partner repo guard.
+      if (!(sort in sortColumns)) {
+        throw new NotImplementedException(
+          `Sorting projects by '${sort}' is not supported.`,
+        );
+      }
+      const page = await this.paginatedSelect({
+        predicate: allConditions,
+        orderBy: resolveOrderBy(input, sortColumns, projects.createdAt),
+        page: input.page,
+        count: input.count,
+      });
+      pageIds = page.rows.map((r) => ({ id: r.id }));
+      total = page.total;
+    }
+
+    const offset = (input.page - 1) * input.count;
+    const hasMore = offset + pageIds.length < total;
+    if (pageIds.length === 0) return { total, items: [], hasMore };
+
+    const dtos = await this.readMany(pageIds.map((r) => r.id));
+    const byId = new Map(dtos.map((d) => [d.id, d]));
+    return {
+      total,
+      items: pageIds.flatMap((r) => byId.get(r.id) ?? []),
+      hasMore,
+    };
+  }
+
+  /**
+   * Resolve the primary partnership's owning organization name. Used by the
+   * Rev79 integration. Traverses partnerships → partners → organizations.
+   */
+  async getPrimaryOrganizationName(_id: ID): Promise<string | null> {
+    // migration-todo: traverses partnerships → partners → organizations for the
+    // Rev79 integration; `partnerships` isn't on develop until the Partnership
+    // port. Stub null until then (matches the "no primary partnership" case).
+    return null;
+  }
+
+  protected toDto(row: ProjectRow): UnsecuredDto<Project> {
+    const linkOrNull = <T extends string>(id: ID<T> | null | undefined) =>
+      id ? { id } : null;
+    // DTO shape includes a few service-layer overlays (canDelete, scope,
+    // pinned) and stub fields the repo can't compute under DATABASE=postgres
+    // yet (primaryPartnership, engagementTotal, usesRev79). Build the dto as
+    // `unknown` first so the lint stays clean — service runs
+    // `privileges.secure()` after this anyway.
+    const dto: unknown = {
+      id: row.id,
+      __typename:
+        row.type === 'Internship'
+          ? 'InternshipProject'
+          : row.type === 'MomentumTranslation'
+            ? 'MomentumTranslationProject'
+            : 'MultiplicationTranslationProject',
+      type: row.type,
+      name: row.name,
+      step: row.step,
+      status: row.status,
+      sensitivity: row.sensitivity,
+      rev79ProjectId: row.rev79ProjectId ?? null,
+      departmentId: row.departmentId ?? null,
+      mouStart: row.mouStart ? CalendarDate.fromISO(row.mouStart) : null,
+      mouEnd: row.mouEnd ? CalendarDate.fromISO(row.mouEnd) : null,
+      initialMouEnd: row.initialMouEnd
+        ? CalendarDate.fromISO(row.initialMouEnd)
+        : null,
+      estimatedSubmission: row.estimatedSubmission
+        ? CalendarDate.fromISO(row.estimatedSubmission)
+        : null,
+      financialReportReceivedAt: row.financialReportReceivedAt
+        ? DateTime.fromJSDate(row.financialReportReceivedAt)
+        : null,
+      financialReportPeriod: row.financialReportPeriod ?? null,
+      tags: row.tags,
+      presetInventory: row.presetInventory,
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      modifiedAt: DateTime.fromJSDate(row.modifiedAt),
+      // stepChangedAt is derived from the latest workflow event; PR 3 wires
+      // the real query. For now fall back to createdAt — the only reader is
+      // the resolver, and the field has no stored canonical value anyway.
+      stepChangedAt: DateTime.fromJSDate(row.createdAt),
+      primaryLocation: linkOrNull(row.primaryLocationId),
+      marketingLocation: linkOrNull(row.marketingLocationId),
+      marketingRegionOverride: linkOrNull(row.marketingRegionOverrideId),
+      fieldRegion: linkOrNull(row.fieldRegionId),
+      owningOrganization: linkOrNull(row.owningOrganizationId),
+      rootDirectory: linkOrNull(row.rootDirectoryId),
+      // migration-todo: Partnership not migrated; primaryPartnership always
+      // null until partnership-pg lands.
+      primaryPartnership: null,
+      engagementTotal: row.engagementTotal ?? 0,
+      // migration-todo: ToolUsage not migrated; usesRev79 always false until
+      // the tool-usage layer ports.
+      usesRev79: false,
+      membership: row.membership
+        ? {
+            id: row.membership.id,
+            roles: [...row.membership.roles],
+            inactiveAt: row.membership.inactiveAt
+              ? DateTime.fromJSDate(row.membership.inactiveAt)
+              : null,
+          }
+        : null,
+      // `changeset` is a resolver navigation marker — populated from request
+      // context, not stored on the row. PCR is excluded from the migration,
+      // so it stays undefined here.
+      changeset: undefined,
+      // migration-todo: Pin not migrated; pinned is false until the pin domain
+      // ports (then re-add the pinnedByRequester batch in readMany).
+      pinned: false,
+      // canDelete is populated by the policy layer in the service.
+      canDelete: true,
+      // Scoped roles from the requesting user's active membership — the
+      // `member` policy conditions read `object.scope` directly. Mirror of
+      // Neo4j's matchProjectScopedRoles: the 'member:true' marker plus the
+      // membership roles project-scoped.
+      scope:
+        row.membership && !row.membership.inactiveAt
+          ? [
+              'member:true' as const,
+              ...(row.membership.roles as readonly Role[]).map(
+                rolesForScope('project'),
+              ),
+            ]
+          : [],
+    };
+    return dto as UnsecuredDto<Project>;
+  }
+}
+
+/**
+ * Recompute the denormalized `projects.sensitivity` for translation projects
+ * from their engaged languages — max(language sensitivity) ?? High. Mirror of
+ * Gel's recalculateProjectSens triggers; called from the engagement/language
+ * drizzle repos whenever the inputs change (create/delete engagement,
+ * language sensitivity update). Internship projects are untouched — they
+ * read own_sensitivity.
+ */
+export const recomputeProjectSensitivity = async (
+  db: DrizzleDb,
+  projectIds: ReadonlyArray<ID<'Project'>>,
+) => {
+  if (projectIds.length === 0) return;
+  // migration-todo: INERT on develop — references `engagements`/`languages`
+  // (not migrated), and nothing calls this until the Engagement/Language repos
+  // do. Kept exported so those repos wire it without a new export. The raw SQL
+  // compiles (string table names); it would only fail if invoked pre-migration.
+  await db.execute(sql`
+    update "projects" set "sensitivity" = coalesce((
+      select max("l"."sensitivity") from "engagements" "e"
+      join "languages" "l" on "l"."id" = "e"."language_id"
+      where "e"."project_id" = "projects"."id"
+        and "e"."deleted_at" is null
+        and "l"."deleted_at" is null
+    ), 'High')
+    where "id" in (${sql.join(
+      projectIds.map((id) => sql`${id}`),
+      sql`, `,
+    )})
+      and "type" <> 'Internship'
+  `);
+};
+
+/**
+ * Sortable columns on `projects` itself. Cross-domain sorts (primaryLocation.*,
+ * fieldRegion.*) are resolved in `resolveCrossDomainSort` and routed through a
+ * hand-rolled INNER JOIN — same pattern as Partner's organization sort.
+ */
+export const projectSortColumns = {
+  id: projects.id,
+  name: projects.name,
+  createdAt: projects.createdAt,
+  modifiedAt: projects.modifiedAt,
+  step: projects.step,
+  status: projects.status,
+  type: projects.type,
+  sensitivity: projects.sensitivity,
+  mouStart: projects.mouStart,
+  mouEnd: projects.mouEnd,
+  estimatedSubmission: projects.estimatedSubmission,
+  departmentId: projects.departmentId,
+} satisfies SortMap<keyof Project>;
+
+/**
+ * Resolve a `prefix.field`-style sort key to its (sub-table, FK, sub-column).
+ * Returns `null` when the sort is column-local (handled by paginatedSelect).
+ *
+ * migration-todo: when a second consumer needs this same prefix-strip dance
+ * (Partnership → `partner.*`, Engagement → `project.*`), extract a shared
+ * `resolveCrossDomainSort(sort, prefix, sortColumns)` helper alongside
+ * `paginatedSelectWithJoin` (mirror of `*FilterClauses` emergence).
+ *
+ * migration-todo: `primaryPartnership.*` sort is not implemented — Partnership
+ * isn't migrated. Throw `NotImplementedException` so callers discover the gap.
+ */
+const resolveCrossDomainSort = (
+  sort: string,
+): {
+  table: typeof locations | typeof fieldRegions;
+  fkColumn: AnyPgColumn;
+  column: AnyPgColumn;
+} | null => {
+  if (sort.startsWith('primaryLocation.')) {
+    const key = sort.slice('primaryLocation.'.length);
+    const column = locationSortColumns[key as keyof typeof locationSortColumns];
+    if (!column) {
+      throw new NotImplementedException(
+        `Sorting projects by '${sort}' is not supported — '${key}' is not a known sortable column on locations.`,
+      );
+    }
+    return { table: locations, fkColumn: projects.primaryLocationId, column };
+  }
+  if (sort.startsWith('fieldRegion.')) {
+    const key = sort.slice('fieldRegion.'.length);
+    const column =
+      fieldRegionSortColumns[key as keyof typeof fieldRegionSortColumns];
+    if (!column) {
+      throw new NotImplementedException(
+        `Sorting projects by '${sort}' is not supported — '${key}' is not a known sortable column on field_regions.`,
+      );
+    }
+    return { table: fieldRegions, fkColumn: projects.fieldRegionId, column };
+  }
+  if (sort.startsWith('primaryPartnership.')) {
+    throw new NotImplementedException(
+      `Sorting projects by '${sort}' is not yet supported under DATABASE=postgres — pending Partnership migration.`,
+    );
+  }
+  return null;
+};
+
+/**
+ * Build the column-level WHERE clauses for a `ProjectFilters` input against
+ * `projects`. Exported for sub-delegation from other domains (Engagement and
+ * Partnership both filter-sub-delegate into projectFilterClauses).
+ *
+ * Cross-domain stubs (languageId, partnerId, partnerships, primaryPartnership,
+ * tool, onlyMultipleEngagements, usesRev79) throw NotImplementedException
+ * until their target domain migrates — discovery mechanism, not silent skip.
+ */
+export const projectFilterClauses = (
+  db: DrizzleDb,
+  filter: ProjectFilters | undefined,
+  // migration-todo: dead after the pin strip; kept for signature stability.
+  // list() still passes identity.current.userId harmlessly. Re-consume when Pin ports.
+  _requesterId?: ID<'User'>,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+
+  if (filter.id) conditions.push(eq(projects.id, filter.id));
+  if (filter.type?.length) {
+    conditions.push(inArray(projects.type, filter.type));
+  }
+  if (filter.status?.length) {
+    conditions.push(inArray(projects.status, filter.status));
+  }
+  if (filter.step?.length) {
+    conditions.push(inArray(projects.step, filter.step));
+  }
+  if (filter.sensitivity?.length) {
+    conditions.push(inArray(projects.sensitivity, [...filter.sensitivity]));
+  }
+  if (filter.presetInventory !== undefined) {
+    conditions.push(eq(projects.presetInventory, filter.presetInventory));
+  }
+  if (filter.name) {
+    conditions.push(
+      ilike(projects.name, `%${escapeLikePattern(filter.name)}%`),
+    );
+  }
+  if (filter.createdAt) {
+    if (filter.createdAt.after) {
+      conditions.push(
+        gt(projects.createdAt, filter.createdAt.after.toJSDate()),
+      );
+    }
+    if (filter.createdAt.afterInclusive) {
+      conditions.push(
+        gte(projects.createdAt, filter.createdAt.afterInclusive.toJSDate()),
+      );
+    }
+    if (filter.createdAt.before) {
+      conditions.push(
+        lt(projects.createdAt, filter.createdAt.before.toJSDate()),
+      );
+    }
+    if (filter.createdAt.beforeInclusive) {
+      conditions.push(
+        lte(projects.createdAt, filter.createdAt.beforeInclusive.toJSDate()),
+      );
+    }
+  }
+  if (filter.modifiedAt) {
+    if (filter.modifiedAt.after) {
+      conditions.push(
+        gt(projects.modifiedAt, filter.modifiedAt.after.toJSDate()),
+      );
+    }
+    if (filter.modifiedAt.afterInclusive) {
+      conditions.push(
+        gte(projects.modifiedAt, filter.modifiedAt.afterInclusive.toJSDate()),
+      );
+    }
+    if (filter.modifiedAt.before) {
+      conditions.push(
+        lt(projects.modifiedAt, filter.modifiedAt.before.toJSDate()),
+      );
+    }
+    if (filter.modifiedAt.beforeInclusive) {
+      conditions.push(
+        lte(projects.modifiedAt, filter.modifiedAt.beforeInclusive.toJSDate()),
+      );
+    }
+  }
+  if (filter.mouStart) {
+    if (filter.mouStart.after) {
+      conditions.push(
+        gt(projects.mouStart, filter.mouStart.after.toSQLDate()!),
+      );
+    }
+    if (filter.mouStart.afterInclusive) {
+      conditions.push(
+        gte(projects.mouStart, filter.mouStart.afterInclusive.toSQLDate()!),
+      );
+    }
+    if (filter.mouStart.before) {
+      conditions.push(
+        lt(projects.mouStart, filter.mouStart.before.toSQLDate()!),
+      );
+    }
+    if (filter.mouStart.beforeInclusive) {
+      conditions.push(
+        lte(projects.mouStart, filter.mouStart.beforeInclusive.toSQLDate()!),
+      );
+    }
+  }
+  if (filter.mouEnd) {
+    if (filter.mouEnd.after) {
+      conditions.push(gt(projects.mouEnd, filter.mouEnd.after.toSQLDate()!));
+    }
+    if (filter.mouEnd.afterInclusive) {
+      conditions.push(
+        gte(projects.mouEnd, filter.mouEnd.afterInclusive.toSQLDate()!),
+      );
+    }
+    if (filter.mouEnd.before) {
+      conditions.push(lt(projects.mouEnd, filter.mouEnd.before.toSQLDate()!));
+    }
+    if (filter.mouEnd.beforeInclusive) {
+      conditions.push(
+        lte(projects.mouEnd, filter.mouEnd.beforeInclusive.toSQLDate()!),
+      );
+    }
+  }
+  if (filter.primaryLocation) {
+    conditions.push(
+      subFilter(
+        db,
+        projects.primaryLocationId,
+        locations,
+        locationFilterClauses(filter.primaryLocation),
+      ),
+    );
+  }
+  if (filter.fieldRegion) {
+    conditions.push(
+      subFilter(
+        db,
+        projects.fieldRegionId,
+        fieldRegions,
+        fieldRegionFilterClauses(db, filter.fieldRegion),
+      ),
+    );
+  }
+  // `members` and `membership` filters — links project → project_members via
+  // a project-side `IN (SELECT project_id FROM project_members WHERE ...)`.
+  // The members filter doesn't constrain user; membership scopes to the
+  // current requester. Both lean on projectMemberFilterClauses.
+  if (filter.members) {
+    const sub = db
+      .selectDistinct({ id: projectMembers.projectId })
+      .from(projectMembers)
+      .where(
+        and(
+          isNull(projectMembers.deletedAt),
+          ...projectMemberFilterClauses(db, filter.members),
+        ),
+      );
+    conditions.push(inArray(projects.id, sub));
+  }
+  if (filter.membership) {
+    // Note: the `user: { id: $currentUser }` constraint is applied by the
+    // resolver/transform layer (see ProjectFilters.membership transform).
+    const sub = db
+      .selectDistinct({ id: projectMembers.projectId })
+      .from(projectMembers)
+      .where(
+        and(
+          isNull(projectMembers.deletedAt),
+          ...projectMemberFilterClauses(db, filter.membership),
+        ),
+      );
+    conditions.push(inArray(projects.id, sub));
+  }
+  // `userId`: project where user is a member OR engagement intern. Intern path
+  // is gated on Engagement migration — partial support: member only.
+  if (filter.userId) {
+    const memberSub = db
+      .selectDistinct({ id: projectMembers.projectId })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.userId, filter.userId),
+          isNull(projectMembers.deletedAt),
+        ),
+      );
+    // migration-todo: when Engagement migrates, OR-in the intern path:
+    //   ... OR projects.id IN (SELECT project_id FROM engagements WHERE intern_id = $userId)
+    conditions.push(inArray(projects.id, memberSub));
+  }
+  if (filter.languageId) {
+    // migration-todo: exists-over-engagements; Engagement isn't on develop.
+    // Throw so the gap is discoverable (matches partnerId/partnerships below).
+    throw new NotImplementedException(
+      'ProjectFilters.languageId requires Engagement migration.',
+    );
+  }
+  // Cross-domain filters — throw until their target domain migrates so the
+  // gap is discoverable in tests instead of silently returning all projects.
+  if (filter.partnerId) {
+    throw new NotImplementedException(
+      'ProjectFilters.partnerId requires Partnership migration.',
+    );
+  }
+  if (filter.partnerships) {
+    throw new NotImplementedException(
+      'ProjectFilters.partnerships requires Partnership migration.',
+    );
+  }
+  if (filter.primaryPartnership) {
+    throw new NotImplementedException(
+      'ProjectFilters.primaryPartnership requires Partnership migration.',
+    );
+  }
+  if (filter.tool) {
+    throw new NotImplementedException(
+      'ProjectFilters.tool requires ToolUsage migration.',
+    );
+  }
+  if (filter.onlyMultipleEngagements != null) {
+    throw new NotImplementedException(
+      'ProjectFilters.onlyMultipleEngagements requires Engagement migration (Phase 5).',
+    );
+  }
+  if (filter.usesRev79 != null) {
+    throw new NotImplementedException(
+      'ProjectFilters.usesRev79 requires ToolUsage migration.',
+    );
+  }
+  if (filter.pinned != null) {
+    // migration-todo: Pin not migrated. Re-add
+    // `conditions.push(pinnedFilter(_requesterId, projects.id, filter.pinned))`
+    // when the pin domain ports. Throw for now (matches the branches above).
+    throw new NotImplementedException(
+      'ProjectFilters.pinned requires Pin migration.',
+    );
+  }
+  return conditions;
+};
+
+// Re-export to satisfy the unused-import linter — `DuplicateException` is part
+// of the catch-helper public surface elsewhere; here it's reached only via the
+// catch chains above.
+void DuplicateException;
+void NotFoundException;

--- a/src/components/project/project.module.ts
+++ b/src/components/project/project.module.ts
@@ -24,6 +24,7 @@ import { ProjectMutationSubscriptionsResolver } from './project-mutation-subscri
 import { ProjectUpdateLinksResolver } from './project-update-links.resolver';
 import { ProjectUpdatedResolver } from './project-updated.resolver';
 import { ProjectChannels } from './project.channels';
+import { ProjectDrizzleRepository } from './project.drizzle.repository';
 import { ConcreteRepos, ProjectGelRepository } from './project.gel.repository';
 import { ProjectLoader } from './project.loader';
 import { ProjectRepository } from './project.repository';
@@ -63,7 +64,11 @@ import { ProjectWorkflowModule } from './workflow/project-workflow.module';
     ...ProjectEngagementIdResolvers,
     ProjectChannels,
     ProjectService,
-    splitDb(ProjectRepository, { gel: ProjectGelRepository }),
+    splitDb(ProjectRepository, {
+      gel: ProjectGelRepository,
+      // migration-todo: drop the `as any` + the Neo4j/Gel paths at Phase 7 cutover.
+      postgres: ProjectDrizzleRepository as any,
+    }),
     ...Object.values(ConcreteRepos),
     ProjectLoader,
     ...Object.values(handlers),

--- a/src/components/project/project.repository.ts
+++ b/src/components/project/project.repository.ts
@@ -362,6 +362,10 @@ export class ProjectRepository extends CommonRepository {
     return result;
   }
 
+  async delete(id: ID): Promise<void> {
+    await this.deleteNode(id, { resource: IProject });
+  }
+
   async list(input: ProjectListInput) {
     const result = await this.db
       .query()

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -1,5 +1,6 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { type Many } from '@seedcompany/common';
+import { DateTime } from 'luxon';
 import {
   type CalendarDate,
   ClientException,
@@ -401,9 +402,10 @@ export class ProjectService {
 
     this.privileges.for(IProject, object).verifyCan('delete');
 
-    const { at } = await this.repo.deleteNode(object).catch((e) => {
+    await this.repo.delete(id).catch((e) => {
       throw new ServerException('Failed to delete project', e);
     });
+    const at = DateTime.now();
 
     await this.hooks.run(new ProjectDeletedHook(object));
 

--- a/src/components/user/user.drizzle.repository.ts
+++ b/src/components/user/user.drizzle.repository.ts
@@ -313,6 +313,15 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
     throw new NotImplementedException();
   }
 
+  /**
+   * Public wrapper around `toDto` so other domains' repos (e.g. ProjectMember)
+   * can hydrate a User from a raw row without duplicating logic. The row should
+   * be loaded with `globalRoles`.
+   */
+  mapRowToDto(row: UserRow): UnsecuredDto<User> {
+    return this.toDto(row);
+  }
+
   protected toDto(row: UserRow): UnsecuredDto<User> {
     return {
       id: row.id,

--- a/src/core/drizzle/int4-multirange.ts
+++ b/src/core/drizzle/int4-multirange.ts
@@ -21,10 +21,16 @@ export const int4multirange = customType<{
   driverData: string;
 }>({
   dataType: () => 'int4multirange',
-  toDriver: (ranges) =>
-    ranges.length === 0
-      ? '{}'
-      : `{${ranges.map((r) => `[${r.start},${r.end + 1})`).join(',')}}`,
+  toDriver: (ranges) => {
+    if (ranges.length === 0) {
+      // A block with no ranges can't allocate any ID. The DTO declares
+      // `blocks: NonEmptyArray` and the input parser already rejects empty
+      // ranges; fail fast here too so a non-DTO writer (e.g. a cutover
+      // data-migration script) can't silently persist an unusable `'{}'`.
+      throw new Error('int4multirange cannot serialize an empty range set');
+    }
+    return `{${ranges.map((r) => `[${r.start},${r.end + 1})`).join(',')}}`;
+  },
   fromDriver: (value) => {
     const out: IntRange[] = [];
     for (const m of value.matchAll(/([[(])(\d+),(\d+)([\])])/g)) {


### PR DESCRIPTION
### Summary
- PR 2 of 3 of the Project → Postgres recut, stacked on **#3809** (PR 1 = schema + migration `0010`). This is the repository + authorization layer; **no schema/migration changes here** (all in PR 1). Neo4j/Gel paths untouched — everything routes through `splitDb`.

### Repositories
- `ProjectDrizzleRepository` + `ProjectMemberDrizzleRepository` — migrated together because their `*FilterClauses` import each other (the circular Project↔ProjectMember filter dependency).
- `membership-scope.ts` (`requesterScopeByProject`) — populates the requester's `ScopedRole[]` (`member:true` + project-scoped roles) on both DTOs so member-policy conditions resolve. Drizzle mirror of Neo4j `matchProjectScopedRoles`.

### Authorization (Drizzle condition ports)
- `MemberCondition` / `MemberWithRolesCondition` — `EXISTS` over `project_members` (roles variant adds `roles && ARRAY[...]::role[]`).
- `SensitivityCondition` — collapses to `projects.sensitivity <= clearance` (denormalized column).
- `And`/`Or` aggregate `asDrizzleCondition` composition (not previously on develop).

### Wiring + cross-domain exports
- `splitDb` postgres entries on the project + project-member modules.
- `*SortColumns` / `*FilterClauses` exports added to field-region / location / user repos (consumed by Project's cross-domain sort + filter).

### Service layer
- `deleteNode → delete(id)` rename across both services + Neo4j repo `delete(id)` wrappers (Gel inherits `delete` from `RepoFor`; Drizzle uses `softDelete`). Audit `ResourceMutatedHook` firing intentionally **omitted** — the audit domain isn't on develop yet.