### PR TITLE
[pg] Report cluster → Postgres (Drizzle), migrations 0019–0021

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
             shard: 1
             total: 1
             test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony|product|film|story|project-workflow)\."
+              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony|product|film|story|project-workflow|periodic-report|rev79)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/src/components/periodic-report/periodic-report.drizzle.repository.ts
+++ b/src/components/periodic-report/periodic-report.drizzle.repository.ts
@@ -101,6 +101,11 @@ export class PeriodicReportDrizzleRepository extends DrizzleDtoRepository<
    * ON CONFLICT DO NOTHING. Returns only the rows actually created.
    */
   async merge(input: MergePeriodicReports) {
+    // Nothing to sync — drizzle's `.values([])` is a runtime error, and there
+    // are no rows to create files for, so short-circuit.
+    if (input.intervals.length === 0) {
+      return [];
+    }
     const isProgress = input.type === 'Progress';
     // Each report owns a `reportFile` DefinedFile placeholder. The FK is stored
     // here; the (version-less) file node is created by createDefinedFile after

--- a/src/components/periodic-report/periodic-report.drizzle.repository.ts
+++ b/src/components/periodic-report/periodic-report.drizzle.repository.ts
@@ -1,0 +1,534 @@
+import { Injectable } from '@nestjs/common';
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  lt,
+  lte,
+  not,
+  or,
+  type SQL,
+  sql,
+} from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  CalendarDate,
+  type DateFilter,
+  generateId,
+  type ID,
+  isSecured,
+  ServerException,
+  type UnsecuredDto,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import { type ChangesOf } from '~/core/database/changes';
+import {
+  DrizzleDtoRepository,
+  resolveOrderBy,
+  type SortMap,
+} from '~/core/drizzle';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import {
+  engagements,
+  fileNodes,
+  periodicReports,
+  projects,
+} from '~/core/drizzle/schema';
+import { type BaseNode } from '~/core/neo4j/results';
+import { type ScopedRole } from '../authorization/dto/role.dto';
+import { FileService } from '../file';
+import { ProgressReportStatus } from '../progress-report/dto';
+import { requesterScopeByProject } from '../project/project-member/membership-scope';
+import {
+  IPeriodicReport,
+  type MergePeriodicReports,
+  type PeriodicReport,
+  type PeriodicReportListInput,
+  type ReportType,
+  type UpdatePeriodicReport,
+} from './dto';
+import { deterministicReportId } from './periodic-report.repository';
+
+type ReportRow = typeof periodicReports.$inferSelect & {
+  project?: ParentProject | null;
+  engagement?: {
+    id: ID<'Engagement'>;
+    createdAt: Date;
+    project?: ParentProject | null;
+  } | null;
+};
+
+interface ParentProject {
+  id: ID<'Project'>;
+  type: string;
+  sensitivity: string;
+  createdAt: Date;
+}
+
+const PROJECT_COLUMNS = {
+  columns: { id: true, type: true, sensitivity: true, createdAt: true },
+} as const;
+
+const RELATIONS = {
+  project: PROJECT_COLUMNS,
+  engagement: {
+    columns: { id: true, createdAt: true },
+    with: { project: PROJECT_COLUMNS },
+  },
+} as const;
+
+@Injectable()
+export class PeriodicReportDrizzleRepository extends DrizzleDtoRepository<
+  typeof periodicReports,
+  PeriodicReport & { id: ID }
+> {
+  constructor(
+    db: DrizzleService,
+    private readonly identity: Identity,
+    private readonly files: FileService,
+  ) {
+    super(db, periodicReports, IPeriodicReport as any);
+  }
+
+  /**
+   * Idempotent bulk-create. Ids are deterministic per
+   * (parent, type, start, end) — identical to the Neo4j derivation — so
+   * existing intervals and concurrent duplicate syncs both resolve via
+   * ON CONFLICT DO NOTHING. Returns only the rows actually created.
+   */
+  async merge(input: MergePeriodicReports) {
+    const isProgress = input.type === 'Progress';
+    // Each report owns a `reportFile` DefinedFile placeholder. The FK is stored
+    // here; the (version-less) file node is created by createDefinedFile after
+    // the rows land, only for those actually inserted.
+    const reportFileIds = new Map<ID, ID<'File'>>();
+    // narrativeFile placeholder mirrors the Neo4j merge, which creates both
+    // DefinedFiles per report (develop's narrativeFile PR postdates mono).
+    const narrativeFileIds = new Map<ID, ID<'File'>>();
+    const values = await Promise.all(
+      input.intervals.map(async (interval) => {
+        const id = deterministicReportId(
+          input.parent,
+          input.type,
+          interval.start,
+          interval.end,
+        );
+        const reportFileId = await generateId<ID<'File'>>();
+        reportFileIds.set(id, reportFileId);
+        const narrativeFileId = await generateId<ID<'File'>>();
+        narrativeFileIds.set(id, narrativeFileId);
+        return {
+          id,
+          type: input.type,
+          projectId: isProgress ? null : (input.parent as ID<'Project'>),
+          engagementId: isProgress ? (input.parent as ID<'Engagement'>) : null,
+          start: interval.start.toISODate(),
+          end: interval.end.toISODate(),
+          status: isProgress ? ProgressReportStatus.NotStarted : null,
+          reportFileId,
+          narrativeFileId,
+        };
+      }),
+    );
+    const inserted = await this.db
+      .insert(periodicReports)
+      .values(values)
+      .onConflictDoNothing({ target: periodicReports.id })
+      .returning({
+        id: periodicReports.id,
+        start: periodicReports.start,
+        end: periodicReports.end,
+      });
+
+    if (inserted.length > 0) {
+      // Progress reports of Multiplication projects are publicly downloadable —
+      // mirrors the Neo4j reportFilePublic rule. Others are private.
+      const isPublic = isProgress && (await this.parentIsMultiplication(input));
+      for (const row of inserted) {
+        await this.files.createDefinedFile(
+          reportFileIds.get(row.id)!,
+          row.end,
+          row.id,
+          'reportFile',
+          undefined,
+          isPublic,
+        );
+        // Same public rule as reportFile — mirrors the Neo4j merge, where
+        // both file nodes take the one isFilePublic flag.
+        await this.files.createDefinedFile(
+          narrativeFileIds.get(row.id)!,
+          row.end,
+          row.id,
+          'narrativeFile',
+          undefined,
+          isPublic,
+        );
+      }
+    }
+
+    return inserted.map((row) => ({
+      id: row.id,
+      interval: {
+        start: CalendarDate.fromISO(row.start),
+        end: CalendarDate.fromISO(row.end),
+      },
+    }));
+  }
+
+  /** Is the merge's parent (engagement, for Progress) under a Multiplication project? */
+  private async parentIsMultiplication(
+    input: MergePeriodicReports,
+  ): Promise<boolean> {
+    const [row] = await this.db
+      .select({ type: projects.type })
+      .from(engagements)
+      .innerJoin(projects, eq(projects.id, engagements.projectId))
+      .where(eq(engagements.id, input.parent as ID<'Engagement'>))
+      .limit(1);
+    return row?.type === 'MultiplicationTranslation';
+  }
+
+  async update<T extends PeriodicReport | UnsecuredDto<PeriodicReport>>(
+    existing: T,
+    simpleChanges: Omit<
+      ChangesOf<PeriodicReport, UpdatePeriodicReport>,
+      'reportFile' | 'narrativeFile'
+    > &
+      Partial<Pick<PeriodicReport, 'start' | 'end'>>,
+  ): Promise<T> {
+    const changes = simpleChanges as Record<string, unknown>;
+    await this.updateColumns(existing.id, {
+      ...('receivedDate' in changes && {
+        receivedDate:
+          (changes.receivedDate as CalendarDate | null)?.toISODate() ?? null,
+      }),
+      ...('narrativeReceivedDate' in changes && {
+        narrativeReceivedDate:
+          (changes.narrativeReceivedDate as CalendarDate | null)?.toISODate() ??
+          null,
+      }),
+      ...('skippedReason' in changes && {
+        skippedReason: changes.skippedReason as string | null,
+      }),
+      ...('start' in changes && {
+        start: (changes.start as CalendarDate).toISODate(),
+      }),
+      ...('end' in changes && {
+        end: (changes.end as CalendarDate).toISODate(),
+      }),
+    });
+    // Merge changes into the given object, secured-aware — same contract as
+    // the Neo4j base's updateProperties().
+    const updated: Record<string, unknown> = { ...existing };
+    for (const [key, value] of Object.entries(changes)) {
+      if (value === undefined) continue;
+      const prev = updated[key];
+      updated[key] = isSecured(prev) ? { ...prev, value } : value;
+    }
+    return updated as T;
+  }
+
+  override async readMany(
+    ids: readonly ID[],
+  ): Promise<Array<UnsecuredDto<PeriodicReport>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db.query.periodicReports.findMany({
+      where: (r) => inArray(r.id, [...ids]),
+      with: RELATIONS,
+    });
+    return await this.hydrate(rows as ReportRow[]);
+  }
+
+  async list(input: PeriodicReportListInput) {
+    const conditions: SQL[] = [];
+    if (input.type) {
+      conditions.push(eq(periodicReports.type, input.type));
+    }
+    if (input.parent) {
+      conditions.push(
+        or(
+          eq(periodicReports.projectId, input.parent as ID<'Project'>),
+          eq(periodicReports.engagementId, input.parent as ID<'Engagement'>),
+        )!,
+      );
+    }
+    for (const [column, filter] of [
+      [periodicReports.start, input.start],
+      [periodicReports.end, input.end],
+    ] as const) {
+      conditions.push(...dateFilterConditions(column, filter));
+    }
+    const sortColumns = {
+      start: periodicReports.start,
+      end: periodicReports.end,
+      type: periodicReports.type,
+      status: periodicReports.status,
+      receivedDate: periodicReports.receivedDate,
+      narrativeReceivedDate: periodicReports.narrativeReceivedDate,
+      createdAt: periodicReports.createdAt,
+      // migration-todo: keys beyond these (skippedReason, status, computed
+      // fields) fall back to `start` — the R4 resolveOrderBy convention;
+      // central unknown-key throw is the tracked fix.
+    } satisfies SortMap<string>;
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: conditions.length > 0 ? and(...conditions) : undefined,
+      orderBy: resolveOrderBy(input, sortColumns, periodicReports.start),
+      page: input.page,
+      count: input.count,
+    });
+    if (rows.length === 0) return { total, items: [], hasMore };
+    const items = await this.readMany(rows.map((r) => r.id));
+    const byId = new Map(items.map((i) => [i.id, i]));
+    return {
+      total,
+      hasMore,
+      items: rows.map((r) => byId.get(r.id)!).filter(Boolean),
+    };
+  }
+
+  matchCurrentDue(_parentId: unknown, _reportType: ReportType): never {
+    // Only consumed by the Neo4j product-progress repo as a cypher fragment.
+    // migration-todo: remove when ProductProgress ports — its drizzle repo
+    // queries current-due reports directly in SQL.
+    throw new ServerException(
+      'matchCurrentDue is a cypher fragment; use getCurrentDue under postgres',
+    );
+  }
+
+  async getByDate(parentId: ID, date: CalendarDate, reportType: ReportType) {
+    const day = date.toISODate();
+    return await this.first(
+      and(
+        this.parentCondition(parentId, reportType),
+        lte(periodicReports.start, day),
+        gte(periodicReports.end, day),
+      ),
+    );
+  }
+
+  async getCurrentDue(parentId: ID, reportType: ReportType) {
+    return await this.first(
+      and(
+        this.parentCondition(parentId, reportType),
+        lt(periodicReports.end, today()),
+      ),
+      [desc(periodicReports.end), asc(periodicReports.start)],
+    );
+  }
+
+  async getNextDue(parentId: ID, reportType: ReportType) {
+    return await this.first(
+      and(
+        this.parentCondition(parentId, reportType),
+        gt(periodicReports.end, today()),
+      ),
+      [asc(periodicReports.end)],
+    );
+  }
+
+  async getLatestReportSubmitted(parentId: ID, type: ReportType) {
+    // "Submitted" = a FileVersion exists under either of the report's files —
+    // the Neo4j guard is `(node)-->(:FileNode)<--(:FileVersion)`, which spans
+    // reportFile AND narrativeFile. Ordered by start (not end), per Neo4j.
+    return await this.first(
+      and(this.parentCondition(parentId, type), hasUploadedFileVersion()),
+      [desc(periodicReports.start)],
+    );
+  }
+
+  async getFinalReport(parentId: ID, type: ReportType) {
+    return await this.first(
+      and(
+        this.parentCondition(parentId, type),
+        eq(periodicReports.start, periodicReports.end),
+      ),
+    );
+  }
+
+  /**
+   * Deletes reports of type under the parent. Mirrors the Neo4j eligibility
+   * rules (periodic-report.repository.ts): progress reports only while still
+   * NotStarted; non-progress reports only while no file has been uploaded
+   * (neither reportFile nor narrativeFile has an active FileVersion).
+   *
+   * A REAL delete — see the schema note on deterministic ids. The
+   * no-uploaded-file guard is what keeps that safe: a report carrying user
+   * data (an uploaded file) is never hard-deleted.
+   */
+  async delete(
+    baseNodeId: ID,
+    type: ReportType,
+    intervals: ReadonlyArray<{
+      start: CalendarDate | null;
+      end: CalendarDate | null;
+    }>,
+  ) {
+    const intervalConditions = intervals.flatMap((interval) => {
+      if (!interval.start && !interval.end) return [];
+      if (!interval.start) {
+        return [lte(periodicReports.end, interval.end!.toISODate())];
+      }
+      if (!interval.end) {
+        return [gte(periodicReports.start, interval.start.toISODate())];
+      }
+      return [
+        and(
+          eq(periodicReports.start, interval.start.toISODate()),
+          eq(periodicReports.end, interval.end.toISODate()),
+        )!,
+      ];
+    });
+    if (intervalConditions.length === 0) return { count: 0 };
+    const deleted = await this.db
+      .delete(periodicReports)
+      .where(
+        and(
+          this.parentCondition(baseNodeId, type),
+          or(...intervalConditions),
+          ...(type === 'Progress'
+            ? [eq(periodicReports.status, ProgressReportStatus.NotStarted)]
+            : // Non-progress reports are deletable only while no file has been
+              // uploaded to EITHER DefinedFile — mirrors the Neo4j
+              // reportFileNode + narrativeFileNode FileVersion guards. Without
+              // this, a Financial/Narrative report with an uploaded file
+              // (real user data) would be hard-DELETEd.
+              [not(hasUploadedFileVersion())]),
+        ),
+      )
+      .returning({ id: periodicReports.id });
+    return { count: deleted.length };
+  }
+
+  private parentCondition(parentId: ID, type: ReportType) {
+    return and(
+      eq(periodicReports.type, type),
+      type === 'Progress'
+        ? eq(periodicReports.engagementId, parentId as ID<'Engagement'>)
+        : eq(periodicReports.projectId, parentId as ID<'Project'>),
+    )!;
+  }
+
+  private async first(predicate: SQL | undefined, orderBy: SQL[] = []) {
+    const [row] = await this.db
+      .select({ id: periodicReports.id })
+      .from(periodicReports)
+      .where(predicate)
+      .orderBy(...orderBy, asc(periodicReports.id))
+      .limit(1);
+    if (!row) return undefined;
+    const [dto] = await this.readMany([row.id]);
+    return dto;
+  }
+
+  private async hydrate(
+    rows: ReportRow[],
+  ): Promise<Array<UnsecuredDto<PeriodicReport>>> {
+    const scopeByProject = await requesterScopeByProject(
+      this.db,
+      this.identity.current.userId,
+      rows.flatMap((r) => this.parentProject(r)?.id ?? []),
+    );
+    return rows.map((row) => {
+      const project = this.parentProject(row);
+      return this.toDto(
+        row,
+        project ? (scopeByProject.get(project.id) ?? []) : [],
+      );
+    });
+  }
+
+  private parentProject(row: ReportRow): ParentProject | undefined {
+    return row.project ?? row.engagement?.project ?? undefined;
+  }
+
+  protected toDto(
+    row: ReportRow,
+    scope: ScopedRole[] = [],
+  ): UnsecuredDto<PeriodicReport> {
+    const project = this.parentProject(row);
+    if (!project) {
+      throw new ServerException(
+        `PeriodicReport ${row.id} has no parent row — FK invariant violated`,
+      );
+    }
+    const isProgress = row.type === 'Progress';
+    // Neo4j-shaped BaseNode so ResourceLoader.loadByBaseNode() on the parent
+    // field keeps working — only labels + properties.{id,createdAt} are read.
+    const parent: BaseNode = isProgress
+      ? {
+          identity: row.engagement!.id,
+          labels: ['LanguageEngagement', 'Engagement', 'BaseNode'],
+          properties: {
+            id: row.engagement!.id,
+            createdAt: DateTime.fromJSDate(row.engagement!.createdAt),
+          },
+        }
+      : {
+          identity: project.id,
+          labels: [`${project.type}Project`, 'Project', 'BaseNode'],
+          properties: {
+            id: project.id,
+            createdAt: DateTime.fromJSDate(project.createdAt),
+          },
+        };
+    const dto: unknown = {
+      id: row.id,
+      type: row.type,
+      ...(isProgress && { __typename: 'ProgressReport', status: row.status }),
+      parent,
+      start: CalendarDate.fromISO(row.start),
+      end: CalendarDate.fromISO(row.end),
+      receivedDate: row.receivedDate
+        ? CalendarDate.fromISO(row.receivedDate)
+        : null,
+      narrativeReceivedDate: row.narrativeReceivedDate
+        ? CalendarDate.fromISO(row.narrativeReceivedDate)
+        : null,
+      skippedReason: row.skippedReason,
+      reportFile: row.reportFileId,
+      narrativeFile: row.narrativeFileId,
+      sensitivity: project.sensitivity,
+      scope,
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      canDelete: true,
+    };
+    return dto as UnsecuredDto<PeriodicReport>;
+  }
+}
+
+const today = () => CalendarDate.local().toISODate();
+
+/**
+ * A live FileVersion exists under either of the report's DefinedFiles
+ * (reportFile or narrativeFile) — the PG mirror of Neo4j's
+ * `(report)-->(:FileNode)<--(:FileVersion)` reachability. Used both as the
+ * "submitted" test and (negated) as the delete-eligibility guard.
+ */
+const hasUploadedFileVersion = () =>
+  sql`exists (
+    select 1 from ${fileNodes} fv
+    where fv.parent_id in (${periodicReports.reportFileId}, ${periodicReports.narrativeFileId})
+      and fv.type = 'FileVersion'
+      and fv.deleted_at is null
+  )`;
+
+const dateFilterConditions = (
+  column: typeof periodicReports.start | typeof periodicReports.end,
+  filter: DateFilter | undefined,
+): SQL[] => {
+  if (!filter) return [];
+  return [
+    ...(filter.after ? [gt(column, filter.after.toISODate())] : []),
+    ...(filter.afterInclusive
+      ? [gte(column, filter.afterInclusive.toISODate())]
+      : []),
+    ...(filter.before ? [lt(column, filter.before.toISODate())] : []),
+    ...(filter.beforeInclusive
+      ? [lte(column, filter.beforeInclusive.toISODate())]
+      : []),
+  ];
+};

