### PR TITLE
Fix swapped UserUpdatedHook args killing director-removal restrictions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,12 @@ jobs:
         run: yarn start -- --gen-schema && yarn gql-tada generate output
 
       - name: E2E Tests
-        run: yarn test:e2e --shard=${{ matrix.shard }}/${{ matrix.total || 6 }} --reporters=github-actions ${{ matrix.test-args }}
+        # --maxWorkers=1: the per-file Neo4j wipe requires spec files to run
+        # sequentially — the shard's Neo4j container is shared, so a wipe at
+        # one file's end would destroy a concurrently-running file's data.
+        # Runner core-counts already made this effectively serial; pin it so a
+        # beefier runner can't silently reintroduce the race.
+        run: yarn test:e2e --maxWorkers=1 --shard=${{ matrix.shard }}/${{ matrix.total || 6 }} --reporters=github-actions ${{ matrix.test-args }}
         env:
           NEO4J_VERSION: ${{ matrix.neo4j-version }}
           DATABASE: ${{ matrix.database }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,12 @@ jobs:
         # one file's end would destroy a concurrently-running file's data.
         # Runner core-counts already made this effectively serial; pin it so a
         # beefier runner can't silently reintroduce the race.
-        run: yarn test:e2e --maxWorkers=1 --shard=${{ matrix.shard }}/${{ matrix.total || 6 }} --reporters=github-actions ${{ matrix.test-args }}
+        # --workerIdleMemoryLimit: with one worker, EVERY spec file's app runs
+        # in the same long-lived process — teardown leaks accumulate and blow
+        # V8's default 4GB heap cap late in the shard (all-shards OOM,
+        # 2026-07-14). Recycling the worker between files when it bloats keeps
+        # serial semantics with bounded memory.
+        run: yarn test:e2e --maxWorkers=1 --workerIdleMemoryLimit=1500MB --shard=${{ matrix.shard }}/${{ matrix.total || 6 }} --reporters=github-actions ${{ matrix.test-args }}
         env:
           NEO4J_VERSION: ${{ matrix.neo4j-version }}
           DATABASE: ${{ matrix.database }}

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -131,7 +131,7 @@ export class UserService {
     };
     const updated = await this.userRepo.update(input);
 
-    const event = new UserUpdatedHook(user, updated, input);
+    const event = new UserUpdatedHook(updated, user, input);
     await this.hooks.run(event);
 
     return this.secure(updated);

--- a/test/region.e2e-spec.ts
+++ b/test/region.e2e-spec.ts
@@ -8,6 +8,7 @@ import {
   createSession,
   createTestApp,
   createZone,
+  errors,
   fragments,
   loginAsAdmin,
   type TestApp,
@@ -37,6 +38,37 @@ describe('Region e2e', () => {
       fieldZone: fieldZone.id,
     });
     expect(region.id).toBeDefined();
+  });
+
+  it('restricts removing the director role while they still direct a region', async () => {
+    const regionDirector = await createPerson(app, {
+      roles: [Role.RegionalDirector],
+    });
+    await createRegion(app, {
+      director: regionDirector.id,
+      fieldZone: fieldZone.id,
+    });
+
+    await expect(
+      app.graphql.mutate(
+        graphql(`
+          mutation updateUser($input: UpdateUser!) {
+            updateUser(input: $input) {
+              user {
+                id
+              }
+            }
+          }
+        `),
+        { input: { id: regionDirector.id, roles: [] } },
+      ),
+    ).rejects.toThrowGqlError(
+      errors.input({
+        message: expect.stringContaining(
+          'still a director for these field regions',
+        ),
+      }),
+    );
   });
 
   it.skip('should have unique name', async () => {

--- a/test/setup/neo4j-wipe.ts
+++ b/test/setup/neo4j-wipe.ts
@@ -14,15 +14,15 @@ import * as Neo from 'neo4j-driver';
  * Safety — this deletes EVERY node in the target database, so two independent
  * gates keep it away from real data (the local compose `db` is a long-lived
  * dev database and the cutover-ETL source; prod runs Neo4j until the PG flip):
- * 1. `NEO4J_TEST_WIPE` must be explicitly set — only the CI workflow sets it.
- *    Nothing keys off ambient env like `CI`, so self-hosted runners or local
- *    shells can't trip it by accident.
+ * 1. `NEO4J_TEST_WIPE` must be explicitly set to `true` — only the CI
+ *    workflow sets it. Nothing keys off ambient env like `CI`, so self-hosted
+ *    runners or local shells can't trip it by accident.
  * 2. The target host must be loopback. A wipe opt-in pointed at a remote host
  *    is always a misconfiguration — we throw loudly instead of silently
  *    skipping, so the flake this exists to fix can't quietly return.
  */
 export const wipeNeo4jAfterFile = async () => {
-  if (!process.env.NEO4J_TEST_WIPE) return;
+  if (process.env.NEO4J_TEST_WIPE !== 'true') return;
   const url = process.env.NEO4J_URL ?? 'bolt://localhost';
   const host = new URL(url).hostname;
   const loopback = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);

--- a/test/zone.e2e-spec.ts
+++ b/test/zone.e2e-spec.ts
@@ -8,6 +8,7 @@ import {
   createSession,
   createTestApp,
   createZone,
+  errors,
   fragments,
   loginAsAdmin,
   type TestApp,
@@ -106,6 +107,34 @@ describe('Field Zone e2e', () => {
     expect(updated).toBeTruthy();
     expect(updated.id).toBe(fieldZone.id);
     expect(updated.name.value).toBe(newName);
+  });
+
+  it('restricts removing the director role while they still direct a zone', async () => {
+    const zoneDirector = await createPerson(app, {
+      roles: ['FieldOperationsDirector'],
+    });
+    await createZone(app, { director: zoneDirector.id });
+
+    await expect(
+      app.graphql.mutate(
+        graphql(`
+          mutation updateUser($input: UpdateUser!) {
+            updateUser(input: $input) {
+              user {
+                id
+              }
+            }
+          }
+        `),
+        { input: { id: zoneDirector.id, roles: [] } },
+      ),
+    ).rejects.toThrowGqlError(
+      errors.input({
+        message: expect.stringContaining(
+          'still a director for these field zones',
+        ),
+      }),
+    );
   });
 
   // This function in location service should be updated because one session couldn't be connected to several users at a time.


### PR DESCRIPTION
### UserUpdatedHook arg swap

- `UserUpdatedHook`'s constructor is `(updated, previous, input)`, but `user.service.ts` passed `(user, updated, input)` — every handler saw the two states reversed since #3634 (Feb 9).
- The only consumers are the region/zone director-removal guards, whose "role was removed" check therefore computed "role was added": removing `RegionalDirector` / `FieldOperationsDirector` from an acting director sailed through, leaving regions/zones pointing at a director without the role.
- One-line arg swap + regression e2e legs on both handlers — verified the legs fail without the fix and pass with it, under both engines.

### e2e CI worker pin (completes #3826)

- #3826 merged without its final review commit, so the per-file Neo4j wipe went live while Jest still runs spec files in parallel within a shard — a finishing file's wipe deletes the shared graph under a concurrently-running one. First hit: #3827's neo4j shard 3 (webhooks.e2e rxjs delivery timeouts).
- `--maxWorkers=1` on the e2e CI invocation makes the wipe's serial precondition explicit, and `NEO4J_TEST_WIPE` tightens to an exact `'true'` check.
