### PR TITLE
[pg] Schema fixes: relax name/code uniqueness (0030) + system-agent workflow actors (0031)

### DIFF
--- a/src/components/language/ethnologue-language/ethnologue-language.drizzle.repository.ts
+++ b/src/components/language/ethnologue-language/ethnologue-language.drizzle.repository.ts
@@ -1,11 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ilike, type SQL } from 'drizzle-orm';
 import { generateId, type ID, type UnsecuredDto } from '~/common';
-import {
-  catchUniqueViolation,
-  DrizzleDtoRepository,
-  escapeLikePattern,
-} from '~/core/drizzle';
+import { DrizzleDtoRepository, escapeLikePattern } from '~/core/drizzle';
 import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
 import { ethnologueLanguages } from '~/core/drizzle/schema';
 import {
@@ -15,16 +11,9 @@ import {
   type UpdateEthnologueLanguage,
 } from '../dto';
 
-const catchCodeUnique = catchUniqueViolation(
-  'ethnologue_languages_code_unique',
-  'code',
-  'EthnologueLanguage with this code already exists.',
-);
-const catchProvisionalCodeUnique = catchUniqueViolation(
-  'ethnologue_languages_provisional_code_unique',
-  'provisionalCode',
-  'EthnologueLanguage with this provisional code already exists.',
-);
+// No unique-violation mapping: neither `code` nor `provisional_code` is unique
+// (migration 0030 — languages share ethnologue codes routinely), so there is no
+// violation to map. The unique key is the ROLV code on `languages`.
 
 @Injectable()
 export class EthnologueLanguageDrizzleRepository extends DrizzleDtoRepository<
@@ -38,40 +27,46 @@ export class EthnologueLanguageDrizzleRepository extends DrizzleDtoRepository<
   async create(
     input: CreateEthnologueLanguage & { languageId: ID },
   ): Promise<UnsecuredDto<EthnologueLanguage>> {
-    // migration-todo: `EthnologueLanguageService.create()` currently passes
-    // `'temp' as ID` for `languageId` because the Language row is created
-    // *after* the EthnologueLanguage in `LanguageRepository.create()` — the
-    // relationship is wired up by the caller via the returned ethnologue
-    // id, so Neo4j never reads `input.languageId`. The Gel repo's `create()`
-    // throws ("Database creates EthnologueLanguages directly. Don't call
-    // this") because Gel creates the row as a side-effect of Language insert.
+    // The insert-Language-first ordering this used to wait for HAS LANDED on the
+    // Drizzle path, so nothing here receives a placeholder id: `splitDb` routes
+    // the ethnologue and Language repositories together, meaning whenever this
+    // repo is live the Drizzle Language repo is its only caller and it passes the
+    // real `languageId`.
     //
-    // Drizzle is the only impl that writes `input.languageId` to a real
-    // column. With `language_id` now nullable (see schema comment), the
-    // 'temp' string still slips through as a non-null bogus id today — the
-    // schema doesn't reject it, but it's still wrong data.
+    // migration-todo: the surviving half is a Neo4j-only fallback.
+    // `EthnologueLanguageService.create()` still passes `'temp' as ID` for the
+    // Neo4j caller, because there the Language row is created *after* the
+    // EthnologueLanguage and the relationship is wired up by the caller via the
+    // returned ethnologue id — so Neo4j never reads `input.languageId`. (The Gel
+    // repo's `create()` throws outright, since Gel creates the row as a
+    // side-effect of the Language insert.) Retire the fallback with the Neo4j
+    // repositories at Phase 7 cutover.
     //
-    // Resolution lands with the Language migration (Phase 3&4) by flipping
-    // the create flow: insert Language first, then EthnologueLanguage with
-    // the real `languageId`. Or, if the global-pool model is in place by
-    // then, the service `create()` becomes "attach existing pool entry by
-    // code if one matches, else insert a new pool entry" — at which point
-    // `languageId` here is the attaching Language and the call to this
-    // repo's `create()` only fires for genuinely new pool entries.
+    // For the record, since an earlier version of this comment said otherwise:
+    // `language_id` carries a real, fully enforced FK to `languages(id)` from
+    // migration 0016 — not `NOT VALID`, not deferrable, never dropped. A literal
+    // `'temp'` would be REJECTED by that FK, not stored as bogus data.
+    //
+    // If the global-pool model arrives instead, the service `create()` becomes
+    // "attach an existing pool entry by code, else insert a new one" — at which
+    // point `languageId` here is the attaching Language and this repo's `create()`
+    // only fires for genuinely new pool entries.
+    //
+    // If that is the path taken: codes are NOT unique (migration 0030 — sharing
+    // is routine, not rare), so "the pool entry matching this code" is
+    // frequently several rows. That step needs an explicit disambiguation rule
+    // decided in application code; it cannot be a single-row lookup, and the
+    // database will not narrow it for you.
     // Dormant until PG mode activates.
     const id = await generateId();
-    await this.db
-      .insert(ethnologueLanguages)
-      .values({
-        id,
-        languageId: input.languageId,
-        code: input.code,
-        provisionalCode: input.provisionalCode,
-        name: input.name,
-        population: input.population,
-      })
-      .catch(catchCodeUnique)
-      .catch(catchProvisionalCodeUnique);
+    await this.db.insert(ethnologueLanguages).values({
+      id,
+      languageId: input.languageId,
+      code: input.code,
+      provisionalCode: input.provisionalCode,
+      name: input.name,
+      population: input.population,
+    });
     return await this.readOne(id);
   }
 
@@ -84,9 +79,7 @@ export class EthnologueLanguageDrizzleRepository extends DrizzleDtoRepository<
       provisionalCode: fields.provisionalCode,
       name: fields.name,
       population: fields.population,
-    })
-      .catch(catchCodeUnique)
-      .catch(catchProvisionalCodeUnique);
+    });
     return await this.readOne(id);
   }
 

