### PR TITLE
[pg] Notifications → Postgres (Drizzle)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
           # full suite.
           - database: postgres
             test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|project-member|tool)\."
+              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|project-member|tool|notification)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/src/components/comments/mention-notification/comment-via-mention-notification.strategy.ts
+++ b/src/components/comments/mention-notification/comment-via-mention-notification.strategy.ts
@@ -1,8 +1,10 @@
 import { node, type Query, relation } from 'cypher-query-builder';
+import { type ID } from '~/common';
 import { createRelationships, exp } from '~/core/neo4j/query';
 import {
   INotificationStrategy,
   type InputOf,
+  type NotificationRow,
   NotificationStrategy,
 } from '../../notifications';
 import { CommentViaMentionNotification } from './comment-via-mention-notification.dto';
@@ -31,5 +33,13 @@ export class CommentViaMentionNotificationStrategy extends INotificationStrategy
             comment: 'comment { .id }',
           }).as(outVar),
         );
+  }
+
+  override saveForDrizzle(input: InputOf<CommentViaMentionNotification>) {
+    return { commentId: input.comment };
+  }
+
+  override hydrateExtraForDrizzle(row: NotificationRow) {
+    return { comment: { id: row.commentId as ID<'Comment'> } };
   }
 }

--- a/src/components/notification-system/system-notification.strategy.ts
+++ b/src/components/notification-system/system-notification.strategy.ts
@@ -1,6 +1,12 @@
 import { node, type Query } from 'cypher-query-builder';
+import { type ID } from '~/common';
+import { type DrizzleDb, users } from '~/core/drizzle';
 import { e } from '~/core/gel';
-import { INotificationStrategy, NotificationStrategy } from '../notifications';
+import {
+  INotificationStrategy,
+  type NotificationRow,
+  NotificationStrategy,
+} from '../notifications';
 import { SystemNotification } from './system-notification.dto';
 
 @NotificationStrategy(SystemNotification)
@@ -12,6 +18,18 @@ export class SystemNotificationStrategy extends INotificationStrategy<SystemNoti
 
   recipientsForGel() {
     return e.User; // all users
+  }
+
+  override async recipientsForDrizzle(
+    _input: unknown,
+    db: DrizzleDb,
+  ): Promise<ReadonlyArray<ID<'User'>>> {
+    const rows = await db.select({ id: users.id }).from(users);
+    return rows.map((row) => row.id);
+  }
+
+  override hydrateExtraForDrizzle(row: NotificationRow) {
+    return { message: row.message };
   }
 
   broadcastTo() {

--- a/src/components/notification-system/system-notification.strategy.ts
+++ b/src/components/notification-system/system-notification.strategy.ts
@@ -1,4 +1,5 @@
 import { node, type Query } from 'cypher-query-builder';
+import { isNull } from 'drizzle-orm';
 import { type ID } from '~/common';
 import { type DrizzleDb, users } from '~/core/drizzle';
 import { e } from '~/core/gel';
@@ -24,7 +25,12 @@ export class SystemNotificationStrategy extends INotificationStrategy<SystemNoti
     _input: unknown,
     db: DrizzleDb,
   ): Promise<ReadonlyArray<ID<'User'>>> {
-    const rows = await db.select({ id: users.id }).from(users);
+    // Neo4j excludes deleted users structurally (relabelled to Deleted_User);
+    // PG user deletion is a soft delete, so filter explicitly.
+    const rows = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(isNull(users.deletedAt));
     return rows.map((row) => row.id);
   }
 

