### PR TITLE
[pg] Engagement + Ceremony → Postgres (Drizzle), migration 0017

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
             shard: 1
             total: 1
             test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language)\."
+              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|ceremony)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
             shard: 1
             total: 1
             test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|ceremony)\."
+              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/src/components/authorization/policies/conditions/is-intern.condition.ts
+++ b/src/components/authorization/policies/conditions/is-intern.condition.ts
@@ -1,4 +1,5 @@
 import { type NonEmptyArray } from '@seedcompany/common';
+import { sql } from 'drizzle-orm';
 import { inspect, type InspectOptionsStylized } from 'util';
 import { type User } from '../../../user/dto';
 import {
@@ -31,8 +32,20 @@ class IsInternCondition<
     return `exists .<intern[is ${InternshipEngagement}]`;
   }
 
-  // migration-todo: add asDrizzleCondition when User is ported to Postgres —
-  // subquery on internship_engagements where intern_id = users.id.
+  asDrizzleCondition() {
+    // Mirrors the cypher: the user row is the intern on ≥1 InternshipEngagement.
+    // Engagement liveness (`deleted_at`) replaces Neo4j's Deleted_ label
+    // rewrite. No project-liveness join on purpose — Neo4j doesn't sever an
+    // engagement's `intern` edge when its project is deleted, and the hydrate
+    // side (user.drizzle.repository.ts `internUserIds`) must stay in lockstep
+    // with this predicate.
+    return sql`exists (
+      select 1 from "engagements" "e"
+      where "e"."intern_id" = "users"."id"
+        and "e"."type" = 'Internship'
+        and "e"."deleted_at" is null
+    )`;
+  }
 
   union(this: void, conditions: NonEmptyArray<this>) {
     return conditions[0];

--- a/src/components/authorization/policies/conditions/member.condition.ts
+++ b/src/components/authorization/policies/conditions/member.condition.ts
@@ -94,12 +94,6 @@ class MemberCondition<
             and "pm"."inactive_at" is null
             and "pm"."deleted_at" is null
         )`;
-      case 'Language':
-        // Mirrors mono: member-visible through ANY project engaging the
-        // language. migration-todo (Engagement recut): restore the
-        // engaging-projects subquery — until `engagements` exists no
-        // membership can be satisfied, so `false` is exact, not a stub.
-        return sql`false`;
       case 'User':
       case 'Unavailability':
         // Neo4j's user list binds no `project` variable, so the cypher is
@@ -247,6 +241,22 @@ const projectIdRefForResource = (resource: EnhancedResource<any>): SQL => {
     case 'BudgetRecord':
       return sql.raw(
         `(select "b"."project_id" from "budgets" "b" where "b"."id" = "budget_records"."budget_id")`,
+      );
+    case 'Engagement':
+    case 'LanguageEngagement':
+    case 'InternshipEngagement':
+      return sql.raw(`"engagements"."project_id"`);
+    case 'Ceremony':
+      return sql.raw(
+        `(select "e"."project_id" from "engagements" "e" where "e"."id" = "ceremonies"."engagement_id")`,
+      );
+    case 'Language':
+      // A language is "member-visible" through ANY project engaging it.
+      // `pm.project_id = any(array(...))` keeps the shared `= ${ref}` template
+      // working with a multi-row subquery.
+      return sql.raw(
+        `any(array(select "e"."project_id" from "engagements" "e"
+          where "e"."language_id" = "languages"."id" and "e"."deleted_at" is null))`,
       );
     // migration-todo: re-add a case per domain as it ports to Postgres
     // (Engagement/Ceremony/Language each dereference to

--- a/src/components/authorization/policies/conditions/sensitivity.condition.ts
+++ b/src/components/authorization/policies/conditions/sensitivity.condition.ts
@@ -202,13 +202,30 @@ const sensitivityRefForResource = (
     case 'Organization':
       // Same interim story as Partner.
       return sql`"organizations"."sensitivity" <= ${accessLiteral}`;
+    case 'Engagement':
+    case 'LanguageEngagement':
+    case 'InternshipEngagement':
+      return sql`(
+        select "p"."sensitivity" from "projects" "p"
+        where "p"."id" = "engagements"."project_id"
+      ) <= ${accessLiteral}`;
+    case 'Ceremony':
+      return sql`(
+        select "p"."sensitivity" from "projects" "p"
+        join "engagements" "e" on "e"."project_id" = "p"."id"
+        where "e"."id" = "ceremonies"."engagement_id"
+      ) <= ${accessLiteral}`;
     case 'Language':
-      // Effective sensitivity = lowest across engaging projects, falling back
-      // to the language's own column when unengaged (mono's coalesce).
-      // migration-todo (Engagement recut): restore the engaging-projects MIN —
-      // with no engagements possible, the fallback is the only live branch, so
-      // the own-column compare is exact.
-      return sql`"languages"."sensitivity" <= ${accessLiteral}`;
+      // Effective sensitivity: lowest across projects engaging the language,
+      // falling back to the language's own (user-set) sensitivity when
+      // unengaged — mirror of the Neo4j hydrate's rankSens ASC pick.
+      return sql`coalesce((
+        select min("p"."sensitivity") from "projects" "p"
+        join "engagements" "e" on "e"."project_id" = "p"."id"
+        where "e"."language_id" = "languages"."id"
+          and "e"."deleted_at" is null
+          and "p"."deleted_at" is null
+      ), "languages"."sensitivity") <= ${accessLiteral}`;
     // migration-todo: re-add a case per domain as it ports to Postgres
     // (Engagement/Ceremony/Language read sensitivity via
     // their parent project). Kept stripped so an unmigrated domain routed

--- a/src/components/authorization/policies/conditions/sensitivity.condition.ts
+++ b/src/components/authorization/policies/conditions/sensitivity.condition.ts
@@ -219,6 +219,13 @@ const sensitivityRefForResource = (
       // Effective sensitivity: lowest across projects engaging the language,
       // falling back to the language's own (user-set) sensitivity when
       // unengaged — mirror of the Neo4j hydrate's rankSens ASC pick.
+      // DELIBERATE divergence from Neo4j's DB-level filter: matchProjectSens
+      // hard-codes 'High' for the no-project case, so an unengaged Low
+      // language is invisible to a sens-gated read under Neo4j but visible
+      // here. The own-sensitivity fallback matches Gel + the hydrate (and
+      // Neo4j's own TODO); currently unreachable since no policy sens-gates
+      // Language object reads — if one ever does, this is the intended
+      // behavior, not a bug.
       return sql`coalesce((
         select min("p"."sensitivity") from "projects" "p"
         join "engagements" "e" on "e"."project_id" = "p"."id"

--- a/src/components/ceremony/ceremony.drizzle.repository.ts
+++ b/src/components/ceremony/ceremony.drizzle.repository.ts
@@ -1,0 +1,173 @@
+import { Injectable } from '@nestjs/common';
+import { and, eq, inArray, isNull, type SQL } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  CalendarDate,
+  generateId,
+  type ID,
+  ServerException,
+  type UnsecuredDto,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import {
+  DrizzleDtoRepository,
+  resolveOrderBy,
+  type SortMap,
+} from '~/core/drizzle';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { ceremonies } from '~/core/drizzle/schema';
+import { type ScopedRole } from '../authorization/dto/role.dto';
+import { requesterScopeByProject } from '../project/project-member/membership-scope';
+import {
+  Ceremony,
+  type CeremonyListInput,
+  type CreateCeremony,
+  type UpdateCeremony,
+} from './dto';
+
+type CeremonyRow = typeof ceremonies.$inferSelect & {
+  engagement?: {
+    id: ID<'Engagement'>;
+    project?: { id: ID<'Project'>; sensitivity: string } | null;
+  } | null;
+};
+
+@Injectable()
+export class CeremonyDrizzleRepository extends DrizzleDtoRepository<
+  typeof ceremonies,
+  Ceremony
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly identity: Identity,
+  ) {
+    super(db, ceremonies, Ceremony);
+  }
+
+  async create(
+    input: CreateCeremony,
+    engagementId?: ID<'Engagement'>,
+  ): Promise<{ id: ID }> {
+    if (!engagementId) {
+      // The Neo4j flow creates the node then connects it from the caller;
+      // under postgres the FK is NOT NULL so the caller must pass it.
+      throw new ServerException(
+        'Ceremony creation under postgres requires the engagement id',
+      );
+    }
+    const id = await generateId<ID<'Ceremony'>>();
+    await this.db.insert(ceremonies).values({
+      id,
+      engagementId,
+      type: input.type,
+      planned: input.planned ?? false,
+      estimatedDate: input.estimatedDate?.toSQLDate() ?? null,
+      actualDate: input.actualDate?.toSQLDate() ?? null,
+    });
+    return { id };
+  }
+
+  override async readMany(
+    ids: readonly ID[],
+  ): Promise<Array<UnsecuredDto<Ceremony>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.ceremonies.findMany({
+      where: (c) => and(inArray(c.id, [...ids]), isNull(c.deletedAt)),
+      with: {
+        engagement: {
+          columns: { id: true },
+          with: { project: { columns: { id: true, sensitivity: true } } },
+        },
+      },
+    });
+    const scopeByProject = await requesterScopeByProject(
+      this.db,
+      this.identity.current.userId,
+      rows.flatMap((r) => r.engagement?.project?.id ?? []),
+    );
+    return (rows as CeremonyRow[]).map((row) =>
+      this.toDto(
+        row,
+        row.engagement?.project
+          ? (scopeByProject.get(row.engagement.project.id) ?? [])
+          : [],
+      ),
+    );
+  }
+
+  async update(
+    changes: UpdateCeremony & { id: ID },
+  ): Promise<UnsecuredDto<Ceremony>> {
+    const { id, ...fields } = changes;
+    await this.updateColumns(id, {
+      planned: fields.planned,
+      ...(fields.estimatedDate !== undefined && {
+        estimatedDate: fields.estimatedDate?.toSQLDate() ?? null,
+      }),
+      ...(fields.actualDate !== undefined && {
+        actualDate: fields.actualDate?.toSQLDate() ?? null,
+      }),
+    });
+    return await this.readOne(id);
+  }
+
+  async delete(id: ID): Promise<void> {
+    await this.softDelete(id);
+  }
+
+  async list(input: CeremonyListInput) {
+    const conditions: SQL[] = [isNull(ceremonies.deletedAt)];
+    if (input.filter?.type) {
+      conditions.push(eq(ceremonies.type, input.filter.type));
+    }
+    const sortColumns = {
+      type: ceremonies.type,
+      planned: ceremonies.planned,
+      estimatedDate: ceremonies.estimatedDate,
+      actualDate: ceremonies.actualDate,
+      createdAt: ceremonies.createdAt,
+    } satisfies SortMap<keyof Ceremony>;
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: and(...conditions),
+      orderBy: resolveOrderBy(input, sortColumns, ceremonies.createdAt),
+      page: input.page,
+      count: input.count,
+    });
+    if (rows.length === 0) return { total, items: [], hasMore };
+    const items = await this.readMany(rows.map((r) => r.id));
+    const byId = new Map(items.map((i) => [i.id, i]));
+    return {
+      total,
+      items: rows.map((r) => byId.get(r.id)!).filter(Boolean),
+      hasMore,
+    };
+  }
+
+  protected toDto(
+    row: CeremonyRow,
+    scope: ScopedRole[] = [],
+  ): UnsecuredDto<Ceremony> {
+    if (!row.engagement?.project) {
+      throw new Error(
+        `Ceremony ${row.id} has no parent engagement/project row — FK invariant violated`,
+      );
+    }
+    const dto: unknown = {
+      id: row.id,
+      __typename: 'Ceremony',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      type: row.type,
+      planned: row.planned,
+      estimatedDate: row.estimatedDate
+        ? CalendarDate.fromISO(row.estimatedDate)
+        : null,
+      actualDate: row.actualDate ? CalendarDate.fromISO(row.actualDate) : null,
+      sensitivity: row.engagement.project.sensitivity,
+      engagement: { id: row.engagement.id },
+      parent: { id: row.engagement.id },
+      canDelete: true,
+      scope,
+    };
+    return dto as UnsecuredDto<Ceremony>;
+  }
+}

