### PR TITLE
Cancel superseded PR runs + cache Gel setup products

### DIFF
--- a/.github/actions/gel-setup/action.yml
+++ b/.github/actions/gel-setup/action.yml
@@ -12,10 +12,40 @@ runs:
       shell: bash
       run: gel project init --no-migrations --non-interactive
 
+    # The migrated (empty) database and the generated TS client are pure
+    # functions of dbschema/ + the generator deps, but rebuilding them takes
+    # ~15-20 min per job. Cache a dump of the migrated DB + the generated
+    # files; on a hit, `gel restore` (seconds) replaces `gel migrate` and the
+    # restored files skip `yarn gel:gen` entirely.
+    - name: Restore migrated-DB dump & generated client
+      id: gel-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          .gel-cache
+          src/core/gel/generated-client
+          src/core/gel/schema.ts
+          src/**/*.edgeql.ts
+        key: gel-setup-${{ runner.os }}-${{ hashFiles('dbschema/**', 'gel.toml', 'yarn.lock') }}
+
     - name: Migrate Gel Schema
+      if: steps.gel-cache.outputs.cache-hit != 'true'
       shell: bash
       run: gel migrate --single-transaction
 
     - name: Generate Gel TS files
+      if: steps.gel-cache.outputs.cache-hit != 'true'
       shell: bash
       run: yarn gel:gen
+
+    - name: Dump migrated DB for cache
+      if: steps.gel-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        mkdir -p .gel-cache
+        gel dump .gel-cache/main.dump
+
+    - name: Restore migrated DB from cache
+      if: steps.gel-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: gel restore .gel-cache/main.dump

--- a/.github/workflows/api-schema.yml
+++ b/.github/workflows/api-schema.yml
@@ -7,6 +7,13 @@ on:
       - synchronize
       - labeled
 
+
+# One active run per branch/PR — a force-push cancels the now-stale run
+# instead of letting it occupy runners for its full duration. Guarded to
+# pull_request so develop/master push runs always complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   generate:
     name: Generate

--- a/.github/workflows/gel.yml
+++ b/.github/workflows/gel.yml
@@ -2,6 +2,13 @@ name: Gel
 on:
   pull_request:
 
+
+# One active run per branch/PR — a force-push cancels the now-stale run
+# instead of letting it occupy runners for its full duration. Guarded to
+# pull_request so develop/master push runs always complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   Clean:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,13 @@ on:
       - master
       - develop
 
+
+# One active run per branch/PR — a force-push cancels the now-stale run
+# instead of letting it occupy runners for its full duration. Guarded to
+# pull_request so develop/master push runs always complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,13 @@ on:
       - master
       - develop
 
+# One active run per branch/PR — a force-push cancels the now-stale run
+# instead of letting it occupy runners for its full duration. Guarded to
+# pull_request so develop/master push runs always complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   Unit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI runs take ~30 min flat regardless of diff size. Per-job step timings (Actions API) show the time is not in the tests: the `Gel Setup` composite action costs **14–20 min in every job** — instance init, a 36-migration `gel migrate`, and `yarn gel:gen` — and the Test workflow runs 13 jobs (6 neo4j + 6 postgres shards + Unit), each paying it independently. Actual test steps are 1–9 min per shard. On top of that, no workflow had a `concurrency` setting, so every force-push left the superseded run occupying ~13 runner slots for its full 30 minutes while the new run queued behind it.

### Cancel superseded PR runs
- `concurrency.group` + `cancel-in-progress` added to the Test, Lint, API Schema, and Gel workflows.
- Scoped to `pull_request` events only — pushes to develop/master never cancel, so the main-branch run history stays unbroken.
- A force-push now kills the stale run immediately and frees its runners.

### Cache the Gel Setup products
- The migrated (empty) DB and the generated TS client are pure functions of `dbschema/` + generator deps, so the `gel-setup` action now caches both: a `gel dump` of the migrated main branch, plus `src/core/gel/generated-client`, `src/core/gel/schema.ts`, and `src/**/*.edgeql.ts`.
- Cache key: `hashFiles('dbschema/**', 'gel.toml', 'yarn.lock')` — any schema or generator-dep change misses and rebuilds.
- On a hit, `gel restore` (seconds) replaces the ~10+ min migrate and `yarn gel:gen` is skipped. The e2e harness's `create schema branch … from main` and gel.yml's `gel migration status` both work off the restored DB, since the dump carries schema + migration history.

### Expected effect
- Gel Setup ~20 min → ~3 min on cache hit; whole Test run **~30 → ~12 min** (new ceiling = slowest neo4j shard's real test time + setup).
- ~300 runner-minutes saved per Test run, plus no more double-billing on force-pushes.