### PR TITLE
[pg] Engine-aware transactions and boot, and the transaction-scoping bugs that surfaced

### DIFF
--- a/src/components/budget/budget-record.drizzle.repository.ts
+++ b/src/components/budget/budget-record.drizzle.repository.ts
@@ -195,7 +195,7 @@ export class BudgetRecordDrizzleRepository extends DrizzleDtoRepository<
       preApprovedAmount: row.preApprovedAmount,
       status: row.budget.status,
       sensitivity: row.budget.project.sensitivity,
-      parent: { id: row.budget.id },
+      parent: { id: row.budget.id, __typename: 'Budget' },
       // PCR is excluded; resolver navigation marker stays undefined.
       changeset: undefined,
       canDelete: true,

--- a/src/components/budget/budget.drizzle.repository.ts
+++ b/src/components/budget/budget.drizzle.repository.ts
@@ -17,7 +17,7 @@ import {
   type SortMap,
 } from '~/core/drizzle';
 import { DrizzleService } from '~/core/drizzle/drizzle.service';
-import { budgets } from '~/core/drizzle/schema';
+import { budgets, type projects } from '~/core/drizzle/schema';
 import { type ScopedRole } from '../authorization/dto/role.dto';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import { type FileId } from '../file/dto';
@@ -32,7 +32,10 @@ import {
 } from './dto';
 
 type BudgetRow = typeof budgets.$inferSelect & {
-  project?: { id: ID<'Project'>; sensitivity: string } | null;
+  project?: Pick<
+    typeof projects.$inferSelect,
+    'id' | 'sensitivity' | 'type'
+  > | null;
 };
 
 @Injectable()
@@ -91,7 +94,8 @@ export class BudgetDrizzleRepository extends DrizzleDtoRepository<
     const rows = await this.db.query.budgets.findMany({
       where: (b) => and(inArray(b.id, [...ids]), isNull(b.deletedAt)),
       with: {
-        project: { columns: { id: true, sensitivity: true } },
+        // `type` feeds the parent ref's __typename (`${type}Project`).
+        project: { columns: { id: true, sensitivity: true, type: true } },
       },
     });
     const scopeByProject = await requesterScopeByProject(
@@ -191,7 +195,10 @@ export class BudgetDrizzleRepository extends DrizzleDtoRepository<
         : null,
       // Assembled by the service via listRecords.
       records: [],
-      parent: { id: row.project.id },
+      parent: {
+        id: row.project.id,
+        __typename: `${row.project.type}Project`,
+      },
       // PCR is excluded; resolver navigation marker stays undefined.
       changeset: undefined,
       canDelete: true,

--- a/src/components/budget/budget.drizzle.repository.ts
+++ b/src/components/budget/budget.drizzle.repository.ts
@@ -184,15 +184,20 @@ export class BudgetDrizzleRepository extends DrizzleDtoRepository<
         `Budget ${row.id} has no parent project row — FK invariant violated`,
       );
     }
