### PR TITLE
[pg] Search → Postgres (Drizzle): UNION-ALL ILIKE global search

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
             shard: 1
             total: 1
             test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony|product|film|story|project-workflow|periodic-report|rev79|pin|known-language|comment|post|audit-log|progress-report-media)\."
+              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony|product|film|story|project-workflow|periodic-report|rev79|pin|known-language|comment|post|audit-log|progress-report-media|search)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/src/components/search/search.drizzle.repository.ts
+++ b/src/components/search/search.drizzle.repository.ts
@@ -1,0 +1,313 @@
+import { Injectable } from '@nestjs/common';
+import { sql, type SQL } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import { type Merge } from 'type-fest';
+import { type ID } from '~/common';
+import { DrizzleService } from '~/core/drizzle';
+import { escapeLikePattern } from '~/core/drizzle/like';
+import { type BaseNode } from '~/core/neo4j/results';
+import type { ResourceMap } from '~/core/resources';
+import { type SearchInput } from './dto';
+
+interface SearchRow {
+  id: ID;
+  kind: string;
+  subtype: string | null;
+  createdAt: string | Date;
+  matchedProps: string[];
+}
+
+interface SearchResultRow {
+  node: BaseNode;
+  matchedProps: readonly string[];
+}
+
+// products.type enum value → concrete GraphQL type name (not a clean suffix).
+const PRODUCT_TYPE_LABELS: Record<string, string> = {
+  DirectScripture: 'DirectScriptureProduct',
+  Derivative: 'DerivativeScriptureProduct',
+  Other: 'OtherProduct',
+};
+
+/**
+ * Postgres global search.
+ *
+ * Neo4j stores every string value in a uniform `Property` node, so a single
+ * global full-text index covers all resources. Postgres has no such table, so
+ * global search is a `UNION ALL` of per-table `ILIKE` matches (`pg_trgm`-style
+ * fuzzy/substring — the team's chosen match strategy over `tsvector`). Each
+ * branch contributes the columns that map to a DTO field; `matchedProps` are
+ * those DTO field names so the service can gate results on field read-perms.
+ * An exact `id` hit on any branch yields `matchedProps: ['id']`, mirroring the
+ * Neo4j base-node-by-id branch.
+ *
+ * The repo returns the same `{ node, matchedProps }` shape as the Neo4j repo,
+ * with `node` a fake {@link BaseNode} (`labels` drive `resolveTypeByBaseNode`),
+ * so the DB-agnostic {@link import('./search.service').SearchService} needs no
+ * changes.
+ *
+ * migration-todo: drop at Phase 7 cutover with the rest of the BaseNode shims.
+ *
+ * Known reduction vs Neo4j (Neo4j matched ANY property value): types with no
+ * meaningful human-text column — Partner (reachable via its Organization's name
+ * through the service's PartnerByOrg path), the Product family, and the
+ * PeriodicReport family (date-range identified, no name) — are not TEXT
+ * searched, but DO keep exact-id parity (id-only branches). Add a text column
+ * to one of those branches if free-text search over it is ever needed.
+ *
+ * Second known reduction: **result ranking**. Neo4j returns full-text hits ordered
+ * by relevance score, so its LIMIT 100 is the best 100 matches. There is no
+ * equivalent score here, so rows come back newest-first instead — deterministic
+ * and explicable, but not relevance. It only diverges once a query matches more
+ * than 100 rows; below that both engines return the same set, just in a different
+ * order, and the service re-shapes results by type anyway. `tsvector` ranking
+ * would close it if search quality ever becomes the complaint.
+ */
+@Injectable()
+export class SearchDrizzleRepository {
+  constructor(private readonly drizzle: DrizzleService) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  async search(
+    input: Merge<SearchInput, { type: Array<keyof ResourceMap> }>,
+  ): Promise<readonly SearchResultRow[]> {
+    const q = input.query;
+    const pattern = `%${escapeLikePattern(q)}%`;
+    const types = new Set<string>(input.type);
+
+    // One UNION ALL branch per searchable table. `cols` are [column, dtoField]
+    // pairs — the column is ILIKE-matched and the DTO field name is what lands
+    // in `matchedProps` for the read-perm gate.
+    // A `cols` of [] makes an id-only branch (exact-id parity, matchedProps =
+    // ['id']) for searchable types with no human-text column. `softDelete:
+    // false` is for tables without a `deleted_at` column (periodic_reports).
+    const branch = (
+      kind: string,
+      table: string,
+      cols: ReadonlyArray<readonly [column: string, prop: string]>,
+      opts: { subtypeCol?: string; softDelete?: boolean } = {},
+    ): SQL => {
+      const { subtypeCol, softDelete = true } = opts;
+      const cases = [
+        sql`case when id = ${q} then 'id' end`,
+        ...cols.map(
+          ([col, prop]) =>
+            sql`case when ${sql.raw(col)} ilike ${pattern} then ${prop} end`,
+        ),
+      ];
+      const conds = [
+        sql`id = ${q}`,
+        ...cols.map(([col]) => sql`${sql.raw(col)} ilike ${pattern}`),
+      ];
+      // Cast the enum discriminator to text so every branch's `subtype` column
+      // shares one type across the UNION.
+      const subtype = subtypeCol
+        ? sql`${sql.raw(subtypeCol)}::text`
+        : sql`null::text`;
+      const match = sql`(${sql.join(conds, sql` or `)})`;
+      const where = softDelete ? sql`deleted_at is null and ${match}` : match;
+      return sql`
+        select id as id, ${kind} as kind, ${subtype} as subtype,
+          created_at as "createdAt",
+          array_remove(array[${sql.join(cases, sql`, `)}], null) as "matchedProps"
+        from ${sql.raw(table)}
+        where ${where}
+      `;
+    };
+
+    // Same as `branch`, but discriminated by a `type` column and filtered to
+    // the requested subtypes (projects, producibles, products, reports).
+    const typedBranch = (
+      kind: string,
+      table: string,
+      cols: ReadonlyArray<readonly [column: string, prop: string]>,
+      subtypes: readonly string[],
+      softDelete = true,
+    ): SQL => {
+      const base = branch(kind, table, cols, {
+        subtypeCol: 'type',
+        softDelete,
+      });
+      const list = sql.join(
+        subtypes.map((s) => sql`${s}`),
+        sql`, `,
+      );
+      return sql`${base} and type in (${list})`;
+    };
+
+    const branches: SQL[] = [];
+    if (types.has('Organization')) {
+      branches.push(
+        branch('Organization', 'organizations', [
+          ['name', 'name'],
+          ['acronym', 'acronym'],
+        ]),
+      );
+    }
+    if (types.has('Language')) {
+      branches.push(
+        branch('Language', 'languages', [
+          ['name', 'name'],
+          ['display_name', 'displayName'],
+        ]),
+      );
+    }
+    if (types.has('EthnologueLanguage')) {
+      // The service rewrites EthnologueLanguage hits to LanguageByEth and
+      // overrides matchedProps to ['ethnologue'], so these props are nominal.
+      branches.push(
+        branch('EthnologueLanguage', 'ethnologue_languages', [
+          ['name', 'name'],
+          ['code', 'code'],
+          ['provisional_code', 'provisionalCode'],
+        ]),
+      );
+    }
+    if (types.has('User')) {
+      branches.push(
+        branch('User', 'users', [
+          ['real_first_name', 'realFirstName'],
+          ['real_last_name', 'realLastName'],
+          ['display_first_name', 'displayFirstName'],
+          ['display_last_name', 'displayLastName'],
+          ['email', 'email'],
+        ]),
+      );
+    }
+    if (types.has('Location')) {
+      branches.push(branch('Location', 'locations', [['name', 'name']]));
+    }
+    if (types.has('FieldZone')) {
+      branches.push(branch('FieldZone', 'field_zones', [['name', 'name']]));
+    }
+    if (types.has('FieldRegion')) {
+      branches.push(branch('FieldRegion', 'field_regions', [['name', 'name']]));
+    }
+    if (types.has('FundingAccount')) {
+      branches.push(
+        branch('FundingAccount', 'funding_accounts', [['name', 'name']]),
+      );
+    }
+    if (types.has('Tool')) {
+      branches.push(
+        branch('Tool', 'tools', [
+          ['name', 'name'],
+          ['description', 'description'],
+        ]),
+      );
+    }
+
+    const projectSubtypes = (
+      [
+        'MomentumTranslation',
+        'MultiplicationTranslation',
+        'Internship',
+      ] as const
+    ).filter((s) => types.has(`${s}Project`));
+    if (projectSubtypes.length) {
+      branches.push(
+        typedBranch('Project', 'projects', [['name', 'name']], projectSubtypes),
+      );
+    }
+
+    const producibleSubtypes = (['Film', 'Story', 'EthnoArt'] as const).filter(
+      (s) => types.has(s),
+    );
+    if (producibleSubtypes.length) {
+      branches.push(
+        typedBranch(
+          'Producible',
+          'producibles',
+          [['name', 'name']],
+          producibleSubtypes,
+        ),
+      );
+    }
+
+    // Public searchable types with no meaningful human-text column are not
+    // text-searched, but keep exact-id parity with Neo4j's global
+    // base-node-by-id arm (id-only branches → matchedProps ['id']).
+    if (types.has('Partner')) {
+      branches.push(branch('Partner', 'partners', []));
+    }
+    const productSubtypes = (
+      ['DirectScripture', 'Derivative', 'Other'] as const
+    ).filter((s) => types.has(PRODUCT_TYPE_LABELS[s]!));
+    if (productSubtypes.length) {
+      branches.push(typedBranch('Product', 'products', [], productSubtypes));
+    }
+    const reportSubtypes = (
+      ['Financial', 'Narrative', 'Progress'] as const
+    ).filter((s) => types.has(`${s}Report`));
+    if (reportSubtypes.length) {
+      // periodic_reports has no deleted_at (real-delete design).
+      branches.push(
+        typedBranch(
+          'PeriodicReport',
+          'periodic_reports',
+          [],
+          reportSubtypes,
+          false,
+        ),
+      );
+    }
+
+    if (branches.length === 0) {
+      return [];
+    }
+
+    // The count is applied by the service after read-perm filtering; this is
+    // just a sane ceiling so we don't return an unbounded set (mirrors Neo4j's
+    // own LIMIT 100 and its rationale).
+    //
+    // The ordering is NOT cosmetic. Neo4j's full-text index returns rows already
+    // ranked by relevance, so its LIMIT 100 takes the best 100. A UNION ALL has
+    // no such ranking, and an unordered LIMIT lets Postgres return ANY 100 rows —
+    // potentially a different 100 for the same query, since nothing obliges it to
+    // pick the same plan twice. Ordering newest-first is not relevance, but it is
+    // deterministic and explicable, which an arbitrary subset is neither.
+    // `id` breaks ties so rows sharing a timestamp (bulk-loaded data does) cannot
+    // reorder between runs either.
+    const result = await this.db.execute<
+      SearchRow & Record<string, unknown>
+    >(sql`
+      select * from (${sql.join(branches, sql` union all `)}) as results
+      order by "createdAt" desc, id
+      limit 100
+    `);
+
+    return result.rows.map((row) => ({
+      node: this.toBaseNode(row),
+      matchedProps: row.matchedProps,
+    }));
+  }
+
+  private toBaseNode(row: SearchRow): BaseNode {
+    const labels =
+      row.kind === 'Project'
+        ? [`${row.subtype!}Project`, 'Project']
+        : row.kind === 'Producible'
+          ? [row.subtype!]
+          : row.kind === 'Product'
+            ? [PRODUCT_TYPE_LABELS[row.subtype!]!]
+            : row.kind === 'PeriodicReport'
+              ? [`${row.subtype!}Report`]
+              : [row.kind];
+    return {
+      identity: row.id,
+      labels: [...labels, 'BaseNode'],
+      properties: {
+        id: row.id,
+        // createdAt is unused by SearchService; parse defensively anyway since
+        // raw `db.execute` returns timestamptz as a Postgres wire string.
+        createdAt:
+          row.createdAt instanceof Date
+            ? DateTime.fromJSDate(row.createdAt)
+            : DateTime.fromSQL(row.createdAt),
+      },
+    };
+  }
+}

