### PR TITLE
Adds `CeremonyEngagementConnectionResolver` and updates `Ceremony` DTO for `Engagement` linkage

### DIFF
--- a/src/components/ceremony/ceremony-engagement-connection.resolver.ts
+++ b/src/components/ceremony/ceremony-engagement-connection.resolver.ts
@@ -1,0 +1,21 @@
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Loader, type LoaderOf } from '~/core/data-loader';
+import { EngagementLoader } from '../engagement';
+import { type Engagement, IEngagement } from '../engagement/dto';
+import { Ceremony } from './dto';
+
+@Resolver(Ceremony)
+export class CeremonyEngagementConnectionResolver {
+  @ResolveField(() => IEngagement, {
+    description: 'The engagement this ceremony belongs to',
+  })
+  async engagement(
+    @Parent() ceremony: Ceremony,
+    @Loader(EngagementLoader) engagements: LoaderOf<EngagementLoader>,
+  ): Promise<Engagement> {
+    return await engagements.load({
+      id: ceremony.engagement.id,
+      view: { active: true },
+    });
+  }
+}

--- a/src/components/ceremony/ceremony.module.ts
+++ b/src/components/ceremony/ceremony.module.ts
@@ -1,6 +1,7 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
+import { CeremonyEngagementConnectionResolver } from './ceremony-engagement-connection.resolver';
 import { CeremonyMutationActorResolver } from './ceremony-mutation-actor.resolver';
 import { CeremonyMutationSubscriptionsResolver } from './ceremony-mutation-subscriptions.resolver';
 import { CeremonyUpdatedResolver } from './ceremony-updated.resolver';
@@ -18,6 +19,7 @@ import * as handlers from './handlers';
     CeremonyResolver,
     CeremonyMutationSubscriptionsResolver,
     CeremonyMutationActorResolver,
+    CeremonyEngagementConnectionResolver,
     CeremonyUpdatedResolver,
     CeremonyService,
     CeremonyChannels,