-    const dto: unknown = {
+    // Not laundered through `unknown` before the cast below: that stops
+    // TypeScript comparing this object to the DTO at all, which is how a field
+    // can go missing or take the wrong shape unnoticed. The direct cast still
+    // allows the service-layer overlays (canDelete, scope) and the fields the
+    // service fills in later.
+    const dto = {
       id: row.id,
       __typename: 'Budget',
       createdAt: DateTime.fromJSDate(row.createdAt),
       status: row.status,
       sensitivity: row.project.sensitivity,
-      universalTemplateFile: row.universalTemplateFileId
-        ? { id: row.universalTemplateFileId }
-        : null,
+      // The bare id, matching both the Neo4j repo and the declared DefinedFile
+      // type. The resolver accepts a null here and yields no file.
+      universalTemplateFile: row.universalTemplateFileId,
       // Assembled by the service via listRecords.
       records: [],
       parent: {

--- a/src/components/budget/dto/budget-record.dto.ts
+++ b/src/components/budget/dto/budget-record.dto.ts
@@ -12,6 +12,7 @@ import {
 } from '~/common';
 import { e } from '~/core/gel';
 import { type BaseNode } from '~/core/neo4j/results';
+import { type LinkToUnknown } from '~/core/resources';
 import { RegisterResource } from '~/core/resources';
 import { ChangesetAware } from '../../changeset/dto';
 import { type BudgetStatus } from './budget-status.enum';
@@ -28,7 +29,7 @@ export class BudgetRecord extends Interfaces {
   static readonly Parent = () => import('./budget.dto').then((m) => m.Budget);
 
   @Field(() => Budget)
-  declare readonly parent: BaseNode;
+  declare readonly parent: LinkToUnknown | BaseNode;
 
   @Calculated()
   readonly organization: Secured<ID>;

--- a/src/components/budget/dto/budget.dto.ts
+++ b/src/components/budget/dto/budget.dto.ts
@@ -12,6 +12,7 @@ import {
 } from '~/common';
 import { e } from '~/core/gel';
 import { type BaseNode } from '~/core/neo4j/results';
+import { type LinkToUnknown } from '~/core/resources';
 import { RegisterResource } from '~/core/resources';
 import { ChangesetAware } from '../../changeset/dto';
 import { type DefinedFile } from '../../file/dto';
@@ -54,7 +55,7 @@ export class Budget extends Interfaces {
     import('../../project/dto').then((m) => m.IProject);
 
   @Field(() => IProject)
-  declare readonly parent: BaseNode;
+  declare readonly parent: LinkToUnknown | BaseNode;
 
   @Field()
   @DbLabel('BudgetStatus')

--- a/src/components/ceremony/ceremony.drizzle.repository.ts
+++ b/src/components/ceremony/ceremony.drizzle.repository.ts
@@ -16,7 +16,11 @@ import {
   type SortMap,
 } from '~/core/drizzle';
 import { DrizzleService } from '~/core/drizzle/drizzle.service';
-import { ceremonies } from '~/core/drizzle/schema';
+import {
+  ceremonies,
+  type engagements,
+  type projects,
+} from '~/core/drizzle/schema';
 import { type ScopedRole } from '../authorization/dto/role.dto';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import { requesterScopeByProject } from '../project/project-member/membership-scope';
@@ -28,10 +32,9 @@ import {
 } from './dto';
 
 type CeremonyRow = typeof ceremonies.$inferSelect & {
-  engagement?: {
-    id: ID<'Engagement'>;
-    project?: { id: ID<'Project'>; sensitivity: string } | null;
-  } | null;
+  engagement?: Pick<typeof engagements.$inferSelect, 'id' | 'type'> & {
+    project?: Pick<typeof projects.$inferSelect, 'id' | 'sensitivity'> | null;
+  };
 };
 
 @Injectable()
@@ -78,7 +81,8 @@ export class CeremonyDrizzleRepository extends DrizzleDtoRepository<
       where: (c) => and(inArray(c.id, [...ids]), isNull(c.deletedAt)),
       with: {
         engagement: {
-          columns: { id: true },
+          // `type` feeds the parent ref's __typename (`${type}Engagement`).
+          columns: { id: true, type: true },
           with: { project: { columns: { id: true, sensitivity: true } } },
         },
       },
@@ -174,7 +178,10 @@ export class CeremonyDrizzleRepository extends DrizzleDtoRepository<
       actualDate: row.actualDate ? CalendarDate.fromISO(row.actualDate) : null,
       sensitivity: row.engagement.project.sensitivity,
       engagement: { id: row.engagement.id },
-      parent: { id: row.engagement.id },
+      parent: {
+        id: row.engagement.id,
+        __typename: `${row.engagement.type}Engagement`,
+      },
       canDelete: true,
       scope,
     };

--- a/src/components/changeset/changeset-aware.resolver.ts
+++ b/src/components/changeset/changeset-aware.resolver.ts
@@ -2,6 +2,7 @@ import { Info, Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { Fields, IsOnlyId, Resource } from '~/common';
 import { Identity } from '~/core/authentication';
+import { isBaseNode } from '~/core/neo4j/results';
 import { ResourceLoader, ResourceResolver } from '~/core/resources';
 import { ChangesetResolver } from './changeset.resolver';
 import { Changeset, ChangesetAware, ChangesetDiff } from './dto';
@@ -33,14 +34,26 @@ export class ChangesetAwareResolver {
     if (!object.parent) {
       return null;
     }
+    // migration-todo: drop this normalization at Phase 7 cutover — it exists
+    // only because the Neo4j/Gel repos hand over a raw graph node. Postgres
+    // repos already emit the typed ref, so under PG this is a no-op.
+    const ref = isBaseNode(object.parent)
+      ? {
+          __typename: this.resourceResolver.resolveTypeByBaseNode(
+            object.parent,
+          ),
+          id: object.parent.properties.id,
+        }
+      : object.parent;
+
     if (isOnlyId) {
       return {
-        __typename: this.resourceResolver.resolveTypeByBaseNode(object.parent),
-        id: object.parent.properties.id,
+        __typename: ref.__typename,
+        id: ref.id,
         changeset: object.changeset,
       };
     }
-    return await this.resources.loadByBaseNode(object.parent);
+    return await this.resources.loadByRef(ref);
   }
 
   @ResolveField(() => ChangesetDiff, {

--- a/src/components/changeset/dto/changeset-aware.dto.ts
+++ b/src/components/changeset/dto/changeset-aware.dto.ts
@@ -2,6 +2,7 @@ import { Field, InterfaceType } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { DbLabel, type ID, IdField } from '~/common';
 import { type BaseNode } from '~/core/neo4j/results';
+import { type LinkToUnknown } from '~/core/resources';
 import { Changeset } from './changeset.dto';
 
 @InterfaceType({
@@ -26,5 +27,16 @@ export abstract class ChangesetAware {
   })
   readonly changeset?: ID;
 
-  readonly parent?: BaseNode;
+  /**
+   * A reference to the resource that owns this one — used for navigation
+   * (breadcrumbs, `project: parent { … }`), not only for changesets.
+   *
+   * Postgres repos emit the typed {@link LinkToUnknown} form. The
+   * {@link BaseNode} arm is only for the Neo4j/Gel repos, which hand over a raw
+   * graph node; `ChangesetAwareResolver.parent` normalizes it.
+   *
+   * migration-todo: drop the `| BaseNode` arm at Phase 7 cutover (and the
+   * normalizing branch in ChangesetAwareResolver.parent with it).
+   */
+  readonly parent?: LinkToUnknown | BaseNode;
 }

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -25,7 +25,11 @@ import {
 } from '~/common';
 import { e } from '~/core/gel';
 import { type BaseNode } from '~/core/neo4j/results';
-import { type LinkTo, RegisterResource } from '~/core/resources';
+import {
+  type LinkTo,
+  type LinkToUnknown,
+  RegisterResource,
+} from '~/core/resources';
 import { ChangesetAware } from '../../changeset/dto';
 import { Commentable } from '../../comments/dto';
 import { SecuredLanguageMilestone } from '../../language/dto';
@@ -86,7 +90,7 @@ class Engagement extends Interfaces {
     Pick<UnsecuredDto<IProject>, 'status' | 'step' | 'type'>;
 
   @Field(() => IProject)
-  declare readonly parent: BaseNode;
+  declare readonly parent: LinkToUnknown | BaseNode;
 
   readonly label: Readonly<{
     project: string;
@@ -178,7 +182,7 @@ export class LanguageEngagement extends Engagement {
   declare readonly __typename: DBNames<typeof e.LanguageEngagement>;
 
   @Field(() => TranslationProject)
-  declare readonly parent: BaseNode;
+  declare readonly parent: LinkToUnknown | BaseNode;
 
   readonly language: Secured<LinkTo<'Language'>>;
 
@@ -233,7 +237,7 @@ export class InternshipEngagement extends Engagement {
   declare readonly __typename: DBNames<typeof e.InternshipEngagement>;
 
   @Field(() => InternshipProject)
-  declare readonly parent: BaseNode;
+  declare readonly parent: LinkToUnknown | BaseNode;
 
   @RequiredWhenNotInDev()
   readonly countryOfOrigin: Secured<LinkTo<'Location'> | null>;

--- a/src/components/engagement/engagement.drizzle.repository.ts
+++ b/src/components/engagement/engagement.drizzle.repository.ts
@@ -760,7 +760,10 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
         : 'default::InternshipEngagement',
       createdAt: DateTime.fromJSDate(row.createdAt),
       modifiedAt: DateTime.fromJSDate(row.modifiedAt),
-      parent: { id: row.project.id },
+      parent: {
+        id: row.project.id,
+        __typename: `${row.project.type}Project`,
+      },
       project: {
         id: row.project.id,
         type: row.project.type,

--- a/src/components/partnership/dto/partnership.dto.ts
+++ b/src/components/partnership/dto/partnership.dto.ts
@@ -13,7 +13,11 @@ import {
 } from '~/common';
 import { e } from '~/core/gel';
 import { type BaseNode } from '~/core/neo4j/results';
-import { type LinkTo, RegisterResource } from '~/core/resources';
+import {
+  type LinkTo,
+  type LinkToUnknown,
+  RegisterResource,
+} from '~/core/resources';
 import { ChangesetAware } from '../../changeset/dto';
 import { Organization } from '../../organization/dto';
 import { SecuredPartnerTypes } from '../../partner/dto';
@@ -39,7 +43,7 @@ export class Partnership extends Interfaces {
   readonly project: LinkTo<'Project'>;
 
   @Field(() => IProject)
-  declare readonly parent: BaseNode;
+  declare readonly parent: LinkToUnknown | BaseNode;
 
   @Field()
   readonly agreementStatus: SecuredPartnershipAgreementStatus;

--- a/src/components/partnership/partnership.drizzle.repository.ts
+++ b/src/components/partnership/partnership.drizzle.repository.ts
@@ -525,7 +525,10 @@ export class PartnershipDrizzleRepository extends DrizzleDtoRepository<
       scope,
       // Required by the `parent` field on the DTO. The service constructs a
       // BaseNode-shaped object; here we just pass the project id through.
-      parent: { id: row.project.id },
+      parent: {
+        id: row.project.id,
+        __typename: `${row.project.type}Project`,
+      },
     };
     return dto as UnsecuredDto<Partnership>;
   }

--- a/src/components/project-change-request/project-change-request.drizzle.repository.ts
+++ b/src/components/project-change-request/project-change-request.drizzle.repository.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@nestjs/common';
+import {
+  type ID,
+  NotFoundException,
+  NotImplementedException,
+  type UnsecuredDto,
+} from '~/common';
+import {
+  type ProjectChangeRequest,
+  type ProjectChangeRequestListInput,
+} from './dto';
+
+/**
+ * Postgres implementation of ProjectChangeRequestRepository.
+ *
+ * Changesets are NOT being carried forward to Postgres — there is no
+ * project_change_requests table and no plan for one. But the
+ * `Project.changeRequests` field is still in the GraphQL schema and cord-field's
+ * live `ProjectOverview` document selects it, so every project page load hits
+ * this repo. Left routed to Neo4j it threw
+ * `Neo4jError: Failed to connect` and broke the whole project page under
+ * DATABASE=postgres.
+ *
+ * So reads answer truthfully — there are no change requests in Postgres, hence
+ * an empty list — while writes fail loudly rather than silently pretending to
+ * succeed. Same posture as `ProjectFilters.partnerId`.
+ *
+ * migration-todo: when the changeset feature is formally removed, delete this
+ * repo along with the whole project-change-request component and the
+ * `Project.changeRequests` field (coordinated with cord-field dropping it from
+ * ProjectOverview).
+ */
+@Injectable()
+export class ProjectChangeRequestDrizzleRepository {
+  async list(_input: ProjectChangeRequestListInput) {
+    return {
+      items: [] as ReadonlyArray<UnsecuredDto<ProjectChangeRequest>>,
+      total: 0,
+      hasMore: false,
+    };
+  }
+
+  async readMany(
+    _ids: readonly ID[],
+  ): Promise<ReadonlyArray<UnsecuredDto<ProjectChangeRequest>>> {
+    return [];
+  }
+
+  async readOne(id: ID): Promise<UnsecuredDto<ProjectChangeRequest>> {
+    throw new NotFoundException(
+      `Change requests do not exist under Postgres (${id})`,
+    );
+  }
+
+  async create(_input: unknown): Promise<never> {
+    throw new NotImplementedException(
+      'Change requests are not supported under Postgres — the changeset feature is not being carried forward.',
+    );
+  }
+
+  async update(_changes: unknown): Promise<never> {
+    throw new NotImplementedException(
+      'Change requests are not supported under Postgres — the changeset feature is not being carried forward.',
+    );
+  }
+
+  async deleteNode(_objectOrId: unknown): Promise<never> {
+    throw new NotImplementedException(
+      'Change requests are not supported under Postgres — the changeset feature is not being carried forward.',
+    );
+  }
+
+  /**
+   * Services call this to diff an existing DTO against an Update input. Nothing
+   * can exist to update, so the only reachable caller already threw in
+   * `readOne`; return no changes rather than pretending otherwise.
+   */
+  getActualChanges() {
+    return {};
+  }
+}

--- a/src/components/project-change-request/project-change-request.module.ts
+++ b/src/components/project-change-request/project-change-request.module.ts
@@ -1,6 +1,8 @@
 import { forwardRef, Module } from '@nestjs/common';
+import { splitDb } from '~/core/database';
 import { AuthorizationModule } from '../authorization/authorization.module';
 import { ProjectModule } from '../project/project.module';
+import { ProjectChangeRequestDrizzleRepository } from './project-change-request.drizzle.repository';
 import { ProjectChangeRequestLoader } from './project-change-request.loader';
 import { ProjectChangeRequestRepository } from './project-change-request.repository';
 import { ProjectChangeRequestResolver } from './project-change-request.resolver';
@@ -11,7 +13,13 @@ import { ProjectChangeRequestService } from './project-change-request.service';
   providers: [
     ProjectChangeRequestResolver,
     ProjectChangeRequestService,
-    ProjectChangeRequestRepository,
+    splitDb(ProjectChangeRequestRepository, {
+      // Changesets are not carried forward to Postgres; the PG repo answers
+      // reads as empty and fails writes loudly.
+      // migration-todo: remove with the whole changeset feature at cutover.
+      // migration-todo: remove `as any` once splitDb types accept drizzle repos.
+      postgres: ProjectChangeRequestDrizzleRepository as any,
+    }),
     ProjectChangeRequestLoader,
   ],
   exports: [ProjectChangeRequestService],

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -14,6 +14,7 @@ import { CliModule } from './cli/cli.module';
 import { ConfigModule } from './config/config.module';
 import { CoreController } from './core.controller';
 import { DataLoaderConfig } from './data-loader/data-loader.config';
+import { TransactionRunner } from './database';
 import { DrizzleModule } from './drizzle/drizzle.module';
 import { EmailConfig } from './email/email.config';
 import { ExceptionFilter } from './exception/exception.filter';
@@ -63,6 +64,7 @@ import { WebhooksModule } from './webhooks/webhooks.module';
   ],
   providers: [
     AwsS3Factory,
+    TransactionRunner,
     ExceptionNormalizer,
     ExceptionFilter,
     { provide: APP_FILTER, useExisting: ExceptionFilter },
@@ -75,6 +77,7 @@ import { WebhooksModule } from './webhooks/webhooks.module';
   exports: [
     HttpModule,
     AwsS3Factory,
+    TransactionRunner,
     ConfigModule,
     CacheModule,
     BroadcasterModule,

--- a/src/core/database/index.ts
+++ b/src/core/database/index.ts
@@ -1,4 +1,5 @@
 export * from './db-type';
 export * from './transaction-hooks';
 export * from './transaction-retry.informer';
+export * from './transaction-runner';
 export * from './split-db.provider';

--- a/src/core/database/transaction-runner.ts
+++ b/src/core/database/transaction-runner.ts
@@ -1,0 +1,102 @@
+import { Injectable, Optional } from '@nestjs/common';
+import { Connection } from 'cypher-query-builder';
+import { ServerException } from '~/common';
+import { ConfigService } from '~/core/config';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { TransactionContext } from '~/core/gel/transaction.context';
+import { type TransactionOptions } from '~/core/neo4j/transaction';
+import { TransactionRetryInformer } from './transaction-retry.informer';
+
+/**
+ * Establishes a database transaction on whichever engine is active.
+ *
+ * This is the single place that knows how each engine begins a transaction.
+ * Everything that needs "run this in a transaction" — the per-engine
+ * `TransactionalMutationsInterceptor`s and the `@Transactional()` decorator —
+ * delegates here, so no caller has to hardcode an engine.
+ *
+ * The engine services are injected `@Optional()` because only the active
+ * engine's is guaranteed to be resolvable.
+ *
+ * migration-todo: at Phase 7 cutover, drop the `neo4j` and `gel` arms (and
+ * their injections) leaving only the Drizzle path.
+ */
+@Injectable()
+export class TransactionRunner {
+  constructor(
+    private readonly config: ConfigService,
+    private readonly retryInformer: TransactionRetryInformer,
+    @Optional() private readonly neo4j?: Connection,
+    @Optional() private readonly drizzle?: DrizzleService,
+    @Optional() private readonly gel?: TransactionContext,
+  ) {}
+
+  /**
+   * @param options Neo4j-only transaction options (metadata, retry config).
+   *   Ignored by the other engines, which take no equivalent.
+   */
+  async inTx<R>(
+    fn: () => Promise<R>,
+    options?: TransactionOptions,
+  ): Promise<R> {
+    switch (this.config.databaseEngine) {
+      case 'postgres':
+        return await this.inDrizzleTx(fn);
+      case 'gel':
+        return await this.required(this.gel, 'gel').inTx(fn);
+      case 'neo4j':
+        return await this.required(this.neo4j, 'neo4j').runInTransaction(
+          fn,
+          options,
+        );
+      default:
+        throw new ServerException(
+          `Cannot start a transaction for unknown database engine '${this.config.databaseEngine}'`,
+        );
+    }
+  }
+
+  /**
+   * Honor {@link TransactionRetryInformer} the way the Neo4j driver does:
+   * handlers mark an error retryable and expect the whole unit to re-run.
+   * Without this loop `markForRetry()` would be a no-op under Postgres.
+   * Same semantics as Neo4j retryable transactions — the body may run more
+   * than once, so it must be idempotent.
+   */
+  private async inDrizzleTx<R>(fn: () => Promise<R>): Promise<R> {
+    const drizzle = this.required(this.drizzle, 'postgres');
+    let attemptsLeft = 3;
+    // eslint-disable-next-line no-constant-condition,@typescript-eslint/no-unnecessary-condition
+    while (true) {
+      attemptsLeft--;
+      try {
+        return await drizzle.inTx(fn);
+      } catch (error) {
+        if (attemptsLeft > 0 && this.markedForRetry(error)) {
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  private markedForRetry(error: unknown): boolean {
+    // The marked error is usually a cause of the thrown one (handlers wrap the
+    // db error in a ServerException) — walk the chain.
+    let current = error;
+    while (current instanceof Error) {
+      if (this.retryInformer.shouldRetry(current)) return true;
+      current = current.cause;
+    }
+    return false;
+  }
+
+  private required<T>(service: T | undefined, engine: string): T {
+    if (!service) {
+      throw new ServerException(
+        `Database engine is '${engine}' but its transaction service is not available`,
+      );
+    }
+    return service;
+  }
+}

--- a/src/core/database/transaction-runner.ts
+++ b/src/core/database/transaction-runner.ts
@@ -40,8 +40,19 @@ export class TransactionRunner {
     options?: TransactionOptions,
   ): Promise<R> {
     switch (this.config.databaseEngine) {
-      case 'postgres':
-        return await this.inDrizzleTx(fn);
+      case 'postgres': {
+        const drizzle = this.required(this.drizzle, 'postgres');
+        // Already inside a transaction: continue in it, and deliberately return
+        // BEFORE the retry loop below rather than relying on inTx to continue.
+        // Entering the loop while nested would multiply the retry budget — the
+        // outer unit's three attempts times this one's — so one markForRetry()
+        // could re-run the body, and every hook it fires, up to nine times.
+        // Neo4j has one retry scope per mutation; keep it that way.
+        if (drizzle.inTransaction) {
+          return await fn();
+        }
+        return await this.inDrizzleTx(drizzle, fn);
+      }
       case 'gel':
         return await this.required(this.gel, 'gel').inTx(fn);
       case 'neo4j':
@@ -63,8 +74,10 @@ export class TransactionRunner {
    * Same semantics as Neo4j retryable transactions — the body may run more
    * than once, so it must be idempotent.
    */
-  private async inDrizzleTx<R>(fn: () => Promise<R>): Promise<R> {
-    const drizzle = this.required(this.drizzle, 'postgres');
+  private async inDrizzleTx<R>(
+    drizzle: DrizzleService,
+    fn: () => Promise<R>,
+  ): Promise<R> {
     let attemptsLeft = 3;
     // eslint-disable-next-line no-constant-condition,@typescript-eslint/no-unnecessary-condition
     while (true) {

--- a/src/core/drizzle/drizzle-transactional-mutations.interceptor.ts
+++ b/src/core/drizzle/drizzle-transactional-mutations.interceptor.ts
@@ -6,16 +6,14 @@ import {
 import { ConfigService } from '~/core/config';
 import { TransactionalMutationsInterceptor } from '~/core/database/abstract-transactional-mutations.interceptor';
 import { TransactionHooks } from '~/core/database/transaction-hooks';
-import { TransactionRetryInformer } from '~/core/database/transaction-retry.informer';
-import { DrizzleService } from './drizzle.service';
+import { TransactionRunner } from '~/core/database/transaction-runner';
 
 @Injectable()
 export class DrizzleTransactionalMutationsInterceptor extends TransactionalMutationsInterceptor {
   constructor(
     txHooks: TransactionHooks,
     private readonly config: ConfigService,
-    private readonly drizzle: DrizzleService,
-    private readonly retryInformer: TransactionRetryInformer,
+    private readonly runner: TransactionRunner,
   ) {
     super(txHooks);
   }
@@ -28,34 +26,8 @@ export class DrizzleTransactionalMutationsInterceptor extends TransactionalMutat
   }
 
   protected async inTx<R>(fn: () => Promise<R>): Promise<R> {
-    // Honor TransactionRetryInformer like the Neo4j driver does: handlers
-    // (e.g. SetDepartmentId's unique-violation race) mark an error retryable
-    // and expect the whole mutation to re-run. Without this loop,
-    // markForRetry() is a no-op under postgres. Same semantics as Neo4j
-    // retryable transactions: the mutation body may execute multiple times.
-    let attemptsLeft = 3;
-    // eslint-disable-next-line no-constant-condition,@typescript-eslint/no-unnecessary-condition
-    while (true) {
-      attemptsLeft--;
-      try {
-        return await this.drizzle.inTx(fn);
-      } catch (error) {
-        if (attemptsLeft > 0 && this.markedForRetry(error)) {
-          continue;
-        }
-        throw error;
-      }
-    }
-  }
-
-  private markedForRetry(error: unknown): boolean {
-    // The marked error is usually a cause of the thrown one (handlers wrap
-    // the db error in a ServerException) — walk the chain.
-    let e = error;
-    while (e instanceof Error) {
-      if (this.retryInformer.shouldRetry(e)) return true;
-      e = e.cause;
-    }
-    return false;
+    // The TransactionRetryInformer retry loop (markForRetry) now lives in the
+    // runner, so every caller gets it — not just mutations.
+    return await this.runner.inTx(fn);
   }
 }

--- a/src/core/drizzle/drizzle.service.ts
+++ b/src/core/drizzle/drizzle.service.ts
@@ -34,7 +34,33 @@ export class DrizzleService implements OnModuleDestroy {
     return client;
   }
 
+  /**
+   * Whether this async context is already running inside a transaction.
+   *
+   * Callers that decide whether to open one need this: nothing about a Drizzle
+   * client tells you which of the two it is, since {@link client} silently
+   * falls back to the pool.
+   */
+  get inTransaction(): boolean {
+    return !!this.als.getStore();
+  }
+
+  /**
+   * Run `fn` inside a transaction, continuing one that is already open rather
+   * than starting a second.
+   *
+   * The continuation is not a nicety. Without it a nested call takes ANOTHER
+   * connection out of the pool and begins a transaction that commits and rolls
+   * back independently — so an inner write survives an outer rollback, and each
+   * nested call holds two pool connections at once, which deadlocks the pool
+   * under concurrency rather than failing. Neo4j's equivalent has always
+   * continued (`runInTransaction` returns the inner call directly when a
+   * transaction is open), so this also keeps the engines behaving the same.
+   */
   async inTx<R>(fn: () => Promise<R>): Promise<R> {
+    if (this.inTransaction) {
+      return await fn();
+    }
     return await this.baseDb.transaction((tx) =>
       this.als.run(tx as DrizzleDb, fn),
     );

--- a/src/core/drizzle/drizzle.service.ts
+++ b/src/core/drizzle/drizzle.service.ts
@@ -7,10 +7,34 @@ import * as schema from './schema/index';
 
 export type DrizzleDb = NodePgDatabase<typeof schema>;
 
+/**
+ * The transaction in effect for one async context, plus whether it is still
+ * usable.
+ *
+ * The flag is the point. An async context that was created inside a transaction
+ * keeps seeing this store after the transaction has settled and its pool
+ * connection has been handed back, so "the store is set" does not mean "there is
+ * a transaction to use". Recording liveness lets that be reported as the mistake
+ * it is instead of surfacing as pg's "Cannot use a released client" from
+ * somewhere unrelated.
+ */
+interface TransactionScope {
+  db: DrizzleDb;
+  alive: boolean;
+}
+
+/** Shared by both callers that find a settled transaction in the store. */
+const outlivedTransaction = () =>
+  new Error(
+    'Database work escaped its transaction: the transaction it was started in has already finished. ' +
+      'Work started inside a transaction must be awaited before that transaction ends. ' +
+      'To run something after a transaction commits, register a TransactionHooks.afterCommit callback instead.',
+  );
+
 @Injectable()
 export class DrizzleService implements OnModuleDestroy {
   private readonly baseDb: DrizzleDb;
-  private readonly als = new AsyncLocalStorage<DrizzleDb>();
+  private readonly als = new AsyncLocalStorage<TransactionScope>();
   private readonly pool: Pool;
 
   constructor(config: ConfigService) {
@@ -26,12 +50,21 @@ export class DrizzleService implements OnModuleDestroy {
   }
 
   get client(): DrizzleDb {
-    const client = this.als.getStore() ?? this.baseDb;
-    if (!client)
+    const scope = this.als.getStore();
+    if (scope) {
+      // Reached only by work that outlived the transaction it started in; see
+      // TransactionScope. Throwing here is the whole point — returning the
+      // settled transaction gives a released-client error from wherever the
+      // query happens to be, and falling back to the pool would be worse still,
+      // quietly running outside the transaction the caller believes it is in.
+      if (!scope.alive) throw outlivedTransaction();
+      return scope.db;
+    }
+    if (!this.baseDb)
       throw new Error(
         'DrizzleService.client accessed but DATABASE is not postgres',
       );
-    return client;
+    return this.baseDb;
   }
 
   /**
@@ -42,7 +75,7 @@ export class DrizzleService implements OnModuleDestroy {
    * falls back to the pool.
    */
   get inTransaction(): boolean {
-    return !!this.als.getStore();
+    return this.als.getStore()?.alive === true;
   }
 
   /**
@@ -56,14 +89,41 @@ export class DrizzleService implements OnModuleDestroy {
    * under concurrency rather than failing. Neo4j's equivalent has always
    * continued (`runInTransaction` returns the inner call directly when a
    * transaction is open), so this also keeps the engines behaving the same.
+   *
+   * **If you actually want an inner failure to stay isolated**, do not reach for
+   * a second `inTx` — call `.transaction()` on the current client, which Drizzle
+   * emits as a savepoint on the same connection. `PartnershipDrizzleRepository`
+   * does exactly that so losing a uniqueness race cannot poison the surrounding
+   * mutation. Continuation here and savepoints there are the two halves of the
+   * same design: joined by default, isolated only where asked for.
+   *
+   * ⚠️ Do not start database work inside a transaction without awaiting it. The
+   * store is scoped to the awaited call chain, so unawaited work can outlive the
+   * transaction: the callback returns, the transaction commits and its pool
+   * client is released, and only then does the stray work call this and find the
+   * store still set — now naming a released client. Before continuation existed
+   * that shape silently ran in a transaction of its own, which was already the
+   * wrong transaction; now it fails loudly instead, which is the better of the
+   * two but still a bug at the call site. No current caller does this.
    */
   async inTx<R>(fn: () => Promise<R>): Promise<R> {
-    if (this.inTransaction) {
+    const current = this.als.getStore();
+    if (current) {
+      if (!current.alive) throw outlivedTransaction();
       return await fn();
     }
-    return await this.baseDb.transaction((tx) =>
-      this.als.run(tx as DrizzleDb, fn),
-    );
+
+    let scope: TransactionScope | undefined;
+    try {
+      return await this.baseDb.transaction((tx) => {
+        scope = { db: tx as DrizzleDb, alive: true };
+        return this.als.run(scope, fn);
+      });
+    } finally {
+      // Settled either way — committed or rolled back — so the transaction is no
+      // longer usable even though contexts created inside it still see it.
+      if (scope) scope.alive = false;
+    }
   }
 
   async onModuleDestroy() {

--- a/src/core/drizzle/live-query-invalidation.spec.ts
+++ b/src/core/drizzle/live-query-invalidation.spec.ts
@@ -42,6 +42,11 @@ import { join, posix, relative, sep } from 'node:path';
  *
  * `create-only` — nothing is watching a brand-new id yet, and no engine
  * invalidates on create.
+ *
+ * `never writes` — the repository has methods NAMED like writes, but every one of
+ * them only throws. This check classifies by method name (see WRITE_METHOD), so a
+ * domain that is not being carried forward to Postgres still reads as a writer
+ * even though it stores nothing. There is no write to invalidate after.
  */
 const EXEMPT: Record<string, string> = {
   // --- parity: verified the Neo4j counterpart has no invalidation either ---
@@ -71,6 +76,12 @@ const EXEMPT: Record<string, string> = {
     'bootstrap upsert of the three fixed system agents',
   'src/components/admin/admin.drizzle.repository.ts':
     'bootstrap only (root user / default org), runs before anything can subscribe',
+
+  // --- named like a writer, but nothing is ever stored ---
+  'src/components/project-change-request/project-change-request.drizzle.repository.ts':
+    'never writes — changesets are not carried forward, so create(), update() ' +
+    'and deleteNode() each throw NotImplementedException and there is no ' +
+    'insert/update/delete anywhere in the file; reads answer empty',
 };
 
 const COMPONENTS = 'src/components';

--- a/src/core/gel/gel-transactional-mutations.interceptor.ts
+++ b/src/core/gel/gel-transactional-mutations.interceptor.ts
@@ -5,8 +5,8 @@ import {
   Injectable,
 } from '@nestjs/common';
 import { ConfigService } from '~/core/config';
+import { TransactionRunner } from '~/core/database/transaction-runner';
 import { TransactionalMutationsInterceptor } from '../database/abstract-transactional-mutations.interceptor';
-import { TransactionRunner } from '../database/transaction-runner';
 
 @Injectable()
 export class GelTransactionalMutationsInterceptor extends TransactionalMutationsInterceptor {

--- a/src/core/gel/gel-transactional-mutations.interceptor.ts
+++ b/src/core/gel/gel-transactional-mutations.interceptor.ts
@@ -6,11 +6,11 @@ import {
 } from '@nestjs/common';
 import { ConfigService } from '~/core/config';
 import { TransactionalMutationsInterceptor } from '../database/abstract-transactional-mutations.interceptor';
-import { TransactionContext } from './transaction.context';
+import { TransactionRunner } from '../database/transaction-runner';
 
 @Injectable()
 export class GelTransactionalMutationsInterceptor extends TransactionalMutationsInterceptor {
-  @Inject(TransactionContext) context: TransactionContext;
+  @Inject(TransactionRunner) runner: TransactionRunner;
   @Inject(ConfigService) config: ConfigService;
 
   async intercept(context: ExecutionContext, next: CallHandler) {
@@ -21,6 +21,6 @@ export class GelTransactionalMutationsInterceptor extends TransactionalMutations
   }
 
   protected async inTx<R>(fn: () => Promise<R>) {
-    return await this.context.inTx(fn);
+    return await this.runner.inTx(fn);
   }
 }

--- a/src/core/gel/gel.module.ts
+++ b/src/core/gel/gel.module.ts
@@ -64,7 +64,9 @@ import './errors';
     splitDb(IdResolver, { gel: AliasIdResolver }),
     GelWarningHandler,
   ],
-  exports: [Gel, Client, IdResolver],
+  // TransactionContext is exported so the engine-agnostic TransactionRunner
+  // can inject it.
+  exports: [Gel, Client, IdResolver, TransactionContext],
 })
 export class GelModule implements OnModuleDestroy {
   constructor(private readonly client: Client) {}

--- a/src/core/gel/transaction.context.ts
+++ b/src/core/gel/transaction.context.ts
@@ -23,6 +23,15 @@ export class TransactionContext
     // independent one — same reason as DrizzleService.inTx: an inner write
     // would otherwise survive an outer rollback. Neo4j's equivalent has always
     // continued.
+    //
+    // Unlike DrizzleService this deliberately does NOT track whether the
+    // transaction is still open, so work that escapes its transaction (started
+    // inside it but never awaited) continues against a settled executor rather
+    // than being refused. That asymmetry is a choice, not an oversight: the
+    // `current` getter below has always handed out a retained store the same
+    // way, this engine has no CI coverage to catch a mistake in the tracking,
+    // and the whole Gel arm is dropped at Phase 7 cutover. Not worth changing
+    // untested code that is scheduled for deletion.
     if (this.getStore()) {
       return await fn();
     }

--- a/src/core/gel/transaction.context.ts
+++ b/src/core/gel/transaction.context.ts
@@ -19,6 +19,14 @@ export class TransactionContext
   }
 
   async inTx<R>(fn: () => Promise<R>): Promise<R> {
+    // Continue an already-open transaction rather than starting a second,
+    // independent one — same reason as DrizzleService.inTx: an inner write
+    // would otherwise survive an outer rollback. Neo4j's equivalent has always
+    // continued.
+    if (this.getStore()) {
+      return await fn();
+    }
+
     const errorMap = new WeakMap<Error, Error>();
 
     try {

--- a/src/core/neo4j/indexer/indexer.module.ts
+++ b/src/core/neo4j/indexer/indexer.module.ts
@@ -23,6 +23,14 @@ export class IndexerModule implements OnModuleInit {
   ) {}
 
   async onModuleInit() {
+    // migration-todo: drop this guard at cutover, along with this whole module.
+    // Index sync retries the connection forever, so without the guard it churns
+    // against an absent Neo4j — and logs driver errors — whenever another engine
+    // is active.
+    if (this.config.databaseEngine !== 'neo4j') {
+      return;
+    }
+
     if (!this.config.dbIndexesCreate) {
       return;
     }

--- a/src/core/neo4j/migration/migration.module.ts
+++ b/src/core/neo4j/migration/migration.module.ts
@@ -17,6 +17,14 @@ export class MigrationModule implements OnApplicationBootstrap {
   ) {}
 
   async onApplicationBootstrap() {
+    // migration-todo: drop this guard at cutover, along with this whole module.
+    // syncUp retries the connection forever, so without the guard it churns
+    // against an absent Neo4j — and logs driver errors — whenever another engine
+    // is active.
+    if (this.config.databaseEngine !== 'neo4j') {
+      return;
+    }
+
     const entryCmd = process.argv.join('');
     if (
       !this.config.dbAutoMigrate ||

--- a/src/core/neo4j/transactional-mutations.interceptor.ts
+++ b/src/core/neo4j/transactional-mutations.interceptor.ts
@@ -1,12 +1,30 @@
-import { Inject, Injectable } from '@nestjs/common';
-import { Connection } from 'cypher-query-builder';
+import {
+  type CallHandler,
+  type ExecutionContext,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+import { ConfigService } from '~/core/config';
+import { TransactionRunner } from '~/core/database/transaction-runner';
 import { TransactionalMutationsInterceptor } from '../database/abstract-transactional-mutations.interceptor';
 
 @Injectable()
 export class Neo4jTransactionalMutationsInterceptor extends TransactionalMutationsInterceptor {
-  @Inject(Connection) db: Connection;
+  @Inject(TransactionRunner) runner: TransactionRunner;
+  @Inject(ConfigService) config: ConfigService;
+
+  async intercept(context: ExecutionContext, next: CallHandler) {
+    // migration-todo: this whole file goes away at cutover, along with the
+    // engine check. Until then it mirrors the Gel/Drizzle interceptors: all
+    // three are registered as APP_INTERCEPTOR, so each must no-op unless it
+    // owns the active engine.
+    if (this.config.databaseEngine !== 'neo4j') {
+      return next.handle();
+    }
+    return await super.intercept(context, next);
+  }
 
   protected async inTx<R>(fn: () => Promise<R>) {
-    return await this.db.runInTransaction(fn);
+    return await this.runner.inTx(fn);
   }
 }

--- a/src/core/neo4j/transactional.decorator.ts
+++ b/src/core/neo4j/transactional.decorator.ts
@@ -17,6 +17,11 @@ const RunnerKey = Symbol('DbTransactionRunner');
  * {@link TransactionRunner}. This previously injected the Neo4j `Connection`
  * directly, which meant decorated methods hit Neo4j regardless of `DATABASE`,
  * bypassing `splitDb`.
+ *
+ * migration-todo: this decorator no longer has anything to do with Neo4j, so it
+ * belongs in `~/core/database` rather than here. Left in place for now because
+ * moving it rewrites the import in every consumer, which would bury the actual
+ * change in this PR. Move it at Phase 7 cutover when the Neo4j folder is emptied.
  */
 export function Transactional(options?: TransactionOptions) {
   return ((

--- a/src/core/neo4j/transactional.decorator.ts
+++ b/src/core/neo4j/transactional.decorator.ts
@@ -1,10 +1,10 @@
 import { Inject } from '@nestjs/common';
-import { Connection } from 'cypher-query-builder';
+import { TransactionRunner } from '~/core/database/transaction-runner';
 import { type TransactionOptions } from './transaction';
 
 type AsyncFn = (...args: any[]) => Promise<any>;
 
-const ConnKey = Symbol('DbConnectionForTransactions');
+const RunnerKey = Symbol('DbTransactionRunner');
 
 /**
  * Ensure the method is ran in a transaction.
@@ -13,7 +13,10 @@ const ConnKey = Symbol('DbConnectionForTransactions');
  * Note that code can be executed multiple times when retrying transient errors.
  * The code executed should be idempotent.
  *
- * This is just a shortcut for calling `Connection.runInTransaction()`.
+ * The transaction is established on whichever database engine is active — see
+ * {@link TransactionRunner}. This previously injected the Neo4j `Connection`
+ * directly, which meant decorated methods hit Neo4j regardless of `DATABASE`,
+ * bypassing `splitDb`.
  */
 export function Transactional(options?: TransactionOptions) {
   return ((
@@ -21,12 +24,12 @@ export function Transactional(options?: TransactionOptions) {
     methodName: string | symbol,
     descriptor: TypedPropertyDescriptor<AsyncFn>,
   ) => {
-    // Use property-based injection to get access to the db connection object
-    // at a known location.
-    if (target[ConnKey] === undefined) {
-      Inject(Connection)(target, ConnKey);
+    // Use property-based injection to get access to the runner at a known
+    // location.
+    if (target[RunnerKey] === undefined) {
+      Inject(TransactionRunner)(target, RunnerKey);
       // ensure prop injection is only done once.
-      target[ConnKey] = null;
+      target[RunnerKey] = null;
     }
 
     const clsName: string = target.constructor.name;
@@ -36,21 +39,18 @@ export function Transactional(options?: TransactionOptions) {
         : methodName;
     const initiator = `${clsName}.${methodDescription}`;
 
-    // Wrap the method in a runInTransaction call
+    // Wrap the method in a transaction
     const origMethod = descriptor.value!;
     descriptor.value = async function (...args: any[]) {
       // @ts-expect-error this works but TS still has problems with indexing on symbols
-      const connection: Connection = this[ConnKey];
-      return await connection.runInTransaction(
-        () => origMethod.apply(this, args),
-        {
-          ...options,
-          metadata: {
-            initiator,
-            ...options?.metadata,
-          },
+      const runner: TransactionRunner = this[RunnerKey];
+      return await runner.inTx(() => origMethod.apply(this, args), {
+        ...options,
+        metadata: {
+          initiator,
+          ...options?.metadata,
         },
-      );
+      });
     };
   }) as MethodDecorator;
 }

--- a/test/partnership.e2e-spec.ts
+++ b/test/partnership.e2e-spec.ts
@@ -96,7 +96,8 @@ describe('Partnership e2e', () => {
    * `loadByBaseNode` path, which returns the real DTO (with `type`) and works —
    * which is why normal client queries never hit this.
    */
-  it.skip('resolves parent (id-only branch)', async () => {
+  // Named so the reason shows up in the test output, not just in the note above.
+  it.skip('resolves parent (id-only branch) — skipped: pre-existing on every engine, Project.resolveType reads `type` and ignores `__typename`', async () => {
     const partnership = await createPartnership(app, { project: project.id });
 
     const onlyId = await app.graphql.query(

--- a/test/partnership.e2e-spec.ts
+++ b/test/partnership.e2e-spec.ts
@@ -70,6 +70,78 @@ describe('Partnership e2e', () => {
     expect(actual.agreementStatus.canEdit).toBe(true);
   });
 
+  /**
+   * `parent` on a ChangesetAware resource is resolved from a Neo4j-shaped
+   * BaseNode (`{ identity, labels, properties }`). A flat `{ id }` is a
+   * TypeError, because both branches of ChangesetAwareResolver.parent read
+   * `.labels` and `.properties.id`. Four Drizzle repos shipped the flat shape;
+   * no spec on any migrated entity queried this field, which is how it survived
+   * three PRs.
+   *
+   * Negative case verified 2026-08-03: with the shape fix reverted this test
+   * fails with `TypeError: Cannot read properties of undefined (reading 'id')`.
+   *
+   * SKIPPED — narrow pre-existing bug, unrelated to the BaseNode shape.
+   * `Partnership.parent` is typed as the `Project` INTERFACE, which carries a
+   * custom `resolveType` (`resolveProjectType`, project.dto.ts:82) that reads
+   * `val.type`. graphql-js always calls a custom resolveType and ignores
+   * `__typename`. The `IsOnlyId` shortcut (changeset-aware.resolver.ts:36-42)
+   * returns `{ __typename, id, changeset }` — no `type` — so selecting ONLY
+   * `id`/`changeset` under `parent` throws:
+   *
+   *   ServerException: Could not resolve project type: 'undefined'
+   *
+   * Identical under DATABASE=neo4j and DATABASE=postgres, so it is pre-existing
+   * and not a migration regression. Selecting any additional field takes the
+   * `loadByBaseNode` path, which returns the real DTO (with `type`) and works —
+   * which is why normal client queries never hit this.
+   */
+  it.skip('resolves parent (id-only branch)', async () => {
+    const partnership = await createPartnership(app, { project: project.id });
+
+    const onlyId = await app.graphql.query(
+      graphql(`
+        query partnershipParentOnlyId($id: ID!) {
+          partnership(id: $id) {
+            parent {
+              id
+            }
+          }
+        }
+      `),
+      { id: partnership.id },
+    );
+    expect(onlyId.partnership.parent?.id).toBe(project.id);
+  });
+
+  /**
+   * The working path, and the regression test for the BaseNode shape fix.
+   *
+   * Selecting any field beyond `id`/`changeset` takes
+   * `ResourceLoader.loadByBaseNode`, which reads `.labels` and
+   * `.properties.id` off the parent BaseNode. Verified on both engines.
+   */
+  it('resolves parent as a hydrated Project', async () => {
+    const partnership = await createPartnership(app, { project: project.id });
+
+    const hydrated = await app.graphql.query(
+      graphql(`
+        query partnershipParentHydrated($id: ID!) {
+          partnership(id: $id) {
+            parent {
+              id
+              __typename
+              createdAt
+            }
+          }
+        }
+      `),
+      { id: partnership.id },
+    );
+    expect(hydrated.partnership.parent?.id).toBe(project.id);
+    expect(hydrated.partnership.parent?.__typename).toMatch(/Project$/);
+  });
+
   it('update partnership', async () => {
     const partnership = await createPartnership(app, { project: project.id });
 

--- a/test/postgres-transactions.e2e-spec.ts
+++ b/test/postgres-transactions.e2e-spec.ts
@@ -1,0 +1,118 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { sql } from 'drizzle-orm';
+import { DrizzleService } from '~/core/drizzle';
+import { createTestApp, type TestApp } from './utility';
+
+// Transaction scoping is engine-specific, so these only mean anything under
+// DATABASE=postgres. Reported as skipped under neo4j rather than passing while
+// asserting nothing.
+// migration-todo: drop the engine check at Phase 7 cutover (always postgres).
+const isPostgres = process.env.DATABASE === 'postgres';
+const describePg = isPostgres ? describe : describe.skip;
+
+/**
+ * A nested transaction must CONTINUE the one already open, not begin a second.
+ *
+ * Nothing else in the suite can tell those two apart, which is how the second
+ * behaviour shipped unnoticed: a mutation that succeeds end to end looks the
+ * same either way, and a mutation that fails inside the innermost call rolls
+ * back either way. The difference only shows when the OUTER unit fails after the
+ * inner one finished — then an independent inner transaction has already
+ * committed and its write survives a rollback that was supposed to undo it.
+ *
+ * The concurrency symptom is worse than the correctness one, and equally
+ * invisible here: each nested call holds a second pool connection for as long as
+ * the outer one lives, so enough concurrent requests leave every connection
+ * waiting on a connection that only frees when those same requests finish. The
+ * e2e suite runs with a single worker, so it can never produce that.
+ */
+describePg('Postgres transaction scoping', () => {
+  let app: TestApp;
+  let drizzle: DrizzleService;
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    drizzle = app.get(DrizzleService);
+    // Own scratch table: the assertions are about transaction boundaries, so
+    // they should not depend on any domain's schema or triggers. Safe to create
+    // because every spec file gets its own ephemeral database.
+    await drizzle.client.execute(
+      sql`create table tx_probe (id text primary key)`,
+    );
+  });
+
+  const backendPid = async () => {
+    const result = await drizzle.client.execute(
+      sql`select pg_backend_pid() as pid`,
+    );
+    const [row] = result.rows as Array<{ pid: number }>;
+    return Number(row!.pid);
+  };
+
+  const probeIds = async () => {
+    const result = await drizzle.client.execute(sql`select id from tx_probe`);
+    return (result.rows as Array<{ id: string }>)
+      .map((row) => row.id)
+      .sort((left, right) => left.localeCompare(right));
+  };
+
+  it('runs a nested transaction on the same connection as its caller', async () => {
+    // Same backend process id means one connection, so one transaction. A
+    // second, independent transaction necessarily comes from another pool
+    // connection and reports a different pid.
+    let outerPid: number | undefined;
+    let innerPid: number | undefined;
+
+    await drizzle.inTx(async () => {
+      outerPid = await backendPid();
+      await drizzle.inTx(async () => {
+        innerPid = await backendPid();
+      });
+    });
+
+    expect(outerPid).toBeDefined();
+    expect(innerPid).toBe(outerPid);
+  });
+
+  it('sees the outer uncommitted write from inside a nested transaction', async () => {
+    // A separate transaction could not read this row — it is uncommitted, and
+    // Postgres defaults to READ COMMITTED.
+    let seenFromNested: string[] = [];
+
+    await drizzle
+      .inTx(async () => {
+        await drizzle.client.execute(
+          sql`insert into tx_probe (id) values ('outer-visible')`,
+        );
+        await drizzle.inTx(async () => {
+          seenFromNested = await probeIds();
+        });
+        throw new Error('rollback so this test leaves nothing behind');
+      })
+      .catch(() => undefined);
+
+    expect(seenFromNested).toEqual(['outer-visible']);
+    expect(await probeIds()).toEqual([]);
+  });
+
+  it('rolls back a nested write when the outer transaction fails afterwards', async () => {
+    // The case that matters and the one no existing spec covers: the inner call
+    // completes, THEN the outer unit throws. With two independent transactions
+    // the inner row is already committed and survives.
+    await expect(
+      drizzle.inTx(async () => {
+        await drizzle.client.execute(
+          sql`insert into tx_probe (id) values ('outer')`,
+        );
+        await drizzle.inTx(async () => {
+          await drizzle.client.execute(
+            sql`insert into tx_probe (id) values ('inner')`,
+          );
+        });
+        throw new Error('outer fails after the nested write completed');
+      }),
+    ).rejects.toThrow('outer fails after the nested write completed');
+
+    expect(await probeIds()).toEqual([]);
+  });
+});

--- a/test/postgres-transactions.e2e-spec.ts
+++ b/test/postgres-transactions.e2e-spec.ts
@@ -115,4 +115,42 @@ describePg('Postgres transaction scoping', () => {
 
     expect(await probeIds()).toEqual([]);
   });
+
+  /**
+   * Work started inside a transaction but not awaited keeps seeing the
+   * transaction's async context after it has settled and its pool connection has
+   * been handed back. Both entry points must say so rather than letting the
+   * query fail somewhere unrelated with "Cannot use a released client".
+   *
+   * Built with an explicit gate rather than a timer: the continuation has to be
+   * registered INSIDE the transaction, so it inherits the context, but must not
+   * run until the transaction has finished. A timer cannot promise that ordering,
+   * since committing is itself a round trip.
+   */
+  const escapedWork = async (work: () => Promise<unknown>) => {
+    let release: (() => void) | undefined;
+    let detached: Promise<unknown> | undefined;
+
+    await drizzle.inTx(async () => {
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      detached = gate.then(work);
+    });
+
+    release!(); // only now — the transaction is already settled
+    return await detached!;
+  };
+
+  it('refuses a query from work that outlived its transaction', async () => {
+    await expect(escapedWork(() => probeIds())).rejects.toThrow(
+      /escaped its transaction/,
+    );
+  });
+
+  it('refuses a nested transaction from work that outlived its transaction', async () => {
+    await expect(
+      escapedWork(async () => await drizzle.inTx(async () => await probeIds())),
+    ).rejects.toThrow(/escaped its transaction/);
+  });
 });


### PR DESCRIPTION
### Summary

Shared plumbing still assumed Neo4j regardless of which database was configured.
This makes it engine-aware, and fixes the transaction-scoping problems that came
to light once transactions started being routed to the engine actually in use.

Four things were reaching for Neo4j unconditionally:

- The Neo4j indexer and auto-migrate ran at boot on every engine, doing work
  against a database the app was not using.
- `@Transactional()` opened its transaction on Neo4j's connection, so a decorated
  method's writes went to Neo4j even when the domain it touched lives elsewhere.
- The Postgres repositories emitted a bare `{ id }` where `parent` is read as a
  graph node. That is not a wrong value but a crash: the resolver reads
  `.labels` and `.properties.id` off it. Four repositories shipped it, and no test
  on any migrated entity ever selected `parent`, which is how it survived three
  changes.
- Asking a project for its change requests threw under Postgres, because the
  repository behind it is Neo4j-only by design — changesets are not being carried
  forward.

Routing transactions to the active engine then exposed two scoping bugs, both
fixed here. Neither is visible in a passing test, which is most of why they are
worth describing carefully.

**A nested transaction started a second, unrelated one.** Repositories never take
a transaction parameter — the service keeps the transaction in an async-local
store and every repository reads a client getter that returns it when set. A
nested call ignored that store and began again from the pool, so it got another
connection and an independent transaction. `updateProject` reaches this today,
because the mutation interceptor has already opened a transaction by the time the
decorated method runs. Consequences: an inner write survived an outer rollback, so
a failed mutation no longer undid everything it did; two pool connections were
held per nested call, which exhausts the pool and hangs rather than failing; and
the retry budget nested, so one retryable error could re-run the method body and
every hook it fires many times over. Neo4j never had any of this — its equivalent
has always continued an open transaction — so the fix restores the behaviour the
other engines already had rather than inventing one.

**Work that outlived its transaction was silently allowed.** An async context
created inside a transaction keeps seeing it after it has settled and its
connection has gone back to the pool, so "a transaction is in the store" did not
mean "there is a transaction to use". Work started inside a transaction and not
awaited lands there. It did not error — the query ran and returned rows, outside
the transaction it believed it was in. For a read that is merely wrong; for a
write it would persist data the caller thought was transactional and that no
rollback would undo. Liveness is now recorded with the transaction and both
entry points refuse a settled one, naming the mistake and pointing at the
supported way to run work after a commit.

### What's added

- A `TransactionRunner` that is the single place knowing how each engine begins a
  transaction. The per-engine mutation interceptors and `@Transactional()` both
  delegate to it, so no caller hardcodes an engine. Carries a `migration-todo` for
  dropping the non-Postgres arms at cutover.
- Transaction continuation in the Drizzle and Gel paths, matching Neo4j. The guard
  sits in three places because they are reached differently: the Drizzle service
  itself, which also covers the admin repository calling it directly; Gel's
  equivalent, which had the identical defect; and the runner, which returns before
  its retry loop — a guard further down would fix the transaction but leave the
  retries nested.
- Liveness tracking on the stored transaction, so a settled one is refused by both
  the client getter and the nested-transaction check rather than quietly used.
- `ChangesetAware.parent` now emits a typed reference from the Postgres
  repositories, with the base declaration widened to accept either shape and the
  resolver normalizing both. The six subclass re-declarations that narrowed it
  back are widened to match — type-only, no runtime or schema effect, since each
  field's GraphQL type comes from its own `@Field()` decorator. `ProgressReport`
  and `Post` keep the narrow form deliberately: different lineage, and their
  resolvers do read the graph-node properties.
- A Postgres `ProjectChangeRequest` repository that answers reads as empty and
  refuses writes, so asking a project for its change requests succeeds instead of
  throwing. Neo4j is untouched.
- Boot skips for the Neo4j indexer and auto-migrate when the engine is not Neo4j.
- `test/postgres-transactions.e2e-spec.ts`, covering both scoping fixes, plus
  `parent` coverage on partnership — the first test anywhere to select that field.

### Validation performed

- Type-check and lint clean.
- **Neo4j, 8 mutation-heavy specs** (project, engagement, partnership, budget,
  user, all three changeset-aware): 96 passed, 0 failed. **Byte-identical before
  and after the transaction work** — which is the point, since production runs
  Neo4j and the transaction runner touches its interceptor and decorator.
- **Neo4j, webhooks**: 59 passed, unchanged.
- **Postgres, full suite**: the same five failing suites as develop, no new
  failures and none fixed, with the added tests passing. Run three times across
  the branch's development; the failing set never moved.
- Every fix has a negative control, because none of these are visible in a
  passing test:
  - Revert the parent shape → the new partnership test fails with the exact
    TypeError the fix removes, and nothing else fails.
  - Remove transaction continuation → all three scoping tests fail, in three
    different ways: different backend connections, the nested read cannot see the
    outer's uncommitted row, and the inner write survives the rollback.
  - Never mark a transaction settled → both escaped-work tests fail while the
    three continuation tests still pass, so they are not restating each other.
- The transaction fix was also reviewed independently against the source by a
  separate model, which confirmed the semantics, the race-freedom of the liveness
  check, that hooks stay inside the correct transaction, and that the test's use
  of the backend connection id is a sound proxy in this context.

Stated plainly rather than left to be assumed: **under Postgres, webhooks goes
from 51 to 53 failing tests.** Two tests that passed there now do not. Webhooks has
no Postgres implementation, the suite is already almost entirely failing on that
engine, and **Neo4j is completely unaffected at 59 of 59** — but it is a real
behaviour change caused by transactions no longer being opened on Neo4j for a
Neo4j-only domain, so it belongs here rather than in a footnote.

### Reviewer cross-checks

- The transaction continuation is in all three places, and the runner's returns
  before the retry loop rather than inside it. A guard in only one place leaves
  either the second transaction or the nested retry budget.
- Nothing relied on a nested transaction being isolated. Where isolation is
  genuinely wanted the pattern is a savepoint — calling `.transaction()` on the
  current client — as the partnership repository does so that losing a uniqueness
  race cannot poison the surrounding mutation. Continuation by default and
  savepoints where asked for are two halves of one design; worth confirming that
  reading holds.
- The parent shape is correct for each of the five repositories, not just the
  tested one. Budget's and Engagement's type derivations are textually identical
  to the proven partnership one; BudgetRecord's fixed typename is a distinct path.
- `ProgressReport` and `Post` must keep the narrow `parent` declaration.
- The `ProjectChangeRequest` stub cannot be reached under Neo4j, and its refusals
  surface as handled errors rather than raw ones.
- Boot skips are tagged with a `migration-todo` naming what to delete at cutover.

### Explicitly out of scope

- **Per-repository `parent` tests for Budget, BudgetRecord and Engagement.** Only
  partnership is covered. Those fields are reachable and untested on both engines —
  the same condition that let the original bug ship. Tracked rather than fixed
  here to keep this from growing further.
- **A dead `parent` key on the Ceremony repository**, along with the extra column
  fetched to build it. Ceremony exposes no `parent` field, so nothing can read it.
  Harmless, and left with the rest of the cleanup.
- **The connection pool has no explicit maximum and no connection timeout.** Not
  introduced here, and not in this diff, but it is what turns any future
  connection-holding bug into an unbounded wait instead of a loud failure. Worth
  its own change.
- **The `parent { id }`-only selection throws** on these types, for a reason
  unrelated to shape: the id-only shortcut omits a field the Project interface's
  custom type resolver needs. Identical on both engines, so pre-existing. Recorded
  as a skipped test with the explanation instead of being left to be rediscovered.
- Webhooks itself, which needs porting before Neo4j goes away.