--- a/src/components/ceremony/ceremony.drizzle.repository.ts
+++ b/src/components/ceremony/ceremony.drizzle.repository.ts
@@ -11,12 +11,14 @@ import {
 import { Identity } from '~/core/authentication';
 import {
   DrizzleDtoRepository,
+  EMPTY_PAGE,
   resolveOrderBy,
   type SortMap,
 } from '~/core/drizzle';
 import { DrizzleService } from '~/core/drizzle/drizzle.service';
 import { ceremonies } from '~/core/drizzle/schema';
 import { type ScopedRole } from '../authorization/dto/role.dto';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import { requesterScopeByProject } from '../project/project-member/membership-scope';
 import {
   Ceremony,
@@ -39,6 +41,7 @@ export class CeremonyDrizzleRepository extends DrizzleDtoRepository<
 > {
   constructor(
     db: DrizzleService,
+    private readonly executor: PolicyExecutor,
     private readonly identity: Identity,
   ) {
     super(db, ceremonies, Ceremony);
@@ -117,6 +120,13 @@ export class CeremonyDrizzleRepository extends DrizzleDtoRepository<
 
   async list(input: CeremonyListInput) {
     const conditions: SQL[] = [isNull(ceremonies.deletedAt)];
+    // Mirror the Neo4j list()'s `filterToReadable` — without it, member/
+    // sensitivity-gated roles could list ceremonies of unreadable projects.
+    // (readMany stays unfiltered: the Neo4j readMany uses the base's opt-in
+    // no-op filterManyToReadable, so unfiltered there is parity.)
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
     if (input.filter?.type) {
       conditions.push(eq(ceremonies.type, input.filter.type));
     }

--- a/src/components/ceremony/ceremony.module.ts
+++ b/src/components/ceremony/ceremony.module.ts
@@ -6,6 +6,7 @@ import { CeremonyMutationActorResolver } from './ceremony-mutation-actor.resolve
 import { CeremonyMutationSubscriptionsResolver } from './ceremony-mutation-subscriptions.resolver';
 import { CeremonyUpdatedResolver } from './ceremony-updated.resolver';
 import { CeremonyChannels } from './ceremony.channels';
+import { CeremonyDrizzleRepository } from './ceremony.drizzle.repository';
 import { CeremonyGelRepository } from './ceremony.gel.repository';
 import { CeremonyLoader } from './ceremony.loader';
 import { CeremonyRepository } from './ceremony.repository';
@@ -25,6 +26,9 @@ import * as handlers from './handlers';
     CeremonyChannels,
     splitDb(CeremonyRepository, {
       gel: CeremonyGelRepository,
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: CeremonyDrizzleRepository as any,
     }),
     CeremonyLoader,
     ...Object.values(handlers),

--- a/src/components/ceremony/ceremony.repository.ts
+++ b/src/components/ceremony/ceremony.repository.ts
@@ -20,7 +20,7 @@ import {
 
 @Injectable()
 export class CeremonyRepository extends DtoRepository(Ceremony) {
-  async create(input: CreateCeremony) {
+  async create(input: CreateCeremony, _engagementId?: ID<'Engagement'>) {
     const initialProps = {
       type: input.type,
       planned: input.planned,
@@ -44,6 +44,10 @@ export class CeremonyRepository extends DtoRepository(Ceremony) {
     const { id, ...simpleChanges } = changes;
     await this.updateProperties({ id }, simpleChanges);
     return await this.readOne(id);
+  }
+
+  async delete(id: ID): Promise<void> {
+    await this.deleteNode(id);
   }
 
   protected hydrate() {

--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -25,8 +25,14 @@ export class CeremonyService {
     private readonly repo: CeremonyRepository,
   ) {}
 
-  async create(input: CreateCeremony): Promise<ID> {
-    const { id } = await this.repo.create(input);
+  async create(
+    input: CreateCeremony,
+    engagementId?: ID<'Engagement'>,
+  ): Promise<ID> {
+    // engagementId is only meaningful under postgres (NOT NULL FK); the
+    // Neo4j repo ignores it and the caller wires the relationship after.
+    // migration-todo: make it required at Phase 7 cutover.
+    const { id } = await this.repo.create(input, engagementId);
 
     this.channels.publishToAll('created', {
       ceremony: id,
@@ -81,13 +87,15 @@ export class CeremonyService {
     // Only called internally, not exposed directly to users
     // this.privileges.for( Ceremony, object).verifyCan('delete');
 
-    const { at } = await this.repo.deleteNode(object).catch((exception) => {
+    try {
+      await this.repo.delete(object.id);
+    } catch (exception) {
       throw new ServerException('Failed to delete Ceremony', exception);
-    });
+    }
 
     this.channels.publishToAll('deleted', {
       ceremony: id,
-      at,
+      at: DateTime.now(),
     });
   }
 }

--- a/src/components/ceremony/handlers/create-engagement-default-ceremony.handler.ts
+++ b/src/components/ceremony/handlers/create-engagement-default-ceremony.handler.ts
@@ -27,6 +27,19 @@ export class CreateEngagementDefaultCeremonyHandler {
     if (this.config.databaseEngine === 'gel') {
       return;
     }
+
+    // Under postgres the FK on ceremonies.engagement_id carries the
+    // relationship — no separate connect step. migration-todo: at Phase 7
+    // cutover drop the Neo4j branch below and keep only this path.
+    if (this.config.databaseEngine === 'postgres') {
+      const ceremonyId = await this.ceremonies.create(input, engagement.id);
+      event.engagement = {
+        ...engagement,
+        ceremony: { id: ceremonyId },
+      };
+      return;
+    }
+
     const ceremonyId = await this.ceremonies.create(input);
 
     // connect ceremonyId to engagement

--- a/src/components/engagement/engagement.drizzle.repository.ts
+++ b/src/components/engagement/engagement.drizzle.repository.ts
@@ -1,0 +1,803 @@
+import { Injectable } from '@nestjs/common';
+import { and, eq, inArray, isNull, sql, type SQL } from 'drizzle-orm';
+import { difference } from 'lodash';
+import { DateTime } from 'luxon';
+import {
+  CalendarDate,
+  DuplicateException,
+  generateId,
+  type ID,
+  InputException,
+  NotFoundException,
+  type ObjectView,
+  ServerException,
+  type UnsecuredDto,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import { getChanges } from '~/core/database/changes';
+import {
+  DrizzleDtoRepository,
+  EMPTY_PAGE,
+  resolveOrderBy,
+  type SortMap,
+} from '~/core/drizzle';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import {
+  engagements,
+  engagementStatusHistory,
+  languages,
+  projects,
+  users,
+} from '~/core/drizzle/schema';
+import { type ScopedRole } from '../authorization/dto/role.dto';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import { FileService } from '../file';
+import { requesterScopeByProject } from '../project/project-member/membership-scope';
+import { recomputeProjectSensitivity } from '../project/project.drizzle.repository';
+import {
+  type CreateInternshipEngagement,
+  type CreateLanguageEngagement,
+  type Engagement,
+  type EngagementListInput,
+  EngagementStatus,
+  IEngagement,
+  InternshipEngagement,
+  LanguageEngagement,
+  type UpdateInternshipEngagement,
+  type UpdateLanguageEngagement,
+} from './dto';
+
+type EngagementRow = typeof engagements.$inferSelect & {
+  project?: Pick<
+    typeof projects.$inferSelect,
+    | 'id'
+    | 'type'
+    | 'status'
+    | 'step'
+    | 'name'
+    | 'sensitivity'
+    | 'mouStart'
+    | 'mouEnd'
+  > | null;
+  language?: Pick<typeof languages.$inferSelect, 'id' | 'name'> | null;
+  intern?: Pick<
+    typeof users.$inferSelect,
+    'id' | 'displayFirstName' | 'displayLastName'
+  > | null;
+  mentor?: { id: ID<'User'> } | null;
+  countryOfOrigin?: { id: ID<'Location'> } | null;
+  ceremony?: { id: ID<'Ceremony'> } | null;
+};
+
+const RELATIONS = {
+  project: {
+    columns: {
+      id: true,
+      type: true,
+      status: true,
+      step: true,
+      name: true,
+      sensitivity: true,
+      mouStart: true,
+      mouEnd: true,
+    },
+  },
+  language: { columns: { id: true, name: true } },
+  intern: {
+    columns: { id: true, displayFirstName: true, displayLastName: true },
+  },
+  mentor: { columns: { id: true } },
+  countryOfOrigin: { columns: { id: true } },
+  ceremony: { columns: { id: true } },
+} as const;
+
+@Injectable()
+export class EngagementDrizzleRepository extends DrizzleDtoRepository<
+  typeof engagements,
+  Engagement & { id: ID }
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly executor: PolicyExecutor,
+    private readonly identity: Identity,
+    private readonly files: FileService,
+  ) {
+    super(db, engagements, IEngagement as any);
+  }
+
+  getActualLanguageChanges = getChanges(LanguageEngagement);
+  getActualInternshipChanges = getChanges(InternshipEngagement);
+
+  override async readOne(
+    id: ID,
+    _view?: ObjectView,
+  ): Promise<UnsecuredDto<Engagement>> {
+    const [dto] = await this.readMany([id]);
+    if (!dto) {
+      throw new NotFoundException('Could not find Engagement');
+    }
+    return dto;
+  }
+
+  override async readMany(
+    ids: readonly ID[],
+    _view?: ObjectView,
+  ): Promise<Array<UnsecuredDto<Engagement>>> {
+    // View accepted for splitDb signature parity; PCR/Changeset is excluded.
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.engagements.findMany({
+      where: (e) => and(inArray(e.id, [...ids]), isNull(e.deletedAt)),
+      with: RELATIONS,
+    });
+    return await this.mapRows(rows as EngagementRow[]);
+  }
+
+  async createLanguageEngagement(
+    input: CreateLanguageEngagement,
+    _changeset?: ID,
+  ): Promise<UnsecuredDto<LanguageEngagement>> {
+    await this.verifyRelationshipEligibility(
+      input.project,
+      input.language,
+      false,
+    );
+    if (input.firstScripture) {
+      await this.verifyFirstScripture({ languageId: input.language });
+    }
+
+    const id = await generateId<ID<'Engagement'>>();
+    const pnpId = await generateId();
+    await this.db.insert(engagements).values({
+      id,
+      projectId: input.project,
+      type: 'Language',
+      status: input.status ?? 'InDevelopment',
+      languageId: input.language,
+      firstScripture: input.firstScripture ?? null,
+      lukePartnership: input.lukePartnership ?? null,
+      openToInvestorVisit: input.openToInvestorVisit ?? null,
+      paratextRegistryId: input.paratextRegistryId ?? null,
+      rev79CommunityId: input.rev79CommunityId ?? null,
+      completeDate: input.completeDate?.toSQLDate() ?? null,
+      disbursementCompleteDate:
+        input.disbursementCompleteDate?.toSQLDate() ?? null,
+      startDateOverride: input.startDateOverride?.toSQLDate() ?? null,
+      endDateOverride: input.endDateOverride?.toSQLDate() ?? null,
+      milestonePlanned: input.milestonePlanned ?? 'Unknown',
+      usingAIAssistedTranslation: input.usingAIAssistedTranslation ?? 'Unknown',
+      pnpId,
+    });
+
+    await this.files.createDefinedFile(pnpId, `PNP`, id, 'pnp', input.pnp);
+
+    await recomputeProjectSensitivity(this.db, [input.project]);
+
+    return (await this.readOne(id)) as UnsecuredDto<LanguageEngagement>;
+  }
+
+  async createInternshipEngagement(
+    input: CreateInternshipEngagement,
+    _changeset?: ID,
+  ): Promise<UnsecuredDto<InternshipEngagement>> {
+    await this.verifyRelationshipEligibility(input.project, input.intern, true);
+
+    if (input.mentor && !(await this.userExists(input.mentor))) {
+      throw new NotFoundException('Could not find mentor', 'mentor');
+    }
+    if (
+      input.countryOfOrigin &&
+      !(await this.locationExists(input.countryOfOrigin))
+    ) {
+      throw new NotFoundException(
+        'Could not find country of origin',
+        'countryOfOrigin',
+      );
+    }
+
+    const id = await generateId<ID<'Engagement'>>();
+    const growthPlanId = await generateId();
+    await this.db.insert(engagements).values({
+      id,
+      projectId: input.project,
+      type: 'Internship',
+      status: input.status ?? 'InDevelopment',
+      internId: input.intern,
+      mentorId: input.mentor ?? null,
+      position: input.position ?? null,
+      methodologies: input.methodologies ? [...input.methodologies] : [],
+      countryOfOriginId: input.countryOfOrigin ?? null,
+      marketable: false,
+      completeDate: input.completeDate?.toSQLDate() ?? null,
+      disbursementCompleteDate:
+        input.disbursementCompleteDate?.toSQLDate() ?? null,
+      startDateOverride: input.startDateOverride?.toSQLDate() ?? null,
+      endDateOverride: input.endDateOverride?.toSQLDate() ?? null,
+      growthPlanId,
+    });
+
+    await this.files.createDefinedFile(
+      growthPlanId,
+      `Growth Plan`,
+      id,
+      'growthPlan',
+      input.growthPlan,
+    );
+
+    return (await this.readOne(id)) as UnsecuredDto<InternshipEngagement>;
+  }
+
+  async updateLanguage(
+    changes: UpdateLanguageEngagement,
+    _changeset?: ID,
+  ): Promise<UnsecuredDto<LanguageEngagement>> {
+    const { id, pnp, status, ...simple } = changes;
+
+    if (pnp) {
+      const engagement = (await this.readOne(
+        id,
+      )) as UnsecuredDto<LanguageEngagement>;
+      if (!engagement.pnp) {
+        throw new ServerException(
+          'Expected PnP file to be created with the engagement',
+        );
+      }
+      await this.files.createFileVersion({ ...pnp, parent: engagement.pnp.id });
+    }
+    if (changes.firstScripture) {
+      await this.verifyFirstScripture({ engagementId: id });
+    }
+
+    await this.updateColumns(id, {
+      firstScripture: simple.firstScripture,
+      lukePartnership: simple.lukePartnership,
+      openToInvestorVisit: simple.openToInvestorVisit,
+      paratextRegistryId: simple.paratextRegistryId,
+      rev79CommunityId: (simple as any).rev79CommunityId,
+      ...(simple.completeDate !== undefined && {
+        completeDate: simple.completeDate?.toSQLDate() ?? null,
+      }),
+      ...(simple.disbursementCompleteDate !== undefined && {
+        disbursementCompleteDate:
+          simple.disbursementCompleteDate?.toSQLDate() ?? null,
+      }),
+      ...(simple.startDateOverride !== undefined && {
+        startDateOverride: simple.startDateOverride?.toSQLDate() ?? null,
+      }),
+      ...(simple.endDateOverride !== undefined && {
+        endDateOverride: simple.endDateOverride?.toSQLDate() ?? null,
+      }),
+      ...((simple as any).initialEndDate !== undefined && {
+        initialEndDate:
+          (
+            (simple as any).initialEndDate as CalendarDate | null
+          )?.toSQLDate() ?? null,
+      }),
+      description: simple.description as any,
+      milestonePlanned: simple.milestonePlanned,
+      milestoneReached: (simple as any).milestoneReached,
+      usingAIAssistedTranslation: simple.usingAIAssistedTranslation,
+      sentPrintingDate: undefined,
+      ...((simple as any).modifiedAt !== undefined && {
+        modifiedAt: ((simple as any).modifiedAt as DateTime).toJSDate(),
+      }),
+    });
+
+    if (status) {
+      await this.applyStatusChange(
+        id,
+        status,
+        ((simple as any).modifiedAt as DateTime | undefined)?.toJSDate(),
+      );
+    }
+
+    return (await this.readOne(id)) as UnsecuredDto<LanguageEngagement>;
+  }
+
+  async updateInternship(
+    changes: UpdateInternshipEngagement,
+    _changeset?: ID,
+  ): Promise<UnsecuredDto<InternshipEngagement>> {
+    const { id, mentor, countryOfOrigin, growthPlan, status, ...simple } =
+      changes;
+
+    if (growthPlan) {
+      const engagement = (await this.readOne(
+        id,
+      )) as UnsecuredDto<InternshipEngagement>;
+      if (!engagement.growthPlan) {
+        throw new ServerException(
+          'Expected Growth Plan file to be created with the engagement',
+        );
+      }
+      await this.files.createFileVersion({
+        ...growthPlan,
+        parent: engagement.growthPlan.id,
+      });
+    }
+
+    await this.updateColumns(id, {
+      ...(mentor !== undefined && { mentorId: mentor }),
+      ...(countryOfOrigin !== undefined && {
+        countryOfOriginId: countryOfOrigin,
+      }),
+      position: simple.position,
+      ...(simple.methodologies !== undefined && {
+        methodologies: [...simple.methodologies],
+      }),
+      ...(simple.completeDate !== undefined && {
+        completeDate: simple.completeDate?.toSQLDate() ?? null,
+      }),
+      ...(simple.disbursementCompleteDate !== undefined && {
+        disbursementCompleteDate:
+          simple.disbursementCompleteDate?.toSQLDate() ?? null,
+      }),
+      ...(simple.startDateOverride !== undefined && {
+        startDateOverride: simple.startDateOverride?.toSQLDate() ?? null,
+      }),
+      ...(simple.endDateOverride !== undefined && {
+        endDateOverride: simple.endDateOverride?.toSQLDate() ?? null,
+      }),
+      ...((simple as any).initialEndDate !== undefined && {
+        initialEndDate:
+          (
+            (simple as any).initialEndDate as CalendarDate | null
+          )?.toSQLDate() ?? null,
+      }),
+      description: simple.description as any,
+      ...((simple as any).modifiedAt !== undefined && {
+        modifiedAt: ((simple as any).modifiedAt as DateTime).toJSDate(),
+      }),
+    });
+
+    if (status) {
+      await this.applyStatusChange(
+        id,
+        status,
+        ((simple as any).modifiedAt as DateTime | undefined)?.toJSDate(),
+      );
+    }
+
+    return (await this.readOne(id)) as UnsecuredDto<InternshipEngagement>;
+  }
+
+  /**
+   * Status change side-effects, mirror of the Gel rewrites: stamp
+   * statusModifiedAt, track suspension/reactivation timestamps, and append
+   * the previous status to history (drives the rules engine's "BackTo"
+   * transitions).
+   */
+  private async applyStatusChange(id: ID, next: EngagementStatus, at?: Date) {
+    const [current] = await this.db
+      .select({ status: engagements.status })
+      .from(engagements)
+      .where(eq(engagements.id, id as ID<'Engagement'>));
+    const prev = current?.status;
+    if (!prev || prev === next) return;
+
+    // Stamp with the update's modifiedAt when available so
+    // statusModifiedAt === modifiedAt (mirror of the Neo4j SetLastStatusDate
+    // handler, which copied updated.modifiedAt).
+    const now = at ?? new Date();
+    await this.db
+      .update(engagements)
+      .set({
+        status: next,
+        statusModifiedAt: now,
+        ...(next === 'Suspended' && { lastSuspendedAt: now }),
+        ...(prev === 'Suspended' && { lastReactivatedAt: now }),
+      })
+      .where(eq(engagements.id, id as ID<'Engagement'>));
+    await this.db.insert(engagementStatusHistory).values({
+      engagementId: id as ID<'Engagement'>,
+      status: prev,
+    });
+  }
+
+  async list(input: EngagementListInput, _changeset?: ID) {
+    const conditions: SQL[] = [isNull(engagements.deletedAt)];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+    conditions.push(...engagementFilterClauses(input.filter));
+
+    const sortColumns = {
+      status: engagements.status,
+      createdAt: engagements.createdAt,
+      modifiedAt: engagements.modifiedAt,
+      type: engagements.type,
+      // startDate/endDate coalesce with the project's mou window.
+      startDate: sql`coalesce(${engagements.startDateOverride}, (
+        select "p"."mou_start" from "projects" "p"
+        where "p"."id" = ${engagements.projectId}
+      ))`,
+      endDate: sql`coalesce(${engagements.endDateOverride}, (
+        select "p"."mou_end" from "projects" "p"
+        where "p"."id" = ${engagements.projectId}
+      ))`,
+      // migration-todo: nameProjectFirst/nameProjectLast, sensitivity,
+      // language.* / project.* delegated sorts, currentProgressReportDue.*.
+      // Unknown keys fall back to createdAt.
+    } as unknown as SortMap<keyof Engagement>;
+
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: and(...conditions),
+      orderBy: resolveOrderBy(input, sortColumns, engagements.createdAt),
+      page: input.page,
+      count: input.count,
+    });
+    if (rows.length === 0) return { total, items: [], hasMore };
+
+    const items = await this.readMany(rows.map((r) => r.id));
+    const byId = new Map(items.map((i) => [i.id, i]));
+    return {
+      total,
+      items: rows.map((r) => byId.get(r.id)!).filter(Boolean),
+      hasMore,
+    };
+  }
+
+  /** Assumed internal and unsecured. */
+  async listAllByProjectId(
+    projectId: ID,
+  ): Promise<Array<UnsecuredDto<Engagement>>> {
+    const rows = await this.db.query.engagements.findMany({
+      where: (e) =>
+        and(eq(e.projectId, projectId as ID<'Project'>), isNull(e.deletedAt)),
+      with: RELATIONS,
+    });
+    return await this.mapRows(rows as EngagementRow[]);
+  }
+
+  async getOngoingEngagementIds(
+    projectId: ID,
+    excludes: EngagementStatus[] = [],
+  ): Promise<readonly ID[]> {
+    const statuses = difference([...EngagementStatus.Ongoing], excludes);
+    if (statuses.length === 0) return [];
+    const rows = await this.db
+      .select({ id: engagements.id })
+      .from(engagements)
+      .where(
+        and(
+          eq(engagements.projectId, projectId as ID<'Project'>),
+          inArray(engagements.status, statuses),
+          isNull(engagements.deletedAt),
+        ),
+      );
+    return rows.map((r) => r.id);
+  }
+
+  protected async verifyRelationshipEligibility(
+    projectId: ID,
+    otherId: ID,
+    isInternship: boolean,
+    _changeset?: ID,
+  ) {
+    const property = isInternship ? 'intern' : 'language';
+    const label = isInternship ? 'person' : 'language';
+
+    const [project] = await this.db
+      .select({ id: projects.id, type: projects.type })
+      .from(projects)
+      .where(
+        and(
+          eq(projects.id, projectId as ID<'Project'>),
+          isNull(projects.deletedAt),
+        ),
+      );
+    if (!project) {
+      throw new NotFoundException('Could not find project', 'project');
+    }
+
+    const isActuallyInternship = project.type === 'Internship';
+    if (isActuallyInternship !== isInternship) {
+      throw new InputException(
+        `Only ${
+          isInternship ? 'Internship' : 'Language'
+        } Engagements can be created on ${
+          isInternship ? 'Internship' : 'Translation'
+        } Projects`,
+        property,
+      );
+    }
+
+    const other = isInternship
+      ? await this.userExists(otherId)
+      : await this.languageExists(otherId);
+    if (!other) {
+      throw new NotFoundException(`Could not find ${label}`, property);
+    }
+
+    const otherColumn = isInternship
+      ? engagements.internId
+      : engagements.languageId;
+    const [duplicate] = await this.db
+      .select({ id: engagements.id })
+      .from(engagements)
+      .where(
+        and(
+          eq(engagements.projectId, projectId as ID<'Project'>),
+          eq(otherColumn, otherId),
+          isNull(engagements.deletedAt),
+        ),
+      )
+      .limit(1);
+    if (duplicate) {
+      throw new DuplicateException(
+        property,
+        `Engagement for this project and ${label} already exists`,
+      );
+    }
+  }
+
+  private async userExists(id: ID) {
+    const [row] = await this.db
+      .select({ id: users.id })
+      .from(users)
+      .where(and(eq(users.id, id as ID<'User'>), isNull(users.deletedAt)))
+      .limit(1);
+    return !!row;
+  }
+
+  private async languageExists(id: ID) {
+    const [row] = await this.db
+      .select({ id: languages.id })
+      .from(languages)
+      .where(
+        and(
+          eq(languages.id, id as ID<'Language'>),
+          isNull(languages.deletedAt),
+        ),
+      )
+      .limit(1);
+    return !!row;
+  }
+
+  private async locationExists(id: ID) {
+    const [row] = await this.db.query.locations
+      .findFirst({
+        where: (l, { eq: eq2, and: and2, isNull: isNull2 }) =>
+          and2(eq2(l.id, id as ID<'Location'>), isNull2(l.deletedAt)),
+        columns: { id: true },
+      })
+      .then((r) => [r]);
+    return !!row;
+  }
+
+  private async doesLanguageHaveExternalFirstScripture(languageId: ID) {
+    const [row] = await this.db
+      .select({ id: languages.id })
+      .from(languages)
+      .where(
+        and(
+          eq(languages.id, languageId as ID<'Language'>),
+          eq(languages.hasExternalFirstScripture, true),
+          isNull(languages.deletedAt),
+        ),
+      )
+      .limit(1);
+    return !!row;
+  }
+
+  private async doOtherEngagementsHaveFirstScripture(languageId: ID) {
+    const [row] = await this.db
+      .select({ id: engagements.id })
+      .from(engagements)
+      .where(
+        and(
+          eq(engagements.languageId, languageId as ID<'Language'>),
+          eq(engagements.firstScripture, true),
+          isNull(engagements.deletedAt),
+        ),
+      )
+      .limit(1);
+    return !!row;
+  }
+
+  private async resolveLanguageId({
+    engagementId,
+    languageId,
+  }: {
+    engagementId?: ID;
+    languageId?: ID;
+  }): Promise<ID> {
+    if (languageId) return languageId;
+    const [row] = await this.db
+      .select({ languageId: engagements.languageId })
+      .from(engagements)
+      .where(eq(engagements.id, engagementId! as ID<'Engagement'>));
+    if (!row?.languageId) {
+      throw new NotFoundException('Could not find engagement language');
+    }
+    return row.languageId;
+  }
+
+  private async verifyFirstScripture(id: {
+    engagementId?: ID;
+    languageId?: ID;
+  }) {
+    const languageId = await this.resolveLanguageId(id);
+    if (await this.doesLanguageHaveExternalFirstScripture(languageId)) {
+      throw new InputException(
+        'First scripture has already been marked as having been done externally',
+        'firstScripture',
+      );
+    }
+    if (await this.doOtherEngagementsHaveFirstScripture(languageId)) {
+      throw new InputException(
+        'Another engagement has already been marked as having done the first scripture',
+        'firstScripture',
+      );
+    }
+  }
+
+  async delete(id: ID, _changeset?: ID): Promise<void> {
+    const [row] = await this.db
+      .select({ projectId: engagements.projectId, type: engagements.type })
+      .from(engagements)
+      .where(eq(engagements.id, id as ID<'Engagement'>));
+    await this.softDelete(id);
+    if (row?.type === 'Language') {
+      await recomputeProjectSensitivity(this.db, [row.projectId]);
+    }
+  }
+
+  private async mapRows(rows: EngagementRow[]) {
+    const scopeByProject = await requesterScopeByProject(
+      this.db,
+      this.identity.current.userId,
+      rows.flatMap((r) => r.project?.id ?? []),
+    );
+    return rows.map((row) =>
+      this.toDto(
+        row,
+        row.project ? (scopeByProject.get(row.project.id) ?? []) : [],
+      ),
+    );
+  }
+
+  protected toDto(
+    row: EngagementRow,
+    scope: ScopedRole[] = [],
+  ): UnsecuredDto<Engagement> {
+    if (!row.project) {
+      throw new Error(
+        `Engagement ${row.id} has no parent project row — FK invariant violated`,
+      );
+    }
+    const isLanguage = row.type === 'Language';
+    const startDate = row.startDateOverride ?? row.project.mouStart ?? null;
+    const endDate = row.endDateOverride ?? row.project.mouEnd ?? null;
+    const dto: unknown = {
+      id: row.id,
+      // The `default::` prefix matches the Neo4j/Gel hydrates —
+      // resolveEngagementType keys off the prefixed form.
+      __typename: isLanguage
+        ? 'default::LanguageEngagement'
+        : 'default::InternshipEngagement',
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      modifiedAt: DateTime.fromJSDate(row.modifiedAt),
+      parent: { id: row.project.id },
+      project: {
+        id: row.project.id,
+        type: row.project.type,
+        status: row.project.status,
+        step: row.project.step,
+      },
+      label: {
+        project: row.project.name,
+        language: row.language?.name ?? null,
+        intern: row.intern
+          ? [row.intern.displayFirstName, row.intern.displayLastName]
+              .filter(Boolean)
+              .join(' ') || null
+          : null,
+      },
+      status: row.status,
+      statusModifiedAt: row.statusModifiedAt
+        ? DateTime.fromJSDate(row.statusModifiedAt)
+        : null,
+      lastSuspendedAt: row.lastSuspendedAt
+        ? DateTime.fromJSDate(row.lastSuspendedAt)
+        : null,
+      lastReactivatedAt: row.lastReactivatedAt
+        ? DateTime.fromJSDate(row.lastReactivatedAt)
+        : null,
+      completeDate: row.completeDate
+        ? CalendarDate.fromISO(row.completeDate)
+        : null,
+      disbursementCompleteDate: row.disbursementCompleteDate
+        ? CalendarDate.fromISO(row.disbursementCompleteDate)
+        : null,
+      startDateOverride: row.startDateOverride
+        ? CalendarDate.fromISO(row.startDateOverride)
+        : null,
+      endDateOverride: row.endDateOverride
+        ? CalendarDate.fromISO(row.endDateOverride)
+        : null,
+      startDate: startDate ? CalendarDate.fromISO(startDate) : null,
+      endDate: endDate ? CalendarDate.fromISO(endDate) : null,
+      initialEndDate: row.initialEndDate
+        ? CalendarDate.fromISO(row.initialEndDate)
+        : null,
+      description: row.description ?? null,
+      sensitivity: row.project.sensitivity,
+      ceremony: row.ceremony ? { id: row.ceremony.id } : null,
+      changeset: undefined,
+      canDelete: true,
+      scope,
+      ...(isLanguage
+        ? {
+            language: { id: row.languageId },
+            firstScripture: row.firstScripture,
+            lukePartnership: row.lukePartnership,
+            openToInvestorVisit: row.openToInvestorVisit,
+            paratextRegistryId: row.paratextRegistryId,
+            rev79CommunityId: row.rev79CommunityId,
+            pnp: row.pnpId ? { id: row.pnpId } : null,
+            sentPrintingDate: row.sentPrintingDate
+              ? CalendarDate.fromISO(row.sentPrintingDate)
+              : null,
+            historicGoal: row.historicGoal,
+            milestonePlanned: row.milestonePlanned,
+            milestoneReached: row.milestoneReached,
+            usingAIAssistedTranslation: row.usingAIAssistedTranslation,
+          }
+        : {
+            intern: { id: row.internId },
+            mentor: row.mentorId ? { id: row.mentorId } : null,
+            position: row.position,
+            methodologies: [...row.methodologies],
+            countryOfOrigin: row.countryOfOriginId
+              ? { id: row.countryOfOriginId }
+              : null,
+            growthPlan: row.growthPlanId ? { id: row.growthPlanId } : null,
+            marketable: row.marketable,
+            webId: row.webId,
+          }),
+    };
+    return dto as UnsecuredDto<Engagement>;
+  }
+}
+
+/**
+ * Column-level WHERE clauses for `EngagementFilters`. Implemented: type,
+ * status, project id, languageId, partnerId. migration-todo: name /
+ * engagedName full-text, startDate/endDate ranges, project/language/intern
+ * sub-filters, milestone/AI filters, tool sub-filter (ToolUsage not
+ * migrated), marketable.
+ */
+export const engagementFilterClauses = (
+  filter: EngagementListInput['filter'],
+): SQL[] => {
+  const conditions: SQL[] = [];
+  if (!filter) return conditions;
+  if (filter.type) {
+    conditions.push(
+      eq(
+        engagements.type,
+        filter.type === 'language' ? 'Language' : 'Internship',
+      ),
+    );
+  }
+  if (filter.status?.length) {
+    conditions.push(inArray(engagements.status, [...filter.status]));
+  }
+  if (filter.project?.id) {
+    conditions.push(eq(engagements.projectId, filter.project.id));
+  }
+  if (filter.languageId) {
+    conditions.push(eq(engagements.languageId, filter.languageId));
+  }
+  if (filter.partnerId) {
+    conditions.push(
+      sql`exists (
+        select 1 from "partnerships" "ps"
+        where "ps"."project_id" = ${engagements.projectId}
+          and "ps"."partner_id" = ${filter.partnerId}
+          and "ps"."deleted_at" is null
+      )`,
+    );
+  }
+  return conditions;
+};

--- a/src/components/engagement/engagement.drizzle.repository.ts
+++ b/src/components/engagement/engagement.drizzle.repository.ts
@@ -9,6 +9,7 @@ import {
   type ID,
   InputException,
   NotFoundException,
+  NotImplementedException,
   type ObjectView,
   ServerException,
   type UnsecuredDto,
@@ -102,6 +103,9 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
     private readonly identity: Identity,
     private readonly files: FileService,
   ) {
+    // migration-todo: as-any bridges the IEngagement interface class into the
+    // concrete-resource slot DrizzleDtoRepository expects (same bridge as
+    // project.module's splitDb cast) — dies with the base-class rework at cutover.
     super(db, engagements, IEngagement as any);
   }
 
@@ -163,6 +167,7 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
         input.disbursementCompleteDate?.toSQLDate() ?? null,
       startDateOverride: input.startDateOverride?.toSQLDate() ?? null,
       endDateOverride: input.endDateOverride?.toSQLDate() ?? null,
+      historicGoal: input.historicGoal ?? null,
       milestonePlanned: input.milestonePlanned ?? 'Unknown',
       usingAIAssistedTranslation: input.usingAIAssistedTranslation ?? 'Unknown',
       pnpId,
@@ -206,7 +211,8 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
       position: input.position ?? null,
       methodologies: input.methodologies ? [...input.methodologies] : [],
       countryOfOriginId: input.countryOfOrigin ?? null,
-      marketable: false,
+      marketable: input.marketable ?? false,
+      webId: input.webId ?? null,
       completeDate: input.completeDate?.toSQLDate() ?? null,
       disbursementCompleteDate:
         input.disbursementCompleteDate?.toSQLDate() ?? null,
@@ -247,6 +253,10 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
       await this.verifyFirstScripture({ engagementId: id });
     }
 
+    // migration-todo: the `(simple as any)` reads bridge fields the service's
+    // getActualChanges diff carries beyond the Update DTO's declared type
+    // (rev79CommunityId / initialEndDate / milestoneReached / modifiedAt) —
+    // type the changes shape properly when the Neo4j repo retires.
     await this.updateColumns(id, {
       firstScripture: simple.firstScripture,
       lukePartnership: simple.lukePartnership,
@@ -273,6 +283,7 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
           )?.toSQLDate() ?? null,
       }),
       description: simple.description as any,
+      historicGoal: simple.historicGoal,
       milestonePlanned: simple.milestonePlanned,
       milestoneReached: (simple as any).milestoneReached,
       usingAIAssistedTranslation: simple.usingAIAssistedTranslation,
@@ -315,12 +326,15 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
       });
     }
 
+    // migration-todo: same `(simple as any)` bridge as updateLanguage above.
     await this.updateColumns(id, {
       ...(mentor !== undefined && { mentorId: mentor }),
       ...(countryOfOrigin !== undefined && {
         countryOfOriginId: countryOfOrigin,
       }),
       position: simple.position,
+      marketable: simple.marketable,
+      webId: simple.webId,
       ...(simple.methodologies !== undefined && {
         methodologies: [...simple.methodologies],
       }),
@@ -384,7 +398,10 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
         status: next,
         statusModifiedAt: now,
         ...(next === 'Suspended' && { lastSuspendedAt: now }),
-        ...(prev === 'Suspended' && { lastReactivatedAt: now }),
+        // Only a true reactivation (Suspended → Active) — Suspended →
+        // Terminated etc. must NOT stamp it (mirrors SetLastStatusDate).
+        ...(prev === 'Suspended' &&
+          next === 'Active' && { lastReactivatedAt: now }),
       })
       .where(eq(engagements.id, id as ID<'Engagement'>));
     await this.db.insert(engagementStatusHistory).values({
@@ -762,10 +779,14 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
 
 /**
  * Column-level WHERE clauses for `EngagementFilters`. Implemented: type,
- * status, project id, languageId, partnerId. migration-todo: name /
- * engagedName full-text, startDate/endDate ranges, project/language/intern
- * sub-filters, milestone/AI filters, tool sub-filter (ToolUsage not
- * migrated), marketable.
+ * status, project id, languageId, partnerId, marketable, milestoneReached,
+ * milestonePlanned, usingAIAssistedTranslation. The rest THROW rather than
+ * silently ignore (the discoverability convention — a silently-dropped filter
+ * returns the full unfiltered set and nothing catches it).
+ * migration-todo: implement the throwing ones as their domains land —
+ * name/engagedName (language/user name joins), startDate/endDate ranges
+ * (COALESCE with the project mou window), project/language/intern sub-filter
+ * composition, tool sub-filter (ToolUsage not migrated).
  */
 export const engagementFilterClauses = (
   filter: EngagementListInput['filter'],
@@ -783,8 +804,16 @@ export const engagementFilterClauses = (
   if (filter.status?.length) {
     conditions.push(inArray(engagements.status, [...filter.status]));
   }
-  if (filter.project?.id) {
-    conditions.push(eq(engagements.projectId, filter.project.id));
+  if (filter.project) {
+    const { id: projectId, ...projectRest } = filter.project;
+    if (projectId) {
+      conditions.push(eq(engagements.projectId, projectId));
+    }
+    if (Object.values(projectRest).some((value) => value !== undefined)) {
+      throw new NotImplementedException(
+        'EngagementFilters.project sub-filters beyond `id` are not implemented for postgres yet',
+      );
+    }
   }
   if (filter.languageId) {
     conditions.push(eq(engagements.languageId, filter.languageId));
@@ -798,6 +827,40 @@ export const engagementFilterClauses = (
           and "ps"."deleted_at" is null
       )`,
     );
+  }
+  if (filter.marketable !== undefined) {
+    conditions.push(eq(engagements.marketable, filter.marketable));
+  }
+  if (filter.milestoneReached !== undefined) {
+    conditions.push(eq(engagements.milestoneReached, filter.milestoneReached));
+  }
+  if (filter.milestonePlanned?.length) {
+    conditions.push(
+      inArray(engagements.milestonePlanned, [...filter.milestonePlanned]),
+    );
+  }
+  if (filter.usingAIAssistedTranslation?.length) {
+    conditions.push(
+      inArray(engagements.usingAIAssistedTranslation, [
+        ...filter.usingAIAssistedTranslation,
+      ]),
+    );
+  }
+  const unimplemented = {
+    name: filter.name,
+    engagedName: filter.engagedName,
+    startDate: filter.startDate,
+    endDate: filter.endDate,
+    language: filter.language,
+    intern: filter.intern,
+    tool: filter.tool,
+  };
+  for (const [key, value] of Object.entries(unimplemented)) {
+    if (value !== undefined) {
+      throw new NotImplementedException(
+        `EngagementFilters.${key} is not implemented for postgres yet`,
+      );
+    }
   }
   return conditions;
 };

--- a/src/components/engagement/engagement.drizzle.repository.ts
+++ b/src/components/engagement/engagement.drizzle.repository.ts
@@ -5,6 +5,7 @@ import { DateTime } from 'luxon';
 import {
   CalendarDate,
   DuplicateException,
+  EnhancedResource,
   generateId,
   type ID,
   InputException,
@@ -34,6 +35,7 @@ import {
 import { type ScopedRole } from '../authorization/dto/role.dto';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import { FileService } from '../file';
+import { IProject } from '../project/dto';
 import { requesterScopeByProject } from '../project/project-member/membership-scope';
 import { recomputeProjectSensitivity } from '../project/project.drizzle.repository';
 import {
@@ -144,8 +146,37 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
   ): Promise<Array<UnsecuredDto<Engagement>>> {
     // View accepted for splitDb signature parity; PCR/Changeset is excluded.
     if (ids.length === 0) return [];
+    // Mirror the Neo4j readMany, which gates by-id reads on the PARENT
+    // PROJECT's readability (privileges.for(IProject).filterToReadable) —
+    // while list() gates by IEngagement, matching the same asymmetry in the
+    // Neo4j repo. The Project condition SQL references the literal
+    // "projects" table, so it runs inside an EXISTS over the unaliased
+    // table correlated on project_id; survivors hydrate normally.
+    const projectConditions: SQL[] = [isNull(projects.deletedAt)];
+    if (
+      !this.executor.applyReadFilter(
+        EnhancedResource.of(IProject),
+        projectConditions,
+      )
+    ) {
+      return [];
+    }
+    const readable = await this.db
+      .select({ id: engagements.id })
+      .from(engagements)
+      .where(
+        and(
+          inArray(engagements.id, [...ids]),
+          isNull(engagements.deletedAt),
+          sql`exists (select 1 from "projects" where "projects"."id" = ${
+            engagements.projectId
+          } and ${and(...projectConditions)})`,
+        ),
+      );
+    if (readable.length === 0) return [];
+    const readableIds = readable.map((row) => row.id);
     const rows = await this.db.query.engagements.findMany({
-      where: (e) => and(inArray(e.id, [...ids]), isNull(e.deletedAt)),
+      where: (e) => inArray(e.id, readableIds),
       with: RELATIONS,
     });
     return await this.mapRows(rows as EngagementRow[]);

--- a/src/components/engagement/engagement.drizzle.repository.ts
+++ b/src/components/engagement/engagement.drizzle.repository.ts
@@ -17,6 +17,7 @@ import {
 import { Identity } from '~/core/authentication';
 import { getChanges } from '~/core/database/changes';
 import {
+  catchUniqueViolation,
   DrizzleDtoRepository,
   EMPTY_PAGE,
   resolveOrderBy,
@@ -47,6 +48,20 @@ import {
   type UpdateInternshipEngagement,
   type UpdateLanguageEngagement,
 } from './dto';
+
+// Backstops for the partial unique indexes when a concurrent create slips
+// past verifyRelationshipEligibility's pre-flight — same field + message so
+// both paths surface the identical DuplicateException.
+const catchDuplicateLanguageEngagement = catchUniqueViolation(
+  'engagements_project_language_active_unique',
+  'language',
+  'Engagement for this project and language already exists',
+);
+const catchDuplicateInternEngagement = catchUniqueViolation(
+  'engagements_project_intern_active_unique',
+  'intern',
+  'Engagement for this project and person already exists',
+);
 
 type EngagementRow = typeof engagements.$inferSelect & {
   project?: Pick<
@@ -151,27 +166,31 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
 
     const id = await generateId<ID<'Engagement'>>();
     const pnpId = await generateId();
-    await this.db.insert(engagements).values({
-      id,
-      projectId: input.project,
-      type: 'Language',
-      status: input.status ?? 'InDevelopment',
-      languageId: input.language,
-      firstScripture: input.firstScripture ?? null,
-      lukePartnership: input.lukePartnership ?? null,
-      openToInvestorVisit: input.openToInvestorVisit ?? null,
-      paratextRegistryId: input.paratextRegistryId ?? null,
-      rev79CommunityId: input.rev79CommunityId ?? null,
-      completeDate: input.completeDate?.toSQLDate() ?? null,
-      disbursementCompleteDate:
-        input.disbursementCompleteDate?.toSQLDate() ?? null,
-      startDateOverride: input.startDateOverride?.toSQLDate() ?? null,
-      endDateOverride: input.endDateOverride?.toSQLDate() ?? null,
-      historicGoal: input.historicGoal ?? null,
-      milestonePlanned: input.milestonePlanned ?? 'Unknown',
-      usingAIAssistedTranslation: input.usingAIAssistedTranslation ?? 'Unknown',
-      pnpId,
-    });
+    await this.db
+      .insert(engagements)
+      .values({
+        id,
+        projectId: input.project,
+        type: 'Language',
+        status: input.status ?? 'InDevelopment',
+        languageId: input.language,
+        firstScripture: input.firstScripture ?? null,
+        lukePartnership: input.lukePartnership ?? null,
+        openToInvestorVisit: input.openToInvestorVisit ?? null,
+        paratextRegistryId: input.paratextRegistryId ?? null,
+        rev79CommunityId: input.rev79CommunityId ?? null,
+        completeDate: input.completeDate?.toSQLDate() ?? null,
+        disbursementCompleteDate:
+          input.disbursementCompleteDate?.toSQLDate() ?? null,
+        startDateOverride: input.startDateOverride?.toSQLDate() ?? null,
+        endDateOverride: input.endDateOverride?.toSQLDate() ?? null,
+        historicGoal: input.historicGoal ?? null,
+        milestonePlanned: input.milestonePlanned ?? 'Unknown',
+        usingAIAssistedTranslation:
+          input.usingAIAssistedTranslation ?? 'Unknown',
+        pnpId,
+      })
+      .catch(catchDuplicateLanguageEngagement);
 
     await this.files.createDefinedFile(pnpId, `PNP`, id, 'pnp', input.pnp);
 
@@ -201,25 +220,28 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
 
     const id = await generateId<ID<'Engagement'>>();
     const growthPlanId = await generateId();
-    await this.db.insert(engagements).values({
-      id,
-      projectId: input.project,
-      type: 'Internship',
-      status: input.status ?? 'InDevelopment',
-      internId: input.intern,
-      mentorId: input.mentor ?? null,
-      position: input.position ?? null,
-      methodologies: input.methodologies ? [...input.methodologies] : [],
-      countryOfOriginId: input.countryOfOrigin ?? null,
-      marketable: input.marketable ?? false,
-      webId: input.webId ?? null,
-      completeDate: input.completeDate?.toSQLDate() ?? null,
-      disbursementCompleteDate:
-        input.disbursementCompleteDate?.toSQLDate() ?? null,
-      startDateOverride: input.startDateOverride?.toSQLDate() ?? null,
-      endDateOverride: input.endDateOverride?.toSQLDate() ?? null,
-      growthPlanId,
-    });
+    await this.db
+      .insert(engagements)
+      .values({
+        id,
+        projectId: input.project,
+        type: 'Internship',
+        status: input.status ?? 'InDevelopment',
+        internId: input.intern,
+        mentorId: input.mentor ?? null,
+        position: input.position ?? null,
+        methodologies: input.methodologies ? [...input.methodologies] : [],
+        countryOfOriginId: input.countryOfOrigin ?? null,
+        marketable: input.marketable ?? false,
+        webId: input.webId ?? null,
+        completeDate: input.completeDate?.toSQLDate() ?? null,
+        disbursementCompleteDate:
+          input.disbursementCompleteDate?.toSQLDate() ?? null,
+        startDateOverride: input.startDateOverride?.toSQLDate() ?? null,
+        endDateOverride: input.endDateOverride?.toSQLDate() ?? null,
+        growthPlanId,
+      })
+      .catch(catchDuplicateInternEngagement);
 
     await this.files.createDefinedFile(
       growthPlanId,
@@ -381,10 +403,14 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
    * transitions).
    */
   private async applyStatusChange(id: ID, next: EngagementStatus, at?: Date) {
+    // Row lock so concurrent status changes serialize: each transition reads
+    // the true previous status before writing its history row (the mutation
+    // interceptor already has us inside a transaction).
     const [current] = await this.db
       .select({ status: engagements.status })
       .from(engagements)
-      .where(eq(engagements.id, id as ID<'Engagement'>));
+      .where(eq(engagements.id, id as ID<'Engagement'>))
+      .for('update');
     const prev = current?.status;
     if (!prev || prev === next) return;
 

--- a/src/components/engagement/engagement.module.ts
+++ b/src/components/engagement/engagement.module.ts
@@ -16,6 +16,7 @@ import {
 } from './engagement-update-links.resolver';
 import { EngagementUpdatedResolver } from './engagement-updated.resolver';
 import { EngagementChannels } from './engagement.channels';
+import { EngagementDrizzleRepository } from './engagement.drizzle.repository';
 import { EngagementGelRepository } from './engagement.gel.repository';
 import { EngagementLoader } from './engagement.loader';
 import { EngagementRepository } from './engagement.repository';
@@ -59,6 +60,9 @@ import { EngagementProductConnectionResolver } from './product-connection.resolv
     EngagementChannels,
     splitDb(EngagementRepository, {
       gel: EngagementGelRepository,
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: EngagementDrizzleRepository as any,
     }),
     EngagementLoader,
     ...Object.values(handlers),

--- a/src/components/engagement/engagement.repository.ts
+++ b/src/components/engagement/engagement.repository.ts
@@ -490,6 +490,10 @@ export class EngagementRepository extends CommonRepository {
     return (await this.readOne(id)) as UnsecuredDto<InternshipEngagement>;
   }
 
+  async delete(id: ID, changeset?: ID): Promise<void> {
+    await this.deleteNode(id, { changeset });
+  }
+
   async list(input: EngagementListInput, changeset?: ID) {
     const result = await this.db
       .query()

--- a/src/components/engagement/engagement.rules.ts
+++ b/src/components/engagement/engagement.rules.ts
@@ -398,7 +398,10 @@ export class EngagementRules {
 
   private async getCurrentStatus(id: ID, changeset?: ID) {
     // migration-todo: collapse this engine-check at Phase 7 cutover — keep
-    // only the postgres branch.
+    // only the postgres branch. The postgres branch intentionally ignores
+    // `changeset`: PCR/Changeset is excluded from the migration, so no
+    // changeset can exist under postgres and the committed row is always
+    // the right answer. Revisit if changesets are ever ported to PG.
     if (this.config.databaseEngine === 'postgres') {
       const [row] = await this.drizzle.client
         .select({ status: engagements.status })
@@ -449,7 +452,9 @@ export class EngagementRules {
   }
 
   private async getCurrentProjectStep(engagementId: ID, changeset?: ID) {
-    // migration-todo: collapse this engine-check at Phase 7 cutover.
+    // migration-todo: collapse this engine-check at Phase 7 cutover. Like
+    // getCurrentStatus, the postgres branch ignores `changeset` — none can
+    // exist under postgres (PCR excluded from the migration).
     if (this.config.databaseEngine === 'postgres') {
       const [row] = await this.drizzle.client
         .select({ step: projects.step })

--- a/src/components/engagement/engagement.rules.ts
+++ b/src/components/engagement/engagement.rules.ts
@@ -2,6 +2,7 @@
 import { Injectable } from '@nestjs/common';
 import { type NonEmptyArray, setOf } from '@seedcompany/common';
 import { node, relation } from 'cypher-query-builder';
+import { desc, eq } from 'drizzle-orm';
 import { first, intersection } from 'lodash';
 import {
   type ID,
@@ -10,6 +11,13 @@ import {
   UnauthorizedException,
 } from '~/common';
 import { Identity } from '~/core/authentication';
+import { ConfigService } from '~/core/config';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import {
+  engagements,
+  engagementStatusHistory,
+  projects,
+} from '~/core/drizzle/schema';
 import { ILogger, Logger } from '~/core/logger';
 import { DatabaseService } from '~/core/neo4j';
 import { ACTIVE, INACTIVE } from '~/core/neo4j/query';
@@ -35,6 +43,8 @@ const rolesThatCanBypassWorkflow = setOf<Role>([Role.Administrator]);
 export class EngagementRules {
   constructor(
     private readonly db: DatabaseService,
+    private readonly drizzle: DrizzleService,
+    private readonly config: ConfigService,
     private readonly identity: Identity,
     // eslint-disable-next-line @seedcompany/no-unused-vars
     @Logger('engagement:rules') private readonly logger: ILogger,
@@ -387,6 +397,19 @@ export class EngagementRules {
   }
 
   private async getCurrentStatus(id: ID, changeset?: ID) {
+    // migration-todo: collapse this engine-check at Phase 7 cutover — keep
+    // only the postgres branch.
+    if (this.config.databaseEngine === 'postgres') {
+      const [row] = await this.drizzle.client
+        .select({ status: engagements.status })
+        .from(engagements)
+        .where(eq(engagements.id, id as ID<'Engagement'>));
+      if (!row) {
+        throw new ServerException('current status not found');
+      }
+      return row.status;
+    }
+
     let currentStatus;
 
     if (changeset) {
@@ -426,6 +449,19 @@ export class EngagementRules {
   }
 
   private async getCurrentProjectStep(engagementId: ID, changeset?: ID) {
+    // migration-todo: collapse this engine-check at Phase 7 cutover.
+    if (this.config.databaseEngine === 'postgres') {
+      const [row] = await this.drizzle.client
+        .select({ step: projects.step })
+        .from(projects)
+        .innerJoin(engagements, eq(engagements.projectId, projects.id))
+        .where(eq(engagements.id, engagementId as ID<'Engagement'>));
+      if (!row) {
+        throw new ServerException(`Could not find project's step`);
+      }
+      return row.step;
+    }
+
     const result = await this.db
       .query()
       .match([
@@ -490,6 +526,18 @@ export class EngagementRules {
 
   /** A list of the engagement's previous status ordered most recent to furthest in the past */
   private async getPreviousStatus(id: ID) {
+    // migration-todo: collapse this engine-check at Phase 7 cutover.
+    if (this.config.databaseEngine === 'postgres') {
+      const rows = await this.drizzle.client
+        .select({ status: engagementStatusHistory.status })
+        .from(engagementStatusHistory)
+        .where(eq(engagementStatusHistory.engagementId, id as ID<'Engagement'>))
+        .orderBy(desc(engagementStatusHistory.at));
+      return rows.map(
+        (r) => r.status,
+      ) as unknown as NonEmptyArray<EngagementStatus>;
+    }
+
     const result = await this.db
       .query()
       .match([

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -1,4 +1,5 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { DateTime } from 'luxon';
 import {
   type CalendarDate,
   type ID,
@@ -373,10 +374,8 @@ export class EngagementService {
       .verifyCan('delete');
 
     await this.hooks.run(new EngagementWillDeleteHook(object));
-    const { at } = await this.repo.deleteNode(object, {
-      resource: resolveEngagementType(object),
-      changeset,
-    });
+    await this.repo.delete(object.id, changeset);
+    const at = DateTime.now();
 
     const payload = this.channels.publishToAll(
       resolveEngagementType(object) === LanguageEngagement

--- a/src/components/engagement/handlers/set-last-status-date.handler.ts
+++ b/src/components/engagement/handlers/set-last-status-date.handler.ts
@@ -1,4 +1,5 @@
 import { ServerException } from '~/common';
+import { ConfigService } from '~/core/config';
 import { OnHook } from '~/core/hooks';
 import { DatabaseService } from '~/core/neo4j';
 import { EngagementStatus, IEngagement } from '../dto';
@@ -6,11 +7,21 @@ import { EngagementUpdatedHook } from '../hooks';
 
 @OnHook(EngagementUpdatedHook)
 export class SetLastStatusDate {
-  constructor(private readonly db: DatabaseService) {}
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly config: ConfigService,
+  ) {}
 
   async handle(event: EngagementUpdatedHook) {
     const { previous, updated } = event;
     if (previous.status === updated.status) {
+      return;
+    }
+    // migration-todo: drop this guard at Phase 7 cutover — under postgres the
+    // drizzle repo's applyStatusChange stamps statusModifiedAt /
+    // lastSuspendedAt / lastReactivatedAt in the same transaction, and the
+    // updated DTO already carries them.
+    if (this.config.databaseEngine === 'postgres') {
       return;
     }
 

--- a/src/components/engagement/handlers/update-engagement-status.handler.ts
+++ b/src/components/engagement/handlers/update-engagement-status.handler.ts
@@ -1,6 +1,5 @@
 import type { MergeExclusive, RequireAtLeastOne } from 'type-fest';
 import { type ID, type UnsecuredDto } from '~/common';
-import { ConfigService } from '~/core/config';
 import { OnHook } from '~/core/hooks';
 import {
   type Project,
@@ -104,7 +103,6 @@ export class UpdateEngagementStatusHandler {
   constructor(
     private readonly repo: EngagementRepository,
     private readonly engagementService: EngagementService,
-    private readonly config: ConfigService,
   ) {}
 
   async handle({
@@ -112,10 +110,6 @@ export class UpdateEngagementStatusHandler {
     previousStep,
     workflowEvent,
   }: ProjectTransitionedHook) {
-    // migration-todo: Engagement isn't migrated to Postgres yet; skip this
-    // Neo4j-only engagement-status sync under DATABASE=postgres. Drop this
-    // guard when engagement-pg lands.
-    if (this.config.databaseEngine === 'postgres') return;
     const engagementStatus = changes.find(
       changeMatcher(previousStep, workflowEvent.to),
     )?.newStatus;

--- a/src/components/language/language.drizzle.repository.ts
+++ b/src/components/language/language.drizzle.repository.ts
@@ -1,12 +1,20 @@
 import { Injectable } from '@nestjs/common';
-import { and, eq, ilike, inArray, isNull, or, type SQL } from 'drizzle-orm';
+import {
+  and,
+  eq,
+  ilike,
+  inArray,
+  isNull,
+  or,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import {
   CalendarDate,
   generateId,
   type ID,
   NotFoundException,
-  NotImplementedException,
   type ObjectView,
   type PaginatedListType,
   type UnsecuredDto,
@@ -21,9 +29,16 @@ import {
   type SortMap,
 } from '~/core/drizzle';
 import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
-import { ethnologueLanguages, languages } from '~/core/drizzle/schema';
+import {
+  engagements,
+  ethnologueLanguages,
+  languages,
+  projects,
+} from '~/core/drizzle/schema';
 import { type ScopedRole } from '../authorization/dto/role.dto';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import { requesterScopeByProject } from '../project/project-member/membership-scope';
+import { recomputeProjectSensitivity } from '../project/project.drizzle.repository';
 import {
   type CreateLanguage,
   type EthnologueLanguage,
@@ -137,10 +152,23 @@ export class LanguageDrizzleRepository extends DrizzleDtoRepository<
       .catch(catchDisplayNameUnique)
       .catch(catchRolvUnique);
 
-    // migration-todo (Engagement recut): restore the project-sensitivity
-    // recompute over engaging projects (mono queries `engagements` +
-    // recomputeProjectSensitivity). No engagements can exist until that
-    // table lands, so there is nothing to recompute here yet.
+    if (fields.sensitivity !== undefined) {
+      // Mirror of Gel's recalculateProjectSens trigger: keep engaging
+      // translation projects' denormalized sensitivity current.
+      const engaged = await this.db
+        .select({ projectId: engagements.projectId })
+        .from(engagements)
+        .where(
+          and(
+            eq(engagements.languageId, id as ID<'Language'>),
+            isNull(engagements.deletedAt),
+          ),
+        );
+      await recomputeProjectSensitivity(
+        this.db,
+        engaged.map((e) => e.projectId),
+      );
+    }
 
     return await this.readOne(id);
   }
@@ -172,16 +200,83 @@ export class LanguageDrizzleRepository extends DrizzleDtoRepository<
       where: (l) => inArray(l.id, readableIds),
       with: { ethnologue: true },
     });
-    // migration-todo (Engagement recut): restore the engagementDerived()
-    // batch — effectiveSensitivity/presetInventory/usesAIAssistance/
-    // firstScriptureEngagement/scope all derive from engaging projects, so
-    // toDto's fallbacks (own sensitivity, false, null, []) are exact while
-    // no engagements can exist.
+    const derived = await this.engagementDerived(rows.map((r) => r.id));
     // migration-todo (Pin recut): restore the pinnedByRequester batch;
     // pinned hardcodes false until then.
     return (rows as LanguageRow[]).map((row) =>
-      this.toDto({ ...row, pinned: false }),
+      this.toDto({ ...row, pinned: false }, derived.get(row.id)),
     );
+  }
+
+  /**
+   * Engagement-derived read-time info per language: the projects engaging it
+   * (effective sensitivity = lowest project sensitivity; requester scope is
+   * the dedup'd union across them; presetInventory = any InDevelopment/Active
+   * project flagged), whether any engagement uses AI-assisted translation,
+   * and the firstScripture engagement. Mirror of the Neo4j hydrate.
+   */
+  private async engagementDerived(languageIds: ReadonlyArray<ID<'Language'>>) {
+    const out = new Map<ID<'Language'>, EngagementDerived>();
+    if (languageIds.length === 0) return out;
+    const rows = await this.db
+      .select({
+        languageId: engagements.languageId,
+        engagementId: engagements.id,
+        firstScripture: engagements.firstScripture,
+        usingAI: engagements.usingAIAssistedTranslation,
+        projectId: projects.id,
+        sensitivity: projects.sensitivity,
+        status: projects.status,
+        presetInventory: projects.presetInventory,
+      })
+      .from(engagements)
+      .innerJoin(projects, eq(engagements.projectId, projects.id))
+      .where(
+        and(
+          inArray(engagements.languageId, [...languageIds]),
+          isNull(engagements.deletedAt),
+          isNull(projects.deletedAt),
+        ),
+      );
+    const scopeByProject = await requesterScopeByProject(
+      this.db,
+      this.identity.current.userId,
+      rows.map((r) => r.projectId),
+    );
+    const sensRank = { Low: 1, Medium: 2, High: 3 } as const;
+    for (const row of rows) {
+      const languageId = row.languageId!;
+      const entry = out.get(languageId) ?? {
+        effectiveSensitivity: undefined,
+        presetInventory: false,
+        usesAIAssistance: false,
+        firstScriptureEngagement: null,
+        scope: new Set<ScopedRole>(),
+      };
+      if (
+        !entry.effectiveSensitivity ||
+        sensRank[row.sensitivity] < sensRank[entry.effectiveSensitivity]
+      ) {
+        entry.effectiveSensitivity = row.sensitivity;
+      }
+      if (
+        row.presetInventory &&
+        (row.status === 'InDevelopment' || row.status === 'Active')
+      ) {
+        entry.presetInventory = true;
+      }
+      if (row.usingAI !== 'None' && row.usingAI !== 'Unknown') {
+        entry.usesAIAssistance = true;
+      }
+      if (row.firstScripture && !entry.firstScriptureEngagement) {
+        entry.firstScriptureEngagement = { id: row.engagementId };
+      }
+      for (const role of scopeByProject.get(row.projectId) ?? []) {
+        entry.scope.add(role);
+      }
+      out.set(languageId, entry);
+    }
+    return out;
   }
 
   async readOneByEth(ethnologueId: ID): Promise<UnsecuredDto<Language>> {
@@ -244,17 +339,32 @@ export class LanguageDrizzleRepository extends DrizzleDtoRepository<
     };
   }
 
-  // migration-todo (Engagement recut): query `engagements` for real. Until
-  // that table lands no engagements can exist, so an empty list is exact —
-  // and it keeps the service's delete guard permissive, correctly.
-  async getEngagementIdsForLanguage(_language: Language): Promise<ID[]> {
-    return [];
+  async getEngagementIdsForLanguage(language: Language): Promise<ID[]> {
+    const rows = await this.db
+      .select({ id: engagements.id })
+      .from(engagements)
+      .where(
+        and(
+          eq(engagements.languageId, language.id as ID<'Language'>),
+          isNull(engagements.deletedAt),
+        ),
+      );
+    return rows.map((r) => r.id);
   }
 
-  // migration-todo (Engagement recut): query `engagements.first_scripture`
-  // for real. Exact while no engagements can exist.
-  async hasFirstScriptureEngagement(_id: ID): Promise<boolean> {
-    return false;
+  async hasFirstScriptureEngagement(id: ID): Promise<boolean> {
+    const [row] = await this.db
+      .select({ id: engagements.id })
+      .from(engagements)
+      .where(
+        and(
+          eq(engagements.languageId, id as ID<'Language'>),
+          eq(engagements.firstScripture, true),
+          isNull(engagements.deletedAt),
+        ),
+      )
+      .limit(1);
+    return !!row;
   }
 
   async delete(id: ID): Promise<void> {
@@ -342,8 +452,7 @@ export const languageFilterClauses = (
   const conditions: SQL[] = [];
   if (!filter) return conditions;
   // migration-todo (Pin recut): restore the pinnedFilter branch; until the
-  // pins table lands the filter is ignored (matches the Project/Partner
-  // recut posture — the pinned e2e stays red at the Pin boundary).
+  // pins table lands the filter is ignored (Project/Partner recut posture).
 
   if (filter.name) {
     const pattern = `%${escapeLikePattern(filter.name)}%`;
@@ -390,11 +499,15 @@ export const languageFilterClauses = (
     );
   }
   if (filter.partnerId) {
-    // migration-todo (Engagement recut): restore the engagements→partnerships
-    // EXISTS. Raw SQL would compile but crash at runtime against the missing
-    // table — fail loud instead.
-    throw new NotImplementedException(
-      'LanguageFilters.partnerId requires the Engagement migration',
+    conditions.push(
+      sql`exists (
+        select 1 from "engagements" "e"
+        join "partnerships" "ps" on "ps"."project_id" = "e"."project_id"
+        where "e"."language_id" = ${languages.id}
+          and "ps"."partner_id" = ${filter.partnerId}
+          and "e"."deleted_at" is null
+          and "ps"."deleted_at" is null
+      )`,
     );
   }
   if (filter.ethnologue) {

--- a/src/components/language/language.drizzle.repository.ts
+++ b/src/components/language/language.drizzle.repository.ts
@@ -368,7 +368,24 @@ export class LanguageDrizzleRepository extends DrizzleDtoRepository<
   }
 
   async delete(id: ID): Promise<void> {
+    // Capture engaging projects BEFORE the soft-delete: the denormalized
+    // projects.sensitivity must be recomputed once this language stops
+    // counting (Neo4j computes sensitivity live, so its delete needs no
+    // equivalent). Same recipe as update()'s sensitivity-change path.
+    const engaged = await this.db
+      .select({ projectId: engagements.projectId })
+      .from(engagements)
+      .where(
+        and(
+          eq(engagements.languageId, id as ID<'Language'>),
+          isNull(engagements.deletedAt),
+        ),
+      );
     await this.softDelete(id);
+    await recomputeProjectSensitivity(
+      this.db,
+      engaged.map((row) => row.projectId),
+    );
   }
 
   protected toDto(

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -219,9 +219,8 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
     const engagementTotalByProject = new Map(
       engagementCounts.map((c) => [c.projectId, c.total]),
     );
-    // migration-todo: engagementTotal is stubbed to 0 until Engagement migrates
-    // (the `engagements` table isn't on develop yet). `pinned` dropped — Pin
-    // isn't migrated; re-add the pinnedByRequester batch when the pin domain ports.
+    // migration-todo: `pinned` dropped — Pin isn't migrated; re-add the
+    // pinnedByRequester batch when the pin domain ports.
     return rows.map((row): UnsecuredDto<Project> => {
       const enriched: ProjectRow = {
         ...row,

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -42,6 +42,7 @@ import {
 } from '~/core/drizzle';
 import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
 import {
+  engagements,
   fieldRegions,
   locations,
   projectMembers,
@@ -82,7 +83,7 @@ const catchDepartmentIdUnique = catchUniqueViolation(
 /**
  * Hydrated Project row: the projects table row + the current user's membership
  * (id, roles, inactive_at) if any. Pulled together in a single SELECT for
- * `readMany`. Cross-domain stubs (engagementTotal, usesRev79, primaryPartnership,
+ * `readMany`. Cross-domain stubs (usesRev79, primaryPartnership,
  * rootDirectory) live in `toDto`.
  */
 type ProjectRow = typeof projects.$inferSelect & {
@@ -199,6 +200,25 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
     const stepChangedByProject = new Map(
       latestEvents.map((e) => [e.projectId, e.at]),
     );
+    const engagementCounts = await this.db
+      .select({
+        projectId: engagements.projectId,
+        total: count(engagements.id),
+      })
+      .from(engagements)
+      .where(
+        and(
+          inArray(
+            engagements.projectId,
+            rows.map((r) => r.id),
+          ),
+          isNull(engagements.deletedAt),
+        ),
+      )
+      .groupBy(engagements.projectId);
+    const engagementTotalByProject = new Map(
+      engagementCounts.map((c) => [c.projectId, c.total]),
+    );
     // migration-todo: engagementTotal is stubbed to 0 until Engagement migrates
     // (the `engagements` table isn't on develop yet). `pinned` dropped — Pin
     // isn't migrated; re-add the pinnedByRequester batch when the pin domain ports.
@@ -207,7 +227,7 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
         ...row,
         membership: membershipByProject.get(row.id) ?? null,
         stepChangedAt: stepChangedByProject.get(row.id) ?? null,
-        engagementTotal: 0,
+        engagementTotal: engagementTotalByProject.get(row.id) ?? 0,
       };
       return this.toDto(enriched);
     });
@@ -631,7 +651,7 @@ const resolveCrossDomainSort = (
  * `projects`. Exported for sub-delegation from other domains (Engagement and
  * Partnership both filter-sub-delegate into projectFilterClauses).
  *
- * Cross-domain stubs (languageId, partnerId, partnerships, primaryPartnership,
+ * Cross-domain stubs (partnerId, partnerships, primaryPartnership,
  * tool, onlyMultipleEngagements, usesRev79) throw NotImplementedException
  * until their target domain migrates — discovery mechanism, not silent skip.
  */
@@ -817,10 +837,13 @@ export const projectFilterClauses = (
     conditions.push(inArray(projects.id, memberSub));
   }
   if (filter.languageId) {
-    // migration-todo: exists-over-engagements; Engagement isn't on develop.
-    // Throw so the gap is discoverable (matches partnerId/partnerships below).
-    throw new NotImplementedException(
-      'ProjectFilters.languageId requires Engagement migration.',
+    conditions.push(
+      sql`exists (
+        select 1 from "engagements" "e"
+        where "e"."project_id" = ${projects.id}
+          and "e"."language_id" = ${filter.languageId}
+          and "e"."deleted_at" is null
+      )`,
     );
   }
   // Cross-domain filters — throw until wired so the gap is discoverable in

--- a/src/components/user/user.drizzle.repository.ts
+++ b/src/components/user/user.drizzle.repository.ts
@@ -21,6 +21,7 @@ import {
 } from '~/core/drizzle';
 import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
 import {
+  engagements,
   userGlobalRoles,
   userOrganizations,
   users,
@@ -41,6 +42,7 @@ import {
 
 type UserRow = typeof users.$inferSelect & {
   globalRoles?: Array<typeof userGlobalRoles.$inferSelect>;
+  isIntern?: boolean;
 };
 
 const catchEmailUnique = catchUniqueViolation(
@@ -63,21 +65,46 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
     super(db, users, User);
   }
 
-  // migration-todo: populate `isIntern` on toDto() (subquery against the
-  // internship_engagements table where intern_id = users.id), and add an
-  // `asDrizzleCondition` to IsInternCondition for the DB-level filter.
   override async readMany(
     ids: readonly ID[],
   ): Promise<Array<UnsecuredDto<User>>> {
-    const rows = await this.db.query.users.findMany({
-      where: (user) => and(inArray(user.id, [...ids]), isNull(user.deletedAt)),
-      with: { globalRoles: true },
-    });
-    return rows.map((row) => this.toDto(row));
+    const [rows, interns] = await Promise.all([
+      this.db.query.users.findMany({
+        where: (user) =>
+          and(inArray(user.id, [...ids]), isNull(user.deletedAt)),
+        with: { globalRoles: true },
+      }),
+      this.internUserIds(ids),
+    ]);
+    return rows.map((row) =>
+      this.toDto({ ...row, isIntern: interns.has(row.id) }),
+    );
+  }
+
+  /**
+   * The subset of `ids` who are the intern on ≥1 live InternshipEngagement —
+   * feeds the `isIntern` flag the IsIntern policy condition reads. Must stay
+   * in lockstep with IsInternCondition.asDrizzleCondition (same predicate).
+   */
+  private async internUserIds(
+    ids: readonly ID[],
+  ): Promise<ReadonlySet<string>> {
+    if (ids.length === 0) return new Set();
+    const rows = await this.db
+      .selectDistinct({ id: engagements.internId })
+      .from(engagements)
+      .where(
+        and(
+          inArray(engagements.internId, [...ids]),
+          eq(engagements.type, 'Internship'),
+          isNull(engagements.deletedAt),
+        ),
+      );
+    return new Set(rows.flatMap((row) => (row.id ? [row.id] : [])));
   }
 
   async readManyActors(ids: readonly ID[]) {
-    const [userRows, agentRows] = await Promise.all([
+    const [userRows, agentRows, interns] = await Promise.all([
       this.db.query.users.findMany({
         where: (user) =>
           and(inArray(user.id, [...ids]), isNull(user.deletedAt)),
@@ -86,11 +113,12 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
       this.db.query.systemAgents.findMany({
         where: (agent) => inArray(agent.id, [...ids]),
       }),
+      this.internUserIds(ids),
     ]);
     return [
-      ...(userRows.map((row) => this.toDto(row)) as Array<
-        UnsecuredDto<User | SystemAgent>
-      >),
+      ...(userRows.map((row) =>
+        this.toDto({ ...row, isIntern: interns.has(row.id) }),
+      ) as Array<UnsecuredDto<User | SystemAgent>>),
       ...agentRows.map(
         (row) =>
           // migration-todo: SystemAgent is abstract; cast bridges plain row → class shape
@@ -217,19 +245,25 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
     });
 
     const ids = rows.map((row) => row.id);
-    const allRoles =
+    const [allRoles, interns] = await Promise.all([
       ids.length > 0
-        ? await this.db
+        ? this.db
             .select()
             .from(userGlobalRoles)
             .where(inArray(userGlobalRoles.userId, ids))
-        : [];
+        : [],
+      this.internUserIds(ids),
+    ]);
     const rolesByUser = groupBy(allRoles, (row) => row.userId);
 
     return {
       total,
       items: rows.map((row) =>
-        this.toDto({ ...row, globalRoles: rolesByUser[row.id] ?? [] }),
+        this.toDto({
+          ...row,
+          globalRoles: rolesByUser[row.id] ?? [],
+          isIntern: interns.has(row.id),
+        }),
       ),
       hasMore,
     };
@@ -253,7 +287,9 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
       where: and(...conditions),
       with: { globalRoles: true },
     });
-    return row ? this.toDto(row) : null;
+    if (!row) return null;
+    const interns = await this.internUserIds([row.id]);
+    return this.toDto({ ...row, isIntern: interns.has(row.id) });
   }
 
   async assignOrganizationToUser({
@@ -316,7 +352,8 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
   /**
    * Public wrapper around `toDto` so other domains' repos (e.g. ProjectMember)
    * can hydrate a User from a raw row without duplicating logic. The row should
-   * be loaded with `globalRoles`.
+   * be loaded with `globalRoles`. `isIntern` stays unset here — embedded users
+   * aren't edit targets, so the IsIntern policy condition never reads them.
    */
   mapRowToDto(row: UserRow): UnsecuredDto<User> {
     return this.toDto(row);
@@ -342,6 +379,7 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
       photo: row.photoId ? { id: row.photoId } : null,
       // migration-todo: pinned is per-requesting-user state, not stored on the user row
       pinned: false,
+      isIntern: row.isIntern,
     };
   }
 }

--- a/src/core/drizzle/migrations/0017_add_engagements.sql
+++ b/src/core/drizzle/migrations/0017_add_engagements.sql
@@ -1,0 +1,131 @@
+-- Engagement + Ceremony domains (Phase 5). Single-table inheritance over
+-- LanguageEngagement / InternshipEngagement with a `type` discriminator
+-- (same approach as projects); the CHECK keeps per-type columns coherent.
+-- Ceremonies are 1:1 with engagements (auto-created by the
+-- EngagementCreatedHook handler, replacing Gel's triggers). Status history
+-- drives the rules engine's "BackTo" dynamic transitions (mirror of Neo4j's
+-- inactive status Property chain). pnp_id / growth_plan_id are deferred FKs
+-- → files(id) (Phase 7).
+
+CREATE TYPE "engagement_type" AS ENUM ('Language', 'Internship');
+
+CREATE TYPE "engagement_status" AS ENUM (
+  'InDevelopment',
+  'DidNotDevelop',
+  'Rejected',
+  'Active',
+  'ActiveChangedPlan',
+  'DiscussingTermination',
+  'DiscussingReactivation',
+  'DiscussingChangeToPlan',
+  'DiscussingSuspension',
+  'Suspended',
+  'FinalizingCompletion',
+  'Terminated',
+  'Completed',
+  'Converted',
+  'Unapproved',
+  'Transferred',
+  'NotRenewed'
+);
+
+CREATE TYPE "language_milestone" AS ENUM (
+  'Unknown', 'None', 'OldTestament', 'NewTestament', 'FullBible'
+);
+
+CREATE TYPE "ai_assisted_translation" AS ENUM (
+  'Unknown', 'None', 'Draft', 'Check', 'DraftAndCheck', 'Other'
+);
+
+CREATE TYPE "ceremony_type" AS ENUM ('Dedication', 'Certification');
+
+CREATE TABLE "engagements" (
+  "id"                            text PRIMARY KEY,
+  "project_id"                    text NOT NULL REFERENCES "projects"("id") ON DELETE CASCADE,
+  "type"                          "engagement_type" NOT NULL,
+  "status"                        "engagement_status" NOT NULL DEFAULT 'InDevelopment',
+  "status_modified_at"            timestamptz,
+  "last_suspended_at"             timestamptz,
+  "last_reactivated_at"           timestamptz,
+  "complete_date"                 date,
+  "disbursement_complete_date"    date,
+  "start_date_override"           date,
+  "end_date_override"             date,
+  "initial_end_date"              date,
+  "description"                   jsonb,
+
+  "language_id"                   text REFERENCES "languages"("id"),
+  "first_scripture"               boolean,
+  "luke_partnership"              boolean,
+  "open_to_investor_visit"        boolean,
+  "paratext_registry_id"          text,
+  "rev79_community_id"            text,
+  "pnp_id"                        text,
+  "sent_printing_date"            date,
+  "historic_goal"                 text,
+  "milestone_planned"             "language_milestone" NOT NULL DEFAULT 'Unknown',
+  "milestone_reached"             boolean,
+  "using_ai_assisted_translation" "ai_assisted_translation" NOT NULL DEFAULT 'Unknown',
+
+  "intern_id"                     text REFERENCES "users"("id"),
+  "mentor_id"                     text REFERENCES "users"("id"),
+  "position"                      text,
+  "methodologies"                 text[] NOT NULL DEFAULT '{}',
+  "country_of_origin_id"          text REFERENCES "locations"("id"),
+  "growth_plan_id"                text,
+  "marketable"                    boolean NOT NULL DEFAULT false,
+  "web_id"                        text,
+
+  "created_at"                    timestamptz NOT NULL DEFAULT now(),
+  "modified_at"                   timestamptz NOT NULL DEFAULT now(),
+  "updated_at"                    timestamptz NOT NULL DEFAULT now(),
+  "deleted_at"                    timestamptz,
+
+  CONSTRAINT "engagements_type_shape_chk" CHECK (
+    ("type" = 'Language' AND "language_id" IS NOT NULL AND "intern_id" IS NULL)
+    OR ("type" = 'Internship' AND "intern_id" IS NOT NULL AND "language_id" IS NULL)
+  )
+);
+
+CREATE UNIQUE INDEX "engagements_project_language_active_unique"
+  ON "engagements" ("project_id", "language_id")
+  WHERE "language_id" IS NOT NULL AND "deleted_at" IS NULL;
+CREATE UNIQUE INDEX "engagements_project_intern_active_unique"
+  ON "engagements" ("project_id", "intern_id")
+  WHERE "intern_id" IS NOT NULL AND "deleted_at" IS NULL;
+CREATE INDEX "engagements_project_id_idx" ON "engagements" ("project_id");
+CREATE INDEX "engagements_language_id_idx" ON "engagements" ("language_id");
+CREATE INDEX "engagements_intern_id_idx" ON "engagements" ("intern_id");
+
+CREATE TABLE "engagement_status_history" (
+  "id"            bigserial PRIMARY KEY,
+  "engagement_id" text NOT NULL REFERENCES "engagements"("id") ON DELETE CASCADE,
+  "status"        "engagement_status" NOT NULL,
+  "at"            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX "engagement_status_history_engagement_id_at_idx"
+  ON "engagement_status_history" ("engagement_id", "at");
+
+CREATE TABLE "ceremonies" (
+  "id"             text PRIMARY KEY,
+  "engagement_id"  text NOT NULL REFERENCES "engagements"("id") ON DELETE CASCADE,
+  "type"           "ceremony_type" NOT NULL,
+  "planned"        boolean NOT NULL DEFAULT false,
+  "estimated_date" date,
+  "actual_date"    date,
+  "created_at"     timestamptz NOT NULL DEFAULT now(),
+  "updated_at"     timestamptz NOT NULL DEFAULT now(),
+  "deleted_at"     timestamptz
+);
+
+CREATE UNIQUE INDEX "ceremonies_engagement_active_unique"
+  ON "ceremonies" ("engagement_id")
+  WHERE "deleted_at" IS NULL;
+
+-- Full FK indexes the invariant suite requires beyond mono's originals:
+-- mentor_id / country_of_origin_id had no coverage at all, and ceremonies'
+-- partial unique on engagement_id can't serve FK-maintenance scans.
+CREATE INDEX "engagements_mentor_id_idx" ON "engagements" ("mentor_id");
+CREATE INDEX "engagements_country_of_origin_id_idx" ON "engagements" ("country_of_origin_id");
+CREATE INDEX "ceremonies_engagement_id_idx" ON "ceremonies" ("engagement_id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1752019200000,
       "tag": "0016_add_languages",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1752105600000,
+      "tag": "0017_add_engagements",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -1698,8 +1698,6 @@ export const ethnologueLanguagesRelations = relations(
 
 // ─── Engagements ───────────────────────────────────────────────────────────
 
-// ─── Engagements ───────────────────────────────────────────────────────────
-
 export const engagementTypeEnum = pgEnum('engagement_type', [
   'Language',
   'Internship',
@@ -1852,8 +1850,6 @@ export const engagements = pgTable(
     index('engagements_intern_id_idx').on(t.internId),
     index('engagements_mentor_id_idx').on(t.mentorId),
     index('engagements_country_of_origin_id_idx').on(t.countryOfOriginId),
-    index('engagements_country_of_origin_id_idx').on(t.countryOfOriginId),
-    index('engagements_mentor_id_idx').on(t.mentorId),
   ],
 );
 

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -2,6 +2,7 @@ import { relations, sql } from 'drizzle-orm';
 import {
   type AnyPgColumn,
   bigint,
+  bigserial,
   boolean,
   check,
   date,
@@ -18,7 +19,12 @@ import {
 } from 'drizzle-orm/pg-core';
 import { type ID, type Role } from '~/common';
 import { type BudgetStatus } from '../../../components/budget/dto/budget-status.enum';
+import { type CeremonyType } from '../../../components/ceremony/dto/ceremony-type.enum';
+import { type InternshipPosition } from '../../../components/engagement/dto/intern-position.enum';
+import { type EngagementStatus } from '../../../components/engagement/dto/status.enum';
 import { type FileNodeType } from '../../../components/file/dto/file-node-type.enum';
+import { type AIAssistedTranslation } from '../../../components/language/dto/ai-assisted-translation.enum';
+import { type LanguageMilestone } from '../../../components/language/dto/language-milestone.enum';
 import { type LocationType } from '../../../components/location/dto/location-type.enum';
 import { type OrganizationReach } from '../../../components/organization/dto/organization-reach.dto';
 import { type OrganizationType } from '../../../components/organization/dto/organization-type.dto';
@@ -26,6 +32,7 @@ import { type PartnerType } from '../../../components/partner/dto/partner-type.e
 import { type FinancialReportingType } from '../../../components/partnership/dto/financial-reporting-type.enum';
 import { type PartnershipAgreementStatus } from '../../../components/partnership/dto/partnership-agreement-status.enum';
 import { type ReportPeriod } from '../../../components/periodic-report/dto/report-period.enum';
+import { type ProductMethodology } from '../../../components/product/dto/product-methodology.enum';
 import { type ProjectStatus } from '../../../components/project/dto/project-status.enum';
 import { type ProjectStep } from '../../../components/project/dto/project-step.enum';
 import { type ProjectType } from '../../../components/project/dto/project-type.enum';
@@ -1690,3 +1697,258 @@ export const ethnologueLanguagesRelations = relations(
 );
 
 // ─── Engagements ───────────────────────────────────────────────────────────
+
+// ─── Engagements ───────────────────────────────────────────────────────────
+
+export const engagementTypeEnum = pgEnum('engagement_type', [
+  'Language',
+  'Internship',
+]);
+
+export const engagementStatusEnum = pgEnum('engagement_status', [
+  'InDevelopment',
+  'DidNotDevelop',
+  'Rejected',
+  'Active',
+  'ActiveChangedPlan',
+  'DiscussingTermination',
+  'DiscussingReactivation',
+  'DiscussingChangeToPlan',
+  'DiscussingSuspension',
+  'Suspended',
+  'FinalizingCompletion',
+  'Terminated',
+  'Completed',
+  // Legacy — only used in historic data.
+  'Converted',
+  'Unapproved',
+  'Transferred',
+  'NotRenewed',
+]);
+
+export const languageMilestoneEnum = pgEnum('language_milestone', [
+  'Unknown',
+  'None',
+  'OldTestament',
+  'NewTestament',
+  'FullBible',
+]);
+
+export const aiAssistedTranslationEnum = pgEnum('ai_assisted_translation', [
+  'Unknown',
+  'None',
+  'Draft',
+  'Check',
+  'DraftAndCheck',
+  'Other',
+]);
+
+/**
+ * Single-table inheritance over LanguageEngagement / InternshipEngagement —
+ * same approach as projects. The `type` discriminator matches the parent
+ * project's type (Language ⟷ Translation projects, Internship ⟷ Internship
+ * projects); the CHECK below keeps the per-type columns coherent.
+ * `position` and `methodologies` are text-typed: large open-ended enums whose
+ * semantics live in the app (methodologies' canonical enum lands with the
+ * Product domain).
+ */
+export const engagements = pgTable(
+  'engagements',
+  {
+    id: text('id').$type<ID<'Engagement'>>().primaryKey(),
+    projectId: text('project_id')
+      .$type<ID<'Project'>>()
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    type: engagementTypeEnum('type').notNull(),
+    status: engagementStatusEnum('status')
+      .$type<EngagementStatus>()
+      .notNull()
+      .default('InDevelopment'),
+    statusModifiedAt: timestamp('status_modified_at', { withTimezone: true }),
+    lastSuspendedAt: timestamp('last_suspended_at', { withTimezone: true }),
+    lastReactivatedAt: timestamp('last_reactivated_at', { withTimezone: true }),
+    completeDate: date('complete_date'),
+    disbursementCompleteDate: date('disbursement_complete_date'),
+    startDateOverride: date('start_date_override'),
+    endDateOverride: date('end_date_override'),
+    initialEndDate: date('initial_end_date'),
+    description: jsonb('description'),
+
+    // ── LanguageEngagement only ──
+    languageId: text('language_id')
+      .$type<ID<'Language'>>()
+      .references(() => languages.id),
+    // Nullable to mirror Neo4j semantics — unset is distinct from false and
+    // surfaces as null in the API.
+    firstScripture: boolean('first_scripture'),
+    lukePartnership: boolean('luke_partnership'),
+    openToInvestorVisit: boolean('open_to_investor_visit'),
+    paratextRegistryId: text('paratext_registry_id'),
+    rev79CommunityId: text('rev79_community_id'),
+    // migration-todo: deferred FK → files(id); populate when File migrates
+    // (Phase 7). Null until then.
+    pnpId: text('pnp_id').$type<ID<'File'>>(),
+    sentPrintingDate: date('sent_printing_date'),
+    historicGoal: text('historic_goal'),
+    milestonePlanned: languageMilestoneEnum('milestone_planned')
+      .$type<LanguageMilestone>()
+      .notNull()
+      .default('Unknown'),
+    milestoneReached: boolean('milestone_reached'),
+    usingAIAssistedTranslation: aiAssistedTranslationEnum(
+      'using_ai_assisted_translation',
+    )
+      .$type<AIAssistedTranslation>()
+      .notNull()
+      .default('Unknown'),
+
+    // ── InternshipEngagement only ──
+    internId: text('intern_id')
+      .$type<ID<'User'>>()
+      .references(() => users.id),
+    mentorId: text('mentor_id')
+      .$type<ID<'User'>>()
+      .references(() => users.id),
+    position: text('position').$type<InternshipPosition>(),
+    methodologies: text('methodologies')
+      .array()
+      .$type<readonly ProductMethodology[]>()
+      .notNull()
+      .default([]),
+    countryOfOriginId: text('country_of_origin_id')
+      .$type<ID<'Location'>>()
+      .references(() => locations.id),
+    // migration-todo: deferred FK → files(id); Phase 7.
+    growthPlanId: text('growth_plan_id').$type<ID<'File'>>(),
+    marketable: boolean('marketable').notNull().default(false),
+    webId: text('web_id'),
+
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    modifiedAt: timestamp('modified_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    check(
+      'engagements_type_shape_chk',
+      sql`(${t.type} = 'Language' AND ${t.languageId} IS NOT NULL AND ${t.internId} IS NULL)
+        OR (${t.type} = 'Internship' AND ${t.internId} IS NOT NULL AND ${t.languageId} IS NULL)`,
+    ),
+    uniqueIndex('engagements_project_language_active_unique')
+      .on(t.projectId, t.languageId)
+      .where(sql`${t.languageId} IS NOT NULL AND ${t.deletedAt} IS NULL`),
+    uniqueIndex('engagements_project_intern_active_unique')
+      .on(t.projectId, t.internId)
+      .where(sql`${t.internId} IS NOT NULL AND ${t.deletedAt} IS NULL`),
+    index('engagements_project_id_idx').on(t.projectId),
+    index('engagements_language_id_idx').on(t.languageId),
+    index('engagements_intern_id_idx').on(t.internId),
+    index('engagements_mentor_id_idx').on(t.mentorId),
+    index('engagements_country_of_origin_id_idx').on(t.countryOfOriginId),
+    index('engagements_country_of_origin_id_idx').on(t.countryOfOriginId),
+    index('engagements_mentor_id_idx').on(t.mentorId),
+  ],
+);
+
+// migration-todo (Product recut): restore `products: many(products)`.
+export const engagementsRelations = relations(engagements, ({ one }) => ({
+  project: one(projects, {
+    fields: [engagements.projectId],
+    references: [projects.id],
+  }),
+  language: one(languages, {
+    fields: [engagements.languageId],
+    references: [languages.id],
+  }),
+  intern: one(users, {
+    fields: [engagements.internId],
+    references: [users.id],
+  }),
+  mentor: one(users, {
+    fields: [engagements.mentorId],
+    references: [users.id],
+  }),
+  countryOfOrigin: one(locations, {
+    fields: [engagements.countryOfOriginId],
+    references: [locations.id],
+  }),
+  ceremony: one(ceremonies, {
+    fields: [engagements.id],
+    references: [ceremonies.engagementId],
+  }),
+}));
+
+/**
+ * Previous statuses, newest first — drives the rules engine's "BackTo"
+ * dynamic transitions (mirror of Neo4j's inactive status Property history).
+ * The repo appends the OLD status whenever status changes.
+ */
+export const engagementStatusHistory = pgTable(
+  'engagement_status_history',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    engagementId: text('engagement_id')
+      .$type<ID<'Engagement'>>()
+      .notNull()
+      .references(() => engagements.id, { onDelete: 'cascade' }),
+    status: engagementStatusEnum('status').$type<EngagementStatus>().notNull(),
+    at: timestamp('at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('engagement_status_history_engagement_id_at_idx').on(
+      t.engagementId,
+      t.at,
+    ),
+  ],
+);
+
+// ─── Ceremonies ────────────────────────────────────────────────────────────
+
+export const ceremonyTypeEnum = pgEnum('ceremony_type', [
+  'Dedication',
+  'Certification',
+]);
+
+export const ceremonies = pgTable(
+  'ceremonies',
+  {
+    id: text('id').$type<ID<'Ceremony'>>().primaryKey(),
+    engagementId: text('engagement_id')
+      .$type<ID<'Engagement'>>()
+      .notNull()
+      .references(() => engagements.id, { onDelete: 'cascade' }),
+    type: ceremonyTypeEnum('type').$type<CeremonyType>().notNull(),
+    planned: boolean('planned').notNull().default(false),
+    estimatedDate: date('estimated_date'),
+    actualDate: date('actual_date'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    // 1:1 with engagement among live rows (Gel: exclusive on .engagement).
+    uniqueIndex('ceremonies_engagement_active_unique')
+      .on(t.engagementId)
+      .where(sql`${t.deletedAt} IS NULL`),
+    // Full FK index — the partial unique above can't serve FK-maintenance scans.
+    index('ceremonies_engagement_id_idx').on(t.engagementId),
+  ],
+);
+
+export const ceremoniesRelations = relations(ceremonies, ({ one }) => ({
+  engagement: one(engagements, {
+    fields: [ceremonies.engagementId],
+    references: [engagements.id],
+  }),
+}));

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -44,6 +44,10 @@ import {
   transitionProject,
 } from './utility/transition-project';
 
+// migration-todo: this leg creates products, which are Neo4j-only until the
+// Product port lands — flip back to `it` under postgres in that PR.
+const itPgPending = process.env.DATABASE === 'postgres' ? it.skip : it;
+
 describe('Engagement e2e', () => {
   let app: TestApp;
   let project: fragments.project;
@@ -457,51 +461,54 @@ describe('Engagement e2e', () => {
       .expectError(errors.notFound());
   });
 
-  it('returns the correct products in language engagement', async () => {
-    project = await createProject(app);
-    language = await runAsAdmin(app, createLanguage);
-    const languageEngagement = await createLanguageEngagement(app, {
-      language: language.id,
-      project: project.id,
-    });
+  itPgPending(
+    'returns the correct products in language engagement',
+    async () => {
+      project = await createProject(app);
+      language = await runAsAdmin(app, createLanguage);
+      const languageEngagement = await createLanguageEngagement(app, {
+        language: language.id,
+        project: project.id,
+      });
 
-    const product1 = await createDirectProduct(app, {
-      engagement: languageEngagement.id,
-    });
-    const product2 = await createDirectProduct(app, {
-      engagement: languageEngagement.id,
-    });
-    const result = await app.graphql.query(
-      graphql(
-        `
-          query engagement($id: ID!) {
-            engagement: languageEngagement(id: $id) {
-              ...languageEngagement
+      const product1 = await createDirectProduct(app, {
+        engagement: languageEngagement.id,
+      });
+      const product2 = await createDirectProduct(app, {
+        engagement: languageEngagement.id,
+      });
+      const result = await app.graphql.query(
+        graphql(
+          `
+            query engagement($id: ID!) {
+              engagement: languageEngagement(id: $id) {
+                ...languageEngagement
+              }
             }
-          }
-        `,
-        [fragments.languageEngagement],
-      ),
-      {
-        id: languageEngagement.id,
-      },
-    );
-    expect(result.engagement.products.total).toEqual(2);
-    expect(result.engagement.products.items).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: product1.id,
-        }),
-      ]),
-    );
-    expect(result.engagement.products.items).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: product2.id,
-        }),
-      ]),
-    );
-  });
+          `,
+          [fragments.languageEngagement],
+        ),
+        {
+          id: languageEngagement.id,
+        },
+      );
+      expect(result.engagement.products.total).toEqual(2);
+      expect(result.engagement.products.items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: product1.id,
+          }),
+        ]),
+      );
+      expect(result.engagement.products.items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: product2.id,
+          }),
+        ]),
+      );
+    },
+  );
 
   it('creates ceremony upon engagement creation', async () => {
     project = await createProject(app);

--- a/test/language.e2e-spec.ts
+++ b/test/language.e2e-spec.ts
@@ -16,12 +16,6 @@ import {
   type TestApp,
 } from './utility';
 
-// migration-todo: these legs create language engagements, which are Neo4j-only
-// until the Engagement port lands — flip back to `it` under postgres in that PR
-// (the engagement-derived fields they assert are wired read-time against
-// language_engagements).
-const itPgPending = process.env.DATABASE === 'postgres' ? it.skip : it;
-
 describe('Language e2e', () => {
   let app: TestApp;
 
@@ -231,104 +225,98 @@ describe('Language e2e', () => {
     expect(languages.items.length).toBeGreaterThan(numLanguages);
   });
 
-  itPgPending(
-    'List with projects -> engagements -> engagement status should not error',
-    async () => {
-      const lang = await createLanguage(app);
-      const project = await createProject(app);
-      await app.graphql.mutate(
-        graphql(`
-          mutation createLanguageEngagement($input: CreateLanguageEngagement!) {
-            createLanguageEngagement(input: $input) {
-              engagement {
-                status {
-                  transitions {
-                    to
-                  }
+  it('List with projects -> engagements -> engagement status should not error', async () => {
+    const lang = await createLanguage(app);
+    const project = await createProject(app);
+    await app.graphql.mutate(
+      graphql(`
+        mutation createLanguageEngagement($input: CreateLanguageEngagement!) {
+          createLanguageEngagement(input: $input) {
+            engagement {
+              status {
+                transitions {
+                  to
                 }
               }
             }
           }
-        `),
-        {
-          input: {
-            language: lang.id,
-            project: project.id,
-          },
+        }
+      `),
+      {
+        input: {
+          language: lang.id,
+          project: project.id,
         },
-      );
-      // test reading new lang
-      const result = await app.graphql.query(
-        graphql(`
-          query {
-            languages {
-              items {
-                projects {
-                  items {
-                    engagements {
-                      items {
-                        status {
-                          transitions {
-                            to
-                          }
+      },
+    );
+    // test reading new lang
+    const result = await app.graphql.query(
+      graphql(`
+        query {
+          languages {
+            items {
+              projects {
+                items {
+                  engagements {
+                    items {
+                      status {
+                        transitions {
+                          to
                         }
                       }
                     }
                   }
                 }
               }
-              hasMore
-              total
             }
+            hasMore
+            total
           }
-        `),
-      );
-      expect(result).toBeTruthy();
-    },
-  );
+        }
+      `),
+    );
+    expect(result).toBeTruthy();
+  });
 
-  itPgPending(
-    'The list of projects the language is engagement in',
-    async () => {
-      const numProjects = 1;
-      const language = await createLanguage(app);
-      const project = await createProject(app);
+  it('The list of projects the language is engagement in', async () => {
+    const numProjects = 1;
+    const language = await createLanguage(app);
+    const project = await createProject(app);
 
-      await Promise.all(
-        times(numProjects).map(() =>
-          createLanguageEngagement(app, {
-            project: project.id,
-            language: language.id,
-          }),
-        ),
-      );
+    await Promise.all(
+      times(numProjects).map(() =>
+        createLanguageEngagement(app, {
+          project: project.id,
+          language: language.id,
+        }),
+      ),
+    );
 
-      const queryProject = await app.graphql.query(
-        graphql(
-          `
-            query language($id: ID!) {
-              language(id: $id) {
-                ...language
-                projects {
-                  items {
-                    ...project
-                  }
-                  hasMore
-                  total
+    const queryProject = await app.graphql.query(
+      graphql(
+        `
+          query language($id: ID!) {
+            language(id: $id) {
+              ...language
+              projects {
+                items {
+                  ...project
                 }
+                hasMore
+                total
               }
             }
-          `,
-          [fragments.language, fragments.project],
-        ),
-        {
-          id: language.id,
-        },
-      );
-      expect(queryProject.language.projects.items.length).toBe(numProjects);
-      expect(queryProject.language.projects.total).toBe(numProjects);
-    },
-  );
+          }
+        `,
+        [fragments.language, fragments.project],
+      ),
+      {
+        id: language.id,
+      },
+    );
+    expect(queryProject.language.projects.items.length).toBe(numProjects);
+    expect(queryProject.language.projects.total).toBe(numProjects);
+  });
 
   it('should throw error if signLanguageCode is not valid', async () => {
     const signLanguageCode = 'XXX1';
@@ -343,64 +331,58 @@ describe('Language e2e', () => {
     );
   });
 
-  itPgPending(
-    'should throw error if trying to set hasExternalFirstScripture=true while language has engagements that have firstScripture=true',
-    async () => {
-      const language = await createLanguage(app);
-      await createLanguageEngagement(app, {
-        language: language.id,
-        firstScripture: true,
-      });
+  it('should throw error if trying to set hasExternalFirstScripture=true while language has engagements that have firstScripture=true', async () => {
+    const language = await createLanguage(app);
+    await createLanguageEngagement(app, {
+      language: language.id,
+      firstScripture: true,
+    });
 
-      await expect(
-        app.graphql.mutate(
-          graphql(
-            `
-              mutation updateLanguage($input: UpdateLanguage!) {
-                updateLanguage(input: $input) {
-                  language {
-                    ...language
-                  }
+    await expect(
+      app.graphql.mutate(
+        graphql(
+          `
+            mutation updateLanguage($input: UpdateLanguage!) {
+              updateLanguage(input: $input) {
+                language {
+                  ...language
                 }
               }
-            `,
-            [fragments.language],
-          ),
-          {
-            input: {
-              id: language.id,
-              hasExternalFirstScripture: true,
-            },
-          },
+            }
+          `,
+          [fragments.language],
         ),
-      ).rejects.toThrowGqlError(
-        errors.input({
-          message:
-            'hasExternalFirstScripture can be set to true if the language has no engagements that have firstScripture=true',
-          field: 'hasExternalFirstScripture',
-        }),
-      );
-    },
-  );
+        {
+          input: {
+            id: language.id,
+            hasExternalFirstScripture: true,
+          },
+        },
+      ),
+    ).rejects.toThrowGqlError(
+      errors.input({
+        message:
+          'hasExternalFirstScripture can be set to true if the language has no engagements that have firstScripture=true',
+        field: 'hasExternalFirstScripture',
+      }),
+    );
+  });
 
-  itPgPending(
-    'can set hasExternalFirstScripture=true if language has no engagements that have firstScripture=true',
-    async () => {
-      const language = await createLanguage(app);
-      await createLanguageEngagement(app, {
-        language: language.id,
-        firstScripture: false,
-      });
+  it('can set hasExternalFirstScripture=true if language has no engagements that have firstScripture=true', async () => {
+    const language = await createLanguage(app);
+    await createLanguageEngagement(app, {
+      language: language.id,
+      firstScripture: false,
+    });
 
-      const updated = await updateLanguage(app, {
-        id: language.id,
-        hasExternalFirstScripture: true,
-      });
-      expect(updated.hasExternalFirstScripture.value).toBe(true);
-    },
-  );
+    const updated = await updateLanguage(app, {
+      id: language.id,
+      hasExternalFirstScripture: true,
+    });
+    expect(updated.hasExternalFirstScripture.value).toBe(true);
+  });
 
-  itPgPending('presetInventory flag', async () => {
+  it('presetInventory flag', async () => {
     const project = await createProject(app, { presetInventory: true });
     const language = await createLanguage(app);
     await createLanguageEngagement(app, {
@@ -427,7 +409,7 @@ describe('Language e2e', () => {
     expect(actual.presetInventory.value).toBe(true);
   });
 
-  itPgPending('List view of languages by presetInventory flag', async () => {
+  it('List view of languages by presetInventory flag', async () => {
     const numLanguages = 2;
 
     await Promise.all(times(numLanguages).map(() => createLanguage(app)));

--- a/test/utility/create-location.ts
+++ b/test/utility/create-location.ts
@@ -6,6 +6,13 @@ import { graphql, type InputOf } from '~/graphql';
 import { type TestApp } from './create-app';
 import * as fragments from './fragments';
 
+// Deal codes from a shuffled deck instead of sampling — the PG partial unique
+// on iso_alpha3 makes random real-code collisions across a spec file likely
+// (only ~250 codes exist). Wraps around if a spec ever exhausts the deck.
+const isoDeck = faker.helpers.shuffle(countries().map((c) => c.alpha3));
+let isoDeckIdx = 0;
+const nextIso = () => isoDeck[isoDeckIdx++ % isoDeck.length]!;
+
 export async function createLocation(
   app: TestApp,
   input: Partial<InputOf<typeof CreateLocationDoc>> = {},
@@ -14,7 +21,7 @@ export async function createLocation(
   const result = await app.graphql.mutate(CreateLocationDoc, {
     input: {
       type: 'County',
-      isoAlpha3: faker.helpers.arrayElement(countries()).alpha3,
+      isoAlpha3: nextIso(),
       ...input,
       name,
     },


### PR DESCRIPTION
### What's in scope

- `engagements` table (migration 0017): single-table inheritance over Language/Internship with a type-shape CHECK (same approach as projects); partial uniques on (project, language) and (project, intern) among live rows; 5 pgEnums (engagement_type, engagement_status, language_milestone, ai_assisted_translation, ceremony_type). `ceremonies` table with its engagement-scoped partial unique.
- `EngagementDrizzleRepository` (+800) and `CeremonyDrizzleRepository` with splitDb wiring; status-change side effects (statusModifiedAt / lastSuspendedAt / lastReactivatedAt + status history) stamped in-transaction, replacing the SetLastStatusDate handler under postgres.
- Language's engagement-derived reads restored to real queries (effectiveSensitivity, presetInventory, usesAIAssistance, firstScriptureEngagement, partnerId filter) — closes the interim stubs from #3825; Project's engagementTotal likewise.
- Auth: real Language/Engagement/Ceremony member + sensitivity condition arms replace the interim ones; **U12** — `IsInternCondition.asDrizzleCondition` + batched `isIntern` hydrate at every user toDto call site (Marketing's intern prop-edits were fail-closed under postgres).
- `EngagementFilters`: type/status/project-id/languageId/partnerId/marketable/milestone*/AI implemented; the 7 cross-domain filters throw NotImplemented rather than silently ignoring (name, engagedName, date ranges, language/intern/tool subs) — each tagged with its restoration point.

### Design decisions

- `lastReactivatedAt` only stamps on Suspended→Active, mirroring the Neo4j handler exactly.
- The engagements type-shape CHECK guarantees intern_id/language_id exclusivity, which the isIntern SQL and the condition arms lean on.
- Project sensitivity denormalization recomputes from all three mutation points (engagement create/delete, language sensitivity update), so the MIN-sensitivity arms never read stale defaults.

### Validation

- Postgres e2e: engagement 30 passed / 2 skipped (Product boundary, tagged), language 17/17 (all six deferred legs un-skipped), user 12/12.
- Neo4j e2e: no behavior change — the port and U12 touch postgres-only paths.
- `yarn type-check` and `yarn lint` clean; migrations 0000–0017 apply to a fresh DB.