--- a/src/components/search/search.module.ts
+++ b/src/components/search/search.module.ts
@@ -1,14 +1,27 @@
 import { Module } from '@nestjs/common';
+import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { LanguageModule } from '../language/language.module';
 import { PartnerModule } from '../partner/partner.module';
+import { SearchDrizzleRepository } from './search.drizzle.repository';
 import { SearchRepository } from './search.repository';
 import { SearchResolver } from './search.resolver';
 import { SearchService } from './search.service';
 
 @Module({
   imports: [PartnerModule, AuthorizationModule, LanguageModule],
-  providers: [SearchResolver, SearchService, SearchRepository],
+  providers: [
+    SearchResolver,
+    SearchService,
+    // migration-todo(cutover-cleanup): drop splitDb + the @ts-expect-error at
+    // Phase 7 — SearchDrizzleRepository becomes the sole repo when the Neo4j
+    // SearchRepository (and its OnIndex indexing hook) is removed.
+    splitDb(SearchRepository, {
+      // @ts-expect-error the postgres repo only implements search(); the
+      // Neo4j-only OnIndex hook isn't needed under postgres.
+      postgres: SearchDrizzleRepository,
+    }),
+  ],
   exports: [SearchService],
 })
 export class SearchModule {}

--- a/test/search.e2e-spec.ts
+++ b/test/search.e2e-spec.ts
@@ -1,0 +1,201 @@
+import { faker } from '@faker-js/faker';
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { CalendarDate, Role } from '~/common';
+import { graphql } from '~/graphql';
+import {
+  createDirectProduct,
+  createLanguage,
+  createLanguageEngagement,
+  createLocation,
+  createOrganization,
+  createPartner,
+  createProject,
+  createSession,
+  createTestApp,
+  registerUser,
+  type TestApp,
+  updateProject,
+} from './utility';
+
+const SearchDoc = graphql(`
+  query search($input: SearchInput!) {
+    search(input: $input) {
+      items {
+        __typename
+        ... on Organization {
+          id
+          name {
+            value
+          }
+        }
+        ... on Location {
+          id
+          name {
+            value
+          }
+        }
+        ... on Partner {
+          id
+        }
+        ... on DirectScriptureProduct {
+          id
+        }
+        ... on NarrativeReport {
+          id
+        }
+      }
+    }
+  }
+`);
+
+// createProject's default MOU window. An engagement has to sit inside its
+// project's window — the engagement fixture otherwise defaults both date
+// overrides to `now`, which lands ~34 years outside it and leaves the pair in a
+// state the app would never produce.
+const engStart = CalendarDate.local(1991, 1, 1);
+const engEnd = engStart.plus({ years: 1 });
+
+describe('Search e2e', () => {
+  let app: TestApp;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await createSession(app);
+    // Administrator so every matched field is readable — search gates results
+    // on the requester's read-perm for the matched field.
+    await registerUser(app, { roles: [Role.Administrator] });
+  });
+
+  it('finds a resource by a substring of its name', async () => {
+    const token = faker.string.alpha(12);
+    const org = await createOrganization(app, {
+      name: `${faker.company.name()} ${token} Inc`,
+    });
+
+    const { search } = await app.graphql.query(SearchDoc, {
+      input: { query: token, count: 25 },
+    });
+
+    const ids = search.items.map((i) => ('id' in i ? i.id : null));
+    expect(ids).toContain(org.id);
+    const match = search.items.find((i) => 'id' in i && i.id === org.id);
+    expect(match?.__typename).toBe('Organization');
+  });
+
+  it('restricts results to the requested type', async () => {
+    // Same token on two different resource types.
+    const token = faker.string.alpha(12);
+    const org = await createOrganization(app, {
+      name: `${faker.company.name()} ${token}`,
+    });
+    const location = await createLocation(app, {
+      name: `${faker.lorem.word()} ${token}`,
+    });
+
+    const { search } = await app.graphql.query(SearchDoc, {
+      input: { query: token, count: 25, type: ['Organization'] },
+    });
+
+    const ids = search.items.map((i) => ('id' in i ? i.id : null));
+    expect(ids).toContain(org.id);
+    expect(ids).not.toContain(location.id);
+    expect(search.items.every((i) => i.__typename === 'Organization')).toBe(
+      true,
+    );
+  });
+
+  it('finds a resource by its exact id', async () => {
+    const org = await createOrganization(app);
+
+    const { search } = await app.graphql.query(SearchDoc, {
+      input: { query: org.id, count: 25 },
+    });
+
+    const ids = search.items.map((i) => ('id' in i ? i.id : null));
+    expect(ids).toContain(org.id);
+  });
+
+  // Partner is a public searchable type with no human-text column, so it's not
+  // text-searched — but exact-id lookup must still work (parity with Neo4j's
+  // global base-node-by-id arm). Regression guard for the id-only branches.
+  it('finds an omitted-text searchable type by exact id (Partner)', async () => {
+    const partner = await createPartner(app);
+
+    const { search } = await app.graphql.query(SearchDoc, {
+      input: { query: partner.id, count: 25 },
+    });
+
+    const ids = search.items.map((i) => ('id' in i ? i.id : null));
+    expect(ids).toContain(partner.id);
+  });
+
+  // Product subtypes are searchable by exact id through the per-subtype id-only
+  // branch (products table, discriminator-filtered). Guards the subtype label
+  // mapping in the PG repo's union — a polymorphic member, not a flat table.
+  it('finds a product subtype by exact id (DirectScriptureProduct)', async () => {
+    const project = await createProject(app);
+    const language = await createLanguage(app);
+    const engagement = await createLanguageEngagement(app, {
+      project: project.id,
+      language: language.id,
+      startDateOverride: engStart.toISO(),
+      endDateOverride: engEnd.toISO(),
+    });
+    const product = await createDirectProduct(app, {
+      engagement: engagement.id,
+    });
+
+    const { search } = await app.graphql.query(SearchDoc, {
+      input: { query: product.id, count: 25 },
+    });
+
+    const ids = search.items.map((i) => ('id' in i ? i.id : null));
+    expect(ids).toContain(product.id);
+  });
+
+  // Periodic reports live in their own branch with NO deleted_at column, so the
+  // PG repo special-cases them (softDelete=false). Exact-id lookup must still
+  // resolve them — this is the branch most likely to regress under that
+  // special-casing.
+  it('finds a periodic report by exact id (NarrativeReport)', async () => {
+    const project = await createProject(app);
+    // Narrative reports are synced into existence when the MOU window is set.
+    await updateProject(app, {
+      id: project.id,
+      mouStart: CalendarDate.fromISO('2020-01-01').toISO(),
+      mouEnd: CalendarDate.fromISO('2020-12-31').toISO(),
+    });
+    const { project: read } = await app.graphql.query(
+      ProjectNarrativeReportsDoc,
+      { id: project.id },
+    );
+    const reportId = read.narrativeReports.items[0]!.id;
+    expect(reportId).toBeTruthy();
+
+    const { search } = await app.graphql.query(SearchDoc, {
+      input: { query: reportId, count: 25 },
+    });
+
+    const ids = search.items.map((i) => ('id' in i ? i.id : null));
+    expect(ids).toContain(reportId);
+  });
+
+  it('returns nothing for a query that matches no resource', async () => {
+    const { search } = await app.graphql.query(SearchDoc, {
+      input: { query: faker.string.alpha(20), count: 25 },
+    });
+    expect(search.items).toHaveLength(0);
+  });
+});
+
+const ProjectNarrativeReportsDoc = graphql(`
+  query ProjectNarrativeReports($id: ID!) {
+    project(id: $id) {
+      narrativeReports {
+        items {
+          id
+        }
+      }
+    }
+  }
+`);