--- a/src/components/notifications/notification.drizzle.repository.ts
+++ b/src/components/notifications/notification.drizzle.repository.ts
@@ -1,0 +1,206 @@
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { type Nil } from '@seedcompany/common';
+import { and, count, desc, eq, isNotNull, isNull, sql } from 'drizzle-orm';
+import { omit } from 'lodash';
+import { DateTime } from 'luxon';
+import {
+  EnhancedResource,
+  generateId,
+  type ID,
+  NotFoundException,
+  type ResourceShape,
+  ServerException,
+  type UnsecuredDto,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import { DrizzleService } from '~/core/drizzle';
+import { notificationRecipients, notifications } from '~/core/drizzle/schema';
+import {
+  type MarkNotificationReadArgs,
+  Notification,
+  type NotificationListInput,
+} from './dto';
+import { NotificationServiceImpl } from './notification.service';
+import {
+  type INotificationStrategy,
+  type NotificationRow,
+} from './notification.strategy';
+
+/** A notifications row joined with the requesting user's per-recipient state. */
+type RequesterRow = NotificationRow & { readAt: Date | null };
+
+@Injectable()
+export class NotificationDrizzleRepository {
+  constructor(
+    @Inject(forwardRef(() => NotificationServiceImpl))
+    private readonly service: NotificationServiceImpl & {},
+    private readonly drizzle: DrizzleService,
+    private readonly identity: Identity,
+  ) {}
+
+  // Transaction-aware client — see DrizzleDtoRepository.db for why a getter.
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  async create(
+    recipients: ReadonlyArray<ID<'User'>> | Nil,
+    type: ResourceShape<any>,
+    input: Record<string, any>,
+  ) {
+    const strategy = this.service.getStrategy(type);
+    const extra = omit(input, [...EnhancedResource.of(Notification).props]);
+    const id = await generateId<ID<'Notification'>>();
+
+    await this.db.insert(notifications).values({
+      id,
+      type: this.getType(type),
+      creatorId: this.identity.currentMaybe?.userId ?? null,
+      ...strategy.saveForDrizzle(extra),
+    });
+
+    const recipientIds = recipients
+      ? [...recipients]
+      : [...(await strategy.recipientsForDrizzle(extra, this.db))];
+    if (recipientIds.length > 0) {
+      await this.db
+        .insert(notificationRecipients)
+        .values(recipientIds.map((userId) => ({ notificationId: id, userId })))
+        .onConflictDoNothing();
+    }
+
+    return {
+      dto: await this.readOne(id),
+      totalRecipients: recipientIds.length,
+      recipients: strategy.returnRecipientsFromDB() ? recipientIds : null,
+    };
+  }
+
+  async markRead({ id, unread }: MarkNotificationReadArgs) {
+    const userId = this.identity.current.userId;
+    const updated = await this.db
+      .update(notificationRecipients)
+      .set({ readAt: unread ? null : new Date() })
+      .where(
+        and(
+          eq(notificationRecipients.notificationId, id),
+          eq(notificationRecipients.userId, userId),
+        ),
+      )
+      .returning({ id: notificationRecipients.notificationId });
+    if (updated.length === 0) {
+      throw new NotFoundException();
+    }
+    return await this.readOne(id);
+  }
+
+  async list(input: NotificationListInput) {
+    const userId = this.identity.current.userId;
+
+    const conditions = [eq(notificationRecipients.userId, userId)];
+    if (input.filter?.unread != null) {
+      conditions.push(
+        input.filter.unread
+          ? isNull(notificationRecipients.readAt)
+          : isNotNull(notificationRecipients.readAt),
+      );
+    }
+    const predicate = and(...conditions);
+    const offset = (input.page - 1) * input.count;
+
+    const [countRows, unreadRows, rows] = await Promise.all([
+      this.db
+        .select({ total: count() })
+        .from(notifications)
+        .innerJoin(
+          notificationRecipients,
+          eq(notificationRecipients.notificationId, notifications.id),
+        )
+        .where(predicate),
+      this.db
+        .select({ total: count() })
+        .from(notificationRecipients)
+        .where(
+          and(
+            eq(notificationRecipients.userId, userId),
+            isNull(notificationRecipients.readAt),
+          ),
+        ),
+      this.db
+        .select({ n: notifications, readAt: notificationRecipients.readAt })
+        .from(notifications)
+        .innerJoin(
+          notificationRecipients,
+          eq(notificationRecipients.notificationId, notifications.id),
+        )
+        .where(predicate)
+        .orderBy(desc(notifications.createdAt), desc(notifications.id))
+        .limit(input.count)
+        .offset(offset),
+    ]);
+
+    const total = countRows[0]?.total ?? 0;
+    return {
+      items: rows.map((row) => this.mapRow({ ...row.n, readAt: row.readAt })),
+      total,
+      totalUnread: unreadRows[0]?.total ?? 0,
+      hasMore: offset + rows.length < total,
+    };
+  }
+
+  /**
+   * Read a single notification with the requesting user's read state. Used
+   * by create/markRead, so the requester may not be a recipient (e.g. the
+   * author of a mention) — a missing recipient row reads as unread, matching
+   * the Neo4j `optional match` behavior.
+   */
+  private async readOne(id: ID): Promise<UnsecuredDto<Notification>> {
+    const userId = this.identity.currentMaybe?.userId;
+    const [row] = await this.db
+      .select({ n: notifications, readAt: notificationRecipients.readAt })
+      .from(notifications)
+      .leftJoin(
+        notificationRecipients,
+        and(
+          eq(notificationRecipients.notificationId, notifications.id),
+          userId ? eq(notificationRecipients.userId, userId) : sql`false`,
+        ),
+      )
+      .where(eq(notifications.id, id));
+    if (!row) {
+      throw new NotFoundException();
+    }
+    return this.mapRow({ ...row.n, readAt: row.readAt });
+  }
+
+  private mapRow(row: RequesterRow): UnsecuredDto<Notification> {
+    const strategy = this.strategyForType(row.type);
+    const dto: unknown = {
+      id: row.id,
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      __typename: `${row.type}Notification`,
+      unread: row.readAt === null,
+      readAt: row.readAt ? DateTime.fromJSDate(row.readAt) : null,
+      ...strategy.hydrateExtraForDrizzle(row),
+    };
+    return dto as UnsecuredDto<Notification>;
+  }
+
+  private strategyForType(type: string): INotificationStrategy<Notification> {
+    for (const [dtoCls, strategy] of this.service.strategyMap) {
+      if (this.getType(dtoCls) === type) {
+        return strategy;
+      }
+    }
+    throw new ServerException(
+      `No notification strategy registered for type ${type}`,
+    );
+  }
+
+  private getType(dtoCls: ResourceShape<Notification>) {
+    return dtoCls.name.replace(
+      'Notification',
+      '',
+    ) as (typeof notifications.type.enumValues)[number];
+  }
+}

--- a/src/components/notifications/notification.drizzle.repository.ts
+++ b/src/components/notifications/notification.drizzle.repository.ts
@@ -45,8 +45,8 @@ export class NotificationDrizzleRepository {
 
   async create(
     recipients: ReadonlyArray<ID<'User'>> | Nil,
-    type: ResourceShape<any>,
-    input: Record<string, any>,
+    type: ResourceShape<Notification>,
+    input: Record<string, unknown>,
   ) {
     const strategy = this.service.getStrategy(type);
     const extra = omit(input, [...EnhancedResource.of(Notification).props]);

--- a/src/components/notifications/notification.module.ts
+++ b/src/components/notifications/notification.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { splitDb } from '~/core/database';
+import { NotificationDrizzleRepository } from './notification.drizzle.repository';
 import { NotificationRepository as GelRepository } from './notification.gel.repository';
 import { NotificationRepository as Neo4jRepository } from './notification.repository';
 import { NotificationResolver } from './notification.resolver';
@@ -13,7 +14,12 @@ import {
     NotificationResolver,
     { provide: NotificationService, useExisting: NotificationServiceImpl },
     NotificationServiceImpl,
-    splitDb(Neo4jRepository, { gel: GelRepository }),
+    splitDb(Neo4jRepository, {
+      gel: GelRepository,
+      // migration-todo: remove `as any` once splitDb types accept drizzle repos
+      // directly; drops with the Neo4j path at Phase 7 cutover.
+      postgres: NotificationDrizzleRepository as any,
+    }),
   ],
   exports: [NotificationService],
 })

--- a/src/components/notifications/notification.strategy.ts
+++ b/src/components/notifications/notification.strategy.ts
@@ -1,11 +1,15 @@
 import { createMetadataDecorator } from '@seedcompany/nest';
 import { type Query } from 'cypher-query-builder';
 import type { AbstractClass, Simplify } from 'type-fest';
-import type { UnwrapSecured } from '~/common';
+import type { ID, UnwrapSecured } from '~/common';
 import type { RawChangeOf } from '~/core/database/changes';
+import type { DrizzleDb, notifications } from '~/core/drizzle';
 import { type $, e } from '~/core/gel';
 import type { QueryFragment } from '~/core/neo4j/query-augmentation/apply';
 import type { Notification } from './dto';
+
+/** A row from the single-table-inheritance `notifications` table. */
+export type NotificationRow = typeof notifications.$inferSelect;
 
 export const NotificationStrategy = createMetadataDecorator({
   types: ['class'],
@@ -63,6 +67,41 @@ export abstract class INotificationStrategy<
   hydrateExtraForNeo4j(outVar: string): QueryFragment | undefined {
     const _used = outVar;
     return undefined;
+  }
+
+  // ── Drizzle / PostgreSQL ──────────────────────────────────────────────
+  // Mirror of the Neo4j/Gel hooks above for the single-table-inheritance
+  // notifications table. migration-todo: at Phase 7 cutover, drop the
+  // *ForNeo4j / *ForGel variants and keep only these.
+
+  /**
+   * Map this subtype's extra input fields to columns on the `notifications`
+   * row. Default assumes input keys already match column names.
+   */
+  saveForDrizzle(input: TInput): Record<string, unknown> {
+    return { ...(input as Record<string, unknown>) };
+  }
+
+  /**
+   * Shape this subtype's extra fields back out of a stored notification row.
+   */
+  // eslint-disable-next-line @seedcompany/no-unused-vars
+  hydrateExtraForDrizzle(row: NotificationRow): Record<string, unknown> {
+    return {};
+  }
+
+  /**
+   * Dynamic recipients selected from the DB. Mirrors {@link recipientsForNeo4j}
+   * / {@link recipientsForGel}; only consulted when the service passes no
+   * explicit recipient list.
+   */
+  async recipientsForDrizzle(
+    // eslint-disable-next-line @seedcompany/no-unused-vars
+    input: TInput,
+    // eslint-disable-next-line @seedcompany/no-unused-vars
+    db: DrizzleDb,
+  ): Promise<ReadonlyArray<ID<'User'>>> {
+    return [];
   }
 }
 

--- a/src/core/drizzle/migrations/0012_add_notifications.sql
+++ b/src/core/drizzle/migrations/0012_add_notifications.sql
@@ -1,0 +1,38 @@
+-- Notifications (Phase 6). Single-table inheritance over notification
+-- subtypes: the `type` discriminator maps to the registered strategy, and
+-- each subtype's extra fields live in nullable columns guarded by the shape
+-- CHECK. Per-recipient read state lives in `notification_recipients` so
+-- `unread` is computed per requesting user, not stored on the notification.
+
+CREATE TYPE "notification_type" AS ENUM ('System', 'CommentViaMention');
+
+CREATE TABLE "notifications" (
+  "id"         text PRIMARY KEY,
+  "type"       "notification_type" NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "creator_id" text REFERENCES "users"("id") ON DELETE SET NULL,
+  -- System
+  "message"    text,
+  -- CommentViaMention. FK-less for now — the comments table lands in a later
+  -- Phase 6 migration; the FK is added then.
+  "comment_id" text,
+  CONSTRAINT "notifications_shape" CHECK (
+    ("type" = 'System' AND "message" IS NOT NULL AND "comment_id" IS NULL)
+    OR ("type" = 'CommentViaMention' AND "comment_id" IS NOT NULL AND "message" IS NULL)
+  )
+);
+
+CREATE INDEX "notifications_created_at_idx" ON "notifications" ("created_at");
+-- FK + deferred-FK indexes (mono added these in 0028; included up front here
+-- per the index-every-FK standard).
+CREATE INDEX "notifications_creator_id_idx" ON "notifications" ("creator_id");
+CREATE INDEX "notifications_comment_id_idx" ON "notifications" ("comment_id");
+
+CREATE TABLE "notification_recipients" (
+  "notification_id" text NOT NULL REFERENCES "notifications"("id") ON DELETE CASCADE,
+  "user_id"         text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "read_at"         timestamptz,
+  CONSTRAINT "notification_recipients_pkey" PRIMARY KEY ("notification_id", "user_id")
+);
+
+CREATE INDEX "notification_recipients_user_id_idx" ON "notification_recipients" ("user_id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1747785600000,
       "tag": "0011_add_partnerships",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1748649600000,
+      "tag": "0012_add_notifications",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -1427,3 +1427,70 @@ export const partnershipsRelations = relations(partnerships, ({ one }) => ({
     references: [partners.id],
   }),
 }));
+
+// ─── Notifications ─────────────────────────────────────────────────────────
+
+export const notificationTypeEnum = pgEnum('notification_type', [
+  'System',
+  'CommentViaMention',
+]);
+
+/**
+ * Single-table inheritance over notification subtypes. The discriminator
+ * (`type`) ⟷ the strategy registered for that DTO (its name minus the
+ * `Notification` suffix), and each subtype's extra fields live in nullable
+ * columns guarded by the `notifications_shape` CHECK. Per-recipient read
+ * state lives in `notification_recipients`, so `unread` is computed against
+ * the requesting user, not stored on the notification.
+ */
+export const notifications = pgTable(
+  'notifications',
+  {
+    id: text('id').$type<ID<'Notification'>>().primaryKey(),
+    type: notificationTypeEnum('type').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    creatorId: text('creator_id')
+      .$type<ID<'User'>>()
+      .references(() => users.id, { onDelete: 'set null' }),
+    // System
+    message: text('message'),
+    // CommentViaMention. FK-less for now — the comments table lands in a later
+    // Phase 6 migration.
+    // migration-todo: add `.references(() => comments.id, { onDelete: 'cascade' })`
+    // once the comments table exists (Comments domain port).
+    commentId: text('comment_id').$type<ID<'Comment'>>(),
+  },
+  (t) => [
+    index('notifications_created_at_idx').on(t.createdAt),
+    // FK + deferred-FK indexes (mono added these later in 0028; recut
+    // includes them up front per the index-every-FK standard).
+    index('notifications_creator_id_idx').on(t.creatorId),
+    index('notifications_comment_id_idx').on(t.commentId),
+    check(
+      'notifications_shape',
+      sql`(${t.type} = 'System' AND ${t.message} IS NOT NULL AND ${t.commentId} IS NULL)
+        OR (${t.type} = 'CommentViaMention' AND ${t.commentId} IS NOT NULL AND ${t.message} IS NULL)`,
+    ),
+  ],
+);
+
+export const notificationRecipients = pgTable(
+  'notification_recipients',
+  {
+    notificationId: text('notification_id')
+      .$type<ID<'Notification'>>()
+      .notNull()
+      .references(() => notifications.id, { onDelete: 'cascade' }),
+    userId: text('user_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    readAt: timestamp('read_at', { withTimezone: true }),
+  },
+  (t) => [
+    primaryKey({ columns: [t.notificationId, t.userId] }),
+    index('notification_recipients_user_id_idx').on(t.userId),
+  ],
+);

--- a/test/notification.e2e-spec.ts
+++ b/test/notification.e2e-spec.ts
@@ -1,0 +1,123 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { graphql } from '~/graphql';
+import {
+  createSession,
+  createTestApp,
+  registerUser,
+  runAsAdmin,
+  type TestApp,
+} from './utility';
+
+describe('Notification e2e', () => {
+  let app: TestApp;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await createSession(app);
+    // The requesting user — system notifications fan out to all users, so
+    // this user is among the recipients of anything created below.
+    await registerUser(app);
+  });
+
+  it('delivers a system notification and tracks per-user read state', async () => {
+    const message = 'The server will restart at midnight.';
+    const { createSystemNotification: created } = await runAsAdmin(app, (a) =>
+      a.graphql.mutate(CreateSystemNotificationDoc, { message }),
+    );
+    expect(created.totalRecipients).toBeGreaterThanOrEqual(1);
+
+    // The requesting user sees it, unread, hydrated as a SystemNotification.
+    const before = await app.graphql.query(NotificationsDoc, { input: {} });
+    const found = before.notifications.items.find(
+      (n) => n.id === created.notification.id,
+    );
+    expect(found).toBeDefined();
+    expect(found?.__typename).toBe('SystemNotification');
+    expect(found?.unread).toBe(true);
+    expect(found?.readAt).toBeNull();
+    if (found?.__typename === 'SystemNotification') {
+      expect(found.message).toBe(message);
+    }
+    expect(before.notifications.totalUnread).toBeGreaterThanOrEqual(1);
+
+    // Mark it read — readAt is set and unread flips.
+    const { readNotification: read } = await app.graphql.mutate(
+      ReadNotificationDoc,
+      { id: created.notification.id, unread: false },
+    );
+    expect(read.unread).toBe(false);
+    expect(read.readAt).toBeTruthy();
+
+    // The unread filter now excludes it.
+    const unreadOnly = await app.graphql.query(NotificationsDoc, {
+      input: { filter: { unread: true } },
+    });
+    expect(
+      unreadOnly.notifications.items.find(
+        (n) => n.id === created.notification.id,
+      ),
+    ).toBeUndefined();
+
+    // Marking unread again restores it.
+    const { readNotification: reUnread } = await app.graphql.mutate(
+      ReadNotificationDoc,
+      { id: created.notification.id, unread: true },
+    );
+    expect(reUnread.unread).toBe(true);
+    expect(reUnread.readAt).toBeNull();
+  });
+
+  it('counts unread independently of the requested page filter', async () => {
+    // Two more system notifications, both unread for the requesting user.
+    await runAsAdmin(app, async (a) => {
+      await a.graphql.mutate(CreateSystemNotificationDoc, { message: 'one' });
+      await a.graphql.mutate(CreateSystemNotificationDoc, { message: 'two' });
+    });
+
+    const readList = await app.graphql.query(NotificationsDoc, {
+      input: { filter: { unread: false } },
+    });
+    // totalUnread reflects all unread, not just the filtered (read) page.
+    expect(readList.notifications.totalUnread).toBeGreaterThanOrEqual(2);
+  });
+});
+
+const CreateSystemNotificationDoc = graphql(`
+  mutation CreateSystemNotification($message: Markdown!) {
+    createSystemNotification(message: $message) {
+      notification {
+        id
+      }
+      totalRecipients
+    }
+  }
+`);
+
+const NotificationsDoc = graphql(`
+  query Notifications($input: NotificationListInput!) {
+    notifications(input: $input) {
+      total
+      totalUnread
+      hasMore
+      items {
+        id
+        __typename
+        unread
+        readAt
+        ... on SystemNotification {
+          message
+        }
+      }
+    }
+  }
+`);
+
+const ReadNotificationDoc = graphql(`
+  mutation ReadNotification($id: ID!, $unread: Boolean) {
+    readNotification(id: $id, unread: $unread) {
+      id
+      unread
+      readAt
+    }
+  }
+`);


