### PR TITLE
[pg] Leaves → Postgres (Drizzle): Pins, KnownLanguages, Comments, Post — migrations 0022–0025

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
             shard: 1
             total: 1
             test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony|product|film|story|project-workflow|periodic-report|rev79)\."
+              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony|product|film|story|project-workflow|periodic-report|rev79|pin|known-language|comment|post)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/src/components/comments/comment-thread.drizzle.repository.ts
+++ b/src/components/comments/comment-thread.drizzle.repository.ts
@@ -1,0 +1,172 @@
+import { Injectable } from '@nestjs/common';
+import { asc, count, eq, inArray } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  generateId,
+  type ID,
+  NotFoundException,
+  type UnsecuredDto,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import {
+  DrizzleService,
+  resolveOrderBy,
+  resolveResourceBaseNode,
+} from '~/core/drizzle';
+import { comments, commentThreads } from '~/core/drizzle/schema';
+import { type BaseNode } from '~/core/neo4j/results';
+import { type CommentThread, type CommentThreadListInput } from './dto';
+import { mapCommentRow } from './map-comment-row';
+
+type ThreadRow = typeof commentThreads.$inferSelect;
+type CommentRow = typeof comments.$inferSelect;
+
+@Injectable()
+export class CommentThreadDrizzleRepository {
+  constructor(
+    private readonly drizzle: DrizzleService,
+    private readonly identity: Identity,
+  ) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  async create(parent: ID): Promise<ID<'CommentThread'>> {
+    const parentNode = await resolveResourceBaseNode(this.db, parent);
+    if (!parentNode) {
+      throw new NotFoundException('Resource does not exist', 'resource');
+    }
+    const id = await generateId<ID<'CommentThread'>>();
+    await this.db.insert(commentThreads).values({
+      id,
+      parentId: parent,
+      // The concrete typename (e.g. 'MomentumTranslationProject', 'User') —
+      // enough for ResourceLoader.loadByBaseNode to find the loader.
+      parentType: parentNode.labels[0]!,
+      creatorId: this.identity.current.userId,
+    });
+    return id;
+  }
+
+  async readOne(id: ID): Promise<UnsecuredDto<CommentThread>> {
+    const rows = await this.readMany([id]);
+    if (rows.length === 0) {
+      throw new NotFoundException();
+    }
+    return rows[0]!;
+  }
+
+  async readMany(
+    ids: readonly ID[],
+  ): Promise<Array<UnsecuredDto<CommentThread>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db
+      .select()
+      .from(commentThreads)
+      .where(inArray(commentThreads.id, ids as Array<ID<'CommentThread'>>));
+    return await this.hydrate(rows);
+  }
+
+  async list(parent: ID | undefined, input: CommentThreadListInput) {
+    const predicate = parent ? eq(commentThreads.parentId, parent) : undefined;
+    const offset = (input.page - 1) * input.count;
+    const [countRows, rows] = await Promise.all([
+      this.db.select({ total: count() }).from(commentThreads).where(predicate),
+      this.db
+        .select()
+        .from(commentThreads)
+        .where(predicate)
+        .orderBy(
+          ...resolveOrderBy(
+            input,
+            { createdAt: commentThreads.createdAt },
+            commentThreads.createdAt,
+          ),
+          asc(commentThreads.id),
+        )
+        .limit(input.count)
+        .offset(offset),
+    ]);
+    const total = countRows[0]?.total ?? 0;
+    return {
+      items: await this.hydrate(rows),
+      total,
+      hasMore: offset + rows.length < total,
+    };
+  }
+
+  async count(parent: ID): Promise<number> {
+    const [row] = await this.db
+      .select({ total: count() })
+      .from(commentThreads)
+      .where(eq(commentThreads.parentId, parent));
+    return row?.total ?? 0;
+  }
+
+  async getBaseNode(id: ID): Promise<BaseNode | undefined> {
+    const [row] = await this.db
+      .select({ createdAt: commentThreads.createdAt })
+      .from(commentThreads)
+      .where(eq(commentThreads.id, id as ID<'CommentThread'>))
+      .limit(1);
+    if (!row) return undefined;
+    return {
+      identity: id,
+      labels: ['CommentThread', 'BaseNode'],
+      properties: { id, createdAt: DateTime.fromJSDate(row.createdAt) },
+    };
+  }
+
+  async deleteNode(objectOrId: { id: ID } | ID): Promise<void> {
+    const id = typeof objectOrId === 'string' ? objectOrId : objectOrId.id;
+    await this.db
+      .delete(commentThreads)
+      .where(eq(commentThreads.id, id as ID<'CommentThread'>));
+  }
+
+  private async hydrate(
+    rows: ThreadRow[],
+  ): Promise<Array<UnsecuredDto<CommentThread>>> {
+    if (rows.length === 0) return [];
+    const threadIds = rows.map((r) => r.id);
+    const commentRows = await this.db
+      .select()
+      .from(comments)
+      .where(inArray(comments.threadId, threadIds))
+      .orderBy(asc(comments.createdAt), asc(comments.id));
+    const byThread = new Map<string, CommentRow[]>();
+    for (const c of commentRows) {
+      const arr = byThread.get(c.threadId) ?? [];
+      arr.push(c);
+      byThread.set(c.threadId, arr);
+    }
+    return rows.map((row) => this.toDto(row, byThread.get(row.id) ?? []));
+  }
+
+  private toDto(
+    row: ThreadRow,
+    threadComments: CommentRow[],
+  ): UnsecuredDto<CommentThread> {
+    const first = threadComments[0];
+    const latest = threadComments[threadComments.length - 1];
+    const dto: unknown = {
+      id: row.id,
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      // Fake BaseNode so ResourceLoader.loadByBaseNode resolves the parent.
+      parent: {
+        identity: row.parentId,
+        labels: [row.parentType, 'BaseNode'],
+        properties: {
+          id: row.parentId,
+          createdAt: DateTime.fromJSDate(row.createdAt),
+        },
+      },
+      creator: row.creatorId,
+      firstComment: first ? mapCommentRow(first) : undefined,
+      latestComment: latest ? mapCommentRow(latest) : undefined,
+      canDelete: true,
+    };
+    return dto as UnsecuredDto<CommentThread>;
+  }
+}

--- a/src/components/comments/comment-thread.drizzle.repository.ts
+++ b/src/components/comments/comment-thread.drizzle.repository.ts
@@ -165,7 +165,6 @@ export class CommentThreadDrizzleRepository {
       creator: row.creatorId,
       firstComment: first ? mapCommentRow(first) : undefined,
       latestComment: latest ? mapCommentRow(latest) : undefined,
-      canDelete: true,
     };
     return dto as UnsecuredDto<CommentThread>;
   }

