### PR TITLE
[pg] Partnership → Postgres (Drizzle)

### DIFF
--- a/src/components/authorization/policies/conditions/member.condition.ts
+++ b/src/components/authorization/policies/conditions/member.condition.ts
@@ -155,19 +155,21 @@ const projectIdRefForResource = (resource: EnhancedResource<any>): SQL => {
       return sql.raw(`"projects"."id"`);
     case 'ProjectMember':
       return sql.raw(`"project_members"."project_id"`);
+    case 'Partnership':
+      return sql.raw(`"partnerships"."project_id"`);
     // migration-todo: re-add a case per domain as it ports to Postgres
-    // (Partnership/Budget/Engagement/Ceremony/Language/BudgetRecord each
-    // dereference to their `project_id` FK — mono has the arms). Kept stripped
-    // so an unmigrated domain routed through Drizzle fails loud here instead of
+    // (Budget/Engagement/Ceremony/Language/BudgetRecord each dereference to
+    // their `project_id` FK — mono has the arms). Kept stripped so an
+    // unmigrated domain routed through Drizzle fails loud here instead of
     // emitting SQL against a non-existent table.
     //
     // Partner is on develop and member-gated (field-partner.policy
-    // `r.Partner.when(member).read`), but it intentionally has NO arm: its
-    // member check must traverse partner→partnership→project→project_members,
-    // and `partnerships` isn't on develop, so it can't be expressed in SQL yet.
-    // It therefore hits `default: throw` — a pre-existing dev-only gap (a
-    // FieldPartner reading Partners under DATABASE=postgres; the admin-run e2e
-    // never exercises it). Add the Partner arm when Partnership migrates.
+    // `r.Partner.when(member).read`), but it intentionally has NO arm — mono
+    // ships none either. Its member check would traverse
+    // partner→partnership→project→project_members; even now that `partnerships`
+    // is on develop, we match mono and leave it at `default: throw`. This is a
+    // pre-existing dev-only gap (a FieldPartner reading Partners under
+    // DATABASE=postgres; the admin-run e2e never exercises it).
     default:
       throw new Error(
         `MemberCondition.asDrizzleCondition: resource ${resource.name} not configured for Drizzle yet; add a case when it migrates.`,

--- a/src/components/authorization/policies/conditions/sensitivity.condition.ts
+++ b/src/components/authorization/policies/conditions/sensitivity.condition.ts
@@ -178,11 +178,16 @@ const sensitivityRefForResource = (
         select "p"."sensitivity" from "projects" "p"
         where "p"."id" = "project_members"."project_id"
       ) <= ${accessLiteral}`;
+    case 'Partnership':
+      return sql`(
+        select "p"."sensitivity" from "projects" "p"
+        where "p"."id" = "partnerships"."project_id"
+      ) <= ${accessLiteral}`;
     // migration-todo: re-add a case per domain as it ports to Postgres
-    // (Partnership/Budget/Engagement/Ceremony/Language/BudgetRecord read
-    // sensitivity via their parent project; Partner has its own derived column —
-    // mono has the arms). Kept stripped so an unmigrated domain routed through
-    // Drizzle fails loud here instead of emitting SQL against a missing table.
+    // (Budget/Engagement/Ceremony/Language/BudgetRecord read sensitivity via
+    // their parent project; Partner has its own derived column — mono has the
+    // arms). Kept stripped so an unmigrated domain routed through Drizzle fails
+    // loud here instead of emitting SQL against a missing table.
     default:
       throw new Error(
         `SensitivityCondition.asDrizzleCondition: resource ${resource.name} not configured for Drizzle yet; add a case when it migrates.`,

--- a/src/components/partnership/partnership.drizzle.repository.ts
+++ b/src/components/partnership/partnership.drizzle.repository.ts
@@ -1,0 +1,576 @@
+import { Injectable } from '@nestjs/common';
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  inArray,
+  isNull,
+  ne,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  CalendarDate,
+  CreationFailed,
+  DuplicateException,
+  generateId,
+  type ID,
+  NotFoundException,
+  NotImplementedException,
+  type ObjectView,
+  type PaginatedListType,
+  type UnsecuredDto,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import {
+  DrizzleDtoRepository,
+  EMPTY_PAGE,
+  isUniqueViolation,
+  resolveOrderBy,
+  type SortMap,
+  subFilter,
+} from '~/core/drizzle';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
+import { partners, partnerships, projects } from '~/core/drizzle/schema';
+import { type ScopedRole } from '../authorization/dto/role.dto';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import { FileService } from '../file';
+import {
+  partnerFilterClauses,
+  partnerSortColumns,
+} from '../partner/partner.drizzle.repository';
+import { requesterScopeByProject } from '../project/project-member/membership-scope';
+import {
+  type CreatePartnership,
+  Partnership,
+  type PartnershipFilters,
+  type PartnershipListInput,
+  type UpdatePartnership,
+} from './dto';
+import { type PartnershipByProjectAndPartnerInput } from './partnership-by-project-and-partner.loader';
+
+/**
+ * Relational findMany row shape: the partnership row plus the parent project
+ * (id, type, sensitivity, mou_start, mou_end — sensitivity inherited onto the
+ * DTO; project mou dates feed the override coalesce) and the partner
+ * (id, organization_id — the DTO carries the partner's organization too,
+ * mirroring the Neo4j hydrate's `org { .id }` overlay).
+ */
+type PartnershipRow = typeof partnerships.$inferSelect & {
+  project: Pick<
+    typeof projects.$inferSelect,
+    'id' | 'type' | 'sensitivity' | 'mouStart' | 'mouEnd'
+  > | null;
+  partner: Pick<typeof partners.$inferSelect, 'id' | 'organizationId'> | null;
+};
+
+@Injectable()
+export class PartnershipDrizzleRepository extends DrizzleDtoRepository<
+  typeof partnerships,
+  Partnership
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+    private readonly identity: Identity,
+    private readonly files: FileService,
+  ) {
+    super(db, partnerships, Partnership);
+  }
+
+  /** Attach the requester's project-scoped roles to each row's DTO. */
+  private async mapRowsWithScope(rows: PartnershipRow[]) {
+    const scopeByProject = await requesterScopeByProject(
+      this.db,
+      this.identity.current.userId,
+      rows.flatMap((r) => r.project?.id ?? []),
+    );
+    return rows.map((row) =>
+      this.toDto(
+        row,
+        row.project ? (scopeByProject.get(row.project.id) ?? []) : [],
+      ),
+    );
+  }
+
+  /**
+   * Create a partnership. Verifies project + partner exist and that no
+   * (project, partner) partnership already exists; the partial unique index
+   * (`partnerships_project_partner_active_unique`) is the DB-level backstop.
+   *
+   * MOU + Agreement defined files: the FKs are stored here; createDefinedFile
+   * makes the (version-less) placeholder nodes after the row lands.
+   *
+   * `changeset` accepted for splitDb signature parity; PCR/Changeset is
+   * excluded from the migration entirely, so it's silently ignored.
+   */
+  async create(input: CreatePartnership, _changeset?: ID): Promise<{ id: ID }> {
+    await this.verifyRelationshipEligibility(input.project, input.partner);
+
+    const id = await generateId<ID<'Partnership'>>();
+    const mouId = await generateId();
+    const agreementId = await generateId();
+    const values = {
+      id,
+      projectId: input.project,
+      partnerId: input.partner,
+      agreementStatus: input.agreementStatus ?? 'NotAttached',
+      mouStatus: input.mouStatus ?? 'NotAttached',
+      mouId,
+      agreementId,
+      mouStartOverride: input.mouStartOverride
+        ? input.mouStartOverride.toSQLDate()
+        : null,
+      mouEndOverride: input.mouEndOverride
+        ? input.mouEndOverride.toSQLDate()
+        : null,
+      types: input.types ? [...input.types] : [],
+      financialReportingType: input.financialReportingType ?? null,
+      primary: input.primary ?? false,
+    };
+    try {
+      // Nested transaction = savepoint, so a primary-race conflict below
+      // doesn't poison the surrounding mutation transaction.
+      await this.db.transaction(async (tx) => {
+        await tx.insert(partnerships).values(values);
+      });
+    } catch (e) {
+      if (
+        values.primary &&
+        isUniqueViolation(e, 'partnerships_project_primary_active_unique')
+      ) {
+        // Lost the primary race — a concurrent create on the same project
+        // already claimed primary (the service's isFirstPartnership check
+        // isn't atomic). Yield and create this one as non-primary.
+        await this.db
+          .insert(partnerships)
+          .values({ ...values, primary: false })
+          .catch((e2) => {
+            throw new CreationFailed(Partnership, { cause: e2 as Error });
+          });
+      } else {
+        throw new CreationFailed(Partnership, { cause: e as Error });
+      }
+    }
+
+    await this.files.createDefinedFile(mouId, `MOU`, id, 'mou', input.mou);
+    await this.files.createDefinedFile(
+      agreementId,
+      `Partner Agreement`,
+      id,
+      'agreement',
+      input.agreement,
+    );
+
+    return { id };
+  }
+
+  /**
+   * Apply a partial change set. The service handles the primary-flag transfer
+   * by calling `removePrimaryFromOtherPartnerships` separately before update;
+   * the partial unique index on `(project_id) WHERE primary = true` is the
+   * DB-level backstop.
+   */
+  async update(
+    changes: Omit<UpdatePartnership, 'mou' | 'agreement'>,
+    _changeset?: ID,
+  ): Promise<void> {
+    const { id, ...fields } = changes;
+    await this.updateColumns(id, {
+      ...(fields.agreementStatus !== undefined && {
+        agreementStatus: fields.agreementStatus,
+      }),
+      ...(fields.mouStatus !== undefined && { mouStatus: fields.mouStatus }),
+      ...(fields.mouStartOverride !== undefined && {
+        mouStartOverride: fields.mouStartOverride
+          ? fields.mouStartOverride.toSQLDate()
+          : null,
+      }),
+      ...(fields.mouEndOverride !== undefined && {
+        mouEndOverride: fields.mouEndOverride
+          ? fields.mouEndOverride.toSQLDate()
+          : null,
+      }),
+      ...(fields.types !== undefined && { types: [...fields.types] }),
+      ...(fields.financialReportingType !== undefined && {
+        financialReportingType: fields.financialReportingType ?? null,
+      }),
+      ...(fields.primary !== undefined && { primary: fields.primary }),
+    });
+  }
+
+  async deleteNode(
+    object: { id: ID } | ID,
+    _options?: { changeset?: ID },
+  ): Promise<void> {
+    const id = typeof object === 'string' ? object : object.id;
+    await this.softDelete(id);
+  }
+
+  override async readMany(
+    ids: readonly ID[],
+    _view?: ObjectView,
+  ): Promise<Array<UnsecuredDto<Partnership>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.partnerships.findMany({
+      where: (p) => and(inArray(p.id, [...ids]), isNull(p.deletedAt)),
+      with: {
+        project: {
+          columns: {
+            id: true,
+            type: true,
+            sensitivity: true,
+            mouStart: true,
+            mouEnd: true,
+          },
+        },
+        partner: { columns: { id: true, organizationId: true } },
+      },
+    });
+    return await this.mapRowsWithScope(rows as PartnershipRow[]);
+  }
+
+  /**
+   * Resolve memberships keyed by `(project, partner)` pairs — drives the
+   * `Project.partnership(partnerId)` resolver via the
+   * PartnershipByProjectAndPartnerLoader. Read permission is enforced at the
+   * resolver layer; this repo path returns the row if it exists.
+   */
+  async readManyByProjectAndPartner(
+    input: readonly PartnershipByProjectAndPartnerInput[],
+  ): Promise<Array<UnsecuredDto<Partnership>>> {
+    if (input.length === 0) return [];
+    const pairs = input.map(
+      (i) =>
+        and(
+          eq(partnerships.projectId, i.project),
+          eq(partnerships.partnerId, i.partner),
+        )!,
+    );
+    const rows = await this.db.query.partnerships.findMany({
+      where: (p) =>
+        and(isNull(p.deletedAt), sql`(${sql.join(pairs, sql` OR `)})`),
+      with: {
+        project: {
+          columns: {
+            id: true,
+            type: true,
+            sensitivity: true,
+            mouStart: true,
+            mouEnd: true,
+          },
+        },
+        partner: { columns: { id: true, organizationId: true } },
+      },
+    });
+    return await this.mapRowsWithScope(rows as PartnershipRow[]);
+  }
+
+  /** Used by SetDepartmentId (multiplication-translation path) + others. */
+  async listAllByProjectId(
+    projectId: ID,
+  ): Promise<Array<UnsecuredDto<Partnership>>> {
+    const rows = await this.db.query.partnerships.findMany({
+      where: (p) => and(eq(p.projectId, projectId), isNull(p.deletedAt)),
+      with: {
+        project: {
+          columns: {
+            id: true,
+            type: true,
+            sensitivity: true,
+            mouStart: true,
+            mouEnd: true,
+          },
+        },
+        partner: { columns: { id: true, organizationId: true } },
+      },
+    });
+    return await this.mapRowsWithScope(rows as PartnershipRow[]);
+  }
+
+  /**
+   * True when `projectId` has no existing live partnerships. Drives
+   * `PartnershipService.create`'s "auto-set primary on the first one" branch.
+   */
+  async isFirstPartnership(projectId: ID, _changeset?: ID): Promise<boolean> {
+    const [row] = await this.db
+      .select({ n: sql<number>`1` })
+      .from(partnerships)
+      .where(
+        and(
+          eq(partnerships.projectId, projectId),
+          isNull(partnerships.deletedAt),
+        ),
+      )
+      .limit(1);
+    return !row;
+  }
+
+  /** True when there are other live partnerships on the same project. */
+  async isAnyOtherPartnerships(id: ID): Promise<boolean> {
+    const row = await this.db.query.partnerships.findFirst({
+      where: (p) => and(eq(p.id, id), isNull(p.deletedAt)),
+      columns: { projectId: true },
+    });
+    if (!row) return false;
+    const [other] = await this.db
+      .select({ n: sql<number>`1` })
+      .from(partnerships)
+      .where(
+        and(
+          eq(partnerships.projectId, row.projectId),
+          ne(partnerships.id, id),
+          isNull(partnerships.deletedAt),
+        ),
+      )
+      .limit(1);
+    return !!other;
+  }
+
+  /**
+   * Clear `primary = false` on every other live partnership on the same
+   * project. The partial unique index
+   * `partnerships_project_primary_active_unique` enforces "at most one
+   * primary"; this method is what makes the app side of the flip atomic.
+   * Returns the affected partnership ids for hook fan-out.
+   */
+  async removePrimaryFromOtherPartnerships(id: ID): Promise<Array<{ id: ID }>> {
+    const row = await this.db.query.partnerships.findFirst({
+      where: (p) => and(eq(p.id, id), isNull(p.deletedAt)),
+      columns: { projectId: true },
+    });
+    if (!row) return [];
+    const affected = await this.db
+      .update(partnerships)
+      .set({ primary: false, updatedAt: new Date() })
+      .where(
+        and(
+          eq(partnerships.projectId, row.projectId),
+          ne(partnerships.id, id),
+          eq(partnerships.primary, true),
+          isNull(partnerships.deletedAt),
+        ),
+      )
+      .returning({ id: partnerships.id });
+    return affected as Array<{ id: ID }>;
+  }
+
+  async list(
+    input: PartnershipListInput,
+    _changeset?: ID,
+  ): Promise<PaginatedListType<UnsecuredDto<Partnership>>> {
+    const conditions: SQL[] = [isNull(partnerships.deletedAt)];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+    conditions.push(...partnershipFilterClauses(this.db, input.filter));
+    const predicate = and(...conditions);
+
+    // Cast to string — `partner.*` keys aren't in `keyof Partnership`.
+    const sort = input.sort as string;
+    const direction = input.order === 'ASC' ? asc : desc;
+
+    // migration-todo: third consumer of the cross-domain JOIN-sort pattern
+    // (Partner → organization.*, Project → primaryLocation.*/fieldRegion.*,
+    // now Partnership → partner.*). Time to extract a shared
+    // `resolveCrossDomainSort` + `paginatedSelectWithJoin` into
+    // `~/core/drizzle`. Tracked as a small follow-up cleanup PR.
+    const partnerSortKey = sort.startsWith('partner.')
+      ? sort.slice('partner.'.length)
+      : null;
+    const partnerSortColumn =
+      partnerSortKey && partnerSortKey in partnerSortColumns
+        ? partnerSortColumns[partnerSortKey as keyof typeof partnerSortColumns]
+        : null;
+    if (partnerSortKey && !partnerSortColumn) {
+      throw new NotImplementedException(
+        `Sorting partnerships by '${sort}' is not supported — ` +
+          `'${partnerSortKey}' is not a known sortable column on \`partners\`.`,
+      );
+    }
+
+    let pageIds: ReadonlyArray<{ id: ID<'Partnership'> }>;
+    let total: number;
+    if (partnerSortColumn) {
+      const offset = (input.page - 1) * input.count;
+      const [countResult, joined] = await Promise.all([
+        this.db.select({ total: count() }).from(partnerships).where(predicate),
+        this.db
+          .select({ id: partnerships.id })
+          .from(partnerships)
+          .innerJoin(partners, eq(partnerships.partnerId, partners.id))
+          .where(predicate)
+          .orderBy(direction(partnerSortColumn), asc(partnerships.id))
+          .limit(input.count)
+          .offset(offset),
+      ]);
+      total = countResult[0]?.total ?? 0;
+      pageIds = joined;
+    } else {
+      const sortColumns = partnershipSortColumns;
+      const page = await this.paginatedSelect({
+        predicate,
+        orderBy: resolveOrderBy(input, sortColumns, partnerships.createdAt),
+        page: input.page,
+        count: input.count,
+      });
+      pageIds = page.rows.map((r) => ({ id: r.id }));
+      total = page.total;
+    }
+    const offset = (input.page - 1) * input.count;
+    const hasMore = offset + pageIds.length < total;
+    if (pageIds.length === 0) return { total, items: [], hasMore };
+
+    const dtos = await this.readMany(pageIds.map((r) => r.id));
+    const byId = new Map(dtos.map((d) => [d.id, d]));
+    return {
+      total,
+      items: pageIds.flatMap((r) => byId.get(r.id) ?? []),
+      hasMore,
+    };
+  }
+
+  private async verifyRelationshipEligibility(
+    projectId: ID,
+    partnerId: ID,
+  ): Promise<void> {
+    const [project, partner, existing] = await Promise.all([
+      this.db
+        .select({ id: projects.id })
+        .from(projects)
+        .where(and(eq(projects.id, projectId), isNull(projects.deletedAt)))
+        .limit(1),
+      this.db
+        .select({ id: partners.id })
+        .from(partners)
+        .where(and(eq(partners.id, partnerId), isNull(partners.deletedAt)))
+        .limit(1),
+      this.db
+        .select({ id: partnerships.id })
+        .from(partnerships)
+        .where(
+          and(
+            eq(partnerships.projectId, projectId),
+            eq(partnerships.partnerId, partnerId),
+            isNull(partnerships.deletedAt),
+          ),
+        )
+        .limit(1),
+    ]);
+    if (!project[0]) {
+      throw new NotFoundException('Could not find project', 'project');
+    }
+    if (!partner[0]) {
+      throw new NotFoundException('Could not find partner', 'partner');
+    }
+    if (existing[0]) {
+      throw new DuplicateException(
+        'project',
+        'Partnership for this project and partner already exists',
+      );
+    }
+  }
+
+  protected toDto(
+    row: PartnershipRow,
+    scope: ScopedRole[] = [],
+  ): UnsecuredDto<Partnership> {
+    if (!row.project || !row.partner) {
+      throw new Error(
+        `Partnership ${row.id} missing parent project/partner — FK invariant violated`,
+      );
+    }
+    // mou date coalesce: override → parent project. The Neo4j hydrate has a
+    // 4-level chain (changeset override → row override → changeset project →
+    // row project); PCR is excluded so the changeset branches collapse to
+    // just the override + parent project pair.
+    const mouStart = row.mouStartOverride ?? row.project.mouStart ?? null;
+    const mouEnd = row.mouEndOverride ?? row.project.mouEnd ?? null;
+    const dto: unknown = {
+      id: row.id,
+      __typename: 'Partnership',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      project: { id: row.project.id },
+      partner: { id: row.partner.id },
+      organization: { id: row.partner.organizationId },
+      sensitivity: row.project.sensitivity,
+      agreementStatus: row.agreementStatus,
+      mouStatus: row.mouStatus,
+      mouStart: mouStart ? CalendarDate.fromISO(mouStart) : null,
+      mouEnd: mouEnd ? CalendarDate.fromISO(mouEnd) : null,
+      mouStartOverride: row.mouStartOverride
+        ? CalendarDate.fromISO(row.mouStartOverride)
+        : null,
+      mouEndOverride: row.mouEndOverride
+        ? CalendarDate.fromISO(row.mouEndOverride)
+        : null,
+      types: [...row.types],
+      financialReportingType: row.financialReportingType ?? null,
+      primary: row.primary,
+      mou: row.mouId ? { id: row.mouId } : null,
+      agreement: row.agreementId ? { id: row.agreementId } : null,
+      // `changeset` is a resolver navigation marker — PCR is excluded so it
+      // stays undefined.
+      changeset: undefined,
+      canDelete: true,
+      // The requester's project-scoped roles — `member` policy conditions
+      // read these for field-level permissions.
+      scope,
+      // Required by the `parent` field on the DTO. The service constructs a
+      // BaseNode-shaped object; here we just pass the project id through.
+      parent: { id: row.project.id },
+    };
+    return dto as UnsecuredDto<Partnership>;
+  }
+}
+
+/**
+ * Sortable columns on `partnerships` itself. Cross-domain sort (`partner.*`)
+ * is resolved inline in `list()` via a hand-rolled INNER JOIN — same pattern
+ * as Partner's `organization.*` and Project's `primaryLocation.*` /
+ * `fieldRegion.*`. See the migration-todo in `list()` for the abstraction
+ * opportunity at the now-third consumer.
+ */
+export const partnershipSortColumns = {
+  createdAt: partnerships.createdAt,
+  primary: partnerships.primary,
+  agreementStatus: partnerships.agreementStatus,
+  mouStatus: partnerships.mouStatus,
+} satisfies SortMap<keyof Partnership>;
+
+/**
+ * Build the column-level WHERE clauses for a `PartnershipFilters` input
+ * against the `partnerships` table. Reusable from sub-filters in other
+ * domains (e.g. Project's `partnerships` / `primaryPartnership` once those
+ * stop being NotImplementedException stubs).
+ */
+export const partnershipFilterClauses = (
+  db: DrizzleDb,
+  filter: PartnershipFilters | undefined,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+  if (filter.projectId) {
+    conditions.push(eq(partnerships.projectId, filter.projectId));
+  }
+  if (filter.types?.length) {
+    const typesLiteral = sql.raw(
+      `array[${filter.types.map((t) => `'${t}'`).join(', ')}]::"partner_type"[]`,
+    );
+    conditions.push(sql`${partnerships.types} && ${typesLiteral}`);
+  }
+  if (filter.partner) {
+    conditions.push(
+      subFilter(
+        db,
+        partnerships.partnerId,
+        partners,
+        partnerFilterClauses(db, filter.partner),
+      ),
+    );
+  }
+  return conditions;
+};

