### PR TITLE
Implement ceremony mutation resolvers and channels for event handling

### DIFF
--- a/src/components/ceremony/ceremony-mutation-actor.resolver.ts
+++ b/src/components/ceremony/ceremony-mutation-actor.resolver.ts
@@ -1,0 +1,29 @@
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { NotFoundException } from '~/common';
+import { Loader, type LoaderOf } from '~/core/data-loader';
+import { ActorLoader } from '../user/actor.loader';
+import { SecuredActor } from '../user/dto';
+import { CeremonyMutationOrDeletion } from './dto';
+
+@Resolver(CeremonyMutationOrDeletion)
+export class CeremonyMutationActorResolver {
+  @ResolveField(() => SecuredActor, {
+    description: 'The actor who initiated the change',
+  })
+  async by(
+    @Parent() mutation: CeremonyMutationOrDeletion,
+    @Loader(ActorLoader) actors: LoaderOf<ActorLoader>,
+  ): Promise<SecuredActor> {
+    const actor = await actors.load(mutation.by).catch((e) => {
+      if (e instanceof NotFoundException) {
+        return undefined;
+      }
+      throw e;
+    });
+    return {
+      canRead: !!actor,
+      canEdit: false,
+      value: actor,
+    };
+  }
+}

--- a/src/components/ceremony/ceremony-mutation-subscriptions.resolver.ts
+++ b/src/components/ceremony/ceremony-mutation-subscriptions.resolver.ts
@@ -1,0 +1,103 @@
+import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { from, map, merge, mergeMap } from 'rxjs';
+import { omitNotFound$, Subscription } from '~/common';
+import { Loader, type LoaderOf } from '~/core/data-loader';
+import { ResourceLoader } from '~/core/resources';
+import {
+  CeremonyChannels,
+  CeremonyCreatedArgs,
+  CeremonyMutationArgs,
+  type CeremonyMutationPayload,
+} from './ceremony.channels';
+import { CeremonyLoader } from './ceremony.loader';
+import {
+  Ceremony,
+  CeremonyCreated,
+  CeremonyDeleted,
+  CeremonyMutation,
+  CeremonyMutationOrDeletion,
+  CeremonyUpdated,
+} from './dto';
+
+@Resolver(CeremonyMutation)
+export class CeremonyMutationSubscriptionsResolver {
+  constructor(
+    private readonly channels: CeremonyChannels,
+    private readonly loaders: ResourceLoader,
+  ) {}
+
+  private verifyReadPermission$() {
+    return mergeMap(
+      <Payload extends CeremonyMutationPayload>(payload: Payload) => {
+        // Omit event if the user watching doesn't have permission to view the ceremony
+        return from(this.loaders.load('Ceremony', payload.ceremony)).pipe(
+          omitNotFound$(),
+          map(() => payload),
+        );
+      },
+    );
+  }
+
+  @Subscription(() => CeremonyCreated)
+  ceremonyCreated(@Args() args: CeremonyCreatedArgs) {
+    return this.channels.created(args).pipe(
+      this.verifyReadPermission$(),
+      map(
+        ({ ceremony, ...rest }): CeremonyCreated => ({
+          __typename: 'CeremonyCreated',
+          ceremonyId: ceremony,
+          ...rest,
+        }),
+      ),
+    );
+  }
+
+  @Subscription(() => CeremonyUpdated)
+  ceremonyUpdated(@Args() args: CeremonyMutationArgs) {
+    return this.channels.updated(args).pipe(
+      this.verifyReadPermission$(),
+      map(
+        ({ ceremony, ...rest }): CeremonyUpdated => ({
+          __typename: 'CeremonyUpdated',
+          ceremonyId: ceremony,
+          ...rest,
+        }),
+      ),
+    );
+  }
+
+  @Subscription(() => CeremonyDeleted)
+  ceremonyDeleted(@Args() args: CeremonyMutationArgs) {
+    return this.channels.deleted(args).pipe(
+      // Cannot read a deleted record.
+      // It is ok IMO to expose an ID that cannot be read anymore.
+      // this.verifyReadPermission$(),
+      map(
+        ({ ceremony, ...rest }): CeremonyDeleted => ({
+          __typename: 'CeremonyDeleted',
+          ceremonyId: ceremony,
+          ...rest,
+        }),
+      ),
+    );
+  }
+
+  @Subscription(() => CeremonyMutationOrDeletion, {
+    description: 'Subscribe to any mutations of ceremony(s)',
+  })
+  ceremonyMutations(@Args() args: CeremonyMutationArgs) {
+    return merge(
+      this.ceremonyCreated(args),
+      this.ceremonyUpdated(args),
+      this.ceremonyDeleted(args),
+    );
+  }
+
+  @ResolveField(() => Ceremony)
+  async ceremony(
+    @Parent() change: CeremonyMutation,
+    @Loader(CeremonyLoader) ceremonies: LoaderOf<CeremonyLoader>,
+  ): Promise<Ceremony> {
+    return await ceremonies.load(change.ceremonyId);
+  }
+}

