### PR TITLE
[pg] Audit log → Postgres (Drizzle): resource-mutation trail + role_at_time — migration 0026

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
             shard: 1
             total: 1
             test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony|product|film|story|project-workflow|periodic-report|rev79|pin|known-language|comment|post)\."
+              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony|product|film|story|project-workflow|periodic-report|rev79|pin|known-language|comment|post|audit-log)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import process from 'node:process';
 import { AdminModule } from './components/admin/admin.module';
+import { AuditModule } from './components/audit/audit.module';
 import { AuthorizationModule } from './components/authorization/authorization.module';
 import { BudgetModule } from './components/budget/budget.module';
 import { CeremonyModule } from './components/ceremony/ceremony.module';
@@ -58,6 +59,7 @@ if (process.env.NODE_ENV !== 'production') {
     AuthorizationModule,
     BudgetModule,
     CeremonyModule,
+    AuditModule,
     CommentModule,
     EthnoArtModule,
     FileModule,

--- a/src/components/audit/audit-log.handler.ts
+++ b/src/components/audit/audit-log.handler.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { OnHook } from '~/core/hooks';
+import { AuditService } from './audit.service';
+import { ResourceMutatedHook } from './resource-mutated.hook';
+
+/**
+ * Writes one audit-log row per resource mutation, in the firing transaction.
+ */
+@Injectable()
+@OnHook(ResourceMutatedHook)
+export class AuditLogHandler {
+  constructor(private readonly audit: AuditService) {}
+
+  async handle(hook: ResourceMutatedHook) {
+    await this.audit.record(hook);
+  }
+}

--- a/src/components/audit/audit.module.ts
+++ b/src/components/audit/audit.module.ts
@@ -1,0 +1,20 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { UserModule } from '../user/user.module';
+import { AuditLogHandler } from './audit-log.handler';
+import { AuditService } from './audit.service';
+import { ResourceMutationRepository } from './resource-mutation.repository';
+import { ResourceMutationResolver } from './resource-mutation.resolver';
+import { ResourceHistoryResolver } from './resource.resolver';
+
+@Module({
+  imports: [forwardRef(() => UserModule)],
+  providers: [
+    AuditService,
+    ResourceMutationRepository,
+    AuditLogHandler,
+    ResourceMutationResolver,
+    ResourceHistoryResolver,
+  ],
+  exports: [AuditService],
+})
+export class AuditModule {}

--- a/src/components/audit/audit.service.ts
+++ b/src/components/audit/audit.service.ts
@@ -27,6 +27,16 @@ export class AuditService {
     if (this.config.databaseEngine !== 'postgres') {
       return;
     }
+    // A no-op update (nothing actually changed) isn't worth an audit row.
+    // Centralized here so every firing service is covered without each having
+    // to guard its own empty-changes case. Creates/deletes always record —
+    // they carry no change set by design.
+    if (
+      hook.action === 'Update' &&
+      (hook.changes == null || Object.keys(hook.changes).length === 0)
+    ) {
+      return;
+    }
     // Only a logged-in *user* is a valid actor. Anonymous sessions carry the
     // Anonymous SystemAgent's id (registration/bootstrap flows), which lives in
     // `system_agents`, not `users` — storing it would violate the actor FK.

--- a/src/components/audit/audit.service.ts
+++ b/src/components/audit/audit.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common';
+import { type ID } from '~/common';
+import { Identity } from '~/core/authentication';
+import { ConfigService } from '~/core/config';
+import {
+  type ResourceMutationList,
+  type ResourceMutationListInput,
+} from './dto/resource-mutation.dto';
+import { type ResourceMutatedHook } from './resource-mutated.hook';
+import { ResourceMutationRepository } from './resource-mutation.repository';
+
+const EMPTY: ResourceMutationList = { items: [], total: 0, hasMore: false };
+
+@Injectable()
+export class AuditService {
+  constructor(
+    private readonly repo: ResourceMutationRepository,
+    private readonly identity: Identity,
+    private readonly config: ConfigService,
+  ) {}
+
+  async record(hook: ResourceMutatedHook): Promise<void> {
+    // The audit log lives in postgres; under neo4j the drizzle client has no
+    // pool, so this is a no-op (no rows captured during the transition).
+    // migration-todo(cutover-cleanup): drop this guard at Phase 7 cutover
+    // (always postgres) — audit is postgres-only by design.
+    if (this.config.databaseEngine !== 'postgres') {
+      return;
+    }
+    // Only a logged-in *user* is a valid actor. Anonymous sessions carry the
+    // Anonymous SystemAgent's id (registration/bootstrap flows), which lives in
+    // `system_agents`, not `users` — storing it would violate the actor FK.
+    // migration-todo: ghost-impersonation sessions also carry a SystemAgent id;
+    // revisit if/when the audit log needs to attribute those.
+    const session = this.identity.currentMaybe;
+    const actorId = session && !session.anonymous ? session.userId : null;
+    // Snapshot the actor's roles AT WRITE TIME — the log is append-only, so a
+    // missing value can never be backfilled. Stored as plain text (decoupled
+    // from the live Role enum) so the historical record survives role changes.
+    const roleAtTime = session ? [...session.roles] : [];
+
+    await this.repo.record({
+      resourceType: hook.resourceType,
+      resourceId: hook.resourceId,
+      action: hook.action,
+      actorId,
+      roleAtTime,
+      changes: serializeChanges(hook.changes),
+    });
+  }
+
+  async list(
+    resourceType: string,
+    resourceId: ID,
+    input: ResourceMutationListInput,
+  ): Promise<ResourceMutationList> {
+    // migration-todo(cutover-cleanup): drop this guard at Phase 7 cutover
+    // (always postgres).
+    if (this.config.databaseEngine !== 'postgres') {
+      return EMPTY;
+    }
+    return await this.repo.listByResource(resourceType, resourceId, input);
+  }
+}
+
+/** Coerce a change set to plain JSON (luxon DateTimes -> ISO, drop undefined). */
+const serializeChanges = (
+  changes: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null =>
+  changes == null
+    ? null
+    : (JSON.parse(JSON.stringify(changes)) as Record<string, unknown>);

--- a/src/components/audit/audit.service.ts
+++ b/src/components/audit/audit.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { type ID } from '~/common';
-import { Identity } from '~/core/authentication';
+import { Identity, type Session } from '~/core/authentication';
 import { ConfigService } from '~/core/config';
 import {
   type ResourceMutationList,
@@ -37,16 +37,22 @@ export class AuditService {
     ) {
       return;
     }
-    // Only a logged-in *user* is a valid actor. Anonymous sessions carry the
-    // Anonymous SystemAgent's id (registration/bootstrap flows), which lives in
-    // `system_agents`, not `users` — storing it would violate the actor FK.
-    // migration-todo: ghost-impersonation sessions also carry a SystemAgent id;
-    // revisit if/when the audit log needs to attribute those.
     const session = this.identity.currentMaybe;
-    const actorId = session && !session.anonymous ? session.userId : null;
+    const { actorId, actorSystemAgent } = resolveActor(session);
+    // The REAL requester behind an impersonated action. `identity.currentMaybe`
+    // is the *effective* session, so without this an admin impersonating a user
+    // would be recorded as that user — wrong data, silently. Always a user: an
+    // impersonator's own session must have resolved to one for impersonation to
+    // take effect at all (SessionManager.resumeSession), which is why this is a
+    // plain FK to `users` while the actor needs two columns.
+    const impersonatorId = session?.impersonator?.userId as
+      | ID<'User'>
+      | undefined;
     // Snapshot the actor's roles AT WRITE TIME — the log is append-only, so a
     // missing value can never be backfilled. Stored as plain text (decoupled
     // from the live Role enum) so the historical record survives role changes.
+    // These are the EFFECTIVE roles, i.e. the ones the policy engine actually
+    // evaluated, so they stay consistent with actorId under impersonation.
     const roleAtTime = session ? [...session.roles] : [];
 
     await this.repo.record({
@@ -54,6 +60,8 @@ export class AuditService {
       resourceId: hook.resourceId,
       action: hook.action,
       actorId,
+      actorSystemAgent,
+      impersonatorId: impersonatorId ?? null,
       roleAtTime,
       changes: serializeChanges(hook.changes),
     });
@@ -72,6 +80,38 @@ export class AuditService {
     return await this.repo.listByResource(resourceType, resourceId, input);
   }
 }
+
+/**
+ * Split a session's identity across the two mutually-exclusive actor columns.
+ *
+ * `Session.userId` holds a User id *or* a SystemAgent id — anonymous sessions
+ * carry the Anonymous agent's, ghost impersonation the Ghost agent's. Both live
+ * in `system_agents`, not `users`, so storing either as `actor_id` violates the
+ * actor FK and (because the audit write shares the mutation's transaction)
+ * takes the whole mutation down with it. The agent is recorded by name instead.
+ *
+ * Falls back to a null actor rather than the agent name if a session somehow
+ * reports anonymous without one, which is the pre-0027 behaviour and the safe
+ * direction: attribution goes missing, nothing crashes.
+ *
+ * migration-todo: `SessionManager.asRole` builds a session with a literal
+ * `'anonymous'` userId and `anonymous: false`, which is neither a user nor an
+ * agent id — recording a mutation under it would violate the actor FK the same
+ * way ghost impersonation did. Unreachable today (both call sites are read-only:
+ * policy-dumper and permission.serializer), and the real fix belongs in
+ * `asRole`, which contradicts its own docblock by dropping the current user.
+ */
+const resolveActor = (
+  session: Session | undefined,
+): { actorId: ID<'User'> | null; actorSystemAgent: string | null } => {
+  if (!session) {
+    return { actorId: null, actorSystemAgent: null };
+  }
+  if (session.anonymous || session.systemAgentName) {
+    return { actorId: null, actorSystemAgent: session.systemAgentName ?? null };
+  }
+  return { actorId: session.userId as ID<'User'>, actorSystemAgent: null };
+};
 
 /** Coerce a change set to plain JSON (luxon DateTimes -> ISO, drop undefined). */
 const serializeChanges = (

--- a/src/components/audit/dto/resource-mutation.dto.ts
+++ b/src/components/audit/dto/resource-mutation.dto.ts
@@ -34,6 +34,22 @@ export class ResourceMutation {
   /** Resolved to a User by the resolver; null for system/anonymous actors. */
   readonly actor: LinkTo<'User'> | null;
 
+  @Field(() => String, {
+    nullable: true,
+    description:
+      'The name of the system agent that performed the mutation (e.g. ' +
+      '"Ghost", "Anonymous"), when it was not a user. Stored as a name ' +
+      'snapshot rather than a reference, for the same reason as `roleAtTime`. ' +
+      'Mutually exclusive with `actor`.',
+  })
+  readonly actorSystemAgent: string | null;
+
+  /**
+   * Resolved to a User by the resolver; null unless the actor was being
+   * impersonated.
+   */
+  readonly impersonator: LinkTo<'User'> | null;
+
   @Field(() => [String], {
     description:
       'The role(s) the actor held at the moment of the mutation. Stored as a ' +
@@ -60,7 +76,10 @@ export interface RecordMutationInput {
   readonly resourceType: string;
   readonly resourceId: ID;
   readonly action: MutationAction;
+  /** Mutually exclusive with {@link actorSystemAgent} (enforced by CHECK). */
   readonly actorId: ID<'User'> | null;
+  readonly actorSystemAgent: string | null;
+  readonly impersonatorId: ID<'User'> | null;
   readonly roleAtTime: readonly string[];
   readonly changes?: Record<string, unknown> | null;
 }

--- a/src/components/audit/dto/resource-mutation.dto.ts
+++ b/src/components/audit/dto/resource-mutation.dto.ts
@@ -1,0 +1,66 @@
+import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-scalars';
+import { type DateTime } from 'luxon';
+import {
+  DateTimeField,
+  type EnumType,
+  type ID,
+  makeEnum,
+  PaginatedList,
+  PaginationInput,
+} from '~/common';
+import { type LinkTo } from '~/core/resources';
+
+export type MutationAction = EnumType<typeof MutationAction>;
+export const MutationAction = makeEnum({
+  name: 'MutationAction',
+  values: ['Create', 'Update', 'Delete'],
+});
+
+/**
+ * One entry in the general audit log — a single create/update/delete of a
+ * resource, who did it, in what role, and (for updates) the changed fields.
+ */
+@ObjectType()
+export class ResourceMutation {
+  readonly id: string;
+
+  @Field(() => MutationAction)
+  readonly action: MutationAction;
+
+  @DateTimeField()
+  readonly at: DateTime;
+
+  /** Resolved to a User by the resolver; null for system/anonymous actors. */
+  readonly actor: LinkTo<'User'> | null;
+
+  @Field(() => [String], {
+    description:
+      'The role(s) the actor held at the moment of the mutation. Stored as a ' +
+      'decoupled snapshot (plain role names, not the live Role enum) so the ' +
+      'append-only record is immune to later role changes; empty for ' +
+      'system/anonymous actors.',
+  })
+  readonly roleAtTime: readonly string[];
+
+  @Field(() => GraphQLJSONObject, {
+    nullable: true,
+    description: 'The fields that changed (updates only)',
+  })
+  readonly changes: Record<string, unknown> | null;
+}
+
+@InputType()
+export class ResourceMutationListInput extends PaginationInput {}
+
+@ObjectType()
+export class ResourceMutationList extends PaginatedList(ResourceMutation) {}
+
+export interface RecordMutationInput {
+  readonly resourceType: string;
+  readonly resourceId: ID;
+  readonly action: MutationAction;
+  readonly actorId: ID<'User'> | null;
+  readonly roleAtTime: readonly string[];
+  readonly changes?: Record<string, unknown> | null;
+}

--- a/src/components/audit/index.ts
+++ b/src/components/audit/index.ts
@@ -1,0 +1,4 @@
+export { AuditModule } from './audit.module';
+export { AuditService } from './audit.service';
+export { ResourceMutatedHook } from './resource-mutated.hook';
+export * from './dto/resource-mutation.dto';

--- a/src/components/audit/resource-mutated.hook.ts
+++ b/src/components/audit/resource-mutated.hook.ts
@@ -1,0 +1,19 @@
+import { type ID } from '~/common';
+import { type MutationAction } from './dto/resource-mutation.dto';
+
+/**
+ * Generic mutation event for the audit log. Domain services fire this (in
+ * addition to their own hooks) on create/update/delete; the audit listener
+ * writes one row per event, in the same transaction.
+ *
+ * `changes` is the diffed field set (from `repo.getActualChanges`) for updates;
+ * omit for create/delete.
+ */
+export class ResourceMutatedHook {
+  constructor(
+    readonly resourceType: string,
+    readonly resourceId: ID,
+    readonly action: MutationAction,
+    readonly changes?: Record<string, unknown> | null,
+  ) {}
+}

--- a/src/components/audit/resource-mutation.repository.ts
+++ b/src/components/audit/resource-mutation.repository.ts
@@ -24,6 +24,8 @@ export class ResourceMutationRepository {
       resourceId: input.resourceId,
       action: input.action,
       actorId: input.actorId,
+      actorSystemAgent: input.actorSystemAgent,
+      impersonatorId: input.impersonatorId,
       roleAtTime: [...input.roleAtTime],
       changes: input.changes ?? null,
     });
@@ -58,6 +60,8 @@ export class ResourceMutationRepository {
       action: row.action,
       at: DateTime.fromJSDate(row.at),
       actor: row.actorId ? { id: row.actorId } : null,
+      actorSystemAgent: row.actorSystemAgent,
+      impersonator: row.impersonatorId ? { id: row.impersonatorId } : null,
       roleAtTime: row.roleAtTime ?? [],
       changes: (row.changes as Record<string, unknown> | null) ?? null,
     }));

--- a/src/components/audit/resource-mutation.repository.ts
+++ b/src/components/audit/resource-mutation.repository.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@nestjs/common';
+import { and, count, desc, eq } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import { type ID } from '~/common';
+import { DrizzleService } from '~/core/drizzle';
+import { resourceMutations } from '~/core/drizzle/schema';
+import {
+  type RecordMutationInput,
+  type ResourceMutation,
+  type ResourceMutationListInput,
+} from './dto/resource-mutation.dto';
+
+@Injectable()
+export class ResourceMutationRepository {
+  constructor(private readonly drizzle: DrizzleService) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  async record(input: RecordMutationInput): Promise<void> {
+    await this.db.insert(resourceMutations).values({
+      resourceType: input.resourceType,
+      resourceId: input.resourceId,
+      action: input.action,
+      actorId: input.actorId,
+      roleAtTime: [...input.roleAtTime],
+      changes: input.changes ?? null,
+    });
+  }
+
+  async listByResource(
+    resourceType: string,
+    resourceId: ID,
+    input: ResourceMutationListInput,
+  ): Promise<{ items: ResourceMutation[]; total: number; hasMore: boolean }> {
+    const predicate = and(
+      eq(resourceMutations.resourceType, resourceType),
+      eq(resourceMutations.resourceId, resourceId),
+    );
+    const offset = (input.page - 1) * input.count;
+    const [countRows, rows] = await Promise.all([
+      this.db
+        .select({ total: count() })
+        .from(resourceMutations)
+        .where(predicate),
+      this.db
+        .select()
+        .from(resourceMutations)
+        .where(predicate)
+        .orderBy(desc(resourceMutations.at), desc(resourceMutations.id))
+        .limit(input.count)
+        .offset(offset),
+    ]);
+    const total = countRows[0]?.total ?? 0;
+    const items = rows.map((row) => ({
+      id: String(row.id),
+      action: row.action,
+      at: DateTime.fromJSDate(row.at),
+      actor: row.actorId ? { id: row.actorId } : null,
+      roleAtTime: row.roleAtTime ?? [],
+      changes: (row.changes as Record<string, unknown> | null) ?? null,
+    }));
+    return { items, total, hasMore: offset + rows.length < total };
+  }
+}

--- a/src/components/audit/resource-mutation.resolver.ts
+++ b/src/components/audit/resource-mutation.resolver.ts
@@ -1,4 +1,5 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
 import { Loader, type LoaderOf } from '~/core/data-loader';
 import { UserLoader } from '../user';
 import { User } from '../user/dto';
@@ -18,5 +19,27 @@ export class ResourceMutationResolver {
       return null;
     }
     return await users.load(mutation.actor.id);
+  }
+
+  @ResolveField(() => User, {
+    nullable: true,
+    description: stripIndent`
+      The real, requesting user behind an impersonated mutation — null when the
+      actor was acting as themselves.
+
+      When set, \`actor\` is who the mutation was performed AS and this is who
+      performed it. Note this equals \`actor\` for role-only impersonation
+      (\`X-CORD-Impersonate-Role\`), which records that a user acted under roles
+      other than their own.
+    `,
+  })
+  async impersonator(
+    @Parent() mutation: ResourceMutation,
+    @Loader(UserLoader) users: LoaderOf<UserLoader>,
+  ): Promise<User | null> {
+    if (!mutation.impersonator) {
+      return null;
+    }
+    return await users.load(mutation.impersonator.id);
   }
 }

--- a/src/components/audit/resource-mutation.resolver.ts
+++ b/src/components/audit/resource-mutation.resolver.ts
@@ -1,0 +1,22 @@
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Loader, type LoaderOf } from '~/core/data-loader';
+import { UserLoader } from '../user';
+import { User } from '../user/dto';
+import { ResourceMutation } from './dto/resource-mutation.dto';
+
+@Resolver(ResourceMutation)
+export class ResourceMutationResolver {
+  @ResolveField(() => User, {
+    nullable: true,
+    description: 'The user who performed the mutation (null if system)',
+  })
+  async actor(
+    @Parent() mutation: ResourceMutation,
+    @Loader(UserLoader) users: LoaderOf<UserLoader>,
+  ): Promise<User | null> {
+    if (!mutation.actor) {
+      return null;
+    }
+    return await users.load(mutation.actor.id);
+  }
+}

--- a/src/components/audit/resource.resolver.ts
+++ b/src/components/audit/resource.resolver.ts
@@ -1,0 +1,43 @@
+import { Info, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { stripIndent } from 'common-tags';
+import { type GraphQLResolveInfo } from 'graphql';
+import { ListArg, Resource } from '~/common';
+import { AuditService } from './audit.service';
+import {
+  ResourceMutationList,
+  ResourceMutationListInput,
+} from './dto/resource-mutation.dto';
+
+/**
+ * Exposes the audit-log `history` field on EVERY resource by resolving it on
+ * the base {@link Resource} interface — implementing object types inherit it,
+ * so no per-domain resolver is needed. A domain's history is populated once its
+ * service fires {@link import('./resource-mutated.hook').ResourceMutatedHook}.
+ */
+@Resolver(Resource)
+export class ResourceHistoryResolver {
+  constructor(private readonly audit: AuditService) {}
+
+  @ResolveField(() => ResourceMutationList, {
+    description: stripIndent`
+      The audit-log history of mutations to this resource.
+
+      An empty list means either this resource has not been mutated, or its
+      type is not tracked in the audit log. Audit coverage spans user-driven
+      mutations across most resources; some types (system-generated, sync-only,
+      or relationship toggles) are intentionally not recorded.
+    `,
+  })
+  async history(
+    @Parent() resource: Resource,
+    @Info() info: GraphQLResolveInfo,
+    @ListArg(ResourceMutationListInput) input: ResourceMutationListInput,
+  ): Promise<ResourceMutationList> {
+    // `info.parentType.name` is the concrete GraphQL type GraphQL already
+    // resolved this object to (e.g. MomentumTranslationProject), which is what
+    // the firing service records under. NOT `resource.__typename` — for the
+    // polymorphic interfaces (Engagement) that holds a Gel FQN like
+    // 'default::LanguageEngagement', which wouldn't match the stored row.
+    return await this.audit.list(info.parentType.name, resource.id, input);
+  }
+}

--- a/src/components/budget/budget.service.ts
+++ b/src/components/budget/budget.service.ts
@@ -9,8 +9,10 @@ import {
   ServerException,
   viewOfChangeset,
 } from '~/common';
+import { Hooks } from '~/core/hooks';
 import { mapListResults } from '~/core/neo4j/results';
 import { HandleIdLookup, ResourceResolver } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import { FileService } from '../file';
 import { type FileId } from '../file/dto';
@@ -39,6 +41,7 @@ export class BudgetService {
     private readonly budgetRepo: BudgetRepository,
     private readonly budgetRecordsRepo: BudgetRecordRepository,
     private readonly resources: ResourceResolver,
+    private readonly hooks: Hooks,
   ) {}
 
   async create(input: CreateBudget): Promise<Budget> {
@@ -56,6 +59,10 @@ export class BudgetService {
         budgetId,
         'universalTemplateFile',
         input.universalTemplateFile,
+      );
+
+      await this.hooks.run(
+        new ResourceMutatedHook('Budget', budgetId, 'Create'),
       );
 
       return await this.readOne(budgetId);
@@ -76,6 +83,10 @@ export class BudgetService {
       const budgetRecord = await this.readOneRecord(
         recordId,
         viewOfChangeset(changeset),
+      );
+
+      await this.hooks.run(
+        new ResourceMutatedHook('BudgetRecord', recordId, 'Create'),
       );
 
       return budgetRecord;
@@ -153,6 +164,9 @@ export class BudgetService {
       universalTemplateFile,
     );
     const updated = await this.budgetRepo.update(budget, simpleChanges);
+    await this.hooks.run(
+      new ResourceMutatedHook('Budget', input.id, 'Update', changes),
+    );
     return updated;
   }
 
@@ -177,6 +191,9 @@ export class BudgetService {
     }
 
     const updated = await this.budgetRecordsRepo.update(br, changes, changeset);
+    await this.hooks.run(
+      new ResourceMutatedHook('BudgetRecord', id, 'Update', changes),
+    );
     return this.privileges.for(BudgetRecord).secure(updated);
   }
 
@@ -191,6 +208,8 @@ export class BudgetService {
     } catch (e) {
       throw new ServerException('Failed to delete budget', e);
     }
+
+    await this.hooks.run(new ResourceMutatedHook('Budget', id, 'Delete'));
   }
 
   async deleteRecord(id: ID, changeset?: ID): Promise<void> {
@@ -199,6 +218,8 @@ export class BudgetService {
     } catch (e) {
       throw new ServerException('Failed to delete Budget Record', e);
     }
+
+    await this.hooks.run(new ResourceMutatedHook('BudgetRecord', id, 'Delete'));
   }
 
   async list(

--- a/src/components/ceremony/ceremony.service.ts
+++ b/src/components/ceremony/ceremony.service.ts
@@ -6,7 +6,9 @@ import {
   ServerException,
   type UnsecuredDto,
 } from '~/common';
+import { Hooks } from '~/core/hooks';
 import { HandleIdLookup } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import { CeremonyChannels } from './ceremony.channels';
 import { CeremonyRepository } from './ceremony.repository';
@@ -23,6 +25,7 @@ export class CeremonyService {
     private readonly privileges: Privileges,
     private readonly channels: CeremonyChannels,
     private readonly repo: CeremonyRepository,
+    private readonly hooks: Hooks,
   ) {}
 
   async create(
@@ -33,6 +36,7 @@ export class CeremonyService {
     // Neo4j repo ignores it and the caller wires the relationship after.
     // migration-todo: make it required at Phase 7 cutover.
     const { id } = await this.repo.create(input, engagementId);
+    await this.hooks.run(new ResourceMutatedHook('Ceremony', id, 'Create'));
 
     this.channels.publishToAll('created', {
       ceremony: id,
@@ -70,6 +74,9 @@ export class CeremonyService {
       id: input.id,
       ...changes,
     });
+    await this.hooks.run(
+      new ResourceMutatedHook('Ceremony', input.id, 'Update', changes),
+    );
 
     const payload = this.channels.publishToAll('updated', {
       ceremony: updated.id,
@@ -92,6 +99,7 @@ export class CeremonyService {
     } catch (exception) {
       throw new ServerException('Failed to delete Ceremony', exception);
     }
+    await this.hooks.run(new ResourceMutatedHook('Ceremony', id, 'Delete'));
 
     this.channels.publishToAll('deleted', {
       ceremony: id,

--- a/src/components/comments/comment.service.ts
+++ b/src/components/comments/comment.service.ts
@@ -67,10 +67,12 @@ export class CommentService {
       throw new CreationFailed(Comment, { cause: exception });
     }
 
+    // Audit the creation before firing downstream notifications, so a
+    // notification failure can't prevent the mutation from being recorded.
+    await this.hooks.run(new ResourceMutatedHook('Comment', dto.id, 'Create'));
+
     const mentionees = this.mentionNotificationService.extract(dto);
     await this.mentionNotificationService.notify(mentionees, dto);
-
-    await this.hooks.run(new ResourceMutatedHook('Comment', dto.id, 'Create'));
 
     return this.secureComment(dto);
   }

--- a/src/components/comments/comment.service.ts
+++ b/src/components/comments/comment.service.ts
@@ -12,8 +12,10 @@ import {
   type UnsecuredDto,
 } from '~/common';
 import { Identity } from '~/core/authentication';
+import { Hooks } from '~/core/hooks';
 import { type BaseNode, isBaseNode } from '~/core/neo4j/results';
 import { ResourceLoader, ResourcesHost } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import { CommentRepository } from './comment.repository';
 import {
@@ -40,6 +42,7 @@ export class CommentService {
     private readonly resourcesHost: ResourcesHost,
     private readonly identity: Identity,
     private readonly mentionNotificationService: CommentViaMentionNotificationService,
+    private readonly hooks: Hooks,
   ) {}
 
   async create(input: CreateComment) {
@@ -66,6 +69,8 @@ export class CommentService {
 
     const mentionees = this.mentionNotificationService.extract(dto);
     await this.mentionNotificationService.notify(mentionees, dto);
+
+    await this.hooks.run(new ResourceMutatedHook('Comment', dto.id, 'Create'));
 
     return this.secureComment(dto);
   }
@@ -133,6 +138,10 @@ export class CommentService {
     this.privileges.for(Comment, object).verifyChanges(changes);
     await this.repo.update(object, changes);
 
+    await this.hooks.run(
+      new ResourceMutatedHook('Comment', input.id, 'Update', changes),
+    );
+
     const updated = await this.repo.readOne(object.id);
 
     const prevMentionees = this.mentionNotificationService.extract(object);
@@ -157,6 +166,8 @@ export class CommentService {
     } catch (exception) {
       throw new ServerException('Failed to delete comment', exception);
     }
+
+    await this.hooks.run(new ResourceMutatedHook('Comment', id, 'Delete'));
   }
 
   async getThreadCount(parent: Commentable) {

--- a/src/components/engagement/engagement.service.ts
+++ b/src/components/engagement/engagement.service.ts
@@ -20,6 +20,7 @@ import { Hooks } from '~/core/hooks';
 import { LiveQueryStore } from '~/core/live-query';
 import { ILogger, Logger } from '~/core/logger';
 import { HandleIdLookup, ResourceLoader } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import { CeremonyService } from '../ceremony';
 import { FileNodeLoader } from '../file';
@@ -88,6 +89,13 @@ export class EngagementService {
 
     const event = new EngagementCreatedHook(engagement, input);
     await this.hooks.run(event);
+    await this.hooks.run(
+      new ResourceMutatedHook(
+        'LanguageEngagement',
+        event.engagement.id,
+        'Create',
+      ),
+    );
 
     this.liveQueryStore.invalidate([
       resolveProjectType(engagement.project),
@@ -121,6 +129,13 @@ export class EngagementService {
 
     const event = new EngagementCreatedHook(engagement, input);
     await this.hooks.run(event);
+    await this.hooks.run(
+      new ResourceMutatedHook(
+        'InternshipEngagement',
+        event.engagement.id,
+        'Create',
+      ),
+    );
 
     this.liveQueryStore.invalidate([
       resolveProjectType(engagement.project),
@@ -244,6 +259,14 @@ export class EngagementService {
       ...changes,
     });
     await this.hooks.run(event);
+    await this.hooks.run(
+      new ResourceMutatedHook(
+        'LanguageEngagement',
+        updated.id,
+        'Update',
+        changes,
+      ),
+    );
 
     const { pnp, ...simplePrevious } = previous;
     const { pnp: newPnp, ...simpleChanges } = changes;
@@ -332,6 +355,14 @@ export class EngagementService {
       ...changes,
     });
     await this.hooks.run(event);
+    await this.hooks.run(
+      new ResourceMutatedHook(
+        'InternshipEngagement',
+        updated.id,
+        'Update',
+        changes,
+      ),
+    );
 
     const { growthPlan, ...simplePrevious } = previous;
     const { growthPlan: newGrowthPlan, ...simpleChanges } = changes;
@@ -375,6 +406,9 @@ export class EngagementService {
 
     await this.hooks.run(new EngagementWillDeleteHook(object));
     await this.repo.delete(object.id, changeset);
+    await this.hooks.run(
+      new ResourceMutatedHook(resolveEngagementType(object).name, id, 'Delete'),
+    );
     const at = DateTime.now();
 
     const payload = this.channels.publishToAll(

--- a/src/components/field-region/field-region.service.ts
+++ b/src/components/field-region/field-region.service.ts
@@ -9,6 +9,7 @@ import {
 } from '~/common';
 import { Hooks } from '~/core/hooks';
 import { HandleIdLookup } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import {
   IProject,
@@ -41,6 +42,9 @@ export class FieldRegionService {
     this.privileges.for(FieldRegion).verifyCan('create');
     await this.validateDirectorRole(input.director);
     const dto = await this.repo.create(input);
+    await this.hooks.run(
+      new ResourceMutatedHook('FieldRegion', dto.id, 'Create'),
+    );
     return this.secure(dto);
   }
 
@@ -80,6 +84,9 @@ export class FieldRegionService {
       ...changes,
     });
     await this.hooks.run(event);
+    await this.hooks.run(
+      new ResourceMutatedHook('FieldRegion', input.id, 'Update', changes),
+    );
 
     return this.secure(updated);
   }
@@ -113,6 +120,8 @@ export class FieldRegionService {
     } catch (exception) {
       throw new ServerException('Failed to delete', exception);
     }
+
+    await this.hooks.run(new ResourceMutatedHook('FieldRegion', id, 'Delete'));
   }
 
   async list(input: FieldRegionListInput): Promise<FieldRegionListOutput> {

--- a/src/components/field-zone/field-zone.service.ts
+++ b/src/components/field-zone/field-zone.service.ts
@@ -9,6 +9,7 @@ import {
 } from '~/common';
 import { Hooks } from '~/core/hooks';
 import { HandleIdLookup } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import { type ProjectListInput, type SecuredProjectList } from '../project/dto';
 import { ProjectService } from '../project/project.service';
@@ -37,6 +38,9 @@ export class FieldZoneService {
     this.privileges.for(FieldZone).verifyCan('create');
     await this.validateDirectorRole(input.director);
     const dto = await this.repo.create(input);
+    await this.hooks.run(
+      new ResourceMutatedHook('FieldZone', dto.id, 'Create'),
+    );
     return this.secure(dto);
   }
 
@@ -77,6 +81,10 @@ export class FieldZoneService {
     });
     await this.hooks.run(event);
 
+    await this.hooks.run(
+      new ResourceMutatedHook('FieldZone', input.id, 'Update', changes),
+    );
+
     return this.secure(updated);
   }
 
@@ -109,6 +117,8 @@ export class FieldZoneService {
     } catch (exception) {
       throw new ServerException('Failed to delete', exception);
     }
+
+    await this.hooks.run(new ResourceMutatedHook('FieldZone', id, 'Delete'));
   }
 
   async list(input: FieldZoneListInput): Promise<FieldZoneListOutput> {

--- a/src/components/file/file.service.ts
+++ b/src/components/file/file.service.ts
@@ -31,6 +31,7 @@ import { Hooks } from '~/core/hooks';
 import { LiveQueryStore } from '~/core/live-query';
 import { ILogger, Logger } from '~/core/logger';
 import { type LinkTo } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { FileBucket } from './bucket';
 import {
   type CreateDefinedFileVersion,
@@ -262,6 +263,11 @@ export class FileService {
 
     parentId && this.liveQueryStore.invalidate(['Directory', parentId]);
 
+    // Not audited: createDirectory is dominated by the auto-created default
+    // project subdirs (Approval Documents/Photos/etc.) fired from
+    // AttachProjectRootDirectoryHandler — auditing it would spam a Directory
+    // Create per project. The high-value file events (upload/rename/move/delete)
+    // are audited below.
     return await this.getDirectory(id);
   }
 
@@ -431,6 +437,10 @@ export class FileService {
     const file = await this.getFile(fileId);
 
     await this.hooks.run(new AfterFileUploadHook(file, fv));
+    // A new version uploaded to the file — audited as a File Update.
+    await this.hooks.run(
+      new ResourceMutatedHook('File', fileId, 'Update', { version: fv.id }),
+    );
 
     return { ...file, newVersion: fv };
   }
@@ -568,6 +578,14 @@ export class FileService {
     const fileNode = await this.repo.getById(input.id);
     if (fileNode.name !== input.name) {
       await this.repo.rename(fileNode, input.name);
+      // fileNode.type is the concrete discriminator (Directory/File/FileVersion).
+      // No-op renames (e.g. the name-sync inside createFileVersion when the name
+      // already matches) don't reach here, so uploads don't double-record.
+      await this.hooks.run(
+        new ResourceMutatedHook(fileNode.type, input.id, 'Update', {
+          name: input.name,
+        }),
+      );
     }
   }
 
@@ -587,11 +605,19 @@ export class FileService {
       ]);
     }
 
+    await this.hooks.run(
+      new ResourceMutatedHook(fileNode.type, input.id, 'Update', {
+        parent: input.parent,
+        ...(input.name ? { name: input.name } : {}),
+      }),
+    );
+
     return await this.getFileNode(input.id);
   }
 
   async delete(id: ID): Promise<void> {
     const fileNode = await this.repo.getById(id);
     await this.repo.delete(fileNode);
+    await this.hooks.run(new ResourceMutatedHook(fileNode.type, id, 'Delete'));
   }
 }

--- a/src/components/funding-account/funding-account.service.ts
+++ b/src/components/funding-account/funding-account.service.ts
@@ -10,8 +10,10 @@ import {
   ServerException,
   type UnsecuredDto,
 } from '~/common';
+import { Hooks } from '~/core/hooks';
 import { mapListResults } from '~/core/neo4j/results';
 import { HandleIdLookup } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import {
   type CreateFundingAccount,
@@ -27,6 +29,7 @@ export class FundingAccountService {
   constructor(
     private readonly privileges: Privileges,
     private readonly repo: FundingAccountRepository,
+    private readonly hooks: Hooks,
   ) {}
 
   async create(input: CreateFundingAccount): Promise<FundingAccount> {
@@ -47,6 +50,10 @@ export class FundingAccountService {
     if (!result) {
       throw new CreationFailed(FundingAccount);
     }
+
+    await this.hooks.run(
+      new ResourceMutatedHook('FundingAccount', result.id, 'Create'),
+    );
 
     return await this.readOne(result.id).catch((e) => {
       throw e instanceof NotFoundException
@@ -78,6 +85,9 @@ export class FundingAccountService {
     const changes = this.repo.getActualChanges(fundingAccount, input);
     this.privileges.for(FundingAccount, fundingAccount).verifyChanges(changes);
     const updated = await this.repo.update({ id: input.id, ...changes });
+    await this.hooks.run(
+      new ResourceMutatedHook('FundingAccount', input.id, 'Update', changes),
+    );
     return await this.secure(updated);
   }
 
@@ -91,6 +101,10 @@ export class FundingAccountService {
     } catch (exception) {
       throw new ServerException('Failed to delete', exception);
     }
+
+    await this.hooks.run(
+      new ResourceMutatedHook('FundingAccount', id, 'Delete'),
+    );
   }
 
   async list(

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -161,7 +161,10 @@ export class LanguageService {
     });
 
     await this.hooks.run(
-      new ResourceMutatedHook('Language', updated.id, 'Update', changes),
+      new ResourceMutatedHook('Language', updated.id, 'Update', {
+        ...changes,
+        ...(ethnologueUpdate ? { ethnologue: ethnologueUpdate.updated } : {}),
+      }),
     );
 
     return {

--- a/src/components/language/language.service.ts
+++ b/src/components/language/language.service.ts
@@ -11,8 +11,10 @@ import {
   ServerException,
   type UnsecuredDto,
 } from '~/common';
+import { Hooks } from '~/core/hooks';
 import { ILogger, Logger } from '~/core/logger';
 import { HandleIdLookup, ResourceLoader } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import { EngagementLoader, EngagementService } from '../engagement';
 import { type EngagementListInput, EngagementStatus } from '../engagement/dto';
@@ -52,6 +54,7 @@ export class LanguageService {
     private readonly loaders: ResourceLoader,
     private readonly channels: LanguageChannels,
     private readonly repo: LanguageRepository,
+    private readonly hooks: Hooks,
     @Logger('language:service') private readonly logger: ILogger,
   ) {}
 
@@ -64,6 +67,10 @@ export class LanguageService {
       language: resultLanguage.id,
       at: resultLanguage.createdAt,
     });
+
+    await this.hooks.run(
+      new ResourceMutatedHook('Language', resultLanguage.id, 'Create'),
+    );
 
     return this.secure(resultLanguage);
   }
@@ -153,6 +160,10 @@ export class LanguageService {
       },
     });
 
+    await this.hooks.run(
+      new ResourceMutatedHook('Language', updated.id, 'Update', changes),
+    );
+
     return {
       language: this.secure(updated),
       payload: updatedPayload,
@@ -168,6 +179,8 @@ export class LanguageService {
       throw new ServerException('Failed to delete', exception);
     });
     const at = DateTime.now();
+
+    await this.hooks.run(new ResourceMutatedHook('Language', id, 'Delete'));
 
     return this.channels.publishToAll('deleted', {
       language: id,

--- a/src/components/location/location.service.ts
+++ b/src/components/location/location.service.ts
@@ -7,8 +7,10 @@ import {
   ServerException,
   type UnsecuredDto,
 } from '~/common';
+import { Hooks } from '~/core/hooks';
 import { HandleIdLookup } from '~/core/resources';
 import { type ResourceNameLike } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges, type UserEdgePrivileges } from '../authorization';
 import { type PropAction } from '../authorization/policy/actions';
 import {
@@ -26,12 +28,15 @@ export class LocationService {
   constructor(
     private readonly privileges: Privileges,
     private readonly repo: LocationRepository,
+    private readonly hooks: Hooks,
   ) {}
 
   async create(input: CreateLocation): Promise<Location> {
     this.privileges.for(Location).verifyCan('create');
 
     const dto = await this.repo.create(input);
+
+    await this.hooks.run(new ResourceMutatedHook('Location', dto.id, 'Create'));
 
     return this.secure(dto);
   }
@@ -58,6 +63,11 @@ export class LocationService {
     this.privileges.for(Location, location).verifyChanges(changes);
 
     const updated = await this.repo.update({ id: input.id, ...changes });
+
+    await this.hooks.run(
+      new ResourceMutatedHook('Location', input.id, 'Update', changes),
+    );
+
     return this.secure(updated);
   }
 
@@ -71,6 +81,8 @@ export class LocationService {
     } catch (exception) {
       throw new ServerException('Failed to delete', exception);
     }
+
+    await this.hooks.run(new ResourceMutatedHook('Location', id, 'Delete'));
   }
 
   async list(input: LocationListInput): Promise<LocationListOutput> {

--- a/src/components/organization/organization.service.ts
+++ b/src/components/organization/organization.service.ts
@@ -5,7 +5,9 @@ import {
   ServerException,
   type UnsecuredDto,
 } from '~/common';
+import { Hooks } from '~/core/hooks';
 import { HandleIdLookup } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import { LocationService } from '../location';
 import {
@@ -27,12 +29,17 @@ export class OrganizationService {
     private readonly privileges: Privileges,
     private readonly locationService: LocationService,
     private readonly repo: OrganizationRepository,
+    private readonly hooks: Hooks,
   ) {}
 
   async create(input: CreateOrganization): Promise<Organization> {
     const created = await this.repo.create(input);
 
     this.privileges.for(Organization, created).verifyCan('create');
+
+    await this.hooks.run(
+      new ResourceMutatedHook('Organization', created.id, 'Create'),
+    );
 
     return this.secure(created);
   }
@@ -61,6 +68,10 @@ export class OrganizationService {
 
     const updated = await this.repo.update({ id: input.id, ...changes });
 
+    await this.hooks.run(
+      new ResourceMutatedHook('Organization', input.id, 'Update', changes),
+    );
+
     return this.secure(updated);
   }
 
@@ -74,6 +85,8 @@ export class OrganizationService {
     } catch (exception) {
       throw new ServerException('Failed to delete', exception);
     }
+
+    await this.hooks.run(new ResourceMutatedHook('Organization', id, 'Delete'));
   }
 
   async list(input: OrganizationListInput): Promise<OrganizationListOutput> {

--- a/src/components/partner/partner.service.ts
+++ b/src/components/partner/partner.service.ts
@@ -8,7 +8,9 @@ import {
   ServerException,
   type UnsecuredDto,
 } from '~/common';
+import { Hooks } from '~/core/hooks';
 import { HandleIdLookup, ResourceLoader } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import { EngagementService } from '../engagement';
 import { type EngagementListInput } from '../engagement/dto';
@@ -53,6 +55,7 @@ export class PartnerService {
     private readonly userService: UserService & {},
     private readonly repo: PartnerRepository,
     private readonly resourceLoader: ResourceLoader,
+    private readonly hooks: Hooks,
   ) {}
 
   async create(input: CreatePartner): Promise<Partner> {
@@ -68,6 +71,10 @@ export class PartnerService {
     const created = await this.repo.create(input);
 
     this.privileges.for(Partner, created).verifyCan('create');
+
+    await this.hooks.run(
+      new ResourceMutatedHook('Partner', created.id, 'Create'),
+    );
 
     return this.secure(created);
   }
@@ -150,6 +157,10 @@ export class PartnerService {
       ...changes,
     });
 
+    await this.hooks.run(
+      new ResourceMutatedHook('Partner', partner.id, 'Update', changes),
+    );
+
     return this.secure(updated);
   }
 
@@ -163,6 +174,8 @@ export class PartnerService {
     } catch (exception: any) {
       throw new ServerException('Failed to delete', exception);
     }
+
+    await this.hooks.run(new ResourceMutatedHook('Partner', id, 'Delete'));
   }
 
   async list(input: PartnerListInput): Promise<PartnerListOutput> {

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -18,6 +18,7 @@ import { Hooks } from '~/core/hooks';
 import { LiveQueryStore } from '~/core/live-query';
 import { ILogger, Logger } from '~/core/logger';
 import { HandleIdLookup, ResourceLoader } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import { FileService } from '../file';
 import { PartnerService } from '../partner';
@@ -114,6 +115,9 @@ export class PartnershipService {
       this.privileges.for(Partnership, partnership).verifyCan('create');
 
       await this.hooks.run(new PartnershipCreatedHook(partnership));
+      await this.hooks.run(
+        new ResourceMutatedHook('Partnership', partnership.id, 'Create'),
+      );
 
       this.liveQueryStore.invalidate([resolveProjectType(project), project.id]);
 
@@ -217,6 +221,9 @@ export class PartnershipService {
     const partnership = await this.readOne(input.id, view);
     const event = new PartnershipUpdatedHook(partnership, object, input);
     await this.hooks.run(event);
+    await this.hooks.run(
+      new ResourceMutatedHook('Partnership', input.id, 'Update', changes),
+    );
     return event.updated;
   }
 
@@ -236,6 +243,7 @@ export class PartnershipService {
     }
 
     await this.hooks.run(new PartnershipWillDeleteHook(object));
+    await this.hooks.run(new ResourceMutatedHook('Partnership', id, 'Delete'));
 
     try {
       await this.repo.deleteNode(object, { changeset });

--- a/src/components/periodic-report/periodic-report.service.ts
+++ b/src/components/periodic-report/periodic-report.service.ts
@@ -13,6 +13,7 @@ import { Hooks } from '~/core/hooks';
 import { ILogger, Logger } from '~/core/logger';
 import { type Variable } from '~/core/neo4j/query';
 import { HandleIdLookup } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import { FileService } from '../file';
 import { ProgressReport } from '../progress-report/dto';
@@ -95,6 +96,19 @@ export class PeriodicReportService {
         narrativeFile,
       );
     }
+
+    // User-driven report edit (received date, skipped reason, uploaded file) —
+    // audited. The date-driven merge()/delete() sync paths are NOT (system
+    // actions with no actor). resolveReportType(...).name is the concrete
+    // subtype: FinancialReport / NarrativeReport / ProgressReport.
+    await this.hooks.run(
+      new ResourceMutatedHook(
+        resolveReportType(current).name,
+        input.id,
+        'Update',
+        changes,
+      ),
+    );
 
     return updated;
   }

--- a/src/components/post/post.service.ts
+++ b/src/components/post/post.service.ts
@@ -12,10 +12,12 @@ import {
   type UnsecuredDto,
 } from '~/common';
 import { Identity } from '~/core/authentication';
+import { Hooks } from '~/core/hooks';
 import { LiveQueryStore } from '~/core/live-query';
 import { ILogger, Logger } from '~/core/logger';
 import { type BaseNode, isBaseNode } from '~/core/neo4j/results';
 import { ResourceLoader, ResourcesHost } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import { type CreatePost, Post, Postable, type UpdatePost } from './dto';
 import { type PostListInput, type SecuredPostList } from './dto/list-posts.dto';
@@ -34,6 +36,7 @@ export class PostService {
     private readonly resourcesHost: ResourcesHost,
     private readonly liveQueryStore: LiveQueryStore,
     @Logger('post:service') private readonly logger: ILogger,
+    private readonly hooks: Hooks,
   ) {}
 
   async create(input: CreatePost): Promise<Post> {
@@ -48,6 +51,10 @@ export class PostService {
 
       const postable = perms.context as ConcretePostable;
       this.liveQueryStore.invalidate([postable.__typename, postable.id]);
+
+      await this.hooks.run(
+        new ResourceMutatedHook('Post', result.dto.id, 'Create'),
+      );
 
       return this.secure(result.dto);
     } catch (exception) {
@@ -70,6 +77,10 @@ export class PostService {
     this.privileges.for(Post, object).verifyChanges(changes);
     const updated = await this.repo.update(object, changes);
 
+    await this.hooks.run(
+      new ResourceMutatedHook('Post', input.id, 'Update', changes),
+    );
+
     return this.secure(updated);
   }
 
@@ -87,6 +98,8 @@ export class PostService {
 
       throw new ServerException('Failed to delete post', exception);
     }
+
+    await this.hooks.run(new ResourceMutatedHook('Post', id, 'Delete'));
   }
 
   async securedList(

--- a/src/components/product/product.service.ts
+++ b/src/components/product/product.service.ts
@@ -12,9 +12,11 @@ import {
   type UnsecuredDto,
 } from '~/common';
 import { compareNullable, ifDiff, isSame } from '~/core/database/changes';
+import { Hooks } from '~/core/hooks';
 import { LiveQueryStore } from '~/core/live-query';
 import { ILogger, Logger } from '~/core/logger';
 import { HandleIdLookup, ResourceResolver } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import {
   getTotalVerseEquivalents,
@@ -66,6 +68,7 @@ export class ProductService {
     private readonly resources: ResourceResolver,
     private readonly liveQueryStore: LiveQueryStore,
     private readonly channels: ProductChannels,
+    private readonly hooks: Hooks,
     @Logger('product:service') private readonly logger: ILogger,
   ) {}
 
@@ -183,6 +186,14 @@ export class ProductService {
       product: created.id,
       at: created.createdAt,
     });
+
+    await this.hooks.run(
+      new ResourceMutatedHook(
+        resolveProductType(created).name,
+        created.id,
+        'Create',
+      ),
+    );
 
     return created;
   }
@@ -338,6 +349,15 @@ export class ProductService {
       ),
     });
 
+    await this.hooks.run(
+      new ResourceMutatedHook(
+        'DirectScriptureProduct',
+        updated.id,
+        'Update',
+        changes,
+      ),
+    );
+
     return { product: updated, payload: updatedPayload };
   }
 
@@ -449,6 +469,15 @@ export class ProductService {
       ),
     });
 
+    await this.hooks.run(
+      new ResourceMutatedHook(
+        'DerivativeScriptureProduct',
+        updated.id,
+        'Update',
+        changes,
+      ),
+    );
+
     return { product: updated, payload: updatedPayload };
   }
 
@@ -538,6 +567,10 @@ export class ProductService {
       updated: OtherProductUpdate.fromInput(changes),
       previous: OtherProductUpdate.pickPrevious(currentProduct, changes),
     });
+
+    await this.hooks.run(
+      new ResourceMutatedHook('OtherProduct', updated.id, 'Update', changes),
+    );
 
     return { product: updated, payload: updatedPayload };
   }
@@ -641,6 +674,14 @@ export class ProductService {
       product: object.id,
       at,
     });
+
+    await this.hooks.run(
+      new ResourceMutatedHook(
+        resolveProductType(object).name,
+        object.id,
+        'Delete',
+      ),
+    );
 
     return { product: object, payload };
   }

--- a/src/components/progress-report/media/progress-report-media.service.ts
+++ b/src/components/progress-report/media/progress-report-media.service.ts
@@ -6,7 +6,9 @@ import {
   type UnsecuredDto,
 } from '~/common';
 import { type DbTypeOf } from '~/core/database';
+import { Hooks } from '~/core/hooks';
 import { ResourceLoader } from '~/core/resources';
+import { ResourceMutatedHook } from '../../audit/resource-mutated.hook';
 import { Privileges, withVariant } from '../../authorization';
 import { FileService } from '../../file';
 import { MediaService } from '../../file/media/media.service';
@@ -29,6 +31,7 @@ export class ProgressReportMediaService {
     private readonly mediaService: MediaService,
     private readonly resources: ResourceLoader,
     private readonly repo: ProgressReportMediaRepository,
+    private readonly hooks: Hooks,
   ) {}
 
   async listForReport(
@@ -82,6 +85,9 @@ export class ProgressReportMediaService {
       input.file,
       ReportMedia.PublicVariants.has(input.variant.key),
     );
+    await this.hooks.run(
+      new ResourceMutatedHook('ProgressReportMedia', initialDto.id, 'Create'),
+    );
   }
 
   async update(input: UpdateMedia): Promise<ReportMedia> {
@@ -105,6 +111,9 @@ export class ProgressReportMediaService {
       category: category !== undefined ? category : existing.category,
     };
     loader.prime(id, updated);
+    await this.hooks.run(
+      new ResourceMutatedHook('ProgressReportMedia', input.id, 'Update'),
+    );
 
     return updated;
   }
@@ -117,6 +126,9 @@ export class ProgressReportMediaService {
 
     await this.repo.deleteNode(id);
     await this.repo.deleteVariantGroupIfEmpty(media.variantGroup);
+    await this.hooks.run(
+      new ResourceMutatedHook('ProgressReportMedia', id, 'Delete'),
+    );
 
     return media.report;
   }

--- a/src/components/progress-report/media/progress-report-media.service.ts
+++ b/src/components/progress-report/media/progress-report-media.service.ts
@@ -112,7 +112,12 @@ export class ProgressReportMediaService {
     };
     loader.prime(id, updated);
     await this.hooks.run(
-      new ResourceMutatedHook('ProgressReportMedia', input.id, 'Update'),
+      new ResourceMutatedHook(
+        'ProgressReportMedia',
+        input.id,
+        'Update',
+        category !== undefined ? { category } : undefined,
+      ),
     );
 
     return updated;

--- a/src/components/progress-report/workflow/progress-report-workflow.service.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.service.ts
@@ -7,6 +7,7 @@ import {
   type UnsecuredDto,
 } from '~/common';
 import { Hooks } from '~/core/hooks';
+import { ResourceMutatedHook } from '../../audit/resource-mutated.hook';
 import { Privileges } from '../../authorization';
 import {
   type ProgressReport,
@@ -83,6 +84,16 @@ export class ProgressReportWorkflowService {
       unsecuredEvent,
     );
     await this.hooks.run(event);
+
+    // Status transitions/bypasses are user-driven mutations → audited as a
+    // ProgressReport Update with the new status.
+    const newStatus = isTransition ? next.to : next;
+    await this.hooks.run(
+      new ResourceMutatedHook('ProgressReport', reportId, 'Update', {
+        status: newStatus,
+        previousStatus: currentStatus,
+      }),
+    );
   }
 
   private validateExecutionInput(

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -10,8 +10,10 @@ import {
   UnauthorizedException,
   type UnsecuredDto,
 } from '~/common';
+import { Hooks } from '~/core/hooks';
 import { LiveQueryStore } from '~/core/live-query';
 import { HandleIdLookup, ResourceLoader } from '~/core/resources';
+import { ResourceMutatedHook } from '../../audit/resource-mutated.hook';
 import { Privileges } from '../../authorization';
 import { UserService } from '../../user';
 import { type User } from '../../user/dto';
@@ -38,6 +40,7 @@ export class ProjectMemberService {
     private readonly privileges: Privileges,
     private readonly channels: ProjectMemberChannels,
     private readonly repo: ProjectMemberRepository,
+    private readonly hooks: Hooks,
   ) {}
 
   async create(
@@ -72,6 +75,10 @@ export class ProjectMemberService {
       member: created.id,
       at: created.createdAt,
     });
+
+    await this.hooks.run(
+      new ResourceMutatedHook('ProjectMember', created.id, 'Create'),
+    );
 
     return this.secure(created);
   }
@@ -150,6 +157,10 @@ export class ProjectMemberService {
       previous: ProjectMemberUpdate.pickPrevious(object, changes),
     });
 
+    await this.hooks.run(
+      new ResourceMutatedHook('ProjectMember', input.id, 'Update', changes),
+    );
+
     return {
       member: this.secure(updated),
       payload: updatedPayload,
@@ -196,6 +207,10 @@ export class ProjectMemberService {
       throw new ServerException('Failed to delete project member', e);
     });
     const at = DateTime.now();
+
+    await this.hooks.run(
+      new ResourceMutatedHook('ProjectMember', id, 'Delete'),
+    );
 
     return this.channels.publishToAll('deleted', {
       program: object.project.type,

--- a/src/components/project/project-member/project-member.service.ts
+++ b/src/components/project/project-member/project-member.service.ts
@@ -76,9 +76,13 @@ export class ProjectMemberService {
       at: created.createdAt,
     });
 
-    await this.hooks.run(
-      new ResourceMutatedHook('ProjectMember', created.id, 'Create'),
-    );
+    // Only audit user-driven memberships; system-created ones (enforcePerms
+    // false) aren't part of the user-facing mutation history.
+    if (enforcePerms) {
+      await this.hooks.run(
+        new ResourceMutatedHook('ProjectMember', created.id, 'Create'),
+      );
+    }
 
     return this.secure(created);
   }

--- a/src/components/project/project.service.ts
+++ b/src/components/project/project.service.ts
@@ -26,6 +26,7 @@ import { type AnyChangesOf } from '~/core/database/changes';
 import { Hooks } from '~/core/hooks';
 import { Transactional } from '~/core/neo4j';
 import { HandleIdLookup } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import { BudgetService } from '../budget';
 import { BudgetStatus, type SecuredBudget } from '../budget/dto';
@@ -186,6 +187,13 @@ export class ProjectService {
 
       const event = new ProjectCreatedHook(project);
       await this.hooks.run(event);
+      await this.hooks.run(
+        new ResourceMutatedHook(
+          resolveProjectType(event.project).name,
+          event.project.id,
+          'Create',
+        ),
+      );
 
       this.channels.publishToAll('created', {
         program: project.type,
@@ -383,6 +391,14 @@ export class ProjectService {
         ...changes,
       });
       await this.hooks.run(event);
+      await this.hooks.run(
+        new ResourceMutatedHook(
+          resolveProjectType(event.updated).name,
+          event.updated.id,
+          'Update',
+          changes,
+        ),
+      );
 
       payload = this.channels.publishToAll('updated', {
         program: event.updated.type,
@@ -408,6 +424,9 @@ export class ProjectService {
     const at = DateTime.now();
 
     await this.hooks.run(new ProjectDeletedHook(object));
+    await this.hooks.run(
+      new ResourceMutatedHook(resolveProjectType(object).name, id, 'Delete'),
+    );
 
     return this.channels.publishToAll('deleted', {
       program: object.type,

--- a/src/components/tools/tool/tool.service.ts
+++ b/src/components/tools/tool/tool.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { type ID, ServerException, type UnsecuredDto } from '~/common';
+import { Hooks } from '~/core/hooks';
 import { HandleIdLookup } from '~/core/resources';
+import { ResourceMutatedHook } from '../../audit/resource-mutated.hook';
 import { Privileges } from '../../authorization';
 import {
   type CreateTool,
@@ -16,6 +18,7 @@ export class ToolService {
   constructor(
     private readonly privileges: Privileges,
     private readonly repo: ToolRepository,
+    private readonly hooks: Hooks,
   ) {}
 
   @HandleIdLookup(Tool)
@@ -44,6 +47,7 @@ export class ToolService {
   async create(input: CreateTool): Promise<Tool> {
     const dto = await this.repo.create(input);
     this.privileges.for(Tool, dto).verifyCan('create');
+    await this.hooks.run(new ResourceMutatedHook('Tool', dto.id, 'Create'));
     return this.secure(dto);
   }
 
@@ -53,6 +57,9 @@ export class ToolService {
     this.privileges.for(Tool, tool).verifyChanges(changes);
 
     const updated = await this.repo.update({ id: input.id, ...changes });
+    await this.hooks.run(
+      new ResourceMutatedHook('Tool', input.id, 'Update', changes),
+    );
     return this.secure(updated);
   }
 
@@ -64,5 +71,6 @@ export class ToolService {
     } catch (exception) {
       throw new ServerException('Failed to delete', exception);
     }
+    await this.hooks.run(new ResourceMutatedHook('Tool', id, 'Delete'));
   }
 }

--- a/src/components/user/education/education.service.ts
+++ b/src/components/user/education/education.service.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { type ID, type ObjectView, type UnsecuredDto } from '~/common';
 import { Identity } from '~/core/authentication';
+import { Hooks } from '~/core/hooks';
 import { HandleIdLookup } from '~/core/resources';
+import { ResourceMutatedHook } from '../../audit/resource-mutated.hook';
 import { Privileges } from '../../authorization';
 import {
   type CreateEducation,
@@ -18,12 +20,16 @@ export class EducationService {
     private readonly privileges: Privileges,
     private readonly identity: Identity,
     private readonly repo: EducationRepository,
+    private readonly hooks: Hooks,
   ) {}
 
   async create(input: CreateEducation): Promise<Education> {
     this.privileges.for(Education).verifyCan('create');
     // create education
     const result = await this.repo.create(input);
+    await this.hooks.run(
+      new ResourceMutatedHook('Education', result.id, 'Create'),
+    );
     return this.secure(result);
   }
 
@@ -52,11 +58,14 @@ export class EducationService {
     }
 
     const updated = await this.repo.update({ id: input.id, ...changes });
+    await this.hooks.run(
+      new ResourceMutatedHook('Education', input.id, 'Update', changes),
+    );
     return this.secure(updated);
   }
 
   async delete(_id: ID): Promise<void> {
-    // Not Implemented
+    // Not Implemented — no audit event until a real delete exists.
   }
 
   async list(input: EducationListInput): Promise<EducationListOutput> {

--- a/src/components/user/unavailability/unavailability.service.ts
+++ b/src/components/user/unavailability/unavailability.service.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { type ID, type ObjectView, type UnsecuredDto } from '~/common';
 import { Identity } from '~/core/authentication';
+import { Hooks } from '~/core/hooks';
 import { HandleIdLookup } from '~/core/resources';
+import { ResourceMutatedHook } from '../../audit/resource-mutated.hook';
 import { Privileges } from '../../authorization';
 import {
   type CreateUnavailability,
@@ -18,11 +20,15 @@ export class UnavailabilityService {
     private readonly privileges: Privileges,
     private readonly identity: Identity,
     private readonly repo: UnavailabilityRepository,
+    private readonly hooks: Hooks,
   ) {}
 
   async create(input: CreateUnavailability): Promise<Unavailability> {
     this.privileges.for(Unavailability).verifyCan('create');
     const result = await this.repo.create(input);
+    await this.hooks.run(
+      new ResourceMutatedHook('Unavailability', result.id, 'Create'),
+    );
     return this.secure(result);
   }
 
@@ -52,12 +58,18 @@ export class UnavailabilityService {
         .verifyChanges(changes);
     }
     const updated = await this.repo.update({ id: input.id, ...changes });
+    await this.hooks.run(
+      new ResourceMutatedHook('Unavailability', input.id, 'Update', changes),
+    );
     return this.secure(updated);
   }
 
   async delete(id: ID): Promise<void> {
     await this.repo.readOne(id);
     await this.repo.delete(id);
+    await this.hooks.run(
+      new ResourceMutatedHook('Unavailability', id, 'Delete'),
+    );
   }
 
   async list(

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -11,6 +11,7 @@ import { Identity } from '~/core/authentication';
 import { Hooks } from '~/core/hooks';
 import { ILogger, Logger } from '~/core/logger';
 import { HandleIdLookup } from '~/core/resources';
+import { ResourceMutatedHook } from '../audit/resource-mutated.hook';
 import { Privileges } from '../authorization';
 import { AssignableRoles } from '../authorization/dto/assignable-roles.dto';
 import { LocationService } from '../location';
@@ -79,6 +80,7 @@ export class UserService {
     }
 
     const { id } = await this.userRepo.create(input);
+    await this.hooks.run(new ResourceMutatedHook('User', id, 'Create'));
     return id;
   }
 
@@ -134,6 +136,9 @@ export class UserService {
 
     const event = new UserUpdatedHook(updated, user, input);
     await this.hooks.run(event);
+    await this.hooks.run(
+      new ResourceMutatedHook('User', user.id, 'Update', changes),
+    );
 
     return this.secure(updated);
   }
@@ -144,6 +149,7 @@ export class UserService {
     // Same-transaction side effects (e.g. session revocation — a deleted
     // user must not keep live sessions).
     await this.hooks.run(new UserDeletedHook(object.id));
+    await this.hooks.run(new ResourceMutatedHook('User', id, 'Delete'));
   }
 
   async list(input: UserListInput): Promise<UserListOutput> {

--- a/src/core/authentication/session/session.dto.ts
+++ b/src/core/authentication/session/session.dto.ts
@@ -14,6 +14,18 @@ class RawSession extends DataObject {
   readonly anonymous: boolean;
 
   /**
+   * The name of the SystemAgent {@link userId} refers to, when it refers to one
+   * rather than to a User — anonymous sessions ('Anonymous') and ghost
+   * impersonation ('Ghost').
+   *
+   * `userId` is typed plain `ID`, not `ID<'User'>`, exactly because of this
+   * ambiguity. Resolving it needs the agent in hand, which only session
+   * creation has, so the answer is recorded here instead of left for each
+   * consumer to reconstruct by comparing ids.
+   */
+  readonly systemAgentName?: string;
+
+  /**
    * The "real", requesting user's session, when they are impersonating.
    */
   readonly impersonator?: Session;

--- a/src/core/authentication/session/session.manager.ts
+++ b/src/core/authentication/session/session.manager.ts
@@ -90,6 +90,10 @@ export class SessionManager {
       issuedAt: DateTime.fromMillis(iat),
       userId: result.userId ?? anon.id,
       anonymous: !result.userId,
+      // No user resolved -> the userId above is the Anonymous agent's, not a
+      // user's. Recorded here so consumers don't have to compare ids to find
+      // out; see Session.systemAgentName.
+      systemAgentName: result.userId ? undefined : anon.name,
       roles: result.roles,
     });
 
@@ -97,6 +101,10 @@ export class SessionManager {
       ? requesterSession.with({
           userId: impersonatee.id ?? requesterSession.userId,
           roles: impersonatee.roles,
+          // Ghost is the one impersonatee that is an agent rather than a user;
+          // undefined otherwise clears the requester's own value (impersonation
+          // requires a logged-in requester, so it is always already undefined).
+          systemAgentName: ghost?.name,
           impersonator: requesterSession,
           impersonatee,
         })

--- a/src/core/drizzle/migrations/0026_add_resource_mutations.sql
+++ b/src/core/drizzle/migrations/0026_add_resource_mutations.sql
@@ -1,0 +1,25 @@
+-- Audit Log. Append-only log of resource mutations: one row per
+-- create/update/delete, written by an in-transaction hook so it's atomic with
+-- the mutation. resource_id is FK-less/polymorphic (spans every resource
+-- table); actor_id is set null on user delete so history outlives the actor.
+-- role_at_time snapshots the actor's global roles at write time as plain text
+-- (NOT the live role enum) so the append-only record is immune to later role
+-- changes.
+
+CREATE TYPE "mutation_action" AS ENUM ('Create', 'Update', 'Delete');
+
+CREATE TABLE "resource_mutations" (
+  "id"            bigserial PRIMARY KEY,
+  "resource_type" text NOT NULL,
+  "resource_id"   text NOT NULL,
+  "action"        "mutation_action" NOT NULL,
+  "actor_id"      text REFERENCES "users"("id") ON DELETE SET NULL,
+  "role_at_time"  text[] NOT NULL DEFAULT '{}',
+  "changes"       jsonb,
+  "at"            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX "resource_mutations_resource_idx"
+  ON "resource_mutations" ("resource_type", "resource_id", "at");
+CREATE INDEX "resource_mutations_actor_id_idx"
+  ON "resource_mutations" ("actor_id");

--- a/src/core/drizzle/migrations/0027_audit_actor_attribution.sql
+++ b/src/core/drizzle/migrations/0027_audit_actor_attribution.sql
@@ -1,0 +1,60 @@
+-- Audit log: attribute impersonated and system-agent actors.
+--
+-- 0026 gave every row one actor column, an FK to `users`. Three distinct
+-- attribution gaps came out of that, all in the same code path:
+--
+--   1. IMPERSONATION WAS SILENTLY MISATTRIBUTED. `Identity.currentMaybe`
+--      returns the EFFECTIVE session, so when an admin impersonated a user,
+--      `actor_id` held the IMPERSONATED user and `role_at_time` held THEIR
+--      roles — the admin who actually performed the mutation was absent from
+--      the record entirely. That is wrong data, not missing data, and it fails
+--      silently: the log confidently attributes an admin's action to an
+--      innocent user. `impersonator_id` now carries the real requester.
+--
+--   2. GHOST IMPERSONATION CRASHED THE MUTATION. `X-CORD-Impersonate-User:
+--      ghost` puts the Ghost SystemAgent's id in `session.userId`
+--      (SessionManager.resumeSession swaps the literal for the agent). That id
+--      lives in `system_agents`, not `users`, so the insert violated
+--      `resource_mutations_actor_id_fkey` — and because the audit write shares
+--      the mutation's transaction, the whole mutation rolled back. Latent only
+--      because the writer no-ops off postgres.
+--
+--   3. SYSTEM-AGENT ACTORS WERE UNRECORDED. Anonymous-session mutations
+--      (registration, bootstrap) stored a NULL actor with no trace of which
+--      agent acted, indistinguishable from "actor unknown".
+--
+-- `actor_system_agent` stores the agent's NAME as text, NOT an FK to
+-- `system_agents.id`. Deliberate, and the same call `role_at_time` already
+-- makes one column over: an audit row is a historical SNAPSHOT, not a set of
+-- live references, so the record has to survive later changes to — or removal
+-- of — the thing it names. Agents are also lazily upserted BY NAME ('Ghost',
+-- 'Anonymous', 'External Mailing Group'), so the name is their natural key,
+-- and the table already declines to hold a hard actor reference: `actor_id` is
+-- ON DELETE SET NULL precisely so history outlives the actor.
+--
+-- `impersonator_id` IS a plain FK to `users`, with no arc, because an
+-- impersonATOR is always a real logged-in user: impersonation only takes
+-- effect when the requester's own session resolved to a user (the
+-- `impersonatee && result.userId` guard in SessionManager.resumeSession), so
+-- it can never be a SystemAgent. Only the impersonATEE can be one — which is
+-- why the two-column shape is needed on actor and nowhere else.
+--
+-- The CHECK is `<= 1`, not `= 1`: a mutation legitimately has no actor at all
+-- when it runs in a session context that holds no session. Existing rows all
+-- satisfy it — `actor_system_agent` is NULL for every one of them.
+--
+-- Role-only impersonation (`X-CORD-Impersonate-Role` with no user) yields
+-- impersonator_id = actor_id. That is NOT a bug and does not want "fixing": it
+-- records "this user acted under roles other than their own", and role_at_time
+-- holds the roles the policy engine actually evaluated.
+
+ALTER TABLE "resource_mutations"
+  ADD COLUMN "impersonator_id" text REFERENCES "users"("id") ON DELETE SET NULL,
+  ADD COLUMN "actor_system_agent" text;
+
+ALTER TABLE "resource_mutations"
+  ADD CONSTRAINT "resource_mutations_actor_shape_chk"
+  CHECK (num_nonnulls("actor_id", "actor_system_agent") <= 1);
+
+CREATE INDEX "resource_mutations_impersonator_id_idx"
+  ON "resource_mutations" ("impersonator_id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1752796800000,
       "tag": "0025_add_posts",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1752883200000,
+      "tag": "0026_add_resource_mutations",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1752883200000,
       "tag": "0026_add_resource_mutations",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1752969600000,
+      "tag": "0027_audit_actor_attribution",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -2688,3 +2688,43 @@ export const posts = pgTable(
     index('posts_creator_id_idx').on(t.creatorId),
   ],
 );
+
+// ─── Audit log ───────────────────────────────────────────────────────────
+
+export const mutationActionEnum = pgEnum('mutation_action', [
+  'Create',
+  'Update',
+  'Delete',
+]);
+
+/**
+ * Append-only log of resource mutations (the general audit log). One row per
+ * create/update/delete, written by an in-transaction hook so it's atomic with
+ * the mutation. `resource_id` is FK-less/polymorphic (spans every resource
+ * table); `actor_id` set-null on user delete so history outlives the actor.
+ * `role_at_time` snapshots the actor's roles at write time (plain text, not the
+ * live role enum). `changes` holds the diffed field set (jsonb).
+ */
+export const resourceMutations = pgTable(
+  'resource_mutations',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    resourceType: text('resource_type').notNull(),
+    resourceId: text('resource_id').$type<ID>().notNull(),
+    action: mutationActionEnum('action').notNull(),
+    actorId: text('actor_id')
+      .$type<ID<'User'>>()
+      .references(() => users.id, { onDelete: 'set null' }),
+    roleAtTime: text('role_at_time').array().notNull().default([]),
+    changes: jsonb('changes'),
+    at: timestamp('at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('resource_mutations_resource_idx').on(
+      t.resourceType,
+      t.resourceId,
+      t.at,
+    ),
+    index('resource_mutations_actor_id_idx').on(t.actorId),
+  ],
+);

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -2704,6 +2704,10 @@ export const mutationActionEnum = pgEnum('mutation_action', [
  * table); `actor_id` set-null on user delete so history outlives the actor.
  * `role_at_time` snapshots the actor's roles at write time (plain text, not the
  * live role enum). `changes` holds the diffed field set (jsonb).
+ *
+ * The actor is EITHER a user or a system agent, never both — see migration 0027
+ * for why the agent side stores a name snapshot instead of an FK, and why
+ * `impersonator_id` needs no such treatment.
  */
 export const resourceMutations = pgTable(
   'resource_mutations',
@@ -2715,16 +2719,35 @@ export const resourceMutations = pgTable(
     actorId: text('actor_id')
       .$type<ID<'User'>>()
       .references(() => users.id, { onDelete: 'set null' }),
+    /**
+     * The SystemAgent that acted, by NAME ('Ghost' | 'Anonymous' | ...), when
+     * the actor was not a user. A snapshot, not a reference — same reasoning as
+     * `role_at_time`.
+     */
+    actorSystemAgent: text('actor_system_agent'),
+    /**
+     * The real, requesting user when `actor_id` is being impersonated. Always a
+     * user (an impersonator can't be a system agent), so a plain FK suffices.
+     */
+    impersonatorId: text('impersonator_id')
+      .$type<ID<'User'>>()
+      .references(() => users.id, { onDelete: 'set null' }),
     roleAtTime: text('role_at_time').array().notNull().default([]),
     changes: jsonb('changes'),
     at: timestamp('at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
+    // `<= 1`, not `= 1`: a write with no session in context has no actor at all.
+    check(
+      'resource_mutations_actor_shape_chk',
+      sql`num_nonnulls(${t.actorId}, ${t.actorSystemAgent}) <= 1`,
+    ),
     index('resource_mutations_resource_idx').on(
       t.resourceType,
       t.resourceId,
       t.at,
     ),
     index('resource_mutations_actor_id_idx').on(t.actorId),
+    index('resource_mutations_impersonator_id_idx').on(t.impersonatorId),
   ],
 );

--- a/test/audit-log.e2e-spec.ts
+++ b/test/audit-log.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from '@jest/globals';
 import { sql } from 'drizzle-orm';
-import { generateId, Role } from '~/common';
+import { CalendarDate, generateId, Role } from '~/common';
 import { DrizzleService } from '~/core/drizzle';
 import { graphql } from '~/graphql';
 import { ResourceMutationRepository } from '../src/components/audit/resource-mutation.repository';
@@ -134,6 +134,8 @@ describe('Audit log (resource_mutations) e2e', () => {
     const engagement = await createLanguageEngagement(app, {
       project: project.id,
       language: language.id,
+      startDateOverride: CalendarDate.fromISO('1991-01-01').toISO(),
+      endDateOverride: CalendarDate.fromISO('1992-01-01').toISO(),
     });
 
     const { engagement: read } = await app.graphql.query(EngagementHistoryDoc, {
@@ -155,6 +157,8 @@ describe('Audit log (resource_mutations) e2e', () => {
     const engagement = await createLanguageEngagement(app, {
       project: project.id,
       language: language.id,
+      startDateOverride: CalendarDate.fromISO('1991-01-01').toISO(),
+      endDateOverride: CalendarDate.fromISO('1992-01-01').toISO(),
     });
     const product = await createDirectProduct(app, {
       engagement: engagement.id,

--- a/test/audit-log.e2e-spec.ts
+++ b/test/audit-log.e2e-spec.ts
@@ -1,0 +1,362 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { sql } from 'drizzle-orm';
+import { generateId, Role } from '~/common';
+import { DrizzleService } from '~/core/drizzle';
+import { graphql } from '~/graphql';
+import { ResourceMutationRepository } from '../src/components/audit/resource-mutation.repository';
+import {
+  createDirectProduct,
+  createLanguage,
+  createLanguageEngagement,
+  createOrganization,
+  createPartnership,
+  createProject,
+  createSession,
+  createTestApp,
+  type fragments,
+  registerUser,
+  runAsAdmin,
+  runInIsolatedSession,
+  type TestApp,
+} from './utility';
+
+// The audit log lives in postgres; under neo4j the writer is a no-op, so the
+// history is expected to be empty there.
+const isPostgres = process.env.DATABASE === 'postgres';
+
+describe('Audit log (resource_mutations) e2e', () => {
+  let app: TestApp;
+  let project: fragments.project;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await createSession(app);
+    await registerUser(app, {
+      roles: [Role.FieldOperationsDirector, Role.Controller],
+    });
+    project = await createProject(app);
+  });
+
+  it('records create + update mutations in a resource history', async () => {
+    const partnership = await createPartnership(app, { project: project.id });
+
+    await app.graphql.mutate(UpdatePartnershipDoc, {
+      input: { id: partnership.id, agreementStatus: 'Signed' },
+    });
+
+    const { partnership: read } = await app.graphql.query(HistoryDoc, {
+      id: partnership.id,
+    });
+    const history = read.history;
+
+    if (!isPostgres) {
+      expect(history.total).toBe(0);
+      return;
+    }
+
+    expect(history.total).toBeGreaterThanOrEqual(2);
+    const actions = history.items.map((i) => i.action);
+    expect(actions).toContain('Create');
+    expect(actions).toContain('Update');
+
+    const update = history.items.find((i) => i.action === 'Update')!;
+    expect(update.actor?.id).toBeTruthy();
+    // role_at_time snapshots the actor's roles at the moment of the mutation.
+    expect(update.roleAtTime).toEqual(
+      expect.arrayContaining(['FieldOperationsDirector', 'Controller']),
+    );
+    // The diffed field set is captured for updates.
+    expect(update.changes).toMatchObject({ agreementStatus: 'Signed' });
+  });
+
+  // Proves `history` is exposed on the base Resource interface (not a
+  // per-domain resolver) and populated by a back-instrumented domain service.
+  it('exposes history on any resource via the Resource interface', async () => {
+    const org = await createOrganization(app);
+    const newName = `${org.name.value ?? 'Org'} (renamed)`;
+
+    await app.graphql.mutate(UpdateOrganizationDoc, {
+      input: { id: org.id, name: newName },
+    });
+
+    const { organization: read } = await app.graphql.query(OrgHistoryDoc, {
+      id: org.id,
+    });
+    const history = read.history;
+
+    if (!isPostgres) {
+      expect(history.total).toBe(0);
+      return;
+    }
+
+    expect(history.total).toBeGreaterThanOrEqual(2);
+    const actions = history.items.map((i) => i.action);
+    expect(actions).toContain('Create');
+    expect(actions).toContain('Update');
+
+    const update = history.items.find((i) => i.action === 'Update')!;
+    expect(update.changes).toMatchObject({ name: newName });
+  });
+
+  // Polymorphic resource: the firing service records under the concrete
+  // subtype (resolveProjectType(...).name) and the interface resolver reads
+  // `info.parentType.name` — they must agree for history to resolve.
+  it('records history for a polymorphic resource (Project)', async () => {
+    const proj = await createProject(app);
+    const newName = 'Renamed ' + proj.id;
+
+    await app.graphql.mutate(UpdateProjectDoc, {
+      input: { id: proj.id, name: newName },
+    });
+
+    const { project: read } = await app.graphql.query(ProjectHistoryDoc, {
+      id: proj.id,
+    });
+    const history = read.history;
+
+    if (!isPostgres) {
+      expect(history.total).toBe(0);
+      return;
+    }
+
+    expect(history.total).toBeGreaterThanOrEqual(2);
+    const actions = history.items.map((i) => i.action);
+    expect(actions).toContain('Create');
+    expect(actions).toContain('Update');
+  });
+
+  // Engagement is a polymorphic interface whose concrete subtype is resolved by
+  // `resolveEngagementType`. The create fires under 'LanguageEngagement' and the
+  // interface resolver reads `info.parentType.name` — same round-trip risk as
+  // Project, but a different resolve helper.
+  it('records history for a polymorphic Engagement (LanguageEngagement)', async () => {
+    const language = await runAsAdmin(app, createLanguage);
+    const engagement = await createLanguageEngagement(app, {
+      project: project.id,
+      language: language.id,
+    });
+
+    const { engagement: read } = await app.graphql.query(EngagementHistoryDoc, {
+      id: engagement.id,
+    });
+
+    if (!isPostgres) {
+      expect(read.history.total).toBe(0);
+      return;
+    }
+    expect(read.history.total).toBeGreaterThanOrEqual(1);
+    expect(read.history.items.map((i) => i.action)).toContain('Create');
+  });
+
+  // Product is polymorphic via `resolveProductType`; the concrete subtype name
+  // must round-trip the same way.
+  it('records history for a polymorphic Product (DirectScriptureProduct)', async () => {
+    const language = await runAsAdmin(app, createLanguage);
+    const engagement = await createLanguageEngagement(app, {
+      project: project.id,
+      language: language.id,
+    });
+    const product = await createDirectProduct(app, {
+      engagement: engagement.id,
+    });
+
+    const { product: read } = await app.graphql.query(ProductHistoryDoc, {
+      id: product.id,
+    });
+
+    if (!isPostgres) {
+      expect(read.history.total).toBe(0);
+      return;
+    }
+    expect(read.history.total).toBeGreaterThanOrEqual(1);
+    expect(read.history.items.map((i) => i.action)).toContain('Create');
+  });
+
+  // Registration runs under an anonymous session: there is no logged-in user,
+  // and the anonymous SystemAgent id lives in `system_agents`, NOT `users`. The
+  // audit row's actor must be null rather than that id, or the actor FK would
+  // blow up. Regression guard for the registration-time crash.
+  it('audits an anonymous-actor mutation with a null actor (no FK violation)', async () => {
+    const newUser = await runInIsolatedSession(app, () =>
+      registerUser(app, { roles: [] }),
+    );
+
+    const { user: read } = await app.graphql.query(UserHistoryDoc, {
+      id: newUser.id,
+    });
+
+    if (!isPostgres) {
+      expect(read.history.total).toBe(0);
+      return;
+    }
+    // registration should record a Create
+    const create = read.history.items.find((i) => i.action === 'Create');
+    expect(create).toBeTruthy();
+    expect(create!.actor).toBeNull();
+  });
+
+  // Audit writes happen inside the triggering mutation's transaction, so if the
+  // mutation later fails the audit row must roll back with it — no orphaned
+  // "this happened" record for something that didn't.
+  it('rolls back the audit row when the surrounding transaction fails', async () => {
+    if (!isPostgres) return;
+
+    const drizzle = app.get(DrizzleService);
+    const repo = app.get(ResourceMutationRepository);
+    const committedId = await generateId();
+    const rolledBackId = await generateId();
+    // The repo's insert uses the ambient (ALS) transaction client, so this
+    // exercises the same in-transaction write path the audit hook takes —
+    // without needing a session context for the actor lookup.
+    const mutation = (resourceId: typeof committedId) => ({
+      resourceType: 'Project',
+      resourceId,
+      action: 'Update' as const,
+      actorId: null,
+      roleAtTime: [],
+      changes: { a: 1 },
+    });
+
+    // Positive control: a record written in a committed tx persists.
+    await drizzle.inTx(async () => {
+      await repo.record(mutation(committedId));
+    });
+
+    // The record is written, then the surrounding tx throws -> it must vanish.
+    await expect(
+      drizzle.inTx(async () => {
+        await repo.record(mutation(rolledBackId));
+        throw new Error('boom: force rollback');
+      }),
+    ).rejects.toThrow('boom');
+
+    const db = drizzle.client;
+    const countFor = async (id: string) => {
+      const res = await db.execute<{ n: number } & Record<string, unknown>>(
+        sql`select count(*)::int as n from resource_mutations where resource_id = ${id}`,
+      );
+      return res.rows[0]!.n;
+    };
+    expect(await countFor(committedId)).toBe(1);
+    expect(await countFor(rolledBackId)).toBe(0);
+  });
+});
+
+const UpdatePartnershipDoc = graphql(`
+  mutation UpdatePartnershipForAudit($input: UpdatePartnership!) {
+    updatePartnership(input: $input) {
+      partnership {
+        id
+      }
+    }
+  }
+`);
+
+const HistoryDoc = graphql(`
+  query PartnershipHistory($id: ID!) {
+    partnership(id: $id) {
+      history {
+        total
+        items {
+          action
+          at
+          actor {
+            id
+          }
+          roleAtTime
+          changes
+        }
+      }
+    }
+  }
+`);
+
+const UpdateOrganizationDoc = graphql(`
+  mutation UpdateOrganizationForAudit($input: UpdateOrganization!) {
+    updateOrganization(input: $input) {
+      organization {
+        id
+      }
+    }
+  }
+`);
+
+const OrgHistoryDoc = graphql(`
+  query OrganizationHistory($id: ID!) {
+    organization(id: $id) {
+      history {
+        total
+        items {
+          action
+          changes
+        }
+      }
+    }
+  }
+`);
+
+const UpdateProjectDoc = graphql(`
+  mutation UpdateProjectForAudit($input: UpdateProject!) {
+    updateProject(input: $input) {
+      project {
+        id
+      }
+    }
+  }
+`);
+
+const ProjectHistoryDoc = graphql(`
+  query ProjectHistory($id: ID!) {
+    project(id: $id) {
+      history {
+        total
+        items {
+          action
+          changes
+        }
+      }
+    }
+  }
+`);
+
+const EngagementHistoryDoc = graphql(`
+  query EngagementHistoryForAudit($id: ID!) {
+    engagement: languageEngagement(id: $id) {
+      history {
+        total
+        items {
+          action
+        }
+      }
+    }
+  }
+`);
+
+const ProductHistoryDoc = graphql(`
+  query ProductHistoryForAudit($id: ID!) {
+    product(id: $id) {
+      history {
+        total
+        items {
+          action
+        }
+      }
+    }
+  }
+`);
+
+const UserHistoryDoc = graphql(`
+  query UserHistoryForAudit($id: ID!) {
+    user(id: $id) {
+      history {
+        total
+        items {
+          action
+          actor {
+            id
+          }
+        }
+      }
+    }
+  }
+`);

--- a/test/audit-log.e2e-spec.ts
+++ b/test/audit-log.e2e-spec.ts
@@ -1,9 +1,15 @@
 import { beforeAll, describe, expect, it } from '@jest/globals';
+import { setOf } from '@seedcompany/common';
 import { sql } from 'drizzle-orm';
-import { CalendarDate, generateId, Role } from '~/common';
+import { CalendarDate, generateId, type ID, Role } from '~/common';
+import { type Session } from '~/core/authentication';
 import { DrizzleService } from '~/core/drizzle';
 import { graphql } from '~/graphql';
+import { AuditService } from '../src/components/audit/audit.service';
+import { ResourceMutatedHook } from '../src/components/audit/resource-mutated.hook';
 import { ResourceMutationRepository } from '../src/components/audit/resource-mutation.repository';
+import { SessionHost } from '../src/core/authentication/session/session.host';
+import { SessionManager } from '../src/core/authentication/session/session.manager';
 import {
   createDirectProduct,
   createLanguage,
@@ -18,6 +24,7 @@ import {
   runAsAdmin,
   runInIsolatedSession,
   type TestApp,
+  type TestUser,
 } from './utility';
 
 // The audit log lives in postgres; under neo4j the writer is a no-op, so the
@@ -183,7 +190,8 @@ describe('Audit log (resource_mutations) e2e', () => {
   // Registration runs under an anonymous session: there is no logged-in user,
   // and the anonymous SystemAgent id lives in `system_agents`, NOT `users`. The
   // audit row's actor must be null rather than that id, or the actor FK would
-  // blow up. Regression guard for the registration-time crash.
+  // blow up. Regression guard for the registration-time crash — and, since 0027,
+  // the agent that acted is named rather than merely omitted.
   it('audits an anonymous-actor mutation with a null actor (no FK violation)', async () => {
     const newUser = await runInIsolatedSession(app, () =>
       registerUser(app, { roles: [] }),
@@ -201,6 +209,8 @@ describe('Audit log (resource_mutations) e2e', () => {
     const create = read.history.items.find((i) => i.action === 'Create');
     expect(create).toBeTruthy();
     expect(create!.actor).toBeNull();
+    expect(create!.actorSystemAgent).toBe('Anonymous');
+    expect(create!.impersonator).toBeNull();
   });
 
   // Audit writes happen inside the triggering mutation's transaction, so if the
@@ -221,6 +231,8 @@ describe('Audit log (resource_mutations) e2e', () => {
       resourceId,
       action: 'Update' as const,
       actorId: null,
+      actorSystemAgent: null,
+      impersonatorId: null,
       roleAtTime: [],
       changes: { a: 1 },
     });
@@ -247,6 +259,149 @@ describe('Audit log (resource_mutations) e2e', () => {
     };
     expect(await countFor(committedId)).toBe(1);
     expect(await countFor(rolledBackId)).toBe(0);
+  });
+
+  // `Identity.currentMaybe` hands back the EFFECTIVE session, so all three of
+  // these used to go wrong in the same place: an impersonated mutation was
+  // recorded as the impersonatee (silently), and a ghost-impersonated one blew
+  // up the actor FK and rolled the mutation back with it.
+  //
+  // Driven at the service layer rather than over HTTP because impersonation is
+  // header-based and the e2e client exposes no per-request headers; sessions are
+  // still built by the real SessionManager path (including its 'ghost' literal
+  // swap and the CanImpersonateHook gate) rather than hand-assembled.
+  describe('actor attribution', () => {
+    let audit: AuditService;
+    let sessions: SessionManager;
+    let host: SessionHost;
+    let db: DrizzleService;
+    let adminToken: string;
+    let adminId: ID<'User'>;
+    let impersonatee: TestUser;
+
+    beforeAll(async () => {
+      if (!isPostgres) return;
+      audit = app.get(AuditService);
+      sessions = app.get(SessionManager);
+      host = app.get(SessionHost);
+      db = app.get(DrizzleService);
+
+      impersonatee = await runInIsolatedSession(app, () =>
+        registerUser(app, { roles: [Role.ProjectManager] }),
+      );
+      // Impersonation is gated on the requester being able to assign every role
+      // they hold (can-impersonate-via-privileges), which today only an
+      // Administrator satisfies — so the root session is the only usable one.
+      adminToken = await runAsAdmin(app, () => app.graphql.authToken);
+      adminId = (await sessions.resumeSession(adminToken)).userId as ID<'User'>;
+    });
+
+    /** Record one Update against a throwaway resource id, under `session`. */
+    const recordAs = async (session: Session) => {
+      const resourceId = await generateId();
+      await host.withSession(session, async () => {
+        await audit.record(
+          new ResourceMutatedHook('Project', resourceId, 'Update', { a: 1 }),
+        );
+      });
+      // Aliased to camelCase so the row type doesn't need snake_case keys.
+      const res = await db.client.execute<{
+        actorId: string | null;
+        actorSystemAgent: string | null;
+        impersonatorId: string | null;
+        roleAtTime: string[];
+      }>(
+        sql`select actor_id           as "actorId",
+                   actor_system_agent as "actorSystemAgent",
+                   impersonator_id    as "impersonatorId",
+                   role_at_time       as "roleAtTime"
+            from resource_mutations where resource_id = ${resourceId}`,
+      );
+      expect(res.rows).toHaveLength(1);
+      return res.rows[0]!;
+    };
+
+    it('records the actor with no impersonator when acting as themselves', async () => {
+      if (!isPostgres) return;
+      const row = await recordAs(await sessions.resumeSession(adminToken));
+      expect(row.actorId).toBe(adminId);
+      expect(row.impersonatorId).toBeNull();
+      expect(row.actorSystemAgent).toBeNull();
+    });
+
+    // The silent-misattribution fix: actor is who it was done AS, impersonator
+    // is who actually did it. Before 0027 only the former was stored, so the
+    // log affirmatively blamed the impersonatee.
+    it('records both the impersonatee and the real requester', async () => {
+      if (!isPostgres) return;
+      const row = await recordAs(
+        await sessions.resumeSession(adminToken, {
+          id: impersonatee.id,
+          roles: setOf([]),
+        }),
+      );
+      expect(row.actorId).toBe(impersonatee.id);
+      expect(row.impersonatorId).toBe(adminId);
+      expect(row.actorSystemAgent).toBeNull();
+      // The effective roles — what the policy engine actually evaluated.
+      expect(row.roleAtTime).toEqual(['ProjectManager']);
+    });
+
+    // Role-only impersonation legitimately yields impersonator == actor. Pinned
+    // so it reads as intended rather than as a bug the next time someone looks.
+    it('records impersonator == actor for role-only impersonation', async () => {
+      if (!isPostgres) return;
+      const row = await recordAs(
+        await sessions.resumeSession(adminToken, {
+          roles: setOf([Role.Consultant]),
+        }),
+      );
+      expect(row.actorId).toBe(adminId);
+      expect(row.impersonatorId).toBe(adminId);
+      expect(row.roleAtTime).toEqual(['Consultant']);
+    });
+
+    // Regression guard for the crash: `session.userId` is the Ghost agent's id,
+    // which lives in `system_agents`. Storing it as actor_id violated the FK and
+    // — since the audit write shares the mutation's transaction — took the whole
+    // mutation down. Now the agent is recorded by name, and the admin behind it
+    // is still attributed.
+    it('records a ghost-impersonated mutation by agent name (no FK violation)', async () => {
+      if (!isPostgres) return;
+      const row = await recordAs(
+        await sessions.resumeSession(adminToken, {
+          id: 'ghost' as ID,
+          roles: setOf([]),
+        }),
+      );
+      expect(row.actorId).toBeNull();
+      expect(row.actorSystemAgent).toBe('Ghost');
+      expect(row.impersonatorId).toBe(adminId);
+    });
+
+    // The two actor columns are mutually exclusive at the DB level, so a future
+    // writer can't half-fill them regardless of what the service does.
+    it('rejects a row naming both a user and a system agent as actor', async () => {
+      if (!isPostgres) return;
+      const resourceId = await generateId();
+      const failure = await db.client
+        .execute(
+          sql`insert into resource_mutations
+                (resource_type, resource_id, action, actor_id, actor_system_agent)
+              values ('Project', ${resourceId}, 'Update', ${adminId}, 'Ghost')`,
+        )
+        .then(
+          () => null,
+          (error: unknown) => error,
+        );
+      // Drizzle wraps the driver error, so assert on the pg error underneath it
+      // — its `constraint` names what rejected, which the wrapper's message
+      // (just the failed SQL) does not.
+      expect(failure).not.toBeNull();
+      expect((failure as { cause?: unknown }).cause).toMatchObject({
+        constraint: 'resource_mutations_actor_shape_chk',
+      });
+    });
   });
 });
 
@@ -361,6 +516,10 @@ const UserHistoryDoc = graphql(`
         items {
           action
           actor {
+            id
+          }
+          actorSystemAgent
+          impersonator {
             id
           }
         }

--- a/test/audit-log.e2e-spec.ts
+++ b/test/audit-log.e2e-spec.ts
@@ -27,6 +27,10 @@ const isPostgres = process.env.DATABASE === 'postgres';
 describe('Audit log (resource_mutations) e2e', () => {
   let app: TestApp;
   let project: fragments.project;
+  // Engagement window shared by the polymorphic-history cases below; the end is
+  // derived from the start so the two dates can't drift apart.
+  const engStart = CalendarDate.local(1991, 1, 1);
+  const engEnd = engStart.plus({ years: 1 });
 
   beforeAll(async () => {
     app = await createTestApp();
@@ -134,8 +138,8 @@ describe('Audit log (resource_mutations) e2e', () => {
     const engagement = await createLanguageEngagement(app, {
       project: project.id,
       language: language.id,
-      startDateOverride: CalendarDate.fromISO('1991-01-01').toISO(),
-      endDateOverride: CalendarDate.fromISO('1992-01-01').toISO(),
+      startDateOverride: engStart.toISO(),
+      endDateOverride: engEnd.toISO(),
     });
 
     const { engagement: read } = await app.graphql.query(EngagementHistoryDoc, {
@@ -157,8 +161,8 @@ describe('Audit log (resource_mutations) e2e', () => {
     const engagement = await createLanguageEngagement(app, {
       project: project.id,
       language: language.id,
-      startDateOverride: CalendarDate.fromISO('1991-01-01').toISO(),
-      endDateOverride: CalendarDate.fromISO('1992-01-01').toISO(),
+      startDateOverride: engStart.toISO(),
+      endDateOverride: engEnd.toISO(),
     });
     const product = await createDirectProduct(app, {
       engagement: engagement.id,

--- a/test/comment.e2e-spec.ts
+++ b/test/comment.e2e-spec.ts
@@ -103,9 +103,11 @@ describe('Comment e2e', () => {
   // ProgressReport and rejected this valid commentable under DATABASE=postgres.
   it('creates a comment on a ProgressReport parent', async () => {
     await runAsAdmin(app, async (a) => {
+      const mouStart = CalendarDate.local(2023, 1, 1);
+      const mouEnd = mouStart.plus({ years: 1 });
       const project = await createProject(a, {
-        mouStart: CalendarDate.local(2023, 1, 1).toISO(),
-        mouEnd: CalendarDate.local(2024, 1, 1).toISO(),
+        mouStart: mouStart.toISO(),
+        mouEnd: mouEnd.toISO(),
       });
       const language = await createLanguage(a);
       const { createEng } = await a.graphql.mutate(CreateLangEngForCommentDoc, {
@@ -113,8 +115,8 @@ describe('Comment e2e', () => {
           project: project.id,
           language: language.id,
           // Match the project MOU window so progress reports land in-window.
-          startDateOverride: CalendarDate.local(2023, 1, 1).toISO(),
-          endDateOverride: CalendarDate.local(2024, 1, 1).toISO(),
+          startDateOverride: mouStart.toISO(),
+          endDateOverride: mouEnd.toISO(),
         },
       });
       const reportId = createEng.engagement.progressReports.items[0]!.id;


### PR DESCRIPTION
### Summary 
Introduces Cord's **audit log** — an append-only record of who changed what. Every user-driven create/update/delete now writes one permanent entry — the actor, the action, which fields changed, when, and **in what role** — inside the same transaction as the change (so a rolled-back mutation leaves no orphan log row). Every record gains a `history` field exposing its own change trail.

This lands migration `0026`. It's stacked on the report + leaves work and retargets to `develop` as those merge.

### What's added
- **Audit component** — `resource_mutations` table (append-only) + `mutation_action` enum; a repository, an `AuditService`, an `@OnHook` writer, and resolvers.
- **`history` on every resource** — resolved on the base `Resource` interface (via the concrete type name), so all object types inherit it with no per-domain wiring.
- **`role_at_time`** — snapshots the actor's roles at the instant of the mutation, captured at write time from the session.
- **24 services instrumented** — each fires `ResourceMutatedHook(type, id, action[, changes])` on create/update/delete.

### Notes for the reviewer (intentional choices)
- **`role_at_time` is stored as `text[]`, not the `role` enum** — a decoupled historical snapshot. The log is append-only, so a value must be captured at write time (no backfill), and storing plain text keeps historical rows immune to future role-enum changes. Exposed in GraphQL as `[String!]!` for the same reason.
- **The audit writer is Postgres-only** — under the legacy engine it's a no-op (no partial history mid-transition), tagged `migration-todo(cutover-cleanup)`. The log begins capturing at cutover.
- **`user.delete` fires both hooks** — the existing session-revocation-on-delete side effect is preserved; the audit event is added alongside it.
- **`progress-report-media`** is instrumented at the service without altering its repository call — its Postgres repository is a later wave; the audit hook is engine-agnostic and lands now.
- **Some resources are intentionally not tracked** — system-generated, sync-only, and relationship-toggle writes don't record.

### Schema / DDL
- `mutation_action` enum: `Create | Update | Delete`.
- `resource_mutations`:
  - `id` bigserial PK · `resource_type` text · `resource_id` text (polymorphic, FK-less — spans every resource) · `action` mutation_action
  - `actor_id` text → `users(id)` **ON DELETE SET NULL** (history outlives the actor)
  - `role_at_time` text[] NOT NULL DEFAULT `'{}'`
  - `changes` jsonb (diffed fields, updates only) · `at` timestamptz DEFAULT now()
  - indexes: `(resource_type, resource_id, at)`, `(actor_id)`

### Validation performed
- `yarn type-check` / `yarn lint`: clean.
- Fresh-DB apply `0000–0026`: clean — verified the table, enum, `role_at_time text[]`, `actor_id` set-null FK, and both indexes.
- **Postgres e2e (audit-log): 7/7** — history records create+update across partnership/project/organization/language-engagement/product; `history` exposed via the Resource interface; actor resolved; `changes` diff captured; `role_at_time` carries the actor's roles; and the audit row rolls back with a failed transaction.
- Note: the generated GraphQL schema types must be regenerated (`--gen-schema` + gql-tada) since `history`/`role_at_time` are new fields — done in CI's setup step.

### Reviewer cross-checks
- `history` uses the concrete GraphQL type name (not `__typename`) to match stored rows.
- `role_at_time` is captured in `AuditService.record` from the session, alongside the actor.
- The write is inside the mutation's transaction (atomicity proven by the rollback test).
- FK column `actor_id` has a full b-tree index.

### Explicitly out of scope
- ProgressReportMedia's Postgres repository (separate wave) — only its audit hook lands here.
- Scoped-per-resource roles in `role_at_time` (v1 captures global roles; scoped is a possible follow-up).
- Removing the Postgres-only guard (a cutover-cleanup item).
