### PR TITLE
[pg] Close the auth-audit findings: readMany read filters + Partner/O…

### DIFF
--- a/src/components/authorization/policies/conditions/member.condition.ts
+++ b/src/components/authorization/policies/conditions/member.condition.ts
@@ -7,6 +7,7 @@ import { type EnhancedResource, type ResourceShape, type Role } from '~/common';
 import { matchProjectScopedRoles } from '~/core/neo4j/query';
 import { rolesForScope, type ScopedRole, splitScope } from '../../dto/role.dto';
 import {
+  type AsCypherParams,
   type AsDrizzleParams,
   type AsEdgeQLParams,
   type Condition,
@@ -34,11 +35,82 @@ class MemberCondition<
     return getScope(object).includes('member:true');
   }
 
-  asCypherCondition() {
+  asCypherCondition(
+    _query: Query,
+    { resource }: AsCypherParams<TResourceStatic>,
+  ) {
+    // The User/Unavailability list queries bind no `project` variable, and
+    // Neo4j 5 rejects pattern expressions that introduce one (42N29). An
+    // anonymous start node keeps the "member of ANY project" semantics
+    // (matching the Drizzle arm's User/Unavailability branch) without
+    // introducing a variable.
+    if (resource.name === 'User' || resource.name === 'Unavailability') {
+      return 'exists(()-[:member { active: true }]->(:ProjectMember)-[:user]->(:User { id: $currentUser }))';
+    }
     return 'exists((project)-[:member { active: true }]->(:ProjectMember)-[:user]->(:User { id: $currentUser }))';
   }
 
   asDrizzleCondition({ resource, session }: AsDrizzleParams<TResourceStatic>) {
+    // Resources that aren't project-scoped rows need bespoke membership SQL —
+    // each mirrors its Neo4j list query's `wrapContext` pattern (see the
+    // corresponding *.repository.ts) instead of a `project_id` column ref.
+    //
+    // Deliberate tightening vs the cypher, all arms: `pm.inactive_at is null`
+    // excludes replaced/inactive memberships that Neo4j's
+    // `[:member { active: true }]` still honors (the rel stays active; only
+    // inactiveAt is set). Matches membership-scope semantics. Recorded in the
+    // pre-cutover audit ledger — do not loosen to match Neo4j.
+    switch (resource.name) {
+      case 'Partner':
+        // partner.repository.ts list(): member of any project connected via a
+        // partnership. Deliberate tightenings vs the cypher: soft-deleted
+        // partnerships and soft-deleted projects don't grant membership here
+        // (Neo4j severs deleted projects via label rewrites; PG must correlate
+        // liveness explicitly).
+        return sql`exists (
+          select 1 from "partnerships" "ps"
+          join "projects" "pj" on "pj"."id" = "ps"."project_id"
+            and "pj"."deleted_at" is null
+          join "project_members" "pm" on "pm"."project_id" = "ps"."project_id"
+          where "ps"."partner_id" = "partners"."id"
+            and "ps"."deleted_at" is null
+            and "pm"."user_id" = ${session.userId}
+            and "pm"."inactive_at" is null
+            and "pm"."deleted_at" is null
+        )`;
+      case 'Organization':
+        // organization.repository.ts list(): the partner chain extended one
+        // hop (project → partnership → partner → organization).
+        return sql`exists (
+          select 1 from "partners" "p"
+          join "partnerships" "ps" on "ps"."partner_id" = "p"."id"
+          join "projects" "pj" on "pj"."id" = "ps"."project_id"
+            and "pj"."deleted_at" is null
+          join "project_members" "pm" on "pm"."project_id" = "ps"."project_id"
+          where "p"."organization_id" = "organizations"."id"
+            and "p"."deleted_at" is null
+            and "ps"."deleted_at" is null
+            and "pm"."user_id" = ${session.userId}
+            and "pm"."inactive_at" is null
+            and "pm"."deleted_at" is null
+        )`;
+      case 'User':
+      case 'Unavailability':
+        // Neo4j's user list binds no `project` variable, so the cypher is
+        // existentially unbound = "requester is an active member of ANY
+        // project" — a requester property, uncorrelated with the target row.
+        // This arm intentionally matches Neo4j. The EdgeQL stub for User is an
+        // always-true TODO (`exists { "…" }` over a literal set) — a known
+        // Gel-vs-PG divergence for the shadow-diff audit, not parity.
+        return sql`exists (
+          select 1 from "project_members" "pm"
+          where "pm"."user_id" = ${session.userId}
+            and "pm"."inactive_at" is null
+            and "pm"."deleted_at" is null
+        )`;
+      default:
+        break; // project-scoped resources fall through to the ref map below
+    }
     const projectIdRef = projectIdRefForResource(resource);
     return sql`exists (
       select 1 from "project_members" "pm"
@@ -145,11 +217,13 @@ class MemberWithRolesCondition<
  * dereference to `projects.id` directly. Project-scoped child resources
  * reference their FK column. Add cases here as each domain ports to Postgres.
  */
-// migration-todo: no membership/sensitivity EXISTS arm correlates
-// `projects.deleted_at`, so members of a soft-deleted project retain access
-// to its child rows under PG — Neo4j severs these chains via Deleted_ label
-// rewrites. Disposition at the pre-cutover audit: liveness joins per-arm, or
-// cascade project soft-delete to project_members/partnerships.
+// migration-todo: the project-scoped base arms below (and the sensitivity
+// subselects) don't correlate `projects.deleted_at`, so members of a
+// soft-deleted project retain access to its child rows under PG — Neo4j
+// severs these chains via Deleted_ label rewrites. The bespoke Partner/Org
+// arms above DO join project liveness. Disposition for the rest at the
+// pre-cutover audit: liveness joins per-arm, or cascade project soft-delete
+// to project_members/partnerships.
 const projectIdRefForResource = (resource: EnhancedResource<any>): SQL => {
   switch (resource.name) {
     case 'Project':
@@ -174,13 +248,9 @@ const projectIdRefForResource = (resource: EnhancedResource<any>): SQL => {
     // unmigrated domain routed through Drizzle fails loud here instead of
     // emitting SQL against a non-existent table.
     //
-    // Partner is on develop and member-gated (field-partner.policy
-    // `r.Partner.when(member).read`), but it intentionally has NO arm — mono
-    // ships none either. Its member check would traverse
-    // partner→partnership→project→project_members; even now that `partnerships`
-    // is on develop, we match mono and leave it at `default: throw`. This is a
-    // pre-existing dev-only gap (a FieldPartner reading Partners under
-    // DATABASE=postgres; the admin-run e2e never exercises it).
+    // Partner/Organization/User are NOT project-scoped rows — their member
+    // checks are bespoke EXISTS branches in asDrizzleCondition above, not
+    // project_id refs here.
     default:
       throw new Error(
         `MemberCondition.asDrizzleCondition: resource ${resource.name} not configured for Drizzle yet; add a case when it migrates.`,

--- a/src/components/authorization/policies/conditions/sensitivity.condition.ts
+++ b/src/components/authorization/policies/conditions/sensitivity.condition.ts
@@ -194,11 +194,19 @@ const sensitivityRefForResource = (
         join "budgets" "b" on "b"."project_id" = "p"."id"
         where "b"."id" = "budget_records"."budget_id"
       ) <= ${accessLiteral}`;
+    case 'Partner':
+      // Own denormalized column. Statically 'High' on create until Language
+      // migrates and wires the real derivation — fail-closed in the interim
+      // (sens-gated roles see nothing rather than everything).
+      return sql`"partners"."sensitivity" <= ${accessLiteral}`;
+    case 'Organization':
+      // Same interim story as Partner.
+      return sql`"organizations"."sensitivity" <= ${accessLiteral}`;
     // migration-todo: re-add a case per domain as it ports to Postgres
     // (Engagement/Ceremony/Language read sensitivity via
-    // their parent project; Partner has its own derived column — mono has the
-    // arms). Kept stripped so an unmigrated domain routed through Drizzle fails
-    // loud here instead of emitting SQL against a missing table.
+    // their parent project). Kept stripped so an unmigrated domain routed
+    // through Drizzle fails loud here instead of emitting SQL against a
+    // missing table.
     //
     // migration-todo: these subselects don't check `projects.deleted_at` —
     // same soft-deleted-project liveness class as projectIdRefForResource in

--- a/src/components/project/project-member/project-member.drizzle.repository.ts
+++ b/src/components/project/project-member/project-member.drizzle.repository.ts
@@ -89,8 +89,25 @@ export class ProjectMemberDrizzleRepository extends DrizzleDtoRepository<
     ids: readonly ID[],
   ): Promise<Array<UnsecuredDto<ProjectMember>>> {
     if (ids.length === 0) return [];
+    // Mirror the Neo4j readMany's `filterManyToReadable`: run the policy read
+    // filter over a plain id-select (its condition SQL references literal
+    // table names, so it can't live inside the relational query), then
+    // hydrate survivors through the normal path.
+    const readConditions: SQL[] = [
+      inArray(projectMembers.id, [...ids]),
+      isNull(projectMembers.deletedAt),
+    ];
+    if (!this.executor.applyReadFilter(this.resource, readConditions)) {
+      return [];
+    }
+    const readable = await this.db
+      .select({ id: projectMembers.id })
+      .from(projectMembers)
+      .where(and(...readConditions));
+    if (readable.length === 0) return [];
+    const readableIds = readable.map((row) => row.id);
     const rows = await this.db.query.projectMembers.findMany({
-      where: (m) => and(inArray(m.id, [...ids]), isNull(m.deletedAt)),
+      where: (m) => inArray(m.id, readableIds),
       with: {
         project: { columns: { id: true, type: true, sensitivity: true } },
         user: { with: { globalRoles: true } },

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -143,8 +143,26 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
     // view collapses to the canonical row — the arg is silently ignored.
     if (ids.length === 0) return [];
     const userId = this.identity.current.userId;
+    // Mirror the Neo4j readMany's `filterToReadable`: without this, member-
+    // gated roles could resolve non-member projects by id. The policy's
+    // condition SQL references literal table names, so it runs over a plain
+    // id-select rather than inside the relational query; survivors hydrate
+    // through the normal path.
+    const readConditions: SQL[] = [
+      inArray(projects.id, [...ids]),
+      isNull(projects.deletedAt),
+    ];
+    if (!this.executor.applyReadFilter(this.resource, readConditions)) {
+      return [];
+    }
+    const readable = await this.db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(and(...readConditions));
+    if (readable.length === 0) return [];
+    const readableIds = readable.map((row) => row.id);
     const rows = await this.db.query.projects.findMany({
-      where: (p) => and(inArray(p.id, [...ids]), isNull(p.deletedAt)),
+      where: (p) => inArray(p.id, readableIds),
     });
     if (rows.length === 0) return [];
 

--- a/test/auth-read-filter.e2e-spec.ts
+++ b/test/auth-read-filter.e2e-spec.ts
@@ -4,8 +4,11 @@ import { graphql } from '~/graphql';
 import {
   createLanguage,
   createLanguageEngagement,
+  createOrganization,
+  createPartner,
   createPartnership,
   createProject,
+  createProjectMember,
   createSession,
   createTestApp,
   registerUser,
@@ -136,6 +139,147 @@ describe('Read-filter hides restricted rows from a non-privileged requester', ()
   });
 });
 
+// The member condition on Partner/Organization traverses the partnership
+// chain (project → partnership → partner [→ organization]), mirroring the
+// Neo4j list queries' wrapContext patterns. The User member condition is
+// "requester is an active member of ANY project" (Neo4j's unbound-project
+// exists()). Each arm gets a negative (non-member/insufficient-sensitivity
+// sees nothing) and a positive (membership flips visibility), so a vacuous
+// empty list can't pass for the wrong reason.
+describe('Member/sensitivity condition arms via the partnership chain', () => {
+  let app: TestApp;
+  let projectId: ID;
+  let orgId: ID;
+  let partnerId: ID;
+  let fieldPartner: TestUser; // Partner+Org reads are member-gated
+  let fundraising: TestUser; // Partner+Org reads are sensitivity-gated
+  let intern: TestUser; // User reads are member-gated (member of ANY project)
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await createSession(app);
+    await registerUser(app, { roles: [Role.Administrator] });
+
+    const project = await createProject(app);
+    projectId = project.id;
+    const org = await createOrganization(app);
+    orgId = org.id;
+    const partner = await createPartner(app, { organization: orgId });
+    partnerId = partner.id;
+    await createPartnership(app, { project: projectId, partner: partnerId });
+
+    fieldPartner = await registerUser(app, { roles: [Role.FieldPartner] });
+    fundraising = await registerUser(app, { roles: [Role.Fundraising] });
+    intern = await registerUser(app, { roles: [Role.Intern] });
+  });
+
+  it('hides a partner and its organization from a non-member', async () => {
+    const admin = await runAsAdmin(app, async () => ({
+      partners: await app.graphql.query(PartnersDoc, {
+        input: { count: 100 },
+      }),
+      orgs: await app.graphql.query(OrganizationsDoc, {
+        input: { count: 100 },
+      }),
+    }));
+    expect(admin.partners.partners.items.map((p) => p.id)).toContain(partnerId);
+    expect(admin.orgs.organizations.items.map((o) => o.id)).toContain(orgId);
+
+    const seen = await fieldPartner.runAs(async () => ({
+      partners: await app.graphql.query(PartnersDoc, {
+        input: { count: 100 },
+      }),
+      orgs: await app.graphql.query(OrganizationsDoc, {
+        input: { count: 100 },
+      }),
+    }));
+    expect(seen.partners.partners.items.map((p) => p.id)).not.toContain(
+      partnerId,
+    );
+    expect(seen.orgs.organizations.items.map((o) => o.id)).not.toContain(orgId);
+  });
+
+  it('hides High-sensitivity partners/orgs from a sensitivity-gated role', async () => {
+    // partners.sensitivity / organizations.sensitivity are statically 'High'
+    // until Language migrates and wires the real derivation, so a
+    // sensMediumOrLower role sees none — fail-closed interim.
+    const seen = await fundraising.runAs(async () => ({
+      partners: await app.graphql.query(PartnersDoc, {
+        input: { count: 100 },
+      }),
+      orgs: await app.graphql.query(OrganizationsDoc, {
+        input: { count: 100 },
+      }),
+    }));
+    expect(seen.partners.partners.items.map((p) => p.id)).not.toContain(
+      partnerId,
+    );
+    expect(seen.orgs.organizations.items.map((o) => o.id)).not.toContain(orgId);
+  });
+
+  it('a non-member sees only themselves in the users list', async () => {
+    const seen = await intern.runAs(
+      async () => await app.graphql.query(UsersDoc, { input: { count: 100 } }),
+    );
+    const ids = seen.users.items.map((u) => u.id);
+    expect(ids).toContain(intern.id);
+    expect(ids).not.toContain(fieldPartner.id);
+  });
+
+  it('a non-member cannot resolve a project by id', async () => {
+    const admin = await runAsAdmin(
+      app,
+      async () => await app.graphql.query(ProjectByIdDoc, { id: projectId }),
+    );
+    expect(admin.project.id).toBe(projectId);
+
+    await intern.runAs(async () => {
+      await expect(
+        app.graphql.query(ProjectByIdDoc, { id: projectId }),
+      ).rejects.toThrow();
+    });
+  });
+
+  it('project membership flips partner/org/user/project visibility', async () => {
+    await runAsAdmin(app, async () => {
+      await createProjectMember(app, {
+        project: projectId,
+        user: fieldPartner.id,
+        roles: [Role.FieldPartner],
+      });
+      await createProjectMember(app, {
+        project: projectId,
+        user: intern.id,
+        roles: [Role.Intern],
+      });
+    });
+
+    // Member arm: the partnership chain now grants partner + org.
+    const seen = await fieldPartner.runAs(async () => ({
+      partners: await app.graphql.query(PartnersDoc, {
+        input: { count: 100 },
+      }),
+      orgs: await app.graphql.query(OrganizationsDoc, {
+        input: { count: 100 },
+      }),
+    }));
+    expect(seen.partners.partners.items.map((p) => p.id)).toContain(partnerId);
+    expect(seen.orgs.organizations.items.map((o) => o.id)).toContain(orgId);
+
+    // User arm: member of ANY project → other users become listable.
+    const users = await intern.runAs(
+      async () => await app.graphql.query(UsersDoc, { input: { count: 100 } }),
+    );
+    expect(users.users.items.map((u) => u.id)).toContain(fieldPartner.id);
+
+    // Project readMany: the member can now resolve the project by id.
+    const project = await intern.runAs(
+      async () => await app.graphql.query(ProjectByIdDoc, { id: projectId }),
+    );
+    expect(project.project.id).toBe(projectId);
+  });
+});
+
 const ProjectsDoc = graphql(`
   query ProjectsForReadFilter($input: ProjectListInput) {
     projects(input: $input) {
@@ -162,6 +306,44 @@ const PartnershipsDoc = graphql(`
       items {
         id
       }
+    }
+  }
+`);
+
+const PartnersDoc = graphql(`
+  query PartnersForReadFilter($input: PartnerListInput) {
+    partners(input: $input) {
+      items {
+        id
+      }
+    }
+  }
+`);
+
+const OrganizationsDoc = graphql(`
+  query OrganizationsForReadFilter($input: OrganizationListInput) {
+    organizations(input: $input) {
+      items {
+        id
+      }
+    }
+  }
+`);
+
+const UsersDoc = graphql(`
+  query UsersForReadFilter($input: UserListInput) {
+    users(input: $input) {
+      items {
+        id
+      }
+    }
+  }
+`);
+
+const ProjectByIdDoc = graphql(`
+  query ProjectByIdForReadFilter($id: ID!) {
+    project(id: $id) {
+      id
     }
   }
 `);


### PR DESCRIPTION
### [pg] Close the auth-audit findings: readMany read filters + Partner/Org/User condition arms

Single commit closing the confirmed findings from the Drizzle auth parity audit, plus a Neo4j 5 bug the new tests exposed. 

### What's in scope

- `Project` and `ProjectMember` `readMany` now apply the policy read filter, matching their `list` methods — previously member-gated roles could resolve non-member rows by id under `DATABASE=postgres`.
- `MemberCondition` gains Drizzle arms for resources that aren't project-scoped rows: Partner (member of any project connected via a partnership), Organization (same chain extended a hop), and User/Unavailability (member of any project). These previously threw "not configured".
- `SensitivityCondition` gains Partner + Organization arms reading their own denormalized columns.
- `MemberCondition.asCypherCondition` fix: the users list binds no `project` variable, and Neo4j 5 rejects pattern expressions that introduce one (42N29) — so member-gated roles listing users got a 500. User/Unavailability now use an anonymous start node; project-scoped resources keep the bound correlation.
- New `test/auth-read-filter.e2e-spec.ts` legs: partner/org hidden from non-members, sensitivity gating, self-only users list, project-by-id denial, and a membership flip exercising all four surfaces.

### Design decisions

- The Cypher fix restores Neo4j 4.x's "member of ANY project" semantics rather than keeping the accidental fail-closed error — it's what the policy always declared, and the Drizzle arm + tests match it.
- Every Drizzle member arm requires `inactive_at is null`, excluding replaced memberships that Neo4j's `active: true` rel still honors — deliberate tightening, matches membership-scope semantics.
- The Partner/Org arms join project liveness (`projects.deleted_at is null`) so members of a soft-deleted project don't retain partner/org visibility — Neo4j gets this via label rewrites; PG has to correlate it explicitly.
- Partner/Org sensitivity is statically High until the language port wires the real derivation — fail-closed interim, so sensitivity-gated roles see nothing rather than everything.
- The readMany filter runs over a plain id-select and survivors hydrate normally, because condition SQL references literal table names.

### Validation

- Postgres e2e: auth-read-filter, partner, organization, project-member — 4 suites, 28 passed, 0 failures.
- Neo4j e2e: auth-read-filter 8/8 (exercises the Cypher fix), user 12/12.
- `yarn type-check` and `yarn lint` clean.
