### PR TITLE
[pg] Run every e2e spec under Postgres, and fix the ordering bug it exposed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,11 @@ jobs:
           --health-start-period 30s
       # Needed for the postgres matrix entries; idle for the neo4j ones.
       postgres:
+        # alpine is fine BECAUSE text ordering no longer depends on the image:
+        # every text sort names the `display_order` collation explicitly
+        # (migration 0032). That makes ordering identical here, on a glibc
+        # Postgres, and across OS upgrades — so CI proves the ordering
+        # production will actually have, whatever image it runs.
         image: postgres:16-alpine
         ports:
           - 5432:5432
@@ -80,23 +85,30 @@ jobs:
           - neo4j
 #          - gel
         include:
-          # Postgres runs only the suites for domains that have a Drizzle repo
-          # on this branch — unmigrated domains fall back to Neo4j via splitDb
-          # and hit cross-engine boundaries. Each entry below MUST have a
-          # matching *.drizzle.repository.ts; add a domain here only in the same
-          # PR that lands its repo. Widen as each phase lands. migration-todo:
-          # drop the filter entirely at Phase 7 cutover so postgres runs the
-          # full suite (and re-shard it to match neo4j).
+          # Postgres runs the WHOLE suite. It used to run an opt-in allowlist of
+          # migrated domains, which is removed deliberately: an allowlist
+          # silently excludes anything nobody remembered to name, and it failed
+          # that way three separate times — a domain whose own migration PR
+          # never added it, a name that didn't match because entries are
+          # anchored to a following `.` (so `periodic-report` never covered
+          # `periodic-report-narrative-file`), and every spec under `test/`
+          # subdirectories, which the pattern's shape could never match at all.
+          # The last of those hid the fact that webhooks was never ported.
           #
-          # Single shard on purpose: the migrated-domain subset is only a few
-          # minutes of tests — six jobs paying the full setup cost for ~1.5 min
-          # of tests each was pure runner waste. Bump `total` (and add shard
-          # entries) as the subset grows.
+          # Suites that genuinely cannot pass under Postgres now switch
+          # themselves off inside the test file (`describe.skip` on a DATABASE
+          # check), so they are reported as skipped, appear in the run output,
+          # and state their reason — instead of being invisible. Currently: the
+          # three *-changeset-aware specs (changesets are not being carried
+          # forward) and webhooks (not ported yet). Add that condition to the
+          # test file — never a filter here.
+          #
+          # Single shard on purpose: the full suite is ~10 min serial, and six
+          # jobs each paying the full setup cost was pure runner waste. Bump
+          # `total` (and add shard entries) if that grows uncomfortable.
           - database: postgres
             shard: 1
             total: 1
-            test-args: >-
-              --testPathPatterns "test/(authentication|user|education|unavailability|file|location|organization|region|zone|funding-account|partner|partnership|project-member|tool|notification|postgres-schema|auth-read-filter|budget|language|engagement|engagement-workflow|ceremony|product|film|story|project-workflow|periodic-report|rev79|pin|known-language|comment|post|audit-log|progress-report-media|search|live-query-invalidation)\."
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -120,7 +132,7 @@ jobs:
         # V8's default 4GB heap cap late in the shard (all-shards OOM,
         # 2026-07-14). Recycling the worker between files when it bloats keeps
         # serial semantics with bounded memory.
-        run: yarn test:e2e --maxWorkers=1 --workerIdleMemoryLimit=1500MB --shard=${{ matrix.shard }}/${{ matrix.total || 6 }} --reporters=github-actions ${{ matrix.test-args }}
+        run: yarn test:e2e --maxWorkers=1 --workerIdleMemoryLimit=1500MB --shard=${{ matrix.shard }}/${{ matrix.total || 6 }} --reporters=github-actions
         env:
           NEO4J_VERSION: ${{ matrix.neo4j-version }}
           DATABASE: ${{ matrix.database }}

--- a/README.md
+++ b/README.md
@@ -18,13 +18,16 @@ Bible translation project management API.
 1. Copy `.env.local.example` to `.env.local` and fill in any required values
 1. Start the databases:
     ```bash
-    docker-compose up -d db postgres
+    docker compose up -d db postgres
     ```