--- a/src/components/periodic-report/periodic-report.module.ts
+++ b/src/components/periodic-report/periodic-report.module.ts
@@ -1,4 +1,5 @@
 import { forwardRef, Module } from '@nestjs/common';
+import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { EngagementModule } from '../engagement/engagement.module';
 import { FileModule } from '../file/file.module';
@@ -8,6 +9,7 @@ import * as handlers from './handlers';
 import { BackfillPeriodicReportNarrativeFileMigration } from './migrations/backfill-periodic-report-narrative-file.migration';
 import { PeriodicReportParentResolver } from './periodic-report-parent.resolver';
 import { PeriodicReportProjectConnectionResolver } from './periodic-report-project-connection.resolver';
+import { PeriodicReportDrizzleRepository } from './periodic-report.drizzle.repository';
 import { PeriodicReportLoader } from './periodic-report.loader';
 import { PeriodicReportRepository } from './periodic-report.repository';
 import { PeriodicReportResolver } from './periodic-report.resolver';
@@ -26,7 +28,11 @@ import { PeriodicReportService } from './periodic-report.service';
     PeriodicReportResolver,
     PeriodicReportProjectConnectionResolver,
     PeriodicReportParentResolver,
-    PeriodicReportRepository,
+    splitDb(PeriodicReportRepository, {
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: PeriodicReportDrizzleRepository as any,
+    }),
     PeriodicReportLoader,
     BackfillPeriodicReportNarrativeFileMigration,
     ...Object.values(handlers),

--- a/src/components/periodic-report/periodic-report.repository.ts
+++ b/src/components/periodic-report/periodic-report.repository.ts
@@ -482,7 +482,7 @@ export class PeriodicReportRepository extends DtoRepository<
  * base64url string (66 bits of SHA-256), which is enough to avoid accidental
  * collisions while being deterministic enough to detect intentional duplicates.
  */