--- a/src/components/comments/comment.drizzle.repository.ts
+++ b/src/components/comments/comment.drizzle.repository.ts
@@ -1,0 +1,115 @@
+import { Injectable } from '@nestjs/common';
+import { asc, count, eq } from 'drizzle-orm';
+import {
+  generateId,
+  type ID,
+  type RichTextDocument,
+  type UnsecuredDto,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import { type ChangesOf } from '~/core/database/changes';
+import {
+  DrizzleDtoRepository,
+  DrizzleService,
+  resolveOrderBy,
+  resolveResourceBaseNode,
+} from '~/core/drizzle';
+import { comments } from '~/core/drizzle/schema';
+import { type BaseNode } from '~/core/neo4j/results';
+import { CommentThreadDrizzleRepository } from './comment-thread.drizzle.repository';
+import {
+  Comment,
+  type CommentListInput,
+  type CreateComment,
+  type UpdateComment,
+} from './dto';
+import { mapCommentRow } from './map-comment-row';
+
+@Injectable()
+export class CommentDrizzleRepository extends DrizzleDtoRepository<
+  typeof comments,
+  Comment
+> {
+  constructor(
+    drizzle: DrizzleService,
+    // Injected concretely (not via the CommentThreadRepository token): the
+    // Drizzle thread repo has no back-reference to comments, so there's no
+    // cycle — and routing both repos through splitDb would deadlock
+    // moduleRef.create on the Neo4j repos' mutual forwardRef cycle.
+    // `service.repo.threads.*` resolves to this under postgres.
+    readonly threads: CommentThreadDrizzleRepository,
+    private readonly identity: Identity,
+  ) {
+    super(drizzle, comments, Comment);
+  }
+
+  protected toDto(row: typeof comments.$inferSelect): UnsecuredDto<Comment> {
+    return mapCommentRow(row);
+  }
+
+  async create(input: CreateComment): Promise<{ id: ID; threadId: ID }> {
+    const threadId =
+      input.thread ?? (await this.threads.create(input.resource));
+    const id = await generateId<ID<'Comment'>>();
+    await this.db.insert(comments).values({
+      id,
+      threadId: threadId,
+      creatorId: this.identity.current.userId,
+      body: input.body,
+    });
+    return { id, threadId };
+  }
+
+  async update(
+    existing: UnsecuredDto<Comment>,
+    changes: ChangesOf<Comment, UpdateComment>,
+  ): Promise<void> {
+    // Mirrors the Neo4j repo: only writes changed scalar props. modifiedAt is
+    // not part of UpdateComment, so (as in Neo4j) it isn't bumped on edit.
+    await this.updateColumns(existing.id, {
+      body: (changes as { body?: RichTextDocument }).body,
+    });
+  }
+
+  /**
+   * Resolve the commentable PARENT id to a BaseNode (loadCommentable calls
+   * this with a parent resource id, not a comment id). Probes the migrated
+   * commentable tables.
+   */
+  async getBaseNode(id: ID): Promise<BaseNode | undefined> {
+    return await resolveResourceBaseNode(this.db, id);
+  }
+
+  async deleteNode(objectOrId: { id: ID } | ID): Promise<void> {
+    const id = typeof objectOrId === 'string' ? objectOrId : objectOrId.id;
+    await this.db.delete(comments).where(eq(comments.id, id as ID<'Comment'>));
+  }
+
+  async list(threadId: ID, input: CommentListInput) {
+    const predicate = eq(comments.threadId, threadId as ID<'CommentThread'>);
+    const offset = (input.page - 1) * input.count;
+    const [countRows, rows] = await Promise.all([
+      this.db.select({ total: count() }).from(comments).where(predicate),
+      this.db
+        .select()
+        .from(comments)
+        .where(predicate)
+        .orderBy(
+          ...resolveOrderBy(
+            input,
+            { createdAt: comments.createdAt },
+            comments.createdAt,
+          ),
+          asc(comments.id),
+        )
+        .limit(input.count)
+        .offset(offset),
+    ]);
+    const total = countRows[0]?.total ?? 0;
+    return {
+      items: rows.map((r) => this.toDto(r)),
+      total,
+      hasMore: offset + rows.length < total,
+    };
+  }
+}

--- a/src/components/comments/comment.module.ts
+++ b/src/components/comments/comment.module.ts
@@ -1,9 +1,12 @@
 import { forwardRef, Module } from '@nestjs/common';
+import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { UserModule } from '../user/user.module';
+import { CommentThreadDrizzleRepository } from './comment-thread.drizzle.repository';
 import { CommentThreadLoader } from './comment-thread.loader';
 import { CommentThreadRepository } from './comment-thread.repository';
 import { CommentThreadResolver } from './comment-thread.resolver';
+import { CommentDrizzleRepository } from './comment.drizzle.repository';
 import { CommentLoader } from './comment.loader';
 import { CommentRepository } from './comment.repository';
 import { CommentResolver } from './comment.resolver';
@@ -22,8 +25,17 @@ import { CommentViaMentionNotificationModule } from './mention-notification/comm
     CreateCommentResolver,
     CommentResolver,
     CommentLoader,
-    CommentRepository,
+    // Only the comment repo is routed through splitDb. The CommentThread token
+    // is consumed solely by the Neo4j comment repo, so it stays a plain
+    // provider; the Drizzle comment repo injects the Drizzle thread repo
+    // concretely. Routing both through splitDb would deadlock moduleRef.create
+    // on the Neo4j repos' mutual forwardRef cycle.
+    // migration-todo: drop the `as any` + the Neo4j path at Phase 7 cutover.
+    splitDb(CommentRepository, {
+      postgres: CommentDrizzleRepository as any,
+    }),
     CommentThreadRepository,
+    CommentThreadDrizzleRepository,
     CommentService,
     CommentThreadLoader,
     CommentableResolver,

--- a/src/components/comments/map-comment-row.ts
+++ b/src/components/comments/map-comment-row.ts
@@ -1,0 +1,24 @@
+import { DateTime } from 'luxon';
+import { type UnsecuredDto } from '~/common';
+import { type comments } from '~/core/drizzle/schema';
+import { type Comment } from './dto';
+
+/**
+ * Map a `comments` row to its UnsecuredDto. Shared by the comment repo's
+ * `toDto` and the thread repo's first/latest-comment hydration so the mapping
+ * lives in one place (and avoids a circular import between the two repos).
+ */
+export const mapCommentRow = (
+  row: typeof comments.$inferSelect,
+): UnsecuredDto<Comment> => {
+  const dto: unknown = {
+    id: row.id,
+    createdAt: DateTime.fromJSDate(row.createdAt),
+    thread: row.threadId,
+    creator: row.creatorId,
+    body: row.body,
+    modifiedAt: DateTime.fromJSDate(row.modifiedAt),
+    canDelete: true,
+  };
+  return dto as UnsecuredDto<Comment>;
+};

--- a/src/components/comments/map-comment-row.ts
+++ b/src/components/comments/map-comment-row.ts
@@ -18,7 +18,6 @@ export const mapCommentRow = (
     creator: row.creatorId,
     body: row.body,
     modifiedAt: DateTime.fromJSDate(row.modifiedAt),
-    canDelete: true,
   };
   return dto as UnsecuredDto<Comment>;
 };

--- a/src/components/comments/mention-notification/comment-via-mention-notification.service.ts
+++ b/src/components/comments/mention-notification/comment-via-mention-notification.service.ts
@@ -16,6 +16,12 @@ export class CommentViaMentionNotificationService {
     mentionees: ReadonlyArray<ID<'User'>>,
     comment: UnsecuredDto<Comment>,
   ) {
+    // Nothing to notify — skip the no-op create. (The Neo4j notification repo
+    // returns undefined for an empty recipient set, which would otherwise throw
+    // in NotificationService.create.)
+    if (mentionees.length === 0) {
+      return;
+    }
     await this.notifications.create(CommentViaMentionNotification, mentionees, {
       comment: comment.id,
     });

--- a/src/components/language/language.drizzle.repository.ts
+++ b/src/components/language/language.drizzle.repository.ts
@@ -37,6 +37,7 @@ import {
 } from '~/core/drizzle/schema';
 import { type ScopedRole } from '../authorization/dto/role.dto';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import { pinnedByRequester, pinnedFilter } from '../pin/pinned-by-requester';
 import { requesterScopeByProject } from '../project/project-member/membership-scope';
 import { recomputeProjectSensitivity } from '../project/project.drizzle.repository';
 import {
@@ -201,10 +202,16 @@ export class LanguageDrizzleRepository extends DrizzleDtoRepository<
       with: { ethnologue: true },
     });
     const derived = await this.engagementDerived(rows.map((r) => r.id));
-    // migration-todo (Pin recut): restore the pinnedByRequester batch;
-    // pinned hardcodes false until then.
+    const pinnedSet = await pinnedByRequester(
+      this.db,
+      this.identity.current.userId,
+      rows.map((r) => r.id),
+    );
     return (rows as LanguageRow[]).map((row) =>
-      this.toDto({ ...row, pinned: false }, derived.get(row.id)),
+      this.toDto(
+        { ...row, pinned: pinnedSet.has(row.id) },
+        derived.get(row.id),
+      ),
     );
   }
 
@@ -464,13 +471,13 @@ interface EngagementDerived {
 export const languageFilterClauses = (
   db: DrizzleDb,
   filter: LanguageFilters | undefined,
-  _requesterId?: ID<'User'>,
+  requesterId?: ID<'User'>,
 ): SQL[] => {
   const conditions: SQL[] = [];
   if (!filter) return conditions;
-  // migration-todo (Pin recut): restore the pinnedFilter branch; until the
-  // pins table lands the filter is ignored (Project/Partner recut posture).
-
+  if (filter.pinned != null) {
+    conditions.push(pinnedFilter(requesterId, languages.id, filter.pinned));
+  }
   if (filter.name) {
     const pattern = `%${escapeLikePattern(filter.name)}%`;
     conditions.push(

--- a/src/components/partner/partner.drizzle.repository.ts
+++ b/src/components/partner/partner.drizzle.repository.ts
@@ -25,6 +25,7 @@ import {
   type PaginatedListType,
   type UnsecuredDto,
 } from '~/common';
+import { Identity } from '~/core/authentication';
 import {
   catchForeignKeyViolation,
   catchUniqueViolation,
@@ -51,6 +52,7 @@ import {
   organizationFilterClauses,
   organizationSortColumns,
 } from '../organization/organization.drizzle.repository';
+import { pinnedByRequester, pinnedFilter } from '../pin/pinned-by-requester';
 import {
   type CreatePartner,
   Partner,
@@ -65,6 +67,7 @@ type PartnerRow = typeof partners.$inferSelect & {
   countries: Array<{ locationId: ID<'Location'> }>;
   languagesOfConsulting: Array<{ languageId: ID<'Language'> }>;
   departmentIdBlock: typeof departmentIdBlocks.$inferSelect | null;
+  pinned?: boolean;
 };
 
 @Injectable()
@@ -75,6 +78,7 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
   constructor(
     db: DrizzleService,
     private readonly executor: PolicyExecutor,
+    private readonly identity: Identity,
   ) {
     super(db, partners, Partner);
   }
@@ -269,7 +273,14 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
         departmentIdBlock: true,
       },
     });
-    return rows.map((row) => this.toDto(row));
+    const pinnedSet = await pinnedByRequester(
+      this.db,
+      this.identity.current.userId,
+      rows.map((r) => r.id),
+    );
+    return rows.map((row) =>
+      this.toDto({ ...row, pinned: pinnedSet.has(row.id) }),
+    );
   }
 
   async list(
@@ -280,7 +291,13 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
       return EMPTY_PAGE;
     }
 
-    conditions.push(...partnerFilterClauses(this.db, input.filter));
+    conditions.push(
+      ...partnerFilterClauses(
+        this.db,
+        input.filter,
+        this.identity.current.userId,
+      ),
+    );
     const predicate = and(...conditions);
 
     // Cast to string because `name` / `organization.*` aren't in `keyof
@@ -591,10 +608,9 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
           : null,
       // migration-todo: derived from project sensitivity; 'High' until Project migrates.
       sensitivity: row.sensitivity,
-      // migration-todo: pinned is per-requesting-user state, not stored on the
-      // partner row. Re-add the requesterId param + pinnedByRequester batch
-      // when the Pin domain migrates to Postgres.
-      pinned: false,
+      // Per-requester pin state — populated by readMany/list via
+      // pinnedByRequester; other internal paths leave it false.
+      pinned: row.pinned ?? false,
     };
   }
 }
@@ -623,6 +639,7 @@ export const partnerSortColumns = {
 export const partnerFilterClauses = (
   db: DrizzleDb,
   filter: PartnerFilters | undefined,
+  requesterId?: ID<'User'>,
 ): SQL[] => {
   const conditions: SQL[] = [];
   if (!filter) return conditions;
@@ -694,8 +711,8 @@ export const partnerFilterClauses = (
       );
     }
   }
