### PR TITLE
[pg] Auth user-liveness cluster — deleted users lose login, sessions, and password reset

### DIFF
--- a/src/components/user/hooks/user-deleted.hook.ts
+++ b/src/components/user/hooks/user-deleted.hook.ts
@@ -1,0 +1,6 @@
+import { type ID } from '~/common';
+
+/** Fired after a user is (soft-)deleted, in the same transaction. */
+export class UserDeletedHook {
+  constructor(readonly id: ID<'User'>) {}
+}

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -41,6 +41,7 @@ import {
   type EducationListInput,
   type SecuredEducationList,
 } from './education/dto';
+import { UserDeletedHook } from './hooks/user-deleted.hook';
 import { UserUpdatedHook } from './hooks/user-updated.hook';
 import { KnownLanguageRepository } from './known-language.repository';
 import { UnavailabilityService } from './unavailability';
@@ -140,6 +141,9 @@ export class UserService {
   async delete(id: ID): Promise<void> {
     const object = await this.readOne(id);
     await this.userRepo.delete(id, object);
+    // Same-transaction side effects (e.g. session revocation — a deleted
+    // user must not keep live sessions).
+    await this.hooks.run(new UserDeletedHook(object.id));
   }
 
   async list(input: UserListInput): Promise<UserListOutput> {

--- a/src/core/authentication/authentication.drizzle.repository.ts
+++ b/src/core/authentication/authentication.drizzle.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { and, eq, ne } from 'drizzle-orm';
+import { and, eq, isNull, ne } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import { type ID, type PublicOf, ServerException } from '~/common';
 import {
@@ -34,16 +34,24 @@ export class AuthenticationDrizzleRepository implements PublicOf<AuthenticationR
     });
     if (!row) return null;
 
-    const roles = (row.user?.globalRoles ?? []).map(
+    // User-liveness: Neo4j enforces this structurally (deleting a user
+    // relabels the node, so the session→user match fails and the session
+    // degrades to anonymous). Mirror that: a soft-deleted user's session
+    // resolves as anonymous instead of retaining its identity. The
+    // delete→revoke-sessions hook deactivates these outright; this guards
+    // any session the hook missed (e.g. created before the hook shipped).
+    const user = row.user && !row.user.deletedAt ? row.user : null;
+    const roles = (user?.globalRoles ?? []).map(
       (globalRole) => globalRole.role,
     );
+    const userId = user ? row.userId : null;
 
     if (!impersonatee) {
-      return { userId: row.userId, roles };
+      return { userId, roles };
     }
 
     const impersonateeRoles = await this.rolesForUser(impersonatee);
-    return { userId: row.userId, roles, impersonateeRoles };
+    return { userId, roles, impersonateeRoles };
   }
 
   async disconnectUserFromSession(token: string) {
@@ -56,7 +64,7 @@ export class AuthenticationDrizzleRepository implements PublicOf<AuthenticationR
 
   async connectSessionToUser(input: LoginInput, session: Session) {
     const user = await this.drizzle.client.query.users.findFirst({
-      where: (user) => eq(user.email, input.email),
+      where: (user) => and(eq(user.email, input.email), isNull(user.deletedAt)),
     });
     if (!user) return undefined;
 
@@ -147,7 +155,7 @@ export class AuthenticationDrizzleRepository implements PublicOf<AuthenticationR
       })
       .from(users)
       .innerJoin(authIdentities, eq(authIdentities.userId, users.id))
-      .where(eq(users.email, email))
+      .where(and(eq(users.email, email), isNull(users.deletedAt)))
       .limit(1);
 
     return rows[0]
@@ -159,8 +167,14 @@ export class AuthenticationDrizzleRepository implements PublicOf<AuthenticationR
   }
 
   async doesEmailAddressExist(email: string) {
+    // Liveness matters here: Neo4j relabels the EmailAddress property node to
+    // Deleted_EmailAddress on user delete, so its existence check is false for
+    // deleted users and forgotPassword silently skips them — same void
+    // response either way, no deletion oracle. savePasswordResetToken below
+    // stays liveness-blind because this gate makes it unreachable for
+    // deleted emails.
     const row = await this.drizzle.client.query.users.findFirst({
-      where: (user) => eq(user.email, email),
+      where: (user) => and(eq(user.email, email), isNull(user.deletedAt)),
     });
     return !!row;
   }
@@ -181,23 +195,30 @@ export class AuthenticationDrizzleRepository implements PublicOf<AuthenticationR
     const row =
       await this.drizzle.client.query.authPasswordResetTokens.findFirst({
         where: (resetToken) => eq(resetToken.token, token),
+        with: { user: { columns: { id: true, deletedAt: true } } },
       });