-1. Setup a Gel instance (the current primary database):
+1. Setup a Gel instance. Gel is not the primary database — see [Database](#database)
+   below — but a number of repositories still use it and its generated client is
+   not committed to the repo, so the project will not compile without this step:
     ```bash
     gel project init
     yarn gel:gen
     ```
+   Re-run `yarn gel:gen` after any change to `dbschema/`.
 
 ## Database
 
@@ -39,9 +42,14 @@ The `DATABASE` env var controls which is active for each domain:
 Both services must be running locally regardless of which mode is active:
 
 ```bash
-docker-compose up -d db        # Neo4j
-docker-compose up -d postgres  # PostgreSQL
+docker compose up -d db        # Neo4j
+docker compose up -d postgres  # PostgreSQL
 ```
+
+Gel is a third database in the tree, left from an earlier migration target. It is
+neither the destination nor the primary store and nothing new is being built on
+it, but it has not been removed yet — so setting it up is still required in order
+to build. See [Setup](#setup) above.
 
 PostgreSQL migrations run automatically on startup when `DATABASE=postgres`.
 To generate a new migration after a schema change:
@@ -53,9 +61,31 @@ yarn migrate:generate
 ## Usage
 
 Develop: `yarn start:dev`  
-Test: `yarn test:e2e`
+Test: `yarn test` (unit) and `yarn test:e2e` (end-to-end)
 
 See scripts in [package.json](./package.json) for other commands to run
+
+### Which database the tests run against
+
+End-to-end specs choose their engine from `DATABASE`, resolved the way the app
+resolves it: a real environment variable first, then the `.env` files, then the
+`neo4j` default. So `DATABASE=postgres` in `.env.local` is enough to run the suite
+against PostgreSQL, and `DATABASE=neo4j yarn test:e2e` overrides that for a single
+run.
+
+`POSTGRES_URL` is the exception — it has to be a **real environment variable**,
+because each spec file creates its own throwaway database before the app, and
+therefore dotenv, has loaded:
+
+```bash
+export POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/cord
+DATABASE=postgres yarn test:e2e
+```
+
+That is deliberate, not an oversight. The end-to-end setup creates and drops
+databases, and it also sweeps leftover `cord_e2e_*` databases on whichever server
+it connects to. Making you pass the URL explicitly keeps that from ever running
+against a server inherited from a file you had forgotten about.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,20 @@ export POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/cord
 DATABASE=postgres yarn test:e2e
 ```
 
-That is deliberate, not an oversight. The end-to-end setup creates and drops
-databases, and it also sweeps leftover `cord_e2e_*` databases on whichever server
-it connects to. Making you pass the URL explicitly keeps that from ever running
-against a server inherited from a file you had forgotten about.
+> [!WARNING]
+> Point this at a **dedicated, disposable PostgreSQL server** — the local
+> `docker compose` one is what it is meant for. Never a production or shared
+> server.
+
+The end-to-end setup needs rights to create and drop databases, and on each run
+it also clears its own leftovers: any database named `cord_e2e_*` more than an
+hour old is dropped `with (force)`, which disconnects whatever is attached to it.
+The sweep is scoped to that prefix and cannot reach application data, but on a
+server someone else is using it can still end their test run.
+
+Requiring the URL to be passed explicitly, rather than reading it from `.env.local`
+alongside everything else, is what keeps all of that from pointing at a server
+inherited from a file you had forgotten about.
 
 ## Documentation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,12 @@ services:
       NEO4J_dbms_security_auth__minimum__password__length: 1
 
   postgres:
+    # alpine is fine BECAUSE text ordering no longer depends on the image: every
+    # text sort names the `display_order` collation explicitly (migration 0032,
+    # applied by displayOrder() in src/core/drizzle/order-by.ts). Without that,
+    # this image would order text differently from a glibc one — alpine links
+    # musl, which has no locale-aware collation and falls back to raw byte
+    # order. Do not sort text without that collation.
     image: postgres:16-alpine
     ports:
       - 5432:5432

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -33,6 +33,12 @@ export default async (): Promise<Config> => {
     // Once per file.
     setupFiles: [
       ...base.setupFiles,
+      // Must come before anything that reads process.env.DATABASE: a test file
+      // decides which database it is testing when it loads, before any app
+      // starts, so it never sees a DATABASE set only in .env.local. This makes
+      // the test files agree with the database the app will actually use. An
+      // explicitly set variable still wins.
+      './test/setup/resolve-engine-env.ts',
       // Set longer timeout.
       // Cannot be done at project level config.
       // Don't want to override cli arg or timeout set below for debugging either.

--- a/src/components/engagement/engagement.drizzle.repository.ts
+++ b/src/components/engagement/engagement.drizzle.repository.ts
@@ -491,6 +491,15 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
       // migration-todo: nameProjectFirst/nameProjectLast, sensitivity,
       // language.* / project.* delegated sorts, currentProgressReportDue.*.
       // Unknown keys fall back to createdAt.
+      //
+      // ⚠️ Whoever adds nameProjectFirst/nameProjectLast: they sort by TEXT and
+      // they have to be `sql` expressions (Neo4j builds them by concatenating a
+      // project's name with its language names, so there is no single column to
+      // point at). `displayOrder()` cannot see inside an expression — it
+      // collates COLUMNS — so an expression comes back uncollated with no error
+      // and nothing failing, and would order differently from every other list
+      // in the app. Write `collate "display_order"` inline in the expression.
+      // The two entries above are exempt only because they sort dates.
     } as unknown as SortMap<keyof Engagement>;
 
     const { rows, total, hasMore } = await this.paginatedSelect({

--- a/src/components/partner/partner.drizzle.repository.ts
+++ b/src/components/partner/partner.drizzle.repository.ts
@@ -29,6 +29,7 @@ import { Identity } from '~/core/authentication';
 import {
   catchForeignKeyViolation,
   catchUniqueViolation,
+  displayOrder,
   DrizzleDtoRepository,
   EMPTY_PAGE,
   resolveOrderBy,
@@ -350,7 +351,7 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
             eq(partners.organizationId, organizations.id),
           )
           .where(predicate)
-          .orderBy(direction(orgSortColumn), asc(partners.id))
+          .orderBy(direction(displayOrder(orgSortColumn)), asc(partners.id))
           .limit(input.count)
           .offset(offset),
       ]);

--- a/src/components/partnership/partnership.drizzle.repository.ts
+++ b/src/components/partnership/partnership.drizzle.repository.ts
@@ -26,6 +26,7 @@ import {
 } from '~/common';
 import { Identity } from '~/core/authentication';
 import {
+  displayOrder,
   DrizzleDtoRepository,
   EMPTY_PAGE,
   isUniqueViolation,
@@ -403,7 +404,10 @@ export class PartnershipDrizzleRepository extends DrizzleDtoRepository<
           .from(partnerships)
           .innerJoin(partners, eq(partnerships.partnerId, partners.id))
           .where(predicate)
-          .orderBy(direction(partnerSortColumn), asc(partnerships.id))
+          .orderBy(
+            direction(displayOrder(partnerSortColumn)),
+            asc(partnerships.id),
+          )
           .limit(input.count)
           .offset(offset),
       ]);

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -33,6 +33,7 @@ import { Identity } from '~/core/authentication';
 import { ConfigService } from '~/core/config';
 import {
   catchUniqueViolation,
+  displayOrder,
   DrizzleDtoRepository,
   EMPTY_PAGE,
   escapeLikePattern,
@@ -401,7 +402,7 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
           .from(projects)
           .leftJoin(joinSort.table, eq(joinSort.fkColumn, joinSort.table.id))
           .where(allConditions)
-          .orderBy(direction(joinSort.column), asc(projects.id))
+          .orderBy(direction(displayOrder(joinSort.column)), asc(projects.id))
           .limit(input.count)
           .offset(offset),
       ]);

--- a/src/core/drizzle/migrations/0032_display_order_collation.sql
+++ b/src/core/drizzle/migrations/0032_display_order_collation.sql
@@ -1,0 +1,39 @@
+-- A collation for ordering text the way people read it, which does not change
+-- with the host operating system.
+--
+-- It ignores three things when comparing:
+--   * case          -> `apple` and `Apple` sort together
+--   * accents       -> `Ñot` sorts as `Not`, between `never` and `zap`
+--   * punctuation
+--      and spaces   -> `[a!-b]` sorts as `ab`, and `A ignore` as `Aignore`
+--
+-- That is exactly how Neo4j orders names today, so lists do not silently
+-- reorder when a domain moves to Postgres.
+--
+-- Why not just use the database's default collation: the default depends on
+-- which C library the Postgres image was built against, and the two disagree.
+-- The alpine image links musl, which does not implement locale-aware
+-- collation at all, so `en_US.utf8` there quietly degrades to raw byte order —
+-- every capital ahead of every lowercase letter, and accented characters after
+-- `z`. A Debian/glibc image with the SAME collation name is locale-aware and
+-- matches Neo4j. So relying on the default means ordering differs between CI
+-- and production depending on their images, with nothing reporting it. It can
+-- also shift under a glibc upgrade, which invalidates text indexes. Naming an
+-- ICU collation explicitly gives identical ordering on every platform and
+-- across OS upgrades.
+--
+-- ⚠️ USE THIS IN `ORDER BY` ONLY — NEVER AS A COLUMN'S COLLATION.
+-- It is non-deterministic (required, so that strings differing only by case or
+-- accent can compare equal for ordering). Postgres refuses `LIKE`/`ILIKE` on a
+-- non-deterministic collation: "nondeterministic collations are not supported
+-- for ILIKE". Global search runs ILIKE against these same name columns, so
+-- attaching this to a column would break search. Applying it per-ORDER BY is
+-- allowed and is what `displayOrder()` in src/core/drizzle/order-by.ts does.
+--
+-- `ka-shifted` is what makes punctuation and spaces ignorable; `ks-level1` is
+-- what makes case and accents ignorable.
+CREATE COLLATION display_order (
+  provider = icu,
+  locale = 'und-u-ka-shifted-ks-level1',
+  deterministic = false
+);

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1753315200000,
       "tag": "0031_workflow_event_system_agent_actor",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1753401600000,
+      "tag": "0032_display_order_collation",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/order-by.spec.ts
+++ b/src/core/drizzle/order-by.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from '@jest/globals';
+import { asc, desc, sql } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import {
+  budgetRecords,
+  engagements,
+  organizations,
+  users,
+} from '~/core/drizzle/schema';
+import { displayOrder } from './order-by';
+
+/**
+ * `displayOrder()` decides, from a column alone, whether to attach the
+ * case/accent-insensitive `display_order` collation. Both ways of getting that
+ * decision wrong are silent:
+ *
+ * - Collating something it should not means a list quietly reorders. That is how
+ *   the user list's default sort — its `id`, an opaque generated identifier —
+ *   ended up case-folded, ordering differently from Neo4j and losing the primary
+ *   key index for every page.
+ * - Skipping something it should collate means one list orders differently from
+ *   every other list in the app.
+ *
+ * Neither shows up as a failure anywhere else: no list spec asserts the default
+ * user ordering, and a wrong decision still produces valid SQL and a full page of
+ * results. So pin the decision itself.
+ */
+describe('displayOrder', () => {
+  const dialect = new PgDialect();
+  const toSql = (col: Parameters<typeof displayOrder>[0]) =>
+    dialect.sqlToQuery(sql`${displayOrder(col)}`).sql;
+
+  const isCollated = (col: Parameters<typeof displayOrder>[0]) =>
+    toSql(col).includes('collate "display_order"');
+
+  it('collates display text', () => {
+    expect(isCollated(organizations.name)).toBe(true);
+    expect(isCollated(users.realLastName)).toBe(true);
+  });
+
+  it('does NOT collate a primary key, which holds an opaque id', () => {
+    // Every id in this schema is a `text` column, so a plain type check would
+    // treat this as prose. `users.id` is the user list's default sort key.
+    expect(isCollated(users.id)).toBe(false);
+    expect(toSql(users.id)).not.toContain('collate');
+  });
+
+  it('does NOT collate a column limited to a fixed set of values', () => {
+    // Codes, not prose — and Postgres cannot collate an enum type at all.
+    expect(isCollated(engagements.status)).toBe(false);
+  });
+
+  it('leaves non-text columns untouched', () => {
+    expect(isCollated(engagements.createdAt)).toBe(false);
+    expect(isCollated(budgetRecords.fiscalYear)).toBe(false);
+  });
+
+  it('emits the collation inside ORDER BY in both directions', () => {
+    // Guards the composition, not just the flag: the collation has to sit on the
+    // expression so `asc`/`desc` still applies to the collated value.
+    for (const dir of [asc, desc]) {
+      const rendered = dialect.sqlToQuery(
+        dir(displayOrder(organizations.name)),
+      ).sql;
+      expect(rendered).toContain('collate "display_order"');
+    }
+  });
+});

--- a/src/core/drizzle/order-by.ts
+++ b/src/core/drizzle/order-by.ts
@@ -37,13 +37,26 @@ const COLLATABLE_COLUMN_TYPES = new Set(['PgText', 'PgVarchar', 'PgChar']);
 /**
  * Order a column the way a reader expects, when it holds display text.
  *
- * Text columns get the {@link DISPLAY_ORDER_COLLATION}; everything else is
- * returned untouched, so dates, numbers and ids keep their natural ordering.
+ * Text columns get the {@link DISPLAY_ORDER_COLLATION}; dates and numbers are
+ * returned untouched and keep their natural ordering.
  *
- * Columns constrained to a fixed set of values are also left alone. Those hold
- * codes rather than prose — a status or a step — so their ordering should stay
- * exactly as written and not depend on how the collation treats an underscore.
- * (Enum-typed columns additionally cannot be collated at all.)
+ * Two kinds of text column are deliberately left alone:
+ *
+ * * **Columns constrained to a fixed set of values.** Those hold codes rather
+ *   than prose — a status or a step — so their ordering should stay exactly as
+ *   written and not depend on how the collation treats an underscore.
+ *   (Enum-typed columns additionally cannot be collated at all.)
+ * * **Primary keys.** They hold opaque generated identifiers, not display text.
+ *   Every id in this schema is a `text` column, so without this they would be
+ *   case-folded like prose. That is not harmless: the user list's default sort
+ *   key is its id, so collating it both reorders that list away from what Neo4j
+ *   returns AND stops the ordering being read off the primary key index,
+ *   turning every page of the default user list into a full scan plus a sort.
+ *
+ * ⚠️ This can only inspect a COLUMN. A sort written as a raw `sql` expression
+ * has no column type, so it falls through here and comes back uncollated — with
+ * no error and nothing failing. A text sort built as an expression has to write
+ * `collate display_order` inline itself.
  *
  * Use this at every text sort, including ones built by hand rather than through
  * {@link resolveOrderBy} — the three list queries that sort by a joined table's
@@ -51,7 +64,9 @@ const COLLATABLE_COLUMN_TYPES = new Set(['PgText', 'PgVarchar', 'PgChar']);
  * order differently from every other list in the app.
  */
 export const displayOrder = (col: AnyPgColumn): SQLWrapper =>
-  COLLATABLE_COLUMN_TYPES.has(col.columnType) && !col.enumValues?.length
+  COLLATABLE_COLUMN_TYPES.has(col.columnType) &&
+  !col.enumValues?.length &&
+  !col.primary
     ? sql`${col} collate ${sql.identifier(DISPLAY_ORDER_COLLATION)}`
     : col;
 

--- a/src/core/drizzle/order-by.ts
+++ b/src/core/drizzle/order-by.ts
@@ -1,4 +1,4 @@
-import { asc, desc, type SQL } from 'drizzle-orm';
+import { asc, desc, sql, type SQL, type SQLWrapper } from 'drizzle-orm';
 import { type AnyPgColumn } from 'drizzle-orm/pg-core';
 import { type Order } from '~/common';
 
@@ -15,6 +15,47 @@ export type SortColumns = AnyPgColumn | readonly AnyPgColumn[];
 export type SortMap<TKey extends string> = Partial<Record<TKey, SortColumns>>;
 
 /**
+ * Collation created in migration 0032. Ignores case, accents, punctuation and
+ * spaces when comparing, which is how Neo4j orders names — so lists do not
+ * silently reorder as domains move to Postgres.
+ *
+ * Named explicitly rather than relying on the database default because the
+ * default depends on which C library the Postgres image was built against: the
+ * alpine image links musl, which has no locale-aware collation and quietly
+ * falls back to raw byte order, while a glibc image with the same collation
+ * name is locale-aware. See the migration for the full explanation.
+ */
+const DISPLAY_ORDER_COLLATION = 'display_order';
+
+/**
+ * Column types Postgres can collate. Deliberately a whitelist: `uuid` also
+ * reports a string data type but cannot be collated, and neither can an enum
+ * type — Postgres raises "collations are not supported by type" for both.
+ */
+const COLLATABLE_COLUMN_TYPES = new Set(['PgText', 'PgVarchar', 'PgChar']);
+
+/**
+ * Order a column the way a reader expects, when it holds display text.
+ *
+ * Text columns get the {@link DISPLAY_ORDER_COLLATION}; everything else is
+ * returned untouched, so dates, numbers and ids keep their natural ordering.
+ *
+ * Columns constrained to a fixed set of values are also left alone. Those hold
+ * codes rather than prose — a status or a step — so their ordering should stay
+ * exactly as written and not depend on how the collation treats an underscore.
+ * (Enum-typed columns additionally cannot be collated at all.)
+ *
+ * Use this at every text sort, including ones built by hand rather than through
+ * {@link resolveOrderBy} — the three list queries that sort by a joined table's
+ * name (partner, partnership, project) do exactly that, and would otherwise
+ * order differently from every other list in the app.
+ */
+export const displayOrder = (col: AnyPgColumn): SQLWrapper =>
+  COLLATABLE_COLUMN_TYPES.has(col.columnType) && !col.enumValues?.length
+    ? sql`${col} collate ${sql.identifier(DISPLAY_ORDER_COLLATION)}`
+    : col;
+
+/**
  * Resolve a list-input's `sort` key to an ORDER BY clause. Unmatched keys
  * fall back to `fallback`.
  */
@@ -25,5 +66,7 @@ export function resolveOrderBy(
 ): SQL[] {
   const dir = input.order === 'ASC' ? asc : desc;
   const cols = map[input.sort] ?? fallback;
-  return (Array.isArray(cols) ? cols : [cols]).map(dir);
+  return (Array.isArray(cols) ? cols : [cols]).map((col) =>
+    dir(displayOrder(col)),
+  );
 }

--- a/test/audit-log.e2e-spec.ts
+++ b/test/audit-log.e2e-spec.ts
@@ -31,6 +31,18 @@ import {
 // history is expected to be empty there.
 const isPostgres = process.env.DATABASE === 'postgres';
 
+// Cases that read `resource_mutations` itself have nothing to check under neo4j —
+// the table has no counterpart there. Declaring them with these instead of
+// returning early inside the body makes jest report them as SKIPPED. A test that
+// returns before it asserts anything still counts as a pass, which reads as
+// coverage that does not exist.
+//
+// The `expect(history.total).toBe(0)` branches further down are deliberately NOT
+// converted: those assert real neo4j behaviour (the writer stays inert and the
+// history query still resolves), so they earn their pass on both engines.
+const itPostgresOnly = isPostgres ? it : it.skip;
+const describePostgresOnly = isPostgres ? describe : describe.skip;
+
 describe('Audit log (resource_mutations) e2e', () => {
   let app: TestApp;
   let project: fragments.project;
@@ -216,50 +228,51 @@ describe('Audit log (resource_mutations) e2e', () => {
   // Audit writes happen inside the triggering mutation's transaction, so if the
   // mutation later fails the audit row must roll back with it — no orphaned
   // "this happened" record for something that didn't.
-  it('rolls back the audit row when the surrounding transaction fails', async () => {
-    if (!isPostgres) return;
+  itPostgresOnly(
+    'rolls back the audit row when the surrounding transaction fails',
+    async () => {
+      const drizzle = app.get(DrizzleService);
+      const repo = app.get(ResourceMutationRepository);
+      const committedId = await generateId();
+      const rolledBackId = await generateId();
+      // The repo's insert uses the ambient (ALS) transaction client, so this
+      // exercises the same in-transaction write path the audit hook takes —
+      // without needing a session context for the actor lookup.
+      const mutation = (resourceId: typeof committedId) => ({
+        resourceType: 'Project',
+        resourceId,
+        action: 'Update' as const,
+        actorId: null,
+        actorSystemAgent: null,
+        impersonatorId: null,
+        roleAtTime: [],
+        changes: { a: 1 },
+      });
 
-    const drizzle = app.get(DrizzleService);
-    const repo = app.get(ResourceMutationRepository);
-    const committedId = await generateId();
-    const rolledBackId = await generateId();
-    // The repo's insert uses the ambient (ALS) transaction client, so this
-    // exercises the same in-transaction write path the audit hook takes —
-    // without needing a session context for the actor lookup.
-    const mutation = (resourceId: typeof committedId) => ({
-      resourceType: 'Project',
-      resourceId,
-      action: 'Update' as const,
-      actorId: null,
-      actorSystemAgent: null,
-      impersonatorId: null,
-      roleAtTime: [],
-      changes: { a: 1 },
-    });
+      // Positive control: a record written in a committed tx persists.
+      await drizzle.inTx(async () => {
+        await repo.record(mutation(committedId));
+      });
 
-    // Positive control: a record written in a committed tx persists.
-    await drizzle.inTx(async () => {
-      await repo.record(mutation(committedId));
-    });
+      // The record is written, then the surrounding tx throws -> it must vanish.
+      await expect(
+        drizzle.inTx(async () => {
+          await repo.record(mutation(rolledBackId));
+          throw new Error('boom: force rollback');
+        }),
+      ).rejects.toThrow('boom');
 
-    // The record is written, then the surrounding tx throws -> it must vanish.
-    await expect(
-      drizzle.inTx(async () => {
-        await repo.record(mutation(rolledBackId));
-        throw new Error('boom: force rollback');
-      }),
-    ).rejects.toThrow('boom');
-
-    const db = drizzle.client;
-    const countFor = async (id: string) => {
-      const res = await db.execute<{ n: number } & Record<string, unknown>>(
-        sql`select count(*)::int as n from resource_mutations where resource_id = ${id}`,
-      );
-      return res.rows[0]!.n;
-    };
-    expect(await countFor(committedId)).toBe(1);
-    expect(await countFor(rolledBackId)).toBe(0);
-  });
+      const db = drizzle.client;
+      const countFor = async (id: string) => {
+        const res = await db.execute<{ n: number } & Record<string, unknown>>(
+          sql`select count(*)::int as n from resource_mutations where resource_id = ${id}`,
+        );
+        return res.rows[0]!.n;
+      };
+      expect(await countFor(committedId)).toBe(1);
+      expect(await countFor(rolledBackId)).toBe(0);
+    },
+  );
 
   // `Identity.currentMaybe` hands back the EFFECTIVE session, so all three of
   // these used to go wrong in the same place: an impersonated mutation was
@@ -270,7 +283,10 @@ describe('Audit log (resource_mutations) e2e', () => {
   // header-based and the e2e client exposes no per-request headers; sessions are
   // still built by the real SessionManager path (including its 'ghost' literal
   // swap and the CanImpersonateHook gate) rather than hand-assembled.
-  describe('actor attribution', () => {
+  // Every case here reads the actor columns on `resource_mutations`, so the whole
+  // block is postgres-only. `describe.skip` also stops the beforeAll below from
+  // running, which is why that hook no longer needs its own engine check.
+  describePostgresOnly('actor attribution', () => {
     let audit: AuditService;
     let sessions: SessionManager;
     let host: SessionHost;
@@ -280,7 +296,6 @@ describe('Audit log (resource_mutations) e2e', () => {
     let impersonatee: TestUser;
 
     beforeAll(async () => {
-      if (!isPostgres) return;
       audit = app.get(AuditService);
       sessions = app.get(SessionManager);
       host = app.get(SessionHost);
@@ -322,7 +337,6 @@ describe('Audit log (resource_mutations) e2e', () => {
     };
 
     it('records the actor with no impersonator when acting as themselves', async () => {
-      if (!isPostgres) return;
       const row = await recordAs(await sessions.resumeSession(adminToken));
       expect(row.actorId).toBe(adminId);
       expect(row.impersonatorId).toBeNull();
@@ -333,7 +347,6 @@ describe('Audit log (resource_mutations) e2e', () => {
     // is who actually did it. Before 0027 only the former was stored, so the
     // log affirmatively blamed the impersonatee.
     it('records both the impersonatee and the real requester', async () => {
-      if (!isPostgres) return;
       const row = await recordAs(
         await sessions.resumeSession(adminToken, {
           id: impersonatee.id,
@@ -350,7 +363,6 @@ describe('Audit log (resource_mutations) e2e', () => {
     // Role-only impersonation legitimately yields impersonator == actor. Pinned
     // so it reads as intended rather than as a bug the next time someone looks.
     it('records impersonator == actor for role-only impersonation', async () => {
-      if (!isPostgres) return;
       const row = await recordAs(
         await sessions.resumeSession(adminToken, {
           roles: setOf([Role.Consultant]),
@@ -367,7 +379,6 @@ describe('Audit log (resource_mutations) e2e', () => {
     // mutation down. Now the agent is recorded by name, and the admin behind it
     // is still attributed.
     it('records a ghost-impersonated mutation by agent name (no FK violation)', async () => {
-      if (!isPostgres) return;
       const row = await recordAs(
         await sessions.resumeSession(adminToken, {
           id: 'ghost' as ID,
@@ -382,7 +393,6 @@ describe('Audit log (resource_mutations) e2e', () => {
     // The two actor columns are mutually exclusive at the DB level, so a future
     // writer can't half-fill them regardless of what the service does.
     it('rejects a row naming both a user and a system agent as actor', async () => {
-      if (!isPostgres) return;
       const resourceId = await generateId();
       const failure = await db.client
         .execute(

--- a/test/engagement-changeset-aware.e2e-spec.ts
+++ b/test/engagement-changeset-aware.e2e-spec.ts
@@ -138,7 +138,21 @@ const activeProject = async (app: TestApp, projectId: ID) => {
   await forceProjectTo(app, projectId, 'Active');
 };
 
-describe('Engagement Changeset Aware e2e', () => {
+// Changesets are not being carried forward to Postgres, so every test here
+// fails at ProjectChangeRequestRepository.create — the repository is Neo4j-only
+// by design, and the Postgres shim answers reads truthfully but refuses writes.
+//
+// Switched off here in the test file rather than left out of a list in the CI
+// workflow, on purpose: a test that switches itself off is reported as skipped
+// and says why, while a test missing from a list is indistinguishable from one
+// that passed.
+//
+// migration-todo: remove this condition and this whole spec at Phase 7 cutover,
+// when the changeset feature and its `changeset: ID` arguments are removed.
+const describeNeo4jOnly =
+  process.env.DATABASE === 'postgres' ? describe.skip : describe;
+
+describeNeo4jOnly('Engagement Changeset Aware e2e', () => {
   let app: TestApp;
   let language: fragments.language;
 

--- a/test/file.e2e-spec.ts
+++ b/test/file.e2e-spec.ts
@@ -49,6 +49,15 @@ import {
   createRootDirectory,
 } from './utility/create-directory';
 
+// Some cases below exercise behaviour that only exists on the postgres side (the
+// recursive-CTE cycle guard, and the live-query announcements the neo4j arm gets
+// from its base helpers instead). Declaring them with these makes jest report
+// them as SKIPPED rather than counting a body that returned before asserting
+// anything as a pass — which reads as coverage that is not there.
+const isPostgres = process.env.DATABASE === 'postgres';
+const itPostgresOnly = isPostgres ? it : it.skip;
+const describePostgresOnly = isPostgres ? describe : describe.skip;
+
 export async function uploadFile(
   app: TestApp,
   parent: ID,
@@ -263,34 +272,34 @@ describe('File e2e', () => {
     expect(parents.map((n) => n.id)).toEqual([c.id, b.id, a.id, root.id]);
   });
 
-  it('cannot move a directory into its own descendant (cycle guard)', async () => {
-    // Postgres-only: the Neo4j move() tolerates a cycle (variable-length
-    // `[:parent*]` match), but the PG recursive CTEs (computeRoots /
-    // computeDirectoryAggregates / delete's subtree walk) have no cycle guard
-    // and would recurse forever — so the guard, and this test, are PG-specific.
-    if (process.env.DATABASE !== 'postgres') {
-      return;
-    }
-    const parent = await createDirectory(app, root.id);
-    const child = await createDirectory(app, parent.id);
+  // Postgres-only: the Neo4j move() tolerates a cycle (variable-length
+  // `[:parent*]` match), but the PG recursive CTEs (computeRoots /
+  // computeDirectoryAggregates / delete's subtree walk) have no cycle guard
+  // and would recurse forever — so the guard, and this test, are PG-specific.
+  itPostgresOnly(
+    'cannot move a directory into its own descendant (cycle guard)',
+    async () => {
+      const parent = await createDirectory(app, root.id);
+      const child = await createDirectory(app, parent.id);
 
-    await app.graphql
-      .mutate(
-        graphql(`
-          mutation moveFileNode($input: MoveFile!) {
-            moveFileNode(input: $input) {
-              id
+      await app.graphql
+        .mutate(
+          graphql(`
+            mutation moveFileNode($input: MoveFile!) {
+              moveFileNode(input: $input) {
+                id
+              }
             }
-          }
-        `),
-        { input: { id: parent.id, parent: child.id } },
-      )
-      .expectError(
-        errors.input({
-          message: 'Cannot move a node into its own descendant',
-        }),
-      );
-  });
+          `),
+          { input: { id: parent.id, parent: child.id } },
+        )
+        .expectError(
+          errors.input({
+            message: 'Cannot move a node into its own descendant',
+          }),
+        );
+    },
+  );
 
   /**
    * The Neo4j file repo announces mutations to the live-query store through its
@@ -306,11 +315,9 @@ describe('File e2e', () => {
    * `mockRestore()` clears `mock.calls`, which makes the positive cases fail and
    * any negative case pass vacuously.
    */
-  describe('live-query invalidation', () => {
-    // Postgres-only: the Neo4j arm gets this from its base helpers and is
-    // unchanged.
-    const isPostgres = process.env.DATABASE === 'postgres';
-
+  // Postgres-only: the Neo4j arm gets this from its base helpers and is
+  // unchanged.
+  describePostgresOnly('live-query invalidation', () => {
     afterEach(() => {
       jest.restoreAllMocks();
     });
@@ -334,7 +341,6 @@ describe('File e2e', () => {
       );
 
     it('announces a rename under the concrete type, not the interface', async () => {
-      if (!isPostgres) return;
       const dir = await createDirectory(app, root.id);
       const spy = watchInvalidations();
 
@@ -365,7 +371,6 @@ describe('File e2e', () => {
     });
 
     it('announces the whole subtree when a directory is deleted', async () => {
-      if (!isPostgres) return;
       const dir = await createDirectory(app, root.id);
       const file = await uploadFile(app, dir.id);
       const spy = watchInvalidations();
@@ -381,7 +386,6 @@ describe('File e2e', () => {
     });
 
     it('announces the parent File when its latest version is deleted', async () => {
-      if (!isPostgres) return;
       const firstUpload = await requestFileUpload(app);
       const file = await uploadFile(app, root.id, {}, firstUpload);
       const secondUpload = await requestFileUpload(app);

--- a/test/organization.e2e-spec.ts
+++ b/test/organization.e2e-spec.ts
@@ -1,6 +1,5 @@
 import { faker } from '@faker-js/faker';
 import { beforeAll, describe, expect, it } from '@jest/globals';
-import { sortBy } from '@seedcompany/common';
 import { times } from 'lodash';
 import { generateId, type ID, isValidId, Role } from '~/common';
 import { graphql } from '~/graphql';
@@ -309,65 +308,95 @@ describe('Organization e2e', () => {
       }
     }
   `);
-  it.skip('List of organizations sorted by name to be alphabetical, ignoring case sensitivity. Order: ASCENDING', async () => {
-    await registerUser(app, {
-      roles: [Role.FieldOperationsDirector],
-      displayFirstName: 'Tammy',
-    });
-    //Create three projects, each beginning with lower or upper-cases
-    await createOrganization(app, {
-      name: 'an Organization ' + faker.string.uuid(),
-    });
-    await createOrganization(app, {
-      name: 'Another Organization' + faker.string.uuid(),
-    });
-    await createOrganization(app, {
-      name: 'Big Organization' + faker.string.uuid(),
-    });
-    await createOrganization(app, {
-      name: 'big Organization also' + faker.string.uuid(),
-    });
-    const { organizations } = await app.graphql.query(Organizations, {
-      input: {
-        sort: 'name',
-        order: 'ASC',
-      },
-    });
-    const items = organizations.items;
-    const sorted = sortBy(items, (org: any) => org.name.value.toLowerCase());
-    expect(sorted).toEqual(items);
+  /**
+   * Seeds four organizations whose names differ ONLY in the case of the first
+   * letter after a shared random prefix — no spaces, digits or punctuation. That
+   * keeps the assertion about case folding and nothing else: every collation
+   * that folds case agrees on `alpha, Bravo, charlie, Delta`, while a
+   * case-sensitive byte sort gives a visibly different `Bravo, Delta, alpha,
+   * charlie`. Names containing spaces would instead be testing how the collation
+   * weights punctuation, which is a separate question with a different answer
+   * per collation.
+   *
+   * Inserted in an order matching neither the expected ascending nor descending
+   * result, so a repository that drops `sort` on the floor cannot pass by luck.
+   */
+  const seedCaseVariants = async () => {
+    const prefix = faker.string.alpha({ length: 10, casing: 'lower' });
+    const ascendingSuffixes = ['alpha', 'Bravo', 'charlie', 'Delta'];
+    for (const suffix of ['charlie', 'Delta', 'alpha', 'Bravo']) {
+      await createOrganization(app, { name: prefix + suffix });
+    }
+    return {
+      prefix,
+      expectedAsc: ascendingSuffixes.map((suffix) => prefix + suffix),
+    };
+  };
+
+  /**
+   * Collects every visible organization name in the order the API returns them.
+   *
+   * Two reasons this pages instead of asking for one big page or using the
+   * `name` filter:
+   *   - `count` is capped at 100, and the shared Neo4j test database accumulates
+   *     organizations across spec files, so one page is not guaranteed to hold
+   *     the seeded four.
+   *   - the `name` filter is NOT equivalent across engines — Neo4j reaches a
+   *     Lucene full-text index (a synthetic prefix glued to a word is one token,
+   *     which an unanchored term query will not match) while Postgres runs a
+   *     substring ILIKE. Filtering server-side would have the two engines
+   *     comparing different result sets, which is the opposite of what a parity
+   *     test should do.
+   *
+   * Bounded, and throws rather than silently returning a partial list.
+   */
+  const allOrgNamesInOrder = async (order: 'ASC' | 'DESC') => {
+    const maxPages = 25;
+    const names: string[] = [];
+    let page = 1;
+    let hasMore = true;
+    while (hasMore) {
+      if (page > maxPages) {
+        throw new Error(
+          `organization list did not terminate within ${maxPages} pages — raise the bound or narrow the query`,
+        );
+      }
+      const { organizations } = await app.graphql.query(Organizations, {
+        input: { sort: 'name', order, count: 100, page },
+      });
+      names.push(
+        ...organizations.items
+          .map((org) => org.name.value)
+          .filter((name): name is string => !!name),
+      );
+      hasMore = organizations.hasMore;
+      page++;
+    }
+    return names;
+  };
+
+  it('sorts organizations by name ignoring case, ascending', async () => {
+    const { prefix, expectedAsc } = await seedCaseVariants();
+
+    const seeded = (await allOrgNamesInOrder('ASC')).filter((name) =>
+      name.startsWith(prefix),
+    );
+
+    // Check the set before the order: if the seeds went missing, this fails
+    // loudly instead of the order assertion quietly passing on a subset.
+    expect(seeded).toHaveLength(expectedAsc.length);
+    expect(seeded).toEqual(expectedAsc);
   });
 
-  it.skip('List of organizations sorted by name to be alphabetical, ignoring case sensitivity. Order: DESCENDING', async () => {
-    await registerUser(app, {
-      roles: [Role.FieldOperationsDirector],
-      displayFirstName: 'Tammy',
-    });
-    //Create three projects, each beginning with lower or upper-cases
-    await createOrganization(app, {
-      name: 'an Organization ' + faker.string.uuid(),
-    });
-    await createOrganization(app, {
-      name: 'Another Organization' + faker.string.uuid(),
-    });
-    await createOrganization(app, {
-      name: 'Big Organization' + faker.string.uuid(),
-    });
-    await createOrganization(app, {
-      name: 'big Organization also' + faker.string.uuid(),
-    });
-    const { organizations } = await app.graphql.query(Organizations, {
-      input: {
-        sort: 'name',
-        order: 'DESC',
-      },
-    });
-    const items = organizations.items;
-    const sorted = sortBy(items, [
-      (org: any) => org.name.value.toLowerCase(),
-      'desc',
-    ]);
-    expect(sorted).toEqual(items);
+  it('sorts organizations by name ignoring case, descending', async () => {
+    const { prefix, expectedAsc } = await seedCaseVariants();
+
+    const seeded = (await allOrgNamesInOrder('DESC')).filter((name) =>
+      name.startsWith(prefix),
+    );
+
+    expect(seeded).toHaveLength(expectedAsc.length);
+    expect(seeded).toEqual([...expectedAsc].reverse());
   });
 
   it('list view of organizations with mismatch parameters', async () => {

--- a/test/partnership-changeset-aware.e2e-spec.ts
+++ b/test/partnership-changeset-aware.e2e-spec.ts
@@ -81,7 +81,21 @@ const activeProject = async (app: TestApp) => {
   return project;
 };
 
-describe('Partnership Changeset Aware e2e', () => {
+// Changesets are not being carried forward to Postgres, so every test here
+// fails at ProjectChangeRequestRepository.create — the repository is Neo4j-only
+// by design, and the Postgres shim answers reads truthfully but refuses writes.
+//
+// Switched off here in the test file rather than left out of a list in the CI
+// workflow, on purpose: a test that switches itself off is reported as skipped
+// and says why, while a test missing from a list is indistinguishable from one
+// that passed.
+//
+// migration-todo: remove this condition and this whole spec at Phase 7 cutover,
+// when the changeset feature and its `changeset: ID` arguments are removed.
+const describeNeo4jOnly =
+  process.env.DATABASE === 'postgres' ? describe.skip : describe;
+
+describeNeo4jOnly('Partnership Changeset Aware e2e', () => {
   let app: TestApp;
 
   beforeAll(async () => {

--- a/test/project-changeset-aware.e2e-spec.ts
+++ b/test/project-changeset-aware.e2e-spec.ts
@@ -79,7 +79,21 @@ const activeProject = async (app: TestApp) => {
   return project;
 };
 
-describe('Project Changeset Aware e2e', () => {
+// Changesets are not being carried forward to Postgres, so every test here
+// fails at ProjectChangeRequestRepository.create — the repository is Neo4j-only
+// by design, and the Postgres shim answers reads truthfully but refuses writes.
+//
+// Switched off here in the test file rather than left out of a list in the CI
+// workflow, on purpose: a test that switches itself off is reported as skipped
+// and says why, while a test missing from a list is indistinguishable from one
+// that passed.
+//
+// migration-todo: remove this condition and this whole spec at Phase 7 cutover,
+// when the changeset feature and its `changeset: ID` arguments are removed.
+const describeNeo4jOnly =
+  process.env.DATABASE === 'postgres' ? describe.skip : describe;
+
+describeNeo4jOnly('Project Changeset Aware e2e', () => {
   let app: TestApp;
 
   beforeAll(async () => {

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -328,10 +328,23 @@ describe('Project e2e', () => {
       .expectError(errors.notFound());
   });
 
-  // migration-todo: the expected ordering here is Neo4j's space/punctuation-
-  // insensitive sort. Decision (2026-06-12): PG keeps its plain collation —
-  // update these expectations to match when this spec joins the postgres CI
-  // subset (Phase 5) or at Phase 7 cutover, whichever comes first.
+  // ONE expectation for both databases. A note here used to say Postgres
+  // ordered names differently and that the difference was accepted (decision of
+  // 2026-06-12). That was measured against the `postgres:16-alpine` image and
+  // was wrong twice over: alpine links musl, which has no locale-aware
+  // collation, so `en_US.utf8` there falls back to raw byte ordering — and a
+  // glibc Postgres with the same collation name orders names exactly as Neo4j
+  // does. So the "difference" was a property of the image, not of Postgres.
+  //
+  // Rather than depend on the image, every text sort now names the
+  // `display_order` collation explicitly (migration 0032, applied by
+  // displayOrder() in src/core/drizzle/order-by.ts). That produces this ordering
+  // on alpine, on glibc, and across OS upgrades — so this asserts that the two
+  // databases genuinely agree, rather than making a separate claim about each.
+  //
+  // If this starts failing with capitals grouped ahead of lowercase and `Ñot a
+  // project` last, a text sort lost that collation. Check that before changing
+  // these expectations.
   it('List of projects sorted by name to be alphabetical', async () => {
     const unsorted = [
       'A ignore spaces',

--- a/test/setup/resolve-engine-env.ts
+++ b/test/setup/resolve-engine-env.ts
@@ -1,3 +1,4 @@
+import { parse } from 'dotenv';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
@@ -31,32 +32,41 @@ import { resolve } from 'node:path';
 // Matches ConfigService's default: env.string('DATABASE').optional('neo4j')
 const APP_DEFAULT_ENGINE = 'neo4j';
 
-// Later files do NOT override earlier ones — first match wins, mirroring
-// dotenv's own "don't clobber what's already set" behaviour.
-const DOTENV_FILES = ['.env.local', '.env'];
+/**
+ * The same files EnvironmentService reads, in the same order — including the
+ * NODE_ENV-specific pair. A `DATABASE` in `.env.development.local` decides what
+ * the app boots, so a resolver that skipped it would reintroduce the exact
+ * disagreement this file exists to remove.
+ *
+ * Earlier files win, and that is checked rather than assumed: the app seeds its
+ * accumulator from `process.env` and expands each file into it, leaving any
+ * already-set key alone. It also drops empty values between files, so an empty
+ * `DATABASE=` does not shadow a later file — hence the truthiness test below.
+ */
+const dotenvFiles = () => {
+  const env = process.env.NODE_ENV || 'development';
+  return [`.env.${env}.local`, `.env.${env}`, '.env.local', '.env'];
+};
 
 const readEngineFromDotenv = (): string | undefined => {
-  for (const file of DOTENV_FILES) {
+  for (const file of dotenvFiles()) {
     let contents: string;
     try {
       contents = readFileSync(resolve(process.cwd(), file), 'utf8');
     } catch {
       continue; // absent or unreadable is normal, not an error
     }
-    for (const rawLine of contents.split('\n')) {
-      const line = rawLine.trim();
-      if (!line || line.startsWith('#')) continue;
-      const match = /^(?:export\s+)?DATABASE\s*=\s*(.*)$/.exec(line);
-      const captured = match?.[1];
-      if (captured === undefined) continue;
-      // Strip surrounding quotes and any trailing comment on an unquoted value.
-      const value = captured
-        .trim()
-        .replace(/^(['"])(.*)\1$/, '$2')
-        .replace(/\s+#.*$/, '')
-        .trim();
-      if (value) return value.toLowerCase();
-    }
+    // Parsed by dotenv itself — the same function EnvironmentService uses — so
+    // quoting, `export ` prefixes and inline comments resolve exactly as they
+    // will for the app. Hand-rolling this got one case wrong: a `#` inside a
+    // quoted value is content, not the start of a comment.
+    //
+    // `${...}` expansion is deliberately NOT mirrored. The app applies
+    // dotenv-expand as well, but an engine name has nothing to interpolate, and
+    // reproducing it here means reproducing the `process.env` swap it needs.
+    // Lowercased because ConfigService reads this same value with .toLowerCase().
+    const value = parse(contents).DATABASE?.trim();
+    if (value) return value.toLowerCase();
   }
   return undefined;
 };

--- a/test/setup/resolve-engine-env.ts
+++ b/test/setup/resolve-engine-env.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Make `process.env.DATABASE` agree with the engine the app will actually boot.
+ *
+ * The app's ConfigService loads dotenv, so a `DATABASE=` line in `.env.local`
+ * decides which database it uses. A test file, however, decides which database
+ * it is testing when it loads — before any app starts — and sees only real
+ * environment variables, which dotenv has not touched.
+ * `test/setup/pg-setup.ts` documents the same blind spot for `POSTGRES_URL`.
+ *
+ * Left alone, those two disagree: a bare `yarn test:e2e` on a machine whose
+ * `.env.local` says postgres runs every spec's *Neo4j* path against a
+ * *Postgres* app. That produced 68 failures across 5 specs on 2026-08-03 and
+ * read exactly like a real regression — the only tell was a suite failing with
+ * counts identical to the Postgres baseline, which two different engines cannot
+ * do.
+ *
+ * It is worse for suites written as "skip when this is Postgres" (webhooks, the
+ * changeset specs): with the variable absent they RUN, against a database that
+ * cannot support them. The older form, "run only when this is Postgres", fails
+ * the harmless way round and merely skips.
+ *
+ * So resolve the same precedence the app uses — real environment first, then
+ * dotenv, then the app's own default — and publish the answer to the
+ * environment before any spec is evaluated. An explicitly-set variable always
+ * wins, so CI (which sets `DATABASE` from the job matrix) is unaffected.
+ */
+
+// Matches ConfigService's default: env.string('DATABASE').optional('neo4j')
+const APP_DEFAULT_ENGINE = 'neo4j';
+
+// Later files do NOT override earlier ones — first match wins, mirroring
+// dotenv's own "don't clobber what's already set" behaviour.
+const DOTENV_FILES = ['.env.local', '.env'];
+
+const readEngineFromDotenv = (): string | undefined => {
+  for (const file of DOTENV_FILES) {
+    let contents: string;
+    try {
+      contents = readFileSync(resolve(process.cwd(), file), 'utf8');
+    } catch {
+      continue; // absent or unreadable is normal, not an error
+    }
+    for (const rawLine of contents.split('\n')) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith('#')) continue;
+      const match = /^(?:export\s+)?DATABASE\s*=\s*(.*)$/.exec(line);
+      const captured = match?.[1];
+      if (captured === undefined) continue;
+      // Strip surrounding quotes and any trailing comment on an unquoted value.
+      const value = captured
+        .trim()
+        .replace(/^(['"])(.*)\1$/, '$2')
+        .replace(/\s+#.*$/, '')
+        .trim();
+      if (value) return value.toLowerCase();
+    }
+  }
+  return undefined;
+};
+
+if (!process.env.DATABASE) {
+  process.env.DATABASE = readEngineFromDotenv() ?? APP_DEFAULT_ENGINE;
+}

--- a/test/webhooks.e2e-spec.ts
+++ b/test/webhooks.e2e-spec.ts
@@ -61,6 +61,35 @@ import { GqlError } from './setup/gql-client/gql-result';
 
 const SHORT = +Duration.from('30s');
 
+// Webhooks has NOT been ported to Postgres: WebhooksRepository extends the
+// Neo4j DtoRepository and builds Cypher, with no Drizzle counterpart and no
+// splitDb routing. Under Postgres the save matches nothing and returns
+// undefined, so WebhookSender.verify dereferences undefined — 51 of the 61
+// tests here fail from that one fault.
+//
+// Switched off here in the test file, rather than left out of a list in the CI
+// workflow, on purpose: this suite used to be missing from that list, which is
+// exactly why nobody noticed the feature had no Postgres implementation. A test
+// that switches itself off is reported as skipped and shows up in the output.
+// A test left out of a list shows up nowhere.
+//
+// What that costs, said plainly rather than buried: 8 tests in this file DO pass
+// under Postgres and no longer run. Seven check that malformed subscription
+// documents are rejected — they pass because bad input is refused before any
+// data is stored — plus one that reads an empty list. They are not switched off
+// one at a time because nine OTHER tests in that same validation group fail, so
+// the group is mixed and per-test conditions would be noisy and fragile in a
+// file that loses this condition entirely once webhooks is ported. All 8 stay
+// covered under Neo4j, which is the database serving production today.
+//
+// migration-todo: webhooks IS being ported (not retired) — remove this condition
+// as part of that port. It has to happen before cutover: Neo4j goes away then,
+// and this feature stops working in production until it is ported. When the
+// condition goes, check that those 8 tests are running again rather than
+// assuming it.
+const describeNeo4jOnly =
+  process.env.DATABASE === 'postgres' ? describe.skip : describe;
+
 describe('Move to Generic Subscriptions Tests', () => {
   it.todo(
     'should execute subscription resolver with webhook owner permissions',
@@ -69,7 +98,7 @@ describe('Move to Generic Subscriptions Tests', () => {
   it.todo('should only access data webhook owner has permission to see');
 });
 
-describe('Webhooks', () => {
+describeNeo4jOnly('Webhooks', () => {
   let app: TestApp;
   let tester: IdentifiedTester;
 


### PR DESCRIPTION
### Summary

Postgres CI only ran the test files named on a hand-maintained list. Anything
missing from that list simply didn't run — and a test that never ran looks
exactly like a test that passed, so the run reported success either way.

That list was wrong in three different ways at once:

- A domain whose own migration PR never added it, so it was never covered.
- A name that didn't match what it looked like it matched. Entries were followed
  by a literal `.`, so `periodic-report` covered `periodic-report.e2e-spec.ts`
  but not `periodic-report-narrative-file.e2e-spec.ts`.
- Every spec inside a `test/` subdirectory. The pattern's shape could not match
  those at all, so an entire directory of tests was invisible.

The third one is why nobody noticed that the webhooks feature has no Postgres
implementation at all — its tests were in the group that could never run.

So Postgres now runs the whole suite. Suites that genuinely cannot pass yet say
so inside the test file and are reported as **skipped, with the reason stated**,
instead of being left off a list where they are indistinguishable from passing.

Running everything surfaced one real bug, and this PR fixes it: **listing
records sorted by name came back in a different order on Postgres than on
Neo4j.** Sorting text in Postgres uses the database's default ordering, and that
default depends on which C library the Postgres image was built against. The
alpine image has no locale-aware ordering at all, so it silently falls back to
raw byte order — every capital letter ahead of every lowercase one. The same
image name on a Debian build behaves differently again, and an OS upgrade can
shift it. The fix names an ordering explicitly in the query, so every
environment sorts identically and matches how Neo4j orders names today.

Two smaller honesty fixes ride along:

- Ten test cases that only apply to Postgres used to `return` early on Neo4j.
  Jest counts that as **passed**, so the Neo4j run claimed ten passing tests
  that never asserted anything. They now report as skipped.
- Two organization sort tests had been disabled long enough that the behaviour
  they covered was unverified. They're restored and now assert case-insensitive
  ordering in both directions.

Because the tests now honour `DATABASE` from the env files — which they
previously ignored — the README gained a short section on which database the
tests run against, and on why `POSTGRES_URL` has to be exported rather than read
from a file. Both are consequences of this change, so they're documented here
rather than left for whoever hits them.

### A previous decision this reverses

A note in `test/project.e2e-spec.ts` recorded a decision from 2026-06-12 that
Postgres would keep its own ordering and the test expectations would be updated
to match, accepting that the two databases sort names differently.

That decision was made from a measurement taken against the alpine image, and
the measurement was misleading: what was observed was not how Postgres orders
names, it was that image having no locale-aware ordering to use. A glibc-based
Postgres with the very same collation name orders names the way Neo4j does. So
the difference being accepted did not need to be accepted, and it would also
have reappeared or shifted depending on which image ran.

Both databases now assert one expectation, and the test says what to check first
if it ever fails again.

### Schema

One new migration, `0032_display_order_collation.sql`:

```sql
CREATE COLLATION display_order (
  provider = icu,
  locale = 'und-u-ka-shifted-ks-level1',
  deterministic = false
);
```

It ignores case, accents, punctuation and spaces when comparing, which is how
names are ordered today — so lists don't silently reorder as domains move over.

Two constraints on it that matter for review:

- **Use it in `ORDER BY` only, never as a column's collation.** It has to be
  non-deterministic so that strings differing only in case or accent can compare
  equal for ordering, and Postgres refuses `LIKE`/`ILIKE` against a
  non-deterministic collation. Global search runs `ILIKE` against these same
  name columns, so attaching it to a column would break search. Per-`ORDER BY`
  is allowed and is what the code does.
- It cannot be applied to every column type. `uuid` reports a string data type
  but cannot be collated, and neither can an enum type — Postgres raises
  "collations are not supported by type" for both.

### What's added

- `src/core/drizzle/order-by.ts` — `displayOrder(col)` attaches the collation
  when the column holds display text, and returns the column untouched
  otherwise. `resolveOrderBy` routes every sort through it. Three kinds of column
  are deliberately left alone:
  - dates and numbers, which keep their natural ordering;
  - columns limited to a fixed set of values, which hold codes such as a status
    or a step and should sort exactly as written rather than depend on how the
    collation treats an underscore (and enum types cannot be collated at all);
  - **primary keys**, which hold opaque generated identifiers. Every id in this
    schema is a text column, so without this they would be case-folded like
    prose. That mattered: the user list's default sort key is its id, and `id` is
    not in that list's sort map, so every user query without an explicit sort
    falls through to it. Collating it reordered the default user list away from
    what Neo4j returns — the opposite of this collation's purpose — and stopped
    the ordering being read off the primary key index, making every page a full
    scan plus a sort. Of the 25 sort-resolver call sites, that is the only
    fallback which is an identifier; the rest fall back to a name, a date or a
    number, and no sort map points at an id column.
- `src/core/drizzle/order-by.spec.ts` (new) — pins the collate/don't-collate
  decision, because nothing else can see it. A wrong decision still produces
  valid SQL and a full page of results.
- The three list queries that sort by a joined table's name (partner,
  partnership, project) build their `ORDER BY` by hand rather than through
  `resolveOrderBy`, so each now calls `displayOrder` directly. Without that they
  would order differently from every other list in the app.
- `.github/workflows/test.yml` — the Postgres file list is removed; the job runs
  the full suite on a single shard. The comment records why an allowlist is not
  the right tool here, so it doesn't get reintroduced.
- `test/setup/resolve-engine-env.ts` (new, registered first in `jest.config.ts`
  `setupFiles`) — makes `process.env.DATABASE` agree with the engine the app will
  actually boot. A test file decides which database it is testing when it loads,
  before any app starts, so it sees only real environment variables and never a
  `DATABASE=` line in `.env.local`. Left alone the two disagree, and every spec
  runs its Neo4j path against a Postgres app — which reads exactly like a
  regression. It resolves the same precedence the app uses (real environment,
  then dotenv, then the app's default), reading the same four env files in the
  same order and parsing them with **dotenv's own `parse`** — the same function
  the app's own environment service calls — so quoting, `export ` prefixes and
  inline comments resolve identically instead of via a lookalike of dotenv's
  rules. An explicitly set variable still wins, so CI is unaffected.
- `test/webhooks.e2e-spec.ts` and the three `*-changeset-aware` specs switch
  themselves off under Postgres, each stating why: webhooks has no Postgres
  implementation yet, and changesets are not being carried forward. Both carry a
  `migration-todo` naming what removes the condition.
- `test/audit-log.e2e-spec.ts` and `test/file.e2e-spec.ts` — the ten
  Postgres-only cases now use `itPostgresOnly` / `describePostgresOnly`. Guards
  that assert real Neo4j behaviour before returning were deliberately left as
  they are; only the ones that asserted nothing changed.
- `test/organization.e2e-spec.ts` — the two restored sort tests seed four records
  whose names differ only by case, then page through the full list and compare
  against the expected order. They page because list input caps `count` at 100.
- `README.md` — a "which database the tests run against" section, the
  `POSTGRES_URL` requirement with its reason, and `docker-compose` corrected to
  `docker compose` in three places. The Gel setup step also claimed Gel was "the
  current primary database", which contradicted the section directly below it
  describing a Neo4j-to-PostgreSQL migration; for a first-time setup it was
  unclear whether Gel was required, optional or historical. It is left from an
  earlier migration target and nothing new is built on it, but its generated
  client is not committed, so the project will not compile without that step —
  now said plainly, with the two sections cross-linked.

### Validation performed

Run against this branch rebased onto develop, clean tree, both engines:

- `yarn type-check` — exit 0. `yarn lint` — exit 0.
- **Postgres, full suite** — 0 failed, 320 passed, 95 skipped, 2 todo; 41 suites
  passed, 4 skipped, exit 0. Before this branch the same full run had 5 failing
  suites and 63 failing tests.
- **Neo4j, every spec file this branch changes** (8 files) — 0 failed, 120
  passed, 19 skipped, exit 0. The rest of the Neo4j suite is CI's job and was not
  run locally.
- The new `displayOrder` unit spec — 5 passed. Then the same spec with the
  primary-key exclusion removed: **exactly one case fails and the other four
  still pass.** A guard that has never failed is not evidence, so it was broken
  on purpose before being trusted.
- The engine resolver, checked in both directions because it loads before every
  spec: with `DATABASE` unset it picks the engine out of the env files and the
  Postgres-only schema spec runs its 14 tests; with `DATABASE=neo4j` set
  explicitly the explicit value wins and those same 14 report skipped.
- Each run wrote its own machine-readable results with the commit stamped, and
  the per-suite counts were checked to sum to the reported totals, rather than
  reading suite names out of console output.

Two limits of the above, stated rather than left to be assumed:

- ⚠️ **The end-to-end suite cannot see the ordering defect this fixes.** The full
  Postgres suite returns identical counts before and after the fix — same
  failures, same passes, same skips, and no suite's passing count changed. No list
  spec asserts the default user ordering. The unit spec is the only detector, and
  that is why it exists.
- The full-suite runs predate the last two commits and were not repeated for
  them. That is deliberate, not skipped work: both local runs and CI set
  `DATABASE` explicitly, which bypasses the code path the resolver commit
  changed, so the suite cannot exercise it — the two-directional check above is
  what covers it. The final commit is documentation only.

The direction of every self-skip was checked on **both** engines, since a
one-directional condition that fires the wrong way round is the failure mode:

- webhooks — 59 skipped on Postgres; 59 **passed** on Neo4j.
- the three changeset specs — all skipped on Postgres; all pass on Neo4j.
- the ten Postgres-only cases — run on Postgres (audit-log 6, file 4); report
  **skipped** on Neo4j, where they previously reported passed.
- the restored organization sort tests — pass on both.
- the project name-ordering test — **passes on both**, which is the point of the
  collation change. It fails on Postgres without it.

The full Postgres run also applies every migration to a fresh database per spec
file, so 0030 → 0031 → 0032 applying in order is exercised rather than reasoned
about.

### Reviewer cross-checks

- The collation appears only in `ORDER BY`, never on a column definition. Worth
  grepping, since attaching it to a name column would break global search rather
  than fail loudly here.
- Whether any column that *should* sort case-insensitively lost it when primary
  keys were excluded. The check that convinced me: no sort map anywhere points at
  an id column, and the user list is the only call site whose fallback is one.
- `displayOrder` can only inspect a column, so a sort written as a raw `sql`
  expression comes back uncollated with no error. The engagement sort map is the
  only place that can hit this today — its two raw expressions sort dates, so
  they are unaffected, but the two name sorts already scheduled there will have
  to name the collation inline. Called out at that call site.
- `displayOrder` skips `uuid` and enum-typed columns. Both raise a Postgres error
  if collated, so a widened list would fail at query time, not at build.
- The migration journal: indexes contiguous, `when` values strictly increasing,
  no duplicates. A duplicate `when` is skipped silently by the migrator rather
  than reported as an error.
- Every self-skip condition reads `DATABASE`. A misspelled variable makes the
  condition never fire, and the suite goes back to failing — or worse, to
  passing while asserting nothing.
- Under Neo4j, webhooks and the three changeset specs must still **run**, not
  skip. The conditions are one-directional on purpose.

### Explicitly out of scope

- **Letting the Postgres job block a merge.** It still runs with
  `continue-on-error`, so a Postgres failure reports without blocking. Flipping
  that is a one-line change and belongs in its own PR, once this one has
  reported green at least once.
- **The webhooks port.** This PR only makes its absence visible. The feature has
  to be ported before Neo4j goes away, and the test file says so.
- **Removing the changeset specs.** They stay until the changeset feature itself
  is removed.
- Re-sharding the Postgres job. One shard is right while the full suite is about
  ten minutes serial; the comment says what to change when that grows.
- **Choosing collated columns explicitly instead of by column type.** Deciding
  from a column's type is a proxy for the real question, and excluding primary
  keys patches the proxy rather than replacing it. The better design names the
  display-text columns outright. It is deliberately not done here: all 25 sort
  targets were checked and, with primary keys excluded, every text column that
  actually gets sorted is one the Neo4j path also case-folds — including the two
  that looked like exceptions, `educations.institution` and `producibles.name`.
  So no ordering difference between the engines remains, and the change would
  touch all 25 sort maps for no change in behaviour. It is tracked for after the
  migration completes, when "match the old ordering" stops being the standard and
  the question becomes which columns should read case-insensitively for a person
  scanning a list.