--- a/src/components/language/language.drizzle.repository.ts
+++ b/src/components/language/language.drizzle.repository.ts
@@ -56,16 +56,9 @@ type LanguageRow = typeof languages.$inferSelect & {
   pinned?: boolean;
 };
 
-const catchNameUnique = catchUniqueViolation(
-  'languages_name_active_unique',
-  'name',
-  'name with this value already exists',
-);
-const catchDisplayNameUnique = catchUniqueViolation(
-  'languages_display_name_active_unique',
-  'displayName',
-  'displayName with this value already exists',
-);
+// No name / displayName equivalents: those columns are not unique (migration
+// 0030 — distinct languages legitimately share a name), so there is no violation
+// to map.
 const catchRolvUnique = catchUniqueViolation(
   'languages_rolv_code_active_unique',
   'registryOfLanguageVarietiesCode',
@@ -112,8 +105,6 @@ export class LanguageDrizzleRepository extends DrizzleDtoRepository<
         tags: input.tags ? [...input.tags] : [],
         isAvailableForReporting: input.isAvailableForReporting ?? false,
       })
-      .catch(catchNameUnique)
-      .catch(catchDisplayNameUnique)
       .catch(catchRolvUnique);
 
     // Mirror of Gel's connectEthnologue trigger: the Language row exists
@@ -148,10 +139,7 @@ export class LanguageDrizzleRepository extends DrizzleDtoRepository<
       hasExternalFirstScripture: fields.hasExternalFirstScripture,
       ...(fields.tags !== undefined && { tags: [...fields.tags] }),
       isAvailableForReporting: fields.isAvailableForReporting,