-    return row
-      ? {
-          email: row.email,
-          token: row.token,
-          userId: row.userId,
-          createdOn: DateTime.fromJSDate(row.createdOn),
-        }
-      : null;
+    // A token whose user has since been soft-deleted is dead — completing
+    // the reset would overwrite the deleted account's identity hash
+    // (account takeover on any future restore). Same invalid-token path as
+    // an unknown token. (savePasswordResetToken stays liveness-blind on
+    // purpose: forgotPassword must not error differently for deleted
+    // emails, and the token can never be consumed.)
+    if (!row?.user || row.user.deletedAt) return null;
+    return {
+      email: row.email,
+      token: row.token,
+      userId: row.userId,
+      createdOn: DateTime.fromJSDate(row.createdOn),
+    };
   }
 
   async updatePasswordViaEmailToken(
     { email }: { email: string },
     passwordHash: string,
   ) {
+    // Liveness backstop for findPasswordResetToken's check above.
     const user = await this.drizzle.client.query.users.findFirst({
-      where: (user) => eq(user.email, email),
+      where: (user) => and(eq(user.email, email), isNull(user.deletedAt)),
     });
     if (!user) {
       throw new ServerException(
@@ -217,9 +238,16 @@ export class AuthenticationDrizzleRepository implements PublicOf<AuthenticationR
   }
 
   async rolesForUser(user: ID) {
+    // Liveness join — Neo4j starts from a `:User` match, so a deleted user
+    // yields [] there; mirror that so stale roles can't feed sessionForUser
+    // / impersonation merges.
     const rows = await this.drizzle.client
       .select({ role: userGlobalRoles.role })
       .from(userGlobalRoles)
+      .innerJoin(
+        users,
+        and(eq(users.id, userGlobalRoles.userId), isNull(users.deletedAt)),
+      )
       .where(eq(userGlobalRoles.userId, user));
     return rows.map((row) => row.role);
   }

--- a/src/core/authentication/authentication.module.ts
+++ b/src/core/authentication/authentication.module.ts
@@ -7,6 +7,7 @@ import { AuthenticationGelRepository } from './authentication.gel.repository';
 import { AuthenticationRepository } from './authentication.repository';
 import { AuthenticationService } from './authentication.service';
 import { CryptoService } from './crypto.service';
+import { DeletedUserLogsThemOutHandler } from './handlers/deleted-user-logs-them-out.handler';
 import { DisablingUserLogsThemOutHandler } from './handlers/disabling-user-logs-them-out.handler';
 import { Identity } from './identity.service';
 import { JwtService } from './jwt.service';
@@ -47,6 +48,7 @@ import { SessionManager } from './session/session.manager';
     CryptoService,
 
     DisablingUserLogsThemOutHandler,
+    DeletedUserLogsThemOutHandler,
   ],
   exports: [Identity],
 })

--- a/src/core/authentication/handlers/deleted-user-logs-them-out.handler.ts
+++ b/src/core/authentication/handlers/deleted-user-logs-them-out.handler.ts
@@ -1,0 +1,18 @@
+import { OnHook } from '~/core/hooks';
+import { UserDeletedHook } from '../../../components/user/hooks/user-deleted.hook';
+import { AuthenticationService } from '../authentication.service';
+
+/**
+ * Soft-deleting a user revokes all their sessions. Neo4j got this only
+ * incidentally (the delete relabels the User node, so session→user matches
+ * fail and the session degrades to anonymous); under Postgres the sessions
+ * would otherwise stay live indefinitely. Runs inside the delete's
+ * transaction, so a rollback also rolls back the revocation.
+ */
+@OnHook(UserDeletedHook)
+export class DeletedUserLogsThemOutHandler {
+  constructor(private readonly auth: AuthenticationService) {}
+  async handle({ id }: UserDeletedHook) {
+    await this.auth.logoutByUser(id);
+  }
+}

--- a/test/authentication.e2e-spec.ts
+++ b/test/authentication.e2e-spec.ts
@@ -95,6 +95,49 @@ describe('Authentication e2e', () => {
     });
   });
 
+  it('deleted users are logged out, cannot login, and cannot reset their password', async () => {
+    const sendEmail = jest.spyOn(app.get(MailerService), 'send');
+    const tester = createTester(app);
+    const admin = await getRootTester(app);
+    const user = await tester.apply(registerUser());
+    const email = user.email.value!;
+
+    // Capture a reset token while the account is still live, to prove the
+    // token dies with the account.
+    await tester.apply(forgotPassword(email));
+    const lastMail = sendEmail.mock.calls.at(-1)![0]! as ForgotPasswordMsg;
+    const { token } = lastMail.body.props;
+    expect(token).toEqual(expect.any(String));
+
+    // Confirm they're logged in, then delete them.
+    const before = await tester.apply(currentUser());
+    expect(before?.id).toBe(user.id);
+    await admin.apply(deleteUser(user.id));
+
+    // Their existing session no longer resolves to them.
+    const after = await tester.apply(currentUser());
+    expect(after).toBeNull();
+
+    // Login is refused — same error as unknown credentials, no
+    // deleted-account oracle.
+    await expect(
+      tester.apply(login({ email, password: user.password })),
+    ).rejects.toThrowGqlError({
+      message: 'Invalid credentials',
+    });
+
+    // The pre-delete reset token cannot be consumed...
+    await expect(
+      tester.apply(resetPassword(token, faker.internet.password())),
+    ).rejects.toThrow();
+    // ...and the account stays locked regardless of what was attempted.
+    await expect(
+      tester.apply(login({ email, password: user.password })),
+    ).rejects.toThrowGqlError({
+      message: 'Invalid credentials',
+    });
+  });
+
   it('Password changed', async () => {
     const tester = createTester(app);
 
@@ -155,6 +198,19 @@ const changePassword =
       { oldPassword, newPassword },
     );
   };