-  // migration-todo: `filter.pinned` is unsupported until the Pin domain
-  // migrates to Postgres (it needs the per-requester `pinnedFilter` helper).
-  // Re-add the `requesterId` param + the `pinnedFilter` branch then.
+  if (filter.pinned !== undefined) {
+    conditions.push(pinnedFilter(requesterId, partners.id, filter.pinned));
+  }
   return conditions;
 };

--- a/src/components/partner/partner.drizzle.repository.ts
+++ b/src/components/partner/partner.drizzle.repository.ts
@@ -711,7 +711,7 @@ export const partnerFilterClauses = (
       );
     }
   }
-  if (filter.pinned !== undefined) {
+  if (filter.pinned != null) {
     conditions.push(pinnedFilter(requesterId, partners.id, filter.pinned));
   }
   return conditions;

--- a/src/components/pin/pin.drizzle.repository.ts
+++ b/src/components/pin/pin.drizzle.repository.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import { and, eq } from 'drizzle-orm';
+import { type ID } from '~/common';
+import { Identity } from '~/core/authentication';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { pins } from '~/core/drizzle/schema';
+
+@Injectable()
+export class PinDrizzleRepository {
+  constructor(
+    private readonly drizzle: DrizzleService,
+    private readonly identity: Identity,
+  ) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  async isPinned(id: ID): Promise<boolean> {
+    const userId = this.identity.current.userId;
+    const [row] = await this.db
+      .select({ resourceId: pins.resourceId })
+      .from(pins)
+      .where(and(eq(pins.userId, userId), eq(pins.resourceId, id)))
+      .limit(1);
+    return !!row;
+  }
+
+  async add(id: ID): Promise<void> {
+    await this.db
+      .insert(pins)
+      .values({ userId: this.identity.current.userId, resourceId: id })
+      .onConflictDoNothing();
+  }
+
+  async remove(id: ID): Promise<void> {
+    await this.db
+      .delete(pins)
+      .where(
+        and(
+          eq(pins.userId, this.identity.current.userId),
+          eq(pins.resourceId, id),
+        ),
+      );
+  }
+}

--- a/src/components/pin/pin.module.ts
+++ b/src/components/pin/pin.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { splitDb } from '~/core/database';
+import { PinDrizzleRepository } from './pin.drizzle.repository';
 import { PinGelRepository } from './pin.gel.repository';
 import { PinRepository } from './pin.repository';
 import { PinResolver } from './pin.resolver';
@@ -9,7 +10,12 @@ import { PinService } from './pin.service';
   providers: [
     PinResolver,
     PinService,
-    splitDb(PinRepository, { gel: PinGelRepository }),
+    splitDb(PinRepository, {
+      gel: PinGelRepository,
+      // migration-todo: `as any` + the Neo4j/Gel paths removed at Phase 7
+      // cutover when splitDb disappears.
+      postgres: PinDrizzleRepository as any,
+    }),
   ],
   exports: [PinService],
 })

--- a/src/components/pin/pinned-by-requester.ts
+++ b/src/components/pin/pinned-by-requester.ts
@@ -1,0 +1,48 @@
+import { and, eq, inArray, type SQL, sql } from 'drizzle-orm';
+import { type AnyPgColumn } from 'drizzle-orm/pg-core';
+import { type ID } from '~/common';
+import { type DrizzleDb } from '~/core/drizzle/drizzle.service';
+import { pins } from '~/core/drizzle/schema';
+
+/**
+ * Which of `resourceIds` the user has pinned. Batch lookup for hydrating the
+ * per-requester `pinned` field on a page of Pinnable rows — same shape as
+ * `requesterScopeByProject`. Returns an empty set for anonymous requesters
+ * (no userId).
+ */
+export const pinnedByRequester = async (
+  db: DrizzleDb,
+  userId: ID<'User'> | undefined,
+  resourceIds: readonly ID[],
+): Promise<Set<ID>> => {
+  if (!userId || resourceIds.length === 0) return new Set();
+  const rows = await db
+    .select({ resourceId: pins.resourceId })
+    .from(pins)
+    .where(
+      and(eq(pins.userId, userId), inArray(pins.resourceId, [...resourceIds])),
+    );
+  return new Set(rows.map((r) => r.resourceId));
+};
+
+/**
+ * `EXISTS`/`NOT EXISTS` predicate for a list filter's `pinned` boolean,
+ * correlated against the domain table's id column. Anonymous requesters
+ * never have pins, so `pinned: true` matches nothing and `pinned: false`
+ * matches everything.
+ */
+export const pinnedFilter = (
+  userId: ID<'User'> | undefined,
+  idColumn: AnyPgColumn,
+  wantPinned: boolean,
+): SQL => {
+  if (!userId) {
+    return wantPinned ? sql`false` : sql`true`;
+  }
+  const exists = sql`exists (
+    select 1 from "pins"
+    where "pins"."user_id" = ${userId}
+      and "pins"."resource_id" = ${idColumn}
+  )`;
+  return wantPinned ? exists : sql`not ${exists}`;
+};

--- a/src/components/post/post.drizzle.repository.ts
+++ b/src/components/post/post.drizzle.repository.ts
@@ -170,6 +170,7 @@ export class PostDrizzleRepository extends DrizzleDtoRepository<
       where ${projectMembers.projectId} = ${posts.parentId}
         and ${projectMembers.userId} = ${userId}
         and ${projectMembers.deletedAt} is null