--- a/src/components/ceremony/ceremony.repository.ts
+++ b/src/components/ceremony/ceremony.repository.ts
@@ -6,6 +6,7 @@ import {
   ACTIVE,
   createNode,
   matchPropsAndProjectSensAndScopedRoles,
+  merge,
   oncePerProject,
   paginate,
   sorting,
@@ -51,12 +52,16 @@ export class CeremonyRepository extends DtoRepository(Ceremony) {
         .match([
           node('project', 'Project'),
           relation('out', '', 'engagement'),
-          node('', 'Engagement'),
+          node('engagement', 'Engagement'),
           relation('out', '', ACTIVE),
           node('node'),
         ])
         .apply(matchPropsAndProjectSensAndScopedRoles())
-        .return<{ dto: UnsecuredDto<Ceremony> }>('props as dto');
+        .return<{ dto: UnsecuredDto<Ceremony> }>(
+          merge('props', {
+            engagement: 'engagement { .id }',
+          }).as('dto'),
+        );
   }
 
   async list({ filter, ...input }: CeremonyListInput) {

--- a/src/components/ceremony/dto/ceremony.dto.ts
+++ b/src/components/ceremony/dto/ceremony.dto.ts
@@ -9,7 +9,7 @@ import {
   SensitivityField,
 } from '~/common';
 import { e } from '~/core/gel';
-import { RegisterResource } from '~/core/resources';
+import { type LinkTo, RegisterResource } from '~/core/resources';
 import { CeremonyType } from './ceremony-type.enum';
 
 @RegisterResource({ db: e.Engagement.Ceremony })
@@ -20,6 +20,8 @@ import { CeremonyType } from './ceremony-type.enum';
 export class Ceremony extends Resource {
   static readonly Parent = () =>
     import('../../engagement/dto').then((m) => m.IEngagement);
+
+  readonly engagement: LinkTo<'Engagement'>;
 
   @Field(() => CeremonyType)
   readonly type: CeremonyType;

--- a/test/ceremony.e2e-spec.ts
+++ b/test/ceremony.e2e-spec.ts
@@ -43,14 +43,14 @@ describe('Ceremony e2e', () => {
     );
     const ceremony = read.ceremony.value;
     expect(ceremony).toBeDefined();
-    return ceremony!;
+    return { ceremony: ceremony!, engagementId: engagement.id };
   }
 
   // `updateCeremony` returns a `CeremonyUpdated` mutation event — the same
   // payload the `ceremonyUpdated` subscription emits. These lock in that shape.
   describe('updateCeremony mutation event', () => {
     it('reports the changed input fields in updatedKeys', async () => {
-      const ceremony = await createCeremony();
+      const { ceremony } = await createCeremony();
 
       const { updatedKeys } = await updateCeremonyReturning(app, {
         id: ceremony.id,
@@ -65,7 +65,7 @@ describe('Ceremony e2e', () => {
     });
 
     it('carries new values in `updated` and prior values in `previous`', async () => {
-      const ceremony = await createCeremony();
+      const { ceremony } = await createCeremony();
       const date = '2020-05-13';
 
       const {
@@ -90,7 +90,7 @@ describe('Ceremony e2e', () => {
     });
 
     it('resolves the acting actor in `by`', async () => {
-      const ceremony = await createCeremony();
+      const { ceremony } = await createCeremony();
 
       const { by } = await updateCeremonyReturning(app, {
         id: ceremony.id,
@@ -101,8 +101,22 @@ describe('Ceremony e2e', () => {
       expect(by.value?.id).toBeDefined();
     });
 
+    // This linkage is what lets consumers (e.g. the Salesforce syncer) resolve
+    // the owning engagement from a `ceremonyUpdated` event, which otherwise only
+    // identifies the ceremony.
+    it('resolves the owning engagement on the ceremony', async () => {
+      const { ceremony, engagementId } = await createCeremony();
+
+      const { ceremony: result } = await updateCeremonyReturning(app, {
+        id: ceremony.id,
+        planned: true,
+      });
+
+      expect(result.engagement.id).toBe(engagementId);
+    });
+
     it('reports no changes when nothing actually changes', async () => {
-      const ceremony = await createCeremony();
+      const { ceremony } = await createCeremony();
 
       // Set planned:true once...
       await updateCeremonyReturning(app, { id: ceremony.id, planned: true });
@@ -147,6 +161,9 @@ const UpdateCeremonyReturningDoc = graphql(`
         }
         estimatedDate {
           value
+        }
+        engagement {
+          id
         }
       }
       by {


### PR DESCRIPTION
This pull request enhances the `Ceremony` GraphQL API by adding support for resolving the engagement that owns a ceremony. It introduces a new resolver, updates the data model and repository to include the engagement linkage, and adds comprehensive end-to-end tests to ensure the engagement is correctly exposed and accessible from ceremony data.

**GraphQL API Enhancements:**

- Added a new `CeremonyEngagementConnectionResolver` that enables resolving the owning engagement for a ceremony via a new `engagement` field. This supports consumers (e.g., Salesforce sync) in identifying a ceremony's parent engagement.
- Registered the new resolver in the `CeremonyModule` providers. [[1]](diffhunk://#diff-c017b28ef1b9b3fc93407bbed4996c3e5a186d181ff080783135e78adb876527R4) [[2]](diffhunk://#diff-c017b28ef1b9b3fc93407bbed4996c3e5a186d181ff080783135e78adb876527R22)

**Data Model and Repository Updates:**

- Updated the `Ceremony` DTO to include a typed `engagement` property, establishing a direct link to the engagement entity. [[1]](diffhunk://#diff-68c50cdea8c549ad48cafe798748c95b6a40b52c222da0a51a5ba42ca5b2670bL12-R12) [[2]](diffhunk://#diff-68c50cdea8c549ad48cafe798748c95b6a40b52c222da0a51a5ba42ca5b2670bR24-R25)
- Modified the `CeremonyRepository` so that ceremony queries now return the engagement's ID as part of the ceremony DTO, enabling the resolver to fetch engagement details efficiently. [[1]](diffhunk://#diff-9470465988e35b73b9e889708b9b24f4e13680f559186cf01f431288b2593eb1R9) [[2]](diffhunk://#diff-9470465988e35b73b9e889708b9b24f4e13680f559186cf01f431288b2593eb1L54-R64)

**Testing Improvements:**

- Extended ceremony end-to-end tests to verify that the owning engagement is correctly resolved and accessible from the ceremony, ensuring the new linkage works as intended. [[1]](diffhunk://#diff-eeea704261053eeebae589e2d2a89df553946cc670fb0ce8b329bb6f8ac33749L46-R53) [[2]](diffhunk://#diff-eeea704261053eeebae589e2d2a89df553946cc670fb0ce8b329bb6f8ac33749L68-R68) [[3]](diffhunk://#diff-eeea704261053eeebae589e2d2a89df553946cc670fb0ce8b329bb6f8ac33749L93-R93) [[4]](diffhunk://#diff-eeea704261053eeebae589e2d2a89df553946cc670fb0ce8b329bb6f8ac33749R104-R119) [[5]](diffhunk://#diff-eeea704261053eeebae589e2d2a89df553946cc670fb0ce8b329bb6f8ac33749R165-R167)