-const deterministicReportId = (
+export const deterministicReportId = (
   parentId: ID,
   type: string,
   start: CalendarDate,

--- a/src/components/product-progress/product-progress.drizzle.repository.ts
+++ b/src/components/product-progress/product-progress.drizzle.repository.ts
@@ -1,0 +1,309 @@
+import { Injectable } from '@nestjs/common';
+import { and, asc, desc, eq, inArray, isNull, lt } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  CalendarDate,
+  generateId,
+  type ID,
+  NotFoundException,
+  type UnsecuredDto,
+  type Variant,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import {
+  engagements,
+  periodicReports,
+  productProgress,
+  products,
+  projects,
+  stepProgress,
+} from '~/core/drizzle/schema';
+import { type ScopedRole } from '../authorization/dto/role.dto';
+import { type ProductStep } from '../product/dto';
+import { requesterScopeByProject } from '../project/project-member/membership-scope';
+import {
+  type ProgressVariantByProductInput,
+  type ProgressVariantByReportInput,
+  type StepProgress as StepProgressDto,
+  type UnsecuredProductProgress,
+  type UpdateProductProgress,
+} from './dto';
+
+type ProgressRow = typeof productProgress.$inferSelect & {
+  steps: Array<typeof stepProgress.$inferSelect>;
+};
+
+@Injectable()
+export class ProductProgressDrizzleRepository {
+  constructor(
+    private readonly drizzle: DrizzleService,
+    private readonly identity: Identity,
+  ) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  async readOne(
+    productId: ID,
+    reportId: ID,
+    variant: Variant,
+  ): Promise<UnsecuredProductProgress> {
+    const product = await this.getProduct(productId);
+    if (!product) {
+      throw new NotFoundException(
+        'Could not find progress for product and report period',
+      );
+    }
+    const rows = await this.progressRows([productId], [reportId], variant.key);
+    return this.toDto(product.steps, productId, reportId, variant.key, rows[0]);
+  }
+
+  async readOneForCurrentReport(input: ProgressVariantByProductInput) {
+    const product = await this.getProduct(input.product.id);
+    if (!product) return undefined;
+    const [report] = await this.db
+      .select({ id: periodicReports.id })
+      .from(periodicReports)
+      .where(
+        and(
+          eq(periodicReports.engagementId, product.engagementId),
+          eq(periodicReports.type, 'Progress'),
+          lt(periodicReports.end, CalendarDate.local().toISODate()),
+        ),
+      )
+      .orderBy(desc(periodicReports.end), asc(periodicReports.start))
+      .limit(1);
+    if (!report) return undefined;
+    return await this.readOne(input.product.id, report.id, input.variant);
+  }
+
+  async readAllProgressReportsForManyProducts(
+    inputs: readonly ProgressVariantByProductInput[],
+  ) {
+    const results = [];
+    for (const input of inputs) {
+      const product = await this.getProduct(input.product.id);
+      if (!product) continue;
+      const reports = await this.db
+        .select({ id: periodicReports.id })
+        .from(periodicReports)
+        .where(
+          and(
+            eq(periodicReports.engagementId, product.engagementId),
+            eq(periodicReports.type, 'Progress'),
+          ),
+        );
+      const progressRows = await this.progressRows(
+        [input.product.id],
+        reports.map((r) => r.id),
+        input.variant.key,
+      );
+      const byReport = new Map(progressRows.map((row) => [row.reportId, row]));
+      results.push({
+        productId: input.product.id,
+        variant: input.variant.key,
+        progressList: reports.map((report) =>
+          this.toDto(
+            product.steps,
+            input.product.id,
+            report.id,
+            input.variant.key,
+            byReport.get(report.id),
+          ),
+        ),
+      });
+    }
+    return results;
+  }
+
+  async readAllProgressReportsForManyReports(
+    inputs: readonly ProgressVariantByReportInput[],
+  ) {
+    const results = [];
+    for (const input of inputs) {
+      const [report] = await this.db
+        .select({
+          id: periodicReports.id,
+          engagementId: periodicReports.engagementId,
+        })
+        .from(periodicReports)
+        .where(eq(periodicReports.id, input.report.id));
+      if (!report?.engagementId) continue;
+      const engagementProducts = await this.db
+        .select({ id: products.id, steps: products.steps })
+        .from(products)
+        .where(
+          and(
+            eq(products.engagementId, report.engagementId),
+            isNull(products.deletedAt),
+          ),
+        );
+      const progressRows = await this.progressRows(
+        engagementProducts.map((p) => p.id),
+        [report.id],
+        input.variant.key,
+      );
+      const byProduct = new Map(
+        progressRows.map((row) => [row.productId, row]),
+      );
+      results.push({
+        reportId: report.id,
+        variant: input.variant.key,
+        progressList: engagementProducts.map((product) =>
+          this.toDto(
+            product.steps,
+            product.id,
+            report.id,
+            input.variant.key,
+            byProduct.get(product.id),
+          ),
+        ),
+      });
+    }
+    return results;
+  }
+
+  async update(input: UpdateProductProgress) {
+    const product = await this.getProduct(input.product);
+    const [report] = await this.db
+      .select({ id: periodicReports.id })
+      .from(periodicReports)
+      .where(eq(periodicReports.id, input.report));
+    if (!product || !report) {
+      throw new NotFoundException(
+        'Could not find product or report to add progress to',
+      );
+    }
+    await this.db
+      .insert(productProgress)
+      .values({
+        id: await generateId(),
+        productId: input.product,
+        reportId: input.report,
+        variant: input.variant.key,
+      })
+      .onConflictDoNothing();
+    const [row] = await this.db
+      .select({ id: productProgress.id })
+      .from(productProgress)
+      .where(
+        and(
+          eq(productProgress.productId, input.product),
+          eq(productProgress.reportId, input.report),
+          eq(productProgress.variant, input.variant.key),
+        ),
+      );
+    for (const step of input.steps) {
+      await this.db
+        .insert(stepProgress)
+        .values({
+          id: await generateId(),
+          progressId: row!.id,
+          step: step.step,
+          completed: step.completed,
+        })
+        .onConflictDoUpdate({
+          target: [stepProgress.progressId, stepProgress.step],
+          set: { completed: step.completed, updatedAt: new Date() },
+        });
+    }
+    return await this.readOne(input.product, input.report, input.variant);
+  }
+
+  async getScope(productId: ID): Promise<{
+    sensitivity: string;
+    scope: ScopedRole[];
+    progressTarget: number;
+    steps: readonly ProductStep[];
+  }> {
+    const [row] = await this.db
+      .select({
+        progressTarget: products.progressTarget,
+        steps: products.steps,
+        projectId: projects.id,
+        sensitivity: projects.sensitivity,
+      })
+      .from(products)
+      .innerJoin(engagements, eq(products.engagementId, engagements.id))
+      .innerJoin(projects, eq(engagements.projectId, projects.id))
+      .where(and(eq(products.id, productId), isNull(products.deletedAt)));
+    if (!row) {
+      throw new NotFoundException('Could not find product');
+    }
+    const scopeByProject = await requesterScopeByProject(
+      this.db,
+      this.identity.current.userId,
+      [row.projectId],
+    );
+    return {
+      sensitivity: row.sensitivity,
+      scope: scopeByProject.get(row.projectId) ?? [],
+      progressTarget: row.progressTarget,
+      steps: row.steps,
+    };
+  }
+
+  private async getProduct(productId: ID) {
+    const [product] = await this.db
+      .select({
+        id: products.id,
+        engagementId: products.engagementId,
+        steps: products.steps,
+        progressTarget: products.progressTarget,
+      })
+      .from(products)
+      .where(and(eq(products.id, productId), isNull(products.deletedAt)));
+    return product;
+  }
+
+  private async progressRows(
+    productIds: readonly ID[],
+    reportIds: readonly ID[],
+    variantKey: string,
+  ): Promise<ProgressRow[]> {
+    if (productIds.length === 0 || reportIds.length === 0) return [];
+    const rows = await this.db.query.productProgress.findMany({
+      where: (pp) =>
+        and(
+          inArray(pp.productId, [...productIds] as Array<ID<'Product'>>),
+          inArray(pp.reportId, [...reportIds]),
+          eq(pp.variant, variantKey),
+        ),
+      with: { steps: true },
+    });
+    return rows as ProgressRow[];
+  }
+
+  private toDto(
+    declaredSteps: readonly ProductStep[],
+    productId: ID,
+    reportId: ID,
+    variant: string,
+    row?: ProgressRow,
+  ): UnsecuredProductProgress {
+    const byStep = new Map(row?.steps.map((s) => [s.step, s]) ?? []);
+    const dto: unknown = {
+      ...(row && {
+        id: row.id,
+        createdAt: DateTime.fromJSDate(row.createdAt),
+      }),
+      productId,
+      reportId,
+      variant,
+      steps: declaredSteps.map((step): UnsecuredDto<StepProgressDto> => {
+        const sp = byStep.get(step);
+        return sp
+          ? {
+              id: sp.id,
+              createdAt: DateTime.fromJSDate(sp.createdAt),
+              step,
+              completed: sp.completed,
+            }
+          : { step, completed: null };
+      }),
+    };
+    return dto as UnsecuredProductProgress;
+  }
+}

--- a/src/components/product-progress/product-progress.module.ts
+++ b/src/components/product-progress/product-progress.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { PeriodicReportModule } from '../periodic-report/periodic-report.module';
 import { ProductModule } from '../product/product.module';
@@ -7,6 +8,7 @@ import * as handlers from './handlers';
 import { ProductConnectionResolver } from './product-connection.resolver';
 import { ProductProgressByProductLoader } from './product-progress-by-product.loader';
 import { ProductProgressByReportLoader } from './product-progress-by-report.loader';
+import { ProductProgressDrizzleRepository } from './product-progress.drizzle.repository';
 import { ProductProgressRepository } from './product-progress.repository';
 import { ProductProgressResolver } from './product-progress.resolver';
 import { ProductProgressService } from './product-progress.service';
@@ -25,7 +27,11 @@ import { StepProgressResolver } from './step-progress.resolver';
     ProductProgressByProductLoader,
     ProductProgressByReportLoader,
     ProductProgressService,
-    ProductProgressRepository,
+    splitDb(ProductProgressRepository, {
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: ProductProgressDrizzleRepository as any,
+    }),
     StepProgressExtractor,
     ...Object.values(handlers),
   ],

--- a/src/components/progress-report/community-stories/progress-report-community-story.drizzle.repository.ts
+++ b/src/components/progress-report/community-stories/progress-report-community-story.drizzle.repository.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { PromptVariantResponseDrizzleRepository } from '../../prompts/prompt-variant-response.drizzle.repository';
+import { ProgressReport } from '../dto';
+import { ProgressReportCommunityStory as CommunityStory } from '../dto/community-stories.dto';
+
+@Injectable()
+export class ProgressReportCommunityStoryDrizzleRepository extends PromptVariantResponseDrizzleRepository(
+  [ProgressReport, 'communityStories'],
+  CommunityStory,
+) {}

--- a/src/components/progress-report/highlights/progress-report-highlights.drizzle.repository.ts
+++ b/src/components/progress-report/highlights/progress-report-highlights.drizzle.repository.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { PromptVariantResponseDrizzleRepository } from '../../prompts/prompt-variant-response.drizzle.repository';
+import { ProgressReport } from '../dto';
+import { ProgressReportHighlight as Highlight } from '../dto/highlights.dto';
+
+@Injectable()
+export class ProgressReportHighlightsDrizzleRepository extends PromptVariantResponseDrizzleRepository(
+  [ProgressReport, 'highlights'],
+  Highlight,
+) {}

--- a/src/components/progress-report/progress-report.module.ts
+++ b/src/components/progress-report/progress-report.module.ts
@@ -1,9 +1,12 @@
 import { forwardRef, Module } from '@nestjs/common';
+import { splitDb } from '~/core/database';
 import { FileModule } from '../file/file.module';
 import { PeriodicReportModule } from '../periodic-report/periodic-report.module';
+import { ProgressReportCommunityStoryDrizzleRepository } from './community-stories/progress-report-community-story.drizzle.repository';
 import { ProgressReportCommunityStoryRepository } from './community-stories/progress-report-community-story.repository';
 import { ProgressReportCommunityStoryResolver } from './community-stories/progress-report-community-story.resolver';
 import { ProgressReportCommunityStoryService } from './community-stories/progress-report-community-story.service';
+import { ProgressReportHighlightsDrizzleRepository } from './highlights/progress-report-highlights.drizzle.repository';
 import { ProgressReportHighlightsRepository } from './highlights/progress-report-highlights.repository';
 import { ProgressReportHighlightsResolver } from './highlights/progress-report-highlights.resolver';
 import { ProgressReportHighlightsService } from './highlights/progress-report-highlights.service';
@@ -19,6 +22,7 @@ import { ProgressReportEngagementConnectionResolver } from './resolvers/progress
 import { ProgressReportParentResolver } from './resolvers/progress-report-parent.resolver';
 import { ProgressReportResolver } from './resolvers/progress-report.resolver';
 import { ReextractPnpResolver } from './resolvers/reextract-pnp.resolver';
+import { ProgressReportTeamNewsDrizzleRepository } from './team-news/progress-report-team-news.drizzle.repository';
 import { ProgressReportTeamNewsRepository } from './team-news/progress-report-team-news.repository';
 import { ProgressReportTeamNewsResolver } from './team-news/progress-report-team-news.resolver';
 import { ProgressReportTeamNewsService } from './team-news/progress-report-team-news.service';
@@ -40,13 +44,23 @@ import { ProgressReportWorkflowModule } from './workflow/progress-report-workflo
     ReextractPnpResolver,
     ProgressReportTeamNewsResolver,
     ProgressReportTeamNewsService,
-    ProgressReportTeamNewsRepository,
+    splitDb(ProgressReportTeamNewsRepository, {
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: ProgressReportTeamNewsDrizzleRepository as any,
+    }),
     ProgressReportHighlightsResolver,
     ProgressReportHighlightsService,
-    ProgressReportHighlightsRepository,
+    splitDb(ProgressReportHighlightsRepository, {
+      // migration-todo: `as any` removed at Phase 7 cutover.
+      postgres: ProgressReportHighlightsDrizzleRepository as any,
+    }),
     ProgressReportCommunityStoryResolver,
     ProgressReportCommunityStoryService,
-    ProgressReportCommunityStoryRepository,
+    splitDb(ProgressReportCommunityStoryRepository, {
+      // migration-todo: `as any` removed at Phase 7 cutover.
+      postgres: ProgressReportCommunityStoryDrizzleRepository as any,
+    }),
     ProgressReportService,
     ProgressReportRepository,
     ProgressReportExtraForPeriodicInterfaceRepository,

--- a/src/components/progress-report/team-news/progress-report-team-news.drizzle.repository.ts
+++ b/src/components/progress-report/team-news/progress-report-team-news.drizzle.repository.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { PromptVariantResponseDrizzleRepository } from '../../prompts/prompt-variant-response.drizzle.repository';
+import { ProgressReport } from '../dto';
+import { ProgressReportTeamNews as TeamNews } from '../dto/team-news.dto';
+
+@Injectable()
+export class ProgressReportTeamNewsDrizzleRepository extends PromptVariantResponseDrizzleRepository(
+  [ProgressReport, 'teamNews'],
+  TeamNews,
+) {}

--- a/src/components/progress-summary/progress-summary.drizzle.repository.ts
+++ b/src/components/progress-summary/progress-summary.drizzle.repository.ts
@@ -1,0 +1,107 @@
+import { Injectable } from '@nestjs/common';
+import { and, inArray, isNull, sql } from 'drizzle-orm';
+import { type ID } from '~/common';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import {
+  periodicReports,
+  products,
+  progressSummaries,
+} from '~/core/drizzle/schema';
+import { type ProgressReport } from '../progress-report/dto';
+import {
+  type FetchedSummaries,
+  type ProgressSummary,
+  SummaryPeriod,
+} from './dto';
+
+@Injectable()
+export class ProgressSummaryDrizzleRepository {
+  constructor(private readonly drizzle: DrizzleService) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  async readMany(reportIds: readonly ID[]): Promise<FetchedSummaries[]> {
+    if (reportIds.length === 0) return [];
+    const reports = await this.db
+      .select({
+        id: periodicReports.id,
+        engagementId: periodicReports.engagementId,
+      })
+      .from(periodicReports)
+      .where(inArray(periodicReports.id, [...reportIds]));
+    const engagementIds = [
+      ...new Set(reports.flatMap((r) => r.engagementId ?? [])),
+    ];
+    const totals =
+      engagementIds.length > 0
+        ? await this.db
+            .select({
+              engagementId: products.engagementId,
+              totalVerses: sql<number>`sum(${products.totalVerses})::float`,
+              totalVerseEquivalents: sql<number>`sum(${products.totalVerseEquivalents})::float`,
+            })
+            .from(products)
+            .where(
+              and(
+                inArray(products.engagementId, engagementIds),
+                isNull(products.deletedAt),
+              ),
+            )
+            .groupBy(products.engagementId)
+        : [];
+    const totalsByEngagement = new Map(totals.map((t) => [t.engagementId, t]));
+    const summaries = await this.db
+      .select()
+      .from(progressSummaries)
+      .where(inArray(progressSummaries.reportId, [...reportIds]));
+    const byReport = new Map<ID, Map<string, ProgressSummary>>();
+    for (const row of summaries) {
+      const map = byReport.get(row.reportId) ?? new Map();
+      map.set(row.period, { planned: row.planned, actual: row.actual });
+      byReport.set(row.reportId, map);
+    }
+    return reports.map((report) => {
+      const t = report.engagementId
+        ? totalsByEngagement.get(report.engagementId)
+        : undefined;
+      const periods = byReport.get(report.id);
+      const dto: unknown = {
+        report: { __typename: 'ProgressReport', id: report.id },
+        totalVerses: t?.totalVerses ?? 0,
+        totalVerseEquivalents: t?.totalVerseEquivalents ?? 0,
+        [SummaryPeriod.ReportPeriod]:
+          periods?.get(SummaryPeriod.ReportPeriod) ?? null,
+        [SummaryPeriod.FiscalYearSoFar]:
+          periods?.get(SummaryPeriod.FiscalYearSoFar) ?? null,
+        [SummaryPeriod.Cumulative]:
+          periods?.get(SummaryPeriod.Cumulative) ?? null,
+      };
+      return dto as FetchedSummaries;
+    });
+  }
+
+  async save(
+    report: ProgressReport,
+    period: SummaryPeriod,
+    data: ProgressSummary,
+  ) {
+    await this.db
+      .insert(progressSummaries)
+      .values({
+        reportId: report.id,
+        period,
+        planned: data.planned,
+        actual: data.actual,
+      })
+      .onConflictDoUpdate({
+        target: [progressSummaries.reportId, progressSummaries.period],
+        set: {
+          planned: data.planned,
+          actual: data.actual,
+          updatedAt: new Date(),
+        },
+      });
+  }
+}

--- a/src/components/progress-summary/progress-summary.module.ts
+++ b/src/components/progress-summary/progress-summary.module.ts
@@ -4,6 +4,7 @@ import { FileModule } from '../file/file.module';
 import { PeriodicReportModule } from '../periodic-report/periodic-report.module';
 import * as handlers from './handlers';
 import { ProgressReportConnectionResolver } from './progress-report-connection.resolver';
+import { ProgressSummaryDrizzleRepository } from './progress-summary.drizzle.repository';
 import { ProgressSummaryExtractor } from './progress-summary.extractor';
 import { ProgressSummaryGelRepository } from './progress-summary.gel.repository';
 import { ProgressSummaryLoader } from './progress-summary.loader';
@@ -18,6 +19,9 @@ import { ProgressSummaryResolver } from './progress-summary.resolver';
     ProgressSummaryLoader,
     splitDb(ProgressSummaryRepository, {
       gel: ProgressSummaryGelRepository,
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: ProgressSummaryDrizzleRepository as any,
     }),
     ProgressSummaryExtractor,
     ...Object.values(handlers),

--- a/src/components/prompts/prompt-variant-response.drizzle.repository.ts
+++ b/src/components/prompts/prompt-variant-response.drizzle.repository.ts
@@ -91,9 +91,16 @@ export const PromptVariantResponseDrizzleRepository = <
           ),
         with: { entries: true },
         orderBy: (r) => [asc(r.createdAt), asc(r.id)],