--- a/src/components/ceremony/ceremony-updated.resolver.ts
+++ b/src/components/ceremony/ceremony-updated.resolver.ts
@@ -1,0 +1,21 @@
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { keys } from '@seedcompany/common';
+import { stripIndent } from 'common-tags';
+import { type CeremonyUpdate, CeremonyUpdated } from './dto';
+
+@Resolver(CeremonyUpdated)
+export class CeremonyUpdatedResolver {
+  @ResolveField(() => [String], {
+    description: stripIndent`
+      A list of keys of the \`CeremonyUpdate\` object which have been updated.
+
+      This can be used to determine which fields have been updated, since
+      GQL cannot distinguish between omitted fields and explicit nulls.
+    `,
+  })
+  updatedKeys(
+    @Parent() { updated }: CeremonyUpdated,
+  ): ReadonlyArray<keyof CeremonyUpdate> {
+    return keys(updated);
+  }
+}

--- a/src/components/ceremony/ceremony.channels.ts
+++ b/src/components/ceremony/ceremony.channels.ts
@@ -1,0 +1,105 @@
+import { Injectable } from '@nestjs/common';
+import { ArgsType } from '@nestjs/graphql';
+import { type Many, many } from '@seedcompany/common';
+import { type DateTime } from 'luxon';
+import type { SetRequired } from 'type-fest';
+import { type ID, IdField } from '~/common';
+import { Identity } from '~/core/authentication';
+import {
+  Broadcaster,
+  type BroadcastChannel as Channel,
+  CompositeChannel as Composite,
+} from '~/core/broadcast';
+import { type CeremonyUpdate } from './dto';
+
+@ArgsType()
+export class CeremonyCreatedArgs {}
+
+@ArgsType()
+export class CeremonyMutationArgs {
+  @IdField({ nullable: true })
+  ceremony?: ID<'Ceremony'>;
+}
+
+export type CeremonyMutationPayload = SetRequired<
+  CeremonyMutationArgs,
+  keyof CeremonyMutationArgs
+> & {
+  at: DateTime;
+  by: ID<'Actor'>;
+};
+
+type Action = 'created' | 'updated' | 'deleted';
+
+/**
+ * Typed channels for ceremony events.
+ */
+@Injectable()
+export class CeremonyChannels {
+  constructor(
+    private readonly identity: Identity,
+    private readonly broadcaster: Broadcaster,
+  ) {}
+
+  /**
+   * Call publish() on the channel action for all arg/filter variations.
+   */
+  publishToAll<Action extends Exclude<keyof CeremonyChannels, 'publishToAll'>>(
+    action: Action,
+    payload: ReturnType<CeremonyChannels[Action]> extends Channel<
+      infer T extends CeremonyMutationPayload
+    >
+      ? Omit<T, 'by'>
+      : never,
+  ) {
+    const by = this.identity.current.userId;
+    const payloadWithBy = { ...payload, by };
+    this.forAllActionChannels(action, payloadWithBy).publish(payloadWithBy);
+    return payloadWithBy;
+  }
+
+  created(
+    args: Omit<CeremonyMutationArgs, 'ceremony'> = {},
+  ): Channel<CeremonyMutationPayload> {
+    return this.forAction('created', args);
+  }
+
+  deleted(args: CeremonyMutationArgs = {}): Channel<CeremonyMutationPayload> {
+    return this.forAction('deleted', args);
+  }
+
+  updated(args: CeremonyMutationArgs = {}): Channel<
+    CeremonyMutationPayload & {
+      previous: CeremonyUpdate;
+      updated: CeremonyUpdate;
+    }
+  > {
+    return this.forAction('updated', args);
+  }
+
+  private forAllActionChannels<T>(
+    action: Action,
+    payload: CeremonyMutationPayload,
+  ): Channel<T> {
+    return Composite.for([
+      this.forAction(action, { ceremony: payload.ceremony }),
+      this.forAction(action, {}),
+    ]);
+  }
+
+  private forAction<T>(action: Action, args: CeremonyMutationArgs): Channel<T> {
+    if (args.ceremony) {
+      if (action === 'created') {
+        return this.channel([]);
+      }
+      return this.channel(`ceremony:${args.ceremony}:${action}`);
+    }
+    return this.channel(`ceremony:${action}`);
+  }
+
+  private channel<T>(channels: Many<string>): Channel<T> {
+    return Composite.for(
+      many(channels).map((name) => this.broadcaster.channel(name)),
+    );
+  }
+}

