### PR TITLE
[pg] FundingAccount department-id blocks + Budget domain (Drizzle)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
             shard: 1
             total: 1
             test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|project-member|tool|notification|postgres-schema|auth-read-filter)\."
+              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
             shard: 1
             total: 1
             test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter)\."
+              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/src/components/authorization/policies/conditions/member.condition.ts
+++ b/src/components/authorization/policies/conditions/member.condition.ts
@@ -145,6 +145,11 @@ class MemberWithRolesCondition<
  * dereference to `projects.id` directly. Project-scoped child resources
  * reference their FK column. Add cases here as each domain ports to Postgres.
  */
+// migration-todo: no membership/sensitivity EXISTS arm correlates
+// `projects.deleted_at`, so members of a soft-deleted project retain access
+// to its child rows under PG — Neo4j severs these chains via Deleted_ label
+// rewrites. Disposition at the pre-cutover audit: liveness joins per-arm, or
+// cascade project soft-delete to project_members/partnerships.
 const projectIdRefForResource = (resource: EnhancedResource<any>): SQL => {
   switch (resource.name) {
     case 'Project':

--- a/src/components/authorization/policies/conditions/member.condition.ts
+++ b/src/components/authorization/policies/conditions/member.condition.ts
@@ -157,8 +157,14 @@ const projectIdRefForResource = (resource: EnhancedResource<any>): SQL => {
       return sql.raw(`"project_members"."project_id"`);
     case 'Partnership':
       return sql.raw(`"partnerships"."project_id"`);
+    case 'Budget':
+      return sql.raw(`"budgets"."project_id"`);
+    case 'BudgetRecord':
+      return sql.raw(
+        `(select "b"."project_id" from "budgets" "b" where "b"."id" = "budget_records"."budget_id")`,
+      );
     // migration-todo: re-add a case per domain as it ports to Postgres
-    // (Budget/Engagement/Ceremony/Language/BudgetRecord each dereference to
+    // (Engagement/Ceremony/Language each dereference to
     // their `project_id` FK — mono has the arms). Kept stripped so an
     // unmigrated domain routed through Drizzle fails loud here instead of
     // emitting SQL against a non-existent table.

--- a/src/components/authorization/policies/conditions/sensitivity.condition.ts
+++ b/src/components/authorization/policies/conditions/sensitivity.condition.ts
@@ -183,8 +183,19 @@ const sensitivityRefForResource = (
         select "p"."sensitivity" from "projects" "p"
         where "p"."id" = "partnerships"."project_id"
       ) <= ${accessLiteral}`;
+    case 'Budget':
+      return sql`(
+        select "p"."sensitivity" from "projects" "p"
+        where "p"."id" = "budgets"."project_id"
+      ) <= ${accessLiteral}`;
+    case 'BudgetRecord':
+      return sql`(
+        select "p"."sensitivity" from "projects" "p"
+        join "budgets" "b" on "b"."project_id" = "p"."id"
+        where "b"."id" = "budget_records"."budget_id"
+      ) <= ${accessLiteral}`;
     // migration-todo: re-add a case per domain as it ports to Postgres
-    // (Budget/Engagement/Ceremony/Language/BudgetRecord read sensitivity via
+    // (Engagement/Ceremony/Language read sensitivity via
     // their parent project; Partner has its own derived column — mono has the
     // arms). Kept stripped so an unmigrated domain routed through Drizzle fails
     // loud here instead of emitting SQL against a missing table.

--- a/src/components/authorization/policies/conditions/sensitivity.condition.ts
+++ b/src/components/authorization/policies/conditions/sensitivity.condition.ts
@@ -199,6 +199,10 @@ const sensitivityRefForResource = (
     // their parent project; Partner has its own derived column — mono has the
     // arms). Kept stripped so an unmigrated domain routed through Drizzle fails
     // loud here instead of emitting SQL against a missing table.
+    //
+    // migration-todo: these subselects don't check `projects.deleted_at` —
+    // same soft-deleted-project liveness class as projectIdRefForResource in
+    // member.condition.ts; disposition together at the pre-cutover audit.
     default:
       throw new Error(
         `SensitivityCondition.asDrizzleCondition: resource ${resource.name} not configured for Drizzle yet; add a case when it migrates.`,

--- a/src/components/budget/budget-record.drizzle.repository.ts
+++ b/src/components/budget/budget-record.drizzle.repository.ts
@@ -1,0 +1,206 @@
+import { Injectable } from '@nestjs/common';
+import { and, eq, inArray, isNull, type SQL } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  generateId,
+  type ID,
+  NotFoundException,
+  type ObjectView,
+  type UnsecuredDto,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import { type ChangesOf } from '~/core/database/changes';
+import {
+  DrizzleDtoRepository,
+  resolveOrderBy,
+  type SortMap,
+} from '~/core/drizzle';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { budgetRecords } from '~/core/drizzle/schema';
+import { type ScopedRole } from '../authorization/dto/role.dto';
+import { requesterScopeByProject } from '../project/project-member/membership-scope';
+import {
+  type Budget,
+  BudgetRecord,
+  type BudgetRecordListInput,
+  type CreateBudgetRecord,
+  type UpdateBudgetRecord,
+} from './dto';
+
+type BudgetRecordRow = typeof budgetRecords.$inferSelect & {
+  budget?: {
+    id: ID<'Budget'>;
+    status: string;
+    project?: { id: ID<'Project'>; sensitivity: string } | null;
+  } | null;
+};
+
+@Injectable()
+export class BudgetRecordDrizzleRepository extends DrizzleDtoRepository<
+  typeof budgetRecords,
+  BudgetRecord
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly identity: Identity,
+  ) {
+    super(db, budgetRecords, BudgetRecord);
+  }
+
+  async create(input: CreateBudgetRecord, _changeset?: ID): Promise<ID> {
+    // Changeset accepted for splitDb signature parity; PCR is excluded.
+    const id = await generateId<ID<'BudgetRecord'>>();
+    await this.db.insert(budgetRecords).values({
+      id,
+      budgetId: input.budget,
+      organizationId: input.organization,
+      fiscalYear: input.fiscalYear,
+      amount: null,
+      initialAmount: null,
+      preApprovedAmount: null,
+    });
+    return id;
+  }
+
+  async update(
+    existing: UnsecuredDto<BudgetRecord>,
+    changes: ChangesOf<Budget, UpdateBudgetRecord>,
+    _changeset?: ID,
+  ) {
+    await this.updateColumns(existing.id, {
+      amount: changes.amount,
+      initialAmount: changes.initialAmount,
+      preApprovedAmount: changes.preApprovedAmount,
+    });
+    return { ...existing, ...changes };
+  }
+
+  async doesRecordExist(input: CreateBudgetRecord): Promise<boolean> {
+    const [row] = await this.db
+      .select({ id: budgetRecords.id })
+      .from(budgetRecords)
+      .where(
+        and(
+          eq(budgetRecords.budgetId, input.budget),
+          eq(budgetRecords.organizationId, input.organization),
+          eq(budgetRecords.fiscalYear, input.fiscalYear),
+          isNull(budgetRecords.deletedAt),
+        ),
+      )
+      .limit(1);
+    return !!row;
+  }
+
+  override async readOne(
+    id: ID,
+    _opts?: { view?: ObjectView },
+  ): Promise<UnsecuredDto<BudgetRecord>> {
+    const [dto] = await this.readMany([id]);
+    if (!dto) {
+      throw new NotFoundException('Could not find BudgetRecord', 'budget');
+    }
+    return dto;
+  }
+
+  override async readMany(
+    ids: readonly ID[],
+  ): Promise<Array<UnsecuredDto<BudgetRecord>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.budgetRecords.findMany({
+      where: (br) => and(inArray(br.id, [...ids]), isNull(br.deletedAt)),
+      with: {
+        budget: {
+          columns: { id: true, status: true },
+          with: { project: { columns: { id: true, sensitivity: true } } },
+        },
+      },
+    });
+    return await this.mapRows(rows as BudgetRecordRow[]);
+  }
+
+  /** All live records of a budget — drives the budget-record sync handler. */
+  async readManyByBudget(
+    budgetId: ID<'Budget'>,
+  ): Promise<Array<UnsecuredDto<BudgetRecord>>> {
+    const rows = await this.db.query.budgetRecords.findMany({
+      where: (br) => and(eq(br.budgetId, budgetId), isNull(br.deletedAt)),
+      with: {
+        budget: {
+          columns: { id: true, status: true },
+          with: { project: { columns: { id: true, sensitivity: true } } },
+        },
+      },
+    });
+    return await this.mapRows(rows as BudgetRecordRow[]);
+  }
+
+  async list(input: BudgetRecordListInput, _view?: ObjectView) {
+    const conditions: SQL[] = [isNull(budgetRecords.deletedAt)];
+    if (input.filter?.budgetId) {
+      conditions.push(eq(budgetRecords.budgetId, input.filter.budgetId));
+    }
+    const sortColumns = {
+      fiscalYear: budgetRecords.fiscalYear,
+      amount: budgetRecords.amount,
+      createdAt: budgetRecords.createdAt,
+    } satisfies SortMap<keyof BudgetRecord>;
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: and(...conditions),
+      orderBy: resolveOrderBy(input, sortColumns, budgetRecords.fiscalYear),
+      page: input.page,
+      count: input.count,
+    });
+    // Bare IDs — the service hydrates each via readOneRecord (mirror of the
+    // Neo4j paginate()-without-hydrate flow).
+    return { items: rows.map((r) => r.id), total, hasMore };
+  }
+
+  async delete(id: ID, _changeset?: ID): Promise<void> {
+    await this.softDelete(id);
+  }
+
+  private async mapRows(rows: BudgetRecordRow[]) {
+    const scopeByProject = await requesterScopeByProject(
+      this.db,
+      this.identity.current.userId,
+      rows.flatMap((r) => r.budget?.project?.id ?? []),
+    );
+    return rows.map((row) =>
+      this.toDto(
+        row,
+        row.budget?.project
+          ? (scopeByProject.get(row.budget.project.id) ?? [])
+          : [],
+      ),
+    );
+  }
+
+  protected toDto(
+    row: BudgetRecordRow,
+    scope: ScopedRole[] = [],
+  ): UnsecuredDto<BudgetRecord> {
+    if (!row.budget?.project) {
+      throw new Error(
+        `BudgetRecord ${row.id} has no parent budget/project row — FK invariant violated`,
+      );
+    }
+    const dto: unknown = {
+      id: row.id,
+      __typename: 'BudgetRecord',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      organization: row.organizationId,
+      fiscalYear: row.fiscalYear,
+      amount: row.amount,
+      initialAmount: row.initialAmount,
+      preApprovedAmount: row.preApprovedAmount,
+      status: row.budget.status,
+      sensitivity: row.budget.project.sensitivity,
+      parent: { id: row.budget.id },
+      // PCR is excluded; resolver navigation marker stays undefined.
+      changeset: undefined,
+      canDelete: true,
+      scope,
+    };
+    return dto as UnsecuredDto<BudgetRecord>;
+  }
+}

--- a/src/components/budget/budget-record.repository.ts
+++ b/src/components/budget/budget-record.repository.ts
@@ -124,6 +124,10 @@ export class BudgetRecordRepository extends DtoRepository<
     return result.dto;
   }
 
+  async delete(id: ID, changeset?: ID): Promise<void> {
+    await this.deleteNode(id, { changeset });
+  }
+
   async list(input: BudgetRecordListInput, view?: ObjectView) {
     const { budgetId } = input.filter ?? {};
     const result = await this.db

--- a/src/components/budget/budget.drizzle.repository.ts
+++ b/src/components/budget/budget.drizzle.repository.ts
@@ -1,0 +1,202 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { and, eq, inArray, isNull, sql, type SQL } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  generateId,
+  type ID,
+  NotFoundException,
+  type ObjectView,
+  type UnsecuredDto,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import { type ChangesOf } from '~/core/database/changes';
+import {
+  DrizzleDtoRepository,
+  EMPTY_PAGE,
+  resolveOrderBy,
+  type SortMap,
+} from '~/core/drizzle';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { budgets } from '~/core/drizzle/schema';
+import { type ScopedRole } from '../authorization/dto/role.dto';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import { type FileId } from '../file/dto';
+import { requesterScopeByProject } from '../project/project-member/membership-scope';
+import { type BudgetRecordDrizzleRepository } from './budget-record.drizzle.repository';
+import { BudgetRecordRepository } from './budget-record.repository';
+import {
+  Budget,
+  type BudgetListInput,
+  type CreateBudget,
+  type UpdateBudget,
+} from './dto';
+
+type BudgetRow = typeof budgets.$inferSelect & {
+  project?: { id: ID<'Project'>; sensitivity: string } | null;
+};
+
+@Injectable()
+export class BudgetDrizzleRepository extends DrizzleDtoRepository<
+  typeof budgets,
+  Budget
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+    private readonly identity: Identity,
+    // Resolves to the Drizzle implementation under DATABASE=postgres, which
+    // is the only engine this repository is instantiated for.
+    @Inject(BudgetRecordRepository)
+    private readonly records: BudgetRecordDrizzleRepository,
+  ) {
+    super(db, budgets, Budget);
+  }
+
+  async create(
+    input: CreateBudget,
+    universalTemplateFileId: FileId,
+  ): Promise<ID> {
+    // The defined-file node is created by the service (createDefinedFile); we
+    // store the FK link here.
+    const id = await generateId<ID<'Budget'>>();
+    await this.db.insert(budgets).values({
+      id,
+      projectId: input.project,
+      status: 'Pending',
+      universalTemplateFileId,
+    });
+    return id;
+  }
+
+  async update(
+    existing: Budget,
+    simpleChanges: Omit<
+      ChangesOf<Budget, UpdateBudget>,
+      'universalTemplateFile'
+    >,
+  ) {
+    await this.updateColumns(existing.id, {
+      status: simpleChanges.status,
+    });
+    return { ...existing, ...simpleChanges };
+  }
+
+  override async readMany(
+    ids: readonly ID[],
+    _view?: ObjectView,
+  ): Promise<Array<UnsecuredDto<Budget>>> {
+    // View param accepted for splitDb signature parity; PCR/Changeset is
+    // excluded from the migration, so it collapses to the canonical row.
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.budgets.findMany({
+      where: (b) => and(inArray(b.id, [...ids]), isNull(b.deletedAt)),
+      with: {
+        project: { columns: { id: true, sensitivity: true } },
+      },
+    });
+    const scopeByProject = await requesterScopeByProject(
+      this.db,
+      this.identity.current.userId,
+      rows.map((r) => r.projectId),
+    );
+    return (rows as BudgetRow[]).map((row) =>
+      this.toDto(row, scopeByProject.get(row.projectId) ?? []),
+    );
+  }
+
+  async list({ filter, ...input }: BudgetListInput) {
+    const conditions: SQL[] = [isNull(budgets.deletedAt)];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+    if (filter?.projectId) {
+      conditions.push(eq(budgets.projectId, filter.projectId));
+    }
+    return await this.listIds(conditions, input);
+  }
+
+  async listUnsecure({ filter, ...input }: BudgetListInput) {
+    const conditions: SQL[] = [isNull(budgets.deletedAt)];
+    if (filter?.projectId) {
+      conditions.push(eq(budgets.projectId, filter.projectId));
+    }
+    return await this.listIds(conditions, input);
+  }
+
+  /**
+   * Both list flavors return bare IDs — the service hydrates each via
+   * `readOne` (mirror of the Neo4j `paginate()`-without-hydrate flow).
+   */
+  private async listIds(
+    conditions: SQL[],
+    input: Omit<BudgetListInput, 'filter'>,
+  ) {
+    const sortColumns = {
+      status: budgets.status,
+      createdAt: budgets.createdAt,
+    } satisfies SortMap<keyof Budget>;
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: and(...conditions),
+      orderBy: resolveOrderBy(input, sortColumns, budgets.createdAt),
+      page: input.page,
+      count: input.count,
+    });
+    return { items: rows.map((r) => r.id), total, hasMore };
+  }
+
+  async listRecordsForSync(projectId: ID, _changeset?: ID) {
+    // Rank Current first, then Pending, then anything else — mirror of the
+    // Neo4j currentBudgetForProject ranking. PCR is excluded, so the
+    // changeset-pending override collapses away.
+    const [budget] = await this.db
+      .select({ id: budgets.id, status: budgets.status })
+      .from(budgets)
+      .where(and(eq(budgets.projectId, projectId), isNull(budgets.deletedAt)))
+      .orderBy(
+        sql`case ${budgets.status}
+          when 'Current' then 0
+          when 'Pending' then 1
+          else 100
+        end`,
+      )
+      .limit(1);
+    if (!budget) {
+      throw new NotFoundException("Could not find project's budget");
+    }
+    const records = await this.records.readManyByBudget(budget.id);
+    return { id: budget.id, status: budget.status, records };
+  }
+
+  async delete(id: ID): Promise<void> {
+    await this.softDelete(id);
+  }
+
+  protected toDto(
+    row: BudgetRow,
+    scope: ScopedRole[] = [],
+  ): UnsecuredDto<Budget> {
+    if (!row.project) {
+      throw new Error(
+        `Budget ${row.id} has no parent project row — FK invariant violated`,
+      );
+    }
+    const dto: unknown = {
+      id: row.id,
+      __typename: 'Budget',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      status: row.status,
+      sensitivity: row.project.sensitivity,
+      universalTemplateFile: row.universalTemplateFileId
+        ? { id: row.universalTemplateFileId }
+        : null,
+      // Assembled by the service via listRecords.
+      records: [],
+      parent: { id: row.project.id },
+      // PCR is excluded; resolver navigation marker stays undefined.
+      changeset: undefined,
+      canDelete: true,
+      scope,
+    };
+    return dto as UnsecuredDto<Budget>;
+  }
+}

--- a/src/components/budget/budget.module.ts
+++ b/src/components/budget/budget.module.ts
@@ -1,4 +1,5 @@
 import { forwardRef, Module } from '@nestjs/common';
+import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { FileModule } from '../file/file.module';
 import { LocationModule } from '../location/location.module';
@@ -8,9 +9,11 @@ import { ProjectModule } from '../project/project.module';
 import { EducationModule } from '../user/education/education.module';
 import { UnavailabilityModule } from '../user/unavailability/unavailability.module';
 import { UserModule } from '../user/user.module';
+import { BudgetRecordDrizzleRepository } from './budget-record.drizzle.repository';
 import { BudgetRecordLoader } from './budget-record.loader';
 import { BudgetRecordRepository } from './budget-record.repository';
 import { BudgetRecordResolver } from './budget-record.resolver';
+import { BudgetDrizzleRepository } from './budget.drizzle.repository';
 import { BudgetLoader } from './budget.loader';
 import { BudgetRepository } from './budget.repository';
 import { BudgetResolver } from './budget.resolver';
@@ -34,8 +37,15 @@ import { MigrateInitialAmountMigration } from './migrations/migrate-adjusted-amo
     BudgetResolver,
     BudgetRecordResolver,
     BudgetService,
-    BudgetRepository,
-    BudgetRecordRepository,
+    splitDb(BudgetRepository, {
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: BudgetDrizzleRepository as any,
+    }),
+    splitDb(BudgetRecordRepository, {
+      // migration-todo: same as above.
+      postgres: BudgetRecordDrizzleRepository as any,
+    }),
     BudgetLoader,
     BudgetRecordLoader,
     MigrateInitialAmountMigration,

--- a/src/components/budget/budget.repository.ts
+++ b/src/components/budget/budget.repository.ts
@@ -100,6 +100,10 @@ export class BudgetRepository extends DtoRepository<
       .run();
   }
 
+  async delete(id: ID): Promise<void> {
+    await this.deleteNode(id);
+  }
+
   async list({ filter, ...input }: BudgetListInput) {
     const result = await this.db
       .query()

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -152,7 +152,8 @@ export class BudgetService {
       'budget.universalTemplateFile',
       universalTemplateFile,
     );
-    return await this.budgetRepo.update(budget, simpleChanges);
+    const updated = await this.budgetRepo.update(budget, simpleChanges);
+    return updated;
   }
 
   async updateRecord(
@@ -186,7 +187,7 @@ export class BudgetService {
     await Promise.all(budget.records.map((br) => this.deleteRecord(br.id)));
 
     try {
-      await this.budgetRepo.deleteNode(budget);
+      await this.budgetRepo.delete(budget.id);
     } catch (e) {
       throw new ServerException('Failed to delete budget', e);
     }
@@ -194,7 +195,7 @@ export class BudgetService {
 
   async deleteRecord(id: ID, changeset?: ID): Promise<void> {
     try {
-      await this.budgetRecordsRepo.deleteNode(id, { changeset });
+      await this.budgetRecordsRepo.delete(id, changeset);
     } catch (e) {
       throw new ServerException('Failed to delete Budget Record', e);
     }

--- a/src/components/budget/handlers/create-project-default-budget.handler.ts
+++ b/src/components/budget/handlers/create-project-default-budget.handler.ts
@@ -1,20 +1,12 @@
-import { ConfigService } from '~/core/config';
 import { OnHook } from '~/core/hooks';
 import { ProjectCreatedHook } from '../../project/hooks';
 import { BudgetService } from '../budget.service';
 
 @OnHook(ProjectCreatedHook)
 export class CreateProjectDefaultBudgetHandler {
-  constructor(
-    private readonly budgets: BudgetService,
-    private readonly config: ConfigService,
-  ) {}
+  constructor(private readonly budgets: BudgetService) {}
 
   async handle({ project }: ProjectCreatedHook) {
-    // migration-todo: Budget isn't migrated to Postgres yet; skip the
-    // Neo4j-only default-budget creation under DATABASE=postgres. Drop this
-    // guard when budget-pg lands.
-    if (this.config.databaseEngine === 'postgres') return;
     await this.budgets.create({ project: project.id });
   }
 }

--- a/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
+++ b/src/components/budget/handlers/sync-budget-records-to-funding-partners.handler.ts
@@ -8,7 +8,6 @@ import {
   UnauthorizedException,
   type UnsecuredDto,
 } from '~/common';
-import { ConfigService } from '~/core/config';
 import { OnHook } from '~/core/hooks';
 import { ILogger, Logger } from '~/core/logger';
 import { PartnerType } from '../../partner/dto';
@@ -44,15 +43,9 @@ export class SyncBudgetRecordsToFundingPartners {
     private readonly budgetRepo: BudgetRepository,
     private readonly partnershipService: PartnershipService,
     @Logger('budget:sync-partnerships') private readonly logger: ILogger,
-    private readonly config: ConfigService,
   ) {}
 
   async handle(event: SubscribedEvent) {
-    // migration-todo: Budget/Partnership aren't migrated to Postgres yet; skip
-    // this Neo4j-only budget-record sync under DATABASE=postgres. Drop this
-    // guard when budget-pg lands (Partnership triggers already can't fire
-    // under postgres until partnership-pg lands).
-    if (this.config.databaseEngine === 'postgres') return;
     this.logger.debug('Partnership/Project mutation, syncing budget records', {
       ...event,
       event: event.constructor.name,

--- a/src/components/budget/handlers/update-project-current-budget-status.handler.ts
+++ b/src/components/budget/handlers/update-project-current-budget-status.handler.ts
@@ -1,4 +1,3 @@
-import { ConfigService } from '~/core/config';
 import { OnHook } from '~/core/hooks';
 import { ProjectStatus, stepToStatus } from '../../project/dto';
 import { ProjectTransitionedHook } from '../../project/workflow/hooks/project-transitioned.hook';
@@ -7,16 +6,9 @@ import { BudgetStatus } from '../dto';
 
 @OnHook(ProjectTransitionedHook)
 export class UpdateProjectBudgetStatusHandler {
-  constructor(
-    private readonly budgets: BudgetService,
-    private readonly config: ConfigService,
-  ) {}
+  constructor(private readonly budgets: BudgetService) {}
 
   async handle(event: ProjectTransitionedHook) {
-    // migration-todo: Budget isn't migrated to Postgres yet; skip this
-    // Neo4j-only budget-status sync under DATABASE=postgres. Drop this guard
-    // when budget-pg lands.
-    if (this.config.databaseEngine === 'postgres') return;
     const { project } = event;
 
     const prevStatus = stepToStatus(event.previousStep);

--- a/src/components/funding-account/funding-account.drizzle.repository.ts
+++ b/src/components/funding-account/funding-account.drizzle.repository.ts
@@ -139,14 +139,10 @@ export class FundingAccountDrizzleRepository extends DrizzleDtoRepository<
   protected toDto(
     row: typeof fundingAccounts.$inferSelect,
   ): UnsecuredDto<FundingAccount> {
-    // migration-todo: departmentIdBlock is deferred to the Project-domain
-    // migration. The Neo4j repo links a DepartmentIdBlock node and the Gel
-    // schema requires one, but the shared IdBlock representation (and its
-    // ProjectType enum) belongs with Project. Nothing reads it in PG mode yet:
-    // its only consumer, SetDepartmentId, is Neo4j-only. When ported, the block
-    // is deterministic from accountNumber:
-    //   range(accountNumber * 10000 + 11 .. (accountNumber + 1) * 10000 - 1)
-    //   programs: [MomentumTranslation, Internship]
+    // departmentIdBlock is intentionally not hydrated: FundingAccount doesn't
+    // expose the block over GraphQL. The block rows ARE live under PG — this
+    // repo writes them (deterministic from accountNumber) and SetDepartmentId
+    // reads them via its own SQL, not through this DTO.
     return {
       id: row.id,
       __typename: 'FundingAccount',

--- a/src/components/funding-account/funding-account.drizzle.repository.ts
+++ b/src/components/funding-account/funding-account.drizzle.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { and, isNull, type SQL } from 'drizzle-orm';
+import { and, eq, isNull, type SQL } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import {
   generateId,
@@ -15,8 +15,9 @@ import {
   type SortMap,
 } from '~/core/drizzle';
 import { DrizzleService } from '~/core/drizzle/drizzle.service';
-import { fundingAccounts } from '~/core/drizzle/schema';
+import { departmentIdBlocks, fundingAccounts } from '~/core/drizzle/schema';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import { ProjectType as Program } from '../project/dto/project-type.enum';
 import {
   type CreateFundingAccount,
   FundingAccount,
@@ -29,6 +30,15 @@ const catchNameUnique = catchUniqueViolation(
   'name',
   'FundingAccount with this name already exists.',
 );
+
+// Same formula as the Neo4j repo: the first 10 IDs of each 10k block are
+// reserved, and the block is inclusive of its last ID.
+const blockOfAccount = (accountNumber: number) => [
+  {
+    start: accountNumber * 10000 + 11,
+    end: (accountNumber + 1) * 10000 - 1,
+  },
+];
 
 @Injectable()
 export class FundingAccountDrizzleRepository extends DrizzleDtoRepository<
@@ -46,12 +56,19 @@ export class FundingAccountDrizzleRepository extends DrizzleDtoRepository<
     input: CreateFundingAccount,
   ): Promise<UnsecuredDto<FundingAccount>> {
     const id = await generateId();
+    const blockId = await generateId();
+    await this.db.insert(departmentIdBlocks).values({
+      id: blockId,
+      range: blockOfAccount(input.accountNumber),
+      programs: [Program.MomentumTranslation, Program.Internship],
+    });
     await this.db
       .insert(fundingAccounts)
       .values({
         id,
         name: input.name,
         accountNumber: input.accountNumber,
+        departmentIdBlockId: blockId,
       })
       .catch(catchNameUnique);
     return await this.readOne(id);
@@ -65,6 +82,26 @@ export class FundingAccountDrizzleRepository extends DrizzleDtoRepository<
       name: fields.name,
       accountNumber: fields.accountNumber,
     }).catch(catchNameUnique);
+    if (fields.accountNumber != null) {
+      const row = await this.db.query.fundingAccounts.findFirst({
+        where: (fa) => eq(fa.id, id as ID<'FundingAccount'>),
+        columns: { departmentIdBlockId: true },
+      });
+      if (row?.departmentIdBlockId) {
+        await this.db
+          .update(departmentIdBlocks)
+          .set({ range: blockOfAccount(fields.accountNumber) })
+          .where(eq(departmentIdBlocks.id, row.departmentIdBlockId));
+      } else {
+        const blockId = await generateId();
+        await this.db.insert(departmentIdBlocks).values({
+          id: blockId,
+          range: blockOfAccount(fields.accountNumber),
+          programs: [Program.MomentumTranslation, Program.Internship],
+        });
+        await this.updateColumns(id, { departmentIdBlockId: blockId });
+      }
+    }
     return await this.readOne(id);
   }
 

--- a/src/components/project/handlers/set-department-id.handler.ts
+++ b/src/components/project/handlers/set-department-id.handler.ts
@@ -49,15 +49,6 @@ export class SetDepartmentId {
       return;
     }
 
-    // migration-todo: the PG path (assignDepartmentIdPg, below) is implemented
-    // but needs funding_accounts.department_id_block_id + populated blocks,
-    // which land with the FundingAccount↔department_id_block migration. No-op
-    // under postgres until then; delete this guard to enable the PG path (the
-    // engine-check below already routes to it).
-    if (this.config.databaseEngine === 'postgres') {
-      return;
-    }
-
     const project =
       event instanceof ProjectTransitionedHook ? event.project : event.updated;
 

--- a/src/components/project/handlers/set-department-id.handler.ts
+++ b/src/components/project/handlers/set-department-id.handler.ts
@@ -130,7 +130,9 @@ export class SetDepartmentId {
             select b.range
             from projects p
             join locations l on l.id = p.primary_location_id
+              and l.deleted_at is null
             join funding_accounts fa on fa.id = l.funding_account_id
+              and fa.deleted_at is null
             join department_id_blocks b on b.id = fa.department_id_block_id
             where p.id = ${projectId}
           ),

--- a/src/core/drizzle/drizzle-transactional-mutations.interceptor.ts
+++ b/src/core/drizzle/drizzle-transactional-mutations.interceptor.ts
@@ -6,6 +6,7 @@ import {
 import { ConfigService } from '~/core/config';
 import { TransactionalMutationsInterceptor } from '~/core/database/abstract-transactional-mutations.interceptor';
 import { TransactionHooks } from '~/core/database/transaction-hooks';
+import { TransactionRetryInformer } from '~/core/database/transaction-retry.informer';
 import { DrizzleService } from './drizzle.service';
 
 @Injectable()
@@ -14,6 +15,7 @@ export class DrizzleTransactionalMutationsInterceptor extends TransactionalMutat
     txHooks: TransactionHooks,
     private readonly config: ConfigService,
     private readonly drizzle: DrizzleService,
+    private readonly retryInformer: TransactionRetryInformer,
   ) {
     super(txHooks);
   }
@@ -26,6 +28,34 @@ export class DrizzleTransactionalMutationsInterceptor extends TransactionalMutat
   }
 
   protected async inTx<R>(fn: () => Promise<R>): Promise<R> {
-    return await this.drizzle.inTx(fn);
+    // Honor TransactionRetryInformer like the Neo4j driver does: handlers
+    // (e.g. SetDepartmentId's unique-violation race) mark an error retryable
+    // and expect the whole mutation to re-run. Without this loop,
+    // markForRetry() is a no-op under postgres. Same semantics as Neo4j
+    // retryable transactions: the mutation body may execute multiple times.
+    let attemptsLeft = 3;
+    while (attemptsLeft > 0) {
+      attemptsLeft--;
+      try {
+        return await this.drizzle.inTx(fn);
+      } catch (error) {
+        if (attemptsLeft > 0 && this.markedForRetry(error)) {
+          continue;
+        }
+        throw error;
+      }
+    }
+    throw new Error('unreachable: retry loop exhausted without throwing');
+  }
+
+  private markedForRetry(error: unknown): boolean {
+    // The marked error is usually a cause of the thrown one (handlers wrap
+    // the db error in a ServerException) — walk the chain.
+    let e = error;
+    while (e instanceof Error) {
+      if (this.retryInformer.shouldRetry(e)) return true;
+      e = e.cause;
+    }
+    return false;
   }
 }

--- a/src/core/drizzle/drizzle-transactional-mutations.interceptor.ts
+++ b/src/core/drizzle/drizzle-transactional-mutations.interceptor.ts
@@ -34,7 +34,8 @@ export class DrizzleTransactionalMutationsInterceptor extends TransactionalMutat
     // markForRetry() is a no-op under postgres. Same semantics as Neo4j
     // retryable transactions: the mutation body may execute multiple times.
     let attemptsLeft = 3;
-    while (attemptsLeft > 0) {
+    // eslint-disable-next-line no-constant-condition,@typescript-eslint/no-unnecessary-condition
+    while (true) {
       attemptsLeft--;
       try {
         return await this.drizzle.inTx(fn);
@@ -45,7 +46,6 @@ export class DrizzleTransactionalMutationsInterceptor extends TransactionalMutat
         throw error;
       }
     }
-    throw new Error('unreachable: retry loop exhausted without throwing');
   }
 
   private markedForRetry(error: unknown): boolean {

--- a/src/core/drizzle/migrations/0014_add_funding_account_department_id_block.sql
+++ b/src/core/drizzle/migrations/0014_add_funding_account_department_id_block.sql
@@ -1,0 +1,11 @@
+-- Links each funding account to its (deterministic) department ID block so
+-- SetDepartmentId can resolve project → primary location → funding account →
+-- block. Blocks are created/maintained by the funding account repository:
+-- range [accountNumber * 10000 + 11, (accountNumber + 1) * 10000 - 1],
+-- programs {MomentumTranslation, Internship}.
+ALTER TABLE "funding_accounts"
+  ADD COLUMN "department_id_block_id" text REFERENCES "department_id_blocks"("id");
+
+-- FK index up front (mono backfilled it in 0028; index-every-FK standard).
+CREATE INDEX "funding_accounts_department_id_block_id_idx"
+  ON "funding_accounts" ("department_id_block_id");

--- a/src/core/drizzle/migrations/0015_add_budgets.sql
+++ b/src/core/drizzle/migrations/0015_add_budgets.sql
@@ -28,6 +28,11 @@ CREATE TABLE "budgets" (
 
 CREATE INDEX "budgets_project_id_idx" ON "budgets" ("project_id");
 
+-- Indexed up front so the File domain can add the REFERENCES clause without a
+-- CREATE INDEX CONCURRENTLY backfill — same convention as partnerships.mou_id.
+CREATE INDEX "budgets_universal_template_file_id_idx"
+  ON "budgets" ("universal_template_file_id");
+
 CREATE TABLE "budget_records" (
   "id"                   text PRIMARY KEY,
   "budget_id"            text NOT NULL REFERENCES "budgets"("id") ON DELETE CASCADE,

--- a/src/core/drizzle/migrations/0015_add_budgets.sql
+++ b/src/core/drizzle/migrations/0015_add_budgets.sql
@@ -47,3 +47,8 @@ CREATE UNIQUE INDEX "budget_records_budget_org_fy_active_unique"
 
 CREATE INDEX "budget_records_organization_id_idx"
   ON "budget_records" ("organization_id");
+
+-- Full FK index — the partial unique (budget_id, organization_id, fiscal_year)
+-- WHERE deleted_at IS NULL leads with budget_id but can't serve FK-maintenance
+-- scans. Flagged by the tightened postgres-schema.e2e invariant.
+CREATE INDEX "budget_records_budget_id_idx" ON "budget_records" ("budget_id");

--- a/src/core/drizzle/migrations/0015_add_budgets.sql
+++ b/src/core/drizzle/migrations/0015_add_budgets.sql
@@ -1,0 +1,49 @@
+-- Budget domain (Phase 5). One project has many budgets over its life;
+-- exactly one is "Current" at a time (app-managed via the project workflow
+-- transition hook). Records are per (partner org, fiscal year) within a
+-- budget, synced from funding partnerships.
+--
+--   - universal_template_file_id is a deferred FK → files(id): plain text
+--     because the budgets row is inserted before createDefinedFile makes the
+--     file node (same ordering as partnerships.mou_id).
+--   - The partial unique index backstops the service's record-uniqueness
+--     check among live rows; soft-deleted records don't block recreation.
+
+CREATE TYPE "budget_status" AS ENUM (
+  'Pending',
+  'Current',
+  'Superceded',
+  'Rejected'
+);
+
+CREATE TABLE "budgets" (
+  "id"                          text PRIMARY KEY,
+  "project_id"                  text NOT NULL REFERENCES "projects"("id") ON DELETE CASCADE,
+  "status"                      "budget_status" NOT NULL DEFAULT 'Pending',
+  "universal_template_file_id"  text,
+  "created_at"                  timestamptz NOT NULL DEFAULT now(),
+  "updated_at"                  timestamptz NOT NULL DEFAULT now(),
+  "deleted_at"                  timestamptz
+);
+
+CREATE INDEX "budgets_project_id_idx" ON "budgets" ("project_id");
+
+CREATE TABLE "budget_records" (
+  "id"                   text PRIMARY KEY,
+  "budget_id"            text NOT NULL REFERENCES "budgets"("id") ON DELETE CASCADE,
+  "organization_id"      text NOT NULL REFERENCES "organizations"("id"),
+  "fiscal_year"          integer NOT NULL,
+  "amount"               double precision,
+  "initial_amount"       double precision,
+  "pre_approved_amount"  double precision,
+  "created_at"           timestamptz NOT NULL DEFAULT now(),
+  "updated_at"           timestamptz NOT NULL DEFAULT now(),
+  "deleted_at"           timestamptz
+);
+
+CREATE UNIQUE INDEX "budget_records_budget_org_fy_active_unique"
+  ON "budget_records" ("budget_id", "organization_id", "fiscal_year")
+  WHERE "deleted_at" IS NULL;
+
+CREATE INDEX "budget_records_organization_id_idx"
+  ON "budget_records" ("organization_id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -99,6 +99,20 @@
       "when": 1751500800000,
       "tag": "0013_add_fk_index_backfill",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1751501000000,
+      "tag": "0014_add_funding_account_department_id_block",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1751501200000,
+      "tag": "0015_add_budgets",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -1589,6 +1589,9 @@ export const budgetRecords = pgTable(
     uniqueIndex('budget_records_budget_org_fy_active_unique')
       .on(t.budgetId, t.organizationId, t.fiscalYear)
       .where(sql`${t.deletedAt} IS NULL`),
+    // Full FK index — the partial unique above leads with budget_id but can't
+    // serve FK-maintenance scans (soft-deleted rows excluded).
+    index('budget_records_budget_id_idx').on(t.budgetId),
     index('budget_records_organization_id_idx').on(t.organizationId),
   ],
 );

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -541,7 +541,7 @@ export const fundingAccounts = pgTable(
     accountNumber: integer('account_number').notNull(),
     // Deterministic from accountNumber (see blockOfAccount in the funding
     // account repos); SetDepartmentId resolves project → primary location →
-    // funding account → block through this FK. Added in 0013.
+    // funding account → block through this FK. Added in 0014.
     departmentIdBlockId: text('department_id_block_id')
       .$type<ID>()
       .references((): AnyPgColumn => departmentIdBlocks.id),
@@ -1548,7 +1548,15 @@ export const budgets = pgTable(
       .defaultNow(),
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
   },
-  (t) => [index('budgets_project_id_idx').on(t.projectId)],
+  (t) => [
+    index('budgets_project_id_idx').on(t.projectId),
+    // Indexed up front so the File domain can add the REFERENCES clause
+    // without a CREATE INDEX CONCURRENTLY backfill — same convention as
+    // partnerships.mou_id/agreement_id.
+    index('budgets_universal_template_file_id_idx').on(
+      t.universalTemplateFileId,
+    ),
+  ],
 );
 
 export const budgetsRelations = relations(budgets, ({ one, many }) => ({

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -17,6 +17,7 @@ import {
   uniqueIndex,
 } from 'drizzle-orm/pg-core';
 import { type ID, type Role } from '~/common';
+import { type BudgetStatus } from '../../../components/budget/dto/budget-status.enum';
 import { type FileNodeType } from '../../../components/file/dto/file-node-type.enum';
 import { type LocationType } from '../../../components/location/dto/location-type.enum';
 import { type OrganizationReach } from '../../../components/organization/dto/organization-reach.dto';
@@ -538,6 +539,12 @@ export const fundingAccounts = pgTable(
     id: text('id').$type<ID<'FundingAccount'>>().primaryKey(),
     name: text('name').notNull(),
     accountNumber: integer('account_number').notNull(),
+    // Deterministic from accountNumber (see blockOfAccount in the funding
+    // account repos); SetDepartmentId resolves project → primary location →
+    // funding account → block through this FK. Added in 0013.
+    departmentIdBlockId: text('department_id_block_id')
+      .$type<ID>()
+      .references((): AnyPgColumn => departmentIdBlocks.id),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -552,6 +559,9 @@ export const fundingAccounts = pgTable(
     uniqueIndex('funding_accounts_name_active_unique')
       .on(t.name)
       .where(sql`${t.deletedAt} IS NULL`),
+    index('funding_accounts_department_id_block_id_idx').on(
+      t.departmentIdBlockId,
+    ),
     check(
       'funding_accounts_account_number_range_chk',
       sql`${t.accountNumber} >= 0 AND ${t.accountNumber} <= 9`,
@@ -1502,3 +1512,94 @@ export const notificationRecipients = pgTable(
     index('notification_recipients_user_id_idx').on(t.userId),
   ],
 );
+
+// ─── Budgets ───────────────────────────────────────────────────────────────
+
+export const budgetStatusEnum = pgEnum('budget_status', [
+  'Pending',
+  'Current',
+  'Superceded',
+  'Rejected',
+]);
+
+export const budgets = pgTable(
+  'budgets',
+  {
+    id: text('id').$type<ID<'Budget'>>().primaryKey(),
+    projectId: text('project_id')
+      .$type<ID<'Project'>>()
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    status: budgetStatusEnum('status')
+      .$type<BudgetStatus>()
+      .notNull()
+      .default('Pending'),
+    // Deferred FK → files(id): kept plain text (not REFERENCES) because
+    // create() inserts this row BEFORE the service's createDefinedFile makes
+    // the file node — same ordering as partnerships.mou_id/agreement_id.
+    universalTemplateFileId: text('universal_template_file_id').$type<
+      ID<'File'>
+    >(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [index('budgets_project_id_idx').on(t.projectId)],
+);
+
+export const budgetsRelations = relations(budgets, ({ one, many }) => ({
+  project: one(projects, {
+    fields: [budgets.projectId],
+    references: [projects.id],
+  }),
+  records: many(budgetRecords),
+}));
+
+export const budgetRecords = pgTable(
+  'budget_records',
+  {
+    id: text('id').$type<ID<'BudgetRecord'>>().primaryKey(),
+    budgetId: text('budget_id')
+      .$type<ID<'Budget'>>()
+      .notNull()
+      .references(() => budgets.id, { onDelete: 'cascade' }),
+    organizationId: text('organization_id')
+      .$type<ID<'Organization'>>()
+      .notNull()
+      .references(() => organizations.id),
+    fiscalYear: integer('fiscal_year').notNull(),
+    amount: doublePrecision('amount'),
+    initialAmount: doublePrecision('initial_amount'),
+    preApprovedAmount: doublePrecision('pre_approved_amount'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    // One record per (budget, partner org, fiscal year) among live rows —
+    // DB backstop for the service's verifyRecordUniqueness check.
+    uniqueIndex('budget_records_budget_org_fy_active_unique')
+      .on(t.budgetId, t.organizationId, t.fiscalYear)
+      .where(sql`${t.deletedAt} IS NULL`),
+    index('budget_records_organization_id_idx').on(t.organizationId),
+  ],
+);
+
+export const budgetRecordsRelations = relations(budgetRecords, ({ one }) => ({
+  budget: one(budgets, {
+    fields: [budgetRecords.budgetId],
+    references: [budgets.id],
+  }),
+  organization: one(organizations, {
+    fields: [budgetRecords.organizationId],
+    references: [organizations.id],
+  }),
+}));

--- a/test/budget.e2e-spec.ts
+++ b/test/budget.e2e-spec.ts
@@ -1,0 +1,184 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { type ID, Role } from '~/common';
+import { graphql } from '~/graphql';
+import { BudgetStatus } from '../src/components/budget/dto';
+import { PartnerType } from '../src/components/partner/dto';
+import {
+  createFundingAccount,
+  createLocation,
+  createPartnership,
+  createProject,
+  createSession,
+  createTestApp,
+  fragments,
+  registerUser,
+  runAsAdmin,
+  type TestApp,
+  updateProject,
+} from './utility';
+import { forceProjectTo } from './utility/transition-project';
+
+describe('Budget e2e', () => {
+  let app: TestApp;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await createSession(app);
+    await registerUser(app, {
+      roles: [Role.FieldOperationsDirector, Role.Controller],
+    });
+  });
+
+  const readBudget = async (projectId: ID) => {
+    const result = await app.graphql.query(ProjectBudgetDoc, {
+      id: projectId,
+    });
+    return result.project.budget.value!;
+  };
+
+  it('first budget starts Pending with no records', async () => {
+    const project = await createProject(app);
+    const budget = await readBudget(project.id);
+    expect(budget.status).toBe(BudgetStatus.Pending);
+    expect(budget.records.length).toBe(0);
+  });
+
+  it('funding partnership syncs records per fiscal year; project mou change resyncs', async () => {
+    const project = await createProject(app);
+    // No mou overrides — the partnership inherits the project's mou window
+    // (1991-01-01 → 1992-01-01 from the createProject defaults), so the
+    // ProjectUpdatedHook resync path is what's under test here.
+    await createPartnership(app, {
+      project: project.id,
+      types: [PartnerType.Funding, PartnerType.Managing],
+      mouStartOverride: null,
+      mouEndOverride: null,
+    });
+
+    let budget = await readBudget(project.id);
+    expect(
+      budget.records
+        .map((record) => record.fiscalYear.value)
+        .sort((yearA, yearB) => yearA! - yearB!),
+    ).toEqual([1991, 1992]);
+
+    await runAsAdmin(app, async () => {
+      await updateProject(app, { id: project.id, mouEnd: '1993-01-01' });
+    });
+
+    budget = await readBudget(project.id);
+    expect(
+      budget.records
+        .map((record) => record.fiscalYear.value)
+        .sort((yearA, yearB) => yearA! - yearB!),
+    ).toEqual([1991, 1992, 1993]);
+  });
+
+  it('updateBudgetRecord sets the amount', async () => {
+    const project = await createProject(app);
+    await createPartnership(app, {
+      project: project.id,
+      types: [PartnerType.Funding, PartnerType.Managing],
+      mouStartOverride: null,
+      mouEndOverride: null,
+    });
+    const budget = await readBudget(project.id);
+    const record = budget.records[0]!;
+
+    const result = await runAsAdmin(app, async () => {
+      return await app.graphql.mutate(UpdateBudgetRecordDoc, {
+        input: { id: record.id, amount: 1234.56 },
+      });
+    });
+    expect(result.updateBudgetRecord.budgetRecord.amount.value).toBe(1234.56);
+
+    const updated = await readBudget(project.id);
+    const updatedRecord = updated.records.find(
+      (candidate) => candidate.id === record.id,
+    )!;
+    expect(updatedRecord.amount.value).toBe(1234.56);
+  });
+
+  it('flips the budget to Current when the project activates', async () => {
+    await runAsAdmin(app, async () => {
+      const fundingAccount = await createFundingAccount(app);
+      const location = await createLocation(app, {
+        fundingAccount: fundingAccount.id,
+      });
+      const project = await createProject(app, {
+        primaryLocation: location.id,
+      });
+
+      const {
+        step: { transitions },
+      } = await forceProjectTo(app, project.id, 'PendingFinanceConfirmation');
+
+      const { transitionProject } = await app.graphql.mutate(
+        TransitionToActiveDoc,
+        {
+          input: {
+            project: project.id,
+            transition: transitions.find(
+              (transition) => transition.to === 'Active',
+            )?.key,
+          },
+        },
+      );
+      const activated = transitionProject.project;
+
+      expect(activated.budget.value!.status).toBe(BudgetStatus.Current);
+      // Department ID allocation rides the same transition — the project →
+      // location → funding account → block chain.
+      expect(activated.departmentId.value).toContain(
+        fundingAccount.accountNumber.value?.toString(),
+      );
+    });
+  });
+});
+
+const ProjectBudgetDoc = graphql(
+  `
+    query projectBudget($id: ID!) {
+      project(id: $id) {
+        budget {
+          canRead
+          canEdit
+          value {
+            ...budget
+          }
+        }
+      }
+    }
+  `,
+  [fragments.budget],
+);
+
+const UpdateBudgetRecordDoc = graphql(
+  `
+    mutation updateBudgetRecord($input: UpdateBudgetRecord!) {
+      updateBudgetRecord(input: $input) {
+        budgetRecord {
+          ...budgetRecord
+        }
+      }
+    }
+  `,
+  [fragments.budgetRecord],
+);
+
+const TransitionToActiveDoc = graphql(`
+  mutation transitionProjectToActive($input: ExecuteProjectTransition!) {
+    transitionProject(input: $input) {
+      project {
+        departmentId {
+          value
+        }
+        budget {
+          value {
+            status
+          }
+        }
+      }
+    }
+  }
+`);


### PR DESCRIPTION
### Summary
Ports the Budget domain to Postgres and gives funding accounts their department-ID blocks, which together activate department-ID assignment under PG. Two commits: a Drizzle-interceptor retry fix, then the schema + repos + handler work.

### What's in scope
- `DrizzleTransactionalMutationsInterceptor` now honors `TransactionRetryInformer`: `markForRetry` was only wired to the Neo4j driver, so PG mutations never retried; the interceptor now retries up to 3× when a flagged error is found on the cause chain.
- Migration 0014: `funding_accounts.department_id_block_id` → `department_id_blocks` + FK index. The funding-account repository creates/maintains each account's block: range `[acct·10000+11, (acct+1)·10000−1]`, programs Momentum + Internship.
- Migration 0015: `budget_status` pgEnum; `budgets` (project FK CASCADE, status default Pending); `budget_records` (budget FK CASCADE, organization FK, fiscal_year, amount fields); FK indexes.
- `BudgetDrizzleRepository` + `BudgetRecordDrizzleRepository`, splitDb `postgres:` arms, and `Budget`/`BudgetRecord` cases in the member + sensitivity Drizzle auth conditions (both read sensitivity via the parent project).
- Removed the `databaseEngine === 'postgres'` early-returns from four handlers that were blocked on these tables: `create-project-default-budget`, `update-project-current-budget-status`, `sync-budget-records-to-funding-partners`, and `set-department-id`. The dept-ID JOIN chain (project → primary location → funding account → block) is now complete, so its CTE path and unique-violation retry run for real.
- Budget service: `deleteNode` → `delete(id)` rename, with matching Neo4j repo wrappers so both engines expose the same method.
- CI: `partnership` added to the postgres test pattern — its one failing test was budget-record creation, which now passes.

### Design decisions
- `budget_records` partial unique `(budget_id, organization_id, fiscal_year) WHERE deleted_at IS NULL` — DB backstop for the service's record-uniqueness check; soft-deleted records don't block recreation.
- `universal_template_file_id` stays plain text (no FK): the row is inserted before `createDefinedFile` creates the file node, so a real FK would fail the insert — same ordering rationale as `partnerships.mou_id`.
- FK indexes ship with the tables rather than in a later backfill migration.

### Validation
- type-check + lint clean.
- `partnership.e2e` fully green under `DATABASE=postgres` (13 pass / 1 pre-existing skip), including budget-record creation through the re-enabled handlers.
- `project.e2e` failures drop 10 → 5; the remaining five are boundaries of domains not yet on Postgres (Pin, Engagement/Language ×3, name collation).
- `postgres-schema.e2e` invariants green over the 0014/0015 DDL; the department-ID race-retry test passes.
