### PR TITLE
[pg] Audit Discovery - Live-query invalidation for the Postgres repositories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
             shard: 1
             total: 1
             test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony|product|film|story|project-workflow|periodic-report|rev79|pin|known-language|comment|post|audit-log|progress-report-media|search)\."
+              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony|product|film|story|project-workflow|periodic-report|rev79|pin|known-language|comment|post|audit-log|progress-report-media|search|live-query-invalidation)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/src/components/product/product.drizzle.repository.ts
+++ b/src/components/product/product.drizzle.repository.ts
@@ -35,7 +35,9 @@ import {
   productCompletionDescriptions,
   products,
 } from '~/core/drizzle/schema';
+import { LiveQueryStore } from '~/core/live-query';
 import { type BaseNode } from '~/core/neo4j/results';
+import { type ResourceLike } from '~/core/resources';
 import { type ScopedRole } from '../authorization/dto/role.dto';
 import { requesterScopeByProject } from '../project/project-member/membership-scope';
 import {
@@ -115,6 +117,7 @@ export class ProductDrizzleRepository {
   constructor(
     private readonly drizzle: DrizzleService,
     private readonly identity: Identity,
+    private readonly liveQueryStore: LiveQueryStore,
   ) {}
 
   // Transaction-aware client — see DrizzleDtoRepository.db for why a getter.
@@ -354,10 +357,15 @@ export class ProductDrizzleRepository {
     }
   }
 
+  // Each of these invalidates with its CONCRETE subtype, matching what the Neo4j
+  // arm passes to `db.updateProperties({ type })` — the store keys on
+  // `${resource.name}:${id}`, so invalidating a generic `Product` here would
+  // emit a key nothing subscribes to and read as a silent no-op.
   async updateProperties(
     object: DirectScriptureProduct,
     changes: DbChanges<DirectScriptureProduct>,
   ) {
+    this.liveQueryStore.invalidate([DirectScriptureProduct, object.id]);
     return await this.applyChanges(object, changes);
   }
 
@@ -365,10 +373,12 @@ export class ProductDrizzleRepository {
     object: DerivativeScriptureProduct,
     changes: DbChanges<DerivativeScriptureProduct>,
   ) {
+    this.liveQueryStore.invalidate([DerivativeScriptureProduct, object.id]);
     return await this.applyChanges(object, changes);
   }
 
   async updateOther(object: OtherProduct, changes: DbChanges<OtherProduct>) {
+    this.liveQueryStore.invalidate([OtherProduct, object.id]);
     return await this.applyChanges(object, changes);
   }
 
@@ -425,7 +435,13 @@ export class ProductDrizzleRepository {
       .where(eq(products.id, productId));
   }
 
-  async delete(id: ID, _resource?: unknown) {
+  async delete(id: ID, resource?: ResourceLike) {
+    // Conditional on `resource` exactly like the Neo4j `deleteNode` it mirrors;
+    // the service passes `resolveProductType(object)`, so it is populated in
+    // practice and carries the concrete subtype.
+    if (resource) {
+      this.liveQueryStore.invalidate([resource, id]);
+    }
     await this.db
       .update(products)
       .set({ deletedAt: new Date(), updatedAt: new Date() })

--- a/src/components/prompts/prompt-variant-response.drizzle.repository.ts
+++ b/src/components/prompts/prompt-variant-response.drizzle.repository.ts
@@ -19,6 +19,7 @@ import {
   promptVariantResponseEntries,
   promptVariantResponses,
 } from '~/core/drizzle/schema';
+import { LiveQueryStore } from '~/core/live-query';
 import { defaultPermanentAfter } from '~/core/neo4j/query/properties/update-property';
 import { type BaseNode } from '~/core/neo4j/results';
 import { type EdgePrivileges, Privileges } from '../authorization';
@@ -59,6 +60,8 @@ export const PromptVariantResponseDrizzleRepository = <
     protected readonly identity: Identity;
     @Inject(DrizzleService)
     protected readonly drizzle: DrizzleService;
+    @Inject(LiveQueryStore)
+    protected readonly liveQueryStore: LiveQueryStore;
 
     protected get db() {
       return this.drizzle.client;
@@ -194,6 +197,11 @@ export const PromptVariantResponseDrizzleRepository = <
     }
 
     async delete(id: ID) {
+      // Mirrors the Neo4j arm, whose `this.deleteNode(id)` invalidates via the
+      // shared base with `this.resource`. `submitResponse`/`changePrompt` are
+      // deliberately NOT invalidated here: their Neo4j counterparts use raw
+      // Cypher with no invalidation either, so leaving them alone is parity.
+      this.liveQueryStore.invalidate([this.resource, id]);
       await this.db
         .update(promptVariantResponses)
         .set({ deletedAt: new Date() })

--- a/src/core/drizzle/dto.repository.ts
+++ b/src/core/drizzle/dto.repository.ts
@@ -8,8 +8,8 @@ import {
   type ResourceShape,
   type UnsecuredDto,
 } from '~/common';
+import { LiveQueryStore } from '~/core/live-query';
 import { getChanges } from '../database/changes';
-import { LiveQueryStore } from '../live-query';
 import { type DrizzleService } from './drizzle.service';
 
 /**

--- a/src/core/drizzle/dto.repository.ts
+++ b/src/core/drizzle/dto.repository.ts
@@ -1,3 +1,4 @@
+import { Inject } from '@nestjs/common';
 import { and, asc, count, eq, inArray, isNull, type SQL } from 'drizzle-orm';
 import { type AnyPgColumn, type PgTable } from 'drizzle-orm/pg-core';
 import {
@@ -8,6 +9,7 @@ import {
   type UnsecuredDto,
 } from '~/common';
 import { getChanges } from '../database/changes';
+import { LiveQueryStore } from '../live-query';
 import { type DrizzleService } from './drizzle.service';
 
 /**
@@ -30,6 +32,28 @@ export const EMPTY_PAGE = {
  *
  * Repos that need related rows (e.g. `with: { globalRoles: true }`) override
  * `readMany` and call `toDto` themselves — the base only handles flat tables.
+ *
+ * ## Live-query invalidation
+ *
+ * `updateColumns()` and `softDelete()` invalidate the mutated resource, matching
+ * what the Neo4j and Gel bases do generically. Without it, the ~12 cord-field
+ * documents carrying `@live` — the detail page of nearly every domain — stay
+ * stale after an edit until the user refreshes manually.
+ *
+ * The call is safe to make inside the mutation transaction: `LiveQueryStoreImpl`
+ * defers the actual work to `TransactionHooks.afterCommit`, which the Drizzle
+ * mutation interceptor runs (it inherits `runAndClear()` from
+ * `TransactionalMutationsInterceptor`). So a rolled-back mutation never
+ * invalidates, and re-execution never reads pre-commit state.
+ *
+ * NOT covered, deliberately:
+ * - **`create`** — a brand-new id has nothing watching it yet. Neither other
+ *   engine invalidates on create either, so this is parity. List-level queries
+ *   (`Query.users`) do go stale on create on ALL THREE engines; that's a
+ *   pre-existing gap, not one this base introduces.
+ * - **Subclass-owned writes** — a repo that hand-rolls its own `update`/`delete`
+ *   instead of going through these two helpers still has to invalidate itself,
+ *   exactly as on the other engines.
  */
 export abstract class DrizzleDtoRepository<
   TTable extends PgTable & {
@@ -40,6 +64,13 @@ export abstract class DrizzleDtoRepository<
   TDto extends { id: ID },
 > {
   protected readonly resource: EnhancedResource<ResourceShape<TDto>>;
+
+  /**
+   * Property-injected, not a constructor param, so no subclass has to thread it
+   * through `super()` — same pattern as the Neo4j and Gel bases, which inject it
+   * the same way.
+   */
+  @Inject() protected readonly liveQueryStore: LiveQueryStore;
 
   /**
    * Diff an existing DTO against an `Update*` input and return only fields
@@ -127,6 +158,7 @@ export abstract class DrizzleDtoRepository<
    * but doesn't require it).
    */
   protected async softDelete(id: ID): Promise<void> {
+    this.liveQueryStore.invalidate([this.resource, id]);
     await this.db
       .update(this.table as PgTable)
       .set({ deletedAt: new Date() })
@@ -144,6 +176,8 @@ export abstract class DrizzleDtoRepository<
   ): Promise<void> {
     const entries = Object.entries(changes).filter(([, v]) => v !== undefined);
     if (entries.length === 0) return;
+    // After the no-op guard: nothing changed means nothing to invalidate.
+    this.liveQueryStore.invalidate([this.resource, id]);
     const set = Object.fromEntries(entries);
     if (this.table.updatedAt) {
       set.updatedAt = new Date();

--- a/src/core/drizzle/live-query-invalidation.spec.ts
+++ b/src/core/drizzle/live-query-invalidation.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from '@jest/globals';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, posix, relative, sep } from 'node:path';
+
+/**
+ * Structural guard for LQ-1.
+ *
+ * The Drizzle repository base invalidates the live-query store on
+ * `updateColumns()` / `softDelete()`, but a repository that hand-rolls its own
+ * writes bypasses that and has to invalidate itself. Nothing stops the next
+ * repository from silently reintroducing the gap, and the symptom — a detail page
+ * that quietly stops refreshing — is invisible in review and in every functional
+ * test.
+ *
+ * So: enumerate every `*.drizzle.repository.ts` that writes, and require each to
+ * either route through the base helpers or mention `liveQueryStore`. Anything
+ * else must be listed below WITH A REASON. A new repository that writes without
+ * invalidating fails this test rather than shipping.
+ *
+ * Same shape as the enum-sync invariant in `postgres-schema.e2e-spec.ts`: pin the
+ * known set so drift is loud.
+ */
+
+/**
+ * Repositories that write but deliberately do not invalidate.
+ *
+ * `parity` — the Neo4j arm does not invalidate here either, so Postgres matches
+ * it. These are a pre-existing gap on ALL engines, not a migration regression;
+ * fixing them is a product decision, not a cutover one.
+ *
+ * `create-only` — nothing is watching a brand-new id yet, and no engine
+ * invalidates on create.
+ */
+const EXEMPT: Record<string, string> = {
+  // --- parity: verified the Neo4j counterpart has no invalidation either ---
+  'src/components/pin/pin.drizzle.repository.ts':
+    'parity — pin.repository.ts extends no invalidating base and never invalidates',
+  'src/components/product-progress/product-progress.drizzle.repository.ts':
+    'parity — product-progress.repository.ts extends no invalidating base',
+  'src/components/progress-summary/progress-summary.drizzle.repository.ts':
+    'parity — progress-summary.repository.ts calls no invalidating base method',
+  'src/components/comments/comment-thread.drizzle.repository.ts':
+    'parity — comment-thread.repository.ts calls no invalidating base method',
+  'src/components/user/known-language.drizzle.repository.ts':
+    'parity — known-language.repository.ts calls no invalidating base method',
+  'src/components/project/workflow/project-workflow.drizzle.repository.ts':
+    'parity — append-only workflow events; no update/delete path to invalidate',
+
+  // --- create-only / bootstrap paths ---
+  'src/components/notifications/notification.drizzle.repository.ts':
+    'create-only; no engine invalidates on create',
+  'src/components/user/system-agent.drizzle.repository.ts':
+    'bootstrap upsert of the three fixed system agents',
+  'src/components/admin/admin.drizzle.repository.ts':
+    'bootstrap only (root user / default org), runs before anything can subscribe',
+
+  // --- genuinely pending ---
+  'src/components/file/file.drizzle.repository.ts':
+    'PENDING: the Neo4j arm DOES invalidate (file.repository.ts:517 update, :569 delete). ' +
+    'Held out only because this file is modified by an in-flight branch; fix it there or ' +
+    'immediately after that merges. This is the one entry here that is a real defect.',
+};
+
+const COMPONENTS = 'src/components';
+
+const walk = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    return entry.isDirectory() ? walk(path) : [path];
+  });
+
+/** Method declarations whose names imply a write. */
+const WRITE_METHOD =
+  /\n\s{2,6}(?:protected |private )?async (?:create|update|delete|remove|add|set|assign|upsert|save|merge)\w*\(/i;
+/** Raw drizzle writes, for repos whose method names don't follow the convention. */
+const RAW_WRITE = /\.\s*(?:update|insert|delete)\s*\(/;
+
+describe('LQ-1 structural guard: drizzle repositories invalidate live queries', () => {
+  const repos = walk(COMPONENTS)
+    .filter((path) => path.endsWith('.drizzle.repository.ts'))
+    .map((path) => ({
+      // POSIX-normalized so the pinned keys above are stable across platforms.
+      key: relative('.', path).split(sep).join(posix.sep),
+      source: readFileSync(path, 'utf8'),
+    }));
+
+  it('finds repositories to check (guards against a broken glob)', () => {
+    // If the walk silently matched nothing, every assertion below would pass
+    // vacuously — the exact failure mode this whole test exists to prevent.
+    expect(repos.length).toBeGreaterThan(20);
+  });
+
+  it('every writing repository either uses the base helpers or invalidates itself', () => {
+    const offenders = repos
+      .filter(
+        ({ source }) => WRITE_METHOD.test(source) || RAW_WRITE.test(source),
+      )
+      .filter(
+        ({ source }) =>
+          !source.includes('this.updateColumns(') &&
+          !source.includes('this.softDelete(') &&
+          !source.includes('liveQueryStore'),
+      )
+      .map(({ key }) => key);
+
+    const unexplained = offenders.filter((key) => !(key in EXEMPT));
+    expect(unexplained).toEqual([]);
+  });
+
+  it('has no stale exemptions', () => {
+    // An exemption for a repo that now invalidates (or no longer exists) is
+    // misleading documentation — make removing it mandatory.
+    const stale = Object.keys(EXEMPT).filter((key) => {
+      const repo = repos.find((candidate) => candidate.key === key);
+      if (!repo) return true;
+      return (
+        repo.source.includes('this.updateColumns(') ||
+        repo.source.includes('this.softDelete(') ||
+        repo.source.includes('liveQueryStore')
+      );
+    });
+    expect(stale).toEqual([]);
+  });
+});

--- a/src/core/drizzle/live-query-invalidation.spec.ts
+++ b/src/core/drizzle/live-query-invalidation.spec.ts
@@ -13,12 +13,24 @@ import { join, posix, relative, sep } from 'node:path';
  * test.
  *
  * So: enumerate every `*.drizzle.repository.ts` that writes, and require each to
- * either route through the base helpers or mention `liveQueryStore`. Anything
- * else must be listed below WITH A REASON. A new repository that writes without
+ * either route through the base helpers or actually call the store. Anything else
+ * must be listed below WITH A REASON. A new repository that writes without
  * invalidating fails this test rather than shipping.
  *
  * Same shape as the enum-sync invariant in `postgres-schema.e2e-spec.ts`: pin the
  * known set so drift is loud.
+ *
+ * Two known limits of a source-text guard, both deliberate:
+ *
+ * - It is file-granular, not method-granular. A repository that invalidates in
+ *   one method satisfies the check even if a sibling method doesn't. Catching
+ *   that needs per-method analysis; the exemption reasons carry the per-method
+ *   detail in the meantime.
+ * - It only sees files named `*.drizzle.repository.ts`. A Postgres-only
+ *   repository that skips the `.drizzle.` infix is invisible to it —
+ *   `src/components/audit/resource-mutation.repository.ts` is the one such file
+ *   today (append-only audit trail, nothing subscribes to it, so nothing to
+ *   invalidate). Renaming it to match the convention is tracked separately.
  */
 
 /**
@@ -45,6 +57,12 @@ const EXEMPT: Record<string, string> = {
     'parity — known-language.repository.ts calls no invalidating base method',
   'src/components/project/workflow/project-workflow.drizzle.repository.ts':
     'parity — append-only workflow events; no update/delete path to invalidate',
+  'src/components/file/media/media.drizzle.repository.ts':
+    'parity — sole writer is save() (an upsert); media.repository.ts extends ' +
+    'CommonRepository but never calls one of its invalidating helpers',
+  'src/components/pnp/extraction-result/pnp-extraction-result.drizzle.repository.ts':
+    'parity — sole writer is save() (an upsert); ' +
+    'pnp-extraction-result.neo4j.repository.ts never invalidates',
 
   // --- create-only / bootstrap paths ---
   'src/components/notifications/notification.drizzle.repository.ts':
@@ -53,12 +71,6 @@ const EXEMPT: Record<string, string> = {
     'bootstrap upsert of the three fixed system agents',
   'src/components/admin/admin.drizzle.repository.ts':
     'bootstrap only (root user / default org), runs before anything can subscribe',
-
-  // --- genuinely pending ---
-  'src/components/file/file.drizzle.repository.ts':
-    'PENDING: the Neo4j arm DOES invalidate (file.repository.ts:517 update, :569 delete). ' +
-    'Held out only because this file is modified by an in-flight branch; fix it there or ' +
-    'immediately after that merges. This is the one entry here that is a real defect.',
 };
 
 const COMPONENTS = 'src/components';
@@ -69,11 +81,45 @@ const walk = (dir: string): string[] =>
     return entry.isDirectory() ? walk(path) : [path];
   });
 
+/**
+ * Blank out comments and quoted strings so a mere mention can't satisfy any
+ * check below. Template literals are left intact on purpose — `RAW_SQL_WRITE`
+ * has to see inside them.
+ */
+const toCode = (source: string) =>
+  source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1')
+    .replace(/'(?:[^'\\\n]|\\.)*'/g, "''")
+    .replace(/"(?:[^"\\\n]|\\.)*"/g, '""');
+
 /** Method declarations whose names imply a write. */
 const WRITE_METHOD =
   /\n\s{2,6}(?:protected |private )?async (?:create|update|delete|remove|add|set|assign|upsert|save|merge)\w*\(/i;
 /** Raw drizzle writes, for repos whose method names don't follow the convention. */
 const RAW_WRITE = /\.\s*(?:update|insert|delete)\s*\(/;
+/**
+ * Raw SQL writes — `db.execute(sql\`UPDATE …\`)` carries no method call the two
+ * patterns above can see, so without this a repository could do every one of its
+ * writes in raw SQL and never register as a writer at all.
+ */
+const RAW_SQL_WRITE =
+  /sql`[^`]*\b(?:update\b|insert\s+into\b|delete\s+from\b)/is;
+
+const writes = (code: string) =>
+  WRITE_METHOD.test(code) || RAW_WRITE.test(code) || RAW_SQL_WRITE.test(code);
+
+/**
+ * Require an actual call. The bare identifier `liveQueryStore` used to satisfy
+ * this, which meant a comment explaining why a method does NOT invalidate
+ * counted as invalidating — the check could be passed by writing prose about it.
+ */
+const INVALIDATE_CALL = /\bliveQueryStore\s*\.\s*invalidate(?:All)?\s*\(/;
+
+const invalidates = (code: string) =>
+  code.includes('this.updateColumns(') ||
+  code.includes('this.softDelete(') ||
+  INVALIDATE_CALL.test(code);
 
 describe('LQ-1 structural guard: drizzle repositories invalidate live queries', () => {
   const repos = walk(COMPONENTS)
@@ -81,8 +127,13 @@ describe('LQ-1 structural guard: drizzle repositories invalidate live queries', 
     .map((path) => ({
       // POSIX-normalized so the pinned keys above are stable across platforms.
       key: relative('.', path).split(sep).join(posix.sep),
-      source: readFileSync(path, 'utf8'),
+      code: toCode(readFileSync(path, 'utf8')),
     }));
+
+  const writers = repos.filter(({ code }) => writes(code));
+  const offenders = writers
+    .filter(({ code }) => !invalidates(code))
+    .map(({ key }) => key);
 
   it('finds repositories to check (guards against a broken glob)', () => {
     // If the walk silently matched nothing, every assertion below would pass
@@ -90,35 +141,27 @@ describe('LQ-1 structural guard: drizzle repositories invalidate live queries', 
     expect(repos.length).toBeGreaterThan(20);
   });
 
-  it('every writing repository either uses the base helpers or invalidates itself', () => {
-    const offenders = repos
-      .filter(
-        ({ source }) => WRITE_METHOD.test(source) || RAW_WRITE.test(source),
-      )
-      .filter(
-        ({ source }) =>
-          !source.includes('this.updateColumns(') &&
-          !source.includes('this.softDelete(') &&
-          !source.includes('liveQueryStore'),
-      )
-      .map(({ key }) => key);
+  it('detects both writers and invalidators (guards against a broken strip)', () => {
+    // `toCode` blanking too much would empty every source and make the offender
+    // list trivially empty. Assert both halves of the classification still find
+    // things, so the guard can't pass by seeing nothing.
+    expect(writers.length).toBeGreaterThan(20);
+    expect(
+      repos.filter(({ code }) => invalidates(code)).length,
+    ).toBeGreaterThan(5);
+  });
 
+  it('every writing repository either uses the base helpers or invalidates itself', () => {
     const unexplained = offenders.filter((key) => !(key in EXEMPT));
     expect(unexplained).toEqual([]);
   });
 
   it('has no stale exemptions', () => {
-    // An exemption for a repo that now invalidates (or no longer exists) is
-    // misleading documentation — make removing it mandatory.
-    const stale = Object.keys(EXEMPT).filter((key) => {
-      const repo = repos.find((candidate) => candidate.key === key);
-      if (!repo) return true;
-      return (
-        repo.source.includes('this.updateColumns(') ||
-        repo.source.includes('this.softDelete(') ||
-        repo.source.includes('liveQueryStore')
-      );
-    });
+    // An exemption is only honest while the repo is still an offender. This
+    // catches all three ways one rots: the file is gone, it now invalidates, or
+    // it no longer writes at all — the last of which a "does it invalidate?"
+    // check on its own would miss.
+    const stale = Object.keys(EXEMPT).filter((key) => !offenders.includes(key));
     expect(stale).toEqual([]);
   });
 });

--- a/test/live-query-invalidation.e2e-spec.ts
+++ b/test/live-query-invalidation.e2e-spec.ts
@@ -6,10 +6,12 @@ import {
   it,
   jest,
 } from '@jest/globals';
-import { Role } from '~/common';
+import { type ID, Role } from '~/common';
 import { LiveQueryStore } from '~/core/live-query';
 import { graphql } from '~/graphql';
 import {
+  createDirectProduct,
+  createLanguageEngagement,
   createOrganization,
   createSession,
   createTestApp,
@@ -56,11 +58,17 @@ const keyOf = (identifier: Identifier): string => {
  */
 describe('Live-query invalidation (Drizzle base) e2e', () => {
   let app: TestApp;
+  let engagement: { id: ID };
 
   beforeAll(async () => {
     app = await createTestApp();
     await createSession(app);
-    await registerUser(app, { roles: [Role.Administrator] });
+    await registerUser(app, {
+      roles: [Role.Administrator, Role.ProjectManager],
+    });
+    if (isPostgres) {
+      engagement = await createLanguageEngagement(app);
+    }
   });
 
   afterEach(() => {
@@ -119,6 +127,26 @@ describe('Live-query invalidation (Drizzle base) e2e', () => {
       `Organization:${org.id}`,
     );
   });
+
+  // Product hand-rolls its own writes, so it invalidates itself rather than
+  // inheriting from the base. The interesting part is the KEY: the store keys on
+  // `${resource.name}:${id}`, and the Neo4j arm passes the CONCRETE subtype
+  // (DirectScriptureProduct, not Product). A generic `Product:` key would emit
+  // something nothing subscribes to — an invalidation that exists and does
+  // nothing, which is worse than none because it looks fixed.
+  it('invalidates a product under its concrete subtype, not the interface', async () => {
+    if (!isPostgres) return;
+    const product = await createDirectProduct(app, {
+      engagement: engagement.id,
+    });
+    const spy = watchInvalidations();
+
+    await app.graphql.mutate(UpdateDirectProductDoc, { id: product.id });
+
+    const keys = spy.mock.calls.map(([arg]) => keyOf(arg));
+    expect(keys).toContain(`DirectScriptureProduct:${product.id}`);
+    expect(keys).not.toContain(`Product:${product.id}`);
+  });
 });
 
 const UpdateOrgDoc = graphql(`
@@ -138,6 +166,16 @@ const DeleteOrgDoc = graphql(`
   mutation DeleteOrgForLiveQuery($id: ID!) {
     deleteOrganization(id: $id) {
       __typename
+    }
+  }
+`);
+
+const UpdateDirectProductDoc = graphql(`
+  mutation UpdateDirectProductForLiveQuery($id: ID!) {
+    updateDirectScriptureProduct(input: { id: $id, describeCompletion: "lq" }) {
+      product {
+        id
+      }
     }
   }
 `);

--- a/test/live-query-invalidation.e2e-spec.ts
+++ b/test/live-query-invalidation.e2e-spec.ts
@@ -1,0 +1,143 @@
+import {
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { Role } from '~/common';
+import { LiveQueryStore } from '~/core/live-query';
+import { graphql } from '~/graphql';
+import {
+  createOrganization,
+  createSession,
+  createTestApp,
+  registerUser,
+  type TestApp,
+} from './utility';
+
+// The Drizzle repository base is only in play under postgres; under the other
+// engines their own bases already invalidate and are unchanged by this fix.
+const isPostgres = process.env.DATABASE === 'postgres';
+
+type Identifier = Parameters<LiveQueryStore['invalidate']>[0];
+
+/**
+ * Resolve an identifier to the key that actually reaches the store, the same way
+ * `LiveQueryStore.invalidateAll` does — so assertions pin the emitted key rather
+ * than merely "something fired".
+ */
+const keyOf = (identifier: Identifier): string => {
+  if (typeof identifier === 'string') {
+    return identifier;
+  }
+  const [res, id] = identifier;
+  const name = typeof res === 'string' ? res : (res as { name: string }).name;
+  return `${name}:${id}`;
+};
+
+/**
+ * Regression guard for LQ-1: the Drizzle repository base did not invalidate the
+ * live-query store on update/delete, while the Neo4j and Gel bases both do it
+ * generically. The consequence was user-visible rather than theoretical — ~12
+ * cord-field documents carry `@live` and they are the detail page of nearly
+ * every domain, so after cutover editing any of them left an open page stale
+ * until manual refresh.
+ *
+ * Organization is the worked example from the audit: its service has no manual
+ * `liveQueryStore.invalidate` call anywhere, so anything observed here came from
+ * the base and nowhere else.
+ *
+ * NOTE on the spy: restore in `afterEach`, NEVER in a `finally` ahead of the
+ * assertions. `mockRestore()` is `mockReset()` + restore, so it clears
+ * `mock.calls` — every assertion then reads an empty array, which fails the
+ * positive cases and passes the negative one no matter what the code does.
+ */
+describe('Live-query invalidation (Drizzle base) e2e', () => {
+  let app: TestApp;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await createSession(app);
+    await registerUser(app, { roles: [Role.Administrator] });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /** Spy on the exact store instance the DI container hands the repositories. */
+  const watchInvalidations = () =>
+    jest.spyOn(app.get(LiveQueryStore), 'invalidate');
+
+  it('invalidates the mutated resource on update', async () => {
+    if (!isPostgres) return;
+    const org = await createOrganization(app);
+    const spy = watchInvalidations();
+
+    const newName = `${org.name.value ?? 'Org'} (renamed)`;
+    const updated = await app.graphql.mutate(UpdateOrgDoc, {
+      input: { id: org.id, name: newName },
+    });
+
+    // Control: proves the mutation actually ran and changed the row, so a zero
+    // invalidation count can only mean the invalidation itself is missing.
+    expect(updated.updateOrganization.organization.name.value).toBe(newName);
+
+    expect(spy.mock.calls.map(([arg]) => keyOf(arg))).toContain(
+      `Organization:${org.id}`,
+    );
+  });
+
+  it('invalidates the mutated resource on soft delete', async () => {
+    if (!isPostgres) return;
+    const org = await createOrganization(app);
+    const spy = watchInvalidations();
+
+    await app.graphql.mutate(DeleteOrgDoc, { id: org.id });
+
+    expect(spy.mock.calls.map(([arg]) => keyOf(arg))).toContain(
+      `Organization:${org.id}`,
+    );
+  });
+
+  // The no-op guard in updateColumns() returns before touching the DB; it must
+  // return before invalidating too, or every empty update wakes every live query
+  // watching that resource for no reason.
+  it('does not invalidate when an update changes nothing', async () => {
+    if (!isPostgres) return;
+    const org = await createOrganization(app);
+    const spy = watchInvalidations();
+
+    // Same name it already has -> getActualChanges yields an empty change set.
+    await app.graphql.mutate(UpdateOrgDoc, {
+      input: { id: org.id, name: org.name.value ?? 'Org' },
+    });
+
+    expect(spy.mock.calls.map(([arg]) => keyOf(arg))).not.toContain(
+      `Organization:${org.id}`,
+    );
+  });
+});
+
+const UpdateOrgDoc = graphql(`
+  mutation UpdateOrgForLiveQuery($input: UpdateOrganization!) {
+    updateOrganization(input: $input) {
+      organization {
+        id
+        name {
+          value
+        }
+      }
+    }
+  }
+`);
+
+const DeleteOrgDoc = graphql(`
+  mutation DeleteOrgForLiveQuery($id: ID!) {
+    deleteOrganization(id: $id) {
+      __typename
+    }
+  }
+`);


### PR DESCRIPTION
### Summary

Some pages in the app update themselves. You have a project open, someone else changes it, and your view refreshes without you doing anything. That works because the server announces "this record changed, re-fetch it" every time something is written.

Under Postgres, the server had stopped announcing.

The two older database layers both announce automatically from a shared base class, so every domain got it for free. The Postgres layer's equivalent base class never did. Twelve of the app's queries depend on those announcements, and they are the detail pages of nearly every domain — project overview, engagement, partner, language, location, user, budget, product, both field region/zone pages, and both progress report views. After the cutover, editing anything on those pages would have left the open page showing stale data until the user manually refreshed.

There were 18 hand-written announcements scattered across about 13 of 55 services, and those still fire. But they mostly announce a *parent* record rather than the one that changed, so any domain that hadn't hand-rolled its own call lost the behavior entirely.

This restores it, and adds a test that stops it from silently happening again.

### What's changed

- **The shared base** (`DrizzleDtoRepository`) now announces changes on `updateColumns()` and `softDelete()`. `liveQueryStore` is property-injected rather than added to the constructor, so no subclass has to thread it through `super()` — the same pattern both other bases already use. That covers 23 of the 42 Postgres repositories.
- **`product`** and **`prompt-variant-response`** hand-roll their own writes and never reach those helpers, so they announce for themselves.
- **A structural guard** (unit test, no database) enumerates every Postgres repository that writes and fails when one neither routes through the base helpers nor announces for itself, unless it's listed with a written reason.

Two lines of actual behavior change in the base; the rest is the two repositories, tests, and documentation.

### How the remaining 19 repositories were assessed

The standard applied was **parity with the existing engines, not perfection** — a gap that exists identically on Neo4j is a pre-existing product issue, not something the migration introduced. Each write path was compared against its Neo4j counterpart, and only three came back as real gaps:

- `product` — Neo4j announces on all three property-update methods (via `db.updateProperties`, which announces at `database.service.ts:340`) and on delete. **Fixed.**
- `prompt-variant-response` — Neo4j announces on delete only. **Fixed.**
- `file` — Neo4j announces on update (`file.repository.ts:517`) and delete (`:569`). **Not fixed here**; see follow-up.

The other 16 need nothing. Six have Neo4j counterparts that don't announce either (`pin`, `product-progress`, `progress-summary`, `comment-thread`, `known-language`, `project-workflow`), three are create-only or bootstrap paths where nothing can be subscribed yet (`notification`, `system-agent`, `admin`), and the rest have no write path at all.

### Two details worth a reviewer's attention

**Products announce under their concrete subtype, not the interface.** The store keys on `${resource.name}:${id}`, and the Neo4j arm passes `DirectScriptureProduct` / `DerivativeScriptureProduct` / `OtherProduct`. A generic `Product:` key would emit something nothing subscribes to — an announcement that exists and does nothing. That failure mode is worse than no announcement at all, because the call sits right there in the diff and reads as correct. There's an assertion pinning the concrete key *and* asserting the interface key is absent.

**Announcing from inside the mutation transaction is deliberate and safe.** Both other bases announce before their write, which looks wrong under Postgres' real transactions — the obvious worry being a live query re-executing against uncommitted state, or announcing a change that then rolls back. Neither happens: `LiveQueryStoreImpl.doInvalidate` defers the work to `TransactionHooks.afterCommit`, and `DrizzleTransactionalMutationsInterceptor` runs those hooks via the `runAndClear()` it inherits. No new deferral machinery was needed; the plumbing existed and was simply unused from this base. The reasoning is in the class docblock so the placement doesn't get "corrected" later.

Also deliberate: the `updateColumns()` call sits **after** the existing no-op guard. An update whose change set came out empty must not wake every live query watching that resource.

### The structural guard, and why it's here

This class of bug was invisible for as long as it was because the symptom — a detail page that quietly stops refreshing — shows up in no functional test and in no code review. Without a guard, the next repository added silently reintroduces it.

Three assertions, and the second two matter as much as the first:

- No unexplained offenders.
- **No stale exemptions** — an exemption for a repository that now announces is misleading documentation, so removing it is mandatory.
- A count floor, so a broken directory walk can't make the whole suite pass vacuously.

### Validation performed

Verified by running, including the negative cases — a guard that has never been observed failing isn't a guard:

- Live-query e2e **4/4** under Postgres. Removing the two base lines makes 2 of 3 base cases fail.
- Structural guard **3/3**. Removing one exemption makes it fail and name the offending file.
- The update test carries a control assertion that the row actually changed, so a zero-announcement result can only mean the announcement is missing — not that the mutation silently didn't run.
- No regressions under Postgres: product 14/15, periodic-report + organization 16/22 (all skips pre-existing).
- Neo4j leg: live-query + product **18/19** (1 pre-existing skip).
- Full unit project **193/196** (3 todo), run the way CI runs it.
- `yarn type-check` and `yarn lint` both exit 0.
- **CI wiring checked on both sides:** the e2e spec is added to the Postgres test-path pattern, which enumerates specs by name — a new file would otherwise never run. The guard needs no wiring; the `Unit` job runs `yarn test` unfiltered.

### Reviewer cross-checks

- That property injection on an abstract base resolves for every subclass. It does, and the spec fails loudly if it doesn't, but it's the least conventional line in the diff.
- That the identifier shape `[resource, id]` matches what the other two bases emit, so keys collide correctly across engines instead of forming parallel namespaces.
- That the `updateColumns()` announcement is after, not before, the empty-change-set early return.
- Whether any of the 23 base-routed repositories has a *second* write path that bypasses the helpers.
- The parity calls in the guard's exemption list — each names the Neo4j file it was checked against, and each is worth a second opinion.

### Follow-up, not in this PR

- **`file` is the one real defect left.** Its Neo4j arm announces on update and delete; the Postgres arm doesn't. It's held out solely because that file is modified by a branch currently in flight, so editing it here would conflict. It's recorded in the guard's exemption list as the single entry flagged a genuine defect, and should land in that branch or immediately after it merges.
- **The six parity repositories are a real gap on all three engines** — live queries don't refresh there today either. Worth a ticket, but it isn't a migration regression and isn't cutover-blocking.
- **No announcement on create**, on any engine. List-level queries go stale when a record is created. Pre-existing; not introduced here.
