### PR TITLE
[pg] Media + PnP → Postgres (Drizzle): File Media, ProgressReportMedi…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
             shard: 1
             total: 1
             test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony|product|film|story|project-workflow|periodic-report|rev79|pin|known-language|comment|post|audit-log)\."
+              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony|product|film|story|project-workflow|periodic-report|rev79|pin|known-language|comment|post|audit-log|progress-report-media)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/src/components/file/file.drizzle.repository.ts
+++ b/src/components/file/file.drizzle.repository.ts
@@ -11,6 +11,7 @@ import {
 import { Identity } from '~/core/authentication';
 import { DrizzleService, resolveOrderBy } from '~/core/drizzle';
 import { fileNodes } from '~/core/drizzle/schema';
+import { LiveQueryStore } from '~/core/live-query';
 import { type BaseNode } from '~/core/neo4j/results';
 import {
   FileListInput,
@@ -18,6 +19,7 @@ import {
   type FileNode,
   FileNodeType,
   FileVersion,
+  resolveFileNode,
 } from './dto';
 import { reverseAttachmentByRootIds } from './resolve-file-attachment';
 
@@ -42,6 +44,7 @@ export class FileDrizzleRepository {
   constructor(
     private readonly drizzle: DrizzleService,
     private readonly identity: Identity,
+    private readonly liveQueryStore: LiveQueryStore,
   ) {}
 
   protected get db() {
@@ -289,6 +292,12 @@ export class FileDrizzleRepository {
   }
 
   async rename(fileNode: FileNode, newName: string): Promise<void> {
+    // Mirrors the Neo4j arm, where `db.updateProperties({ type:
+    // resolveFileNode(fileNode) })` announces under the CONCRETE type. The store
+    // keys on `${resource.name}:${id}`, so `FileNode:` — the interface — would
+    // emit something nothing subscribes to. FileService.rename() already skips
+    // the call when the name is unchanged, so this never fires as a no-op.
+    this.liveQueryStore.invalidate([resolveFileNode(fileNode), fileNode.id]);
     await this.db
       .update(fileNodes)
       .set({ name: newName })
@@ -352,7 +361,7 @@ export class FileDrizzleRepository {
 
   async delete(fileNode: FileNode): Promise<void> {
     // Soft-delete the node and its whole subtree.
-    await this.db.execute(sql`
+    const deleted = await this.db.execute<{ id: ID; type: FileNodeType }>(sql`
       WITH RECURSIVE subtree AS (
         SELECT id FROM ${fileNodes} WHERE id = ${fileNode.id}
         UNION ALL
@@ -360,14 +369,24 @@ export class FileDrizzleRepository {
       )
       UPDATE ${fileNodes} SET deleted_at = now()
       WHERE id IN (SELECT id FROM subtree)
+      RETURNING id, type
     `);
+    // The Neo4j arm's `deleteNode(fileNode, { resource: resolveFileNode(...) })`
+    // announces the top node only. RETURNING gives us the whole subtree for free
+    // — no extra round trip — so a live query watching a file *inside* a deleted
+    // directory is told as well. Deliberately better than Neo4j here rather than
+    // a divergence to be reverted. FileNodeType's values are exactly the
+    // registered resource names, so the row's `type` is the key we want.
+    this.liveQueryStore.invalidateAll(
+      deleted.rows.map((row) => [row.type, row.id] as const),
+    );
     // Neo4j computes a File's latest version dynamically from its *active*
     // versions, so deleting the current version falls back to the previous one
     // (or none). We denormalize latest_version_id, so repoint any surviving
     // File whose latest version was just soft-deleted to its newest remaining
     // version — or null, which makes it a version-less placeholder (not-found),
     // matching Neo4j's "no active version" state.
-    await this.db.execute(sql`
+    const repointed = await this.db.execute<{ id: ID<'File'> }>(sql`
       UPDATE ${fileNodes} f
       SET latest_version_id = (
         SELECT v.id FROM ${fileNodes} v
@@ -384,7 +403,15 @@ export class FileDrizzleRepository {
           SELECT lv.deleted_at FROM ${fileNodes} lv
           WHERE lv.id = f.latest_version_id
         ) IS NOT NULL
+      RETURNING f.id
     `);
+    // These Files survived, but their surfaced mimeType/size/modifiedAt just
+    // changed with the repoint, and they are not in the subtree above. Same
+    // free-RETURNING reasoning; deleting a FileVersion otherwise left the parent
+    // File's open page showing the removed version's metadata.
+    this.liveQueryStore.invalidateAll(
+      repointed.rows.map((row) => [FileNodeType.File, row.id] as const),
+    );
   }
 
   // ─── hydration ─────────────────────────────────────────────────────────────

--- a/src/components/file/file.drizzle.repository.ts
+++ b/src/components/file/file.drizzle.repository.ts
@@ -19,6 +19,7 @@ import {
   FileNodeType,
   FileVersion,
 } from './dto';
+import { reverseAttachmentByRootIds } from './resolve-file-attachment';
 
 type FileNodeRow = typeof fileNodes.$inferSelect;
 
@@ -441,6 +442,14 @@ export class FileDrizzleRepository {
       .map((r) => r.id);
     const aggregates = await this.computeDirectoryAggregates(dirIds);
 
+    // The resource each node's tree root is attached to (reverse-lookup across
+    // the consuming DefinedFile FK columns). Batched over distinct roots.
+    const distinctRootIds = [...new Set([...roots.values()].map((r) => r.id))];
+    const attachmentByRoot = await reverseAttachmentByRootIds(
+      this.db,
+      distinctRootIds,
+    );
+
     return rows.map((row) => {
       const root = roots.get(row.id);
       const rootNode = root
@@ -454,12 +463,14 @@ export class FileDrizzleRepository {
         createdAt: toDateTime(row.createdAt),
         createdById: row.createdById,
         root: rootNode,
-        // rootAttachedTo: nothing points at file nodes until consuming FKs land
-        // in PR #2. Point it at the root node itself (a Directory) — its type is
-        // never ProgressReportMedia, so the file-is-media-check handler that
-        // destructures this on every upload short-circuits cleanly.
-        // migration-todo (PR #2): reverse-lookup across consuming FK columns.
-        rootAttachedTo: [rootNode, 'dir'] as [BaseNode, string],
+        // The resource holding the tree root. Falls back to the root node
+        // itself (a Directory — never ProgressReportMedia, so the upload-time
+        // file-is-media check short-circuits) when nothing references it, e.g.
+        // a test root dir or a free-floating tree.
+        rootAttachedTo: attachmentByRoot.get(root?.id ?? row.id) ?? [
+          rootNode,
+          'dir',
+        ],
         canDelete: true,
       };
 

--- a/src/components/file/media/hooks/can-update.hook.ts
+++ b/src/components/file/media/hooks/can-update.hook.ts
@@ -20,8 +20,14 @@ export class CanUpdateMediaUserMetadataHook {
   ) {}
 
   @Once() getAttachedResource() {
+    const attachedTo = this.media.attachedTo;
+    if (!attachedTo) {
+      // No resolvable owner → can't attribute the media, so no handler can
+      // authorize the update. Callers treat this as "abstain" (fail closed).
+      return undefined;
+    }
     const attachedResName = this.resourceResolver.resolveTypeByBaseNode(
-      this.media.attachedTo[0],
+      attachedTo[0],
     );
     const attachedResource = this.resourceHost.getByName(attachedResName);
     return attachedResource;

--- a/src/components/file/media/media.drizzle.repository.ts
+++ b/src/components/file/media/media.drizzle.repository.ts
@@ -65,6 +65,11 @@ export class MediaDrizzleRepository {
     return await Promise.all(rows.map((row) => this.toDto(row)));
   }
 
+  // No live-query invalidation, deliberately: the Neo4j `save` is raw Cypher
+  // that reaches none of CommonRepository's announcing helpers, so it is silent
+  // too. Matching it keeps this a pre-existing product gap on every engine
+  // rather than a cutover regression. Media is also always read through its
+  // FileVersion, which the file repo does announce.
   async save(input: SaveInput): Promise<AnyMedia> {
     if (input.__typename) {
       // Detection result — upsert the full media row keyed on the file version.

--- a/src/components/file/media/media.drizzle.repository.ts
+++ b/src/components/file/media/media.drizzle.repository.ts
@@ -1,0 +1,196 @@
+import { Injectable } from '@nestjs/common';
+import { eq, inArray, or, type SQL } from 'drizzle-orm';
+import type { Except, RequireAtLeastOne } from 'type-fest';
+import {
+  generateId,
+  type ID,
+  NotFoundException,
+  ServerException,
+} from '~/common';
+import { DrizzleService } from '~/core/drizzle';
+import { fileNodes, media } from '~/core/drizzle/schema';
+import { type BaseNode } from '~/core/neo4j/results';
+import { resolveFileRootAttachment } from '../resolve-file-attachment';
+import { type AnyMedia } from './media.dto';
+
+type MediaRow = typeof media.$inferSelect;
+type SaveInput = RequireAtLeastOne<Pick<AnyMedia, 'id' | 'file'>> &
+  Partial<Except<AnyMedia, 'attachedTo'>>;
+
+/**
+ * Postgres/Drizzle implementation of Media (Phase 7). One `media` row per
+ * FileVersion (Image/Video/Audio sidecar). `attachedTo` — the resource holding
+ * the root file node — is resolved by reverse-lookup across the consuming
+ * DefinedFile FK columns (see resolveFileRootAttachment).
+ *
+ * migration-todo (cutover): drop alongside the Neo4j MediaRepository.
+ */
+@Injectable()
+export class MediaDrizzleRepository {
+  constructor(private readonly drizzle: DrizzleService) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  async readOne(
+    input: RequireAtLeastOne<Pick<AnyMedia, 'id' | 'file'>>,
+  ): Promise<AnyMedia> {
+    const [media] = await this.readMany(
+      input.id ? { mediaIds: [input.id] } : { fvIds: [input.file!] },
+    );
+    if (!media) {
+      throw new NotFoundException('Media not found');
+    }
+    return media;
+  }
+
+  async readMany(
+    input: RequireAtLeastOne<Record<'fvIds' | 'mediaIds', readonly ID[]>>,
+  ): Promise<AnyMedia[]> {
+    const conditions: SQL[] = [];
+    if (input.fvIds?.length) {
+      conditions.push(inArray(media.fileVersionId, input.fvIds as ID[]));
+    }
+    if (input.mediaIds?.length) {
+      conditions.push(inArray(media.id, input.mediaIds as ID[]));
+    }
+    if (conditions.length === 0) {
+      return [];
+    }
+    const rows = await this.db
+      .select()
+      .from(media)
+      .where(conditions.length === 1 ? conditions[0] : or(...conditions));
+    return await Promise.all(rows.map((row) => this.toDto(row)));
+  }
+
+  async save(input: SaveInput): Promise<AnyMedia> {
+    if (input.__typename) {
+      // Detection result — upsert the full media row keyed on the file version.
+      if (!input.file) {
+        throw new ServerException('Media save requires a file version');
+      }
+      const values = toDbValues(input);
+      await this.db
+        .insert(media)
+        .values({
+          id: await generateId(),
+          fileVersionId: input.file,
+          type: input.__typename,
+          mimeType: input.mimeType ?? '',
+          ...values,
+        })
+        .onConflictDoUpdate({ target: media.fileVersionId, set: values });
+    } else {
+      // Metadata-only update (altText/caption) of existing media.
+      const set = toDbValues(input);
+      const result = input.id
+        ? await this.db
+            .update(media)
+            .set(set)
+            .where(eq(media.id, input.id))
+            .returning({ id: media.id })
+        : await this.db
+            .update(media)
+            .set(set)
+            .where(eq(media.fileVersionId, input.file!))
+            .returning({ id: media.id });
+      if (result.length === 0) {
+        if (input.id) {
+          const exists = await this.getBaseNode(input.id, 'Media');
+          if (!exists) throw new NotFoundException('Media could not be found');
+        }
+        if (input.file) {
+          const exists = await this.getBaseNode(input.file, 'FileVersion');
+          if (!exists) {
+            throw new NotFoundException(
+              'Media could not be saved to nonexistent file',
+            );
+          }
+        }
+        throw new ServerException('Failed to save media info');
+      }
+    }
+
+    return await this.readOne(
+      input.id ? { id: input.id } : { file: input.file! },
+    );
+  }
+
+  async getBaseNode(
+    id: ID,
+    label: 'Media' | 'FileVersion',
+  ): Promise<BaseNode | undefined> {
+    const table = label === 'Media' ? media : fileNodes;
+    const [row] = await this.db
+      .select({ createdAt: table.createdAt })
+      .from(table)
+      .where(eq(table.id, id))
+      .limit(1);
+    if (!row) {
+      return undefined;
+    }
+    return {
+      identity: id,
+      labels: [label, 'BaseNode'],
+      properties: { id },
+    } as unknown as BaseNode;
+  }
+
+  private async toDto(row: MediaRow): Promise<AnyMedia> {
+    const attachedTo = await resolveFileRootAttachment(
+      this.db,
+      row.fileVersionId,
+    );
+    const base = {
+      __typename: row.type,
+      id: row.id,
+      file: row.fileVersionId,
+      mimeType: row.mimeType,
+      altText: row.altText,
+      caption: row.caption,
+      attachedTo,
+    };
+    if (row.type === 'Image') {
+      return {
+        ...base,
+        dimensions: { width: row.width ?? 0, height: row.height ?? 0 },
+      } as unknown as AnyMedia;
+    }
+    if (row.type === 'Video') {
+      return {
+        ...base,
+        dimensions: { width: row.width ?? 0, height: row.height ?? 0 },
+        duration: row.duration ?? 0,
+      } as unknown as AnyMedia;
+    }
+    return { ...base, duration: row.duration ?? 0 } as unknown as AnyMedia;
+  }
+}
+
+/** Map a save input to media column values, mirroring the Neo4j `toDbShape`. */
+const toDbValues = (input: SaveInput): Record<string, unknown> => {
+  const values: Record<string, unknown> = {};
+  if (input.altText !== undefined) values.altText = input.altText;
+  if (input.caption !== undefined) values.caption = input.caption;
+  if (input.mimeType !== undefined) values.mimeType = input.mimeType;
+  if (input.__typename) {
+    values.type = input.__typename;
+    // Visual types carry dimensions; clear them otherwise.
+    if (input.__typename === 'Image' || input.__typename === 'Video') {
+      values.width = input.dimensions?.width ?? null;
+      values.height = input.dimensions?.height ?? null;
+    } else {
+      values.width = null;
+      values.height = null;
+    }
+    // Temporal types carry duration; clear it otherwise.
+    if (input.__typename === 'Audio' || input.__typename === 'Video') {
+      values.duration = input.duration ?? null;
+    } else {
+      values.duration = null;
+    }
+  }
+  return values;
+};

--- a/src/components/file/media/media.drizzle.repository.ts
+++ b/src/components/file/media/media.drizzle.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { eq, inArray, or, type SQL } from 'drizzle-orm';
+import { DateTime } from 'luxon';
 import type { Except, RequireAtLeastOne } from 'type-fest';
 import {
   generateId,
@@ -10,7 +11,10 @@ import {
 import { DrizzleService } from '~/core/drizzle';
 import { fileNodes, media } from '~/core/drizzle/schema';
 import { type BaseNode } from '~/core/neo4j/results';
-import { resolveFileRootAttachment } from '../resolve-file-attachment';
+import {
+  type Attachment,
+  resolveFileRootAttachments,
+} from '../resolve-file-attachment';
 import { type AnyMedia } from './media.dto';
 
 type MediaRow = typeof media.$inferSelect;
@@ -62,7 +66,16 @@ export class MediaDrizzleRepository {
       .select()
       .from(media)
       .where(conditions.length === 1 ? conditions[0] : or(...conditions));
-    return await Promise.all(rows.map((row) => this.toDto(row)));
+    // Resolve every row's attachment in ONE pass. Doing it inside toDto meant a
+    // recursive ancestor CTE plus the 11-branch UNION per row — 2N round trips
+    // on the path a DataLoader batches.
+    const attachments = await resolveFileRootAttachments(
+      this.db,
+      rows.map((row) => row.fileVersionId),
+    );
+    return rows.map((row) =>
+      this.toDto(row, attachments.get(row.fileVersionId)),
+    );
   }
 
   // No live-query invalidation, deliberately: the Neo4j `save` is raw Cypher
@@ -139,15 +152,15 @@ export class MediaDrizzleRepository {
     return {
       identity: id,
       labels: [label, 'BaseNode'],
-      properties: { id },
+      // createdAt was selected but dropped here, while BaseNode.properties
+      // declares it required — the cast hid the gap. Current callers only test
+      // truthiness, so it was a latent undefined-read rather than a live bug.
+      properties: { id, createdAt: DateTime.fromJSDate(row.createdAt) },
     } as unknown as BaseNode;
   }
 
-  private async toDto(row: MediaRow): Promise<AnyMedia> {
-    const attachedTo = await resolveFileRootAttachment(
-      this.db,
-      row.fileVersionId,
-    );
+  /** Synchronous: the caller resolves attachments in one batch beforehand. */
+  private toDto(row: MediaRow, attachedTo: Attachment | undefined): AnyMedia {
     const base = {
       __typename: row.type,
       id: row.id,

--- a/src/components/file/media/media.dto.ts
+++ b/src/components/file/media/media.dto.ts
@@ -74,8 +74,12 @@ export class Media extends MediaUserMetadata {
 
   readonly file: ID<FileVersion>;
 
-  /** The resource that holds the root file node that this media is attached to */
-  readonly attachedTo: [resource: BaseNode, relation: string];
+  /**
+   * The resource that holds the root file node that this media is attached to.
+   * Absent when the root can't be resolved to a live resource (e.g. the owner
+   * was soft-deleted, or a free-floating tree) — consumers must guard for it.
+   */
+  readonly attachedTo?: [resource: BaseNode, relation: string];
 
   @Field(() => String)
   readonly mimeType: string;

--- a/src/components/file/media/media.module.ts
+++ b/src/components/file/media/media.module.ts
@@ -1,10 +1,12 @@
 import { forwardRef, Module } from '@nestjs/common';
+import { splitDb } from '~/core/database';
 import { FileModule } from '../file.module';
 import { DetectExistingMediaMigration } from './detect-existing-media.migration';
 import { DimensionsResolver } from './dimensions.resolver';
 import { CanUpdateMediaUserMetadataHook } from './hooks/can-update.hook';
 import { MediaByFileVersionLoader } from './media-by-file-version.loader';
 import { MediaDetector } from './media-detector.service';
+import { MediaDrizzleRepository } from './media.drizzle.repository';
 import { MediaLoader } from './media.loader';
 import { MediaRepository } from './media.repository';
 import { MediaResolver } from './media.resolver';
@@ -17,7 +19,10 @@ import { MediaService } from './media.service';
     MediaByFileVersionLoader,
     MediaDetector,
     MediaLoader,
-    MediaRepository,
+    // migration-todo: drop the `as any` + the Neo4j path at Phase 7 cutover.
+    splitDb(MediaRepository, {
+      postgres: MediaDrizzleRepository as any,
+    }),
     MediaResolver,
     MediaService,
     DetectExistingMediaMigration,

--- a/src/components/file/media/media.service.ts
+++ b/src/components/file/media/media.service.ts
@@ -5,12 +5,10 @@ import {
   createAndInject,
   type ID,
   NotFoundException,
-  NotImplementedException,
   Polls,
   ServerException,
   UnauthorizedException,
 } from '~/common';
-import { ConfigService } from '~/core/config';
 import { Hooks } from '~/core/hooks';
 import { type FileVersion } from '../dto';
 import { CanUpdateMediaUserMetadataHook } from './hooks/can-update.hook';
@@ -24,19 +22,10 @@ export class MediaService {
     private readonly detector: MediaDetector,
     private readonly repo: MediaRepository,
     private readonly hooks: Hooks,
-    private readonly config: ConfigService,
     private readonly moduleRef: ModuleRef,
   ) {}
 
   async detectAndSave(file: FileVersion, metadata?: MediaUserMetadata) {
-    // migration-todo (PR #2): Media has no Postgres repository yet — its
-    // `attachedTo` needs the same reverse-lookup across consuming FK columns as
-    // File.rootAttachedTo, which lands in PR #2. Until then, skip detection
-    // under Postgres so uploads don't fall through to the Neo4j MediaRepository.
-    // Drop this guard at Phase 7 cutover.
-    if (this.config.databaseEngine === 'postgres') {
-      return null;
-    }
     const media = await this.detector.detect(file);
     if (!media) {
       return null;
@@ -52,14 +41,6 @@ export class MediaService {
   async updateUserMetadata(
     input: RequireAtLeastOne<Pick<AnyMedia, 'id' | 'file'>> & MediaUserMetadata,
   ) {
-    // migration-todo (PR #2): same as detectAndSave — Media has no Postgres
-    // repository yet. Fail explicitly rather than reading/writing through the
-    // Neo4j MediaRepository cross-engine. Drop this guard at Phase 7 cutover.
-    if (this.config.databaseEngine === 'postgres') {
-      throw new NotImplementedException(
-        'Media metadata is not yet supported under Postgres',
-      );
-    }
     const media = await this.repo.readOne(input);
     const canUpdatePoll = new Polls.Poll<boolean>();
     const event = await createAndInject(

--- a/src/components/file/resolve-file-attachment.ts
+++ b/src/components/file/resolve-file-attachment.ts
@@ -4,7 +4,7 @@ import { type ID } from '~/common';
 import { type DrizzleDb } from '~/core/drizzle';
 import { type BaseNode } from '~/core/neo4j/results';
 
-type Attachment = [resource: BaseNode, relation: string];
+export type Attachment = [resource: BaseNode, relation: string];
 
 /**
  * Reverse of {@link resolveResourceBaseNode}: given file tree *root* ids, find
@@ -97,27 +97,64 @@ export async function reverseAttachmentByRootIds(
 }
 
 /**
- * Single-file convenience: walk from a file node to its tree root, then resolve
- * the attached resource. Backs `Media.attachedTo`. Returns undefined when
- * nothing references the root (e.g. a test root dir, or a free-floating tree).
+ * BATCHED: walk many file nodes to their tree roots, then resolve each root's
+ * attached resource — two queries total regardless of input size.
+ *
+ * The per-node version below is a wrapper over this one. Media's `readMany` is
+ * the batch path a DataLoader feeds, and calling the single version per row cost
+ * a recursive ancestor CTE **plus** the 11-branch UNION for every media row —
+ * 2N round trips for one page.
+ */
+export async function resolveFileRootAttachments(
+  db: DrizzleDb,
+  startFileNodeIds: readonly ID[],
+): Promise<Map<ID, Attachment>> {
+  const out = new Map<ID, Attachment>();
+  const starts = [...new Set(startFileNodeIds)];
+  if (starts.length === 0) {
+    return out;
+  }
+  const ids = sql.join(
+    starts.map((id) => sql`${id}`),
+    sql`, `,
+  );
+  // Carry the originating id through the recursion so one walk serves every
+  // start node; DISTINCT ON picks each start's deepest ancestor, i.e. its root.
+  const rootRes = await db.execute<{ startId: ID; rootId: ID }>(sql`
+    WITH RECURSIVE ancestors AS (
+      SELECT id AS start_id, id, parent_id, 0 AS depth
+        FROM file_nodes WHERE id IN (${ids})
+      UNION ALL
+      SELECT a.start_id, p.id, p.parent_id, a.depth + 1
+        FROM ancestors a JOIN file_nodes p ON p.id = a.parent_id
+    )
+    SELECT DISTINCT ON (start_id) start_id AS "startId", id AS "rootId"
+      FROM ancestors ORDER BY start_id, depth DESC
+  `);
+  const rootByStart = new Map(
+    rootRes.rows.map((row) => [row.startId, row.rootId]),
+  );
+  const attachmentByRoot = await reverseAttachmentByRootIds(db, [
+    ...new Set(rootByStart.values()),
+  ]);
+  for (const [startId, rootId] of rootByStart) {
+    const attachment = attachmentByRoot.get(rootId);
+    if (attachment) {
+      out.set(startId, attachment);
+    }
+  }
+  return out;
+}
+
+/**
+ * Single-file convenience over {@link resolveFileRootAttachments}. Backs
+ * `Media.attachedTo` on the single-read paths. Returns undefined when nothing
+ * references the root (e.g. a test root dir, or a free-floating tree).
  */
 export async function resolveFileRootAttachment(
   db: DrizzleDb,
   startFileNodeId: ID,
 ): Promise<Attachment | undefined> {
-  const rootRes = await db.execute<{ rootId: ID }>(sql`
-    WITH RECURSIVE ancestors AS (
-      SELECT id, parent_id, 0 AS depth FROM file_nodes WHERE id = ${startFileNodeId}
-      UNION ALL
-      SELECT p.id, p.parent_id, a.depth + 1
-      FROM ancestors a JOIN file_nodes p ON p.id = a.parent_id
-    )
-    SELECT id AS "rootId" FROM ancestors ORDER BY depth DESC LIMIT 1
-  `);
-  const rootId = rootRes.rows[0]?.rootId;
-  if (!rootId) {
-    return undefined;
-  }
-  const map = await reverseAttachmentByRootIds(db, [rootId]);
-  return map.get(rootId);
+  const map = await resolveFileRootAttachments(db, [startFileNodeId]);
+  return map.get(startFileNodeId);
 }

--- a/src/components/file/resolve-file-attachment.ts
+++ b/src/components/file/resolve-file-attachment.ts
@@ -1,0 +1,123 @@
+import { sql } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import { type ID } from '~/common';
+import { type DrizzleDb } from '~/core/drizzle';
+import { type BaseNode } from '~/core/neo4j/results';
+
+type Attachment = [resource: BaseNode, relation: string];
+
+/**
+ * Reverse of {@link resolveResourceBaseNode}: given file tree *root* ids, find
+ * the resource each root is attached to — by matching the root id against every
+ * consuming DefinedFile FK column — and build the owning resource as a
+ * Neo4j-shaped {@link BaseNode}. The Postgres equivalent of the Neo4j
+ * `MATCH (resource)-[rel]->(root)` in the File/Media hydrate.
+ *
+ * Batched (one UNION query for all roots) because FileNode.rootAttachedTo is
+ * computed for every hydrated node.
+ *
+ * migration-todo: delete at Phase 7 cutover with the Neo4j/BaseNode shims.
+ */
+export async function reverseAttachmentByRootIds(
+  db: DrizzleDb,
+  rootIds: readonly ID[],
+): Promise<Map<ID, Attachment>> {
+  const map = new Map<ID, Attachment>();
+  if (rootIds.length === 0) {
+    return map;
+  }
+  const ids = sql.join(
+    rootIds.map((id) => sql`${id}`),
+    sql`, `,
+  );
+  // Each consuming table's DefinedFile FK column → (root id, owner, relation,
+  // concrete resource label). project/engagement carry a subtype discriminator.
+  // The relation name mirrors the Neo4j `{propName}Node` edge but isn't read by
+  // any consumer (only the resource matters), so the clean propName is fine.
+  const rows = await db.execute<{
+    rootId: ID;
+    ownerId: ID;
+    label: string;
+    relation: string;
+    createdAt: Date | string;
+  }>(sql`
+    SELECT root_directory_id AS "rootId", id AS "ownerId", type || 'Project' AS "label",
+           'rootDirectory' AS "relation", created_at AS "createdAt"
+      FROM projects WHERE root_directory_id IN (${ids}) AND deleted_at IS NULL
+    UNION ALL
+    SELECT photo_id, id, 'User', 'photo', created_at
+      FROM users WHERE photo_id IN (${ids}) AND deleted_at IS NULL
+    UNION ALL
+    SELECT map_image_id, id, 'Location', 'mapImage', created_at
+      FROM locations WHERE map_image_id IN (${ids}) AND deleted_at IS NULL
+    UNION ALL
+    SELECT mou_id, id, 'Partnership', 'mou', created_at
+      FROM partnerships WHERE mou_id IN (${ids}) AND deleted_at IS NULL
+    UNION ALL
+    SELECT agreement_id, id, 'Partnership', 'agreement', created_at
+      FROM partnerships WHERE agreement_id IN (${ids}) AND deleted_at IS NULL
+    UNION ALL
+    SELECT pnp_id, id, type || 'Engagement', 'pnp', created_at
+      FROM engagements WHERE pnp_id IN (${ids}) AND deleted_at IS NULL
+    UNION ALL
+    SELECT growth_plan_id, id, type || 'Engagement', 'growthPlan', created_at
+      FROM engagements WHERE growth_plan_id IN (${ids}) AND deleted_at IS NULL
+    UNION ALL
+    SELECT universal_template_file_id, id, 'Budget', 'universalTemplateFile', created_at
+      FROM budgets WHERE universal_template_file_id IN (${ids}) AND deleted_at IS NULL
+    UNION ALL
+    SELECT file_id, id, 'ProgressReportMedia', 'media', created_at
+      FROM progress_report_media WHERE file_id IN (${ids}) AND deleted_at IS NULL
+    UNION ALL
+    -- reportFile + narrativeFile live on the base PeriodicReport, so the label
+    -- is the concrete report type: 'Progress'/'Financial'/'Narrative' || 'Report'.
+    -- No deleted_at filter — periodic_reports isn't soft-deleted (it cascades
+    -- from its parent project/engagement), so the column doesn't exist.
+    SELECT report_file_id, id, type || 'Report', 'reportFile', created_at
+      FROM periodic_reports WHERE report_file_id IN (${ids})
+    UNION ALL
+    SELECT narrative_file_id, id, type || 'Report', 'narrativeFile', created_at
+      FROM periodic_reports WHERE narrative_file_id IN (${ids})
+  `);
+  for (const r of rows.rows) {
+    const baseNode: BaseNode = {
+      identity: r.ownerId,
+      labels: [r.label, 'BaseNode'],
+      properties: {
+        id: r.ownerId,
+        createdAt:
+          r.createdAt instanceof Date
+            ? DateTime.fromJSDate(r.createdAt)
+            : DateTime.fromSQL(r.createdAt),
+      },
+    } as unknown as BaseNode;
+    map.set(r.rootId, [baseNode, r.relation]);
+  }
+  return map;
+}
+
+/**
+ * Single-file convenience: walk from a file node to its tree root, then resolve
+ * the attached resource. Backs `Media.attachedTo`. Returns undefined when
+ * nothing references the root (e.g. a test root dir, or a free-floating tree).
+ */
+export async function resolveFileRootAttachment(
+  db: DrizzleDb,
+  startFileNodeId: ID,
+): Promise<Attachment | undefined> {
+  const rootRes = await db.execute<{ rootId: ID }>(sql`
+    WITH RECURSIVE ancestors AS (
+      SELECT id, parent_id, 0 AS depth FROM file_nodes WHERE id = ${startFileNodeId}
+      UNION ALL
+      SELECT p.id, p.parent_id, a.depth + 1
+      FROM ancestors a JOIN file_nodes p ON p.id = a.parent_id
+    )
+    SELECT id AS "rootId" FROM ancestors ORDER BY depth DESC LIMIT 1
+  `);
+  const rootId = rootRes.rows[0]?.rootId;
+  if (!rootId) {
+    return undefined;
+  }
+  const map = await reverseAttachmentByRootIds(db, [rootId]);
+  return map.get(rootId);
+}

--- a/src/components/pnp/extraction-result/pnp-extraction-result.drizzle.repository.ts
+++ b/src/components/pnp/extraction-result/pnp-extraction-result.drizzle.repository.ts
@@ -81,6 +81,11 @@ export class PnpExtractionResultDrizzleRepository {
     });
   }
 
+  // No live-query invalidation, deliberately: the Neo4j `save` is raw Cypher
+  // that reaches none of CommonRepository's announcing helpers, so it is silent
+  // too — matching it keeps this a pre-existing gap on every engine rather than
+  // a cutover regression. In practice this runs during upload, right before the
+  // file repo announces the new version anyway.
   async save(
     file: ID<'FileVersion'>,
     result: PnpExtractionResult,

--- a/src/components/pnp/extraction-result/pnp-extraction-result.drizzle.repository.ts
+++ b/src/components/pnp/extraction-result/pnp-extraction-result.drizzle.repository.ts
@@ -1,0 +1,116 @@
+import { Injectable } from '@nestjs/common';
+import { eq, inArray } from 'drizzle-orm';
+import { type ID } from '~/common';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import {
+  fileNodes,
+  pnpExtractionResultProblems,
+  pnpExtractionResults,
+} from '~/core/drizzle/schema';
+import {
+  type PnpExtractionResult,
+  PnpProblemSeverity,
+  PnpProblemType,
+  type StoredProblem,
+} from './extraction-result.dto';
+import { type PnpExtractionResultLoadResult } from './pnp-extraction-result.loader';
+
+const severityOrder = [...PnpProblemSeverity.values];
+const severityIndex = (typeId: string): number => {
+  const severity = PnpProblemType.types.get(typeId as never)?.severity;
+  return severity ? severityOrder.indexOf(severity) : 99;
+};
+
+/**
+ * Postgres/Drizzle implementation of PnpExtractionResultRepository.
+ * Results are keyed by File (the FileVersion's parent); problems live in a child
+ * table. Severity + rendering come from PnpProblemType in code, so no types
+ * table. migration-todo (cutover): drop alongside the Neo4j repository.
+ *
+ * migration-todo: the LanguageEngagement-list pnp filters/sorters (hasError /
+ * totalErrors) aren't ported — add when a postgres engagement-list-by-pnp-error
+ * path needs them.
+ */
+@Injectable()
+export class PnpExtractionResultDrizzleRepository {
+  constructor(private readonly drizzle: DrizzleService) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  async read(
+    files: ReadonlyArray<ID<'File'>>,
+  ): Promise<readonly PnpExtractionResultLoadResult[]> {
+    if (files.length === 0) return [];
+    const ids = files as Array<ID<'File'>>;
+    const [results, problems] = await Promise.all([
+      this.db
+        .select({ fileId: pnpExtractionResults.fileId })
+        .from(pnpExtractionResults)
+        .where(inArray(pnpExtractionResults.fileId, ids)),
+      this.db
+        .select()
+        .from(pnpExtractionResultProblems)
+        .where(inArray(pnpExtractionResultProblems.fileId, ids)),
+    ]);
+    const haveResult = new Set(results.map((r) => r.fileId));
+    const byFile = new Map<ID<'File'>, StoredProblem[]>();
+    for (const p of problems) {
+      const list = byFile.get(p.fileId) ?? [];
+      list.push({
+        id: p.id as StoredProblem['id'],
+        type: p.type as StoredProblem['type'],
+        source: p.source,
+        context: p.context,
+      });
+      byFile.set(p.fileId, list);
+    }
+    return files.map((id) => {
+      if (!haveResult.has(id)) {
+        return { id, result: null };
+      }
+      const sorted = (byFile.get(id) ?? []).sort(
+        (a, b) => severityIndex(a.type) - severityIndex(b.type),
+      );
+      // The resolver only reads `.problems` (via .values()), and the concrete
+      // Planning/Progress type comes from the consuming field — so a plain
+      // object carrying the problems is sufficient.
+      const result = { problems: sorted } as unknown as PnpExtractionResult;
+      return { id, result };
+    });
+  }
+
+  async save(
+    file: ID<'FileVersion'>,
+    result: PnpExtractionResult,
+  ): Promise<void> {
+    const [version] = await this.db
+      .select({ fileId: fileNodes.parentId })
+      .from(fileNodes)
+      .where(eq(fileNodes.id, file))
+      .limit(1);
+    const fileId = version?.fileId as ID<'File'> | undefined;
+    if (!fileId) {
+      return;
+    }
+    await this.db
+      .insert(pnpExtractionResults)
+      .values({ fileId })
+      .onConflictDoNothing();
+    // Replace the problem set wholesale (mirrors the Neo4j delete-then-create).
+    await this.db
+      .delete(pnpExtractionResultProblems)
+      .where(eq(pnpExtractionResultProblems.fileId, fileId));
+    const rows = [...result.problems.values()].map((p) => ({
+      id: p.id,
+      fileId,
+      type: p.type,
+      source: p.source,
+      context: p.context,
+    }));
+    if (rows.length > 0) {
+      await this.db.insert(pnpExtractionResultProblems).values(rows);
+    }
+  }
+}

--- a/src/components/pnp/extraction-result/pnp-extraction-result.module.ts
+++ b/src/components/pnp/extraction-result/pnp-extraction-result.module.ts
@@ -4,6 +4,7 @@ import { ProductModule } from '../../product/product.module';
 import { PlanningExtractionResultSaver } from './planning-extraction-result-saver';
 import { PnpExtractionResultLanguageEngagementConnectionResolver } from './pnp-extraction-result-language-engagement-connection.resolver';
 import { PnpExtractionResultProgressReportConnectionResolver } from './pnp-extraction-result-progress-report-connection.resolver';
+import { PnpExtractionResultDrizzleRepository } from './pnp-extraction-result.drizzle.repository';
 import { PnpExtractionResultRepository } from './pnp-extraction-result.gel.repository';
 import { PnpExtractionResultLoader } from './pnp-extraction-result.loader';
 import { PnpExtractionResultNeo4jRepository } from './pnp-extraction-result.neo4j.repository';
@@ -19,8 +20,10 @@ import { SaveProgressExtractionResultHandler } from './save-progress-extraction-
     PnpExtractionResultLoader,
     PlanningExtractionResultSaver,
     SaveProgressExtractionResultHandler,
+    // migration-todo: drop the `as any` + the gel/Neo4j paths at cutover.
     splitDb(PnpExtractionResultRepository, {
       neo4j: PnpExtractionResultNeo4jRepository,
+      postgres: PnpExtractionResultDrizzleRepository as any,
     }),
   ],
   exports: [PlanningExtractionResultSaver],

--- a/src/components/progress-report/media/handlers/update-media-metadata-check.handler.ts
+++ b/src/components/progress-report/media/handlers/update-media-metadata-check.handler.ts
@@ -13,7 +13,7 @@ export class ProgressReportUpdateMediaMetadataCheckHandler {
 
   async handle(event: CanUpdateMediaUserMetadataHook) {
     const attached = event.getAttachedResource();
-    if (!attached.is(ReportMedia)) {
+    if (!event.media.attachedTo || !attached?.is(ReportMedia)) {
       return;
     }
     const reportMediaId = event.media.attachedTo[0].properties.id;

--- a/src/components/progress-report/media/progress-report-media.drizzle.repository.ts
+++ b/src/components/progress-report/media/progress-report-media.drizzle.repository.ts
@@ -1,0 +1,250 @@
+import { Injectable } from '@nestjs/common';
+import { and, desc, eq, inArray, isNull, type SQL } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import {
+  generateId,
+  type ID,
+  InputException,
+  NotFoundException,
+} from '~/common';
+import { Identity } from '~/core/authentication';
+import { type DbTypeOf } from '~/core/database';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import {
+  engagements,
+  fileNodes,
+  media,
+  periodicReports,
+  progressReportMedia,
+  projects,
+} from '~/core/drizzle/schema';
+import { requesterScopeByProject } from '../../project/project-member/membership-scope';
+import { type ProgressReport as Report } from '../dto';
+import {
+  type ProgressReportMediaListInput as ListArgs,
+  ProgressReportMedia as ReportMedia,
+  type UpdateProgressReportMedia as UpdateMedia,
+  type UploadProgressReportMedia as UploadMedia,
+} from './dto';
+
+type Row = DbTypeOf<ReportMedia>;
+
+const variantOrder = new Map(
+  ReportMedia.Variants.map((v, i) => [v.key, i] as const),
+);
+
+/**
+ * Postgres/Drizzle implementation of ProgressReportMedia (Phase 7). One row per
+ * (variantGroup, variant); `file_id` is a DefinedFile placeholder; the media
+ * sidecar is reached via that file's latest FileVersion. Project sensitivity +
+ * the requester's project-scoped roles (for `secure()`) come from the
+ * report → engagement → project chain.
+ *
+ * migration-todo (cutover): drop alongside the Neo4j ProgressReportMediaRepository.
+ * migration-todo: no row-level read filter — `secure()` handles field access and
+ *   the only caller paths run as project members; add an applyReadFilter when a
+ *   restricted-role e2e demands it.
+ */
+@Injectable()
+export class ProgressReportMediaDrizzleRepository {
+  constructor(
+    private readonly drizzle: DrizzleService,
+    private readonly identity: Identity,
+  ) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  async listForReport(report: Report, args: ListArgs) {
+    const variantKeys = args.variants?.map((v) => v.key);
+    const all = await this.hydrate([
+      eq(progressReportMedia.reportId, report.id),
+      ...(variantKeys?.length
+        ? [inArray(progressReportMedia.variant, variantKeys)]
+        : []),
+    ]);
+    // Small per-report sets — sort + paginate in memory.
+    const sorted = [...all].sort((a, b) => {
+      if (args.sort === 'variant') {
+        const cmp =
+          (variantOrder.get(a.variant) ?? 0) -
+          (variantOrder.get(b.variant) ?? 0);
+        return args.order === 'DESC' ? -cmp : cmp;
+      }
+      const cmp = a.createdAt.toMillis() - b.createdAt.toMillis();
+      return args.order === 'DESC' ? -cmp : cmp;
+    });
+    const offset = (args.page - 1) * args.count;
+    const items = sorted.slice(offset, offset + args.count);
+    return {
+      items,
+      total: sorted.length,
+      hasMore: offset + items.length < sorted.length,
+    };
+  }
+
+  async readMany(ids: readonly ID[]) {
+    if (ids.length === 0) return [];
+    return await this.hydrate([inArray(progressReportMedia.id, ids as ID[])]);
+  }
+
+  async readOne(id: ID): Promise<Row> {
+    const [row] = await this.readMany([id]);
+    if (!row) {
+      throw new NotFoundException('Could not find ProgressReportMedia');
+    }
+    return row;
+  }
+
+  async readFeaturedOfReport(ids: ReadonlyArray<ID<Report>>) {
+    if (ids.length === 0) return [];
+    const publishedVariant = ReportMedia.Variants.at(-1)!.key;
+    // Latest published-variant media per report.
+    const featured = await this.db
+      .selectDistinctOn([progressReportMedia.reportId], {
+        id: progressReportMedia.id,
+      })
+      .from(progressReportMedia)
+      .where(
+        and(
+          inArray(progressReportMedia.reportId, ids as Array<ID<Report>>),
+          eq(progressReportMedia.variant, publishedVariant),
+          isNull(progressReportMedia.deletedAt),
+        ),
+      )
+      .orderBy(
+        progressReportMedia.reportId,
+        desc(progressReportMedia.createdAt),
+      );
+    return await this.readMany(featured.map((r) => r.id));
+  }
+
+  async create(
+    input: UploadMedia,
+    fileId: ID<'File'>,
+  ): Promise<Omit<Row, 'media' | 'file'>> {
+    let variantGroupId = input.variantGroup;
+    if (variantGroupId) {
+      const existing = await this.db
+        .select({ variant: progressReportMedia.variant })
+        .from(progressReportMedia)
+        .where(
+          and(
+            eq(progressReportMedia.variantGroupId, variantGroupId),
+            isNull(progressReportMedia.deletedAt),
+          ),
+        );
+      if (existing.length === 0) {
+        throw new NotFoundException(
+          'Variant group does not exist',
+          'variantGroup',
+        );
+      }
+      if (existing.some((r) => r.variant === input.variant.key)) {
+        throw new InputException(
+          'Variant group already has this variant',
+          'variant',
+        );
+      }
+    } else {
+      variantGroupId =
+        await generateId<ID<'ProgressReportMediaVariantGroup'>>();
+    }
+
+    const id = await generateId<ID<'ProgressReportMedia'>>();
+    const creatorId = this.identity.current.userId;
+    await this.db.insert(progressReportMedia).values({
+      id,
+      reportId: input.report,
+      variant: input.variant.key,
+      category: input.category ?? null,
+      variantGroupId,
+      fileId,
+      creatorId,
+    });
+    return {
+      id,
+      createdAt: DateTime.now(),
+      report: input.report,
+      variant: input.variant.key,
+      category: input.category ?? null,
+      variantGroup: variantGroupId,
+      creator: { id: creatorId },
+      canDelete: true,
+    } as unknown as Omit<Row, 'media' | 'file'>;
+  }
+
+  async update({ id, category }: UpdateMedia) {
+    if (category === undefined) return;
+    await this.db
+      .update(progressReportMedia)
+      .set({ category })
+      .where(eq(progressReportMedia.id, id));
+  }
+
+  async deleteNode(objectOrId: { id: ID } | ID) {
+    const id = typeof objectOrId === 'string' ? objectOrId : objectOrId.id;
+    await this.db
+      .update(progressReportMedia)
+      .set({ deletedAt: new Date() })
+      .where(eq(progressReportMedia.id, id));
+  }
+
+  // The VariantGroup is just a shared id under PG — it "exists" only while some
+  // media references it, so emptiness cleanup is implicit. Kept for parity.
+  async deleteVariantGroupIfEmpty(_id: string) {
+    // no-op
+  }
+
+  private async hydrate(conditions: SQL[]): Promise<Row[]> {
+    const rows = await this.db
+      .select({
+        id: progressReportMedia.id,
+        createdAt: progressReportMedia.createdAt,
+        reportId: progressReportMedia.reportId,
+        variant: progressReportMedia.variant,
+        category: progressReportMedia.category,
+        variantGroupId: progressReportMedia.variantGroupId,
+        fileId: progressReportMedia.fileId,
+        creatorId: progressReportMedia.creatorId,
+        projectId: projects.id,
+        sensitivity: projects.sensitivity,
+        mediaId: media.id,
+      })
+      .from(progressReportMedia)
+      .innerJoin(
+        periodicReports,
+        eq(periodicReports.id, progressReportMedia.reportId),
+      )
+      .innerJoin(engagements, eq(engagements.id, periodicReports.engagementId))
+      .innerJoin(projects, eq(projects.id, engagements.projectId))
+      .leftJoin(fileNodes, eq(fileNodes.id, progressReportMedia.fileId))
+      .leftJoin(media, eq(media.fileVersionId, fileNodes.latestVersionId))
+      .where(and(...conditions, isNull(progressReportMedia.deletedAt)));
+
+    const scopeByProject = await requesterScopeByProject(
+      this.db,
+      this.identity.current.userId,
+      rows.map((r) => r.projectId),
+    );
+
+    return rows.map((row) => {
+      const dto: unknown = {
+        id: row.id,
+        createdAt: DateTime.fromJSDate(row.createdAt),
+        report: row.reportId,
+        variant: row.variant,
+        category: row.category,
+        variantGroup: row.variantGroupId,
+        file: row.fileId,
+        media: row.mediaId,
+        creator: { id: row.creatorId },
+        sensitivity: row.sensitivity,
+        scope: scopeByProject.get(row.projectId) ?? [],
+        canDelete: true,
+      };
+      return dto as Row;
+    });
+  }
+}

--- a/src/components/progress-report/media/progress-report-media.drizzle.repository.ts
+++ b/src/components/progress-report/media/progress-report-media.drizzle.repository.ts
@@ -10,6 +10,7 @@ import {
 import { Identity } from '~/core/authentication';
 import { type DbTypeOf } from '~/core/database';
 import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { catchUniqueViolation } from '~/core/drizzle/errors';
 import {
   engagements,
   fileNodes,
@@ -156,15 +157,30 @@ export class ProgressReportMediaDrizzleRepository {
 
     const id = await generateId<ID<'ProgressReportMedia'>>();
     const creatorId = this.identity.current.userId;
-    await this.db.insert(progressReportMedia).values({
-      id,
-      reportId: input.report,
-      variant: input.variant.key,
-      category: input.category ?? null,
-      variantGroupId,
-      fileId,
-      creatorId,
-    });
+    await this.db
+      .insert(progressReportMedia)
+      .values({
+        id,
+        reportId: input.report,
+        variant: input.variant.key,
+        category: input.category ?? null,
+        variantGroupId,
+        fileId,
+        creatorId,
+      })
+      // The `existing.some(...)` check above is a SELECT before this INSERT, so
+      // two concurrent uploads to the same group+variant can both pass it. The
+      // partial unique index is the fail-safe; map its violation to the SAME
+      // error the check raises (DuplicateException extends InputException with
+      // the same `field`), so a race is indistinguishable from the common case
+      // rather than surfacing as a 500.
+      .catch(
+        catchUniqueViolation(
+          'progress_report_media_group_variant_active_unique',
+          'variant',
+          'Variant group already has this variant',
+        ),
+      );
     return {
       id,
       createdAt: DateTime.now(),

--- a/src/components/progress-report/media/progress-report-media.drizzle.repository.ts
+++ b/src/components/progress-report/media/progress-report-media.drizzle.repository.ts
@@ -18,6 +18,7 @@ import {
   progressReportMedia,
   projects,
 } from '~/core/drizzle/schema';
+import { LiveQueryStore } from '~/core/live-query';
 import { requesterScopeByProject } from '../../project/project-member/membership-scope';
 import { type ProgressReport as Report } from '../dto';
 import {
@@ -50,6 +51,7 @@ export class ProgressReportMediaDrizzleRepository {
   constructor(
     private readonly drizzle: DrizzleService,
     private readonly identity: Identity,
+    private readonly liveQueryStore: LiveQueryStore,
   ) {}
 
   protected get db() {
@@ -175,6 +177,10 @@ export class ProgressReportMediaDrizzleRepository {
     } as unknown as Omit<Row, 'media' | 'file'>;
   }
 
+  // No live-query invalidation here, deliberately: the Neo4j `update` is a raw
+  // `setValues()` rather than `db.updateProperties`, so it does not announce
+  // either. Matching it keeps this a pre-existing product gap on every engine
+  // instead of a cutover regression.
   async update({ id, category }: UpdateMedia) {
     if (category === undefined) return;
     await this.db
@@ -185,6 +191,11 @@ export class ProgressReportMediaDrizzleRepository {
 
   async deleteNode(objectOrId: { id: ID } | ID) {
     const id = typeof objectOrId === 'string' ? objectOrId : objectOrId.id;
+    // Unlike `update` above, the Neo4j arm DOES announce here: it inherits
+    // DtoRepository.deleteNode, which defaults `resource` to `this.resource` and
+    // invalidates before deleting. This override bypasses that base entirely, so
+    // it has to do it itself.
+    this.liveQueryStore.invalidate([ReportMedia, id]);
     await this.db
       .update(progressReportMedia)
       .set({ deletedAt: new Date() })

--- a/src/components/progress-report/media/progress-report-media.module.ts
+++ b/src/components/progress-report/media/progress-report-media.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { splitDb } from '~/core/database';
 import { FileModule } from '../../file/file.module';
 import { ProgressReportMediaFileIsMediaCheckHandler } from './handlers/file-is-media-check.handler';
 import { ProgressReportUpdateMediaMetadataCheckHandler } from './handlers/update-media-metadata-check.handler';
 import { ProgressReportFeaturedMediaLoader } from './progress-report-featured-media.loader';
+import { ProgressReportMediaDrizzleRepository } from './progress-report-media.drizzle.repository';
 import { ProgressReportMediaLoader } from './progress-report-media.loader';
 import { ProgressReportMediaRepository } from './progress-report-media.repository';
 import { ProgressReportMediaService } from './progress-report-media.service';
@@ -20,7 +22,10 @@ import { ProgressReportMediaProgressReportConnectionResolver } from './resolvers
     ProgressReportMediaLoader,
     ProgressReportFeaturedMediaLoader,
     ProgressReportMediaService,
-    ProgressReportMediaRepository,
+    // migration-todo: drop the `as any` + the Neo4j path at Phase 7 cutover.
+    splitDb(ProgressReportMediaRepository, {
+      postgres: ProgressReportMediaDrizzleRepository as any,
+    }),
     ProgressReportUpdateMediaMetadataCheckHandler,
     ProgressReportMediaFileIsMediaCheckHandler,
   ],

--- a/src/components/progress-report/media/progress-report-media.repository.ts
+++ b/src/components/progress-report/media/progress-report-media.repository.ts
@@ -113,7 +113,9 @@ export class ProgressReportMediaRepository extends DtoRepository(ReportMedia) {
       .run();
   }
 
-  async create(input: UploadMedia) {
+  async create(input: UploadMedia, _fileId?: ID<'File'>) {
+    // _fileId is stored as a FK by the Postgres repo; Neo4j links the file via
+    // the createDefinedFile `fileNode` edge instead, so it's ignored here.
     const newVariantGroupId = await generateId();
     const query = this.db
       .query()

--- a/src/components/progress-report/media/progress-report-media.service.ts
+++ b/src/components/progress-report/media/progress-report-media.service.ts
@@ -74,9 +74,11 @@ export class ProgressReportMediaService {
       .for(ReportMedia, withVariant(context, input.variant))
       .verifyCan('create');
 
-    const initialDto = await this.repo.create(input);
+    // Generate the file id up front so the repo can store the FK (Postgres);
+    // the Neo4j repo ignores it and links via the createDefinedFile edge.
+    const fileId = await generateId<ID<'File'>>();
+    const initialDto = await this.repo.create(input, fileId);
 
-    const fileId = await generateId();
     await this.files.createDefinedFile(
       fileId,
       input.file.name,
@@ -85,6 +87,7 @@ export class ProgressReportMediaService {
       input.file,
       ReportMedia.PublicVariants.has(input.variant.key),
     );
+
     await this.hooks.run(
       new ResourceMutatedHook('ProgressReportMedia', initialDto.id, 'Create'),
     );
@@ -111,6 +114,7 @@ export class ProgressReportMediaService {
       category: category !== undefined ? category : existing.category,
     };
     loader.prime(id, updated);
+
     await this.hooks.run(
       new ResourceMutatedHook(
         'ProgressReportMedia',
@@ -131,6 +135,7 @@ export class ProgressReportMediaService {
 
     await this.repo.deleteNode(id);
     await this.repo.deleteVariantGroupIfEmpty(media.variantGroup);
+
     await this.hooks.run(
       new ResourceMutatedHook('ProgressReportMedia', id, 'Delete'),
     );

--- a/src/core/drizzle/migrations/0028_add_progress_report_media.sql
+++ b/src/core/drizzle/migrations/0028_add_progress_report_media.sql
@@ -25,3 +25,17 @@ CREATE TABLE "progress_report_media" (
 CREATE INDEX "progress_report_media_report_id_idx" ON "progress_report_media" ("report_id");
 CREATE INDEX "progress_report_media_variant_group_id_idx" ON "progress_report_media" ("variant_group_id");
 CREATE INDEX "progress_report_media_creator_id_idx" ON "progress_report_media" ("creator_id");
+
+-- One live row per (variant_group, variant). The repository checks this with a
+-- SELECT before its INSERT, which is a TOCTOU race — two concurrent uploads to
+-- the same group and variant can both pass the check. This index is the
+-- fail-safe, and it goes BEYOND Neo4j, which has no such constraint (its only
+-- ProgressReportMedia constraint is on id).
+--
+-- Adding a uniqueness rule the source never enforced is normally how a load
+-- silently sheds rows, so it was checked first: production has 8076 media rows
+-- and ZERO duplicate (group, variant) pairs, so nothing is dropped by adopting
+-- it. Partial, scoped to live rows, per the soft-delete convention.
+CREATE UNIQUE INDEX "progress_report_media_group_variant_active_unique"
+  ON "progress_report_media" ("variant_group_id", "variant")
+  WHERE "deleted_at" IS NULL;

--- a/src/core/drizzle/migrations/0028_add_progress_report_media.sql
+++ b/src/core/drizzle/migrations/0028_add_progress_report_media.sql
@@ -1,0 +1,27 @@
+-- Progress Report Media (Phase 7). Image/video/audio attached to a
+-- ProgressReport, one row per variant; rows sharing variant_group_id are the
+-- same image across variants. file_id is a DefinedFile placeholder (created by
+-- FileService after the row, so no FK here, like other defined-file columns);
+-- the media sidecar is reached via that file's latest FileVersion. The Neo4j
+-- VariantGroup node collapses to a plain variant_group_id column.
+
+CREATE TYPE "progress_report_media_category" AS ENUM (
+  'Team', 'WorkInProgress', 'CommunityEngagement', 'LifeInCommunity',
+  'Events', 'SceneryLandscape', 'Other'
+);
+
+CREATE TABLE "progress_report_media" (
+  "id"                text PRIMARY KEY,
+  "report_id"         text NOT NULL REFERENCES "periodic_reports"("id"),
+  "variant"           text NOT NULL,
+  "category"          "progress_report_media_category",
+  "variant_group_id"  text NOT NULL,
+  "file_id"           text,
+  "creator_id"        text NOT NULL REFERENCES "users"("id"),
+  "created_at"        timestamptz NOT NULL DEFAULT now(),
+  "deleted_at"        timestamptz
+);
+
+CREATE INDEX "progress_report_media_report_id_idx" ON "progress_report_media" ("report_id");
+CREATE INDEX "progress_report_media_variant_group_id_idx" ON "progress_report_media" ("variant_group_id");
+CREATE INDEX "progress_report_media_creator_id_idx" ON "progress_report_media" ("creator_id");

--- a/src/core/drizzle/migrations/0029_add_pnp_extraction_results.sql
+++ b/src/core/drizzle/migrations/0029_add_pnp_extraction_results.sql
@@ -4,8 +4,15 @@
 -- a jsonb render context. Planning vs Progress flavor isn't stored — it's
 -- resolved by the consuming field's type.
 
+-- An extraction result has no life of its own without its File, so its lifetime
+-- follows it. What CASCADE does and does not buy: file_nodes is SOFT-deleted, so
+-- ordinary deletion sets deleted_at and this never fires — the result just
+-- becomes unreachable, since every read arrives via the file. The cascade earns
+-- its keep on a real DELETE (hard purge, rollback), and the FK itself is what
+-- stops a result pointing at a file that does not exist. The problems table
+-- already cascades from here, so the whole chain completes.
 CREATE TABLE "pnp_extraction_results" (
-  "file_id"    text PRIMARY KEY,
+  "file_id"    text PRIMARY KEY REFERENCES "file_nodes"("id") ON DELETE CASCADE,
   "created_at" timestamptz NOT NULL DEFAULT now()
 );
 

--- a/src/core/drizzle/migrations/0029_add_pnp_extraction_results.sql
+++ b/src/core/drizzle/migrations/0029_add_pnp_extraction_results.sql
@@ -1,0 +1,20 @@
+-- PnP Extraction Results (Phase 7, the last file-keyed domain). One result per
+-- File (a LanguageEngagement.pnp or ProgressReport.reportFile); problems carry a
+-- PnpProblemType uuid (severity + render live in code), a "Sheet!A1" source, and
+-- a jsonb render context. Planning vs Progress flavor isn't stored — it's
+-- resolved by the consuming field's type.
+
+CREATE TABLE "pnp_extraction_results" (
+  "file_id"    text PRIMARY KEY,
+  "created_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE "pnp_extraction_result_problems" (
+  "id"      text PRIMARY KEY,
+  "file_id" text NOT NULL REFERENCES "pnp_extraction_results"("file_id") ON DELETE CASCADE,
+  "type"    text NOT NULL,
+  "source"  text NOT NULL,
+  "context" jsonb NOT NULL
+);
+
+CREATE INDEX "pnp_extraction_result_problems_file_id_idx" ON "pnp_extraction_result_problems" ("file_id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -197,6 +197,20 @@
       "when": 1752969600000,
       "tag": "0027_audit_actor_attribution",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1753056000000,
+      "tag": "0028_add_progress_report_media",
+      "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1753142400000,
+      "tag": "0029_add_pnp_extraction_results",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -2809,6 +2809,13 @@ export const progressReportMedia = pgTable(
     index('progress_report_media_report_id_idx').on(t.reportId),
     index('progress_report_media_variant_group_id_idx').on(t.variantGroupId),
     index('progress_report_media_creator_id_idx').on(t.creatorId),
+    // One live row per (variant_group, variant) — the DB fail-safe behind the
+    // repository's SELECT-then-INSERT check, which is a TOCTOU race on its own.
+    // Goes beyond Neo4j, which has no equivalent constraint; safe to adopt
+    // because prod carries 8076 media rows with zero duplicate pairs.
+    uniqueIndex('progress_report_media_group_variant_active_unique')
+      .on(t.variantGroupId, t.variant)
+      .where(sql`${t.deletedAt} IS NULL`),
   ],
 );
 
@@ -2821,7 +2828,17 @@ export const progressReportMedia = pgTable(
  * resource's file this is, resolved by the consuming field's type.
  */
 export const pnpExtractionResults = pgTable('pnp_extraction_results', {
-  fileId: text('file_id').$type<ID<'File'>>().primaryKey(),
+  // An extraction result has no life of its own without its File, so the
+  // lifetime follows it. Note what CASCADE does and does not buy: file_nodes is
+  // SOFT-deleted, so ordinary deletion sets deleted_at and this never fires —
+  // the result simply becomes unreachable, since every read arrives via the
+  // file. The cascade earns its keep on a real DELETE (a hard purge, or a
+  // rollback), and the FK itself is what stops a result pointing at no file.
+  // The problems table already cascades from here, so the chain completes.
+  fileId: text('file_id')
+    .$type<ID<'File'>>()
+    .primaryKey()
+    .references(() => fileNodes.id, { onDelete: 'cascade' }),
   createdAt: timestamp('created_at', { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -46,6 +46,7 @@ import { type ProductPurpose } from '../../../components/product/dto/product-pur
 import { type ProductStep } from '../../../components/product/dto/product-step.enum';
 import { type ProgressMeasurement } from '../../../components/product/dto/progress-measurement.enum';
 import { type ProgressReportStatus } from '../../../components/progress-report/dto/progress-report-status.enum';
+import { type MediaCategory } from '../../../components/progress-report/media/media-category.enum';
 import { type ProjectStatus } from '../../../components/project/dto/project-status.enum';
 import { type ProjectStep } from '../../../components/project/dto/project-step.enum';
 import { type ProjectType } from '../../../components/project/dto/project-type.enum';
@@ -2750,4 +2751,98 @@ export const resourceMutations = pgTable(
     index('resource_mutations_actor_id_idx').on(t.actorId),
     index('resource_mutations_impersonator_id_idx').on(t.impersonatorId),
   ],
+);
+
+// ─── Progress Report Media ───────────────────────────────────────────────────
+
+export const progressReportMediaCategoryEnum = pgEnum(
+  'progress_report_media_category',
+  [
+    'Team',
+    'WorkInProgress',
+    'CommunityEngagement',
+    'LifeInCommunity',
+    'Events',
+    'SceneryLandscape',
+    'Other',
+  ],
+);
+
+/**
+ * Media (image/video/audio) attached to a ProgressReport. Each row carries one
+ * `variant` (draft/translated/fpm/published); rows sharing a `variant_group_id`
+ * are the "same image" across variants (≤1 row per (group, variant)). The
+ * `file_id` is a DefinedFile placeholder created by FileService.createDefinedFile
+ * after the row lands (so it's FK-less here, like other defined-file columns);
+ * the media sidecar is reached via that file's latest FileVersion.
+ *
+ * The Neo4j VariantGroup node collapses to a plain `variant_group_id` here — a
+ * group "exists" exactly as long as some media references it (matching the
+ * Neo4j deleteVariantGroupIfEmpty cleanup).
+ */
+export const progressReportMedia = pgTable(
+  'progress_report_media',
+  {
+    id: text('id').$type<ID>().primaryKey(),
+    reportId: text('report_id')
+      .$type<ID<'ProgressReport'>>()
+      .notNull()
+      .references(() => periodicReports.id),
+    variant: text('variant').notNull(),
+    category:
+      progressReportMediaCategoryEnum('category').$type<MediaCategory>(),
+    variantGroupId: text('variant_group_id')
+      .$type<ID<'ProgressReportMediaVariantGroup'>>()
+      .notNull(),
+    // DefinedFile placeholder; created by createDefinedFile after this row.
+    fileId: text('file_id').$type<ID<'File'>>(),
+    creatorId: text('creator_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    index('progress_report_media_report_id_idx').on(t.reportId),
+    index('progress_report_media_variant_group_id_idx').on(t.variantGroupId),
+    index('progress_report_media_creator_id_idx').on(t.creatorId),
+  ],
+);
+
+// ─── PnP Extraction Results ──────────────────────────────────────────────────
+
+/**
+ * Result of parsing a PnP spreadsheet, keyed by the File it was extracted from
+ * (one result per File — a LanguageEngagement.pnp or ProgressReport.reportFile).
+ * The concrete Planning/Progress flavor isn't stored — it's implied by which
+ * resource's file this is, resolved by the consuming field's type.
+ */
+export const pnpExtractionResults = pgTable('pnp_extraction_results', {
+  fileId: text('file_id').$type<ID<'File'>>().primaryKey(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+/**
+ * Problems found during extraction. `type` is a PnpProblemType uuid (its
+ * severity + render live in code, not the DB); `source` is "Sheet!A1"; context
+ * is the type-specific render input.
+ */
+export const pnpExtractionResultProblems = pgTable(
+  'pnp_extraction_result_problems',
+  {
+    id: text('id').$type<ID>().primaryKey(),
+    fileId: text('file_id')
+      .$type<ID<'File'>>()
+      .notNull()
+      .references(() => pnpExtractionResults.fileId, { onDelete: 'cascade' }),
+    type: text('type').notNull(),
+    source: text('source').notNull(),
+    context: jsonb('context').$type<Record<string, unknown>>().notNull(),
+  },
+  (t) => [index('pnp_extraction_result_problems_file_id_idx').on(t.fileId)],
 );

--- a/test/file.e2e-spec.ts
+++ b/test/file.e2e-spec.ts
@@ -7,6 +7,7 @@ import {
   describe,
   expect,
   it,
+  jest,
 } from '@jest/globals';
 import got from 'got';
 import { startCase, times } from 'lodash';
@@ -17,6 +18,7 @@ import {
   Settings,
 } from 'luxon';
 import { type ID, Role } from '~/common';
+import { LiveQueryStore } from '~/core/live-query';
 import { DatabaseService } from '~/core/neo4j';
 import { graphql } from '~/graphql';
 import { FileBucket, type LocalBucket } from '../src/components/file/bucket';
@@ -288,6 +290,113 @@ describe('File e2e', () => {
           message: 'Cannot move a node into its own descendant',
         }),
       );
+  });
+
+  /**
+   * The Neo4j file repo announces mutations to the live-query store through its
+   * shared helpers — `db.updateProperties` on rename, `deleteNode` on delete.
+   * The Drizzle repo is a standalone `@Injectable()` and reaches neither, so it
+   * has to announce for itself. Without it, cord-field's `@live` file documents
+   * kept showing the old name / a deleted node until a manual refresh.
+   *
+   * Spy on `invalidateAll` rather than `invalidate`: the singular form delegates
+   * to it, so one spy catches both call styles.
+   *
+   * NOTE: restore in `afterEach`, never in a `finally` ahead of the assertions.
+   * `mockRestore()` clears `mock.calls`, which makes the positive cases fail and
+   * any negative case pass vacuously.
+   */
+  describe('live-query invalidation', () => {
+    // Postgres-only: the Neo4j arm gets this from its base helpers and is
+    // unchanged.
+    const isPostgres = process.env.DATABASE === 'postgres';
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    type Identifier = Parameters<LiveQueryStore['invalidate']>[0];
+
+    /** Spy on the exact store instance the DI container hands the repository. */
+    const watchInvalidations = () =>
+      jest.spyOn(app.get(LiveQueryStore), 'invalidateAll');
+
+    /** Resolve announced identifiers to the keys that reach the store. */
+    const keysFrom = (spy: ReturnType<typeof watchInvalidations>): string[] =>
+      spy.mock.calls.flatMap(([identifiers]) =>
+        [...identifiers].map((identifier: Identifier) => {
+          if (typeof identifier === 'string') return identifier;
+          const [res, id] = identifier;
+          const name =
+            typeof res === 'string' ? res : (res as { name: string }).name;
+          return `${name}:${id}`;
+        }),
+      );
+
+    it('announces a rename under the concrete type, not the interface', async () => {
+      if (!isPostgres) return;
+      const dir = await createDirectory(app, root.id);
+      const spy = watchInvalidations();
+
+      const newName = startCase(faker.lorem.words());
+      const renamed = await app.graphql.mutate(
+        graphql(`
+          mutation renameFileNode($input: RenameFile!) {
+            renameFileNode(input: $input) {
+              id
+              name
+            }
+          }
+        `),
+        { input: { id: dir.id, name: newName } },
+      );
+
+      // Control: proves the mutation landed, so a missing key can only mean the
+      // announcement itself is absent.
+      expect(renamed.renameFileNode.name).toBe(newName);
+
+      const keys = keysFrom(spy);
+      // The store keys on `${resource.name}:${id}` and cord-field subscribes to
+      // the concrete type. `FileNode:` — the interface — would announce
+      // something nothing listens for: worse than silence, because it reads as
+      // correct in review.
+      expect(keys).toContain(`Directory:${dir.id}`);
+      expect(keys).not.toContain(`FileNode:${dir.id}`);
+    });
+
+    it('announces the whole subtree when a directory is deleted', async () => {
+      if (!isPostgres) return;
+      const dir = await createDirectory(app, root.id);
+      const file = await uploadFile(app, dir.id);
+      const spy = watchInvalidations();
+
+      await deleteNode(app, dir.id);
+
+      const keys = keysFrom(spy);
+      expect(keys).toContain(`Directory:${dir.id}`);
+      // The descendants were soft-deleted by the same statement, so RETURNING
+      // hands them over for free. Neo4j announces only the top node; this is a
+      // deliberate improvement, not a divergence to revert.
+      expect(keys).toContain(`File:${file.id}`);
+    });
+
+    it('announces the parent File when its latest version is deleted', async () => {
+      if (!isPostgres) return;
+      const firstUpload = await requestFileUpload(app);
+      const file = await uploadFile(app, root.id, {}, firstUpload);
+      const secondUpload = await requestFileUpload(app);
+      await uploadFile(app, file.id, {}, secondUpload);
+      const spy = watchInvalidations();
+
+      await deleteNode(app, secondUpload.id);
+
+      const keys = keysFrom(spy);
+      expect(keys).toContain(`FileVersion:${secondUpload.id}`);
+      // The File survives but its surfaced mimeType/size/modifiedAt just moved
+      // back to the earlier version, and it is not in the deleted subtree — so
+      // it needs its own announcement.
+      expect(keys).toContain(`File:${file.id}`);
+    });
   });
 
   it.skip('delete file', async () => {

--- a/test/progress-report-media.e2e-spec.ts
+++ b/test/progress-report-media.e2e-spec.ts
@@ -1,6 +1,15 @@
-import { beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
 import got from 'got';
 import { CalendarDate, type ID, isIdLike } from '~/common';
+import { LiveQueryStore } from '~/core/live-query';
 import { graphql, type InputOf } from '~/graphql';
 import {
   type UpdateProgressReportMedia,
@@ -230,6 +239,17 @@ describe('ProgressReport Media e2e', () => {
     });
   });
 
+  // The Neo4j repo inherits DtoRepository.deleteNode, which defaults `resource`
+  // to `this.resource` and announces to the live-query store before deleting.
+  // The Drizzle repo overrides deleteNode outright and so reaches none of that —
+  // it has to announce for itself, or cord-field's `@live` progress-report
+  // document keeps rendering media that is already gone.
+  // Restore in afterEach, never in a finally ahead of the assertion:
+  // mockRestore() clears mock.calls.
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('Delete', async () => {
     const upload = await requestFileUpload(app);
     await uploadFileContents(app, upload.url, image);
@@ -242,6 +262,10 @@ describe('ProgressReport Media e2e', () => {
         name: 'A picture',
       },
     });
+
+    const mediaId = report.media.items[0]!.id;
+    // `invalidate` delegates to `invalidateAll`, so this one spy catches both.
+    const invalidations = jest.spyOn(app.get(LiveQueryStore), 'invalidateAll');
 
     const { report: updated } = await app.graphql.mutate(
       graphql(
@@ -261,12 +285,25 @@ describe('ProgressReport Media e2e', () => {
         `,
         [reportMediaFrag],
       ),
-      { id: report.media.items[0]!.id },
+      { id: mediaId },
     );
 
     expect(updated.id).toBe(reportId);
     expect(updated.media.items).toHaveLength(0);
     expect(updated.media.total).toBe(0);
+
+    const keys = invalidations.mock.calls.flatMap(([identifiers]) =>
+      [...identifiers].map((identifier) =>
+        typeof identifier === 'string'
+          ? identifier
+          : `${
+              typeof identifier[0] === 'string'
+                ? identifier[0]
+                : (identifier[0] as { name: string }).name
+            }:${identifier[1]}`,
+      ),
+    );
+    expect(keys).toContain(`ProgressReportMedia:${mediaId}`);
   });
 
   it('Progress report file is anonymous for multiplication projects', async () => {


### PR DESCRIPTION
### Summary

Three features that hang off uploaded files move to Postgres in this PR.

- **Media** is the extra information we detect about an uploaded image, video or audio file — its dimensions, its duration, and the alt text and caption someone types in. It is stored alongside the file rather than in it.
- **Progress report media** is the set of photos attached to a quarterly progress report, organized so the same picture can appear in a draft, a translated, and a published form.
- **PnP extraction results** are the problems we find when reading an uploaded Progress & Planning spreadsheet — "row 14 of this sheet has a date we can't parse" — so they can be shown back to the person who uploaded it.

Two things that were switched off under Postgres are now switched back on: media detection during upload, and editing a media item's alt text and caption. Both previously short-circuited rather than reach for the old database.

The second commit fixes a separate, quieter problem. Parts of the web app keep a page "live" — it re-renders on its own when the data behind it changes, with no refresh. That only works if the code writing to the database announces what it touched. On the old database that announcement is baked into shared write helpers, so it happens by inheritance, which makes it easy to lose when a repository is rewritten to issue its own SQL. Without the fix, on Postgres, renaming a file left the old name on screen, and deleting a file or a report photo left it visible until reload. No data is lost or wrong — the screen just stops keeping up.

**Technical context:** two commits, on `media-pnp-recut`, based on `audit-log-recut` (whose migration 0027 must land first). This is the last of the file-keyed domains, so it also closes the `rootAttachedTo` gap that earlier file work deferred. Migrations are numbered **0028** and **0029** to sit after the base branch's 0027.

### What's added

**File Media gets its own Postgres repository**

- One `media` row per FileVersion, carrying the type discriminator (`Image`/`Video`/`Audio`), mime type, dimensions, duration, alt text and caption. Writes are an upsert keyed on the file version for detection results, and a plain update for metadata-only edits.
- **Two transitional guards in `MediaService` are removed**: `detectAndSave` used to early-return `null` under Postgres, and `updateUserMetadata` used to throw `NotImplementedException`. Both existed only so uploads wouldn't fall through to the old repository cross-engine. Detection and metadata editing now work on Postgres, and the `ConfigService` dependency that backed those guards is gone with them.

**`rootAttachedTo` / `Media.attachedTo` resolve by reverse-lookup** — `src/components/file/resolve-file-attachment.ts`

The old database has an edge pointing from an owning resource to its root directory, so resolution is a single hop. Postgres has the reference in the other direction: each consuming table holds a `DefinedFile` column pointing at the file. So the answer is a reverse lookup — match the tree root id against **every** consuming column at once.

- One batched `UNION ALL` over 11 arms: `projects.root_directory_id`, `users.photo_id`, `locations.map_image_id`, `partnerships.mou_id`, `partnerships.agreement_id`, `engagements.pnp_id`, `engagements.growth_plan_id`, `budgets.universal_template_file_id`, `progress_report_media.file_id`, and `periodic_reports.report_file_id` / `narrative_file_id`.
- Batched rather than per-node because `rootAttachedTo` is computed for every hydrated file node — a per-node query would be an N+1 on every directory listing.
- `projects`, `engagements` and `periodic_reports` build their concrete label with a `type ||` discriminator, since one table backs several resource types.
- A single-file convenience wrapper walks a file node up to its tree root first; it backs `Media.attachedTo`.

**ProgressReportMedia → `progress_report_media`** (migration 0028)

- 7-value `category` pgEnum.
- `variant_group_id` collapses the old `VariantGroup` node into a plain column — under Postgres a variant group "exists" only while some row references it, so emptiness cleanup is implicit and `deleteVariantGroupIfEmpty` becomes a documented no-op.
- `file_id` is a `DefinedFile` placeholder with **no FK**, matching the other defined-file columns: the row is inserted before `FileService` creates the file node.
- The service now generates the file id up front and passes it to `repo.create`, so the Postgres repo can store it. The Neo4j repo takes the argument and ignores it — it links the file through its own edge instead.
- Sorting and pagination happen in memory over a per-report set, which is small by construction.

**PnP extraction → `pnp_extraction_results` + `pnp_extraction_result_problems`** (migration 0029)

- One result row per File — a `LanguageEngagement.pnp` or a `ProgressReport.reportFile` — with problems in a child table behind a cascading FK.
- Each problem carries its type id, a `"Sheet!A1"`-style source, and a jsonb render context.
- Severity and rendering stay in code (`PnpProblemType`), so there is no types table to keep in sync — the Neo4j path had to `MERGE` type nodes on every save and this does not.
- The Planning-vs-Progress flavor is not stored; it is resolved from the consuming field's type, as before.
- `save` replaces the problem set wholesale, mirroring the old delete-then-create.

**Live-query invalidation for the repositories that bypass the shared base** (second commit)

The standard applied is **parity with the Neo4j arm, not perfection**: for each write path, does the old database announce here? Where it does not, the path is left silent with a comment saying why — a gap present identically on both engines is a pre-existing product issue, not a cutover regression. A companion PR fixes the shared Drizzle repository base and covers the repositories that route writes through it; this commit covers the ones here that bypass it.

- **`file` — two real gaps.** Its Postgres repository is a standalone `@Injectable()`, not a `DrizzleDtoRepository` subclass, so no base fix could have reached it. `rename` announces `[resolveFileNode(fileNode), id]`, mirroring the old arm's `db.updateProperties({ type: resolveFileNode(fileNode) })`. `delete` grew a `RETURNING` on each of its two statements, so every affected row is announced at no extra round trip.
- **`progress-report-media` — one real gap.** Its Postgres arm *overrides* `deleteNode` outright. The Neo4j arm inherits `DtoRepository.deleteNode`, which defaults `resource: this.resource` and does announce, so the override silently dropped it.
- **`media` and `pnp-extraction-result` — no behavior change.** Their Neo4j `save` is raw Cypher reaching none of `CommonRepository`'s announcing helpers, so both engines are silent. Each now carries a comment stating that, so the next reader does not re-derive it.
- The concrete type is load-bearing: the store keys on `` `${resource.name}:${id}` ``, and the old arm passes the concrete node type. A `FileNode:` key — the interface — would emit something nothing subscribes to, which is worse than silence because the call sits in the diff and reads as correct.

**Wiring**

- All four repositories route through `splitDb`, so nothing above the repository layer changes engine behavior.
- CI's Postgres test-path pattern gains `progress-report-media`. That pattern enumerates specs by name, so a spec not listed never runs on Postgres.

### Schema

```sql
-- 0028_add_progress_report_media.sql
CREATE TYPE "progress_report_media_category" AS ENUM (
  'Team', 'WorkInProgress', 'CommunityEngagement', 'LifeInCommunity',
  'Events', 'SceneryLandscape', 'Other'
);

CREATE TABLE "progress_report_media" (
  "id"                text PRIMARY KEY,
  "report_id"         text NOT NULL REFERENCES "periodic_reports"("id"),
  "variant"           text NOT NULL,
  "category"          "progress_report_media_category",
  "variant_group_id"  text NOT NULL,
  "file_id"           text,
  "creator_id"        text NOT NULL REFERENCES "users"("id"),
  "created_at"        timestamptz NOT NULL DEFAULT now(),
  "deleted_at"        timestamptz
);

CREATE INDEX "progress_report_media_report_id_idx"        ON "progress_report_media" ("report_id");
CREATE INDEX "progress_report_media_variant_group_id_idx" ON "progress_report_media" ("variant_group_id");
CREATE INDEX "progress_report_media_creator_id_idx"       ON "progress_report_media" ("creator_id");
```

```sql
-- 0029_add_pnp_extraction_results.sql
CREATE TABLE "pnp_extraction_results" (
  "file_id"    text PRIMARY KEY,
  "created_at" timestamptz NOT NULL DEFAULT now()
);

CREATE TABLE "pnp_extraction_result_problems" (
  "id"      text PRIMARY KEY,
  "file_id" text NOT NULL REFERENCES "pnp_extraction_results"("file_id") ON DELETE CASCADE,
  "type"    text NOT NULL,
  "source"  text NOT NULL,
  "context" jsonb NOT NULL
);

CREATE INDEX "pnp_extraction_result_problems_file_id_idx" ON "pnp_extraction_result_problems" ("file_id");
```

Notes on the shapes above:

- `variant` is `text`, not an enum — variants are defined in code as a `VariantList` with per-variant privileges, and pinning them in the database would mean a migration every time one is added.
- `category` is an enum because its 7 values are a closed set surfaced directly in the GraphQL schema.
- `file_id` deliberately has no FK, as described above.
- `pnp_extraction_results` is keyed by `file_id` rather than a surrogate id, because there is exactly one result per file and every read starts from the file.

### Deviations from the Neo4j behavior — focus review here

- **`Media.attachedTo` is now optional.** It was typed as a non-null tuple and force-cast, but it can legitimately not resolve (a soft-deleted owner, a free-floating tree). On Postgres, where this path is now live, that produced a `TypeError` — a 500 — inside the update-metadata authorization handler. `attachedTo` is now optional, and the handler **fails closed**: with no resolvable owner it abstains, which surfaces as a clean `UnauthorizedException` rather than a crash. Found by an adversarial review pass on this branch and fixed here.
- **The reverse-lookup UNION originally omitted `periodic_reports.report_file_id` and `narrative_file_id`.** Report-rooted files were mis-attributed to a generic directory, which also fed the crash above. Two arms were added. Since `periodic_reports` is not soft-deleted — it cascades from its parent project or engagement — those two arms carry no `deleted_at` filter, unlike every other arm. That asymmetry is intentional; the column does not exist.
- **`rootAttachedTo` falls back to the root node itself** (a Directory) when nothing references the root, e.g. a test root directory. A Directory is never a `ProgressReportMedia`, so the upload-time file-is-media check short-circuits cleanly on the fallback.
- **Postgres announces *more* than the old database in two places, on purpose**, both commented in-code so they are not "fixed" back later: `delete` announces the whole soft-deleted subtree rather than just the top node, so a live query on a file *inside* a deleted directory is told; and it announces any surviving `File` whose `latest_version_id` was repointed, because deleting a `FileVersion` changes that File's surfaced mimeType/size/modifiedAt while the File is not in the deleted subtree at all. Both ride the `RETURNING` of statements that already run, so neither adds a query.
- **`progress-report-media.update` is left silent deliberately.** The old `update` is a raw `setValues()` rather than `db.updateProperties`, so it does not announce either.
- **Migrations were renumbered** from an earlier 0027/0028 to 0028/0029 so they sit after the base branch's audit-log migration. Both the index and the timestamp collided; the journal was re-verified afterward rather than assumed.

### Validation performed

Distinguishing what was tested from what was only read: everything below was run.

- `yarn type-check` and `yarn lint` both exit 0.
- **Fresh-database apply, 0000 → 0029, clean.** `progress_report_media`, `pnp_extraction_results`, `pnp_extraction_result_problems` and the category enum all verified present afterward.
- **Postgres e2e:** `file` + `progress-report-media` — **25 passed / 4 pre-existing skips**. Exercises media detection, the fail-closed metadata update, `File.rootAttachedTo` and `Media.attachedTo` hydration including the two report arms, and the new live-query assertions. Earlier in the branch the same two specs plus `user` ran **34 passed** on Postgres.
- **Neo4j e2e:** the same two specs, **25 passed / 4 skips** — same count as Postgres. This is what makes the un-gated progress-report-media invalidation assertion meaningful: it pins the parity claim itself, not just the Postgres arm. The same three specs were 34 passed under Neo4j earlier in the branch.
- **`audit-log` + `postgres-schema` on Postgres: 26/26**, which is what proves 0027 → 0029 apply in order on a fresh database and that the renumbered files are actually picked up.
- **Unit project, unfiltered as CI runs it: 190 passed / 3 todo.**
- **The live-query tests were verified by their negative case first.** Four type-valid probes — a bogus key on the two `invalidate` calls, `.slice(0, 0)` on the two `RETURNING` maps, which keeps `tsc` green where commenting out would not — make **exactly those four tests fail and no others**. Each assertion has been observed doing its job rather than assumed to.

### Reviewer cross-checks

Worth verifying independently rather than taking on trust:

- **Is any consuming `DefinedFile` column missing from the reverse-lookup UNION?** This is the highest-value check in the PR. A missing arm is silent: the file resolves to a generic directory instead of its owner, with no error. Two arms were already missed once. The check is to enumerate every FK column in the schema that points at a file node and confirm each has an arm.
- **`progress_report_media_category`'s 7 values against the DTO enum**, in both directions.
- **`schema/index.ts` against the two `.sql` files** — column types, nullability, index names.
- **Journal integrity:** index contiguous 0–29, `when` strictly increasing, no duplicate timestamps, and journal tags matching the `.sql` filenames exactly both ways.
- **`FileNodeType`'s values are exactly the registered resource names** (`Directory`, `File`, `FileVersion` — see the `ResourceMap` declarations in `file.dto.ts`). That implicit coupling is what lets a row's `type` be passed straight through as an invalidation key.
- **The announcement sits before the write in `rename` but after it in `delete`** — inconsistent at a glance, and intentional, since `delete` needs its `RETURNING` rows first. Both are safe because `LiveQueryStoreImpl.doInvalidate` defers to `TransactionHooks.afterCommit`, so a rolled-back mutation never announces regardless of ordering.
- **`RETURNING f.id` on the repoint statement** returns only rows the `UPDATE` matched — Files whose latest version was just soft-deleted — not every File.

### Explicitly out of scope

- **The PnP filters and sorters on the LanguageEngagement list** (`hasError`, `totalErrors`) are not ported. Tagged `migration-todo`; add when a Postgres engagement-list-by-PnP-error path needs them.
- **`progress-report-media` has no row-level read filter.** `secure()` handles field access and the only caller paths run as project members. Tagged `migration-todo`; add an `applyReadFilter` when a restricted-role case demands it.
- **`move` does not announce the moved node**, nor the aggregate changes on its grandparent directories. The service announces the old and new immediate parents on both engines and the old database announces no more than that. Parity, pre-existing everywhere, worth a separate non-migration ticket.
- **Create paths announce nothing** on any engine, so a list query goes stale on create everywhere. Deliberately unchanged.
- **The `as any` in the Media `splitDb` call** is transition-only typing, tagged `migration-todo` to drop with the Neo4j path.
- **One follow-up lives in the companion base PR, not here.** That PR carries a structural unit test enumerating every Postgres repository that writes and failing when one neither routes through the base helpers nor announces itself. Because this PR fixes `file` and adds three repositories, that test's exemption list needs three edits once both are in — delete the `file` entry, add `media` and `pnp-extraction-result` as parity. It is not a silent dependency: both of the test's assertions fail loudly and name the offending file.