+
+const deleteUser = (userId: ID) => async (tester: Tester) => {
+  await tester.run(
+    graphql(`
+      mutation DeleteUser($id: ID!) {
+        deleteUser(id: $id) {
+          __typename
+        }
+      }
+    `),
+    { id: userId },
+  );
+};
 
 const disableUser = (userId: ID) => async (tester: Tester) => {
   await tester.run(


### PR DESCRIPTION
### Summary 

When you delete a user in Cord, they shouldn't be able to do anything anymore. On Neo4j that
happens for free: deleting a user relabels its node, so every query that looks up "a User" just
stops finding them — the database's shape enforces it. Postgres doesn't work that way: a deleted
user is just a row with a `deleted_at` timestamp, and a query only excludes them if it explicitly
says `WHERE deleted_at IS NULL`. The auth queries were written without that clause, so under
Postgres, deleting a user quietly did almost nothing:

- They could **still log in** with their password.
- If already logged in, their **session kept working forever**.
- They could run "forgot password" and **reset their way back into the account**.
- Internal role lookups still treated them as active.

None of this is live today — Neo4j is still primary — but it all becomes real at the flip, which
is why the audit ranked this the top pre-cutover fix. This PR adds the missing "and they're not
deleted" condition to every place auth looks up a user, and adds one behavior neither engine
really had: deleting a user now revokes all their sessions immediately, logging them out
everywhere. Tests delete a user and then try to log in / reuse their session / reset their
password — they fail on the old code and pass with the fix, on both databases.

### What's added

- **Liveness predicates** (`isNull(user.deletedAt)`) on: `getInfoForLogin` (deleted users could
  log in), `connectSessionToUser`, `findPasswordResetToken` + `updatePasswordViaEmailToken`
  backstop (reset-flow account takeover), `rolesForUser` (stale roles into
  sessionForUser/asUser/impersonation), and `resumeSession` (deleted users kept live sessions;
  now degrades to an anonymous session rather than erroring).
- **`doesEmailAddressExist` liveness** (found by adversarial review 7/16): Neo4j's check matches
  the `:EmailAddress` label, which the delete relabels away — so `forgotPassword` silently skips
  deleted accounts on Neo4j but was sending a real reset email + inserting a dead token row under
  PG. Same void response either way = no deletion oracle. `savePasswordResetToken` stays
  liveness-blind deliberately — unreachable for deleted emails behind this gate (commented).
- **Session revocation on delete**: `UserService.delete` fires `UserDeletedHook` →
  `DeletedUserLogsThemOutHandler` calls `auth.logoutByUser(id)`. Runs **inside the delete's
  transaction** deliberately — it's a row write, so a rollback of the delete rolls back the
  revocation (the effects-after-commit rule applies to emails, not DB writes).

### Intentional decisions (review attention here)

- Not a mono port — original work against the audit findings; no mono counterpart to diff.
- `resumeSession` for a deleted user **degrades to anonymous** instead of throwing — mirrors
  Neo4j's incidental behavior.
- The `doesEmailAddressExist` fix reverses the audit ledger's earlier "leave blind = parity"
  note, which was wrong (contradicted by the same ledger's U5 reasoning); ledger corrected.
- Handler lives in `core/authentication/handlers/` beside its `Disabling…` twin — the effect is
  auth-domain, the trigger is user-domain.

### Validation performed

- **Tested**: `authentication` + `user` e2e — **17/17 on BOTH engines**, re-run after the develop
  rebase (#3825 + #3827 base) and again after the review fix. New legs verified
  **red-without-fix on PG** (fix reverted → legs fail; reapplied → green).
- **Tested**: `yarn type-check` + `yarn eslint --max-warnings 0` on touched files, clean.
- **Reviewed**: multi-lens adversarial review (7/16) — 1 finding raised, 1 confirmed and fixed,
  0 refuted-but-shipped.
- **By reading, not testing**: Neo4j behavior unchanged — the Neo4j repository file is untouched;
  label-rewrite parity claims verified against `authentication.repository.ts:266-273`.