+        // Mirror the Neo4j repo's paginate({ count: 25, page: 1 }): cap the
+        // page and probe one extra row for hasMore rather than returning every
+        // row (which also bounds the payload).
+        limit: 26,
       });
-      const items = rows.map((row) => this.toDto(row as ResponseRow));
-      return { items, total: items.length, hasMore: false };
+      const hasMore = rows.length > 25;
+      const items = rows
+        .slice(0, 25)
+        .map((row) => this.toDto(row as ResponseRow));
+      return { items, total: items.length, hasMore };
     }
 
     async readOne(
@@ -128,6 +135,14 @@ export const PromptVariantResponseDrizzleRepository = <
       return await this.readOne(id);
     }
 
+    // migration-todo: this read-then-write is not serialized. Two concurrent
+    // submits for the same (response_id, variant) can both see no active entry
+    // (or both retire the same one) and then race into the partial unique
+    // index — the loser fails with a unique-violation (no bad data lands; the
+    // index is the fail-safe). The Neo4j path is atomic in a single query.
+    // Deferred: serialize with a tx + `SELECT ... FOR UPDATE` on the parent
+    // response, or a conflict-aware upsert. Low-priority given the backstop and
+    // the rarity of concurrent same-variant submits.
     async submitResponse(input: UpdatePromptVariantResponse<TVariant>) {
       const now = new Date();
       const [entry] = await this.db

--- a/src/components/prompts/prompt-variant-response.drizzle.repository.ts
+++ b/src/components/prompts/prompt-variant-response.drizzle.repository.ts
@@ -1,0 +1,225 @@
+import { Inject } from '@nestjs/common';
+import { and, asc, eq, isNull } from 'drizzle-orm';
+import { LazyGetter as Once } from 'lazy-get-decorator';
+import { DateTime } from 'luxon';
+import {
+  EnhancedResource,
+  generateId,
+  type ID,
+  NotFoundException,
+  type PaginatedListType,
+  type ResourceShape,
+  type UnsecuredDto,
+  type VariantList,
+  type VariantOf,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import {
+  promptVariantResponseEntries,
+  promptVariantResponses,
+} from '~/core/drizzle/schema';
+import { defaultPermanentAfter } from '~/core/neo4j/query/properties/update-property';
+import { type BaseNode } from '~/core/neo4j/results';
+import { type EdgePrivileges, Privileges } from '../authorization';
+import { type ChildListAction } from '../authorization/policy/actions';
+import {
+  type ChangePrompt,
+  type ChoosePrompt,
+  type PromptVariantResponse,
+  type UpdatePromptVariantResponse,
+} from './dto';
+import { type ListEdge } from './prompt-variant-response.repository';
+
+type ResponseRow = typeof promptVariantResponses.$inferSelect & {
+  entries: Array<typeof promptVariantResponseEntries.$inferSelect>;
+};
+
+/**
+ * Drizzle mirror of {@link import('./prompt-variant-response.repository').PromptVariantResponseRepository}.
+ * All subtypes share the prompt_variant_responses/_entries table pair,
+ * scoped by `resource_type`.
+ */
+export const PromptVariantResponseDrizzleRepository = <
+  Parent extends ResourceShape<any>,
+  TResourceStatic extends ResourceShape<PromptVariantResponse<TVariant>> & {
+    Variants: VariantList<TVariant>;
+  },
+  TVariant extends string = VariantOf<TResourceStatic>,
+>(
+  parentEdge: ListEdge<Parent>,
+  resource: TResourceStatic,
+) => {
+  abstract class PromptVariantResponseDrizzleRepositoryClass {
+    readonly resource = EnhancedResource.of(resource);
+
+    @Inject(Privileges)
+    protected readonly privilegesService: Privileges;
+    @Inject(Identity)
+    protected readonly identity: Identity;
+    @Inject(DrizzleService)
+    protected readonly drizzle: DrizzleService;
+
+    protected get db() {
+      return this.drizzle.client;
+    }
+
+    @Once()
+    get edge() {
+      return this.privilegesService.forEdge(
+        ...(parentEdge as [any, any]),
+      ) as EdgePrivileges<Parent, any, ChildListAction>;
+    }
+
+    // migration-todo: the Neo4j hydrate applies filterToReadable() row-level;
+    // this port (and readOne below) deliberately relies on the service's
+    // parent-edge `edge.can('read')` gate instead — equivalent today because
+    // PVR read grants are resource-level, not per-row. If a per-row condition
+    // (e.g. creator-based) is ever added, port an EXISTS predicate mirroring
+    // oncePerProjectFromProgressReportChild here.
+    async list(
+      parentId: ID,
+    ): Promise<
+      PaginatedListType<UnsecuredDto<PromptVariantResponse<TVariant>>>
+    > {
+      const rows = await this.db.query.promptVariantResponses.findMany({
+        where: (r) =>
+          and(
+            eq(r.parentId, parentId),
+            eq(r.resourceType, resource.name),
+            isNull(r.deletedAt),
+          ),
+        with: { entries: true },
+        orderBy: (r) => [asc(r.createdAt), asc(r.id)],
+      });
+      const items = rows.map((row) => this.toDto(row as ResponseRow));
+      return { items, total: items.length, hasMore: false };
+    }
+
+    async readOne(
+      id: ID,
+    ): Promise<UnsecuredDto<PromptVariantResponse<TVariant>>> {
+      const row = await this.db.query.promptVariantResponses.findFirst({
+        where: (r) =>
+          and(
+            eq(r.id, id),
+            eq(r.resourceType, resource.name),
+            isNull(r.deletedAt),
+          ),
+        with: { entries: true },
+      });
+      if (!row) {
+        throw new NotFoundException(`Could not find ${resource.name}`);
+      }
+      return this.toDto(row as ResponseRow);
+    }
+
+    async create(
+      input: ChoosePrompt,
+    ): Promise<UnsecuredDto<PromptVariantResponse<TVariant>>> {
+      const id = await generateId();
+      await this.db.insert(promptVariantResponses).values({
+        id,
+        resourceType: resource.name,
+        parentId: input.resource,
+        prompt: input.prompt,
+        creatorId: this.identity.current.userId,
+      });
+      return await this.readOne(id);
+    }
+
+    async submitResponse(input: UpdatePromptVariantResponse<TVariant>) {
+      const now = new Date();
+      const [entry] = await this.db
+        .select()
+        .from(promptVariantResponseEntries)
+        .where(
+          and(
+            eq(promptVariantResponseEntries.responseId, input.id),
+            eq(promptVariantResponseEntries.variant, input.variant),
+            isNull(promptVariantResponseEntries.deletedAt),
+          ),
+        );
+      const permanentCutoff = DateTime.now().minus(defaultPermanentAfter);
+      const isPermanent =
+        entry && DateTime.fromJSDate(entry.createdAt) <= permanentCutoff;
+      if (entry && !isPermanent) {
+        // Still within the edit window — overwrite in place.
+        await this.db
+          .update(promptVariantResponseEntries)
+          .set({ response: input.response, modifiedAt: now })
+          .where(eq(promptVariantResponseEntries.id, entry.id));
+      } else {
+        if (entry) {
+          // Past the window — retire the old entry, keeping history.
+          await this.db
+            .update(promptVariantResponseEntries)
+            .set({ deletedAt: now })
+            .where(eq(promptVariantResponseEntries.id, entry.id));
+        }
+        await this.db.insert(promptVariantResponseEntries).values({
+          responseId: input.id,
+          variant: input.variant,
+          response: input.response,
+          creatorId: this.identity.current.userId,
+        });
+      }
+      await this.db
+        .update(promptVariantResponses)
+        .set({ modifiedAt: now, updatedAt: now })
+        .where(eq(promptVariantResponses.id, input.id));
+    }
+
+    async changePrompt(input: ChangePrompt) {
+      const now = new Date();
+      await this.db
+        .update(promptVariantResponses)
+        .set({ prompt: input.prompt, modifiedAt: now, updatedAt: now })
+        .where(eq(promptVariantResponses.id, input.id));
+    }
+
+    async delete(id: ID) {
+      await this.db
+        .update(promptVariantResponses)
+        .set({ deletedAt: new Date() })
+        .where(eq(promptVariantResponses.id, id));
+    }
+
+    protected toDto(
+      row: ResponseRow,
+    ): UnsecuredDto<PromptVariantResponse<TVariant>> {
+      // Neo4j-shaped BaseNode so ResourceLoader.loadByBaseNode() keeps
+      // working for the parent field / privilege context — only labels +
+      // properties.id are read (createdAt is along for type shape).
+      const parentResource = EnhancedResource.of(parentEdge[0] as any);
+      const parent: BaseNode = {
+        identity: row.parentId,
+        labels: [parentResource.name, 'BaseNode'],
+        properties: {
+          id: row.parentId,
+          createdAt: DateTime.fromJSDate(row.createdAt),
+        },
+      };
+      const dto: unknown = {
+        id: row.id,
+        createdAt: DateTime.fromJSDate(row.createdAt),
+        modifiedAt: DateTime.fromJSDate(row.modifiedAt),
+        creator: { id: row.creatorId },
+        parent,
+        prompt: row.prompt,
+        responses: row.entries
+          .filter((e) => !e.deletedAt)
+          .map((e) => ({
+            variant: e.variant,
+            response: e.response,
+            creator: { id: e.creatorId },
+            modifiedAt: DateTime.fromJSDate(e.modifiedAt ?? e.createdAt),
+          })),
+        canDelete: true,
+      };
+      return dto as UnsecuredDto<PromptVariantResponse<TVariant>>;
+    }
+  }
+
+  return PromptVariantResponseDrizzleRepositoryClass;
+};

--- a/src/components/prompts/prompt-variant-response.repository.ts
+++ b/src/components/prompts/prompt-variant-response.repository.ts
@@ -236,6 +236,10 @@ export const PromptVariantResponseRepository = <
         .executeAndLogStats();
     }
 
+    async delete(id: ID) {
+      await this.deleteNode(id);
+    }
+
     async changePrompt(input: ChangePrompt) {
       // @ts-expect-error uhhhh yolo ¯\_(ツ)_/¯
       const resource: typeof PromptVariantResponse = this.resource.type;

--- a/src/components/prompts/prompt-variant-response.service.ts
+++ b/src/components/prompts/prompt-variant-response.service.ts
@@ -268,7 +268,7 @@ export const PromptVariantResponseListService = <
       const privileges = this.resourcePrivileges.forContext(context);
       privileges.verifyCan('delete');
 
-      await this.repo.deleteNode(id);
+      await this.repo.delete(id);
 
       return response;
     }

--- a/src/components/rev79/rev79.drizzle.repository.ts
+++ b/src/components/rev79/rev79.drizzle.repository.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common';
+import { and, eq, isNotNull, isNull } from 'drizzle-orm';
+import { type ID } from '~/common';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { engagements, languages, projects } from '~/core/drizzle/schema';
+
+@Injectable()
+export class Rev79DrizzleRepository {
+  constructor(private readonly drizzle: DrizzleService) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  async findProjectsByRev79Id(
+    rev79ProjectId: string,
+  ): Promise<ReadonlyArray<{ id: ID<'Project'> }>> {
+    return await this.db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(
+        and(
+          eq(projects.rev79ProjectId, rev79ProjectId),
+          isNull(projects.deletedAt),
+        ),
+      );
+  }
+
+  async findCommunitiesByRev79ProjectId(
+    projectId: ID<'Project'>,
+  ): Promise<ReadonlyArray<{ id: string; name: string }>> {
+    const rows = await this.db
+      .select({ id: engagements.rev79CommunityId, name: languages.name })
+      .from(engagements)
+      .innerJoin(languages, eq(engagements.languageId, languages.id))
+      .where(
+        and(
+          eq(engagements.projectId, projectId),
+          isNotNull(engagements.rev79CommunityId),
+          isNull(engagements.deletedAt),
+        ),
+      );
+    return rows.map((row) => ({ id: row.id!, name: row.name }));
+  }
+
+  async findEngagementsByRev79CommunityId(
+    projectId: ID<'Project'>,
+    rev79CommunityId: string,
+  ): Promise<ReadonlyArray<{ id: ID<'LanguageEngagement'> }>> {
+    const rows = await this.db
+      .select({ id: engagements.id })
+      .from(engagements)
+      .where(
+        and(
+          eq(engagements.projectId, projectId),
+          eq(engagements.rev79CommunityId, rev79CommunityId),
+          isNull(engagements.deletedAt),
+        ),
+      );
+    return rows as Array<{ id: ID<'LanguageEngagement'> }>;
+  }
+}

--- a/src/components/rev79/rev79.drizzle.repository.ts
+++ b/src/components/rev79/rev79.drizzle.repository.ts
@@ -54,6 +54,11 @@ export class Rev79DrizzleRepository {
         and(
           eq(engagements.projectId, projectId),
           eq(engagements.rev79CommunityId, rev79CommunityId),
+          // Constrain to LanguageEngagements — the Neo4j repo matches the
+          // `:LanguageEngagement` label. The shared engagements table doesn't
+          // enforce rev79CommunityId is null for Internships, so without this
+          // an Internship id could be returned as an ID<'LanguageEngagement'>.
+          isNotNull(engagements.languageId),
           isNull(engagements.deletedAt),
         ),
       );

--- a/src/components/rev79/rev79.drizzle.repository.ts
+++ b/src/components/rev79/rev79.drizzle.repository.ts
@@ -38,6 +38,10 @@ export class Rev79DrizzleRepository {
           eq(engagements.projectId, projectId),
           isNotNull(engagements.rev79CommunityId),
           isNull(engagements.deletedAt),
+          // Exclude soft-deleted languages — Neo4j matches the `:Language`
+          // label, which excludes deleted (relabeled) nodes. Without this an
+          // active engagement joined to a deleted language leaks that community.
+          isNull(languages.deletedAt),
         ),
       );
     return rows.map((row) => ({ id: row.id!, name: row.name }));

