### PR TITLE
[pg] Product family → Postgres (Drizzle), migration 0018

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
             shard: 1
             total: 1
             test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony)\."
+              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony|product|film|story|project-workflow)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/src/components/ethno-art/ethno-art.drizzle.repository.ts
+++ b/src/components/ethno-art/ethno-art.drizzle.repository.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { ProducibleDrizzleRepository } from '../product/producible.drizzle.repository';
+import { EthnoArt } from './dto';
+
+@Injectable()
+export class EthnoArtDrizzleRepository extends ProducibleDrizzleRepository<EthnoArt> {
+  constructor(db: DrizzleService) {
+    super(db, EthnoArt, 'EthnoArt');
+  }
+}

--- a/src/components/ethno-art/ethno-art.module.ts
+++ b/src/components/ethno-art/ethno-art.module.ts
@@ -2,6 +2,7 @@ import { forwardRef, Module } from '@nestjs/common';
 import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { ScriptureModule } from '../scripture/scripture.module';
+import { EthnoArtDrizzleRepository } from './ethno-art.drizzle.repository';
 import { EthnoArtGelRepository } from './ethno-art.gel.repository';
 import { EthnoArtLoader } from './ethno-art.loader';
 import { EthnoArtRepository } from './ethno-art.repository';
@@ -15,6 +16,9 @@ import { EthnoArtService } from './ethno-art.service';
     EthnoArtResolver,
     splitDb(EthnoArtRepository, {
       gel: EthnoArtGelRepository,
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: EthnoArtDrizzleRepository as any,
     }),
     EthnoArtService,
   ],

--- a/src/components/ethno-art/ethno-art.repository.ts
+++ b/src/components/ethno-art/ethno-art.repository.ts
@@ -81,6 +81,10 @@ export class EthnoArtRepository extends DtoRepository(EthnoArt) {
     return await this.readOne(input.id);
   }
 
+  async delete(id: ID) {
+    await this.deleteNode(id);
+  }
+
   async readOne(id: ID) {
     return (await super.readOne(id)) as UnsecuredDto<EthnoArt>;
   }

--- a/src/components/ethno-art/ethno-art.service.ts
+++ b/src/components/ethno-art/ethno-art.service.ts
@@ -71,7 +71,7 @@ export class EthnoArtService {
     this.privileges.for(EthnoArt, ethnoArt).verifyCan('delete');
 
     try {
-      await this.repo.deleteNode(ethnoArt);
+      await this.repo.delete(ethnoArt.id);
     } catch (exception) {
       throw new ServerException('Failed to delete', exception);
     }

--- a/src/components/film/film.drizzle.repository.ts
+++ b/src/components/film/film.drizzle.repository.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { ProducibleDrizzleRepository } from '../product/producible.drizzle.repository';
+import { Film } from './dto';
+
+@Injectable()
+export class FilmDrizzleRepository extends ProducibleDrizzleRepository<Film> {
+  constructor(db: DrizzleService) {
+    super(db, Film, 'Film');
+  }
+}

--- a/src/components/film/film.module.ts
+++ b/src/components/film/film.module.ts
@@ -2,6 +2,7 @@ import { forwardRef, Module } from '@nestjs/common';
 import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { ScriptureModule } from '../scripture';
+import { FilmDrizzleRepository } from './film.drizzle.repository';
 import { FilmGelRepository } from './film.gel.repository';
 import { FilmLoader } from './film.loader';
 import { FilmRepository } from './film.repository';
@@ -15,6 +16,9 @@ import { FilmService } from './film.service';
     FilmService,
     splitDb(FilmRepository, {
       gel: FilmGelRepository,
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: FilmDrizzleRepository as any,
     }),
     FilmLoader,
   ],

--- a/src/components/film/film.repository.ts
+++ b/src/components/film/film.repository.ts
@@ -81,6 +81,10 @@ export class FilmRepository extends DtoRepository(Film) {
     return await this.readOne(input.id);
   }
 
+  async delete(id: ID) {
+    await this.deleteNode(id);
+  }
+
   async readOne(id: ID) {
     return (await super.readOne(id)) as UnsecuredDto<Film>;
   }

--- a/src/components/film/film.service.ts
+++ b/src/components/film/film.service.ts
@@ -67,7 +67,7 @@ export class FilmService {
     this.privileges.for(Film, film).verifyCan('delete');
 
     try {
-      await this.repo.deleteNode(film);
+      await this.repo.delete(film.id);
     } catch (exception) {
       throw new ServerException('Failed to delete', exception);
     }

--- a/src/components/product/producible.drizzle.repository.ts
+++ b/src/components/product/producible.drizzle.repository.ts
@@ -1,0 +1,150 @@
+import { sortBy } from '@seedcompany/common';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  generateId,
+  type ID,
+  type Order,
+  type PaginatedListType,
+  type Range,
+  type ResourceShape,
+  type SecuredString,
+  type UnsecuredDto,
+} from '~/common';
+import {
+  DrizzleDtoRepository,
+  resolveOrderBy,
+  type SortMap,
+} from '~/core/drizzle';
+import { type DrizzleService } from '~/core/drizzle/drizzle.service';
+import { catchUniqueViolation } from '~/core/drizzle/errors';
+import { producibles } from '~/core/drizzle/schema';
+import { ScriptureRange, type ScriptureRangeInput } from '../scripture/dto';
+import { type Producible } from './dto';
+
+type ProducibleTypeName = (typeof producibles.type.enumValues)[number];
+
+type ProducibleDto = Producible & { name: SecuredString };
+
+const parseRefs = (refs: ReadonlyArray<Range<number>>) =>
+  sortBy(refs, [(r) => r.start, (r) => r.end]).map(ScriptureRange.fromIds);
+
+/**
+ * Shared CRUD for the shape-identical producibles (Film / Story / EthnoArt) —
+ * one table, the `type` column standing in for the Neo4j label. Each concrete
+ * repo pins its discriminator and inherits everything.
+ */
+export abstract class ProducibleDrizzleRepository<
+  TDto extends ProducibleDto,
+> extends DrizzleDtoRepository<typeof producibles, TDto> {
+  protected constructor(
+    db: DrizzleService,
+    dto: ResourceShape<TDto>,
+    protected readonly type: ProducibleTypeName,
+  ) {
+    super(db, producibles, dto);
+  }
+
+  async create(input: {
+    name: string;
+    scriptureReferences?: readonly ScriptureRangeInput[];
+  }): Promise<UnsecuredDto<TDto>> {
+    const id = await generateId();
+    await this.db
+      .insert(producibles)
+      .values({
+        id,
+        type: this.type,
+        name: input.name,
+        scriptureReferences: (input.scriptureReferences ?? []).map(
+          ScriptureRange.fromReferences,
+        ),
+      })
+      .catch(
+        catchUniqueViolation(
+          'producibles_type_name_active_unique',
+          'name',
+          `${this.type} with this name already exists`,
+        ),
+      );
+    return await this.readOne(id);
+  }
+
+  async update(changes: {
+    id: ID;
+    name?: string;
+    scriptureReferences?: readonly ScriptureRangeInput[] | null;
+  }): Promise<UnsecuredDto<TDto>> {
+    const { id, name, scriptureReferences } = changes;
+    await this.updateColumns(id, {
+      name,
+      ...(scriptureReferences !== undefined && {
+        scriptureReferences: (scriptureReferences ?? []).map(
+          ScriptureRange.fromReferences,
+        ),
+      }),
+    }).catch(
+      catchUniqueViolation(
+        'producibles_type_name_active_unique',
+        'name',
+        `${this.type} with this name already exists`,
+      ),
+    );
+    return await this.readOne(id);
+  }
+
+  override async readMany(
+    ids: readonly ID[],
+  ): Promise<Array<UnsecuredDto<TDto>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db
+      .select()
+      .from(producibles)
+      .where(
+        and(
+          inArray(producibles.id, [...ids]),
+          eq(producibles.type, this.type),
+          isNull(producibles.deletedAt),
+        ),
+      );
+    return rows.map((row) => this.toDto(row));
+  }
+
+  async delete(id: ID): Promise<void> {
+    await this.softDelete(id);
+  }
+
+  async list(input: {
+    sort: string;
+    order: Order;
+    page: number;
+    count: number;
+  }): Promise<PaginatedListType<UnsecuredDto<TDto>>> {
+    const sortColumns = {
+      name: producibles.name,
+      createdAt: producibles.createdAt,
+    } satisfies SortMap<string>;
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: and(
+        eq(producibles.type, this.type),
+        isNull(producibles.deletedAt),
+      ),
+      orderBy: resolveOrderBy(input, sortColumns, producibles.name),
+      page: input.page,
+      count: input.count,
+    });
+    return { total, hasMore, items: rows.map((row) => this.toDto(row)) };
+  }
+
+  protected toDto(row: typeof producibles.$inferSelect): UnsecuredDto<TDto> {
+    const dto: unknown = {
+      id: row.id,
+      __typename: this.type,
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      name: row.name,
+      scriptureReferences: parseRefs(row.scriptureReferences),
+      canDelete: true,
+    };
+    return dto as UnsecuredDto<TDto>;
+  }
+}