### PR DESCRIPTION
### Summary 

Global search is the box that searches everything at once — projects, people, languages, organizations, files. Today it runs on the old database, which happens to store every piece of text in one uniform place, so a single index covers everything.

Postgres has no such place. Text lives in whatever column it belongs to. So this rebuilds global search as one query per searchable table, combined into a single result — each table contributing the columns worth matching against.

What a user sees is unchanged: same box, same results, same permission rules about who can see what.

Sits in the Postgres migration series; nothing here touches the old database's behavior. Branch `search-recut`, based on `develop`.

### What's added

- A Postgres search implementation combining per-table case-insensitive substring matches into one result set, routed through the existing engine switch so nothing above the repository changes.
- Each matched column reports which DTO field it came from, which is what lets the service apply per-field read permissions exactly as before.
- Searchable types with no meaningful text column — Partner, the Product family, the PeriodicReport family — still match on an exact id, preserving that path from the old implementation.
- A synthetic base-node result shape, so the database-agnostic search service is untouched.
- Seven end-to-end tests covering substring matching, type restriction, exact-id lookup, the three id-only types, and the empty-result case. They run against both engines unmodified.
- Search added to the Postgres CI pattern.

### No schema changes

Search adds no tables, columns, indexes or enums, so there is no migration in this PR. Worth stating explicitly since every sibling PR in this series has one.