--- a/src/components/rev79/rev79.module.ts
+++ b/src/components/rev79/rev79.module.ts
@@ -5,6 +5,7 @@ import { ProductProgressModule } from '../product-progress/product-progress.modu
 import { ProgressReportModule } from '../progress-report/progress-report.module';
 import { ProjectModule } from '../project/project.module';
 import { FixRev79ActiveFlagMigration } from './migrations/fix-rev79-active-flag.migration';
+import { Rev79DrizzleRepository } from './rev79.drizzle.repository';
 import { Rev79GelRepository } from './rev79.gel.repository';
 import { Rev79Repository } from './rev79.repository';
 import { Rev79Resolver } from './rev79.resolver';
@@ -20,7 +21,12 @@ import { Rev79Service } from './rev79.service';
   providers: [
     Rev79Resolver,
     Rev79Service,
-    splitDb(Rev79Repository, { gel: Rev79GelRepository }),
+    splitDb(Rev79Repository, {
+      gel: Rev79GelRepository,
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path.
+      postgres: Rev79DrizzleRepository as any,
+    }),
     FixRev79ActiveFlagMigration,
   ],
 })

--- a/src/core/drizzle/migrations/0019_add_periodic_reports.sql
+++ b/src/core/drizzle/migrations/0019_add_periodic_reports.sql
@@ -1,0 +1,51 @@
+-- Periodic Reports (Phase 5). Single table over FinancialReport /
+-- NarrativeReport / ProgressReport. Financial+Narrative hang off projects;
+-- Progress hangs off (language) engagements — the parent CHECK keeps the FK
+-- coherent with the type. Ids are deterministic (sha256 of
+-- parent:type:start:end, same derivation as Neo4j), so concurrent syncs
+-- resolve via ON CONFLICT (id) DO NOTHING. No deleted_at: deletion is real
+-- (eligible rows carry no user data, and a soft-deleted row would block the
+-- deterministic id from being recreated when dates change back).
+-- report_file_id / narrative_file_id are plain text, no FK — S4 class: the
+-- createDefinedFile fan-out inserts this row before its file rows; real FKs
+-- land with the S4 option-2 reorder at cutover cleanup. status is
+-- ProgressReport-only, driven by the progress-report workflow.
+
+CREATE TYPE "report_type" AS ENUM ('Financial', 'Narrative', 'Progress');
+
+CREATE TYPE "progress_report_status" AS ENUM (
+  'NotStarted',
+  'InProgress',
+  'PendingTranslation',
+  'InReview',
+  'Approved',
+  'Published'
+);
+
+CREATE TABLE "periodic_reports" (
+  "id"             text PRIMARY KEY,
+  "type"           "report_type" NOT NULL,
+  "project_id"     text REFERENCES "projects"("id") ON DELETE CASCADE,
+  "engagement_id"  text REFERENCES "engagements"("id") ON DELETE CASCADE,
+  "start"          date NOT NULL,
+  "end"            date NOT NULL,
+  "received_date"  date,
+  "skipped_reason" text,
+  "report_file_id" text,
+  "narrative_file_id" text,
+  "narrative_received_date" date,
+  "status"         "progress_report_status",
+  "created_at"     timestamptz NOT NULL DEFAULT now(),
+  "updated_at"     timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT "periodic_reports_parent_shape_chk" CHECK (
+    ("type" IN ('Financial', 'Narrative') AND "project_id" IS NOT NULL AND "engagement_id" IS NULL)
+    OR ("type" = 'Progress' AND "engagement_id" IS NOT NULL AND "project_id" IS NULL)
+  ),
+  CONSTRAINT "periodic_reports_status_shape_chk" CHECK (
+    ("type" = 'Progress') = ("status" IS NOT NULL)
+  )
+);
+
+CREATE INDEX "periodic_reports_project_id_idx" ON "periodic_reports" ("project_id");
+CREATE INDEX "periodic_reports_engagement_id_idx" ON "periodic_reports" ("engagement_id");