--- a/src/components/ceremony/ceremony.module.ts
+++ b/src/components/ceremony/ceremony.module.ts
@@ -1,6 +1,10 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
+import { CeremonyMutationActorResolver } from './ceremony-mutation-actor.resolver';
+import { CeremonyMutationSubscriptionsResolver } from './ceremony-mutation-subscriptions.resolver';
+import { CeremonyUpdatedResolver } from './ceremony-updated.resolver';
+import { CeremonyChannels } from './ceremony.channels';
 import { CeremonyGelRepository } from './ceremony.gel.repository';
 import { CeremonyLoader } from './ceremony.loader';
 import { CeremonyRepository } from './ceremony.repository';
@@ -12,7 +16,11 @@ import * as handlers from './handlers';
   imports: [forwardRef(() => AuthorizationModule)],
   providers: [
     CeremonyResolver,
+    CeremonyMutationSubscriptionsResolver,
+    CeremonyMutationActorResolver,
+    CeremonyUpdatedResolver,
     CeremonyService,
+    CeremonyChannels,
     splitDb(CeremonyRepository, {
       gel: CeremonyGelRepository,
     }),

--- a/src/components/ceremony/ceremony.resolver.ts
+++ b/src/components/ceremony/ceremony.resolver.ts
@@ -1,10 +1,15 @@
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { DateTime } from 'luxon';
+import { Identity } from '~/core/authentication';
 import { CeremonyService } from '../ceremony';
 import { CeremonyUpdated, UpdateCeremony } from './dto';
 
 @Resolver()
 export class CeremonyResolver {
-  constructor(private readonly service: CeremonyService) {}
+  constructor(
+    private readonly service: CeremonyService,
+    private readonly identity: Identity,
+  ) {}
 
   @Mutation(() => CeremonyUpdated, {
     description: 'Update a ceremony',
@@ -12,7 +17,19 @@ export class CeremonyResolver {
   async updateCeremony(
     @Args('input') input: UpdateCeremony,
   ): Promise<CeremonyUpdated> {
-    const ceremony = await this.service.update(input);
-    return { ceremony };
+    const {
+      ceremony,
+      payload = {
+        updated: {},
+        previous: {},
+        at: DateTime.now(),
+        by: this.identity.current.userId,
+      },
+    } = await this.service.update(input);
+    return {
+      __typename: 'CeremonyUpdated',
+      ceremonyId: ceremony.id,
+      ...payload,
+    };
   }
 }

--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { DateTime } from 'luxon';
 import {
   type ID,
   type ObjectView,
@@ -7,18 +8,30 @@ import {
 } from '~/common';
 import { HandleIdLookup } from '~/core/resources';
 import { Privileges } from '../authorization';
+import { CeremonyChannels } from './ceremony.channels';
 import { CeremonyRepository } from './ceremony.repository';
-import { Ceremony, type CreateCeremony, type UpdateCeremony } from './dto';
+import {
+  Ceremony,
+  CeremonyUpdate,
+  type CreateCeremony,
+  type UpdateCeremony,
+} from './dto';
 
 @Injectable()
 export class CeremonyService {
   constructor(
     private readonly privileges: Privileges,
+    private readonly channels: CeremonyChannels,
     private readonly repo: CeremonyRepository,
   ) {}
 
   async create(input: CreateCeremony): Promise<ID> {
     const { id } = await this.repo.create(input);
+
+    this.channels.publishToAll('created', {
+      ceremony: id,
+      at: DateTime.now(),
+    });
 
     return id;
   }
@@ -38,15 +51,28 @@ export class CeremonyService {
     return this.privileges.for(Ceremony).secure(dto);
   }
 
-  async update(input: UpdateCeremony): Promise<Ceremony> {
+  async update(input: UpdateCeremony) {
     const object = await this.repo.readOne(input.id);
     const changes = this.repo.getActualChanges(object, input);
+
+    if (Object.keys(changes).length === 0) {
+      return { ceremony: this.secure(object) };
+    }
+
     this.privileges.for(Ceremony, object).verifyChanges(changes);
     const updated = await this.repo.update({
       id: input.id,
       ...changes,
     });
-    return this.secure(updated);
+
+    const payload = this.channels.publishToAll('updated', {
+      ceremony: updated.id,
+      at: DateTime.now(),
+      updated: CeremonyUpdate.fromInput(changes),
+      previous: CeremonyUpdate.pickPrevious(object, changes),
+    });
+
+    return { ceremony: this.secure(updated), payload };
   }
 
   async delete(id: ID): Promise<void> {
@@ -55,10 +81,13 @@ export class CeremonyService {
     // Only called internally, not exposed directly to users
     // this.privileges.for( Ceremony, object).verifyCan('delete');
 
-    try {
-      await this.repo.deleteNode(object);
-    } catch (exception) {
+    const { at } = await this.repo.deleteNode(object).catch((exception) => {
       throw new ServerException('Failed to delete Ceremony', exception);
-    }
+    });
+
+    this.channels.publishToAll('deleted', {
+      ceremony: id,
+      at,
+    });
   }
 }

--- a/src/components/ceremony/dto/ceremony-mutations.dto.ts
+++ b/src/components/ceremony/dto/ceremony-mutations.dto.ts
@@ -1,0 +1,55 @@
+import { Field, InterfaceType, ObjectType } from '@nestjs/graphql';
+import { DateTime } from 'luxon';
+import {
+  AsUpdateType,
+  DateTimeField,
+  Grandparent,
+  type ID,
+  IdField,
+} from '~/common';
+import type { Ceremony } from './ceremony.dto';
+import { UpdateCeremony } from './update-ceremony.dto';
+
+@InterfaceType()
+export class CeremonyMutationOrDeletion {
+  readonly __typename: string;
+
+  /** Why here? See {@link ProjectMutation.projectId} */
+  @IdField()
+  readonly ceremonyId: ID<Ceremony>;
+
+  @DateTimeField()
+  readonly at: DateTime;
+
+  readonly by: ID<'Actor'>;
+}
+
+@InterfaceType({ implements: [CeremonyMutationOrDeletion] })
+export class CeremonyMutation extends CeremonyMutationOrDeletion {}
+
+@ObjectType({ implements: [CeremonyMutation] })
+export class CeremonyCreated extends CeremonyMutation {
+  declare readonly __typename: 'CeremonyCreated';
+}
+
+@ObjectType()
+export class CeremonyUpdate extends AsUpdateType(UpdateCeremony, {
+  omit: ['id'],
+  links: [],
+}) {}
+
+@ObjectType({ implements: [CeremonyMutation] })
+export class CeremonyUpdated extends CeremonyMutation {
+  declare readonly __typename: 'CeremonyUpdated';
+
+  @Field({ middleware: [Grandparent.store] })
+  readonly previous: CeremonyUpdate;
+
+  @Field({ middleware: [Grandparent.store] })
+  readonly updated: CeremonyUpdate;
+}
+
+@ObjectType({ implements: [CeremonyMutationOrDeletion] })
+export class CeremonyDeleted extends CeremonyMutationOrDeletion {
+  declare readonly __typename: 'CeremonyDeleted';
+}

--- a/src/components/ceremony/dto/index.ts
+++ b/src/components/ceremony/dto/index.ts
@@ -3,3 +3,4 @@ export * from './list-ceremony.dto';
 export * from './ceremony.dto';
 export * from './ceremony-type.enum';
 export * from './update-ceremony.dto';
+export * from './ceremony-mutations.dto';

--- a/src/components/ceremony/dto/update-ceremony.dto.ts
+++ b/src/components/ceremony/dto/update-ceremony.dto.ts
@@ -1,6 +1,5 @@
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { Field, InputType } from '@nestjs/graphql';
 import { type CalendarDate, DateField, type ID, IdField } from '~/common';
-import { Ceremony } from './ceremony.dto';
 
 @InputType()
 export abstract class UpdateCeremony {
@@ -15,10 +14,4 @@ export abstract class UpdateCeremony {
 
   @DateField({ nullable: true })
   readonly actualDate?: CalendarDate | null;
-}
-
-@ObjectType()
-export abstract class CeremonyUpdated {
-  @Field()
-  readonly ceremony: Ceremony;
 }

--- a/test/ceremony.e2e-spec.ts
+++ b/test/ceremony.e2e-spec.ts
@@ -1,0 +1,160 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { Role } from '~/common';
+import { graphql, type InputOf } from '~/graphql';
+import {
+  createLanguageEngagement,
+  createSession,
+  createTestApp,
+  registerUser,
+  type TestApp,
+} from './utility';
+
+describe('Ceremony e2e', () => {
+  let app: TestApp;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await createSession(app);
+    // ProjectManager to create the project/engagement, FieldOperationsDirector
+    // to update the ceremony.
+    await registerUser(app, {
+      roles: [Role.ProjectManager, Role.FieldOperationsDirector],
+    });
+  });
+
+  // A ceremony has no direct create mutation — one is created automatically
+  // when an engagement is created. So we spin up an engagement to get one.
+  async function createCeremony() {
+    const engagement = await createLanguageEngagement(app);
+    const { engagement: read } = await app.graphql.query(
+      graphql(`
+        query engagementCeremony($id: ID!) {
+          engagement(id: $id) {
+            id
+            ceremony {
+              value {
+                id
+              }
+            }
+          }
+        }
+      `),
+      { id: engagement.id },
+    );
+    const ceremony = read.ceremony.value;
+    expect(ceremony).toBeDefined();
+    return ceremony!;
+  }
+
+  // `updateCeremony` returns a `CeremonyUpdated` mutation event — the same
+  // payload the `ceremonyUpdated` subscription emits. These lock in that shape.
+  describe('updateCeremony mutation event', () => {
+    it('reports the changed input fields in updatedKeys', async () => {
+      const ceremony = await createCeremony();
+
+      const { updatedKeys } = await updateCeremonyReturning(app, {
+        id: ceremony.id,
+        planned: true,
+        estimatedDate: '2020-05-13',
+      });
+
+      expect(updatedKeys).toContain('planned');
+      expect(updatedKeys).toContain('estimatedDate');
+      // Untouched fields are not reported.
+      expect(updatedKeys).not.toContain('actualDate');
+    });
+
+    it('carries new values in `updated` and prior values in `previous`', async () => {
+      const ceremony = await createCeremony();
+      const date = '2020-05-13';
+
+      const {
+        updated,
+        previous,
+        ceremony: result,
+      } = await updateCeremonyReturning(app, {
+        id: ceremony.id,
+        planned: true,
+        estimatedDate: date,
+      });
+
+      // The new values are reflected in `updated` and on the resolved ceremony.
+      expect(updated.planned).toBe(true);
+      expect(updated.estimatedDate).toBe(date);
+      expect(result.planned.value).toBe(true);
+      expect(result.estimatedDate.value).toBe(date);
+
+      // `previous` only carries the keys that changed, at their prior values —
+      // a freshly created ceremony had no estimated date.
+      expect(previous.estimatedDate).toBeNull();
+    });
+
+    it('resolves the acting actor in `by`', async () => {
+      const ceremony = await createCeremony();
+
+      const { by } = await updateCeremonyReturning(app, {
+        id: ceremony.id,
+        planned: true,
+      });
+
+      expect(by.canRead).toBe(true);
+      expect(by.value?.id).toBeDefined();
+    });
+
+    it('reports no changes when nothing actually changes', async () => {
+      const ceremony = await createCeremony();
+
+      // Set planned:true once...
+      await updateCeremonyReturning(app, { id: ceremony.id, planned: true });
+      // ...then again with the same value — nothing changed.
+      const { updatedKeys } = await updateCeremonyReturning(app, {
+        id: ceremony.id,
+        planned: true,
+      });
+
+      expect(updatedKeys).toHaveLength(0);
+    });
+  });
+});
+
+async function updateCeremonyReturning(
+  app: TestApp,
+  input: InputOf<typeof UpdateCeremonyReturningDoc>,
+) {
+  const result = await app.graphql.mutate(UpdateCeremonyReturningDoc, {
+    input,
+  });
+  return result.updateCeremony;
+}
+const UpdateCeremonyReturningDoc = graphql(`
+  mutation updateCeremonyReturning($input: UpdateCeremony!) {
+    updateCeremony(input: $input) {
+      updatedKeys
+      updated {
+        planned
+        estimatedDate
+        actualDate
+      }
+      previous {
+        planned
+        estimatedDate
+        actualDate
+      }
+      ceremony {
+        id
+        planned {
+          value
+        }
+        estimatedDate {
+          value
+        }
+      }
+      by {
+        canRead
+        value {
+          id
+        }
+      }
+    }
+  }
+`);


### PR DESCRIPTION
This pull request introduces a comprehensive set of changes to add real-time GraphQL subscriptions and richer mutation event payloads for the `Ceremony` resource. The update includes new event types for creation, update, and deletion, and enhances the `updateCeremony` mutation to return detailed information about changes, including which fields were updated, their previous values, and the actor responsible for the mutation. Additionally, the service now broadcasts events on all mutations, and new resolvers and tests are added to support and verify this behavior.

**GraphQL Schema & Event Model Enhancements:**

- Added new GraphQL types and interfaces for ceremony mutation events (`CeremonyCreated`, `CeremonyUpdated`, `CeremonyDeleted`, etc.), including fields for `ceremonyId`, `at` (timestamp), `by` (actor), and detailed change tracking (`updated`, `previous`, and `updatedKeys`).
- Updated the `updateCeremony` mutation to return a `CeremonyUpdated` event with the new schema, including the changed fields and actor information. [[1]](diffhunk://#diff-c12932227e9e60679b5df16ebdb80e982681583514a1f7686a77ff76e3f3b1d9R2-R33) [[2]](diffhunk://#diff-b100c9db5ab14efe19f06af144ddd86288436c8c803e5293a95c889b9eac28eeL19-L24)

**Real-Time Subscriptions:**

- Implemented the `CeremonyMutationSubscriptionsResolver` to provide real-time GraphQL subscriptions for ceremony creation, updates, deletions, and a combined mutation stream.
- Added a resolver to expose which fields were updated in a ceremony mutation via the `updatedKeys` field.
- Added a resolver to resolve the actor (`by`) who performed the mutation.

**Backend Broadcasting & Service Changes:**

- Introduced the `CeremonyChannels` service to broadcast ceremony events for all mutations, and integrated it into the `CeremonyService` for create, update, and delete operations. [[1]](diffhunk://#diff-586bfe64eb0075766afff23c4723970d4b8c9898d1b255f6fc75a62fc3c1891eR1-R105) [[2]](diffhunk://#diff-063f3bdfb7c9bf758687dbff5761037795a239af09298a98eed3afb4fa1e4512R11-R35) [[3]](diffhunk://#diff-063f3bdfb7c9bf758687dbff5761037795a239af09298a98eed3afb4fa1e4512L41-R75) [[4]](diffhunk://#diff-063f3bdfb7c9bf758687dbff5761037795a239af09298a98eed3afb4fa1e4512L58-R91)
- Updated the ceremony module to register the new resolvers and event channel provider. [[1]](diffhunk://#diff-c017b28ef1b9b3fc93407bbed4996c3e5a186d181ff080783135e78adb876527R4-R7) [[2]](diffhunk://#diff-c017b28ef1b9b3fc93407bbed4996c3e5a186d181ff080783135e78adb876527R19-R23)

**Testing:**

- Added end-to-end tests to verify the new mutation event payloads, including checks for updated fields, previous values, actor resolution, and no-op updates.

**Export/Import Cleanups:**

- Updated exports to include the new DTOs and removed the old `CeremonyUpdated` object type. [[1]](diffhunk://#diff-44f7c21de0dec41e7b7c9912dd87f1991ee7bad2cb5345f845c6cdfacfe31449R6) [[2]](diffhunk://#diff-b100c9db5ab14efe19f06af144ddd86288436c8c803e5293a95c889b9eac28eeL1-L3)

These changes collectively enable clients to subscribe to ceremony changes in real time and receive detailed, actionable information about what changed and who made the change.