### Intentional behavior differences from the old implementation

Both are documented in the repository file; these are the two things to weigh.

- **Result ranking.** The old database returns hits pre-ranked by relevance, so its 100-row ceiling takes the best 100. There is no equivalent score for a combined per-table query, so results come back newest-first with id as a tie-break. This only diverges once a query matches more than 100 rows — below that, both return the same set. Deterministic ordering was chosen over an arbitrary subset, which is what an unordered limit produces. Adopting full-text vectors would close the gap if search quality becomes a complaint.
- **Text search coverage.** The old implementation matched any stored value, including on types with no human-readable name. Those types now match by exact id only. Partner remains reachable by text through its organization's name, which the service already resolves.

### Validation performed

- `yarn type-check` and `yarn lint` clean.
- Search end-to-end on **Postgres: 7 passed**. Same spec on **Neo4j: 7 passed** — same tests, both engines, no engine-specific branches in the test.
- Schema invariants spec on Postgres: passed alongside search, 21 tests total.
- Full unit suite: 190 passed, 3 todo.
- Rebase verified by content, not by commit identity: pre- and post-rebase patches over `src` and `test` are byte-identical, so the only change is the CI list resolution.

### Reviewer cross-checks

- Every publicly searchable type has a branch — 21 types, worth confirming against the searchable map in the search DTO rather than trusting the list.
- Project and product subtype filters use the database's own enum values, which differ from the GraphQL type names (`MomentumTranslation` versus `MomentumTranslationProject`, `DirectScripture` versus `DirectScriptureProduct`). Both mappings are in the repository file.
- The ethnologue branch depends on the service adding that type when a language search is requested. If that ever changes, the branch silently stops contributing.
- Table and column names are interpolated as raw SQL. All are hardcoded in this file, never user input — the user's query itself is parameterized and its wildcards escaped.
- One table in the set has no soft-delete column and is handled explicitly; the rest filter it.

### Explicitly out of scope

- Relevance ranking via full-text vectors.
- Text search over the id-only types.
- Any change to the old database's search path, the search service, or the GraphQL contract.