-    })
-      .catch(catchNameUnique)
-      .catch(catchDisplayNameUnique)
-      .catch(catchRolvUnique);
+    }).catch(catchRolvUnique);
 
     if (fields.sensitivity !== undefined) {
       // Mirror of Gel's recalculateProjectSens trigger: keep engaging

--- a/src/components/project/workflow/project-workflow.drizzle.repository.ts
+++ b/src/components/project/workflow/project-workflow.drizzle.repository.ts
@@ -15,7 +15,7 @@ import {
  * PostgreSQL implementation of the canonical `ProjectWorkflowRepository`.
  *
  * `projects.step` is kept in sync by an `AFTER INSERT` trigger on
- * `project_workflow_events` (see migration 0009 — `sync_project_step_from_event`).
+ * `project_workflow_events` (see migration 0010 — `sync_project_step_from_event`).
  * App code never writes to `projects.step` directly; insert an event and the
  * trigger does the rest. `modified_at` is bumped in the same trigger.
  *
@@ -79,13 +79,13 @@ export class ProjectWorkflowDrizzleRepository {
     const fromStep: ProjectStep | null = projectRow?.step ?? null;
 
     const id = await generateId<ID<'ProjectWorkflowEvent'>>();
-    const who = this.identity.current.userId;
+    const actor = this.resolveActor();
     const at = new Date();
 
     await this.db.insert(projectWorkflowEvents).values({
       id,
       projectId: input.project,
-      who,
+      ...actor,
       fromStep,
       toStep: input.to,
       transitionKey: input.transition ?? null,
@@ -96,7 +96,7 @@ export class ProjectWorkflowDrizzleRepository {
     return this.toDto({
       id,
       projectId: input.project,
-      who,
+      ...actor,
       fromStep,
       toStep: input.to,
       transitionKey: input.transition ?? null,
@@ -108,6 +108,63 @@ export class ProjectWorkflowDrizzleRepository {
         step: fromStep ?? input.to,
       },
     });
+  }
+
+  /**
+   * Which actor column this event belongs in.
+   *
+   * `identity.current.userId` holds a SystemAgent's id whenever the session
+   * resolved to an agent rather than a person: an anonymous session (the Anonymous
+   * agent) or Ghost impersonation. Both set `systemAgentName` in
+   * `SessionManager.resumeSession`, which is what makes the discriminator below
+   * work, and the audit writer discriminates on the same field.
+   *
+   * Do NOT read a population claim from this method. The agent-actored events
+   * already in the data did not arrive through here — they came from the
+   * step-history backfill, which writes directly and never calls `recordEvent`.
+   * Migration 0031's header is the single source for that. (The Neo4j writer
+   * cannot produce one at all: it builds the `who` relationship against the `User`
+   * label, which system agents never carry.)
+   *
+   * Exactly one column is returned non-null, satisfying
+   * `project_workflow_events_actor_shape_chk` (migration 0031).
+   *
+   * migration-todo: TWO session shapes slip past the discriminator, and in both the
+   * failure is the foreign key to `users` — never the actor-shape CHECK, so that
+   * constraint is not what protects this.
+   *
+   * 1. REACHABLE TODAY, over a request header. `resumeSession` resolves the Ghost
+   *    agent only when the impersonatee id is the literal `'ghost'`; any other id
+   *    passes straight through, and `systemAgentName` is set from `ghost?.name`.
+   *    So a requester who sends a SystemAgent's REAL id as the impersonatee gets a
+   *    session whose `userId` is that agent while `systemAgentName` stays
+   *    undefined. The branch below reads it as a person, writes the agent id into
+   *    `who`, fails the FK, and rolls the whole transition back. Nothing validates
+   *    that the impersonatee is a live user. The underlying gap is pre-existing,
+   *    engine-independent, and mirrored in the audit writer, so it is not this
+   *    migration's to fix — but it is not hypothetical either.
+   * 2. Unreachable today. `SessionManager.asRole` builds a session with the literal
+   *    placeholder `userId: 'anonymous'`, `anonymous: false`, and no
+   *    `systemAgentName`. Both call sites are read-only permission serializers
+   *    (`policy-dumper.ts`, `permission.serializer.ts`), and `executeTransition`
+   *    does no identity switching around `recordEvent`. The fix belongs in
+   *    `asRole`.
+   *
+   * A safer shape for this method would be to treat an id that is not a live user
+   * as an agent, or to fail with a domain error naming the session shape, rather
+   * than handing an unresolvable id to the FK. Note this copy also omits the audit
+   * writer's `session.anonymous ||` half — equivalent today, and it would catch
+   * neither shape above (shape 2 sets `anonymous: false`; shape 1 has a real
+   * logged-in requester).
+   */
+  private resolveActor(): {
+    who: ID<'User'> | null;
+    whoSystemAgentId: ID<'SystemAgent'> | null;
+  } {
+    const session = this.identity.current;
+    return session.systemAgentName
+      ? { who: null, whoSystemAgentId: session.userId as ID<'SystemAgent'> }
+      : { who: session.userId as ID<'User'>, whoSystemAgentId: null };
   }
 
   /**
@@ -154,7 +211,11 @@ export class ProjectWorkflowDrizzleRepository {
       __typename: 'ProjectWorkflowEvent',
       createdAt: DateTime.fromJSDate(row.at),
       at: DateTime.fromJSDate(row.at),
-      who: { id: row.who },
+      // Exactly one actor column is set (CHECK, migration 0031). The resolver
+      // hydrates whichever id through `ActorLoader`, which resolves users and
+      // system agents alike and returns `SecuredActor` — so nothing downstream
+      // needs to know which of the two it got.
+      who: { id: (row.who ?? row.whoSystemAgentId)! },
       // `transition` is the transition key (a string id resolved to a
       // WorkflowTransition object at the resolver layer). null when the
       // transition was bypassed or dynamic.

--- a/src/core/drizzle/migrations/0030_relax_name_and_code_uniqueness.sql
+++ b/src/core/drizzle/migrations/0030_relax_name_and_code_uniqueness.sql
@@ -1,0 +1,110 @@
+-- Drop five unique indexes that enforce uniqueness the source data does not have.
+--
+-- WHERE THEY CAME FROM — two different stories, and the distinction matters to
+-- anyone tempted to put them back:
+--
+--   * The two LANGUAGE NAME columns were a misreading of Neo4j. The comment above
+--     them claimed to mirror `LanguageName` / `LanguageDisplayName` constraints.
+--     Those constraints DO NOT EXIST — nothing in the Neo4j constraint set covers
+--     a language name or a display name, and the Gel schema does not constrain
+--     them either.
+--   * The LOCATION iso_alpha3 and both ETHNOLOGUE CODE columns came from Gel,
+--     which this schema was ported from and which STILL DECLARES THEM EXCLUSIVE
+--     today — `dbschema/location.gel` (isoAlpha3) and `dbschema/language.gel`
+--     (code, provisionalCode). For the ethnologue pair that traces to the planned
+--     global-pool model, which wanted codes unique across the whole pool; see the
+--     note on the table in schema/index.ts.
+--
+-- So Postgres has been rejecting data Neo4j accepts on all five columns, and on
+-- three of them Gel is now the copy that is out of step — the same source data
+-- could not have loaded into Gel either. **If you arrive here intending to restore
+-- uniqueness because you found it declared in `dbschema/`, that declaration is the
+-- stale one, not this migration.**
+--
+-- This is a correctness fix, not an accommodation for the data migration. It
+-- breaks two different ways, and each alone would justify the change:
+--
+--   1. FUNCTIONALLY WRONG, TODAY, INDEPENDENT OF ANY MIGRATION. Language names
+--      are not unique in this domain — two genuinely distinct languages can
+--      share a name, and real data contains such groups. Every one was checked:
+--      each is distinguishable, with at most one null ROLV code per group, i.e.
+--      distinct languages that happen to share a name, not accidental
+--      duplicates. Ethnologue codes are shared far more widely still, and
+--      nearly every duplicate-code group is separable by ROLV code. Under these
+--      indexes the next person creating a legitimately distinct language with an
+--      existing name is simply refused, on either engine, forever.
+--
+--   2. SILENT DATA LOSS AT LOAD. The loader cannot insert a row that violates a
+--      unique index, so it drops it — and then everything hanging off it, since
+--      `engagements_type_shape_chk` forbids a null language_id. Verified end to
+--      end against a real dataset: a dropped language cascades through its
+--      engagements, ceremonies, products, periodic reports, product progress,
+--      step progress, and summaries, so a modest number of rejected languages
+--      removes orders of magnitude more rows than it looks like. Reconciliation
+--      reports each table separately, so one root cause reads as seven
+--      unrelated problems.
+--
+-- WHAT IS DELIBERATELY KEPT, and why the distinction matters:
+--
+--   * `languages_rolv_code_active_unique` — the ROLV code IS the unique natural
+--     key for a language, and real data agrees: no duplicates among live codes,
+--     so the cleanup done a few months back held. This is the constraint that
+--     was always meant; the two name indexes were never it.
+--   * `locations_name_active_unique` — untouched. Only iso_alpha3 is dropped
+--     here; nothing has shown location names to be non-unique.
+--   * `ethnologue_languages_language_id_unique` — structural (one ethnologue row
+--     per language), not a natural key.
+--
+-- All five remain partial (`WHERE deleted_at IS NULL`), so dropping them changes
+-- nothing about the soft-delete convention; the columns simply stop being keys.
+--
+-- NO PLAIN INDEXES REPLACE THEM, deliberately — but the reason is table size, not
+-- the columns being unused. Stating it precisely matters here, because a loose
+-- claim about how these columns are read is exactly what got the uniqueness
+-- written in the first place:
+--
+--   * As PREDICATES they are unservable by a b-tree. Language name/display-name
+--     and both ethnologue codes are only ever matched with `ILIKE '%pattern%'`,
+--     and nothing filters on `locations.iso_alpha3` at all — it is projected,
+--     written, and resolved to an ISO country in application code.
+--   * As SORT KEYS three of them are live and client-selectable: `languages.name`
+--     and `languages.display_name` (the `sortColumns` map in
+--     language.drizzle.repository.ts) and `locations.iso_alpha3` (the same map in
+--     location.drizzle.repository.ts). The GraphQL `sort` argument is a plain
+--     string, so `sort: "displayName"` or `sort: "isoAlpha3"` is a request the API
+--     accepts today, on both engines. Not hypothetical.
+--
+-- Replacements are still not worth it, because of the tables and the query shape
+-- rather than the columns: both tables are small, and the list path issues an
+-- unconditional `count(*)` over the whole table alongside every page query, so
+-- the table gets scanned no matter what index exists. Measured on a scratch table
+-- of comparable size, dropping the index moved the paged sort from an incremental
+-- sort over an index scan to a sort over a sequential scan — a sub-millisecond
+-- difference. Real, and negligible.
+--
+-- If sorting one of these lists ever becomes a hot path, add a PLAIN non-unique
+-- b-tree. Do not restore the uniqueness: the data does not have it (see above).
+--
+-- SEARCH INDEXING IS NOT AT PARITY. This is a Postgres-only gap that arms at
+-- cutover, not behaviour shared with the current engine — worth stating plainly,
+-- because an earlier draft of this header claimed the opposite:
+--
+--   * The two LANGUAGE columns ARE indexed on Neo4j: a Lucene full-text index
+--     (`LanguageName`, analyzer `standard-folding`, declared in
+--     language.repository.ts) reached through the `fullText` filter. Postgres runs
+--     `ILIKE '%pattern%'` over both columns with no text index at all — the only
+--     GIN index in the entire schema is on the project-member roles array. And
+--     beyond speed: a tokenising, diacritic-folding analyzer and a raw substring
+--     match DO NOT RETURN THE SAME ROWS, so this is a behavioural difference in
+--     search, not merely a slower one. Global search takes the same substring path.
+--   * The two ETHNOLOGUE CODE columns are unindexed on both engines.
+--
+-- Tracked as a follow-up: either trigram/GIN indexes, or an accepted difference
+-- that gets written down. Dropping the uniques above neither causes nor worsens
+-- it — a unique b-tree could not serve a leading-wildcard match either.
+
+DROP INDEX "languages_name_active_unique";
+DROP INDEX "languages_display_name_active_unique";
+DROP INDEX "ethnologue_languages_code_unique";
+DROP INDEX "ethnologue_languages_provisional_code_unique";
+DROP INDEX "locations_iso_alpha3_active_unique";

--- a/src/core/drizzle/migrations/0031_workflow_event_system_agent_actor.sql
+++ b/src/core/drizzle/migrations/0031_workflow_event_system_agent_actor.sql
@@ -1,0 +1,69 @@
+-- Let a project workflow event be attributed to a SystemAgent, not just a User.
+--
+-- `project_workflow_events.who` was `NOT NULL REFERENCES users(id)`, which encodes
+-- "every step transition was performed by a logged-in person". That is not true,
+-- and not true by a wide margin: in real data the clear majority of events have a
+-- SystemAgent actor. Under the old shape every one of them violates the FK, so
+-- the load drops them — most of every project's step history, silently, because a
+-- dropped row is not an error. Local development data hid this almost entirely,
+-- which is why it surfaced only against a production-shaped copy.
+--
+-- Nothing above the repository needs to change FOR READS, because the read path
+-- already models this correctly and only the Postgres column was behind:
+--
+--   * Neo4j matches `node('who', 'Actor')`, not `node('who', 'User')` — it has
+--     always allowed either, which is how those rows came to exist.
+--   * `ProjectWorkflowEventResolver.who` resolves through `ActorLoader` and
+--     returns `SecuredActor`, so the GraphQL contract is already a User-or-
+--     SystemAgent union. (The `Secured<LinkTo<'User'>>` on the shared
+--     `WorkflowEvent` DTO is a stale TypeScript annotation, not the contract.)
+--   * `system_agents` already exists and the loader already populates it.
+--
+-- On the WRITE side there is one known gap, pre-existing and not caused by this
+-- migration: the step-change email handler looks the actor up as a person, so an
+-- agent-authored transition that carries notification recipients throws — and
+-- since hooks run inside the transition's transaction, the whole transition rolls
+-- back. This migration changes only WHERE that fails: before, the insert was
+-- rejected at the `who` foreign key; now the insert succeeds and the hook throws
+-- instead. It strictly improves the no-recipients case, which now succeeds. Neo4j
+-- fails the same flow for the same reason (its actor edge is matched with a `User`
+-- label that agents do not carry), so this is parity rather than a regression, and
+-- the fix is tracked as post-cutover work. Note the pre-existing agent-actored
+-- events all came from the step-history backfill, which writes directly and never
+-- fires a hook — reads of them are fine.
+--
+-- SHAPE: two nullable columns and a CHECK, matching `resource_mutations`'
+-- actor arc from 0027 rather than inventing a second idiom for the same problem.
+--
+-- ONE DELIBERATE DIVERGENCE FROM 0027: this stores the agent's ID as a real FK,
+-- where the audit log stores its NAME as text. Not an inconsistency — the two
+-- tables want different things. An audit row is a historical SNAPSHOT (it
+-- snapshots `role_at_time` for the same reason) and must survive the removal of
+-- what it names, so a hard reference is wrong there. A workflow event is live
+-- project history whose actor is READ BACK as a hydrated object: Neo4j models it
+-- as an edge to a real Actor node, and `ActorLoader` needs an id. Storing a name
+-- here would mean a name->id lookup on every read to reconstruct what the FK
+-- gives directly, and the loader already carries the agent ids across.
+--
+-- The CHECK is `= 1`, not 0027's `<= 1`: a transition cannot happen without an
+-- actor (`identity.current` throws where the audit writer tolerates no session),
+-- Neo4j's `who` edge is always present, and real data confirms it — no event
+-- lacks an actor, and none carries an actor that is neither a live user nor a
+-- system agent.
+--
+-- No ON DELETE clause on the new FK, matching `who`'s existing plain reference:
+-- agents are lazily upserted by name and effectively permanent, and an event
+-- losing its actor should fail loudly rather than quietly rewrite history.
+
+ALTER TABLE "project_workflow_events"
+  ALTER COLUMN "who" DROP NOT NULL;
+
+ALTER TABLE "project_workflow_events"
+  ADD COLUMN "who_system_agent_id" text REFERENCES "system_agents"("id");
+
+ALTER TABLE "project_workflow_events"
+  ADD CONSTRAINT "project_workflow_events_actor_shape_chk"
+  CHECK (num_nonnulls("who", "who_system_agent_id") = 1);
+
+CREATE INDEX "project_workflow_events_who_system_agent_id_idx"
+  ON "project_workflow_events" ("who_system_agent_id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -211,6 +211,20 @@
       "when": 1753142400000,
       "tag": "0029_add_pnp_extraction_results",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1753228800000,
+      "tag": "0030_relax_name_and_code_uniqueness",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1753315200000,
+      "tag": "0031_workflow_event_system_agent_actor",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -321,13 +321,14 @@ export const locations = pgTable(
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
   },
   (t) => [
-    // Partial unique indexes scoped to live rows so soft-deleted records
-    // don't block reuse of their name / iso_alpha3.
+    // Partial unique index scoped to live rows so soft-deleted records don't
+    // block reuse of their name. `iso_alpha3` is deliberately NOT unique —
+    // Neo4j never constrained it, and nothing *filters* on it (the resolver reads
+    // the value and resolves the ISO country in app code). It IS a selectable
+    // sort key though, so it is not unread; there is simply no index behind that
+    // sort, which this table's size makes fine. See migration 0030.
     uniqueIndex('locations_name_active_unique')
       .on(t.name)
-      .where(sql`${t.deletedAt} IS NULL`),
-    uniqueIndex('locations_iso_alpha3_active_unique')
-      .on(t.isoAlpha3)
       .where(sql`${t.deletedAt} IS NULL`),
     index('locations_default_marketing_region_id_idx').on(
       t.defaultMarketingRegionId,
@@ -599,24 +600,33 @@ export const ethnologueLanguages = pgTable(
   'ethnologue_languages',
   {
     id: text('id').$type<ID<'EthnologueLanguage'>>().primaryKey(),
-    // migration-todo: add REFERENCES languages(id) ON DELETE SET NULL when
-    // Language migrates in Phase 3&4. Deliberately NOT `ON DELETE CASCADE`
-    // and `language_id` is nullable — preserves the path to the planned
-    // future model where EthnologueLanguage is a global pool of canonical
-    // language records and `language_id` is a *soft attachment* (a new
-    // Language hooks into an existing pool entry by code, rather than
-    // creating its own Ethnologue). Deleting a Language should release the
-    // attachment, not destroy the pool entry. The Apollo client already
-    // treats EthnologueLanguage as a value object (`typePolicies.base.ts:43`
-    // — `keyFields: false`), and no codepath calls a delete on it.
+    // The reference to `languages(id)` ALREADY EXISTS — added by migration 0016
+    // and fully enforced. (An earlier version of this comment still asked for it
+    // to be added "when Language migrates"; Language migrated, and the FK came
+    // with it.)
     //
-    // The `code` / `provisional_code` partial uniques stay GLOBAL (not
-    // scoped to attached rows) because the future global-pool model
-    // requires codes to be unique across the entire pool — orphaned and
-    // attached alike. Today that means deleting a Language and then
-    // creating a new one with the same code throws on the unique index;
-    // that error path is the seed of the future "attach existing pool
-    // entry by code" logic.
+    // migration-todo: only the `ON DELETE SET NULL` half is outstanding.
+    // Deliberately NOT `ON DELETE CASCADE`, and `language_id` stays nullable —
+    // that preserves the path to the planned future model where
+    // EthnologueLanguage is a global pool of canonical language records and
+    // `language_id` is a *soft attachment* (a new Language hooks into an existing
+    // pool entry by code rather than creating its own Ethnologue). Deleting a
+    // Language should release the attachment, not destroy the pool entry. The
+    // Apollo client already treats EthnologueLanguage as a value object
+    // (`typePolicies.base.ts:43` — `keyFields: false`), and no codepath calls a
+    // delete on it.
+    //
+    // Codes are NOT unique — see migration 0030 and the note further down this
+    // table. An earlier version of this comment said the `code` /
+    // `provisional_code` uniques stayed GLOBAL to support that pool model, and
+    // that recreating a Language with an existing code would throw on the unique
+    // index. Neither is true any more: ethnologue codes are shared across a large
+    // share of languages, so a pool keyed uniquely by code cannot exist, and 0030
+    // drops both indexes along with the handlers that translated their
+    // violations. So when the pool model is built, "attach to the existing entry
+    // by code" has to disambiguate MULTIPLE candidates per code in application
+    // code — a single-row lookup by code is not something the database can
+    // guarantee.
     //
     // Separate-ticket cleanup (out of scope here): `EthnologueLanguage.canDelete`
     // (on the DTO) and the `r.EthnologueLanguage.create.read.edit.delete`
@@ -658,12 +668,10 @@ export const ethnologueLanguages = pgTable(
     // Full FK index — the partial unique above can't serve FK-maintenance
     // scans. Added in 0016 alongside the REFERENCES attach.
     index('ethnologue_languages_language_id_idx').on(t.languageId),
-    uniqueIndex('ethnologue_languages_code_unique')
-      .on(t.code)
-      .where(sql`${t.code} IS NOT NULL AND ${t.deletedAt} IS NULL`),
-    uniqueIndex('ethnologue_languages_provisional_code_unique')
-      .on(t.provisionalCode)
-      .where(sql`${t.provisionalCode} IS NOT NULL AND ${t.deletedAt} IS NULL`),
+    // `code` and `provisional_code` are deliberately NOT unique. Languages share
+    // ethnologue codes routinely, and Neo4j never constrained either column. The
+    // unique key for a language is its ROLV code, over on `languages`. See
+    // migration 0030.
   ],
 );
 
@@ -1285,10 +1293,18 @@ export const projectWorkflowEvents = pgTable(
       .$type<ID<'Project'>>()
       .notNull()
       .references(() => projects.id, { onDelete: 'cascade' }),
+    // Exactly one of `who` / `who_system_agent_id` is set — a transition always
+    // has an actor, but it is a User or a SystemAgent. Most events are
+    // agent-driven, and Neo4j has always matched `node('who','Actor')`.
+    // See migration 0031, and `resource_mutations` for the same arc on the audit
+    // log (which stores the agent's name, not an FK — the reasoning for the
+    // difference is in 0031's header).
     who: text('who')
       .$type<ID<'User'>>()
-      .notNull()
       .references(() => users.id),
+    whoSystemAgentId: text('who_system_agent_id')
+      .$type<ID<'SystemAgent'>>()
+      .references(() => systemAgents.id),
     // Nullable for synthetic/initial events; populated for normal transitions.
     fromStep: projectStepEnum('from_step').$type<ProjectStep>(),
     toStep: projectStepEnum('to_step').$type<ProjectStep>().notNull(),
@@ -1305,6 +1321,13 @@ export const projectWorkflowEvents = pgTable(
       t.at.desc(),
     ),
     index('project_workflow_events_who_idx').on(t.who),
+    index('project_workflow_events_who_system_agent_id_idx').on(
+      t.whoSystemAgentId,
+    ),
+    check(
+      'project_workflow_events_actor_shape_chk',
+      sql`num_nonnulls(${t.who}, ${t.whoSystemAgentId}) = 1`,
+    ),
   ],
 );
 
@@ -1678,14 +1701,13 @@ export const languages = pgTable(
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
   },
   (t) => [
-    // Partial uniques scoped to live rows — mirror of the Neo4j LanguageName /
-    // LanguageDisplayName / RegistryOfLanguageAndVariantsCode constraints.
-    uniqueIndex('languages_name_active_unique')
-      .on(t.name)
-      .where(sql`${t.deletedAt} IS NULL`),
-    uniqueIndex('languages_display_name_active_unique')
-      .on(t.displayName)
-      .where(sql`${t.deletedAt} IS NULL`),
+    // The ROLV code is the unique natural key for a language; the names
+    // deliberately are NOT. Distinct languages legitimately share a name — real
+    // data contains such groups, each separable by ROLV — and Neo4j never
+    // constrained them. The comment that used to sit here claimed these mirrored
+    // Neo4j `LanguageName` / `LanguageDisplayName` constraints; those constraints
+    // do not exist, and the claim misled two separate pieces of work. Partial,
+    // scoped to live rows. See migration 0030.
     uniqueIndex('languages_rolv_code_active_unique')
       .on(t.registryOfLanguageVarietiesCode)
       .where(


### PR DESCRIPTION
### Summary

Two schema problems, both found while preparing for the dry run. Each would have silently destroyed data during the load, and one is also wrong today independent of any migration.

**Postgres was enforcing five uniqueness rules that the real system doesn't have.**

Two of them — language name and display name — came from a misreading. A comment claimed they mirrored constraints in the current database; those constraints don't exist there, and never did. The other three — a location's ISO code and both ethnologue codes — were inherited from the schema this was ported from, which still declares them unique today. That declaration is the stale one, not this change.

This breaks in two independent ways:

- **It's wrong right now.** Two genuinely distinct languages can share a name, and real data contains such groups — each one separable by its ROLV code, so these are distinct languages, not accidental duplicates. Ethnologue codes are shared far more widely still. Under these rules, the next person creating a legitimately distinct language that happens to share a name is simply refused. Forever, on either database.
- **It would drop data at load, quietly.** The loader can't insert a row that violates a unique rule, so it skips it — and then everything hanging off that row goes too, because a language is required downstream. A handful of rejected languages removes orders of magnitude more rows than it appears to: engagements, ceremonies, products, periodic reports, progress and summaries all follow. Worse, reconciliation reports each table separately, so a single root cause reads as seven unrelated problems.

**Workflow events couldn't record that the system did something.**

The actor column required a real user, which encodes "every project step change was made by a logged-in person." That isn't true — most step transitions are performed by the system, not a person. Under the old shape every one of those rows fails the foreign key, so the load drops them: most of every project's step history, gone, and silently, because a skipped row isn't an error. Local development data hid this almost completely; it only surfaced against a production-shaped copy.

Reads already handled this correctly — the current database has always allowed either kind of actor, and the API already returns a person-or-system union. Only the Postgres column was behind.

### How

- **Drop the five rules; keep the three that are real.** The ROLV code stays unique because it genuinely is a language's natural key. Location *names* stay unique — only the ISO code is dropped. The one-ethnologue-row-per-language rule stays, because it's structural rather than a natural key. All five dropped rules were already scoped to non-deleted rows, so nothing about the soft-delete convention changes; those columns simply stop being keys.
- **Nothing replaces them, deliberately** — and the reason is the tables, not the columns being unused. As filters these columns are only ever matched with a "contains" search, which no b-tree can serve regardless of uniqueness. As sort keys three of them are genuinely reachable by clients today. But both tables are small, and the list path runs an unconditional count over the whole table beside every page query, so it gets scanned whatever index exists. Measured on a comparable table, removing the index moved a paged sort from an index scan to a sequential scan — a sub-millisecond difference. If one of these lists ever becomes hot, add a plain non-unique index; don't restore uniqueness.
- **Let a workflow event point at either a person or a system actor**, with a database-level rule that exactly one of the two is always set — so a row can never be ambiguous about who acted, and can never be empty. This deliberately reuses the same shape the audit log adopted for the same problem rather than inventing a second idiom.
- **Repository error handling that existed only to catch the dropped rules is removed**, since it's now unreachable.

### Judgement calls worth a reviewer's attention

- **The system-actor reference is stored as an id, where the audit log stores a name.** That's intentional, not an inconsistency. An audit row is a historical snapshot and has to survive the removal of the thing it names, so a hard reference would be wrong there. A workflow event's actor is live project history that gets read back as a hydrated object, so it needs an id — storing a name would mean a lookup on every read to rebuild exactly what a reference already gives us.
- **A known write-path gap, pre-existing and not introduced here.** The step-change notification handler looks the actor up as a person, so a system-authored transition that carries notification recipients throws — and because hooks run inside the transition's transaction, the whole transition rolls back rather than half-committing. This change only moves *where* that fails: previously the insert was rejected outright, now the insert succeeds and the handler throws instead. It strictly improves the no-recipients case, which now works. The current database fails the same flow for the same reason, so this is parity rather than a regression, and the fix is tracked as post-cutover work. The system-actored events that already exist came from a backfill that writes directly and fires no hooks, so reading them is fine.
- **Search indexing is not at parity, and this is worth stating plainly** because an earlier version of this reasoning claimed the opposite. The two language columns *are* indexed on the current database, with a text index that tokenises and folds accents. Postgres matches them with a plain substring comparison and no text index at all. Those two approaches don't return the same rows — so it's a behavioural difference in search, not just a slower one. Tracked as a follow-up: either trigram indexes, or an accepted difference that gets written down. Dropping the unique rules neither causes nor worsens it, since a unique index couldn't serve a leading-wildcard match either.

### Validation performed

- Every migration applies cleanly from scratch, and the schema-invariants spec verifies the migration journal is contiguous with strictly increasing, non-duplicated timestamps.
- Postgres end-to-end on the affected surfaces: **4 suites, 0 failed, 75 passed** — schema invariants, language, project workflow, engagement.
- The live-query structural check passes, including its stale-exemption assertion. Worth noting because that check landed after this work began and inspects every Postgres repository, three of which this touches.
- `yarn type-check` and `yarn lint` clean.
- Rebased onto current develop with no content change — the patch is byte-identical to the pre-rebase version, so earlier review findings still apply as-is.

### Explicitly out of scope

- **Text-search parity** for the two language columns, described above.
- **The notification handler's person-only actor lookup**, which matches current behaviour and is tracked as post-cutover work.
