### PR TITLE
Wipe Neo4j between e2e spec files in CI + widen director-change timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,10 @@ jobs:
           NEO4J_VERSION: ${{ matrix.neo4j-version }}
           DATABASE: ${{ matrix.database }}
           POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/cord
+          # Opt-in for the between-spec-file Neo4j wipe (test/setup/neo4j-wipe.ts).
+          # The wipe additionally refuses any non-loopback NEO4J_URL. Only set
+          # this where Neo4j is an ephemeral per-job service container.
+          NEO4J_TEST_WIPE: true
         # neo4j is the production engine → blocking (required to merge).
         # postgres is dev-only until the cutover, so keep it running for
         # migration signal but DON'T gate merges on it — a PG failure on a

--- a/test/features/director-change-replaces-memberships-on-open-projects.e2e-spec.ts
+++ b/test/features/director-change-replaces-memberships-on-open-projects.e2e-spec.ts
@@ -291,7 +291,9 @@ it('director change replaces memberships on open projects', async () => {
   expect(after.get('closed', 'new')).toBeUndefined();
   expect(after.get('closed', 'unrelated')).toBeUndefined();
   // endregion
-});
+  // ~24 create/transition mutations in one test — the global 2m e2e timeout
+  // is marginal for it on slow CI runners (chronic shard flake).
+}, 300_000);
 
 async function fetchMembers(app: TestApp, projectId: ID) {
   const res = await app.graphql.query(

--- a/test/setup/create-app.ts
+++ b/test/setup/create-app.ts
@@ -20,7 +20,8 @@ afterAll(async () => {
     await app.close();
   }
   // Gel/PG are ephemeral per-file DBs (cleaned per app above); Neo4j is one
-  // shared instance per CI job, so it gets wiped here instead. No-op locally.
+  // shared instance per CI job, so it gets wiped here instead. No-op unless
+  // NEO4J_TEST_WIPE is explicitly set (only the CI workflow sets it).
   await wipeNeo4jAfterFile();
 });
 

--- a/test/setup/create-app.ts
+++ b/test/setup/create-app.ts
@@ -9,6 +9,7 @@ import { LogLevel } from '~/core/logger';
 import { LevelMatcher } from '~/core/logger/level-matcher';
 import { AppModule } from '../../src/app.module';
 import { ephemeralGel } from './gel-setup';
+import { wipeNeo4jAfterFile } from './neo4j-wipe';
 import { ephemeralPg } from './pg-setup';
 
 export type TestApp = Pick<NestHttpApplication, 'get'>;
@@ -18,6 +19,9 @@ afterAll(async () => {
   for (const app of appsToClose) {
     await app.close();
   }
+  // Gel/PG are ephemeral per-file DBs (cleaned per app above); Neo4j is one
+  // shared instance per CI job, so it gets wiped here instead. No-op locally.
+  await wipeNeo4jAfterFile();
 });
 
 export const createApp = async ({

--- a/test/setup/neo4j-wipe.ts
+++ b/test/setup/neo4j-wipe.ts
@@ -1,0 +1,43 @@
+import * as Neo from 'neo4j-driver';
+
+/**
+ * Wipe the Neo4j database after a spec file — CI ONLY.
+ *
+ * Why: CI gives each E2E shard ONE Neo4j service container shared by every
+ * spec file in the shard (unlike Gel/PG, which get ephemeral per-file DBs).
+ * Data accumulates across files, so heavy specs run on an ever-fatter graph
+ * and intermittently blow their timeouts depending on runner speed — the
+ * chronic "neo4j 3/6 / 5/6" flake. Wiping at file teardown gives every file
+ * the same empty starting state; the app re-bootstraps root/default objects
+ * on its next boot exactly as it does on a fresh container.
+ *
+ * NEVER runs locally (gated on CI env): the local compose `db` is a
+ * long-lived dev database — and the cutover-ETL source — so wiping it would
+ * destroy real data. Local runs keep today's accumulate-forever behavior.
+ */
+export const wipeNeo4jAfterFile = async () => {
+  if (!process.env.CI) return;
+  const url = process.env.NEO4J_URL ?? 'bolt://localhost';
+  const auth = process.env.NEO4J_USERNAME
+    ? Neo.auth.basic(
+        process.env.NEO4J_USERNAME,
+        process.env.NEO4J_PASSWORD ?? '',
+      )
+    : undefined;
+  const driver = auth ? Neo.driver(url, auth) : Neo.driver(url);
+  try {
+    const session = driver.session({
+      database: process.env.NEO4J_DBNAME || undefined,
+      defaultAccessMode: Neo.session.WRITE,
+    });
+    try {
+      // Test datasets are small (a few thousand nodes per file at most), so a
+      // single-pass delete is fine — no need for apoc batching.
+      await session.run('MATCH (n) DETACH DELETE n');
+    } finally {
+      await session.close();
+    }
+  } finally {
+    await driver.close();
+  }
+};

--- a/test/setup/neo4j-wipe.ts
+++ b/test/setup/neo4j-wipe.ts
@@ -1,7 +1,7 @@
 import * as Neo from 'neo4j-driver';
 
 /**
- * Wipe the Neo4j database after a spec file — CI ONLY.
+ * Wipe the Neo4j database after a spec file — explicit opt-in + localhost only.
  *
  * Why: CI gives each E2E shard ONE Neo4j service container shared by every
  * spec file in the shard (unlike Gel/PG, which get ephemeral per-file DBs).
@@ -11,13 +11,28 @@ import * as Neo from 'neo4j-driver';
  * the same empty starting state; the app re-bootstraps root/default objects
  * on its next boot exactly as it does on a fresh container.
  *
- * NEVER runs locally (gated on CI env): the local compose `db` is a
- * long-lived dev database — and the cutover-ETL source — so wiping it would
- * destroy real data. Local runs keep today's accumulate-forever behavior.
+ * Safety — this deletes EVERY node in the target database, so two independent
+ * gates keep it away from real data (the local compose `db` is a long-lived
+ * dev database and the cutover-ETL source; prod runs Neo4j until the PG flip):
+ * 1. `NEO4J_TEST_WIPE` must be explicitly set — only the CI workflow sets it.
+ *    Nothing keys off ambient env like `CI`, so self-hosted runners or local
+ *    shells can't trip it by accident.
+ * 2. The target host must be loopback. A wipe opt-in pointed at a remote host
+ *    is always a misconfiguration — we throw loudly instead of silently
+ *    skipping, so the flake this exists to fix can't quietly return.
  */
 export const wipeNeo4jAfterFile = async () => {
-  if (!process.env.CI) return;
+  if (!process.env.NEO4J_TEST_WIPE) return;
   const url = process.env.NEO4J_URL ?? 'bolt://localhost';
+  const host = new URL(url).hostname;
+  const loopback = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+  if (!loopback.has(host)) {
+    throw new Error(
+      `NEO4J_TEST_WIPE is set but NEO4J_URL points at non-loopback host "${host}".` +
+        ' Refusing to wipe a remote Neo4j — fix the environment: the wipe is' +
+        ' only for ephemeral per-job test containers.',
+    );
+  }
   const auth = process.env.NEO4J_USERNAME
     ? Neo.auth.basic(
         process.env.NEO4J_USERNAME,


### PR DESCRIPTION
### Problem

Chronic flaky neo4j e2e shards (usually 3/6 or 5/6): timeout-flavored failures,
pass on rerun, lately near-every-run. Diagnosis from a month of Actions data:
E2E step time has been flat (~5.5m avg per shard) the whole time — this is not a
slowdown. The mechanism is that each CI shard shares **one Neo4j service
container across all of its spec files with no between-file cleanup** (Gel and
PG get ephemeral per-file databases; Neo4j never did). Data accumulates across
files, so the heaviest specs run on an ever-fatter graph and intermittently
blow marginal timeouts depending on runner hardware:

- The director-change feature spec — ~24 mutations in a single test — riding
  the global 120s e2e timeout (its shard's signature failure).
- webhooks.e2e — server-side request aborts under load (the other shard's).
- Frequency rose recently because new spec files (ceremony, notifications,
  language-population) fattened the pile and reshuffled which shards the heavy
  specs land in.

### Changes

- **`test/setup/neo4j-wipe.ts` (new)** — `MATCH (n) DETACH DELETE n` at
  spec-file teardown, wired into `createApp`'s per-file `afterAll`. Every file
  starts on an empty graph; the app re-bootstraps root/default objects on its
  next boot exactly as it does on a fresh container.
- **director-change spec** — explicit 300s test timeout instead of riding the
  global 120s ceiling.
- **test.yml** — sets the wipe's opt-in env var on the e2e step.

### Safety (infra-reviewed)

The wipe deletes every node in the target database, so it's double-gated:

- **Explicit opt-in**: requires `NEO4J_TEST_WIPE`, set only inside the test
  workflow's e2e step. Ambient `CI` is deliberately not consulted — our
  CodeBuild sets `CI=true` on every project, so keying off it would arm the
  wipe outside GitHub Actions.
- **Loopback-only**: any non-loopback `NEO4J_URL` makes the wipe throw loudly
  (failing the run) rather than proceed or silently skip — so a misconfig can
  neither wipe a real database nor quietly reintroduce the flake.
- Infra reviewed the diff and verified no CI context exposes real `NEO4J_*`
  env/secrets in either repo.

### Validation

- Spec file run against a throwaway Neo4j container with the opt-in set:
  green, database verified empty afterward (wipe fires through both gates).
- Same spec run **again on the wiped database**: green — proves clean-graph
  re-bootstrap, the main behavioral risk of this change.
- Normal local run leaves the local dev database untouched (100K+ nodes
  intact) — locally nothing changes at all.
- type-check + lint clean.

### Not in this PR (tracked follow-ups)

- workflowEvents N+1 loader fix — the only change that shortens green-path
  runtime (~1–2 min off the worst shard).
- RedisMock's unhandled rxjs TimeoutErrors — makes webhook-shard failures
  unreadable when they do happen.
- Shard rebalancing — max shard runs ~8m of tests vs the 5.5m average.
