### PR TITLE
[pg] Project workflow recut (PR 3 of 3)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
           # full suite.
           - database: postgres
             test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|tool)\."
+              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|project-member|tool)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/src/components/authorization/policy/conditions/aggregate.condition.ts
+++ b/src/components/authorization/policy/conditions/aggregate.condition.ts
@@ -69,6 +69,10 @@ export abstract class AggregateConditions<
   asDrizzleCondition(params: AsDrizzleParams<TResourceStatic>): SQL {
     const inner = this.conditions.map((condition) => {
       if (!condition.asDrizzleCondition) {
+        // migration-todo: fires for conditions not yet ported to Drizzle
+        // (creator / enum-field / variant / etc.) — port each alongside the
+        // first migrated domain whose policies need it. Post-cutover the
+        // throw stays as the fail-loud for brand-new conditions.
         throw new Error(
           `Condition ${condition.constructor.name} has not been ported to Drizzle — implement asDrizzleCondition`,
         );

--- a/src/components/budget/handlers/create-project-default-budget.handler.ts
+++ b/src/components/budget/handlers/create-project-default-budget.handler.ts
@@ -1,12 +1,20 @@
+import { ConfigService } from '~/core/config';
 import { OnHook } from '~/core/hooks';
 import { ProjectCreatedHook } from '../../project/hooks';
 import { BudgetService } from '../budget.service';
 
 @OnHook(ProjectCreatedHook)
 export class CreateProjectDefaultBudgetHandler {
-  constructor(private readonly budgets: BudgetService) {}
+  constructor(
+    private readonly budgets: BudgetService,
+    private readonly config: ConfigService,
+  ) {}
 
   async handle({ project }: ProjectCreatedHook) {
+    // migration-todo: Budget isn't migrated to Postgres yet; skip the
+    // Neo4j-only default-budget creation under DATABASE=postgres. Drop this
+    // guard when budget-pg lands.
+    if (this.config.databaseEngine === 'postgres') return;
     await this.budgets.create({ project: project.id });
   }
 }

--- a/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
+++ b/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
@@ -8,6 +8,7 @@ import {
   UnauthorizedException,
   type UnsecuredDto,
 } from '~/common';
+import { ConfigService } from '~/core/config';
 import { OnHook } from '~/core/hooks';
 import { ILogger, Logger } from '~/core/logger';
 import { PartnerType } from '../../partner/dto';
@@ -43,9 +44,15 @@ export class SyncBudgetRecordsToFundingPartners {
     private readonly budgetRepo: BudgetRepository,
     private readonly partnershipService: PartnershipService,
     @Logger('budget:sync-partnerships') private readonly logger: ILogger,
+    private readonly config: ConfigService,
   ) {}
 
   async handle(event: SubscribedEvent) {
+    // migration-todo: Budget/Partnership aren't migrated to Postgres yet; skip
+    // this Neo4j-only budget-record sync under DATABASE=postgres. Drop this
+    // guard when budget-pg lands (Partnership triggers already can't fire
+    // under postgres until partnership-pg lands).
+    if (this.config.databaseEngine === 'postgres') return;
     this.logger.debug('Partnership/Project mutation, syncing budget records', {
       ...event,
       event: event.constructor.name,

--- a/src/components/budget/handlers/update-project-current-budget-status.handler.ts
+++ b/src/components/budget/handlers/update-project-current-budget-status.handler.ts
@@ -1,3 +1,4 @@
+import { ConfigService } from '~/core/config';
 import { OnHook } from '~/core/hooks';
 import { ProjectStatus, stepToStatus } from '../../project/dto';
 import { ProjectTransitionedHook } from '../../project/workflow/hooks/project-transitioned.hook';
@@ -6,9 +7,16 @@ import { BudgetStatus } from '../dto';
 
 @OnHook(ProjectTransitionedHook)
 export class UpdateProjectBudgetStatusHandler {
-  constructor(private readonly budgets: BudgetService) {}
+  constructor(
+    private readonly budgets: BudgetService,
+    private readonly config: ConfigService,
+  ) {}
 
   async handle(event: ProjectTransitionedHook) {
+    // migration-todo: Budget isn't migrated to Postgres yet; skip this
+    // Neo4j-only budget-status sync under DATABASE=postgres. Drop this guard
+    // when budget-pg lands.
+    if (this.config.databaseEngine === 'postgres') return;
     const { project } = event;
 
     const prevStatus = stepToStatus(event.previousStep);

--- a/src/components/engagement/handlers/update-engagement-status.handler.ts
+++ b/src/components/engagement/handlers/update-engagement-status.handler.ts
@@ -1,5 +1,6 @@
 import type { MergeExclusive, RequireAtLeastOne } from 'type-fest';
 import { type ID, type UnsecuredDto } from '~/common';
+import { ConfigService } from '~/core/config';
 import { OnHook } from '~/core/hooks';
 import {
   type Project,
@@ -103,6 +104,7 @@ export class UpdateEngagementStatusHandler {
   constructor(
     private readonly repo: EngagementRepository,
     private readonly engagementService: EngagementService,
+    private readonly config: ConfigService,
   ) {}
 
   async handle({
@@ -110,6 +112,10 @@ export class UpdateEngagementStatusHandler {
     previousStep,
     workflowEvent,
   }: ProjectTransitionedHook) {
+    // migration-todo: Engagement isn't migrated to Postgres yet; skip this
+    // Neo4j-only engagement-status sync under DATABASE=postgres. Drop this
+    // guard when engagement-pg lands.
+    if (this.config.databaseEngine === 'postgres') return;
     const engagementStatus = changes.find(
       changeMatcher(previousStep, workflowEvent.to),
     )?.newStatus;

--- a/src/components/file/handlers/attach-project-root-directory.handler.ts
+++ b/src/components/file/handlers/attach-project-root-directory.handler.ts
@@ -1,10 +1,18 @@
+import { eq } from 'drizzle-orm';
+import { ConfigService } from '~/core/config';
+import { DrizzleService } from '~/core/drizzle';
+import { projects } from '~/core/drizzle/schema';
 import { OnHook } from '~/core/hooks';
 import { ProjectCreatedHook } from '../../project/hooks';
 import { FileService } from '../file.service';
 
 @OnHook(ProjectCreatedHook)
 export class AttachProjectRootDirectoryHandler {
-  constructor(private readonly files: FileService) {}
+  constructor(
+    private readonly files: FileService,
+    private readonly config: ConfigService,
+    private readonly drizzle: DrizzleService,
+  ) {}
 
   async handle(event: ProjectCreatedHook) {
     const { project } = event;
@@ -28,6 +36,17 @@ export class AttachProjectRootDirectoryHandler {
     ];
     for (const folder of folders) {
       await this.files.createDirectory(rootDirId, folder);
+    }
+
+    // Neo4j persists this as the project's `rootDirectory` relationship (made by
+    // createRootDirectory). Postgres has no back-edge — set the FK column on the
+    // project row directly. Runs in the create transaction (tx-aware client).
+    // migration-todo: drop this engine check at Phase 7 cutover (always PG).
+    if (this.config.databaseEngine === 'postgres') {
+      await this.drizzle.client
+        .update(projects)
+        .set({ rootDirectoryId: rootDirId })
+        .where(eq(projects.id, project.id));
     }
   }
 }

--- a/src/components/project/handlers/set-department-id.handler.ts
+++ b/src/components/project/handlers/set-department-id.handler.ts
@@ -1,13 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { isNull, node, not, relation } from 'cypher-query-builder';
+import { eq, sql } from 'drizzle-orm';
 import {
   ClientException,
   type ID,
+  NotImplementedException,
   ServerException,
   type UnsecuredDto,
 } from '~/common';
 import { ConfigService } from '~/core/config';
 import { TransactionRetryInformer } from '~/core/database';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { isUniqueViolation } from '~/core/drizzle/errors';
+import { projects } from '~/core/drizzle/schema';
 import { OnHook } from '~/core/hooks';
 import { DatabaseService, UniquenessError } from '~/core/neo4j';
 import {
@@ -30,6 +35,7 @@ import { ProjectTransitionedHook } from '../workflow/hooks/project-transitioned.
 export class SetDepartmentId {
   constructor(
     private readonly db: DatabaseService,
+    private readonly drizzle: DrizzleService,
     private readonly config: ConfigService,
     private readonly retryInformer: TransactionRetryInformer,
   ) {}
@@ -37,6 +43,8 @@ export class SetDepartmentId {
   @OnHook(ProjectTransitionedHook)
   @OnHook(ProjectUpdatedHook)
   async handle(event: ProjectTransitionedHook | ProjectUpdatedHook) {
+    // migration-todo: collapse the gel-early-return at Phase 7 cutover when
+    // the Gel path is removed.
     if (this.config.databaseEngine === 'gel') {
       return;
     }
@@ -54,18 +62,130 @@ export class SetDepartmentId {
       return;
     }
 
-    const block = await this.getDepartmentIdBlockId(project);
+    // migration-todo: collapse this engine-check at Phase 7 cutover — drop
+    // the Neo4j branch + assignDepartmentIdNeo4j + DatabaseService injection,
+    // keep only the PG path.
+    const departmentId =
+      this.config.databaseEngine === 'postgres'
+        ? await this.assignDepartmentIdPg(project)
+        : await this.assignDepartmentIdNeo4j(project);
 
-    const departmentId = await this.assignDepartmentIdForProject(
-      project,
-      block,
-    );
     const changed = { ...project, departmentId };
-
     if (event instanceof ProjectTransitionedHook) {
       event.project = changed;
     } else {
       event.updated = changed;
+    }
+  }
+
+  private async assignDepartmentIdNeo4j(project: UnsecuredDto<Project>) {
+    const block = await this.getDepartmentIdBlockId(project);
+    return await this.assignDepartmentIdForProject(project, block);
+  }
+
+  /**
+   * PG path — resolves the DepartmentIdBlock via the FK chain
+   * `project.primary_location_id → locations.funding_account_id →
+   * funding_accounts.department_id_block_id`, enumerates the block's
+   * `range int4multirange`, picks the smallest 5-digit-padded id that
+   * isn't already used, and UPDATEs `projects.department_id`. Catches PG
+   * unique violation 23505 on the partial-unique index and marks the
+   * transaction for retry — mirror of the Neo4j UniquenessError flow.
+   *
+   * MultiplicationTranslation projects route via partnership → partner
+   * instead, but `partnerships` isn't migrated — throws NotImplementedException
+   * with a clear message until partnership-pg lands.
+   *
+   * `funding_accounts` (develop) + `department_id_blocks` (Partner) + `locations`
+   * are all present on the recut base, so the FK chain resolves. Raw SQL is used
+   * for the enumeration itself — `unnest(range)` + `lateral generate_series`
+   * over the `int4multirange` don't have a clean query-builder form.
+   *
+   * `external_department_ids` exclusion is dropped — that table is part of an
+   * unmigrated domain. migration-todo: re-add the exclusion when that domain
+   * ports (probably with the broader Finance/Admin work).
+   */
+  private async assignDepartmentIdPg(project: UnsecuredDto<Project>) {
+    if (project.type === 'MultiplicationTranslation') {
+      // migration-todo: implement the partnership → partner → block path
+      // when partnership-pg lands. Until then this branch never fires in
+      // production (DATABASE=postgres is dev-only), but it'd surface as a
+      // failed transition if hit. Mirror of the Neo4j repo's `holder` switch.
+      throw new NotImplementedException(
+        'SetDepartmentId for MultiplicationTranslation projects requires Partnership migration — pending.',
+      );
+    }
+    if (!project.primaryLocation) {
+      throw new ClientException(
+        'Project must have a primary location to continue',
+      );
+    }
+
+    const projectId = project.id;
+    let nextId: string;
+    try {
+      const { rows } = await this.drizzle.client.execute<{ nextId: string }>(
+        sql`
+          with block_range as (
+            select b.range
+            from projects p
+            join locations l on l.id = p.primary_location_id
+            join funding_accounts fa on fa.id = l.funding_account_id
+            join department_id_blocks b on b.id = fa.department_id_block_id
+            where p.id = ${projectId}
+          ),
+          enumerated as (
+            select case
+              when id < 10000 then lpad(id::text, 5, '0')
+              else id::text
+            end as dept_id
+            from block_range,
+                 unnest(block_range.range) as r,
+                 lateral generate_series(lower(r), upper(r) - 1) as id
+          ),
+          used as (
+            select department_id from projects
+            where department_id is not null and deleted_at is null
+            -- migration-todo: also exclude external_department_ids when that
+            -- table migrates (likely Admin domain).
+          )
+          select dept_id as "nextId" from enumerated
+          where dept_id not in (select department_id from used)
+          order by dept_id asc
+          limit 1
+        `,
+      );
+      const first = rows[0];
+      if (!first) {
+        throw new ServerException('No department ID is available');
+      }
+      nextId = first.nextId;
+    } catch (e) {
+      if (e instanceof ServerException) throw e;
+      throw new ServerException(
+        'Could not resolve next available department ID',
+        e,
+      );
+    }
+
+    try {
+      await this.drizzle.client
+        .update(projects)
+        .set({ departmentId: nextId, modifiedAt: new Date() })
+        .where(eq(projects.id, projectId));
+      return nextId;
+    } catch (e) {
+      if (isUniqueViolation(e, 'projects_department_id_active_unique')) {
+        // Mirror of the Neo4j path: signal the transaction interceptor to
+        // retry. A concurrent assignment grabbed the same id between our
+        // SELECT and UPDATE; reading + writing again will pick the next one.
+        this.retryInformer.markForRetry(e as Error);
+        throw new ServerException(
+          "Could not set Project's Department ID (retryable)",
+          e,
+        );
+      }
+      throw new ServerException("Could not set Project's Department ID", e);
     }
   }
 

--- a/src/components/project/handlers/set-department-id.handler.ts
+++ b/src/components/project/handlers/set-department-id.handler.ts
@@ -49,6 +49,15 @@ export class SetDepartmentId {
       return;
     }
 
+    // migration-todo: the PG path (assignDepartmentIdPg, below) is implemented
+    // but needs funding_accounts.department_id_block_id + populated blocks,
+    // which land with the FundingAccount↔department_id_block migration. No-op
+    // under postgres until then; delete this guard to enable the PG path (the
+    // engine-check below already routes to it).
+    if (this.config.databaseEngine === 'postgres') {
+      return;
+    }
+
     const project =
       event instanceof ProjectTransitionedHook ? event.project : event.updated;
 

--- a/src/components/project/handlers/set-initial-mou-end.handler.ts
+++ b/src/components/project/handlers/set-initial-mou-end.handler.ts
@@ -1,4 +1,8 @@
+import { eq } from 'drizzle-orm';
 import { ServerException } from '~/common';
+import { ConfigService } from '~/core/config';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { projects } from '~/core/drizzle/schema';
 import { OnHook } from '~/core/hooks';
 import { DatabaseService } from '~/core/neo4j';
 import { IProject, ProjectStatus } from '../dto';
@@ -10,7 +14,11 @@ type SubscribedEvent = ProjectCreatedHook | ProjectTransitionedHook;
 @OnHook(ProjectCreatedHook)
 @OnHook(ProjectTransitionedHook)
 export class SetInitialMouEnd {
-  constructor(private readonly db: DatabaseService) {}
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly drizzle: DrizzleService,
+    private readonly config: ConfigService,
+  ) {}
 
   async handle(event: SubscribedEvent) {
     const { project } = event;
@@ -26,6 +34,20 @@ export class SetInitialMouEnd {
     }
 
     try {
+      // migration-todo: collapse this engine-check at Phase 7 cutover — drop
+      // the Neo4j branch + DatabaseService injection, keep only the PG path.
+      if (this.config.databaseEngine === 'postgres') {
+        await this.drizzle.client
+          .update(projects)
+          .set({
+            initialMouEnd: project.mouEnd ? project.mouEnd.toSQLDate() : null,
+          })
+          .where(eq(projects.id, project.id));
+        // Mutate the hook payload so downstream handlers see the new value.
+        event.project = { ...project, initialMouEnd: project.mouEnd ?? null };
+        return;
+      }
+
       const updatedProject = await this.db.updateProperties({
         type: IProject,
         object: project,
@@ -33,12 +55,7 @@ export class SetInitialMouEnd {
           initialMouEnd: project.mouEnd || null,
         },
       });
-
-      if (event instanceof ProjectTransitionedHook) {
-        event.project = updatedProject;
-      } else {
-        event.project = updatedProject;
-      }
+      event.project = updatedProject;
     } catch (exception) {
       throw new ServerException(
         'Could not set initial mou end on project',

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -12,6 +12,7 @@ import {
   isNull,
   lt,
   lte,
+  max,
   sql,
   type SQL,
 } from 'drizzle-orm';
@@ -45,6 +46,7 @@ import {
   locations,
   projectMembers,
   projects,
+  projectWorkflowEvents,
 } from '~/core/drizzle/schema';
 import { rolesForScope } from '../authorization/dto/role.dto';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
@@ -85,6 +87,8 @@ const catchDepartmentIdUnique = catchUniqueViolation(
  */
 type ProjectRow = typeof projects.$inferSelect & {
   engagementTotal?: number;
+  /** Latest workflow-event `at`, if any — batched in `readMany`. */
+  stepChangedAt?: Date | null;
   membership?: {
     id: ID<'ProjectMember'>;
     roles: readonly string[];
@@ -162,6 +166,21 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
     const membershipByProject = new Map(
       memberships.map((m) => [m.projectId, m]),
     );
+    // Latest workflow-event timestamp per project — `stepChangedAt` derives
+    // from it at read time (toDto falls back to createdAt, matching Gel's
+    // `latestWorkflowEvent.at ?? createdAt`). Served by the
+    // (project_id, at DESC) index; events are append-only (no soft delete).
+    const latestEvents = await this.db
+      .select({
+        projectId: projectWorkflowEvents.projectId,
+        at: max(projectWorkflowEvents.at),
+      })
+      .from(projectWorkflowEvents)
+      .where(inArray(projectWorkflowEvents.projectId, [...ids]))
+      .groupBy(projectWorkflowEvents.projectId);
+    const stepChangedByProject = new Map(
+      latestEvents.map((e) => [e.projectId, e.at]),
+    );
     // migration-todo: engagementTotal is stubbed to 0 until Engagement migrates
     // (the `engagements` table isn't on develop yet). `pinned` dropped — Pin
     // isn't migrated; re-add the pinnedByRequester batch when the pin domain ports.
@@ -169,6 +188,7 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
       const enriched: ProjectRow = {
         ...row,
         membership: membershipByProject.get(row.id) ?? null,
+        stepChangedAt: stepChangedByProject.get(row.id) ?? null,
         engagementTotal: 0,
       };
       return this.toDto(enriched);
@@ -427,10 +447,9 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
       presetInventory: row.presetInventory,
       createdAt: DateTime.fromJSDate(row.createdAt),
       modifiedAt: DateTime.fromJSDate(row.modifiedAt),
-      // stepChangedAt is derived from the latest workflow event; PR 3 wires
-      // the real query. For now fall back to createdAt — the only reader is
-      // the resolver, and the field has no stored canonical value anyway.
-      stepChangedAt: DateTime.fromJSDate(row.createdAt),
+      // Derived from the latest workflow event (batched in readMany), falling
+      // back to createdAt — Gel parity: `latestWorkflowEvent.at ?? createdAt`.
+      stepChangedAt: DateTime.fromJSDate(row.stepChangedAt ?? row.createdAt),
       primaryLocation: linkOrNull(row.primaryLocationId),
       marketingLocation: linkOrNull(row.marketingLocationId),
       marketingRegionOverride: linkOrNull(row.marketingRegionOverrideId),
@@ -796,16 +815,19 @@ export const projectFilterClauses = (
     );
   }
   if (filter.tool) {
+    // migration-todo: wire when ToolUsage migrates (exists-over-tool_usages).
     throw new NotImplementedException(
       'ProjectFilters.tool requires ToolUsage migration.',
     );
   }
   if (filter.onlyMultipleEngagements != null) {
+    // migration-todo: wire when Engagement migrates (count-over-engagements).
     throw new NotImplementedException(
       'ProjectFilters.onlyMultipleEngagements requires Engagement migration (Phase 5).',
     );
   }
   if (filter.usesRev79 != null) {
+    // migration-todo: wire when ToolUsage migrates (Rev79 tool usage check).
     throw new NotImplementedException(
       'ProjectFilters.usesRev79 requires ToolUsage migration.',
     );

--- a/src/components/project/workflow/project-workflow.drizzle.repository.ts
+++ b/src/components/project/workflow/project-workflow.drizzle.repository.ts
@@ -1,0 +1,179 @@
+import { Injectable } from '@nestjs/common';
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import { generateId, type ID, type UnsecuredDto } from '~/common';
+import { Identity } from '~/core/authentication';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { projects, projectWorkflowEvents } from '~/core/drizzle/schema';
+import { type ProjectStep } from '../dto';
+import {
+  type ExecuteProjectTransition,
+  type ProjectWorkflowEvent as WorkflowEvent,
+} from './dto';
+
+/**
+ * PostgreSQL implementation of the canonical `ProjectWorkflowRepository`.
+ *
+ * `projects.step` is kept in sync by an `AFTER INSERT` trigger on
+ * `project_workflow_events` (see migration 0009 — `sync_project_step_from_event`).
+ * App code never writes to `projects.step` directly; insert an event and the
+ * trigger does the rest. `modified_at` is bumped in the same trigger.
+ *
+ * `status` is a `GENERATED ALWAYS AS (CASE step ... END) STORED` column, so it
+ * follows step automatically — no extra write needed.
+ *
+ * `stepChangedAt` derives from the event's `at` timestamp at read time on the
+ * Project resolver; nothing is stored on `projects` for it.
+ */
+// migration-todo: `PublicOf<ProjectWorkflowRepository>` widens to every
+// public/protected member of the Gel base (privileges, getActualChanges,
+// isUnique, etc.) which this class doesn't reproduce. Same trade as every
+// other Drizzle repo — we rely on the `as any` cast at splitDb registration
+// time and lose compile-time enforcement here. Collapses at Phase 7 cutover.
+@Injectable()
+export class ProjectWorkflowDrizzleRepository {
+  constructor(
+    private readonly drizzle: DrizzleService,
+    private readonly identity: Identity,
+  ) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  async readMany(
+    ids: readonly ID[],
+  ): Promise<Array<UnsecuredDto<WorkflowEvent>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.projectWorkflowEvents.findMany({
+      where: (e) => inArray(e.id, [...ids]),
+      with: { project: { columns: { id: true, type: true, step: true } } },
+    });
+    return rows.map((row) => this.toDto(row));
+  }
+
+  async list(projectId: ID): Promise<Array<UnsecuredDto<WorkflowEvent>>> {
+    const rows = await this.db.query.projectWorkflowEvents.findMany({
+      where: (e) => eq(e.projectId, projectId),
+      with: { project: { columns: { id: true, type: true, step: true } } },
+      orderBy: (e, { asc }) => [asc(e.at)],
+    });
+    return rows.map((row) => this.toDto(row));
+  }
+
+  /**
+   * Insert a workflow event. The trigger handles `projects.step` /
+   * `modified_at` sync. We capture the project's current step *before* insert
+   * so the returned dto can carry `project.previousStep` — same surface as the
+   * Neo4j repo, where `previousStep` is read from the pre-update Property
+   * node within the same transaction.
+   */
+  async recordEvent(
+    input: Omit<ExecuteProjectTransition, 'bypassTo'> & { to: ProjectStep },
+  ): Promise<UnsecuredDto<WorkflowEvent>> {
+    const [projectRow] = await this.db
+      .select({ step: projects.step, type: projects.type })
+      .from(projects)
+      .where(eq(projects.id, input.project))
+      .limit(1);
+    const fromStep: ProjectStep | null = projectRow?.step ?? null;
+
+    const id = await generateId<ID<'ProjectWorkflowEvent'>>();
+    const who = this.identity.current.userId;
+    const at = new Date();
+
+    await this.db.insert(projectWorkflowEvents).values({
+      id,
+      projectId: input.project,
+      who,
+      fromStep,
+      toStep: input.to,
+      transitionKey: input.transition ?? null,
+      notes: input.notes ?? null,
+      at,
+    });
+
+    return this.toDto({
+      id,
+      projectId: input.project,
+      who,
+      fromStep,
+      toStep: input.to,
+      transitionKey: input.transition ?? null,
+      notes: input.notes ?? null,
+      at,
+      project: {
+        id: input.project,
+        type: projectRow!.type,
+        step: fromStep ?? input.to,
+      },
+    });
+  }
+
+  /**
+   * Walk this project's event history and return the most recent `to_step`
+   * matching any of `steps`. Drives the `BackToActive` dynamic step in
+   * `project-workflow.ts` (and any future dynamic-state resolver). Returns
+   * null when the project has never reached one of those steps.
+   */
+  async mostRecentStep(
+    projectId: ID<'Project'>,
+    steps: readonly ProjectStep[],
+  ): Promise<ProjectStep | null> {
+    if (steps.length === 0) return null;
+    const rows = await this.db
+      .select({ step: projectWorkflowEvents.toStep })
+      .from(projectWorkflowEvents)
+      .where(
+        and(
+          eq(projectWorkflowEvents.projectId, projectId),
+          inArray(projectWorkflowEvents.toStep, [...steps]),
+        ),
+      )
+      .orderBy(desc(projectWorkflowEvents.at))
+      .limit(1);
+    return rows[0]?.step ?? null;
+  }
+
+  protected toDto(
+    row: typeof projectWorkflowEvents.$inferSelect & {
+      project?: { id: ID<'Project'>; type: string; step: ProjectStep } | null;
+    },
+  ): UnsecuredDto<WorkflowEvent> & {
+    project: { id: ID<'Project'>; type: string; previousStep: ProjectStep };
+  } {
+    if (!row.project) {
+      // Schema FK is NOT NULL → the relational findMany typing widens to nullable
+      // but the row always exists. Loud failure beats silent NaN.
+      throw new Error(
+        `ProjectWorkflowEvent ${row.id} missing parent project row — FK invariant violated`,
+      );
+    }
+    const dto: unknown = {
+      id: row.id,
+      __typename: 'ProjectWorkflowEvent',
+      createdAt: DateTime.fromJSDate(row.at),
+      at: DateTime.fromJSDate(row.at),
+      who: { id: row.who },
+      // `transition` is the transition key (a string id resolved to a
+      // WorkflowTransition object at the resolver layer). null when the
+      // transition was bypassed or dynamic.
+      transition: row.transitionKey ?? null,
+      to: row.toStep,
+      notes: row.notes ?? null,
+      project: {
+        id: row.project.id,
+        type: row.project.type,
+        // `previousStep` = the project's step at the time the event was
+        // observed (post-trigger, this *is* the previous step from the
+        // event's POV because the trigger has already moved the project to
+        // `to_step`). `recordEvent` overrides this with the captured
+        // `fromStep` so its caller sees the correct value.
+        previousStep: row.fromStep ?? row.project.step,
+      },
+    };
+    return dto as UnsecuredDto<WorkflowEvent> & {
+      project: { id: ID<'Project'>; type: string; previousStep: ProjectStep };
+    };
+  }
+}

--- a/src/components/project/workflow/project-workflow.module.ts
+++ b/src/components/project/workflow/project-workflow.module.ts
@@ -6,6 +6,7 @@ import { ProjectWorkflowNotificationHandler } from './handlers/project-workflow-
 import { StepHistoryToWorkflowEventsMigration } from './migrations/step-history-to-workflow-events.migration';
 import { ProjectWorkflowEventLoader } from './project-workflow-event.loader';
 import { ProjectWorkflowChannels } from './project-workflow.channels';
+import { ProjectWorkflowDrizzleRepository } from './project-workflow.drizzle.repository';
 import { ProjectWorkflowFlowchart } from './project-workflow.flowchart';
 import { ProjectWorkflowEventGranter } from './project-workflow.granter';
 import { ProjectWorkflowNeo4jRepository } from './project-workflow.neo4j.repository';
@@ -31,6 +32,9 @@ import { ProjectWorkflowMutationSubscriptionsResolver } from './resolvers/projec
     ProjectWorkflowEventGranter,
     splitDb(ProjectWorkflowRepository, {
       neo4j: ProjectWorkflowNeo4jRepository,
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: ProjectWorkflowDrizzleRepository as any,
     }),
     ProjectWorkflowFlowchart,
     ProjectWorkflowNotificationHandler,

--- a/src/core/drizzle/errors.ts
+++ b/src/core/drizzle/errors.ts
@@ -19,6 +19,23 @@ const findDatabaseError = (e: unknown): DatabaseError | undefined => {
 };
 
 /**
+ * Whether the error (or anything in its cause chain) is a PostgreSQL
+ * unique-constraint violation on a constraint whose name contains
+ * `constraintMatch`. For callers that need to branch instead of rethrow.
+ */
+export const isUniqueViolation = (
+  e: unknown,
+  constraintMatch: string,
+): boolean => {
+  const dbError = findDatabaseError(e);
+  return (
+    !!dbError &&
+    dbError.code === PgErrorCode.UniqueViolation &&
+    !!dbError.constraint?.includes(constraintMatch)
+  );
+};
+
+/**
  * Promise `.catch()` handler that maps a PostgreSQL unique-constraint
  * violation to a `DuplicateException`. `constraintMatch` is checked as a
  * substring against the failing constraint name.


### PR DESCRIPTION
### Summary
- Ports the Project **workflow** repository, the transition-hook PG paths, and project-mutation side-effect handling under Postgres. No schema/migration changes (all in PR 1, #3809). Neo4j/Gel paths untouched — everything routes through `splitDb`.

### Workflow repository
- `ProjectWorkflowDrizzleRepository` (`recordEvent` / `list` / `readMany` / `mostRecentStep`). **Inserts events only** — the migration-`0010` `AFTER INSERT` trigger syncs `projects.step` + `modified_at`; `status` follows via the `GENERATED` column. Never writes `step` directly.
- `splitDb` postgres entry on the workflow module; `isUniqueViolation` added to `errors.ts`.

### Transition-hook PG paths
- **SetInitialMouEnd** — writes `projects.initial_mou_end` and mutates the hook payload so downstream handlers see the new value.
- **SetDepartmentId** — PG path implemented (`unnest(range)` + `generate_series` + `isUniqueViolation` retry), but **guarded to no-op** under postgres until the FundingAccount↔department_id_block migration lands (Wave-2 dep). One-line un-guard when it does.

### Project-mutation side-effect guards (cross-domain)
- No-op under postgres until their domains migrate: default-budget create, budget-status update, budget-record sync (Budget); engagement-status update (Engagement). Read-only date-diff/validate hooks self-no-op — no guard needed.
- **rootDirectory WIRED** (File is on develop): `AttachProjectRootDirectoryHandler` creates the root dir + 4 default subdirs and writes `projects.root_directory_id`.

### Validation
- Reviewed via the adversarial `review-pr` workflow — **clean** (no findings on the workflow code; the sort-guard findings it surfaced were in PR 2 and are fixed there).
- Under `DATABASE=postgres`: `project-member.e2e` green; `project.e2e` at the Project-only ceiling (18/30 — all remaining failures are downstream-domain boundaries: Budget/Engagement/Language/Partnership/Pin/FundingAccount + name-collation, none Project-stack bugs). `project-workflow.e2e` is gated on unmigrated Language. type-check + lint clean.