### PR DESCRIPTION
### Schema / DDL (migration 0012)
- `notification_type` pgEnum: `System | CommentViaMention`.
- `notifications` — single-table inheritance: the `type` discriminator maps to the registered strategy; subtype fields are nullable columns guarded by the `notifications_shape` CHECK (`System` ⇒ `message` NOT NULL + `comment_id` NULL; `CommentViaMention` ⇒ inverse).
- `creator_id` → `users(id) ON DELETE SET NULL`.
- `comment_id` is **FK-less plain text** — the comments table lands in a later Phase-6 recut; a `migration-todo` comment marks where the FK gets added.
- `notification_recipients` — composite PK `(notification_id, user_id)`, both FKs CASCADE; `read_at` nullable, so `unread` is computed per requesting user, never stored on the notification.
- Indexes: `created_at`, `creator_id`, `comment_id`, `notification_recipients.user_id`.

### What's added
- Strategy pattern extended for Drizzle: `saveForDrizzle` (input → row columns), `hydrateExtraForDrizzle` (row → subtype DTO fields), `recipientsForDrizzle` (recipient resolution) on the base class with defaults; both existing strategies override as needed. A `migration-todo` on the base notes the `*ForNeo4j`/`*ForGel` variants drop at Phase-7 cutover.
- Repo covers create (notification + recipient fan-out), list with unread filter/count keyed to the requesting user via `notification_recipients`, and mark-read.