--- a/src/components/partnership/partnership.module.ts
+++ b/src/components/partnership/partnership.module.ts
@@ -7,6 +7,7 @@ import { PartnerModule } from '../partner/partner.module';
 import { ProjectModule } from '../project/project.module';
 import * as handlers from './handlers';
 import { PartnershipByProjectAndPartnerLoader } from './partnership-by-project-and-partner.loader';
+import { PartnershipDrizzleRepository } from './partnership.drizzle.repository';
 import { PartnershipGelRepository } from './partnership.gel.repository';
 import { PartnershipLoader } from './partnership.loader';
 import { PartnershipRepository } from './partnership.repository';
@@ -26,6 +27,9 @@ import { PartnershipService } from './partnership.service';
     PartnershipService,
     splitDb(PartnershipRepository, {
       gel: PartnershipGelRepository,
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: PartnershipDrizzleRepository as any,
     }),
     PartnershipLoader,
     PartnershipByProjectAndPartnerLoader,

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -401,11 +401,17 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
    * Resolve the primary partnership's owning organization name. Used by the
    * Rev79 integration. Traverses partnerships → partners → organizations.
    */
-  async getPrimaryOrganizationName(_id: ID): Promise<string | null> {
-    // migration-todo: traverses partnerships → partners → organizations for the
-    // Rev79 integration; `partnerships` isn't on develop until the Partnership
-    // port. Stub null until then (matches the "no primary partnership" case).
-    return null;
+  async getPrimaryOrganizationName(id: ID): Promise<string | null> {
+    const rows = await this.db.execute<{ name: string }>(sql`
+      select "o"."name" from "partnerships" "ps"
+      join "partners" "pt" on "pt"."id" = "ps"."partner_id"
+      join "organizations" "o" on "o"."id" = "pt"."organization_id"
+      where "ps"."project_id" = ${id}
+        and "ps"."primary" = true
+        and "ps"."deleted_at" is null
+      limit 1
+    `);
+    return rows.rows[0]?.name ?? null;
   }
 
   protected toDto(row: ProjectRow): UnsecuredDto<Project> {
@@ -456,8 +462,9 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
       fieldRegion: linkOrNull(row.fieldRegionId),
       owningOrganization: linkOrNull(row.owningOrganizationId),
       rootDirectory: linkOrNull(row.rootDirectoryId),
-      // migration-todo: Partnership not migrated; primaryPartnership always
-      // null until partnership-pg lands.
+      // migration-todo: Partnership is on develop, but per-project
+      // primaryPartnership hydration is not yet wired (mono stubs it null too).
+      // Wire via a `partnerships` subquery (primary = true) as a follow-up.
       primaryPartnership: null,
       engagementTotal: row.engagementTotal ?? 0,
       // migration-todo: ToolUsage not migrated; usesRev79 always false until
@@ -561,8 +568,9 @@ export const projectSortColumns = {
  * `resolveCrossDomainSort(sort, prefix, sortColumns)` helper alongside
  * `paginatedSelectWithJoin` (mirror of `*FilterClauses` emergence).
  *
- * migration-todo: `primaryPartnership.*` sort is not implemented — Partnership
- * isn't migrated. Throw `NotImplementedException` so callers discover the gap.
+ * migration-todo: `primaryPartnership.*` sort is not implemented. Partnership
+ * is on develop now, but mono leaves this sort stubbed too; wire it as a
+ * follow-up. Throw `NotImplementedException` so callers discover the gap.
  */
 const resolveCrossDomainSort = (
   sort: string,
@@ -797,21 +805,26 @@ export const projectFilterClauses = (
       'ProjectFilters.languageId requires Engagement migration.',
     );
   }
-  // Cross-domain filters — throw until their target domain migrates so the
-  // gap is discoverable in tests instead of silently returning all projects.
+  // Cross-domain filters — throw until wired so the gap is discoverable in
+  // tests instead of silently returning all projects.
+  //
+  // migration-todo: Partnership is on develop now, so these three can be wired
+  // via `subFilter(db, projects.id, partnerships, [...])` reusing the exported
+  // `partnershipFilterClauses`. Mono leaves them stubbed too, so kept deferred
+  // to a follow-up rather than writing new (untested-on-mono) filter SQL here.
   if (filter.partnerId) {
     throw new NotImplementedException(
-      'ProjectFilters.partnerId requires Partnership migration.',
+      'ProjectFilters.partnerId is not yet wired under Postgres.',
     );
   }
   if (filter.partnerships) {
     throw new NotImplementedException(
-      'ProjectFilters.partnerships requires Partnership migration.',
+      'ProjectFilters.partnerships is not yet wired under Postgres.',
     );
   }
   if (filter.primaryPartnership) {
     throw new NotImplementedException(
-      'ProjectFilters.primaryPartnership requires Partnership migration.',
+      'ProjectFilters.primaryPartnership is not yet wired under Postgres.',
     );
   }
   if (filter.tool) {

--- a/src/core/drizzle/migrations/0011_add_partnerships.sql
+++ b/src/core/drizzle/migrations/0011_add_partnerships.sql
@@ -1,0 +1,76 @@
+-- Migration: add Partnership.
+-- Plus the supporting `partnership_agreement_status` enum.
+--
+-- Settled design decisions (see migration_postgres.md):
+--   - Single `partnerships` table with FKs to `projects` + `partners`.
+--   - `mou_id` / `agreement_id` are plain text, NOT foreign keys. File is on
+--     develop (0008), so the target table exists — but the repo's create()
+--     inserts the partnership row FIRST and calls files.createDefinedFile()
+--     AFTER, so the referenced file nodes don't exist at insert time. A real
+--     FK would fail the insert; kept deferred (plain text) for that ordering.
+--     Indexed below so a later REFERENCES add (or a reorder to create the
+--     files first) needs no CREATE INDEX CONCURRENTLY.
+--   - Partial unique on (project_id, partner_id) for live rows — backstops
+--     the duplicate check the Neo4j repo's verifyRelationshipEligibility
+--     performs at the app layer.
+--   - Partial unique on (project_id) where primary = true — DB-level
+--     enforcement of "one primary partnership per project". App's
+--     removePrimaryFromOtherPartnerships clears the existing flag in the
+--     same transaction.
+--   - PCR/Changeset is excluded from the migration; mou_*_override columns
+--     live on the row directly. Date coalesce (override → parent project)
+--     happens in the repo's toDto.
+
+CREATE TYPE "partnership_agreement_status" AS ENUM (
+  'NotAttached',
+  'AwaitingSignature',
+  'Signed'
+);
+--> statement-breakpoint
+
+CREATE TABLE "partnerships" (
+  "id"                       text                              PRIMARY KEY,
+  "project_id"               text                              NOT NULL REFERENCES "projects"("id") ON DELETE CASCADE,
+  "partner_id"               text                              NOT NULL REFERENCES "partners"("id") ON DELETE CASCADE,
+  "agreement_status"         "partnership_agreement_status"    NOT NULL DEFAULT 'NotAttached',
+  "mou_status"               "partnership_agreement_status"    NOT NULL DEFAULT 'NotAttached',
+  -- migration-todo: plain text (not FK) because create() inserts this row
+  -- before files.createDefinedFile() makes the file nodes. Add REFERENCES
+  -- "file_nodes"("id") only if create() is reordered to write the files first.
+  "mou_id"                   text,
+  "agreement_id"             text,
+  "mou_start_override"       date,
+  "mou_end_override"         date,
+  "types"                    "partner_type"[]                  NOT NULL DEFAULT '{}',
+  "financial_reporting_type" "financial_reporting_type",
+  "primary"                  boolean                           NOT NULL DEFAULT false,
+  "created_at"               timestamptz                       NOT NULL DEFAULT now(),
+  "updated_at"               timestamptz                       NOT NULL DEFAULT now(),
+  "deleted_at"               timestamptz
+);
+--> statement-breakpoint
+
+-- One partnership per (project, partner) pair on live rows.
+CREATE UNIQUE INDEX "partnerships_project_partner_active_unique"
+  ON "partnerships" ("project_id", "partner_id") WHERE "deleted_at" IS NULL;
+--> statement-breakpoint
+
+-- At most one primary partnership per project on live rows. DB-level
+-- enforcement of the "one primary per project" invariant; app's
+-- removePrimaryFromOtherPartnerships clears the flag elsewhere atomically.
+CREATE UNIQUE INDEX "partnerships_project_primary_active_unique"
+  ON "partnerships" ("project_id")
+  WHERE "primary" = true AND "deleted_at" IS NULL;
+--> statement-breakpoint
+
+-- The composite unique above covers the leftmost column (project_id), but
+-- partner-side lookups (e.g. "find partnerships for partner X") need their
+-- own index.
+CREATE INDEX "partnerships_partner_id_idx" ON "partnerships" ("partner_id");
+--> statement-breakpoint
+
+-- mou_id / agreement_id indexed now so adding a REFERENCES clause later
+-- doesn't require CREATE INDEX CONCURRENTLY.
+CREATE INDEX "partnerships_mou_id_idx"       ON "partnerships" ("mou_id");
+--> statement-breakpoint
+CREATE INDEX "partnerships_agreement_id_idx" ON "partnerships" ("agreement_id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1747699200000,
       "tag": "0010_add_projects",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1747785600000,
+      "tag": "0011_add_partnerships",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -23,6 +23,7 @@ import { type OrganizationReach } from '../../../components/organization/dto/org
 import { type OrganizationType } from '../../../components/organization/dto/organization-type.dto';
 import { type PartnerType } from '../../../components/partner/dto/partner-type.enum';
 import { type FinancialReportingType } from '../../../components/partnership/dto/financial-reporting-type.enum';
+import { type PartnershipAgreementStatus } from '../../../components/partnership/dto/partnership-agreement-status.enum';
 import { type ReportPeriod } from '../../../components/periodic-report/dto/report-period.enum';
 import { type ProjectStatus } from '../../../components/project/dto/project-status.enum';
 import { type ProjectStep } from '../../../components/project/dto/project-step.enum';
@@ -1331,3 +1332,98 @@ export const projectWorkflowEventsRelations = relations(
     }),
   }),
 );
+
+// ─── Partnership ───────────────────────────────────────────────────────────
+
+export const partnershipAgreementStatusEnum = pgEnum(
+  'partnership_agreement_status',
+  ['NotAttached', 'AwaitingSignature', 'Signed'],
+);
+
+/**
+ * Partnership — links a Project to a Partner with agreement state, MOU dates,
+ * partner types (a subset of the partner's `approved_programs`-style types),
+ * a financial reporting type, and a `primary` flag (one primary per project).
+ *
+ * `mou_id` / `agreement_id` are plain text, not FKs: create() inserts this row
+ * before files.createDefinedFile() makes the file nodes, so a real FK would
+ * fail the insert. See migration 0011 for the ordering rationale.
+ *
+ * PCR/Changeset is excluded from the migration — no overrides table, the
+ * `mou_*_override` columns live on the row directly and the date coalesce
+ * (override → parent project) happens in `toDto`.
+ */
+export const partnerships = pgTable(
+  'partnerships',
+  {
+    id: text('id').$type<ID<'Partnership'>>().primaryKey(),
+    projectId: text('project_id')
+      .$type<ID<'Project'>>()
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    partnerId: text('partner_id')
+      .$type<ID<'Partner'>>()
+      .notNull()
+      .references(() => partners.id, { onDelete: 'cascade' }),
+    agreementStatus: partnershipAgreementStatusEnum('agreement_status')
+      .$type<PartnershipAgreementStatus>()
+      .notNull()
+      .default('NotAttached'),
+    mouStatus: partnershipAgreementStatusEnum('mou_status')
+      .$type<PartnershipAgreementStatus>()
+      .notNull()
+      .default('NotAttached'),
+    // migration-todo: plain text (not FK) because create() inserts this row
+    // before files.createDefinedFile() makes the file nodes. Add REFERENCES
+    // file_nodes(id) only if create() is reordered to write the files first.
+    mouId: text('mou_id').$type<ID<'File'>>(),
+    agreementId: text('agreement_id').$type<ID<'File'>>(),
+    mouStartOverride: date('mou_start_override'),
+    mouEndOverride: date('mou_end_override'),
+    types: partnerTypeEnum('types')
+      .array()
+      .$type<readonly PartnerType[]>()
+      .notNull()
+      .default([]),
+    financialReportingType: financialReportingTypeEnum(
+      'financial_reporting_type',
+    ).$type<FinancialReportingType>(),
+    primary: boolean('primary').notNull().default(false),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    // One partnership per (project, partner) pair on live rows. Mirror of the
+    // Neo4j repo's `verifyRelationshipEligibility` duplicate check; backstops
+    // it at the DB level.
+    uniqueIndex('partnerships_project_partner_active_unique')
+      .on(t.projectId, t.partnerId)
+      .where(sql`${t.deletedAt} IS NULL`),
+    // At most one primary partnership per project on live rows. Drives
+    // `removePrimaryFromOtherPartnerships` invariant.
+    uniqueIndex('partnerships_project_primary_active_unique')
+      .on(t.projectId)
+      .where(sql`${t.primary} = true AND ${t.deletedAt} IS NULL`),
+    index('partnerships_partner_id_idx').on(t.partnerId),
+    // Deferred-FK columns indexed now to avoid CREATE INDEX CONCURRENTLY when
+    // a REFERENCES clause is later added.
+    index('partnerships_mou_id_idx').on(t.mouId),
+    index('partnerships_agreement_id_idx').on(t.agreementId),
+  ],
+);
+
+export const partnershipsRelations = relations(partnerships, ({ one }) => ({
+  project: one(projects, {
+    fields: [partnerships.projectId],
+    references: [projects.id],
+  }),
+  partner: one(partners, {
+    fields: [partnerships.partnerId],
+    references: [partners.id],
+  }),
+}));


### PR DESCRIPTION
### Summary
Near-verbatim port — Partnership isn't Pinnable, has no language columns, no audit in the repo, and PCR/changesets are fully excluded.

### Schema (migration 0011)
- New `partnership_agreement_status` enum (`NotAttached` / `AwaitingSignature` / `Signed`); reuses `partner_type` and `financial_reporting_type`.
- `partnerships` table (14 cols) with FKs to `projects` + `partners` (both `ON DELETE CASCADE`).
- `mou_id` / `agreement_id` are **plain text, not FKs** — `create()` inserts the row before `files.createDefinedFile()` makes the file nodes, so a real FK would fail the insert. Indexed now so a later `REFERENCES` add needs no `CREATE INDEX CONCURRENTLY`.
- Two partial-unique indexes: one per `(project_id, partner_id)` live row (dup backstop), one per `(project_id) WHERE primary = true` live row (one-primary invariant).

### Repo / wiring
- `partnership.drizzle.repository.ts` ported as-is: create with primary-race retry, `list()` with `partner.*` JOIN sort, `override → parent-project` MOU-date coalesce in `toDto`.
- `splitDb` postgres arm on the module.
- One `Partnership` case added to each of the member + sensitivity auth conditions.

### Project follow-on (enabled by Partnership landing)
- Un-stubbed `getPrimaryOrganizationName` (Rev79 join: partnerships → partners → organizations).
- Refreshed the now-stale "requires Partnership migration" comments on Project's still-deferred filter/sort/hydration stubs (mono defers these too; wiring them is a separate follow-up).