--- a/src/core/drizzle/migrations/0020_add_prompt_variant_responses.sql
+++ b/src/core/drizzle/migrations/0020_add_prompt_variant_responses.sql
@@ -1,0 +1,43 @@
+-- Prompt Variant Responses (Phase 5). Generic container shared by every
+-- PromptVariantResponse subtype (ProgressReport team news / highlights /
+-- community stories). resource_type is the concrete DTO name (stands in for
+-- the Neo4j label); parent_id is intentionally FK-less — parents span tables
+-- as domains migrate. Prompts are code-defined; only the chosen prompt id is
+-- stored. Entries are one row per (response, variant): edits within the
+-- permanent-after window update in place, later edits soft-delete and insert
+-- (mirror of Neo4j's deactivate+create history chain).
+
+CREATE TABLE "prompt_variant_responses" (
+  "id"            text PRIMARY KEY,
+  "resource_type" text NOT NULL,
+  "parent_id"     text NOT NULL,
+  "prompt"        text NOT NULL,
+  "creator_id"    text NOT NULL REFERENCES "users"("id"),
+  "created_at"    timestamptz NOT NULL DEFAULT now(),
+  "modified_at"   timestamptz NOT NULL DEFAULT now(),
+  "updated_at"    timestamptz NOT NULL DEFAULT now(),
+  "deleted_at"    timestamptz
+);
+
+CREATE INDEX "prompt_variant_responses_parent_id_idx"
+  ON "prompt_variant_responses" ("parent_id");
+
+CREATE TABLE "prompt_variant_response_entries" (
+  "id"          bigserial PRIMARY KEY,
+  "response_id" text NOT NULL REFERENCES "prompt_variant_responses"("id") ON DELETE CASCADE,
+  "variant"     text NOT NULL,
+  "response"    jsonb,
+  "creator_id"  text NOT NULL REFERENCES "users"("id"),
+  "created_at"  timestamptz NOT NULL DEFAULT now(),
+  "modified_at" timestamptz NOT NULL DEFAULT now(),
+  "deleted_at"  timestamptz
+);
+
+CREATE UNIQUE INDEX "prompt_variant_response_entries_response_variant_active_unique"
+  ON "prompt_variant_response_entries" ("response_id", "variant")
+  WHERE "deleted_at" IS NULL;
+
+-- Full FK indexes (mono added these in later backfills; inline here).
+CREATE INDEX "prompt_variant_responses_creator_id_idx" ON "prompt_variant_responses" ("creator_id");
+CREATE INDEX "prompt_variant_response_entries_response_id_idx" ON "prompt_variant_response_entries" ("response_id");
+CREATE INDEX "prompt_variant_response_entries_creator_id_idx" ON "prompt_variant_response_entries" ("creator_id");

--- a/src/core/drizzle/migrations/0021_add_product_progress.sql
+++ b/src/core/drizzle/migrations/0021_add_product_progress.sql
@@ -1,0 +1,49 @@
+-- Product Progress + Progress Summaries (Phase 5). product_progress exists
+-- once any step progress is reported for a (product, report, variant);
+-- step_progress rows hang off it and unreported steps surface as placeholders
+-- at read time, ordered by the product's declared steps. progress_summaries
+-- holds the PnP-extracted planned/actual figures per (report, period) — the
+-- write path is the extractor (File domain, Phase 7); reads serve the
+-- ProgressReport summary fields.
+
+CREATE TABLE "product_progress" (
+  "id"         text PRIMARY KEY,
+  "product_id" text NOT NULL REFERENCES "products"("id") ON DELETE CASCADE,
+  "report_id"  text NOT NULL REFERENCES "periodic_reports"("id") ON DELETE CASCADE,
+  "variant"    text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX "product_progress_product_report_variant_unique"
+  ON "product_progress" ("product_id", "report_id", "variant");
+CREATE INDEX "product_progress_report_id_idx" ON "product_progress" ("report_id");
+
+CREATE TABLE "step_progress" (
+  "id"          text PRIMARY KEY,
+  "progress_id" text NOT NULL REFERENCES "product_progress"("id") ON DELETE CASCADE,
+  -- product_step enum (0018) — matches the sibling products.steps column;
+  -- mono kept text only because its chain had no product_step type.
+  "step"        "product_step" NOT NULL,
+  "completed"   double precision,
+  "created_at"  timestamptz NOT NULL DEFAULT now(),
+  "updated_at"  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX "step_progress_progress_step_unique"
+  ON "step_progress" ("progress_id", "step");
+
+CREATE TYPE "summary_period" AS ENUM ('ReportPeriod', 'FiscalYearSoFar', 'Cumulative');
+
+CREATE TABLE "progress_summaries" (
+  "id"         bigserial PRIMARY KEY,
+  "report_id"  text NOT NULL REFERENCES "periodic_reports"("id") ON DELETE CASCADE,
+  "period"     "summary_period" NOT NULL,
+  "planned"    double precision NOT NULL,
+  "actual"     double precision NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX "progress_summaries_report_period_unique"
+  ON "progress_summaries" ("report_id", "period");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -134,6 +134,27 @@
       "when": 1752192000000,
       "tag": "0018_add_products",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1752278400000,
+      "tag": "0019_add_periodic_reports",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1752364800000,
+      "tag": "0020_add_prompt_variant_responses",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1752451200000,
+      "tag": "0021_add_product_progress",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -32,11 +32,13 @@ import { type PartnerType } from '../../../components/partner/dto/partner-type.e
 import { type FinancialReportingType } from '../../../components/partnership/dto/financial-reporting-type.enum';
 import { type PartnershipAgreementStatus } from '../../../components/partnership/dto/partnership-agreement-status.enum';
 import { type ReportPeriod } from '../../../components/periodic-report/dto/report-period.enum';
+import { type ReportType } from '../../../components/periodic-report/dto/report-type.enum';
 import { type ProductMedium } from '../../../components/product/dto/product-medium.enum';
 import { type ProductMethodology } from '../../../components/product/dto/product-methodology.enum';
 import { type ProductPurpose } from '../../../components/product/dto/product-purpose.enum';
 import { type ProductStep } from '../../../components/product/dto/product-step.enum';
 import { type ProgressMeasurement } from '../../../components/product/dto/progress-measurement.enum';
+import { type ProgressReportStatus } from '../../../components/progress-report/dto/progress-report-status.enum';
 import { type ProjectStatus } from '../../../components/project/dto/project-status.enum';
 import { type ProjectStep } from '../../../components/project/dto/project-step.enum';
 import { type ProjectType } from '../../../components/project/dto/project-type.enum';
@@ -2203,6 +2205,305 @@ export const productCompletionDescriptions = pgTable(
     uniqueIndex('product_completion_descriptions_value_methodology_unique').on(
       t.value,
       t.methodology,
+    ),
+  ],
+);
+
+// ─── Periodic Reports ──────────────────────────────────────────────────────
+
+export const reportTypeEnum = pgEnum('report_type', [
+  'Financial',
+  'Narrative',
+  'Progress',
+]);
+
+export const progressReportStatusEnum = pgEnum('progress_report_status', [
+  'NotStarted',
+  'InProgress',
+  'PendingTranslation',
+  'InReview',
+  'Approved',
+  'Published',
+]);
+
+/**
+ * Single table over FinancialReport / NarrativeReport / ProgressReport.
+ * Financial+Narrative hang off projects; Progress hangs off (language)
+ * engagements — the CHECK keeps the parent FK coherent with the type.
+ *
+ * The id is deterministic — sha256(parent:type:start:end), same derivation as
+ * Neo4j — so concurrent syncs computing rows for the same interval collide on
+ * the PK and resolve via ON CONFLICT DO NOTHING. Deletion is a REAL delete
+ * (no deleted_at): eligible rows carry no user data (no file, NotStarted),
+ * and a soft-deleted row would block the deterministic id from ever being
+ * recreated when dates change back.
+ *
+ * `status` is ProgressReport-only (workflow-driven; plain column like
+ * engagement.status).
+ */
+export const periodicReports = pgTable(
+  'periodic_reports',
+  {
+    id: text('id').$type<ID>().primaryKey(),
+    type: reportTypeEnum('type').$type<ReportType>().notNull(),
+    projectId: text('project_id')
+      .$type<ID<'Project'>>()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    engagementId: text('engagement_id')
+      .$type<ID<'Engagement'>>()
+      .references(() => engagements.id, { onDelete: 'cascade' }),
+    start: date('start').notNull(),
+    end: date('end').notNull(),
+    receivedDate: date('received_date'),
+    skippedReason: text('skipped_reason'),
+    // migration-todo(cutover-cleanup): plain text, no FK — S4 class. The
+    // file_nodes table exists (0008), but the createDefinedFile fan-out
+    // inserts this row before its file rows; real FKs land with the S4
+    // option-2 reorder at cutover cleanup.
+    reportFileId: text('report_file_id').$type<ID<'File'>>(),
+    // Columns-mono-style per Rob 2026-07-16 (periodic_report_files join-table
+    // redesign = post-cutover ticket). Same S4 deferred-FK class as above.
+    narrativeFileId: text('narrative_file_id').$type<ID<'File'>>(),
+    narrativeReceivedDate: date('narrative_received_date'),
+    status: progressReportStatusEnum('status').$type<ProgressReportStatus>(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    check(
+      'periodic_reports_parent_shape_chk',
+      sql`(${t.type} IN ('Financial', 'Narrative') AND ${t.projectId} IS NOT NULL AND ${t.engagementId} IS NULL)
+        OR (${t.type} = 'Progress' AND ${t.engagementId} IS NOT NULL AND ${t.projectId} IS NULL)`,
+    ),
+    check(
+      'periodic_reports_status_shape_chk',
+      sql`(${t.type} = 'Progress') = (${t.status} IS NOT NULL)`,
+    ),
+    index('periodic_reports_project_id_idx').on(t.projectId),
+    index('periodic_reports_engagement_id_idx').on(t.engagementId),
+  ],
+);
+
+export const periodicReportsRelations = relations(
+  periodicReports,
+  ({ one }) => ({
+    project: one(projects, {
+      fields: [periodicReports.projectId],
+      references: [projects.id],
+    }),
+    engagement: one(engagements, {
+      fields: [periodicReports.engagementId],
+      references: [engagements.id],
+    }),
+  }),
+);
+
+// ─── Prompt Variant Responses ──────────────────────────────────────────────
+
+/**
+ * Generic prompt-response container shared by every PromptVariantResponse
+ * subtype (ProgressReport team news / highlights / community stories; more
+ * later). `resource_type` is the concrete DTO name (stands in for the Neo4j
+ * label); `parent_id` is intentionally FK-less — parents span tables
+ * (periodic_reports today, others as domains migrate). Prompts are
+ * code-defined; only the chosen prompt id is stored.
+ */
+export const promptVariantResponses = pgTable(
+  'prompt_variant_responses',
+  {
+    id: text('id').$type<ID>().primaryKey(),
+    resourceType: text('resource_type').notNull(),
+    parentId: text('parent_id').$type<ID>().notNull(),
+    prompt: text('prompt').notNull(),
+    creatorId: text('creator_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    modifiedAt: timestamp('modified_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    index('prompt_variant_responses_parent_id_idx').on(t.parentId),
+    index('prompt_variant_responses_creator_id_idx').on(t.creatorId),
+  ],
+);
+
+/**
+ * One row per (response, variant) — the actual rich-text answers. Edits
+ * within the permanent-after window update in place; later edits soft-delete
+ * the old row and insert a new one (mirror of Neo4j's deactivate+create
+ * history chain).
+ */
+export const promptVariantResponseEntries = pgTable(
+  'prompt_variant_response_entries',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    responseId: text('response_id')
+      .$type<ID>()
+      .notNull()
+      .references(() => promptVariantResponses.id, { onDelete: 'cascade' }),
+    variant: text('variant').notNull(),
+    response: jsonb('response'),
+    creatorId: text('creator_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    modifiedAt: timestamp('modified_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    uniqueIndex(
+      'prompt_variant_response_entries_response_variant_active_unique',
+    )
+      .on(t.responseId, t.variant)
+      .where(sql`${t.deletedAt} IS NULL`),
+    // Full FK index — the partial unique can't serve FK-maintenance scans.
+    index('prompt_variant_response_entries_response_id_idx').on(t.responseId),
+    index('prompt_variant_response_entries_creator_id_idx').on(t.creatorId),
+  ],
+);
+
+export const promptVariantResponsesRelations = relations(
+  promptVariantResponses,
+  ({ many }) => ({
+    entries: many(promptVariantResponseEntries),
+  }),
+);
+
+export const promptVariantResponseEntriesRelations = relations(
+  promptVariantResponseEntries,
+  ({ one }) => ({
+    parent: one(promptVariantResponses, {
+      fields: [promptVariantResponseEntries.responseId],
+      references: [promptVariantResponses.id],
+    }),
+  }),
+);
+
+// ─── Product Progress + Progress Summaries ─────────────────────────────────
+
+/**
+ * Progress container per (product, report, variant) — exists once any step
+ * progress is reported. Step rows hang off it; unreported steps surface as
+ * placeholders at read time, ordered by the product's declared steps.
+ */
+export const productProgress = pgTable(
+  'product_progress',
+  {
+    id: text('id').$type<ID>().primaryKey(),
+    productId: text('product_id')
+      .$type<ID<'Product'>>()
+      .notNull()
+      .references(() => products.id, { onDelete: 'cascade' }),
+    reportId: text('report_id')
+      .$type<ID>()
+      .notNull()
+      .references(() => periodicReports.id, { onDelete: 'cascade' }),
+    variant: text('variant').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('product_progress_product_report_variant_unique').on(
+      t.productId,
+      t.reportId,
+      t.variant,
+    ),
+    index('product_progress_report_id_idx').on(t.reportId),
+  ],
+);
+
+export const stepProgress = pgTable(
+  'step_progress',
+  {
+    id: text('id').$type<ID>().primaryKey(),
+    progressId: text('progress_id')
+      .$type<ID>()
+      .notNull()
+      .references(() => productProgress.id, { onDelete: 'cascade' }),
+    // product_step enum — matches products.steps (mono had no enum type).
+    step: productStepEnum('step').$type<ProductStep>().notNull(),
+    completed: doublePrecision('completed'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('step_progress_progress_step_unique').on(t.progressId, t.step),
+  ],
+);
+
+export const productProgressRelations = relations(
+  productProgress,
+  ({ many }) => ({
+    steps: many(stepProgress),
+  }),
+);
+
+export const stepProgressRelations = relations(stepProgress, ({ one }) => ({
+  progress: one(productProgress, {
+    fields: [stepProgress.progressId],
+    references: [productProgress.id],
+  }),
+}));
+
+export const summaryPeriodEnum = pgEnum('summary_period', [
+  'ReportPeriod',
+  'FiscalYearSoFar',
+  'Cumulative',
+]);
+
+/**
+ * Extracted planned/actual figures per (progress report, period) — written
+ * by the PnP extractor on report file upload (File domain, Phase 7); the
+ * read path serves the ProgressReport summary fields.
+ */
+export const progressSummaries = pgTable(
+  'progress_summaries',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    reportId: text('report_id')
+      .$type<ID>()
+      .notNull()
+      .references(() => periodicReports.id, { onDelete: 'cascade' }),
+    period: summaryPeriodEnum('period').notNull(),
+    planned: doublePrecision('planned').notNull(),
+    actual: doublePrecision('actual').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('progress_summaries_report_period_unique').on(
+      t.reportId,
+      t.period,
     ),
   ],
 );

--- a/test/periodic-report.e2e-spec.ts
+++ b/test/periodic-report.e2e-spec.ts
@@ -1,0 +1,419 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { CalendarDate, Role } from '~/common';
+import { graphql } from '~/graphql';
+import {
+  createLanguage,
+  createLanguageEngagement,
+  createProject,
+  createSession,
+  createTestApp,
+  registerUser,
+  requestFileUpload,
+  runAsAdmin,
+  type TestApp,
+  uploadFileContents,
+} from './utility';
+import { createDirectProduct } from './utility/create-product-direct';
+import { updateProject } from './utility/update-project';
+
+describe('Periodic Report e2e', () => {
+  let app: TestApp;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await createSession(app);
+    await registerUser(app, {
+      roles: [Role.ProjectManager, Role.FieldOperationsDirector],
+    });
+  });
+
+  it('syncs narrative reports quarterly when project dates change', async () => {
+    const project = await createProject(app);
+    // The sync runs on update, not create.
+    await updateProject(app, {
+      id: project.id,
+      mouStart: CalendarDate.fromISO('2020-01-01').toISO(),
+      mouEnd: CalendarDate.fromISO('2020-12-31').toISO(),
+    });
+
+    const result = await app.graphql.query(ProjectReportsDoc, {
+      id: project.id,
+    });
+    const { narrativeReports } = result.project;
+    // 4 quarters + the final report (start = end = quarter end)
+    expect(narrativeReports.total).toBe(5);
+    const quarters = narrativeReports.items.filter((r) => r.start !== r.end);
+    expect(quarters).toHaveLength(4);
+    expect(quarters.map((r) => r.start)).toEqual([
+      '2020-01-01',
+      '2020-04-01',
+      '2020-07-01',
+      '2020-10-01',
+    ]);
+    const finalReport = narrativeReports.items.find((r) => r.start === r.end);
+    expect(finalReport?.start).toBe('2020-12-31');
+  });
+
+  it('syncs financial reports by the report period', async () => {
+    const project = await createProject(app);
+    await updateProject(app, {
+      id: project.id,
+      mouStart: CalendarDate.fromISO('2020-01-01').toISO(),
+      mouEnd: CalendarDate.fromISO('2020-06-30').toISO(),
+      financialReportPeriod: 'Monthly',
+    });
+
+    const result = await app.graphql.query(ProjectReportsDoc, {
+      id: project.id,
+    });
+    const { financialReports } = result.project;
+    const monthly = financialReports.items.filter((r) => r.start !== r.end);
+    expect(monthly).toHaveLength(6);
+
+    // Switching the period replaces the reports.
+    await updateProject(app, {
+      id: project.id,
+      financialReportPeriod: 'Quarterly',
+    });
+    const after = await app.graphql.query(ProjectReportsDoc, {
+      id: project.id,
+    });
+    const quarterly = after.project.financialReports.items.filter(
+      (r) => r.start !== r.end,
+    );
+    expect(quarterly).toHaveLength(2);
+  });
+
+  it('creates progress reports for each engagement quarter', async () => {
+    const project = await createProject(app, {
+      mouStart: CalendarDate.fromISO('2020-01-01').toISO(),
+      mouEnd: CalendarDate.fromISO('2020-12-31').toISO(),
+    });
+    const language = await runAsAdmin(app, createLanguage);
+    const engagement = await createLanguageEngagement(app, {
+      project: project.id,
+      language: language.id,
+      startDateOverride: CalendarDate.fromISO('2020-01-01').toISO(),
+      endDateOverride: CalendarDate.fromISO('2020-06-30').toISO(),
+    });
+
+    const result = await app.graphql.query(EngagementReportsDoc, {
+      id: engagement.id,
+    });
+    const { progressReports } = result.engagement;
+    const quarters = progressReports.items.filter((r) => r.start !== r.end);
+    expect(quarters).toHaveLength(2);
+    expect(quarters.map((r) => r.start)).toEqual(['2020-01-01', '2020-04-01']);
+    for (const report of progressReports.items) {
+      expect(report.type).toBe('Progress');
+      expect(report.status.value).toBe('NotStarted');
+    }
+  });
+
+  it('shrinking engagement dates removes unstarted reports', async () => {
+    const project = await createProject(app, {
+      mouStart: CalendarDate.fromISO('2020-01-01').toISO(),
+      mouEnd: CalendarDate.fromISO('2020-12-31').toISO(),
+    });
+    const language = await runAsAdmin(app, createLanguage);
+    const engagement = await createLanguageEngagement(app, {
+      project: project.id,
+      language: language.id,
+      startDateOverride: CalendarDate.fromISO('2020-01-01').toISO(),
+      endDateOverride: CalendarDate.fromISO('2020-12-31').toISO(),
+    });
+
+    await app.graphql.mutate(UpdateEngagementDatesDoc, {
+      id: engagement.id,
+      endDateOverride: CalendarDate.fromISO('2020-06-30').toISO(),
+    });
+
+    const result = await app.graphql.query(EngagementReportsDoc, {
+      id: engagement.id,
+    });
+    const quarters = result.engagement.progressReports.items.filter(
+      (r) => r.start !== r.end,
+    );
+    expect(quarters).toHaveLength(2);
+  });
+
+  it('records product progress against a report', async () => {
+    const project = await createProject(app, {
+      mouStart: CalendarDate.fromISO('2020-01-01').toISO(),
+      mouEnd: CalendarDate.fromISO('2020-12-31').toISO(),
+    });
+    const language = await runAsAdmin(app, createLanguage);
+    const engagement = await createLanguageEngagement(app, {
+      project: project.id,
+      language: language.id,
+      startDateOverride: CalendarDate.fromISO('2020-01-01').toISO(),
+      endDateOverride: CalendarDate.fromISO('2020-12-31').toISO(),
+    });
+    const product = await createDirectProduct(app, {
+      engagement: engagement.id,
+      steps: ['ExegesisAndFirstDraft', 'TeamCheck'],
+      progressStepMeasurement: 'Percent',
+    });
+    const reports = await app.graphql.query(EngagementReportsDoc, {
+      id: engagement.id,
+    });
+    const report = reports.engagement.progressReports.items.find(
+      (r) => r.start !== r.end,
+    )!;
+
+    const updated = await app.graphql.mutate(UpdateProductProgressDoc, {
+      input: {
+        product: product.id,
+        report: report.id,
+        steps: [{ step: 'ExegesisAndFirstDraft', completed: 25 }],
+      },
+    });
+    const { steps } = updated.updateProductProgress;
+    // Ordered by the product's declared steps; unreported steps are
+    // placeholders with a null completed value.
+    expect(steps.map((s) => s.step)).toEqual([
+      'ExegesisAndFirstDraft',
+      'TeamCheck',
+    ]);
+    expect(steps[0]!.completed.value).toBe(25);
+    expect(steps[1]!.completed.value).toBeNull();
+  });
+
+  // Data-loss regression guard. When a report's interval falls out of the MOU
+  // window the sync hard-deletes it — UNLESS a file has been uploaded against
+  // it. A report someone uploaded must never silently vanish because the dates
+  // shifted. This is a cross-engine parity test: neo4j already preserves
+  // file-bearing reports; the PG repo must match (it previously did not).
+  it('preserves a report with an uploaded file when its interval falls out of range', async () => {
+    const project = await createProject(app);
+    await updateProject(app, {
+      id: project.id,
+      mouStart: CalendarDate.fromISO('2020-01-01').toISO(),
+      mouEnd: CalendarDate.fromISO('2020-12-31').toISO(),
+    });
+
+    const before = await app.graphql.query(ProjectReportsDoc, {
+      id: project.id,
+    });
+    const q3 = before.project.narrativeReports.items.find(
+      (r) => r.start === '2020-07-01',
+    )!;
+    const q4 = before.project.narrativeReports.items.find(
+      (r) => r.start === '2020-10-01',
+    )!;
+    expect(q3).toBeTruthy();
+    expect(q4).toBeTruthy();
+
+    // Attach a real file version to the Q4 report.
+    const { id: uploadId, url } = await requestFileUpload(app);
+    await uploadFileContents(app, url);
+    await app.graphql.mutate(UploadPeriodicReportDoc, {
+      input: {
+        report: q4.id,
+        file: { upload: uploadId, name: 'q4-report.pdf' },
+      },
+    });
+
+    // Shrink the MOU so both Q3 and Q4 now fall out of range.
+    await updateProject(app, {
+      id: project.id,
+      mouEnd: CalendarDate.fromISO('2020-06-30').toISO(),
+    });
+
+    const after = await app.graphql.query(ProjectReportsDoc, {
+      id: project.id,
+    });
+    const remaining = after.project.narrativeReports.items.map((r) => r.id);
+
+    // Q3 had no file -> the sync hard-deletes it. Proves the delete path
+    // actually executed (otherwise the Q4 assertion would pass vacuously).
+    expect(remaining).not.toContain(q3.id);
+    // Q4 had an uploaded file -> it must survive the date shift.
+    expect(remaining).toContain(q4.id);
+  });
+
+  // Narrative twin of the guard above: a NARRATIVE-only upload must also
+  // protect the report from the date-shift hard delete, and the
+  // narrativeReceivedDate round-trip proves the update + hydrate paths.
+  it('preserves a report with an uploaded narrative file when its interval falls out of range', async () => {
+    const project = await createProject(app);
+    await updateProject(app, {
+      id: project.id,
+      mouStart: CalendarDate.fromISO('2020-01-01').toISO(),
+      mouEnd: CalendarDate.fromISO('2020-12-31').toISO(),
+    });
+
+    const before = await app.graphql.query(ProjectReportsDoc, {
+      id: project.id,
+    });
+    const q3 = before.project.narrativeReports.items.find(
+      (r) => r.start === '2020-07-01',
+    )!;
+    const q4 = before.project.narrativeReports.items.find(
+      (r) => r.start === '2020-10-01',
+    )!;
+
+    // Attach a narrative file version + received date to Q4 only.
+    const { id: uploadId, url } = await requestFileUpload(app);
+    await uploadFileContents(app, url);
+    const updated = await app.graphql.mutate(UpdatePeriodicReportDoc, {
+      input: {
+        id: q4.id,
+        narrativeFile: { upload: uploadId, name: 'q4-narrative.pdf' },
+        narrativeReceivedDate: CalendarDate.fromISO('2020-11-15').toISO(),
+      },
+    });
+    expect(updated.updatePeriodicReport.narrativeReceivedDate.value).toBe(
+      '2020-11-15',
+    );
+
+    // Shrink the MOU so both Q3 and Q4 fall out of range.
+    await updateProject(app, {
+      id: project.id,
+      mouEnd: CalendarDate.fromISO('2020-06-30').toISO(),
+    });
+
+    const after = await app.graphql.query(ProjectReportsDoc, {
+      id: project.id,
+    });
+    const remaining = after.project.narrativeReports.items.map((r) => r.id);
+    expect(remaining).not.toContain(q3.id);
+    // Narrative-only upload must protect the report, same as a report file.
+    expect(remaining).toContain(q4.id);
+  });
+
+  it('updates receivedDate and skippedReason', async () => {
+    const project = await createProject(app);
+    await updateProject(app, {
+      id: project.id,
+      mouStart: CalendarDate.fromISO('2021-01-01').toISO(),
+      mouEnd: CalendarDate.fromISO('2021-03-31').toISO(),
+    });
+    const reports = await app.graphql.query(ProjectReportsDoc, {
+      id: project.id,
+    });
+    const report = reports.project.narrativeReports.items[0]!;
+
+    const updated = await app.graphql.mutate(UpdatePeriodicReportDoc, {
+      input: {
+        id: report.id,
+        receivedDate: CalendarDate.fromISO('2021-04-15').toISO(),
+        skippedReason: 'COVID',
+      },
+    });
+    expect(updated.updatePeriodicReport.receivedDate.value).toBe('2021-04-15');
+    expect(updated.updatePeriodicReport.skippedReason.value).toBe('COVID');
+
+    // Mono asserts the audit-log `history` here (ResourceMutatedHook +
+    // resource_mutations) — restore with the audit-log wave, which brings the
+    // schema field this queries.
+  });
+});
+
+const UploadPeriodicReportDoc = graphql(`
+  mutation UploadPeriodicReportForGuard($input: UploadPeriodicReportFile!) {
+    uploadPeriodicReport(input: $input) {
+      id
+    }
+  }
+`);
+
+const reportFields = graphql(`
+  fragment reportFields on PeriodicReport {
+    id
+    type
+    start
+    end
+    receivedDate {
+      value
+    }
+    skippedReason {
+      value
+    }
+  }
+`);
+
+const ProjectReportsDoc = graphql(
+  `
+    query ProjectReports($id: ID!) {
+      project(id: $id) {
+        narrativeReports {
+          total
+          items {
+            ...reportFields
+          }
+        }
+        financialReports {
+          total
+          items {
+            ...reportFields
+          }
+        }
+      }
+    }
+  `,
+  [reportFields],
+);
+
+const EngagementReportsDoc = graphql(
+  `
+    query EngagementReports($id: ID!) {
+      engagement: languageEngagement(id: $id) {
+        progressReports {
+          total
+          items {
+            ...reportFields
+            ... on ProgressReport {
+              status {
+                value
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+  [reportFields],
+);
+
+const UpdatePeriodicReportDoc = graphql(`
+  mutation UpdatePeriodicReport($input: UpdatePeriodicReport!) {
+    updatePeriodicReport(input: $input) {
+      id
+      receivedDate {
+        value
+      }
+      narrativeReceivedDate {
+        value
+      }
+      skippedReason {
+        value
+      }
+    }
+  }
+`);
+
+const UpdateProductProgressDoc = graphql(`
+  mutation UpdateProductProgress($input: UpdateProductProgress!) {
+    updateProductProgress(input: $input) {
+      steps {
+        step
+        completed {
+          value
+        }
+      }
+    }
+  }
+`);
+
+const UpdateEngagementDatesDoc = graphql(`
+  mutation UpdateEngagementDates($id: ID!, $endDateOverride: Date) {
+    updateLanguageEngagement(
+      input: { id: $id, endDateOverride: $endDateOverride }
+    ) {
+      engagement {
+        id
+      }
+    }
+  }
+`);

--- a/test/postgres-schema.e2e-spec.ts
+++ b/test/postgres-schema.e2e-spec.ts
@@ -4,13 +4,16 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { type MadeEnum, Role, Sensitivity } from '~/common';
 import { type DrizzleDb, DrizzleService } from '~/core/drizzle';
+import { EngagementStatus } from '../src/components/engagement/dto';
 import { PartnerType } from '../src/components/partner/dto';
+import { ReportType } from '../src/components/periodic-report/dto';
 import {
   ProductMedium,
   ProductMethodology,
   ProductPurpose,
   ProductStep,
 } from '../src/components/product/dto';
+import { ProgressReportStatus } from '../src/components/progress-report/dto';
 import { ProjectStep, stepToStatus } from '../src/components/project/dto';
 import { createTestApp, type TestApp } from './utility';
 
@@ -138,11 +141,6 @@ describePg('Postgres schema invariants', () => {
   // must equal its TypeScript counterpart's value set — a value present on one
   // side but not the other is a write that fails at runtime or a filter that
   // silently never matches.
-  // migration-todo: restore ['engagement_status', EngagementStatus],
-  // ['progress_report_status', ProgressReportStatus], and
-  // ['report_type', ReportType] (mono's full curated list) as the Engagement
-  // and Report-cluster domains recut onto develop — their pg enums don't
-  // exist here yet.
   const enumPairs: ReadonlyArray<[pgName: string, tsEnum: MadeEnum<string>]> = [
     ['project_step', ProjectStep],
     ['partner_type', PartnerType],
@@ -152,6 +150,9 @@ describePg('Postgres schema invariants', () => {
     ['product_purpose', ProductPurpose],
     ['product_step', ProductStep],
     ['product_methodology', ProductMethodology],
+    ['engagement_status', EngagementStatus],
+    ['report_type', ReportType],
+    ['progress_report_status', ProgressReportStatus],
   ];
 
   it.each(enumPairs)(


### PR DESCRIPTION
### Summary

Cord generates recurring reports for every project and engagement — financial and narrative
reports for projects, quarterly progress reports for language engagements. Progress reports are
also where per-product progress percentages and Rev79-submitted content (team news, community
stories) live. This PR teaches all of that to run on Postgres: the report tables and their sync
logic (reports appear/disappear when project dates change — but a report anyone uploaded a file
against is never deleted), the prompt-response machinery, per-step product progress, extracted
planned-vs-actual summaries, and the Rev79 project lookup. Behavior is proven identical on both
engines by the same test suite, and the whole diff was adversarially reviewed pre-commit.

### Adversarial review (pre-commit, 2026-07-17)

- 6 findings (1 P2, 4 P3, 1 P4), ALL fixed in this diff. The P2: a Financial/Narrative report
  with a narrative-only upload would have been hard-deleted on MOU date shifts — now guarded and
  covered by a dedicated cross-engine e2e leg ("preserves a report with an uploaded narrative
  file…"), which also closes the narrativeFile coverage gap.

### Validation performed

- **Tested**: fresh-DB apply 0000–0021 (`ON_ERROR_STOP`, exit 0) — re-run after the enum change.
- **Tested**: dual-engine e2e `--runInBand`: **PG 46✓/1skip** (periodic-report, rev79, product,
  postgres-schema incl. the 3 new enum-parity legs) · **Neo4j 32✓/1skip** (same minus the
  PG-only schema suite). Both file-preservation guards pass on both engines.
- **Tested**: `yarn type-check` + `yarn lint` at zero warnings.
- **By reading**: FK-index coverage per table; schema↔SQL parity across all three migrations.

### Reviewer cross-checks

- periodic_reports CHECKs vs type invariants (Financial/Narrative ⇒ project; Progress ⇒
  engagement + non-null status); deterministic-id derivation vs Neo4j.
- `hasUploadedFileVersion()` SQL: `parent_id IN (report_file_id, narrative_file_id)` with
  FileVersion type + liveness — confirm NULL columns behave (IN with NULL simply doesn't match).
- getLatestReportSubmitted orders by **start desc** (Neo4j sorts on start, not end).
- Journal idx 19/20/21, strictly increasing `when`.

### Explicitly out of scope

- ProgressReportMedia + PnP extraction (~8/5 wave; F3 rides it).
- Audit log (stripped hook sites + the spec's history leg — audit wave ~7/31).
- ETL extractors (next wave; the two CHECKs have no Neo4j counterpart — U9/ETH1 guard class).