+        and ${projectMembers.inactiveAt} is null
     ))`;
   }
 }

--- a/src/components/post/post.drizzle.repository.ts
+++ b/src/components/post/post.drizzle.repository.ts
@@ -1,0 +1,175 @@
+import { Injectable } from '@nestjs/common';
+import { and, asc, count, eq, inArray, type SQL, sql } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  generateId,
+  type ID,
+  NotFoundException,
+  type UnsecuredDto,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import { type ChangesOf } from '~/core/database/changes';
+import {
+  DrizzleDtoRepository,
+  DrizzleService,
+  resolveOrderBy,
+  resolveResourceBaseNode,
+  type SortMap,
+} from '~/core/drizzle';
+import { posts, projectMembers } from '~/core/drizzle/schema';
+import { type BaseNode } from '~/core/neo4j/results';
+import { type CreatePost, Post, type UpdatePost } from './dto';
+import { type PostListInput } from './dto/list-posts.dto';
+
+@Injectable()
+export class PostDrizzleRepository extends DrizzleDtoRepository<
+  typeof posts,
+  Post
+> {
+  constructor(
+    drizzle: DrizzleService,
+    private readonly identity: Identity,
+  ) {
+    super(drizzle, posts, Post);
+  }
+
+  protected toDto(row: typeof posts.$inferSelect): UnsecuredDto<Post> {
+    const dto: unknown = {
+      id: row.id,
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      // Fake BaseNode so ResourceLoader.loadByBaseNode resolves the parent.
+      parent: {
+        identity: row.parentId,
+        labels: [row.parentType, 'BaseNode'],
+        properties: {
+          id: row.parentId,
+          createdAt: DateTime.fromJSDate(row.createdAt),
+        },
+      },
+      creator: { id: row.creatorId },
+      type: row.type,
+      shareability: row.shareability,
+      body: row.body,
+      modifiedAt: DateTime.fromJSDate(row.modifiedAt),
+      canDelete: true,
+    };
+    return dto as UnsecuredDto<Post>;
+  }
+
+  async create(input: CreatePost): Promise<{ dto: UnsecuredDto<Post> }> {
+    const parentNode = await resolveResourceBaseNode(this.db, input.parent);
+    if (!parentNode) {
+      throw new NotFoundException('Resource does not exist', 'parent');
+    }
+    const id = await generateId<ID<'Post'>>();
+    await this.db.insert(posts).values({
+      id,
+      parentId: input.parent,
+      parentType: parentNode.labels[0]!,
+      creatorId: this.identity.current.userId,
+      type: input.type,
+      shareability: input.shareability,
+      body: input.body,
+    });
+    // Hydrated without the auth filter — mirrors the Neo4j create path, which
+    // returns the post directly to its creator.
+    const [row] = await this.db.select().from(posts).where(eq(posts.id, id));
+    return { dto: this.toDto(row!) };
+  }
+
+  async update(
+    existing: UnsecuredDto<Post>,
+    changes: ChangesOf<Post, UpdatePost>,
+  ): Promise<UnsecuredDto<Post>> {
+    const c = changes as Partial<typeof posts.$inferInsert>;
+    await this.updateColumns(existing.id, {
+      type: c.type,
+      shareability: c.shareability,
+      body: c.body,
+    });
+    const [row] = await this.db
+      .select()
+      .from(posts)
+      .where(eq(posts.id, existing.id));
+    if (!row) throw new NotFoundException();
+    return this.toDto(row);
+  }
+
+  async readMany(ids: readonly ID[]): Promise<Array<UnsecuredDto<Post>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db
+      .select()
+      .from(posts)
+      .where(
+        and(inArray(posts.id, ids as Array<ID<'Post'>>), this.authFilter()),
+      );
+    return rows.map((row) => this.toDto(row));
+  }
+
+  async securedList({ filter, ...input }: PostListInput) {
+    const conditions = [this.authFilter()];
+    if (filter?.parentId) {
+      conditions.push(eq(posts.parentId, filter.parentId));
+    }
+    const predicate = and(...conditions);
+    const offset = (input.page - 1) * input.count;
+    const [countRows, rows] = await Promise.all([
+      this.db.select({ total: count() }).from(posts).where(predicate),
+      this.db
+        .select()
+        .from(posts)
+        .where(predicate)
+        .orderBy(
+          ...resolveOrderBy(
+            input,
+            {
+              createdAt: posts.createdAt,
+              modifiedAt: posts.modifiedAt,
+              type: posts.type,
+              shareability: posts.shareability,
+              body: posts.body,
+            } satisfies SortMap<keyof Post>,
+            posts.createdAt,
+          ),
+          asc(posts.id),
+        )
+        .limit(input.count)
+        .offset(offset),
+    ]);
+    const total = countRows[0]?.total ?? 0;
+    return {
+      items: rows.map((row) => this.toDto(row)),
+      total,
+      hasMore: offset + rows.length < total,
+    };
+  }
+
+  async getBaseNode(id: ID): Promise<BaseNode | undefined> {
+    return await resolveResourceBaseNode(this.db, id);
+  }
+
+  async deleteNode(objectOrId: { id: ID } | ID): Promise<void> {
+    const id = typeof objectOrId === 'string' ? objectOrId : objectOrId.id;
+    await this.db.delete(posts).where(eq(posts.id, id as ID<'Post'>));
+  }
+
+  /**
+   * A post is visible when its shareability isn't Membership, or when the
+   * requester is an active member of the (Project) parent. Only Project
+   * parents have members, so Membership posts on Language/Partner are hidden —
+   * matching the Neo4j member-path filter. Gated on 'Membership' only; a
+   * (deprecated) 'ProjectTeam' value is treated as unrestricted, as in Neo4j.
+   */
+  private authFilter(): SQL {
+    const userId = this.identity.currentMaybe?.userId;
+    if (!userId) {
+      return sql`${posts.shareability} <> 'Membership'`;
+    }
+    return sql`(${posts.shareability} <> 'Membership' or exists (
+      select 1 from ${projectMembers}
+      where ${projectMembers.projectId} = ${posts.parentId}
+        and ${projectMembers.userId} = ${userId}
+        and ${projectMembers.deletedAt} is null
+    ))`;
+  }
+}

--- a/src/components/post/post.drizzle.repository.ts
+++ b/src/components/post/post.drizzle.repository.ts
@@ -51,7 +51,6 @@ export class PostDrizzleRepository extends DrizzleDtoRepository<
       shareability: row.shareability,
       body: row.body,
       modifiedAt: DateTime.fromJSDate(row.modifiedAt),
-      canDelete: true,
     };
     return dto as UnsecuredDto<Post>;
   }

--- a/src/components/post/post.module.ts
+++ b/src/components/post/post.module.ts
@@ -1,6 +1,8 @@
 import { forwardRef, Module } from '@nestjs/common';
+import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { UserModule } from '../user/user.module';
+import { PostDrizzleRepository } from './post.drizzle.repository';
 import { PostLoader } from './post.loader';
 import { PostRepository } from './post.repository';
 import { PostResolver } from './post.resolver';
@@ -15,7 +17,10 @@ import { PostableResolver } from './postable.resolver';
   providers: [
     PostResolver,
     PostService,
-    PostRepository,
+    // migration-todo: drop the `as any` + the Neo4j path at Phase 7 cutover.
+    splitDb(PostRepository, {
+      postgres: PostDrizzleRepository as any,
+    }),
     PostableResolver,
     PostLoader,
   ],

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -59,6 +59,7 @@ import {
   locationFilterClauses,
   locationSortColumns,
 } from '../location/location.drizzle.repository';
+import { pinnedByRequester, pinnedFilter } from '../pin/pinned-by-requester';
 import {
   type CreateProject,
   IProject,
@@ -88,6 +89,7 @@ const catchDepartmentIdUnique = catchUniqueViolation(
  */
 type ProjectRow = typeof projects.$inferSelect & {
   engagementTotal?: number;
+  pinned?: boolean;
   /** Latest workflow-event `at`, if any — batched in `readMany`. */
   stepChangedAt?: Date | null;
   membership?: {
@@ -219,14 +221,18 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
     const engagementTotalByProject = new Map(
       engagementCounts.map((c) => [c.projectId, c.total]),
     );
-    // migration-todo: `pinned` dropped — Pin isn't migrated; re-add the
-    // pinnedByRequester batch when the pin domain ports.
+    const pinnedSet = await pinnedByRequester(
+      this.db,
+      userId,
+      rows.map((r) => r.id),
+    );
     return rows.map((row): UnsecuredDto<Project> => {
       const enriched: ProjectRow = {
         ...row,
         membership: membershipByProject.get(row.id) ?? null,
         stepChangedAt: stepChangedByProject.get(row.id) ?? null,
         engagementTotal: engagementTotalByProject.get(row.id) ?? 0,
+        pinned: pinnedSet.has(row.id),
       };
       return this.toDto(enriched);
     });
@@ -520,9 +526,9 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
       // context, not stored on the row. PCR is excluded from the migration,
       // so it stays undefined here.
       changeset: undefined,
-      // migration-todo: Pin not migrated; pinned is false until the pin domain
-      // ports (then re-add the pinnedByRequester batch in readMany).
-      pinned: false,
+      // Per-requester pin state — populated by readMany via pinnedByRequester;
+      // other internal paths leave it false.
+      pinned: row.pinned ?? false,
       // canDelete is populated by the policy layer in the service.
       canDelete: true,
       // Scoped roles from the requesting user's active membership — the
@@ -657,9 +663,7 @@ const resolveCrossDomainSort = (
 export const projectFilterClauses = (
   db: DrizzleDb,
   filter: ProjectFilters | undefined,
-  // migration-todo: dead after the pin strip; kept for signature stability.
-  // list() still passes identity.current.userId harmlessly. Re-consume when Pin ports.
-  _requesterId?: ID<'User'>,
+  requesterId?: ID<'User'>,
 ): SQL[] => {
   const conditions: SQL[] = [];
   if (!filter) return conditions;
@@ -886,12 +890,7 @@ export const projectFilterClauses = (
     );
   }
   if (filter.pinned != null) {
-    // migration-todo: Pin not migrated. Re-add
-    // `conditions.push(pinnedFilter(_requesterId, projects.id, filter.pinned))`
-    // when the pin domain ports. Throw for now (matches the branches above).
-    throw new NotImplementedException(
-      'ProjectFilters.pinned requires Pin migration.',
-    );
+    conditions.push(pinnedFilter(requesterId, projects.id, filter.pinned));
   }
   return conditions;
 };

--- a/src/components/user/known-language.drizzle.repository.ts
+++ b/src/components/user/known-language.drizzle.repository.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@nestjs/common';
+import { and, asc, eq } from 'drizzle-orm';
+import { type ID } from '~/common';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { knownLanguages } from '~/core/drizzle/schema';
+import { type KnownLanguage, type ModifyKnownLanguageArgs } from './dto';
+
+@Injectable()
+export class KnownLanguageDrizzleRepository {
+  constructor(private readonly drizzle: DrizzleService) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  async create({
+    user,
+    language,
+    languageProficiency,
+  }: ModifyKnownLanguageArgs): Promise<void> {
+    // Idempotent: the Neo4j flow replaces the exact (user, language,
+    // proficiency) edge, so a re-create is a no-op.
+    await this.db
+      .insert(knownLanguages)
+      .values({
+        userId: user,
+        languageId: language,
+        proficiency: languageProficiency,
+      })
+      .onConflictDoNothing();
+  }
+
+  async delete({
+    user,
+    language,
+    languageProficiency,
+  }: ModifyKnownLanguageArgs): Promise<void> {
+    await this.db
+      .delete(knownLanguages)
+      .where(
+        and(
+          eq(knownLanguages.userId, user),
+          eq(knownLanguages.languageId, language),
+          eq(knownLanguages.proficiency, languageProficiency),
+        ),
+      );
+  }
+
+  async list(userId: ID): Promise<KnownLanguage[]> {
+    const rows = await this.db
+      .select({
+        language: knownLanguages.languageId,
+        proficiency: knownLanguages.proficiency,
+      })
+      .from(knownLanguages)
+      .where(eq(knownLanguages.userId, userId as ID<'User'>))
+      .orderBy(asc(knownLanguages.createdAt));
+    return rows.map((row) => ({
+      language: row.language,
+      proficiency: row.proficiency,
+    }));
+  }
+}

--- a/src/components/user/user.drizzle.repository.ts
+++ b/src/components/user/user.drizzle.repository.ts
@@ -29,6 +29,7 @@ import {
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import { FileService } from '../file';
 import { type FileId } from '../file/dto';
+import { pinnedByRequester } from '../pin/pinned-by-requester';
 import {
   type AssignOrganizationToUser,
   type CreatePerson,
@@ -43,6 +44,7 @@ import {
 type UserRow = typeof users.$inferSelect & {
   globalRoles?: Array<typeof userGlobalRoles.$inferSelect>;
   isIntern?: boolean;
+  pinned?: boolean;
 };
 
 const catchEmailUnique = catchUniqueViolation(
@@ -76,8 +78,17 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
       }),
       this.internUserIds(ids),
     ]);
+    const pinnedSet = await pinnedByRequester(
+      this.db,
+      this.identity.currentMaybe?.userId,
+      rows.map((r) => r.id),
+    );
     return rows.map((row) =>
-      this.toDto({ ...row, isIntern: interns.has(row.id) }),
+      this.toDto({
+        ...row,
+        isIntern: interns.has(row.id),
+        pinned: pinnedSet.has(row.id),
+      }),
     );
   }
 
@@ -255,6 +266,11 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
       this.internUserIds(ids),
     ]);
     const rolesByUser = groupBy(allRoles, (row) => row.userId);
+    const pinnedSet = await pinnedByRequester(
+      this.db,
+      this.identity.currentMaybe?.userId,
+      ids,
+    );
 
     return {
       total,
@@ -263,6 +279,7 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
           ...row,
           globalRoles: rolesByUser[row.id] ?? [],
           isIntern: interns.has(row.id),
+          pinned: pinnedSet.has(row.id),
         }),
       ),
       hasMore,
@@ -377,8 +394,9 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
       title: row.title ?? null,
       gender: row.gender ?? null,
       photo: row.photoId ? { id: row.photoId } : null,
-      // migration-todo: pinned is per-requesting-user state, not stored on the user row
-      pinned: false,
+      // Per-requester pin state — populated by readMany/list via
+      // pinnedByRequester; other internal paths (actors, byEmail) leave it false.
+      pinned: row.pinned ?? false,
       isIntern: row.isIntern,
     };
   }

--- a/src/components/user/user.module.ts
+++ b/src/components/user/user.module.ts
@@ -10,6 +10,7 @@ import { TimeZoneModule } from '../timezone';
 import { ActorLoader } from './actor.loader';
 import { AssignableRolesResolver } from './assignable-roles.resolver';
 import { EducationModule } from './education/education.module';
+import { KnownLanguageDrizzleRepository } from './known-language.drizzle.repository';
 import { KnownLanguageRepository } from './known-language.repository';
 import { KnownLanguageResolver } from './known-language.resolver';
 import { AddActorLabelMigration } from './migrations/add-actor-label.migration';
@@ -52,7 +53,10 @@ import { UserService } from './user.service';
       // migration-todo: remove `as any` once splitDb types accept drizzle repos directly
       postgres: UserDrizzleRepository as any,
     }),
-    KnownLanguageRepository,
+    splitDb(KnownLanguageRepository, {
+      // migration-todo: `as any` + the Neo4j path removed at Phase 7 cutover.
+      postgres: KnownLanguageDrizzleRepository as any,
+    }),
     {
       ...splitDb(SystemAgentNeo4jRepository, {
         neo4j: SystemAgentNeo4jRepository,

--- a/src/core/drizzle/index.ts
+++ b/src/core/drizzle/index.ts
@@ -7,5 +7,6 @@ export * from './int4-multirange';
 export * from './like';
 export * from './order-by';
 export * from './pg-error-codes';
+export * from './resolve-resource-base-node';
 export * from './schema/index';
 export * from './sub-filter';

--- a/src/core/drizzle/migrations/0022_add_pins.sql
+++ b/src/core/drizzle/migrations/0022_add_pins.sql
@@ -1,0 +1,13 @@
+-- Pins (Phase 6). Per-user pins over any resource; resource_id is FK-less
+-- because a user can pin any Pinnable (Project, Language, Partner, User, …)
+-- which span tables — same rationale as prompt_variant_responses.parent_id.
+-- The composite PK makes pin/unpin idempotent and the per-requester `pinned`
+-- field lookup a PK hit. user_id (the PK's leading column) needs no separate
+-- FK index; resource_id is FK-less.
+
+CREATE TABLE "pins" (
+  "user_id"     text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "resource_id" text NOT NULL,
+  "created_at"  timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "pins_pkey" PRIMARY KEY ("user_id", "resource_id")
+);

--- a/src/core/drizzle/migrations/0023_add_known_languages.sql
+++ b/src/core/drizzle/migrations/0023_add_known_languages.sql
@@ -1,0 +1,21 @@
+-- Known Languages (Phase 6). A user's known languages at a proficiency
+-- level. A user may know a language at more than one proficiency (the Neo4j
+-- create only replaces the exact (user, language, proficiency) edge), so the
+-- PK spans all three and create is an idempotent ON CONFLICT DO NOTHING.
+
+CREATE TYPE "language_proficiency" AS ENUM (
+  'Beginner', 'Conversational', 'Skilled', 'Fluent'
+);
+
+CREATE TABLE "known_languages" (
+  "user_id"     text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "language_id" text NOT NULL REFERENCES "languages"("id") ON DELETE CASCADE,
+  "proficiency" "language_proficiency" NOT NULL,
+  "created_at"  timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "known_languages_pkey" PRIMARY KEY ("user_id", "language_id", "proficiency")
+);
+
+CREATE INDEX "known_languages_user_id_idx" ON "known_languages" ("user_id");
+-- language_id is an FK but not the PK's leading column, so it needs its own
+-- full b-tree index for FK-maintenance / cascade scans.
+CREATE INDEX "known_languages_language_id_idx" ON "known_languages" ("language_id");

--- a/src/core/drizzle/migrations/0024_add_comments.sql
+++ b/src/core/drizzle/migrations/0024_add_comments.sql
@@ -1,0 +1,35 @@
+-- Comments (Phase 6). Comment threads attach to any Commentable resource via
+-- a polymorphic, FK-less parent_id + parent_type discriminator (parents span
+-- tables: User/Language/Partner/Project/Engagement/ProgressReport). Comments
+-- hang off a thread and are hard-deleted (cascade), matching
+-- CommentService.delete.
+--
+-- Also installs the deferred FK from notifications.comment_id (added FK-less in
+-- migration 0012) now that the comments table exists.
+
+CREATE TABLE "comment_threads" (
+  "id"          text PRIMARY KEY,
+  "parent_id"   text NOT NULL,
+  "parent_type" text NOT NULL,
+  "creator_id"  text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "created_at"  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX "comment_threads_parent_id_idx" ON "comment_threads" ("parent_id");
+CREATE INDEX "comment_threads_creator_id_idx" ON "comment_threads" ("creator_id");
+
+CREATE TABLE "comments" (
+  "id"          text PRIMARY KEY,
+  "thread_id"   text NOT NULL REFERENCES "comment_threads"("id") ON DELETE CASCADE,
+  "creator_id"  text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "body"        jsonb NOT NULL,
+  "created_at"  timestamptz NOT NULL DEFAULT now(),
+  "modified_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX "comments_thread_id_idx" ON "comments" ("thread_id");
+CREATE INDEX "comments_creator_id_idx" ON "comments" ("creator_id");
+
+ALTER TABLE "notifications"
+  ADD CONSTRAINT "notifications_comment_id_fk"
+  FOREIGN KEY ("comment_id") REFERENCES "comments"("id") ON DELETE CASCADE;

--- a/src/core/drizzle/migrations/0025_add_posts.sql
+++ b/src/core/drizzle/migrations/0025_add_posts.sql
@@ -1,0 +1,26 @@
+-- Posts (Phase 6). Posts attach to any Postable resource (Language/Partner/
+-- Project) via a polymorphic, FK-less parent_id + parent_type discriminator.
+-- Membership-shareability visibility is enforced in the repo against
+-- project_members. shareability keeps the deprecated 'ProjectTeam' value for
+-- parity with Neo4j (stored verbatim).
+
+CREATE TYPE "post_type" AS ENUM ('Note', 'Story', 'Prayer');
+
+CREATE TYPE "post_shareability" AS ENUM (
+  'Membership', 'ProjectTeam', 'Internal', 'AskToShareExternally', 'External'
+);
+
+CREATE TABLE "posts" (
+  "id"           text PRIMARY KEY,
+  "parent_id"    text NOT NULL,
+  "parent_type"  text NOT NULL,
+  "creator_id"   text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "type"         "post_type" NOT NULL,
+  "shareability" "post_shareability" NOT NULL,
+  "body"         text NOT NULL,
+  "created_at"   timestamptz NOT NULL DEFAULT now(),
+  "modified_at"  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX "posts_parent_id_idx" ON "posts" ("parent_id");
+CREATE INDEX "posts_creator_id_idx" ON "posts" ("creator_id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -155,6 +155,34 @@
       "when": 1752451200000,
       "tag": "0021_add_product_progress",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1752537600000,
+      "tag": "0022_add_pins",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1752624000000,
+      "tag": "0023_add_known_languages",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1752710400000,
+      "tag": "0024_add_comments",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1752796800000,
+      "tag": "0025_add_posts",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/resolve-resource-base-node.ts
+++ b/src/core/drizzle/resolve-resource-base-node.ts
@@ -1,0 +1,105 @@
+import { and, eq, isNull } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import { type ID } from '~/common';
+import { type BaseNode } from '~/core/neo4j/results';
+import { type DrizzleDb } from './drizzle.service';
+import {
+  engagements,
+  languages,
+  partners,
+  periodicReports,
+  projects,
+  users,
+} from './schema';
+
+/**
+ * Resolve an arbitrary resource id to a Neo4j-shaped {@link BaseNode} by
+ * probing the candidate parent tables. Polymorphic-parent domains (Comments,
+ * Post) hand the service this node so `ResourceLoader.loadByBaseNode` can
+ * resolve the concrete type from `labels` and load the full DTO — the same job
+ * the Neo4j `DtoRepository.getBaseNode(id)` did against the single graph.
+ *
+ * Covers the union of Commentable + Postable parents that are migrated:
+ * User, Language, Partner, Project, Engagement, ProgressReport. The caller's
+ * `verifyImplements(parent, Commentable|Postable)` rejects any match that isn't
+ * valid for its domain (e.g. a User parent for a Post).
+ *
+ * migration-todo: delete at Phase 7 cutover with the rest of the Neo4j/BaseNode
+ * compatibility shims.
+ */
+export const resolveResourceBaseNode = async (
+  db: DrizzleDb,
+  id: ID,
+): Promise<BaseNode | undefined> => {
+  const mk = (labels: string[], createdAt: Date): BaseNode => ({
+    identity: id,
+    labels: [...labels, 'BaseNode'],
+    properties: { id, createdAt: DateTime.fromJSDate(createdAt) },
+  });
+
+  const [user, language, partner, project, engagement, progressReport] =
+    await Promise.all([
+      db
+        .select({ createdAt: users.createdAt })
+        .from(users)
+        .where(and(eq(users.id, id as ID<'User'>), isNull(users.deletedAt)))
+        .limit(1),
+      db
+        .select({ createdAt: languages.createdAt })
+        .from(languages)
+        .where(
+          and(
+            eq(languages.id, id as ID<'Language'>),
+            isNull(languages.deletedAt),
+          ),
+        )
+        .limit(1),
+      db
+        .select({ createdAt: partners.createdAt })
+        .from(partners)
+        .where(
+          and(eq(partners.id, id as ID<'Partner'>), isNull(partners.deletedAt)),
+        )
+        .limit(1),
+      db
+        .select({ createdAt: projects.createdAt, type: projects.type })
+        .from(projects)
+        .where(
+          and(eq(projects.id, id as ID<'Project'>), isNull(projects.deletedAt)),
+        )
+        .limit(1),
+      db
+        .select({ createdAt: engagements.createdAt, type: engagements.type })
+        .from(engagements)
+        .where(
+          and(
+            eq(engagements.id, id as ID<'Engagement'>),
+            isNull(engagements.deletedAt),
+          ),
+        )
+        .limit(1),
+      // ProgressReport is a periodic_reports row (type='Progress'); it's
+      // Commentable. periodic_reports has no deleted_at (real-delete design).
+      db
+        .select({ createdAt: periodicReports.createdAt })
+        .from(periodicReports)
+        .where(
+          and(eq(periodicReports.id, id), eq(periodicReports.type, 'Progress')),
+        )
+        .limit(1),
+    ]);
+
+  if (user[0]) return mk(['User'], user[0].createdAt);
+  if (language[0]) return mk(['Language'], language[0].createdAt);
+  if (partner[0]) return mk(['Partner'], partner[0].createdAt);
+  if (project[0])
+    return mk([`${project[0].type}Project`, 'Project'], project[0].createdAt);
+  if (engagement[0])
+    return mk(
+      [`${engagement[0].type}Engagement`, 'Engagement'],
+      engagement[0].createdAt,
+    );
+  if (progressReport[0])
+    return mk(['ProgressReport'], progressReport[0].createdAt);
+  return undefined;
+};

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -17,7 +17,12 @@ import {
   timestamp,
   uniqueIndex,
 } from 'drizzle-orm/pg-core';
-import { type ID, type Range, type Role } from '~/common';
+import {
+  type ID,
+  type Range,
+  type RichTextDocument,
+  type Role,
+} from '~/common';
 import { type BudgetStatus } from '../../../components/budget/dto/budget-status.enum';
 import { type CeremonyType } from '../../../components/ceremony/dto/ceremony-type.enum';
 import { type InternshipPosition } from '../../../components/engagement/dto/intern-position.enum';
@@ -33,6 +38,8 @@ import { type FinancialReportingType } from '../../../components/partnership/dto
 import { type PartnershipAgreementStatus } from '../../../components/partnership/dto/partnership-agreement-status.enum';
 import { type ReportPeriod } from '../../../components/periodic-report/dto/report-period.enum';
 import { type ReportType } from '../../../components/periodic-report/dto/report-type.enum';
+import { type PostType } from '../../../components/post/dto/post-type.enum';
+import { type PostShareability } from '../../../components/post/dto/shareability.dto';
 import { type ProductMedium } from '../../../components/product/dto/product-medium.enum';
 import { type ProductMethodology } from '../../../components/product/dto/product-methodology.enum';
 import { type ProductPurpose } from '../../../components/product/dto/product-purpose.enum';
@@ -44,6 +51,7 @@ import { type ProjectStep } from '../../../components/project/dto/project-step.e
 import { type ProjectType } from '../../../components/project/dto/project-type.enum';
 import { type ToolKey } from '../../../components/tools/tool/dto/tool-key.enum';
 import { type Gender } from '../../../components/user/dto/gender.enum';
+import { type LanguageProficiency } from '../../../components/user/dto/language-proficiency.enum';
 import { int4multirange } from '../int4-multirange';
 
 export const userStatusEnum = pgEnum('user_status', ['Active', 'Disabled']);
@@ -1488,10 +1496,12 @@ export const notifications = pgTable(
     // System
     message: text('message'),
     // CommentViaMention. FK-less for now — the comments table lands in a later
-    // Phase 6 migration.
-    // migration-todo: add `.references(() => comments.id, { onDelete: 'cascade' })`
-    // once the comments table exists (Comments domain port).
-    commentId: text('comment_id').$type<ID<'Comment'>>(),
+    // Phase 6 migration. FK to comments added with the Comments migration
+    // (0024) — a deferred (thunked) reference since `comments` is declared
+    // later in this file.
+    commentId: text('comment_id')
+      .$type<ID<'Comment'>>()
+      .references(() => comments.id, { onDelete: 'cascade' }),
   },
   (t) => [
     index('notifications_created_at_idx').on(t.createdAt),
@@ -2505,5 +2515,176 @@ export const progressSummaries = pgTable(
       t.reportId,
       t.period,
     ),
+  ],
+);
+
+// ─── Pins ──────────────────────────────────────────────────────────────────
+
+/**
+ * Per-user pins over any resource. `resource_id` is FK-less because a user can
+ * pin any Pinnable (Project, Language, Partner, User, …) which span tables —
+ * same rationale as prompt_variant_responses.parent_id. The composite PK makes
+ * pin/unpin idempotent and the per-requester `pinned` field lookup a PK hit.
+ */
+export const pins = pgTable(
+  'pins',
+  {
+    userId: text('user_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    resourceId: text('resource_id').$type<ID>().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [primaryKey({ columns: [t.userId, t.resourceId] })],
+);
+
+// ─── Known Languages ─────────────────────────────────────────────────────────
+
+export const languageProficiencyEnum = pgEnum('language_proficiency', [
+  'Beginner',
+  'Conversational',
+  'Skilled',
+  'Fluent',
+]);
+
+/**
+ * A user's known languages, at a proficiency level. A user may know a
+ * language at more than one proficiency (the Neo4j create only replaces the
+ * exact (user, language, proficiency) edge), so the PK spans all three and
+ * create is an idempotent ON CONFLICT DO NOTHING.
+ */
+export const knownLanguages = pgTable(
+  'known_languages',
+  {
+    userId: text('user_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    languageId: text('language_id')
+      .$type<ID<'Language'>>()
+      .notNull()
+      .references(() => languages.id, { onDelete: 'cascade' }),
+    proficiency: languageProficiencyEnum('proficiency')
+      .$type<LanguageProficiency>()
+      .notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.userId, t.languageId, t.proficiency] }),
+    index('known_languages_user_id_idx').on(t.userId),
+    index('known_languages_language_id_idx').on(t.languageId),
+  ],
+);
+
+// ─── Comments ────────────────────────────────────────────────────────────────
+
+/**
+ * A comment thread attached to any Commentable resource. `parent_id` is
+ * FK-less and polymorphic (User/Language/Partner/Project/Engagement/
+ * ProgressReport span tables, same rationale as
+ * prompt_variant_responses.parent_id); `parent_type` is the discriminator used
+ * to rebuild the parent's fake BaseNode at read time.
+ */
+export const commentThreads = pgTable(
+  'comment_threads',
+  {
+    id: text('id').$type<ID<'CommentThread'>>().primaryKey(),
+    parentId: text('parent_id').$type<ID>().notNull(),
+    parentType: text('parent_type').notNull(),
+    creatorId: text('creator_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    index('comment_threads_parent_id_idx').on(t.parentId),
+    index('comment_threads_creator_id_idx').on(t.creatorId),
+  ],
+);
+
+/**
+ * Comments hang off a thread. Hard DELETE (no soft-delete): deleting the
+ * thread's first comment deletes the thread row, and the cascade removes the
+ * rest — matching CommentService.delete.
+ */
+export const comments = pgTable(
+  'comments',
+  {
+    id: text('id').$type<ID<'Comment'>>().primaryKey(),
+    threadId: text('thread_id')
+      .$type<ID<'CommentThread'>>()
+      .notNull()
+      .references(() => commentThreads.id, { onDelete: 'cascade' }),
+    creatorId: text('creator_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    body: jsonb('body').$type<RichTextDocument>().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    modifiedAt: timestamp('modified_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    index('comments_thread_id_idx').on(t.threadId),
+    index('comments_creator_id_idx').on(t.creatorId),
+  ],
+);
+
+// ─── Posts ───────────────────────────────────────────────────────────────────
+
+export const postTypeEnum = pgEnum('post_type', ['Note', 'Story', 'Prayer']);
+
+// 5-value to match Neo4j exactly: 'ProjectTeam' is a deprecated alias for
+// 'Membership' and is stored verbatim.
+// migration-todo: post-cutover, consider collapsing 'ProjectTeam' -> 'Membership'.
+export const postShareabilityEnum = pgEnum('post_shareability', [
+  'Membership',
+  'ProjectTeam',
+  'Internal',
+  'AskToShareExternally',
+  'External',
+]);
+
+/**
+ * Posts attach to any Postable resource (Language/Partner/Project) via a
+ * polymorphic FK-less parent_id + parent_type discriminator. Membership
+ * shareability is enforced in the repo against project_members.
+ */
+export const posts = pgTable(
+  'posts',
+  {
+    id: text('id').$type<ID<'Post'>>().primaryKey(),
+    parentId: text('parent_id').$type<ID>().notNull(),
+    parentType: text('parent_type').notNull(),
+    creatorId: text('creator_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    type: postTypeEnum('type').$type<PostType>().notNull(),
+    shareability: postShareabilityEnum('shareability')
+      .$type<PostShareability>()
+      .notNull(),
+    body: text('body').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    modifiedAt: timestamp('modified_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    index('posts_parent_id_idx').on(t.parentId),
+    index('posts_creator_id_idx').on(t.creatorId),
   ],
 );

--- a/test/comment.e2e-spec.ts
+++ b/test/comment.e2e-spec.ts
@@ -109,7 +109,13 @@ describe('Comment e2e', () => {
       });
       const language = await createLanguage(a);
       const { createEng } = await a.graphql.mutate(CreateLangEngForCommentDoc, {
-        input: { project: project.id, language: language.id },
+        input: {
+          project: project.id,
+          language: language.id,
+          // Match the project MOU window so progress reports land in-window.
+          startDateOverride: CalendarDate.local(2023, 1, 1).toISO(),
+          endDateOverride: CalendarDate.local(2024, 1, 1).toISO(),
+        },
       });
       const reportId = createEng.engagement.progressReports.items[0]!.id;
       expect(reportId).toBeTruthy();

--- a/test/comment.e2e-spec.ts
+++ b/test/comment.e2e-spec.ts
@@ -1,0 +1,213 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { CalendarDate } from '~/common';
+import { graphql } from '~/graphql';
+import {
+  createLanguage,
+  createProject,
+  createSession,
+  createTestApp,
+  registerUser,
+  runAsAdmin,
+  type TestApp,
+} from './utility';
+
+/** Minimal block-editor document the RichText (JSONObject) scalar accepts. */
+const doc = (text: string) => ({
+  version: '1',
+  time: 1,
+  blocks: [{ id: text, type: 'paragraph', data: { text } }],
+});
+
+interface RichDoc {
+  blocks: Array<{ data: { text: string } }>;
+}
+const textOf = (value: unknown) => (value as RichDoc).blocks[0]!.data.text;
+
+describe('Comment e2e', () => {
+  let app: TestApp;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await createSession(app);
+    await registerUser(app);
+  });
+
+  it('creates, lists, updates, and deletes comments on a commentable', async () => {
+    await runAsAdmin(app, async (a) => {
+      const language = await createLanguage(a);
+
+      // First comment creates a new thread on the language.
+      const { createComment } = await a.graphql.mutate(CreateCommentDoc, {
+        input: { resource: language.id, body: doc('First comment') },
+      });
+      const first = createComment.comment;
+      const threadId = createComment.commentThread.id;
+      expect(first.id).toBeTruthy();
+      expect(textOf(first.body.value)).toBe('First comment');
+
+      // The thread is listed on the parent, hydrated with its first comment.
+      const listed = await a.graphql.query(CommentThreadsDoc, {
+        resource: language.id,
+      });
+      expect(listed.commentThreads.total).toBe(1);
+      expect(listed.commentThreads.items[0]!.id).toBe(threadId);
+      expect(listed.commentThreads.items[0]!.firstComment.id).toBe(first.id);
+
+      // Second comment attaches to the existing thread.
+      const { createComment: secondCreated } = await a.graphql.mutate(
+        CreateCommentDoc,
+        {
+          input: {
+            resource: language.id,
+            thread: threadId,
+            body: doc('Second comment'),
+          },
+        },
+      );
+      const second = secondCreated.comment;
+
+      const withTwo = await a.graphql.query(CommentThreadCommentsDoc, {
+        id: threadId,
+      });
+      expect(withTwo.commentThread.comments.total).toBe(2);
+      expect(
+        withTwo.commentThread.comments.items
+          .map((c) => textOf(c.body.value))
+          .sort((x, y) => x.localeCompare(y)),
+      ).toEqual(['First comment', 'Second comment']);
+
+      // Update the second comment's body.
+      const { updateComment } = await a.graphql.mutate(UpdateCommentDoc, {
+        input: { id: second.id, body: doc('Edited second') },
+      });
+      expect(textOf(updateComment.comment.body.value)).toBe('Edited second');
+
+      // Deleting a non-first comment leaves the thread intact.
+      await a.graphql.mutate(DeleteCommentDoc, { id: second.id });
+      const afterOne = await a.graphql.query(CommentThreadCommentsDoc, {
+        id: threadId,
+      });
+      expect(afterOne.commentThread.comments.total).toBe(1);
+
+      // Deleting the first (thread-owning) comment removes the whole thread.
+      await a.graphql.mutate(DeleteCommentDoc, { id: first.id });
+      const afterAll = await a.graphql.query(CommentThreadsDoc, {
+        resource: language.id,
+      });
+      expect(afterAll.commentThreads.total).toBe(0);
+    });
+  });
+
+  // ProgressReport implements Commentable. Regression guard for the PG
+  // parent-resolution path (resolveResourceBaseNode), which previously excluded
+  // ProgressReport and rejected this valid commentable under DATABASE=postgres.
+  it('creates a comment on a ProgressReport parent', async () => {
+    await runAsAdmin(app, async (a) => {
+      const project = await createProject(a, {
+        mouStart: CalendarDate.local(2023, 1, 1).toISO(),
+        mouEnd: CalendarDate.local(2024, 1, 1).toISO(),
+      });
+      const language = await createLanguage(a);
+      const { createEng } = await a.graphql.mutate(CreateLangEngForCommentDoc, {
+        input: { project: project.id, language: language.id },
+      });
+      const reportId = createEng.engagement.progressReports.items[0]!.id;
+      expect(reportId).toBeTruthy();
+
+      const { createComment } = await a.graphql.mutate(CreateCommentDoc, {
+        input: { resource: reportId, body: doc('Report comment') },
+      });
+      expect(createComment.comment.id).toBeTruthy();
+
+      const listed = await a.graphql.query(CommentThreadsDoc, {
+        resource: reportId,
+      });
+      expect(listed.commentThreads.total).toBe(1);
+    });
+  });
+});
+
+const CreateLangEngForCommentDoc = graphql(`
+  mutation CreateLangEngForComment($input: CreateLanguageEngagement!) {
+    createEng: createLanguageEngagement(input: $input) {
+      engagement {
+        id
+        ... on LanguageEngagement {
+          progressReports(input: { count: 1 }) {
+            items {
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+`);
+
+const CreateCommentDoc = graphql(`
+  mutation CreateComment($input: CreateComment!) {
+    createComment(input: $input) {
+      comment {
+        id
+        body {
+          value
+        }
+      }
+      commentThread {
+        id
+      }
+    }
+  }
+`);
+
+const CommentThreadsDoc = graphql(`
+  query CommentThreads($resource: ID!) {
+    commentThreads(resource: $resource) {
+      total
+      items {
+        id
+        firstComment {
+          id
+        }
+      }
+    }
+  }
+`);
+
+const CommentThreadCommentsDoc = graphql(`
+  query CommentThreadComments($id: ID!) {
+    commentThread(id: $id) {
+      id
+      comments {
+        total
+        items {
+          id
+          body {
+            value
+          }
+        }
+      }
+    }
+  }
+`);
+
+const UpdateCommentDoc = graphql(`
+  mutation UpdateComment($input: UpdateComment!) {
+    updateComment(input: $input) {
+      comment {
+        id
+        body {
+          value
+        }
+      }
+    }
+  }
+`);
+
+const DeleteCommentDoc = graphql(`
+  mutation DeleteComment($id: ID!) {
+    deleteComment(id: $id) {
+      __typename
+    }
+  }
+`);

--- a/test/known-language.e2e-spec.ts
+++ b/test/known-language.e2e-spec.ts
@@ -1,0 +1,114 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { graphql } from '~/graphql';
+import {
+  createLanguage,
+  createPerson,
+  createSession,
+  createTestApp,
+  registerUser,
+  runAsAdmin,
+  type TestApp,
+} from './utility';
+
+describe('KnownLanguage e2e', () => {
+  let app: TestApp;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await createSession(app);
+    await registerUser(app);
+  });
+
+  it('adds, lists, and removes a known language at a proficiency', async () => {
+    const person = await createPerson(app);
+    const language = await runAsAdmin(app, createLanguage);
+
+    await app.graphql.mutate(ModifyDoc('createKnownLanguage'), {
+      user: person.id,
+      language: language.id,
+      languageProficiency: 'Skilled',
+    });
+
+    let result = await app.graphql.query(KnownLanguagesDoc, { id: person.id });
+    expect(result.user.knownLanguages).toEqual([
+      { language: { id: language.id }, proficiency: 'Skilled' },
+    ]);
+
+    // Re-adding the same edge is idempotent.
+    await app.graphql.mutate(ModifyDoc('createKnownLanguage'), {
+      user: person.id,
+      language: language.id,
+      languageProficiency: 'Skilled',
+    });
+    result = await app.graphql.query(KnownLanguagesDoc, { id: person.id });
+    expect(result.user.knownLanguages).toHaveLength(1);
+
+    await app.graphql.mutate(ModifyDoc('deleteKnownLanguage'), {
+      user: person.id,
+      language: language.id,
+      languageProficiency: 'Skilled',
+    });
+    result = await app.graphql.query(KnownLanguagesDoc, { id: person.id });
+    expect(result.user.knownLanguages).toHaveLength(0);
+  });
+
+  it('tracks the same language at multiple proficiencies independently', async () => {
+    const person = await createPerson(app);
+    const language = await runAsAdmin(app, createLanguage);
+
+    for (const proficiency of ['Beginner', 'Fluent'] as const) {
+      await app.graphql.mutate(ModifyDoc('createKnownLanguage'), {
+        user: person.id,
+        language: language.id,
+        languageProficiency: proficiency,
+      });
+    }
+    let result = await app.graphql.query(KnownLanguagesDoc, { id: person.id });
+    expect(
+      result.user.knownLanguages
+        .map((k) => k.proficiency)
+        .sort((a, b) => a.localeCompare(b)),
+    ).toEqual(['Beginner', 'Fluent']);
+
+    // Removing one proficiency leaves the other.
+    await app.graphql.mutate(ModifyDoc('deleteKnownLanguage'), {
+      user: person.id,
+      language: language.id,
+      languageProficiency: 'Beginner',
+    });
+    result = await app.graphql.query(KnownLanguagesDoc, { id: person.id });
+    expect(result.user.knownLanguages).toEqual([
+      { language: { id: language.id }, proficiency: 'Fluent' },
+    ]);
+  });
+});
+
+const ModifyDoc = (name: 'createKnownLanguage' | 'deleteKnownLanguage') =>
+  graphql(`
+    mutation Modify(
+      $user: ID!
+      $language: ID!
+      $languageProficiency: LanguageProficiency!
+    ) {
+      ${name}(
+        user: $user
+        language: $language
+        languageProficiency: $languageProficiency
+      ) {
+        id
+      }
+    }
+  `);
+
+const KnownLanguagesDoc = graphql(`
+  query KnownLanguages($id: ID!) {
+    user(id: $id) {
+      knownLanguages {
+        language {
+          id
+        }
+        proficiency
+      }
+    }
+  }
+`);

--- a/test/post.e2e-spec.ts
+++ b/test/post.e2e-spec.ts
@@ -1,0 +1,127 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { graphql } from '~/graphql';
+import {
+  createLanguage,
+  createSession,
+  createTestApp,
+  registerUser,
+  runAsAdmin,
+  type TestApp,
+} from './utility';
+
+describe('Post e2e', () => {
+  let app: TestApp;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await createSession(app);
+    await registerUser(app);
+  });
+
+  it('creates posts, hides Membership posts on a member-less parent, updates and deletes', async () => {
+    await runAsAdmin(app, async (a) => {
+      const language = await createLanguage(a);
+
+      // Internal shareability — always visible.
+      const { createPost: internal } = await a.graphql.mutate(CreatePostDoc, {
+        input: {
+          parent: language.id,
+          type: 'Note',
+          shareability: 'Internal',
+          body: 'Internal note',
+        },
+      });
+      expect(internal.post.id).toBeTruthy();
+      expect(internal.post.body.value).toBe('Internal note');
+      expect(internal.post.shareability).toBe('Internal');
+
+      // Membership shareability — create returns it to the author, but a
+      // Language has no members, so it's hidden from the list.
+      const { createPost: membership } = await a.graphql.mutate(CreatePostDoc, {
+        input: {
+          parent: language.id,
+          type: 'Prayer',
+          shareability: 'Membership',
+          body: 'Members only',
+        },
+      });
+      expect(membership.post.id).toBeTruthy();
+
+      const listed = await a.graphql.query(PostsDoc, { id: language.id });
+      const ids = listed.language.posts.items.map((p) => p.id);
+      expect(ids).toContain(internal.post.id);
+      expect(ids).not.toContain(membership.post.id);
+
+      // Update the visible post.
+      const { updatePost } = await a.graphql.mutate(UpdatePostDoc, {
+        input: {
+          id: internal.post.id,
+          type: 'Note',
+          shareability: 'Internal',
+          body: 'Edited note',
+        },
+      });
+      expect(updatePost.post.body.value).toBe('Edited note');
+
+      // Delete it — it drops out of the list.
+      await a.graphql.mutate(DeletePostDoc, { id: internal.post.id });
+      const afterDelete = await a.graphql.query(PostsDoc, { id: language.id });
+      expect(afterDelete.language.posts.items.map((p) => p.id)).not.toContain(
+        internal.post.id,
+      );
+    });
+  });
+});
+
+const CreatePostDoc = graphql(`
+  mutation CreatePost($input: CreatePost!) {
+    createPost(input: $input) {
+      post {
+        id
+        type
+        shareability
+        body {
+          value
+        }
+      }
+    }
+  }
+`);
+
+const PostsDoc = graphql(`
+  query LanguagePosts($id: ID!) {
+    language(id: $id) {
+      posts {
+        total
+        items {
+          id
+          shareability
+          body {
+            value
+          }
+        }
+      }
+    }
+  }
+`);
+
+const UpdatePostDoc = graphql(`
+  mutation UpdatePost($input: UpdatePost!) {
+    updatePost(input: $input) {
+      post {
+        id
+        body {
+          value
+        }
+      }
+    }
+  }
+`);
+
+const DeletePostDoc = graphql(`
+  mutation DeletePost($id: ID!) {
+    deletePost(id: $id) {
+      __typename
+    }
+  }
+`);


### PR DESCRIPTION
### Summary 
This moves the last four small features off the legacy graph database onto Postgres. They're independent of each other:

- **Pins** — lets a user bookmark any record (a project, language, partner, etc.). Each user sees only their own pins. On the Postgres path the per-user "is this pinned by me?" flag had been shipping hardcoded to `false`; this PR makes it real everywhere it's shown and makes "filter to just my pins" work.
- **Known languages** — the languages a user knows, with a proficiency level. These reads/writes now actually run against Postgres — previously, under the Postgres engine, they still fell through to the legacy query path.
- **Comments** — threaded comments that can be attached to many different record types (users, languages, partners, projects, engagements, progress reports).
- **Posts** — short notes attached to a record, each with a visibility setting controlling who can see it.

Technical context: final wave of the Neo4j→Postgres port. It's stacked on the report-cluster PR — **base is `report-recut`** and will retarget to `develop` automatically once that merges (chain: develop → product #3829 → report → this). Migrations 0022–0025.

### What's added

- **Pins (migration 0022)** — new `pins` table plus `PinDrizzleRepository` (is-pinned / add / remove, keyed to the current user). Two reusable pieces: `pinnedByRequester` (batch-populates the flag during hydration) and `pinnedFilter` (an EXISTS / NOT-EXISTS predicate for list filtering). The four consumer repositories — partner, user, project, language — now populate the real `pinned` value in their `readMany`/`list` and honor `filter.pinned` (they previously returned the `false` stub). Anonymous requesters resolve correctly: `pinned:true` matches nothing, `pinned:false` matches everything.
- **KnownLanguages (0023)** — new `known_languages` table + `KnownLanguageDrizzleRepository` (idempotent create via `ON CONFLICT DO NOTHING`, delete, list), routed through `splitDb` on the user module. New `language_proficiency` pgEnum.
- **Comments (0024)** — `comment_threads` + `comments` tables (hard delete, cascade). Polymorphic parent resolution via a new `resolveResourceBaseNode` helper that probes the migrated parent tables. Installs the `notifications.comment_id` foreign key (the column had landed FK-less in migration 0012).
- **Post (0025)** — `posts` table with `post_type` and a 5-value `post_shareability` pgEnum. Membership-based shareability is enforced in-repo against `project_members`. Sort map covers the type's own scalar columns.

### Notes for the reviewer (intentional choices)

- **Comment audit-event firing is not wired here.** The comment and post services are unchanged from their current form; the `ResourceMutatedHook` audit instrumentation lands with the audit domain, not this PR. Called out so it isn't flagged as missing.
- **Post `ProjectTeam` shareability value is kept verbatim** to preserve current (Neo4j) behavior. Collapsing it to `Membership` is a tagged post-migration TODO, out of scope here.
- **Every FK column has a b-tree index, added directly in the domain migration** (`known_languages_language_id_idx`, `comment_threads_creator_id_idx`, `comments_creator_id_idx`, `posts_creator_id_idx`). Pins needs none — `user_id` leads the composite PK and `resource_id` is intentionally FK-less (polymorphic).
- **Comment module wiring:** only `CommentRepository` is routed through `splitDb`; `CommentThreadRepository` stays a plain provider and the Drizzle comment repo injects the thread repo concretely — this avoids a `moduleRef`/`forwardRef` cycle (documented in the module).

### Schema / DDL

- `pins` — `(user_id → users ON DELETE CASCADE, resource_id [FK-less, polymorphic], created_at)`, composite PK `(user_id, resource_id)`.
- `known_languages` — `(user_id, language_id → languages, proficiency language_proficiency, created_at)`, PK over `(user_id, language_id, proficiency)`. New enum `language_proficiency`.
- `comment_threads` — `(id, creator_id → users, parent [polymorphic], created_at)`.
- `comments` — `(id, thread_id → comment_threads ON DELETE CASCADE, creator_id → users, body, created_at, modified_at)`, hard delete.
- `notifications.comment_id` — FK constraint `notifications_comment_id_fk → comments(id) ON DELETE CASCADE` added here (column pre-existed FK-less from 0012).
- `posts` — `(id, creator_id → users, parent [polymorphic], type post_type, shareability post_shareability, body, created_at, modified_at)`. New enums `post_type`, `post_shareability` (5 values incl. `ProjectTeam`).
- Journal indices 0022–0025, contiguous.

### Validation performed

- **Fresh-DB migration apply 0000–0025**: clean — verified the 5 new tables, 3 new enums, all four folded-in FK indexes, and the `notifications_comment_id_fk` constraint.
- **`yarn type-check` / `yarn lint`**: clean.
- **Postgres e2e** (tested): pin + comment + post + known-language + postgres-schema + user = **32/32**; partner + language green; project **50/51** (the sole failure is the pre-existing name-sort collation baseline, untouched by this PR — the pin wiring in this PR actually fixed the previously-failing Pin legs).
- **Reference-engine e2e** (Neo4j oracle, tested): pin + comment + post + known-language = **6/6** parity. These four specs are new — there was no prior e2e for either engine.

### Reviewer cross-checks

- `resolveResourceBaseNode` probe list = the union of Commentable + Postable parents (User/Language/Partner/Project/Engagement/ProgressReport); each candidate filters `deleted_at IS NULL`. The services' `verifyImplements` rejects a valid-but-wrong parent (e.g. a User handed to a Post).
- Enum↔DTO parity: `language_proficiency`, `post_type`, `post_shareability` values match their DTO enums exactly (the `postgres-schema` e2e asserts this).
- Schema↔SQL: the `schema/index.ts` definitions agree with the raw `0022`–`0025` `.sql` (columns, enums, indexes, the deferred `notifications.comment_id` reference).
- `notifications.comment_id`: schema carries the thunked cascade reference; the constraint itself is created in 0024.

### Explicitly out of scope

- Comment/Post `ResourceMutatedHook` audit firing → audit domain.
- The CommentViaMention notification path exists but stays unexercised — mention `extract()` is still a `[]` stub on both engines (unchanged here).
- Post `ProjectTeam` → `Membership` collapse — tagged post-migration TODO.
- Name-sort collation ordering (project) — standing cutover decision, not this PR.