--- a/src/components/product/producible.drizzle.repository.ts
+++ b/src/components/product/producible.drizzle.repository.ts
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon';
 import {
   generateId,
   type ID,
+  NotFoundException,
   type Order,
   type PaginatedListType,
   type Range,
@@ -70,12 +71,36 @@ export abstract class ProducibleDrizzleRepository<
     return await this.readOne(id);
   }
 
+  /**
+   * Neo4j scoped every mutation by label; on the shared table the base
+   * `updateColumns`/`softDelete` helpers filter by id alone, so without this
+   * guard a Film mutation could hit a Story row via a cross-type id. Fails
+   * closed with NotFound, matching the Neo4j no-label-match behavior.
+   */
+  private async verifyType(id: ID): Promise<void> {
+    const rows = await this.db
+      .select({ id: producibles.id })
+      .from(producibles)
+      .where(
+        and(
+          eq(producibles.id, id),
+          eq(producibles.type, this.type),
+          isNull(producibles.deletedAt),
+        ),
+      )
+      .limit(1);
+    if (rows.length === 0) {
+      throw new NotFoundException(`Could not find ${this.type}`);
+    }
+  }
+
   async update(changes: {
     id: ID;
     name?: string;
     scriptureReferences?: readonly ScriptureRangeInput[] | null;
   }): Promise<UnsecuredDto<TDto>> {
     const { id, name, scriptureReferences } = changes;
+    await this.verifyType(id);
     await this.updateColumns(id, {
       name,
       ...(scriptureReferences !== undefined && {
@@ -111,6 +136,7 @@ export abstract class ProducibleDrizzleRepository<
   }
 
   async delete(id: ID): Promise<void> {
+    await this.verifyType(id);
     await this.softDelete(id);
   }
 

--- a/src/components/product/product.drizzle.repository.ts
+++ b/src/components/product/product.drizzle.repository.ts
@@ -1,0 +1,646 @@
+import { Injectable } from '@nestjs/common';
+import { sortBy } from '@seedcompany/common';
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  ilike,
+  inArray,
+  isNotNull,
+  isNull,
+  type SQL,
+} from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  CreationFailed,
+  generateId,
+  type ID,
+  isSecured,
+  type Range,
+  ServerException,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import { type DbChanges, getChanges } from '~/core/database/changes';
+import {
+  DrizzleService,
+  escapeLikePattern,
+  resolveOrderBy,
+  type SortMap,
+} from '~/core/drizzle';
+import {
+  engagements,
+  producibles,
+  productCompletionDescriptions,
+  products,
+} from '~/core/drizzle/schema';
+import { type BaseNode } from '~/core/neo4j/results';
+import { type ScopedRole } from '../authorization/dto/role.dto';
+import { requesterScopeByProject } from '../project/project-member/membership-scope';
+import {
+  ScriptureRange,
+  type UnspecifiedScripturePortionInput,
+} from '../scripture/dto';
+import {
+  ApproachToMethodologies,
+  type CreateDerivativeScriptureProduct,
+  type CreateDirectScriptureProduct,
+  type CreateOtherProduct,
+  DerivativeScriptureProduct,
+  DirectScriptureProduct,
+  type ProductMethodology as Methodology,
+  OtherProduct,
+  type ProducibleType,
+  type Product,
+  type ProductCompletionDescriptionSuggestionsInput,
+  type ProductListInput,
+} from './dto';
+import { type HydratedProductRow } from './product.repository';
+
+type ProductRow = typeof products.$inferSelect & {
+  engagement?: {
+    id: ID<'Engagement'>;
+    project?: { id: ID<'Project'>; sensitivity: string } | null;
+  } | null;
+  produces?: typeof producibles.$inferSelect | null;
+};
+
+const RELATIONS = {
+  engagement: {
+    columns: { id: true },
+    with: { project: { columns: { id: true, sensitivity: true } } },
+  },
+  produces: true,
+} as const;
+
+/** The Neo4j label each concrete product type carries ⟷ the discriminator. */
+const PRODUCT_TYPE_BY_LABEL: Record<
+  string,
+  (typeof products.type.enumValues)[number]
+> = {
+  DirectScriptureProduct: 'DirectScripture',
+  DerivativeScriptureProduct: 'Derivative',
+  OtherProduct: 'Other',
+};
+
+const PRODUCIBLE_TYPES = producibles.type.enumValues;
+
+const parseRefs = (refs: ReadonlyArray<Range<number>>) =>
+  sortBy(refs, [(r) => r.start, (r) => r.end]).map(ScriptureRange.fromIds);
+
+/**
+ * Columns the generic `update*Properties()` calls may touch — everything else
+ * (scripture refs, produces, unspecified portion) flows through its own
+ * dedicated method, mirroring the Neo4j repo's split.
+ */
+const SIMPLE_CHANGE_COLUMNS = [
+  'mediums',
+  'purposes',
+  'methodology',
+  'steps',
+  'describeCompletion',
+  'placeholderDescription',
+  'progressStepMeasurement',
+  'progressTarget',
+  'totalVerses',
+  'totalVerseEquivalents',
+  'composite',
+  'title',
+  'description',
+] as const;
+
+@Injectable()
+export class ProductDrizzleRepository {
+  constructor(
+    private readonly drizzle: DrizzleService,
+    private readonly identity: Identity,
+  ) {}
+
+  // Transaction-aware client — see DrizzleDtoRepository.db for why a getter.
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  getActualDirectChanges = getChanges(DirectScriptureProduct);
+  getActualDerivativeChanges = getChanges(DerivativeScriptureProduct);
+  getActualOtherChanges = getChanges(OtherProduct);
+
+  async readMany(ids: readonly ID[]): Promise<HydratedProductRow[]> {
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.products.findMany({
+      where: (p) => and(inArray(p.id, [...ids]), isNull(p.deletedAt)),
+      with: RELATIONS,
+    });
+    return await this.hydrate(rows as ProductRow[]);
+  }
+
+  private async hydrate(rows: ProductRow[]): Promise<HydratedProductRow[]> {
+    const scopeByProject = await requesterScopeByProject(
+      this.db,
+      this.identity.current.userId,
+      rows.flatMap((r) => r.engagement?.project?.id ?? []),
+    );
+    return rows.map((row) =>
+      this.mapRow(
+        row,
+        row.engagement?.project
+          ? (scopeByProject.get(row.engagement.project.id) ?? [])
+          : [],
+      ),
+    );
+  }
+
+  private mapRow(row: ProductRow, scope: ScopedRole[]): HydratedProductRow {
+    if (!row.engagement?.project) {
+      throw new ServerException(
+        `Product ${row.id} has no parent engagement/project row — FK invariant violated`,
+      );
+    }
+    const isDerivative = row.type === 'Derivative';
+    const isOther = row.type === 'Other';
+    const produces =
+      isDerivative && row.produces
+        ? {
+            id: row.produces.id,
+            // Shaped like Neo4j's labels(produces) for
+            // ResourceResolver.resolveType().
+            __typename: [row.produces.type, 'Producible'],
+            createdAt: DateTime.fromJSDate(row.produces.createdAt),
+            name: row.produces.name,
+            scriptureReferences: parseRefs(row.produces.scriptureReferences),
+            canDelete: true,
+          }
+        : null;
+    const ownRefs = isDerivative
+      ? (row.scriptureReferencesOverride ?? [])
+      : row.scriptureReferences;
+    const dto: unknown = {
+      id: row.id,
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      engagement: row.engagementId,
+      project: row.engagement.project.id,
+      sensitivity: row.engagement.project.sensitivity,
+      scope,
+      canDelete: true,
+      mediums: row.mediums,
+      purposes: row.purposes,
+      methodology: row.methodology,
+      steps: row.steps,
+      describeCompletion: row.describeCompletion,
+      placeholderDescription: row.placeholderDescription,
+      progressStepMeasurement: row.progressStepMeasurement,
+      progressTarget: row.progressTarget,
+      totalVerses: row.totalVerses,
+      totalVerseEquivalents: row.totalVerseEquivalents,
+      pnpIndex: row.pnpIndex ?? undefined,
+      scriptureReferences: parseRefs(ownRefs),
+      isOverriding: isDerivative && row.scriptureReferencesOverride !== null,
+      produces,
+      unspecifiedScripture:
+        row.unspecifiedScriptureBook != null &&
+        row.unspecifiedScriptureTotalVerses != null
+          ? {
+              book: row.unspecifiedScriptureBook,
+              totalVerses: row.unspecifiedScriptureTotalVerses,
+            }
+          : null,
+      ...(isDerivative && { composite: row.composite ?? false }),
+      title: isOther ? row.title : null,
+      description: isOther ? row.description : null,
+    };
+    return dto as HydratedProductRow;
+  }
+
+  /**
+   * Lookup shim for the service's pre-flight existence checks. Returns a
+   * Neo4j-shaped BaseNode so `ResourceResolver.resolveTypeByBaseNode()` keeps
+   * working — only `labels` and `properties.{id,createdAt}` are consumed.
+   */
+  async getBaseNode(id: ID, label?: unknown): Promise<BaseNode | undefined> {
+    const asBaseNode = (labels: string[], createdAt: Date): BaseNode => ({
+      identity: id,
+      labels: [...labels, 'BaseNode'],
+      properties: { id, createdAt: DateTime.fromJSDate(createdAt) },
+    });
+    if (label === 'Engagement') {
+      const [row] = await this.db
+        .select({ type: engagements.type, createdAt: engagements.createdAt })
+        .from(engagements)
+        .where(and(eq(engagements.id, id), isNull(engagements.deletedAt)));
+      return row
+        ? asBaseNode([`${row.type}Engagement`, 'Engagement'], row.createdAt)
+        : undefined;
+    }
+    if (label === 'Producible') {
+      const [row] = await this.db
+        .select({ type: producibles.type, createdAt: producibles.createdAt })
+        .from(producibles)
+        .where(and(eq(producibles.id, id), isNull(producibles.deletedAt)));
+      return row
+        ? asBaseNode([row.type, 'Producible'], row.createdAt)
+        : undefined;
+    }
+    throw new ServerException(
+      `ProductDrizzleRepository.getBaseNode: label ${String(
+        label,
+      )} not supported`,
+    );
+  }
+
+  async findProducible(produces: ID | undefined) {
+    if (!produces) return undefined;
+    const [row] = await this.db
+      .select({ id: producibles.id })
+      .from(producibles)
+      .where(and(eq(producibles.id, produces), isNull(producibles.deletedAt)));
+    return row;
+  }
+
+  async create(
+    input: (CreateDerivativeScriptureProduct | CreateDirectScriptureProduct) & {
+      totalVerses: number;
+      totalVerseEquivalents: number;
+    },
+  ): Promise<ID> {
+    const isDerivative = 'produces' in input && !!input.produces;
+    const Product = isDerivative
+      ? DerivativeScriptureProduct
+      : DirectScriptureProduct;
+    await this.verifyLanguageEngagement(input.engagement, Product);
+    const id = await generateId<ID<'Product'>>();
+    const derivative = isDerivative
+      ? (input as CreateDerivativeScriptureProduct)
+      : undefined;
+    const direct = !isDerivative
+      ? (input as CreateDirectScriptureProduct)
+      : undefined;
+    await this.db.insert(products).values({
+      id,
+      engagementId: input.engagement,
+      type: isDerivative ? 'Derivative' : 'DirectScripture',
+      mediums: input.mediums ?? [],
+      purposes: input.purposes ?? [],
+      methodology: input.methodology,
+      steps: input.steps ?? [],
+      describeCompletion: input.describeCompletion,
+      placeholderDescription: input.placeholderDescription,
+      progressTarget: input.progressTarget,
+      progressStepMeasurement: input.progressStepMeasurement ?? 'Percent',
+      totalVerses: input.totalVerses,
+      totalVerseEquivalents: input.totalVerseEquivalents,
+      pnpIndex: input.pnpIndex,
+      createdAt: input.createdAt?.toJSDate(),
+      ...(derivative && {
+        producesId: derivative.produces,
+        composite: derivative.composite ?? false,
+        scriptureReferencesOverride: derivative.scriptureReferencesOverride
+          ? derivative.scriptureReferencesOverride.map(
+              ScriptureRange.fromReferences,
+            )
+          : null,
+      }),
+      ...(direct && {
+        scriptureReferences: (direct.scriptureReferences ?? []).map(
+          ScriptureRange.fromReferences,
+        ),
+        ...(direct.unspecifiedScripture && {
+          unspecifiedScriptureBook: direct.unspecifiedScripture.book,
+          unspecifiedScriptureTotalVerses:
+            direct.unspecifiedScripture.totalVerses,
+        }),
+      }),
+    });
+    return id;
+  }
+
+  async createOther(input: CreateOtherProduct): Promise<ID> {
+    await this.verifyLanguageEngagement(input.engagement, OtherProduct);
+    const id = await generateId<ID<'Product'>>();
+    await this.db.insert(products).values({
+      id,
+      engagementId: input.engagement,
+      type: 'Other',
+      title: input.title,
+      description: input.description,
+      mediums: input.mediums ?? [],
+      purposes: input.purposes ?? [],
+      methodology: input.methodology,
+      steps: input.steps ?? [],
+      describeCompletion: input.describeCompletion,
+      placeholderDescription: input.placeholderDescription,
+      progressTarget: input.progressTarget,
+      progressStepMeasurement: input.progressStepMeasurement ?? 'Percent',
+    });
+    return id;
+  }
+
+  /**
+   * Products hang off LanguageEngagements only — the Neo4j repo enforces this
+   * via the typed relationship target; here it's a pre-flight check.
+   */
+  private async verifyLanguageEngagement(
+    engagementId: ID,
+    resource: ConstructorParameters<typeof CreationFailed>[0],
+  ) {
+    const [eng] = await this.db
+      .select({ type: engagements.type })
+      .from(engagements)
+      .where(
+        and(eq(engagements.id, engagementId), isNull(engagements.deletedAt)),
+      );
+    if (!eng || eng.type !== 'Language') {
+      throw new CreationFailed(resource);
+    }
+  }
+
+  async updateProperties(
+    object: DirectScriptureProduct,
+    changes: DbChanges<DirectScriptureProduct>,
+  ) {
+    return await this.applyChanges(object, changes);
+  }
+
+  async updateDerivativeProperties(
+    object: DerivativeScriptureProduct,
+    changes: DbChanges<DerivativeScriptureProduct>,
+  ) {
+    return await this.applyChanges(object, changes);
+  }
+
+  async updateOther(object: OtherProduct, changes: DbChanges<OtherProduct>) {
+    return await this.applyChanges(object, changes);
+  }
+
+  /**
+   * Write the simple-column subset of `changes`, then return `object` with
+   * the changes merged in (secured-aware), matching the Neo4j
+   * `db.updateProperties()` contract the service relies on.
+   */
+  private async applyChanges<T extends { id: ID }>(
+    object: T,
+    changes: Record<string, unknown>,
+  ): Promise<T> {
+    const cols: Record<string, unknown> = {};
+    for (const key of SIMPLE_CHANGE_COLUMNS) {
+      const value = changes[key];
+      if (value !== undefined) {
+        cols[key] = value;
+      }
+    }
+    if (Object.keys(cols).length > 0) {
+      cols.updatedAt = new Date();
+      await this.db
+        .update(products)
+        .set(cols)
+        .where(eq(products.id, object.id));
+    }
+    const updated: Record<string, unknown> = { ...object };
+    for (const [key, value] of Object.entries(changes)) {
+      if (value === undefined) continue;
+      const prev = updated[key];
+      updated[key] = isSecured(prev) ? { ...prev, value } : value;
+    }
+    return updated as T;
+  }
+
+  async updateProducible(input: { id: ID }, produces: ID) {
+    await this.db
+      .update(products)
+      .set({ producesId: produces, updatedAt: new Date() })
+      .where(eq(products.id, input.id));
+  }
+
+  async updateUnspecifiedScripture(
+    productId: ID,
+    input: UnspecifiedScripturePortionInput | null,
+  ) {
+    await this.db
+      .update(products)
+      .set({
+        unspecifiedScriptureBook: input?.book ?? null,
+        unspecifiedScriptureTotalVerses: input?.totalVerses ?? null,
+        updatedAt: new Date(),
+      })
+      .where(eq(products.id, productId));
+  }
+
+  async delete(id: ID, _resource?: unknown) {
+    await this.db
+      .update(products)
+      .set({ deletedAt: new Date(), updatedAt: new Date() })
+      .where(eq(products.id, id));
+  }
+
+  async list(input: ProductListInput) {
+    const { approach, methodology, placeholder, engagementId } =
+      input.filter ?? {};
+    const methodologies = [
+      ...(approach ? ApproachToMethodologies[approach] : []),
+      ...(methodology ? [methodology] : []),
+    ];
+    const conditions: SQL[] = [isNull(products.deletedAt)];
+    if (engagementId) {
+      conditions.push(eq(products.engagementId, engagementId));
+    }
+    if (methodologies.length > 0) {
+      conditions.push(inArray(products.methodology, methodologies));
+    }
+    if (placeholder !== undefined) {
+      conditions.push(
+        placeholder
+          ? isNotNull(products.placeholderDescription)
+          : isNull(products.placeholderDescription),
+      );
+    }
+    const predicate = and(...conditions);
+    const offset = (input.page - 1) * input.count;
+    const [countResult, idRows] = await Promise.all([
+      this.db.select({ total: count() }).from(products).where(predicate),
+      this.db
+        .select({ id: products.id })
+        .from(products)
+        .where(predicate)
+        .orderBy(
+          ...resolveOrderBy(
+            input,
+            // migration-todo: array/jsonb keys (mediums, purposes, steps,
+            // scriptureReferences) and relation-derived keys deliberately
+            // fall back to createdAt — the Neo4j `sorting(Product, input)`
+            // sorts any prop lexically, but no client sorts products by
+            // those; revisit at cutover if one appears.
+            {
+              createdAt: products.createdAt,
+              methodology: products.methodology,
+              describeCompletion: products.describeCompletion,
+              placeholderDescription: products.placeholderDescription,
+              progressStepMeasurement: products.progressStepMeasurement,
+              progressTarget: products.progressTarget,
+            } satisfies SortMap<keyof Product>,
+            products.createdAt,
+          ),
+          asc(products.id),
+        )
+        .limit(input.count)
+        .offset(offset),
+    ]);
+    const total = countResult[0]?.total ?? 0;
+    const items = await this.readMany(idRows.map((r) => r.id));
+    const byId = new Map(items.map((i) => [i.id, i]));
+    return {
+      total,
+      hasMore: offset + idRows.length < total,
+      items: idRows.map((r) => byId.get(r.id)!).filter(Boolean),
+    };
+  }
+
+  async mergeCompletionDescription(
+    description: string,
+    methodology: Methodology,
+  ) {
+    await this.db
+      .insert(productCompletionDescriptions)
+      .values({ value: description, methodology })
+      .onConflictDoUpdate({
+        target: [
+          productCompletionDescriptions.value,
+          productCompletionDescriptions.methodology,
+        ],
+        set: { lastUsedAt: new Date() },
+      });
+  }
+
+  async suggestCompletionDescriptions({
+    query: queryInput,
+    methodology,
+    ...input
+  }: ProductCompletionDescriptionSuggestionsInput) {
+    const conditions: SQL[] = [];
+    if (methodology) {
+      conditions.push(
+        eq(productCompletionDescriptions.methodology, methodology),
+      );
+    }
+    if (queryInput) {
+      conditions.push(
+        ilike(
+          productCompletionDescriptions.value,
+          `%${escapeLikePattern(queryInput)}%`,
+        ),
+      );
+    }
+    const predicate = conditions.length > 0 ? and(...conditions) : undefined;
+    const offset = (input.page - 1) * input.count;
+    const [countResult, rows] = await Promise.all([
+      this.db
+        .select({ total: count() })
+        .from(productCompletionDescriptions)
+        .where(predicate),
+      this.db
+        .select({ value: productCompletionDescriptions.value })
+        .from(productCompletionDescriptions)
+        .where(predicate)
+        // No Lucene relevance under PG — most-recently-used approximates it.
+        .orderBy(desc(productCompletionDescriptions.lastUsedAt))
+        .limit(input.count)
+        .offset(offset),
+    ]);
+    const total = countResult[0]?.total ?? 0;
+    return {
+      total,
+      hasMore: offset + rows.length < total,
+      items: rows.map((r) => r.value),
+    };
+  }
+
+  // ── PnP sync/extraction helpers (exercised on PnP upload — File domain) ──
+
+  async listIdsAndScriptureRefs(engagementId: ID) {
+    const rows = await this.db
+      .select({
+        id: products.id,
+        pnpIndex: products.pnpIndex,
+        scriptureReferences: products.scriptureReferences,
+        book: products.unspecifiedScriptureBook,
+        totalVerses: products.unspecifiedScriptureTotalVerses,
+      })
+      .from(products)
+      .where(
+        and(
+          eq(products.engagementId, engagementId),
+          eq(products.type, 'DirectScripture'),
+          isNull(products.deletedAt),
+        ),
+      );
+    return rows.map((row) => ({
+      id: row.id as ID,
+      pnpIndex: row.pnpIndex ?? undefined,
+      scriptureRanges: row.scriptureReferences,
+      unspecifiedScripture:
+        row.book != null && row.totalVerses != null
+          ? { book: row.book, totalVerses: row.totalVerses }
+          : null,
+    }));
+  }
+
+  async listIdsWithPnpIndexes(engagementId: ID, type?: string) {
+    const conditions: SQL[] = [
+      eq(products.engagementId, engagementId),
+      isNotNull(products.pnpIndex),
+      isNull(products.deletedAt),
+    ];
+    const mapped = type ? PRODUCT_TYPE_BY_LABEL[type] : undefined;
+    if (mapped) {
+      conditions.push(eq(products.type, mapped));
+    }
+    const rows = await this.db
+      .select({ id: products.id, pnpIndex: products.pnpIndex })
+      .from(products)
+      .where(and(...conditions));
+    return rows.map((row) => ({
+      id: row.id as ID,
+      pnpIndex: row.pnpIndex!,
+    }));
+  }
+
+  async listIdsWithProducibleNames(engagementId: ID, type?: ProducibleType) {
+    const producibleType = PRODUCIBLE_TYPES.find((t) => t === type);
+    if (type && !producibleType) {
+      // A concrete-product type was passed — no producible rows carry it.
+      return [];
+    }
+    const rows = await this.db
+      .select({ id: products.id, name: producibles.name })
+      .from(products)
+      .innerJoin(producibles, eq(products.producesId, producibles.id))
+      .where(
+        and(
+          eq(products.engagementId, engagementId),
+          isNull(products.deletedAt),
+          producibleType ? eq(producibles.type, producibleType) : undefined,
+        ),
+      );
+    return rows.map((row) => ({ id: row.id as ID, name: row.name }));
+  }
+
+  async getProducibleIdsByNames(
+    names: readonly string[],
+    type?: ProducibleType,
+  ) {
+    const producibleType = PRODUCIBLE_TYPES.find((t) => t === type);
+    if (type && !producibleType) {
+      return [];
+    }
+    const rows = await this.db
+      .select({ id: producibles.id, name: producibles.name })
+      .from(producibles)
+      .where(
+        and(
+          inArray(producibles.name, [...names]),
+          isNull(producibles.deletedAt),
+          producibleType ? eq(producibles.type, producibleType) : undefined,
+        ),
+      );
+    return rows.map((row) => ({ id: row.id as ID, name: row.name }));
+  }
+}

--- a/src/components/product/product.drizzle.repository.ts
+++ b/src/components/product/product.drizzle.repository.ts
@@ -590,6 +590,11 @@ export class ProductDrizzleRepository {
       isNull(products.deletedAt),
     ];
     const mapped = type ? PRODUCT_TYPE_BY_LABEL[type] : undefined;
+    // An unrecognized label matches nothing on Neo4j (label filter), so an
+    // unmapped type must return empty rather than silently dropping the filter.
+    if (type && !mapped) {
+      return [];
+    }
     if (mapped) {
       conditions.push(eq(products.type, mapped));
     }

--- a/src/components/product/product.module.ts
+++ b/src/components/product/product.module.ts
@@ -1,4 +1,5 @@
 import { forwardRef, Module } from '@nestjs/common';
+import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { FileModule } from '../file/file.module';
 import { PnpExtractionResultModule } from '../pnp/extraction-result/pnp-extraction-result.module';
@@ -13,6 +14,7 @@ import { ProductMutationLinksResolver } from './product-mutation-links.resolver'
 import { ProductMutationSubscriptionsResolver } from './product-mutation-subscriptions.resolver';
 import { ProductUpdatedResolver } from './product-updated.resolver';
 import { ProductChannels } from './product.channels';
+import { ProductDrizzleRepository } from './product.drizzle.repository';
 import { ProductExtractor } from './product.extractor';
 import { ProductLoader } from './product.loader';
 import { ProductRepository } from './product.repository';
@@ -36,7 +38,11 @@ import { ProductService } from './product.service';
     ProductLoader,
     ProductService,
     ProductChannels,
-    ProductRepository,
+    splitDb(ProductRepository, {
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: ProductDrizzleRepository as any,
+    }),
     ProductExtractor,
     PnpProductSyncService,
     FixNaNTotalVerseEquivalentsMigration,

--- a/src/components/product/product.repository.ts
+++ b/src/components/product/product.repository.ts
@@ -34,6 +34,7 @@ import {
   paginate,
   sorting,
 } from '~/core/neo4j/query';
+import { type ResourceLike } from '~/core/resources';
 import { ScriptureReferenceRepository } from '../scripture';
 import {
   ScriptureRange as RawScriptureRange,
@@ -80,6 +81,10 @@ export type HydratedProductRow = Merge<
 export class ProductRepository extends CommonRepository {
   constructor(private readonly scriptureRefs: ScriptureReferenceRepository) {
     super();
+  }
+
+  async delete(id: ID, resource?: ResourceLike) {
+    await this.deleteNode(id, { resource });
   }
 
   async readMany(ids: readonly ID[]) {

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -627,10 +627,9 @@ export class ProductService {
 
     this.privileges.for(Product, object).verifyCan('delete');
 
-    const { at } = await this.repo
-      .deleteNode(object, {
-        resource: resolveProductType(object),
-      })
+    const at = DateTime.now();
+    await this.repo
+      .delete(object.id, resolveProductType(object))
       .catch((exception) => {
         throw new ServerException('Failed to delete', exception);
       });

--- a/src/components/scripture/scripture-reference.service.ts
+++ b/src/components/scripture/scripture-reference.service.ts
@@ -1,5 +1,9 @@
 import { sortBy } from '@seedcompany/common';
+import { eq } from 'drizzle-orm';
 import { type ID } from '~/common';
+import { ConfigService } from '~/core/config';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { products } from '~/core/drizzle/schema';
 import { ILogger, Logger } from '~/core/logger';
 import { ScriptureRange, type ScriptureRangeInput } from './dto';
 import {
@@ -11,6 +15,8 @@ export class ScriptureReferenceService {
   constructor(
     @Logger('scripture-reference:service') private readonly logger: ILogger,
     private readonly repo: ScriptureReferenceRepository,
+    private readonly config: ConfigService,
+    private readonly drizzle: DrizzleService,
   ) {}
 
   async create(
@@ -33,6 +39,26 @@ export class ScriptureReferenceService {
     options: { isOverriding?: boolean } = {},
   ): Promise<void> {
     if (scriptureRefs === undefined) {
+      return;
+    }
+
+    // Under postgres, scripture refs live as jsonb columns on the products
+    // row (the only flow that reaches this service post-`splitDb` — the
+    // producible drizzle repos write their own column). A null override
+    // means "not overriding", replacing Neo4j's isOverriding flag.
+    // migration-todo: this branch IS the postgres implementation — at Phase 7
+    // cutover drop the engine check + the Neo4j path below (repo calls),
+    // leaving only this body.
+    if (this.config.databaseEngine === 'postgres') {
+      const refs = scriptureRefs?.map(ScriptureRange.fromReferences) ?? null;
+      await this.drizzle.client
+        .update(products)
+        .set(
+          options.isOverriding
+            ? { scriptureReferencesOverride: refs }
+            : { scriptureReferences: refs ?? [] },
+        )
+        .where(eq(products.id, producibleId));
       return;
     }
 

--- a/src/components/story/story.drizzle.repository.ts
+++ b/src/components/story/story.drizzle.repository.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { ProducibleDrizzleRepository } from '../product/producible.drizzle.repository';
+import { Story } from './dto';
+
+@Injectable()
+export class StoryDrizzleRepository extends ProducibleDrizzleRepository<Story> {
+  constructor(db: DrizzleService) {
+    super(db, Story, 'Story');
+  }
+}

--- a/src/components/story/story.module.ts
+++ b/src/components/story/story.module.ts
@@ -2,6 +2,7 @@ import { forwardRef, Module } from '@nestjs/common';
 import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { ScriptureModule } from '../scripture';
+import { StoryDrizzleRepository } from './story.drizzle.repository';
 import { StoryGelRepository } from './story.gel.repository';
 import { StoryLoader } from './story.loader';
 import { StoryRepository } from './story.repository';
@@ -15,6 +16,9 @@ import { StoryService } from './story.service';
     StoryService,
     splitDb(StoryRepository, {
       gel: StoryGelRepository,
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: StoryDrizzleRepository as any,
     }),
     StoryLoader,
   ],

--- a/src/components/story/story.repository.ts
+++ b/src/components/story/story.repository.ts
@@ -81,6 +81,10 @@ export class StoryRepository extends DtoRepository(Story) {
     return await this.readOne(input.id);
   }
 
+  async delete(id: ID) {
+    await this.deleteNode(id);
+  }
+
   async readOne(id: ID) {
     return (await super.readOne(id)) as UnsecuredDto<Story>;
   }

--- a/src/components/story/story.service.ts
+++ b/src/components/story/story.service.ts
@@ -67,7 +67,7 @@ export class StoryService {
     this.privileges.for(Story, story).verifyCan('delete');
 
     try {
-      await this.repo.deleteNode(story);
+      await this.repo.delete(story.id);
     } catch (exception) {
       throw new ServerException('Failed to delete', exception);
     }

--- a/src/core/drizzle/migrations/0018_add_products.sql
+++ b/src/core/drizzle/migrations/0018_add_products.sql
@@ -1,0 +1,140 @@
+-- Product family (Phase 5). Producibles (Film / Story / EthnoArt) share one
+-- table — shape-identical, the discriminator stands in for the Neo4j label.
+-- Products are single-table inheritance over DirectScriptureProduct /
+-- DerivativeScriptureProduct / OtherProduct (same approach as projects and
+-- engagements). Scripture references are jsonb lists of {start, end} verse-id
+-- pairs (the same shape Neo4j stores on ScriptureRange nodes); a null
+-- scripture_references_override on a Derivative product means "not
+-- overriding" (use the producible's list), replacing Neo4j's isOverriding
+-- flag. product_completion_descriptions is the describeCompletion suggestion
+-- store (ILIKE replaces the Neo4j full-text index).
+
+CREATE TYPE "producible_type" AS ENUM ('Film', 'Story', 'EthnoArt');
+
+CREATE TYPE "product_type" AS ENUM ('DirectScripture', 'Derivative', 'Other');
+
+CREATE TYPE "progress_measurement" AS ENUM ('Number', 'Percent', 'Boolean');
+
+-- Product vocabulary enums — mirror the app enums in
+-- src/components/product/dto (postgres-schema.e2e enforces parity) and Gel's
+-- Product::Medium/Purpose/Step/Methodology scalars.
+
+CREATE TYPE "product_medium" AS ENUM
+  ('Print', 'Web', 'EBook', 'App', 'TrainedStoryTellers', 'Audio', 'Video', 'Other');
+
+CREATE TYPE "product_purpose" AS ENUM
+  ('EvangelismChurchPlanting', 'ChurchLife', 'ChurchMaturity', 'SocialIssues', 'Discipleship');
+
+CREATE TYPE "product_step" AS ENUM (
+  'ExegesisAndFirstDraft',
+  'TeamCheck',
+  'CommunityTesting',
+  'BackTranslation',
+  'ConsultantCheck',
+  'InternalizationAndDrafting',
+  'PeerRevision',
+  'ConsistencyCheckAndFinalEdits',
+  'Craft',
+  'Test',
+  'Check',
+  'Record',
+  'Develop',
+  'Translate',
+  'Completed'
+);
+
+CREATE TYPE "product_methodology" AS ENUM (
+  'Paratext',
+  'OtherWritten',
+  'Render',
+  'Audacity',
+  'AdobeAudition',
+  'OtherOralTranslation',
+  'StoryTogether',
+  'SeedCompanyMethod',
+  'OneStory',
+  'Craft2Tell',
+  'OtherOralStories',
+  'Film',
+  'SignLanguage',
+  'OtherVisual'
+);
+
+-- 0017 left engagements.methodologies as text[] with the note that the
+-- canonical enum lands with the Product domain — this is that landing.
+-- (Dev-only chain: only ever applied to fresh/disposable databases.)
+ALTER TABLE "engagements"
+  ALTER COLUMN "methodologies" DROP DEFAULT,
+  ALTER COLUMN "methodologies" TYPE "product_methodology"[]
+    USING "methodologies"::"product_methodology"[],
+  ALTER COLUMN "methodologies" SET DEFAULT '{}';
+
+CREATE TABLE "producibles" (
+  "id"                   text PRIMARY KEY,
+  "type"                 "producible_type" NOT NULL,
+  "name"                 text NOT NULL,
+  "scripture_references" jsonb NOT NULL DEFAULT '[]',
+  "created_at"           timestamptz NOT NULL DEFAULT now(),
+  "updated_at"           timestamptz NOT NULL DEFAULT now(),
+  "deleted_at"           timestamptz
+);
+
+CREATE UNIQUE INDEX "producibles_type_name_active_unique"
+  ON "producibles" ("type", "name")
+  WHERE "deleted_at" IS NULL;
+
+CREATE TABLE "products" (
+  "id"                                text PRIMARY KEY,
+  "engagement_id"                     text NOT NULL REFERENCES "engagements"("id") ON DELETE CASCADE,
+  "type"                              "product_type" NOT NULL,
+  "mediums"                           "product_medium"[] NOT NULL DEFAULT '{}',
+  "purposes"                          "product_purpose"[] NOT NULL DEFAULT '{}',
+  "methodology"                       "product_methodology",
+  "steps"                             "product_step"[] NOT NULL DEFAULT '{}',
+  "describe_completion"               text,
+  "placeholder_description"           text,
+  "progress_step_measurement"         "progress_measurement" NOT NULL DEFAULT 'Percent',
+  "progress_target"                   double precision NOT NULL DEFAULT 100,
+
+  "scripture_references"              jsonb NOT NULL DEFAULT '[]',
+  "scripture_references_override"     jsonb,
+  "unspecified_scripture_book"        text,
+  "unspecified_scripture_total_verses" integer,
+  "total_verses"                      integer NOT NULL DEFAULT 0,
+  "total_verse_equivalents"           double precision NOT NULL DEFAULT 0,
+
+  "produces_id"                       text REFERENCES "producibles"("id"),
+  "composite"                         boolean,
+
+  "title"                             text,
+  "description"                       text,
+
+  "pnp_index"                         integer,
+
+  "created_at"                        timestamptz NOT NULL DEFAULT now(),
+  "updated_at"                        timestamptz NOT NULL DEFAULT now(),
+  "deleted_at"                        timestamptz,
+
+  CONSTRAINT "products_type_shape_chk" CHECK (
+    ("type" = 'DirectScripture' AND "produces_id" IS NULL AND "title" IS NULL)
+    OR ("type" = 'Derivative' AND "produces_id" IS NOT NULL AND "title" IS NULL)
+    OR ("type" = 'Other' AND "title" IS NOT NULL AND "produces_id" IS NULL)
+  ),
+  CONSTRAINT "products_unspecified_scripture_chk" CHECK (
+    ("unspecified_scripture_book" IS NULL) = ("unspecified_scripture_total_verses" IS NULL)
+  )
+);
+
+CREATE INDEX "products_engagement_id_idx" ON "products" ("engagement_id");
+CREATE INDEX "products_produces_id_idx" ON "products" ("produces_id");
+
+CREATE TABLE "product_completion_descriptions" (
+  "id"           bigserial PRIMARY KEY,
+  "value"        text NOT NULL,
+  "methodology"  "product_methodology" NOT NULL,
+  "last_used_at" timestamptz NOT NULL DEFAULT now(),
+  "created_at"   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX "product_completion_descriptions_value_methodology_unique"
+  ON "product_completion_descriptions" ("value", "methodology");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -131,7 +131,7 @@
     {
       "idx": 18,
       "version": "7",
-      "when": 1752105600000,
+      "when": 1752192000000,
       "tag": "0018_add_products",
       "breakpoints": true
     }

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1752105600000,
       "tag": "0017_add_engagements",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1752105600000,
+      "tag": "0018_add_products",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -17,7 +17,7 @@ import {
   timestamp,
   uniqueIndex,
 } from 'drizzle-orm/pg-core';
-import { type ID, type Role } from '~/common';
+import { type ID, type Range, type Role } from '~/common';
 import { type BudgetStatus } from '../../../components/budget/dto/budget-status.enum';
 import { type CeremonyType } from '../../../components/ceremony/dto/ceremony-type.enum';
 import { type InternshipPosition } from '../../../components/engagement/dto/intern-position.enum';
@@ -32,7 +32,11 @@ import { type PartnerType } from '../../../components/partner/dto/partner-type.e
 import { type FinancialReportingType } from '../../../components/partnership/dto/financial-reporting-type.enum';
 import { type PartnershipAgreementStatus } from '../../../components/partnership/dto/partnership-agreement-status.enum';
 import { type ReportPeriod } from '../../../components/periodic-report/dto/report-period.enum';
+import { type ProductMedium } from '../../../components/product/dto/product-medium.enum';
 import { type ProductMethodology } from '../../../components/product/dto/product-methodology.enum';
+import { type ProductPurpose } from '../../../components/product/dto/product-purpose.enum';
+import { type ProductStep } from '../../../components/product/dto/product-step.enum';
+import { type ProgressMeasurement } from '../../../components/product/dto/progress-measurement.enum';
 import { type ProjectStatus } from '../../../components/project/dto/project-status.enum';
 import { type ProjectStep } from '../../../components/project/dto/project-step.enum';
 import { type ProjectType } from '../../../components/project/dto/project-type.enum';
@@ -1696,6 +1700,66 @@ export const ethnologueLanguagesRelations = relations(
   }),
 );
 
+// ─── Product vocabulary enums ──────────────────────────────────────────────
+// Declared ahead of the Engagements section because engagements.methodologies
+// shares product_methodology. Value sets mirror the app enums in
+// src/components/product/dto (postgres-schema.e2e enforces parity) and Gel's
+// Product::Medium/Purpose/Step/Methodology scalars.
+
+export const productMediumEnum = pgEnum('product_medium', [
+  'Print',
+  'Web',
+  'EBook',
+  'App',
+  'TrainedStoryTellers',
+  'Audio',
+  'Video',
+  'Other',
+]);
+
+export const productPurposeEnum = pgEnum('product_purpose', [
+  'EvangelismChurchPlanting',
+  'ChurchLife',
+  'ChurchMaturity',
+  'SocialIssues',
+  'Discipleship',
+]);
+
+export const productStepEnum = pgEnum('product_step', [
+  'ExegesisAndFirstDraft',
+  'TeamCheck',
+  'CommunityTesting',
+  'BackTranslation',
+  'ConsultantCheck',
+  'InternalizationAndDrafting',
+  'PeerRevision',
+  'ConsistencyCheckAndFinalEdits',
+  'Craft',
+  'Test',
+  'Check',
+  'Record',
+  'Develop',
+  'Translate',
+  'Completed',
+]);
+
+export const productMethodologyEnum = pgEnum('product_methodology', [
+  'Paratext',
+  'OtherWritten',
+  'Render',
+  'Audacity',
+  'AdobeAudition',
+  'OtherOralTranslation',
+  'StoryTogether',
+  'SeedCompanyMethod',
+  'OneStory',
+  'Craft2Tell',
+  'OtherOralStories',
+  'Film',
+  'SignLanguage',
+  'OtherVisual',
+]);
+
 // ─── Engagements ───────────────────────────────────────────────────────────
 
 export const engagementTypeEnum = pgEnum('engagement_type', [
@@ -1746,9 +1810,9 @@ export const aiAssistedTranslationEnum = pgEnum('ai_assisted_translation', [
  * same approach as projects. The `type` discriminator matches the parent
  * project's type (Language ⟷ Translation projects, Internship ⟷ Internship
  * projects); the CHECK below keeps the per-type columns coherent.
- * `position` and `methodologies` are text-typed: large open-ended enums whose
- * semantics live in the app (methodologies' canonical enum lands with the
- * Product domain).
+ * `position` is text-typed (InternshipPosition lives in the app; convert with
+ * the internship vocab if ever needed). `methodologies` uses the
+ * product_methodology enum declared above with the product vocabulary.
  */
 export const engagements = pgTable(
   'engagements',
@@ -1809,7 +1873,7 @@ export const engagements = pgTable(
       .$type<ID<'User'>>()
       .references(() => users.id),
     position: text('position').$type<InternshipPosition>(),
-    methodologies: text('methodologies')
+    methodologies: productMethodologyEnum('methodologies')
       .array()
       .$type<readonly ProductMethodology[]>()
       .notNull()
@@ -1853,8 +1917,8 @@ export const engagements = pgTable(
   ],
 );
 
-// migration-todo (Product recut): restore `products: many(products)`.
-export const engagementsRelations = relations(engagements, ({ one }) => ({
+export const engagementsRelations = relations(engagements, ({ one, many }) => ({
+  products: many(products),
   project: one(projects, {
     fields: [engagements.projectId],
     references: [projects.id],
@@ -1948,3 +2012,197 @@ export const ceremoniesRelations = relations(ceremonies, ({ one }) => ({
     references: [engagements.id],
   }),
 }));
+
+// ─── Producibles ───────────────────────────────────────────────────────────
+
+export const producibleTypeEnum = pgEnum('producible_type', [
+  'Film',
+  'Story',
+  'EthnoArt',
+]);
+
+/**
+ * Film / Story / EthnoArt share one table — they are shape-identical
+ * (name + scripture references); the discriminator stands in for the Neo4j
+ * label. Scripture references are stored as the same `{start, end}` verse-id
+ * pairs Neo4j stores on ScriptureRange nodes; they are only ever read/written
+ * as a whole list, so jsonb over a child table.
+ */
+export const producibles = pgTable(
+  'producibles',
+  {
+    id: text('id').$type<ID>().primaryKey(),
+    type: producibleTypeEnum('type').notNull(),
+    name: text('name').notNull(),
+    scriptureReferences: jsonb('scripture_references')
+      .$type<ReadonlyArray<Range<number>>>()
+      .notNull()
+      .default([]),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    // Name is unique per type among live rows (matches Neo4j per-label check).
+    uniqueIndex('producibles_type_name_active_unique')
+      .on(t.type, t.name)
+      .where(sql`${t.deletedAt} IS NULL`),
+  ],
+);
+
+// ─── Products ──────────────────────────────────────────────────────────────
+
+export const productTypeEnum = pgEnum('product_type', [
+  'DirectScripture',
+  'Derivative',
+  'Other',
+]);
+
+export const progressMeasurementEnum = pgEnum('progress_measurement', [
+  'Number',
+  'Percent',
+  'Boolean',
+]);
+
+/**
+ * Single-table inheritance over DirectScriptureProduct /
+ * DerivativeScriptureProduct / OtherProduct (same approach as projects and
+ * engagements). mediums/purposes/steps/methodology use the product vocabulary
+ * pgEnums (declared above the Engagements section), mirroring Gel's scalars.
+ *
+ * Scripture columns mirror how the DTOs distinguish the subtypes:
+ * - Direct: `scriptureReferences` (or the unspecified-portion pair for legacy
+ *   data where only a verse total is known).
+ * - Derivative: `scriptureReferencesOverride`; null means "not overriding"
+ *   (use the producible's list) — this replaces Neo4j's `isOverriding` flag.
+ */
+export const products = pgTable(
+  'products',
+  {
+    id: text('id').$type<ID<'Product'>>().primaryKey(),
+    engagementId: text('engagement_id')
+      .$type<ID<'Engagement'>>()
+      .notNull()
+      .references(() => engagements.id, { onDelete: 'cascade' }),
+    type: productTypeEnum('type').notNull(),
+    mediums: productMediumEnum('mediums')
+      .array()
+      .$type<readonly ProductMedium[]>()
+      .notNull()
+      .default([]),
+    purposes: productPurposeEnum('purposes')
+      .array()
+      .$type<readonly ProductPurpose[]>()
+      .notNull()
+      .default([]),
+    methodology:
+      productMethodologyEnum('methodology').$type<ProductMethodology>(),
+    steps: productStepEnum('steps')
+      .array()
+      .$type<readonly ProductStep[]>()
+      .notNull()
+      .default([]),
+    describeCompletion: text('describe_completion'),
+    placeholderDescription: text('placeholder_description'),
+    progressStepMeasurement: progressMeasurementEnum(
+      'progress_step_measurement',
+    )
+      .$type<ProgressMeasurement>()
+      .notNull()
+      .default('Percent'),
+    progressTarget: doublePrecision('progress_target').notNull().default(100),
+
+    scriptureReferences: jsonb('scripture_references')
+      .$type<ReadonlyArray<Range<number>>>()
+      .notNull()
+      .default([]),
+    scriptureReferencesOverride: jsonb('scripture_references_override').$type<
+      ReadonlyArray<Range<number>>
+    >(),
+    unspecifiedScriptureBook: text('unspecified_scripture_book'),
+    unspecifiedScriptureTotalVerses: integer(
+      'unspecified_scripture_total_verses',
+    ),
+    totalVerses: integer('total_verses').notNull().default(0),
+    totalVerseEquivalents: doublePrecision('total_verse_equivalents')
+      .notNull()
+      .default(0),
+
+    // ── DerivativeScriptureProduct only ──
+    producesId: text('produces_id')
+      .$type<ID>()
+      .references(() => producibles.id),
+    composite: boolean('composite'),
+
+    // ── OtherProduct only ──
+    title: text('title'),
+    description: text('description'),
+
+    pnpIndex: integer('pnp_index'),
+
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    check(
+      'products_type_shape_chk',
+      sql`(${t.type} = 'DirectScripture' AND ${t.producesId} IS NULL AND ${t.title} IS NULL)
+        OR (${t.type} = 'Derivative' AND ${t.producesId} IS NOT NULL AND ${t.title} IS NULL)
+        OR (${t.type} = 'Other' AND ${t.title} IS NOT NULL AND ${t.producesId} IS NULL)`,
+    ),
+    check(
+      'products_unspecified_scripture_chk',
+      sql`(${t.unspecifiedScriptureBook} IS NULL) = (${t.unspecifiedScriptureTotalVerses} IS NULL)`,
+    ),
+    index('products_engagement_id_idx').on(t.engagementId),
+    index('products_produces_id_idx').on(t.producesId),
+  ],
+);
+
+export const productsRelations = relations(products, ({ one }) => ({
+  engagement: one(engagements, {
+    fields: [products.engagementId],
+    references: [engagements.id],
+  }),
+  produces: one(producibles, {
+    fields: [products.producesId],
+    references: [producibles.id],
+  }),
+}));
+
+/**
+ * Suggestion store for `describeCompletion` — merged on every product
+ * create/update that sets one (mirror of the Neo4j full-text-indexed
+ * ProductCompletionDescription nodes; suggestions use ILIKE here).
+ */
+export const productCompletionDescriptions = pgTable(
+  'product_completion_descriptions',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    value: text('value').notNull(),
+    methodology: productMethodologyEnum('methodology')
+      .$type<ProductMethodology>()
+      .notNull(),
+    lastUsedAt: timestamp('last_used_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('product_completion_descriptions_value_methodology_unique').on(
+      t.value,
+      t.methodology,
+    ),
+  ],
+);

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -44,10 +44,6 @@ import {
   transitionProject,
 } from './utility/transition-project';
 
-// migration-todo: this leg creates products, which are Neo4j-only until the
-// Product port lands — flip back to `it` under postgres in that PR.
-const itPgPending = process.env.DATABASE === 'postgres' ? it.skip : it;
-
 describe('Engagement e2e', () => {
   let app: TestApp;
   let project: fragments.project;
@@ -461,54 +457,51 @@ describe('Engagement e2e', () => {
       .expectError(errors.notFound());
   });
 
-  itPgPending(
-    'returns the correct products in language engagement',
-    async () => {
-      project = await createProject(app);
-      language = await runAsAdmin(app, createLanguage);
-      const languageEngagement = await createLanguageEngagement(app, {
-        language: language.id,
-        project: project.id,
-      });
+  it('returns the correct products in language engagement', async () => {
+    project = await createProject(app);
+    language = await runAsAdmin(app, createLanguage);
+    const languageEngagement = await createLanguageEngagement(app, {
+      language: language.id,
+      project: project.id,
+    });
 
-      const product1 = await createDirectProduct(app, {
-        engagement: languageEngagement.id,
-      });
-      const product2 = await createDirectProduct(app, {
-        engagement: languageEngagement.id,
-      });
-      const result = await app.graphql.query(
-        graphql(
-          `
-            query engagement($id: ID!) {
-              engagement: languageEngagement(id: $id) {
-                ...languageEngagement
-              }
+    const product1 = await createDirectProduct(app, {
+      engagement: languageEngagement.id,
+    });
+    const product2 = await createDirectProduct(app, {
+      engagement: languageEngagement.id,
+    });
+    const result = await app.graphql.query(
+      graphql(
+        `
+          query engagement($id: ID!) {
+            engagement: languageEngagement(id: $id) {
+              ...languageEngagement
             }
-          `,
-          [fragments.languageEngagement],
-        ),
-        {
-          id: languageEngagement.id,
-        },
-      );
-      expect(result.engagement.products.total).toEqual(2);
-      expect(result.engagement.products.items).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: product1.id,
-          }),
-        ]),
-      );
-      expect(result.engagement.products.items).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: product2.id,
-          }),
-        ]),
-      );
-    },
-  );
+          }
+        `,
+        [fragments.languageEngagement],
+      ),
+      {
+        id: languageEngagement.id,
+      },
+    );
+    expect(result.engagement.products.total).toEqual(2);
+    expect(result.engagement.products.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: product1.id,
+        }),
+      ]),
+    );
+    expect(result.engagement.products.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: product2.id,
+        }),
+      ]),
+    );
+  });
 
   it('creates ceremony upon engagement creation', async () => {
     project = await createProject(app);

--- a/test/postgres-schema.e2e-spec.ts
+++ b/test/postgres-schema.e2e-spec.ts
@@ -5,6 +5,12 @@ import { resolve } from 'node:path';
 import { type MadeEnum, Role, Sensitivity } from '~/common';
 import { type DrizzleDb, DrizzleService } from '~/core/drizzle';
 import { PartnerType } from '../src/components/partner/dto';
+import {
+  ProductMedium,
+  ProductMethodology,
+  ProductPurpose,
+  ProductStep,
+} from '../src/components/product/dto';
 import { ProjectStep, stepToStatus } from '../src/components/project/dto';
 import { createTestApp, type TestApp } from './utility';
 
@@ -142,6 +148,10 @@ describePg('Postgres schema invariants', () => {
     ['partner_type', PartnerType],
     ['role', Role],
     ['sensitivity', Sensitivity],
+    ['product_medium', ProductMedium],
+    ['product_purpose', ProductPurpose],
+    ['product_step', ProductStep],
+    ['product_methodology', ProductMethodology],
   ];
 
   it.each(enumPairs)(


### PR DESCRIPTION
Ports Products and the three producible kinds (Film, Story, EthnoArt) to Postgres, plus the `describeCompletion` suggestion store. Single commit, ~1,330 insertions across 24 files. Products reference engagements, which the base PR adds.

### What's in scope

- Migration 0018: `producibles` (one table for Film/Story/EthnoArt with a `type` discriminator; name unique per type among live rows), `products` (single-table inheritance over DirectScripture/Derivative/Other with a type-shape CHECK and an unspecified-scripture pairing CHECK), `product_completion_descriptions` (unique on value + methodology); FK indexes on `engagement_id` and `produces_id`
- 4 product vocabulary pgEnums — `product_medium`, `product_purpose`, `product_step`, `product_methodology` — used by the products columns and completion-description store; `engagements.methodologies` is ALTERed from `text[]` to `product_methodology[]` (its 0017 comment deferred the enum to this PR)
- Drizzle repositories: a shared producible repo with thin Film/Story/EthnoArt subclasses, and the Product repo (create/update/delete for all three subtypes, list, readMany, completion-description suggestions, availableSteps)
- `splitDb` postgres arms + module wiring for all four domains
- `scripture-reference.service`: postgres branch writes scripture references as jsonb columns on the products row
- Postgres CI e2e pattern gains `product|film|story|project-workflow`; the schema-invariant suite's enum-parity check extends to the 4 new enums
- `test/engagement.e2e-spec.ts`: drops the products-pending skip now that products exist under postgres

### Design decisions

- mediums/purposes/steps/methodology are **pgEnums**, matching the Gel scalars — value sets verified identical to the app enums, and the postgres-schema e2e invariant keeps them in sync; legacy values in old data will fail loudly at import rather than slip in as text
- Scripture references are jsonb lists of `{start, end}` verse-id pairs — they're only ever read/written as whole lists; a null `scripture_references_override` on a Derivative product means "not overriding" (use the producible's list), replacing the `isOverriding` flag
- Film/Story/EthnoArt share one table — they're shape-identical (name + scripture refs); the discriminator stands in for the label
- Subtype invariants (Derivative requires `produces_id`, Other requires `title`, etc.) are enforced by a DB CHECK, not just app code
- `list()` maps the six directly-sortable scalar sort keys; array/jsonb keys deliberately fall back to `createdAt` (commented in place)
- Completion-description suggestions use ILIKE in place of the Neo4j full-text index

### Validation

- type-check + lint clean; migrations 0000–0018 apply clean on a fresh database (including the `engagements.methodologies` ALTER; column types verified via information_schema)
- Postgres e2e: 9 suites green across the two validation rounds — 102 passed / 5 pre-existing skips on the full set, then 69 passed / 4 skips re-running the enum-affected six (product, film, story, engagement, engagement-workflow, postgres-schema)
- Neo4j e2e: 66 passed / 4 skips, no regressions
