### PR TITLE
[pg] Language → Postgres (Drizzle), migration 0016

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
             shard: 1
             total: 1
             test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget)\."
+              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/src/components/authorization/policies/conditions/member.condition.ts
+++ b/src/components/authorization/policies/conditions/member.condition.ts
@@ -94,6 +94,12 @@ class MemberCondition<
             and "pm"."inactive_at" is null
             and "pm"."deleted_at" is null
         )`;
+      case 'Language':
+        // Mirrors mono: member-visible through ANY project engaging the
+        // language. migration-todo (Engagement recut): restore the
+        // engaging-projects subquery — until `engagements` exists no
+        // membership can be satisfied, so `false` is exact, not a stub.
+        return sql`false`;
       case 'User':
       case 'Unavailability':
         // Neo4j's user list binds no `project` variable, so the cypher is

--- a/src/components/authorization/policies/conditions/sensitivity.condition.ts
+++ b/src/components/authorization/policies/conditions/sensitivity.condition.ts
@@ -202,6 +202,13 @@ const sensitivityRefForResource = (
     case 'Organization':
       // Same interim story as Partner.
       return sql`"organizations"."sensitivity" <= ${accessLiteral}`;
+    case 'Language':
+      // Effective sensitivity = lowest across engaging projects, falling back
+      // to the language's own column when unengaged (mono's coalesce).
+      // migration-todo (Engagement recut): restore the engaging-projects MIN —
+      // with no engagements possible, the fallback is the only live branch, so
+      // the own-column compare is exact.
+      return sql`"languages"."sensitivity" <= ${accessLiteral}`;
     // migration-todo: re-add a case per domain as it ports to Postgres
     // (Engagement/Ceremony/Language read sensitivity via
     // their parent project). Kept stripped so an unmigrated domain routed

--- a/src/components/language/ethnologue-language/ethnologue-language.service.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.service.ts
@@ -16,11 +16,22 @@ export class EthnologueLanguageService {
     private readonly repo: EthnologueLanguageRepository,
   ) {}
 
-  async create(input: CreateEthnologueLanguage): Promise<ID> {
+  async create(
+    input: CreateEthnologueLanguage,
+    languageId?: ID<'Language'>,
+  ): Promise<ID> {
     this.privileges.for(EthnologueLanguage).verifyCan('create');
 
-    //TODO - remove the passed in languageId after migration
-    return (await this.repo.create({ languageId: 'temp' as ID, ...input })).id;
+    // languageId is only meaningful under postgres (real FK column); the
+    // Neo4j repo ignores it and wires the relationship from the Language
+    // side after this returns. migration-todo: make it required at Phase 7
+    // cutover and drop the 'temp' fallback.
+    return (
+      await this.repo.create({
+        languageId: (languageId ?? 'temp') as ID,
+        ...input,
+      })
+    ).id;
   }
 
   async readOne(id: ID, sensitivity: Sensitivity): Promise<EthnologueLanguage> {

--- a/src/components/language/language.drizzle.repository.ts
+++ b/src/components/language/language.drizzle.repository.ts
@@ -150,8 +150,26 @@ export class LanguageDrizzleRepository extends DrizzleDtoRepository<
     _view?: ObjectView,
   ): Promise<Array<UnsecuredDto<Language>>> {
     if (ids.length === 0) return [];
+    // Mirror the Neo4j readMany's `filterManyToReadable`: without this,
+    // member/sensitivity-gated roles could resolve unreadable languages by
+    // id (readOne delegates here too). The condition SQL references literal
+    // table names, so it runs over a plain id-select rather than inside the
+    // relational query; survivors hydrate through the normal path.
+    const readConditions: SQL[] = [
+      inArray(languages.id, [...ids]),
+      isNull(languages.deletedAt),
+    ];
+    if (!this.executor.applyReadFilter(this.resource, readConditions)) {
+      return [];
+    }
+    const readable = await this.db
+      .select({ id: languages.id })
+      .from(languages)
+      .where(and(...readConditions));
+    if (readable.length === 0) return [];
+    const readableIds = readable.map((row) => row.id);
     const rows = await this.db.query.languages.findMany({
-      where: (l) => and(inArray(l.id, [...ids]), isNull(l.deletedAt)),
+      where: (l) => inArray(l.id, readableIds),
       with: { ethnologue: true },
     });
     // migration-todo (Engagement recut): restore the engagementDerived()

--- a/src/components/language/language.drizzle.repository.ts
+++ b/src/components/language/language.drizzle.repository.ts
@@ -1,0 +1,400 @@
+import { Injectable } from '@nestjs/common';
+import { and, eq, ilike, inArray, isNull, or, type SQL } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  CalendarDate,
+  generateId,
+  type ID,
+  NotFoundException,
+  NotImplementedException,
+  type ObjectView,
+  type PaginatedListType,
+  type UnsecuredDto,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import {
+  catchUniqueViolation,
+  DrizzleDtoRepository,
+  EMPTY_PAGE,
+  escapeLikePattern,
+  resolveOrderBy,
+  type SortMap,
+} from '~/core/drizzle';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
+import { ethnologueLanguages, languages } from '~/core/drizzle/schema';
+import { type ScopedRole } from '../authorization/dto/role.dto';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import {
+  type CreateLanguage,
+  type EthnologueLanguage,
+  Language,
+  type LanguageFilters,
+  type LanguageListInput,
+  type UpdateLanguage,
+} from './dto';
+import { EthnologueLanguageService } from './ethnologue-language';
+import { ethnologueLanguageFilterClauses } from './ethnologue-language/ethnologue-language.drizzle.repository';
+
+type LanguageRow = typeof languages.$inferSelect & {
+  ethnologue?: typeof ethnologueLanguages.$inferSelect | null;
+  pinned?: boolean;
+};
+
+const catchNameUnique = catchUniqueViolation(
+  'languages_name_active_unique',
+  'name',
+  'name with this value already exists',
+);
+const catchDisplayNameUnique = catchUniqueViolation(
+  'languages_display_name_active_unique',
+  'displayName',
+  'displayName with this value already exists',
+);
+const catchRolvUnique = catchUniqueViolation(
+  'languages_rolv_code_active_unique',
+  'registryOfLanguageVarietiesCode',
+  'registryOfLanguageVarietiesCode with this value already exists',
+);
+
+@Injectable()
+export class LanguageDrizzleRepository extends DrizzleDtoRepository<
+  typeof languages,
+  Language
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+    private readonly identity: Identity,
+    private readonly ethnologueLanguageService: EthnologueLanguageService,
+  ) {
+    super(db, languages, Language);
+  }
+
+  async create(input: CreateLanguage): Promise<UnsecuredDto<Language>> {
+    const id = await generateId<ID<'Language'>>();
+    await this.db
+      .insert(languages)
+      .values({
+        id,
+        name: input.name,
+        displayName: input.displayName,
+        displayNamePronunciation: input.displayNamePronunciation ?? null,
+        sensitivity: input.sensitivity ?? 'High',
+        isDialect: input.isDialect ?? false,
+        populationOverride: input.populationOverride ?? null,
+        registryOfLanguageVarietiesCode:
+          (input.registryOfLanguageVarietiesCode !== undefined
+            ? input.registryOfLanguageVarietiesCode
+            : input.registryOfDialectsCode) ?? null,
+        leastOfThese: input.leastOfThese ?? false,
+        leastOfTheseReason: input.leastOfTheseReason ?? null,
+        isSignLanguage: input.isSignLanguage ?? false,
+        signLanguageCode: input.signLanguageCode ?? null,
+        sponsorEstimatedEndDate:
+          input.sponsorEstimatedEndDate?.toSQLDate() ?? null,
+        hasExternalFirstScripture: input.hasExternalFirstScripture ?? false,
+        tags: input.tags ? [...input.tags] : [],
+        isAvailableForReporting: input.isAvailableForReporting ?? false,
+      })
+      .catch(catchNameUnique)
+      .catch(catchDisplayNameUnique)
+      .catch(catchRolvUnique);
+
+    // Mirror of Gel's connectEthnologue trigger: the Language row exists
+    // first, then the EthnologueLanguage attaches to it (resolves the
+    // 'temp' languageId hack documented in the ethnologue drizzle repo).
+    await this.ethnologueLanguageService.create(input.ethnologue ?? {}, id);
+
+    return await this.readOne(id);
+  }
+
+  async update(
+    changes: Omit<UpdateLanguage, 'ethnologue'>,
+    _changeset?: ID,
+  ): Promise<UnsecuredDto<Language>> {
+    const { id, ...fields } = changes;
+    await this.updateColumns(id, {
+      name: fields.name,
+      displayName: fields.displayName,
+      displayNamePronunciation: fields.displayNamePronunciation,
+      sensitivity: fields.sensitivity,
+      isDialect: fields.isDialect,
+      populationOverride: fields.populationOverride,
+      registryOfLanguageVarietiesCode: fields.registryOfLanguageVarietiesCode,
+      leastOfThese: fields.leastOfThese,
+      leastOfTheseReason: fields.leastOfTheseReason,
+      isSignLanguage: fields.isSignLanguage,
+      signLanguageCode: fields.signLanguageCode,
+      ...(fields.sponsorEstimatedEndDate !== undefined && {
+        sponsorEstimatedEndDate:
+          fields.sponsorEstimatedEndDate?.toSQLDate() ?? null,
+      }),
+      hasExternalFirstScripture: fields.hasExternalFirstScripture,
+      ...(fields.tags !== undefined && { tags: [...fields.tags] }),
+      isAvailableForReporting: fields.isAvailableForReporting,
+    })
+      .catch(catchNameUnique)
+      .catch(catchDisplayNameUnique)
+      .catch(catchRolvUnique);
+
+    // migration-todo (Engagement recut): restore the project-sensitivity
+    // recompute over engaging projects (mono queries `engagements` +
+    // recomputeProjectSensitivity). No engagements can exist until that
+    // table lands, so there is nothing to recompute here yet.
+
+    return await this.readOne(id);
+  }
+
+  override async readMany(
+    ids: readonly ID[],
+    _view?: ObjectView,
+  ): Promise<Array<UnsecuredDto<Language>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.languages.findMany({
+      where: (l) => and(inArray(l.id, [...ids]), isNull(l.deletedAt)),
+      with: { ethnologue: true },
+    });
+    // migration-todo (Engagement recut): restore the engagementDerived()
+    // batch — effectiveSensitivity/presetInventory/usesAIAssistance/
+    // firstScriptureEngagement/scope all derive from engaging projects, so
+    // toDto's fallbacks (own sensitivity, false, null, []) are exact while
+    // no engagements can exist.
+    // migration-todo (Pin recut): restore the pinnedByRequester batch;
+    // pinned hardcodes false until then.
+    return (rows as LanguageRow[]).map((row) =>
+      this.toDto({ ...row, pinned: false }),
+    );
+  }
+
+  async readOneByEth(ethnologueId: ID): Promise<UnsecuredDto<Language>> {
+    const eth = await this.db.query.ethnologueLanguages.findFirst({
+      where: (e) => eq(e.id, ethnologueId as ID<'EthnologueLanguage'>),
+      columns: { languageId: true },
+    });
+    if (!eth?.languageId) {
+      throw new NotFoundException('No Language exists for this Ethnologue id');
+    }
+    return await this.readOne(eth.languageId);
+  }
+
+  async list(
+    input: LanguageListInput,
+  ): Promise<PaginatedListType<UnsecuredDto<Language>>> {
+    const conditions: SQL[] = [isNull(languages.deletedAt)];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+    conditions.push(
+      ...languageFilterClauses(
+        this.db,
+        input.filter,
+        this.identity.current.userId,
+      ),
+    );
+
+    const sortColumns = {
+      name: languages.name,
+      displayName: languages.displayName,
+      sensitivity: languages.sensitivity,
+      isDialect: languages.isDialect,
+      leastOfThese: languages.leastOfThese,
+      isSignLanguage: languages.isSignLanguage,
+      isAvailableForReporting: languages.isAvailableForReporting,
+      registryOfLanguageVarietiesCode:
+        languages.registryOfLanguageVarietiesCode,
+      createdAt: languages.createdAt,
+      // migration-todo (Engagement step): population (override ?? ethnologue),
+      // ethnologue.* delegation, and usesAIAssistance sorts. Unknown sort keys
+      // fall back to name via resolveOrderBy.
+    } satisfies SortMap<keyof Language>;
+
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: and(...conditions),
+      orderBy: resolveOrderBy(input, sortColumns, languages.name),
+      page: input.page,
+      count: input.count,
+    });
+    if (rows.length === 0) return { total, items: [], hasMore };
+
+    // Two-phase: paged IDs → readMany picks up the ethnologue relation.
+    const items = await this.readMany(rows.map((r) => r.id));
+    const byId = new Map(items.map((i) => [i.id, i]));
+    return {
+      total,
+      items: rows.map((r) => byId.get(r.id)!).filter(Boolean),
+      hasMore,
+    };
+  }
+
+  // migration-todo (Engagement recut): query `engagements` for real. Until
+  // that table lands no engagements can exist, so an empty list is exact —
+  // and it keeps the service's delete guard permissive, correctly.
+  async getEngagementIdsForLanguage(_language: Language): Promise<ID[]> {
+    return [];
+  }
+
+  // migration-todo (Engagement recut): query `engagements.first_scripture`
+  // for real. Exact while no engagements can exist.
+  async hasFirstScriptureEngagement(_id: ID): Promise<boolean> {
+    return false;
+  }
+
+  async delete(id: ID): Promise<void> {
+    await this.softDelete(id);
+  }
+
+  protected toDto(
+    row: LanguageRow,
+    derived?: EngagementDerived,
+  ): UnsecuredDto<Language> {
+    if (!row.ethnologue) {
+      throw new Error(
+        `Language ${row.id} has no attached EthnologueLanguage — create-flow invariant violated`,
+      );
+    }
+    const ethnologue = {
+      id: row.ethnologue.id,
+      __typename: 'EthnologueLanguage',
+      code: row.ethnologue.code,
+      provisionalCode: row.ethnologue.provisionalCode,
+      name: row.ethnologue.name,
+      population: row.ethnologue.population,
+    } as unknown as UnsecuredDto<EthnologueLanguage>;
+
+    const dto: unknown = {
+      id: row.id,
+      __typename: 'Language',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      name: row.name,
+      displayName: row.displayName,
+      displayNamePronunciation: row.displayNamePronunciation,
+      sensitivity: row.sensitivity,
+      // Lowest sensitivity across projects engaging this language; falls back
+      // to own sensitivity when unengaged (mirror of Neo4j rankSens ASC pick).
+      effectiveSensitivity: derived?.effectiveSensitivity ?? row.sensitivity,
+      isDialect: row.isDialect,
+      populationOverride: row.populationOverride,
+      population: row.populationOverride ?? row.ethnologue.population,
+      registryOfLanguageVarietiesCode: row.registryOfLanguageVarietiesCode,
+      leastOfThese: row.leastOfThese,
+      leastOfTheseReason: row.leastOfTheseReason,
+      isSignLanguage: row.isSignLanguage,
+      signLanguageCode: row.signLanguageCode,
+      sponsorEstimatedEndDate: row.sponsorEstimatedEndDate
+        ? CalendarDate.fromISO(row.sponsorEstimatedEndDate)
+        : null,
+      hasExternalFirstScripture: row.hasExternalFirstScripture,
+      firstScriptureEngagement: derived?.firstScriptureEngagement ?? null,
+      tags: [...row.tags],
+      isAvailableForReporting: row.isAvailableForReporting,
+      presetInventory: derived?.presetInventory ?? false,
+      usesAIAssistance: derived?.usesAIAssistance ?? false,
+      pinned: row.pinned ?? false,
+      ethnologue,
+      // Scoped roles aggregated (dedup'd) across all projects engaging this
+      // language — mirror of the Neo4j hydrate's collected scopedRoles.
+      scope: derived ? [...derived.scope] : [],
+      changeset: undefined,
+      canDelete: true,
+    };
+    return dto as UnsecuredDto<Language>;
+  }
+}
+
+interface EngagementDerived {
+  effectiveSensitivity:
+    | (typeof languages.$inferSelect)['sensitivity']
+    | undefined;
+  presetInventory: boolean;
+  usesAIAssistance: boolean;
+  firstScriptureEngagement: { id: ID } | null;
+  scope: Set<ScopedRole>;
+}
+
+/**
+ * Column-level WHERE clauses for `LanguageFilters`. presetInventory /
+ * usesAIAssistance list filters remain unimplemented (rarely used;
+ * migration-todo if a consumer surfaces).
+ */
+export const languageFilterClauses = (
+  db: DrizzleDb,
+  filter: LanguageFilters | undefined,
+  _requesterId?: ID<'User'>,
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+  // migration-todo (Pin recut): restore the pinnedFilter branch; until the
+  // pins table lands the filter is ignored (matches the Project/Partner
+  // recut posture — the pinned e2e stays red at the Pin boundary).
+
+  if (filter.name) {
+    const pattern = `%${escapeLikePattern(filter.name)}%`;
+    conditions.push(
+      or(
+        ilike(languages.name, pattern),
+        ilike(languages.displayName, pattern),
+      )!,
+    );
+  }
+  if (filter.sensitivity?.length) {
+    conditions.push(inArray(languages.sensitivity, [...filter.sensitivity]));
+  }
+  if (filter.leastOfThese != null) {
+    conditions.push(eq(languages.leastOfThese, filter.leastOfThese));
+  }
+  if (filter.isSignLanguage != null) {
+    conditions.push(eq(languages.isSignLanguage, filter.isSignLanguage));
+  }
+  if (filter.isDialect != null) {
+    conditions.push(eq(languages.isDialect, filter.isDialect));
+  }
+  if (filter.isAvailableForReporting != null) {
+    conditions.push(
+      eq(languages.isAvailableForReporting, filter.isAvailableForReporting),
+    );
+  }
+  const rolv =
+    filter.registryOfLanguageVarietiesCode ?? filter.registryOfDialectsCode;
+  if (rolv) {
+    conditions.push(
+      ilike(
+        languages.registryOfLanguageVarietiesCode,
+        `%${escapeLikePattern(rolv)}%`,
+      ),
+    );
+  }
+  if (filter.signLanguageCode) {
+    conditions.push(
+      ilike(
+        languages.signLanguageCode,
+        `%${escapeLikePattern(filter.signLanguageCode)}%`,
+      ),
+    );
+  }
+  if (filter.partnerId) {
+    // migration-todo (Engagement recut): restore the engagements→partnerships
+    // EXISTS. Raw SQL would compile but crash at runtime against the missing
+    // table — fail loud instead.
+    throw new NotImplementedException(
+      'LanguageFilters.partnerId requires the Engagement migration',
+    );
+  }
+  if (filter.ethnologue) {
+    const ethConditions = ethnologueLanguageFilterClauses(
+      db,
+      filter.ethnologue,
+    );
+    if (ethConditions.length > 0) {
+      conditions.push(
+        inArray(
+          languages.id,
+          db
+            .select({ id: ethnologueLanguages.languageId })
+            .from(ethnologueLanguages)
+            .where(and(...ethConditions)),
+        ),
+      );
+    }
+  }
+  return conditions;
+};

--- a/src/components/language/language.module.ts
+++ b/src/components/language/language.module.ts
@@ -14,6 +14,7 @@ import { LanguageMutationSubscriptionsResolver } from './language-mutation-subsc
 import { LanguageUpdateLinksResolver } from './language-update-links.resolver';
 import { LanguageUpdatedResolver } from './language-updated.resolver';
 import { LanguageChannels } from './language.channels';
+import { LanguageDrizzleRepository } from './language.drizzle.repository';
 import { LanguageGelRepository } from './language.gel.repository';
 import { LanguageLoader } from './language.loader';
 import { LanguageRepository } from './language.repository';
@@ -40,11 +41,14 @@ import { RegistryOfDialectToRegistryOfLanguageVarietiesMigration } from './migra
     EthnologueLanguageService,
     splitDb(EthnologueLanguageRepository, {
       gel: EthnologueLanguageGelRepository,
-      // migration-todo: remove `as any` once splitDb types accept drizzle repos directly
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
       postgres: EthnologueLanguageDrizzleRepository as any,
     }),
     splitDb(LanguageRepository, {
       gel: LanguageGelRepository,
+      // migration-todo: same as above.
+      postgres: LanguageDrizzleRepository as any,
     }),
     LanguageLoader,
     InternalFirstScriptureResolver,

--- a/src/components/language/language.repository.ts
+++ b/src/components/language/language.repository.ts
@@ -256,6 +256,10 @@ export class LanguageRepository extends DtoRepository<
         );
   }
 
+  async delete(id: ID): Promise<void> {
+    await this.deleteNode(id);
+  }
+
   async list(input: LanguageListInput) {
     const result = await this.db
       .query()

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -164,9 +164,10 @@ export class LanguageService {
 
     this.privileges.for(Language, object).verifyCan('delete');
 
-    const { at } = await this.repo.deleteNode(object).catch((exception) => {
+    await this.repo.delete(id).catch((exception) => {
       throw new ServerException('Failed to delete', exception);
     });
+    const at = DateTime.now();
 
     return this.channels.publishToAll('deleted', {
       language: id,

--- a/src/core/drizzle/migrations/0016_add_languages.sql
+++ b/src/core/drizzle/migrations/0016_add_languages.sql
@@ -1,0 +1,50 @@
+-- Language domain (Phase 5, with Engagement). The user-settable sensitivity
+-- lives here; effectiveSensitivity is computed at read time across engaging
+-- projects. Engagement-derived fields (usesAIAssistance, presetInventory,
+-- firstScriptureEngagement) are read-time queries against language_engagements
+-- once that table lands (same phase).
+--
+-- Also attaches the deferred FK on ethnologue_languages.language_id (created
+-- in 0007 before this table existed). Plain REFERENCES — no cascade — per the
+-- soft-attachment / future-global-pool model documented on that table.
+
+CREATE TABLE "languages" (
+  "id"                                  text PRIMARY KEY,
+  "name"                                text NOT NULL,
+  "display_name"                        text NOT NULL,
+  "display_name_pronunciation"          text,
+  "sensitivity"                         "sensitivity" NOT NULL DEFAULT 'High',
+  "is_dialect"                          boolean NOT NULL DEFAULT false,
+  "population_override"                 integer,
+  "registry_of_language_varieties_code" text,
+  "least_of_these"                      boolean NOT NULL DEFAULT false,
+  "least_of_these_reason"               text,
+  "is_sign_language"                    boolean NOT NULL DEFAULT false,
+  "sign_language_code"                  text,
+  "sponsor_estimated_end_date"          date,
+  "has_external_first_scripture"        boolean NOT NULL DEFAULT false,
+  "tags"                                text[] NOT NULL DEFAULT '{}',
+  "is_available_for_reporting"          boolean NOT NULL DEFAULT false,
+  "created_at"                          timestamptz NOT NULL DEFAULT now(),
+  "updated_at"                          timestamptz NOT NULL DEFAULT now(),
+  "deleted_at"                          timestamptz
+);
+
+CREATE UNIQUE INDEX "languages_name_active_unique"
+  ON "languages" ("name") WHERE "deleted_at" IS NULL;
+CREATE UNIQUE INDEX "languages_display_name_active_unique"
+  ON "languages" ("display_name") WHERE "deleted_at" IS NULL;
+CREATE UNIQUE INDEX "languages_rolv_code_active_unique"
+  ON "languages" ("registry_of_language_varieties_code")
+  WHERE "registry_of_language_varieties_code" IS NOT NULL
+    AND "deleted_at" IS NULL;
+
+ALTER TABLE "ethnologue_languages"
+  ADD CONSTRAINT "ethnologue_languages_language_id_fkey"
+  FOREIGN KEY ("language_id") REFERENCES "languages"("id");
+
+-- Full FK index — language_id's partial unique (live rows only) can't serve
+-- FK-maintenance scans. Flagged by the postgres-schema.e2e invariant the
+-- moment the REFERENCES above landed.
+CREATE INDEX "ethnologue_languages_language_id_idx"
+  ON "ethnologue_languages" ("language_id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1751501200000,
       "tag": "0015_add_budgets",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1752019200000,
+      "tag": "0016_add_languages",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -602,7 +602,9 @@ export const ethnologueLanguages = pgTable(
     // surfaces only because `secure()` injects it as standard Resource
     // boilerplate, and the `.delete` policy bit is never exercised. Prune
     // both in a follow-up PR.
-    languageId: text('language_id').$type<ID<'Language'>>(),
+    languageId: text('language_id')
+      .$type<ID<'Language'>>()
+      .references((): AnyPgColumn => languages.id),
     code: text('code'),
     provisionalCode: text('provisional_code'),
     name: text('name'),
@@ -631,6 +633,9 @@ export const ethnologueLanguages = pgTable(
     uniqueIndex('ethnologue_languages_language_id_unique')
       .on(t.languageId)
       .where(sql`${t.deletedAt} IS NULL`),
+    // Full FK index — the partial unique above can't serve FK-maintenance
+    // scans. Added in 0016 alongside the REFERENCES attach.
+    index('ethnologue_languages_language_id_idx').on(t.languageId),
     uniqueIndex('ethnologue_languages_code_unique')
       .on(t.code)
       .where(sql`${t.code} IS NOT NULL AND ${t.deletedAt} IS NULL`),
@@ -638,11 +643,6 @@ export const ethnologueLanguages = pgTable(
       .on(t.provisionalCode)
       .where(sql`${t.provisionalCode} IS NOT NULL AND ${t.deletedAt} IS NULL`),
   ],
-);
-
-export const ethnologueLanguagesRelations = relations(
-  ethnologueLanguages,
-  () => ({}),
 );
 
 // ─── Tools ─────────────────────────────────────────────────────────────────
@@ -1614,3 +1614,79 @@ export const budgetRecordsRelations = relations(budgetRecords, ({ one }) => ({
     references: [organizations.id],
   }),
 }));
+
+// ─── Languages ─────────────────────────────────────────────────────────────
+
+export const languages = pgTable(
+  'languages',
+  {
+    id: text('id').$type<ID<'Language'>>().primaryKey(),
+    name: text('name').notNull(),
+    displayName: text('display_name').notNull(),
+    displayNamePronunciation: text('display_name_pronunciation'),
+    // User-settable. `effectiveSensitivity` is computed at read time as the
+    // lowest sensitivity across projects engaging this language (mirror of
+    // the Neo4j hydrate); falls back to this column when unengaged.
+    sensitivity: sensitivityEnum('sensitivity').notNull().default('High'),
+    isDialect: boolean('is_dialect').notNull().default(false),
+    populationOverride: integer('population_override'),
+    registryOfLanguageVarietiesCode: text(
+      'registry_of_language_varieties_code',
+    ),
+    leastOfThese: boolean('least_of_these').notNull().default(false),
+    leastOfTheseReason: text('least_of_these_reason'),
+    isSignLanguage: boolean('is_sign_language').notNull().default(false),
+    signLanguageCode: text('sign_language_code'),
+    sponsorEstimatedEndDate: date('sponsor_estimated_end_date'),
+    hasExternalFirstScripture: boolean('has_external_first_scripture')
+      .notNull()
+      .default(false),
+    tags: text('tags').array().$type<readonly string[]>().notNull().default([]),
+    isAvailableForReporting: boolean('is_available_for_reporting')
+      .notNull()
+      .default(false),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    // Partial uniques scoped to live rows — mirror of the Neo4j LanguageName /
+    // LanguageDisplayName / RegistryOfLanguageAndVariantsCode constraints.
+    uniqueIndex('languages_name_active_unique')
+      .on(t.name)
+      .where(sql`${t.deletedAt} IS NULL`),
+    uniqueIndex('languages_display_name_active_unique')
+      .on(t.displayName)
+      .where(sql`${t.deletedAt} IS NULL`),
+    uniqueIndex('languages_rolv_code_active_unique')
+      .on(t.registryOfLanguageVarietiesCode)
+      .where(
+        sql`${t.registryOfLanguageVarietiesCode} IS NOT NULL AND ${t.deletedAt} IS NULL`,
+      ),
+  ],
+);
+
+export const languagesRelations = relations(languages, ({ one }) => ({
+  // 1:1 — the FK lives on ethnologue_languages.language_id (soft attachment;
+  // see that table's comment for the future global-pool model).
+  ethnologue: one(ethnologueLanguages, {
+    fields: [languages.id],
+    references: [ethnologueLanguages.languageId],
+  }),
+}));
+
+export const ethnologueLanguagesRelations = relations(
+  ethnologueLanguages,
+  ({ one }) => ({
+    language: one(languages, {
+      fields: [ethnologueLanguages.languageId],
+      references: [languages.id],
+    }),
+  }),
+);
+
+// ─── Engagements ───────────────────────────────────────────────────────────

--- a/test/language.e2e-spec.ts
+++ b/test/language.e2e-spec.ts
@@ -16,6 +16,12 @@ import {
   type TestApp,
 } from './utility';
 
+// migration-todo: these legs create language engagements, which are Neo4j-only
+// until the Engagement port lands — flip back to `it` under postgres in that PR
+// (the engagement-derived fields they assert are wired read-time against
+// language_engagements).
+const itPgPending = process.env.DATABASE === 'postgres' ? it.skip : it;
+
 describe('Language e2e', () => {
   let app: TestApp;
 
@@ -225,98 +231,104 @@ describe('Language e2e', () => {
     expect(languages.items.length).toBeGreaterThan(numLanguages);
   });
 
-  it('List with projects -> engagements -> engagement status should not error', async () => {
-    const lang = await createLanguage(app);
-    const project = await createProject(app);
-    await app.graphql.mutate(
-      graphql(`
-        mutation createLanguageEngagement($input: CreateLanguageEngagement!) {
-          createLanguageEngagement(input: $input) {
-            engagement {
-              status {
-                transitions {
-                  to
+  itPgPending(
+    'List with projects -> engagements -> engagement status should not error',
+    async () => {
+      const lang = await createLanguage(app);
+      const project = await createProject(app);
+      await app.graphql.mutate(
+        graphql(`
+          mutation createLanguageEngagement($input: CreateLanguageEngagement!) {
+            createLanguageEngagement(input: $input) {
+              engagement {
+                status {
+                  transitions {
+                    to
+                  }
                 }
               }
             }
           }
-        }
-      `),
-      {
-        input: {
-          language: lang.id,
-          project: project.id,
+        `),
+        {
+          input: {
+            language: lang.id,
+            project: project.id,
+          },
         },
-      },
-    );
-    // test reading new lang
-    const result = await app.graphql.query(
-      graphql(`
-        query {
-          languages {
-            items {
-              projects {
-                items {
-                  engagements {
-                    items {
-                      status {
-                        transitions {
-                          to
+      );
+      // test reading new lang
+      const result = await app.graphql.query(
+        graphql(`
+          query {
+            languages {
+              items {
+                projects {
+                  items {
+                    engagements {
+                      items {
+                        status {
+                          transitions {
+                            to
+                          }
                         }
                       }
                     }
                   }
                 }
               }
+              hasMore
+              total
             }
-            hasMore
-            total
           }
-        }
-      `),
-    );
-    expect(result).toBeTruthy();
-  });
+        `),
+      );
+      expect(result).toBeTruthy();
+    },
+  );
 
-  it('The list of projects the language is engagement in', async () => {
-    const numProjects = 1;
-    const language = await createLanguage(app);
-    const project = await createProject(app);
+  itPgPending(
+    'The list of projects the language is engagement in',
+    async () => {
+      const numProjects = 1;
+      const language = await createLanguage(app);
+      const project = await createProject(app);
 
-    await Promise.all(
-      times(numProjects).map(() =>
-        createLanguageEngagement(app, {
-          project: project.id,
-          language: language.id,
-        }),
-      ),
-    );
+      await Promise.all(
+        times(numProjects).map(() =>
+          createLanguageEngagement(app, {
+            project: project.id,
+            language: language.id,
+          }),
+        ),
+      );
 
-    const queryProject = await app.graphql.query(
-      graphql(
-        `
-          query language($id: ID!) {
-            language(id: $id) {
-              ...language
-              projects {
-                items {
-                  ...project
+      const queryProject = await app.graphql.query(
+        graphql(
+          `
+            query language($id: ID!) {
+              language(id: $id) {
+                ...language
+                projects {
+                  items {
+                    ...project
+                  }
+                  hasMore
+                  total
                 }
-                hasMore
-                total
               }
             }
-          }
-        `,
-        [fragments.language, fragments.project],
-      ),
-      {
-        id: language.id,
-      },
-    );
-    expect(queryProject.language.projects.items.length).toBe(numProjects);
-    expect(queryProject.language.projects.total).toBe(numProjects);
-  });
+          `,
+          [fragments.language, fragments.project],
+        ),
+        {
+          id: language.id,
+        },
+      );
+      expect(queryProject.language.projects.items.length).toBe(numProjects);
+      expect(queryProject.language.projects.total).toBe(numProjects);
+    },
+  );
 
   it('should throw error if signLanguageCode is not valid', async () => {
     const signLanguageCode = 'XXX1';
@@ -331,58 +343,64 @@ describe('Language e2e', () => {
     );
   });
 
-  it('should throw error if trying to set hasExternalFirstScripture=true while language has engagements that have firstScripture=true', async () => {
-    const language = await createLanguage(app);
-    await createLanguageEngagement(app, {
-      language: language.id,
-      firstScripture: true,
-    });
+  itPgPending(
+    'should throw error if trying to set hasExternalFirstScripture=true while language has engagements that have firstScripture=true',
+    async () => {
+      const language = await createLanguage(app);
+      await createLanguageEngagement(app, {
+        language: language.id,
+        firstScripture: true,
+      });
 
-    await expect(
-      app.graphql.mutate(
-        graphql(
-          `
-            mutation updateLanguage($input: UpdateLanguage!) {
-              updateLanguage(input: $input) {
-                language {
-                  ...language
+      await expect(
+        app.graphql.mutate(
+          graphql(
+            `
+              mutation updateLanguage($input: UpdateLanguage!) {
+                updateLanguage(input: $input) {
+                  language {
+                    ...language
+                  }
                 }
               }
-            }
-          `,
-          [fragments.language],
-        ),
-        {
-          input: {
-            id: language.id,
-            hasExternalFirstScripture: true,
+            `,
+            [fragments.language],
+          ),
+          {
+            input: {
+              id: language.id,
+              hasExternalFirstScripture: true,
+            },
           },
-        },
-      ),
-    ).rejects.toThrowGqlError(
-      errors.input({
-        message:
-          'hasExternalFirstScripture can be set to true if the language has no engagements that have firstScripture=true',
-        field: 'hasExternalFirstScripture',
-      }),
-    );
-  });
+        ),
+      ).rejects.toThrowGqlError(
+        errors.input({
+          message:
+            'hasExternalFirstScripture can be set to true if the language has no engagements that have firstScripture=true',
+          field: 'hasExternalFirstScripture',
+        }),
+      );
+    },
+  );
 
-  it('can set hasExternalFirstScripture=true if language has no engagements that have firstScripture=true', async () => {
-    const language = await createLanguage(app);
-    await createLanguageEngagement(app, {
-      language: language.id,
-      firstScripture: false,
-    });
+  itPgPending(
+    'can set hasExternalFirstScripture=true if language has no engagements that have firstScripture=true',
+    async () => {
+      const language = await createLanguage(app);
+      await createLanguageEngagement(app, {
+        language: language.id,
+        firstScripture: false,
+      });
 
-    const updated = await updateLanguage(app, {
-      id: language.id,
-      hasExternalFirstScripture: true,
-    });
-    expect(updated.hasExternalFirstScripture.value).toBe(true);
-  });
+      const updated = await updateLanguage(app, {
+        id: language.id,
+        hasExternalFirstScripture: true,
+      });
+      expect(updated.hasExternalFirstScripture.value).toBe(true);
+    },
+  );
 
-  it('presetInventory flag', async () => {
+  itPgPending('presetInventory flag', async () => {
     const project = await createProject(app, { presetInventory: true });
     const language = await createLanguage(app);
     await createLanguageEngagement(app, {
@@ -409,7 +427,7 @@ describe('Language e2e', () => {
     expect(actual.presetInventory.value).toBe(true);
   });
 
-  it('List view of languages by presetInventory flag', async () => {
+  itPgPending('List view of languages by presetInventory flag', async () => {
     const numLanguages = 2;
 
     await Promise.all(times(numLanguages).map(() => createLanguage(app)));

--- a/test/utility/create-language.ts
+++ b/test/utility/create-language.ts
@@ -5,6 +5,18 @@ import { graphql, type InputOf } from '~/graphql';
 import { type TestApp } from './create-app';
 import * as fragments from './fragments';
 
+// Deal 3-letter codes from a sequential counter (random start) instead of
+// sampling — the unique constraints on ethnologue code/provisional_code make
+// random draws collide across a spec file (26³ combos, birthday math). Same
+// deck idea as create-location's isoAlpha3.
+let ethCodeCounter = faker.number.int({ max: 26 ** 3 - 1 });
+const nextEthCode = () => {
+  const n = ethCodeCounter++ % 26 ** 3;
+  return [(n / 676) | 0, (n / 26) | 0, n]
+    .map((part) => String.fromCharCode(97 + (part % 26)))
+    .join('');
+};
+
 export async function createLanguage(
   app: TestApp,
   input: Partial<InputOf<typeof CreateLanguageDoc>> = {},
@@ -20,8 +32,8 @@ export async function createLanguage(
     leastOfThese: faker.datatype.boolean(),
     leastOfTheseReason: faker.lorem.sentence(),
     ethnologue: {
-      code: faker.helpers.replaceSymbols('???').toLowerCase(),
-      provisionalCode: faker.helpers.replaceSymbols('???').toLowerCase(),
+      code: nextEthCode(),
+      provisionalCode: nextEthCode(),
       name: faker.person.firstName(),
       // this represents the largest number that is less than the 32-bit max for GraphQL
       population: faker.number.int({ max: 2147483647 }),


### PR DESCRIPTION
### What's in scope

- `languages` table (migration 0016): user-settable `sensitivity` (default High), soft-delete, and partial unique indexes on `name`, `display_name`, and the RoLV code among live rows.
- Attaches the deferred FK `ethnologue_languages.language_id → languages.id` (column predates this table, from 0007), plus its full FK index.
- `LanguageDrizzleRepository` (+400) with splitDb wiring; create flow inserts the Language row first, then the ethnologue row against it.
- Authorization arms for Language: membership and effective-sensitivity conditions.
- Six e2e legs that create language engagements are skipped under `DATABASE=postgres` (engagements aren't ported yet); `language` joins the postgres CI pattern with the remaining 11 running.

### Design decisions

- Engagement-derived fields (`presetInventory`, `firstScriptureEngagement`, AI-assistance rollup) and the engaging-projects sensitivity minimum are read-time queries against `language_engagements` — deferred to the Engagement PR, which also re-enables the six skipped legs.
- The interim condition arms are exact, not stubs: with no engagements table, member-visibility is correctly `false`, and effective sensitivity correctly collapses to the language's own column (the unengaged fallback). Both carry `migration-todo` comments naming the restoration point.
- The ethnologue FK is plain REFERENCES with no cascade, preserving the soft-attachment model documented on that table.

### Validation

- Postgres e2e: language 11 passed / 6 skipped (engagement-dependent); postgres-schema invariants 7/7 with 0016 applied.
- Neo4j e2e: language 17/17 — every leg runs, zero behavior change.
- `yarn type-check` and `yarn lint` clean.