### PR TITLE
[pg] Fill in Project.marketingRegion under Postgres, and stop hiding DTO mismatches

### DIFF
--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -93,6 +93,11 @@ type ProjectRow = typeof projects.$inferSelect & {
   pinned?: boolean;
   /** Latest workflow-event `at`, if any — batched in `readMany`. */
   stepChangedAt?: Date | null;
+  /**
+   * The marketing location's default region — batched in `readMany`. Feeds
+   * `marketingRegion`, which falls back to this when there's no override.
+   */
+  inheritedMarketingRegionId?: ID<'Location'> | null;
   membership?: {
     id: ID<'ProjectMember'>;
     roles: readonly string[];
@@ -222,6 +227,34 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
     const engagementTotalByProject = new Map(
       engagementCounts.map((c) => [c.projectId, c.total]),
     );
+    // A project with no marketing region override inherits the one its
+    // marketing location points at — the same fallback the Neo4j repo does with
+    // `coalesce`. Soft-deleted locations contribute nothing, matching Neo4j,
+    // where a deleted location's link is no longer active.
+    const marketingLocationIds = [
+      ...new Set(
+        rows
+          .map((row) => row.marketingLocationId)
+          .filter((id): id is ID<'Location'> => id !== null),
+      ),
+    ];
+    const marketingLocations = marketingLocationIds.length
+      ? await this.db
+          .select({
+            id: locations.id,
+            defaultMarketingRegionId: locations.defaultMarketingRegionId,
+          })
+          .from(locations)
+          .where(
+            and(
+              inArray(locations.id, marketingLocationIds),
+              isNull(locations.deletedAt),
+            ),
+          )
+      : [];
+    const inheritedRegionByLocation = new Map(
+      marketingLocations.map((loc) => [loc.id, loc.defaultMarketingRegionId]),
+    );
     const pinnedSet = await pinnedByRequester(
       this.db,
       userId,
@@ -234,6 +267,9 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
         stepChangedAt: stepChangedByProject.get(row.id) ?? null,
         engagementTotal: engagementTotalByProject.get(row.id) ?? 0,
         pinned: pinnedSet.has(row.id),
+        inheritedMarketingRegionId: row.marketingLocationId
+          ? (inheritedRegionByLocation.get(row.marketingLocationId) ?? null)
+          : null,
       };
       return this.toDto(enriched);
     });
@@ -461,12 +497,13 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
   protected toDto(row: ProjectRow): UnsecuredDto<Project> {
     const linkOrNull = <T extends string>(id: ID<T> | null | undefined) =>
       id ? { id } : null;
-    // DTO shape includes a few service-layer overlays (canDelete, scope,
-    // pinned) and stub fields the repo can't compute under DATABASE=postgres
-    // yet (primaryPartnership, engagementTotal, usesRev79). Build the dto as
-    // `unknown` first so the lint stays clean — service runs
-    // `privileges.secure()` after this anyway.
-    const dto: unknown = {
+    // Deliberately NOT laundered through `unknown` before the cast below: that
+    // stops TypeScript comparing this object to the DTO at all, and is what let
+    // `marketingRegion` go missing here unnoticed. The direct cast still allows
+    // the service-layer overlays (canDelete, scope, pinned) and the stub fields
+    // this repo can't compute yet, while catching a field that is absent or the
+    // wrong shape.
+    const dto = {
       id: row.id,
       __typename:
         row.type === 'Internship'
@@ -503,6 +540,11 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
       primaryLocation: linkOrNull(row.primaryLocationId),
       marketingLocation: linkOrNull(row.marketingLocationId),
       marketingRegionOverride: linkOrNull(row.marketingRegionOverrideId),
+      // Effective region: the override if set, else the marketing location's
+      // default (batched in readMany). Matches the Neo4j repo's coalesce.
+      marketingRegion: linkOrNull(
+        row.marketingRegionOverrideId ?? row.inheritedMarketingRegionId,
+      ),
       fieldRegion: linkOrNull(row.fieldRegionId),
       owningOrganization: linkOrNull(row.owningOrganizationId),
       rootDirectory: linkOrNull(row.rootDirectoryId),

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -100,7 +100,10 @@ type ProjectRow = typeof projects.$inferSelect & {
   inheritedMarketingRegionId?: ID<'Location'> | null;
   membership?: {
     id: ID<'ProjectMember'>;
-    roles: readonly string[];
+    // `Role`, not `string` — the column is a role enum array, and the DTO's
+    // `membership.roles` is typed from it. Declaring this loosely meant the DTO
+    // needed a cast to get the type back, which is what hid the mismatch.
+    roles: readonly Role[];
     inactiveAt: Date | null;
   } | null;
 };
@@ -497,13 +500,14 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
   protected toDto(row: ProjectRow): UnsecuredDto<Project> {
     const linkOrNull = <T extends string>(id: ID<T> | null | undefined) =>
       id ? { id } : null;
-    // Deliberately NOT laundered through `unknown` before the cast below: that
-    // stops TypeScript comparing this object to the DTO at all, and is what let
-    // `marketingRegion` go missing here unnoticed. The direct cast still allows
-    // the service-layer overlays (canDelete, scope, pinned) and the stub fields
-    // this repo can't compute yet, while catching a field that is absent or the
-    // wrong shape.
-    const dto = {
+    // Typed here rather than asserted on the way out. An earlier version built
+    // this as `unknown` and asserted it, which stops TypeScript comparing the
+    // object to the DTO at all — that is how `marketingRegion` went missing
+    // unnoticed. Declaring the type checks every field where it is written, so a
+    // missing or wrong-shaped one is reported by name. `canDelete` is
+    // intersected in because `UnsecuredDto` drops it on purpose: the policy layer
+    // in the service decides it, but every repository still sets it.
+    const dto: UnsecuredDto<Project> & { canDelete: boolean } = {
       id: row.id,
       __typename:
         row.type === 'Internship'
@@ -582,13 +586,11 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
         row.membership && !row.membership.inactiveAt
           ? [
               'member:true' as const,
-              ...(row.membership.roles as readonly Role[]).map(
-                rolesForScope('project'),
-              ),
+              ...row.membership.roles.map(rolesForScope('project')),
             ]
           : [],
     };
-    return dto as UnsecuredDto<Project>;
+    return dto;
   }
 }
 

--- a/src/components/prompts/prompt-variant-response.drizzle.repository.ts
+++ b/src/components/prompts/prompt-variant-response.drizzle.repository.ts
@@ -223,7 +223,7 @@ export const PromptVariantResponseDrizzleRepository = <
           createdAt: DateTime.fromJSDate(row.createdAt),
         },
       };
-      const dto: unknown = {
+      const dto = {
         id: row.id,
         createdAt: DateTime.fromJSDate(row.createdAt),
         modifiedAt: DateTime.fromJSDate(row.modifiedAt),
@@ -231,12 +231,17 @@ export const PromptVariantResponseDrizzleRepository = <
         parent,
         prompt: row.prompt,
         responses: row.entries
-          .filter((e) => !e.deletedAt)
-          .map((e) => ({
-            variant: e.variant,
-            response: e.response,
-            creator: { id: e.creatorId },
-            modifiedAt: DateTime.fromJSDate(e.modifiedAt ?? e.createdAt),
+          .filter((entry) => !entry.deletedAt)
+          .map((entry) => ({
+            // The column is plain text; which variants are valid depends on the
+            // subtype this repository was built for, which isn't knowable here.
+            // Narrowed deliberately, and only for this field.
+            variant: entry.variant as TVariant,
+            response: entry.response,
+            creator: { id: entry.creatorId },
+            modifiedAt: DateTime.fromJSDate(
+              entry.modifiedAt ?? entry.createdAt,
+            ),
           })),
         canDelete: true,
       };

--- a/src/components/prompts/prompt-variant-response.drizzle.repository.ts
+++ b/src/components/prompts/prompt-variant-response.drizzle.repository.ts
@@ -223,7 +223,11 @@ export const PromptVariantResponseDrizzleRepository = <
           createdAt: DateTime.fromJSDate(row.createdAt),
         },
       };
-      const dto = {
+      // `canDelete` is intersected in because `UnsecuredDto` deliberately drops
+      // it — the policy layer in the service decides it.
+      const dto: UnsecuredDto<PromptVariantResponse<TVariant>> & {
+        canDelete: boolean;
+      } = {
         id: row.id,
         createdAt: DateTime.fromJSDate(row.createdAt),
         modifiedAt: DateTime.fromJSDate(row.modifiedAt),
@@ -245,7 +249,7 @@ export const PromptVariantResponseDrizzleRepository = <
           })),
         canDelete: true,
       };
-      return dto as UnsecuredDto<PromptVariantResponse<TVariant>>;
+      return dto;
     }
   }
 

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -50,6 +50,7 @@ import { type MediaCategory } from '../../../components/progress-report/media/me
 import { type ProjectStatus } from '../../../components/project/dto/project-status.enum';
 import { type ProjectStep } from '../../../components/project/dto/project-step.enum';
 import { type ProjectType } from '../../../components/project/dto/project-type.enum';
+import { type Prompt } from '../../../components/prompts/dto/prompt.dto';
 import { type ToolKey } from '../../../components/tools/tool/dto/tool-key.enum';
 import { type Gender } from '../../../components/user/dto/gender.enum';
 import { type LanguageProficiency } from '../../../components/user/dto/language-proficiency.enum';
@@ -2351,7 +2352,9 @@ export const promptVariantResponses = pgTable(
     id: text('id').$type<ID>().primaryKey(),
     resourceType: text('resource_type').notNull(),
     parentId: text('parent_id').$type<ID>().notNull(),
-    prompt: text('prompt').notNull(),
+    // Holds a Prompt's id, not its text — prompts are defined in app code
+    // rather than a table, which is why there's no FK to point at.
+    prompt: text('prompt').$type<ID<Prompt>>().notNull(),
     creatorId: text('creator_id')
       .$type<ID<'User'>>()
       .notNull()

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -2391,7 +2391,9 @@ export const promptVariantResponseEntries = pgTable(
       .notNull()
       .references(() => promptVariantResponses.id, { onDelete: 'cascade' }),
     variant: text('variant').notNull(),
-    response: jsonb('response'),
+    // Always a rich-text document, so say so — untyped jsonb reads back as
+    // `unknown`, which then needs a cast at every use.
+    response: jsonb('response').$type<RichTextDocument | null>(),
     creatorId: text('creator_id')
       .$type<ID<'User'>>()
       .notNull()

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -928,62 +928,80 @@ describe('Project e2e', () => {
     });
   });
 
-  it('takes marketingRegion from the marketing location, and lets the override win', async () => {
-    await runAsAdmin(app, async () => {
-      const inheritedRegion = await createLocation(app);
+  describe('marketingRegion', () => {
+    const readMarketingRegion = async (id: ID) => {
+      const result = await app.graphql.query(
+        graphql(`
+          query projectMarketingRegion($id: ID!) {
+            project(id: $id) {
+              marketingRegion {
+                canRead
+                value {
+                  id
+                }
+              }
+            }
+          }
+        `),
+        { id },
+      );
+      return result.project.marketingRegion;
+    };
+
+    /** A project whose marketing location carries a default region. */
+    const createProjectWithMarketingLocation = async () => {
+      const locationDefaultRegion = await createLocation(app);
       const marketingLocation = await createLocation(app, {
-        defaultMarketingRegion: inheritedRegion.id,
+        defaultMarketingRegion: locationDefaultRegion.id,
       });
       const project = await createProject(app, {
         marketingLocation: marketingLocation.id,
         fieldRegion: fieldRegion.id,
       });
+      return { project, locationDefaultRegion };
+    };
 
-      const readMarketingRegion = async () => {
-        const result = await app.graphql.query(
+    it('comes from the marketing location when nothing overrides it', async () => {
+      await runAsAdmin(app, async () => {
+        const { project, locationDefaultRegion } =
+          await createProjectWithMarketingLocation();
+
+        const marketingRegion = await readMarketingRegion(project.id);
+        expect(marketingRegion.canRead).toBe(true);
+        expect(marketingRegion.value?.id).toBe(locationDefaultRegion.id);
+      });
+    });
+
+    it('uses the override in place of the marketing location default', async () => {
+      await runAsAdmin(app, async () => {
+        const { project, locationDefaultRegion } =
+          await createProjectWithMarketingLocation();
+        const overrideRegion = await createLocation(app);
+
+        await app.graphql.mutate(
           graphql(`
-            query projectMarketingRegion($id: ID!) {
-              project(id: $id) {
-                marketingRegion {
-                  canRead
-                  value {
-                    id
-                  }
+            mutation setMarketingRegionOverride($input: UpdateProject!) {
+              updateProject(input: $input) {
+                project {
+                  id
                 }
               }
             }
           `),
-          { id: project.id },
-        );
-        return result.project.marketingRegion;
-      };
-
-      // Nothing overrides it, so it comes from the marketing location's default.
-      const inherited = await readMarketingRegion();
-      expect(inherited.canRead).toBe(true);
-      expect(inherited.value?.id).toBe(inheritedRegion.id);
-
-      const overrideRegion = await createLocation(app);
-      await app.graphql.mutate(
-        graphql(`
-          mutation setMarketingRegionOverride($input: UpdateProject!) {
-            updateProject(input: $input) {
-              project {
-                id
-              }
-            }
-          }
-        `),
-        {
-          input: {
-            id: project.id,
-            marketingRegionOverride: overrideRegion.id,
+          {
+            input: {
+              id: project.id,
+              marketingRegionOverride: overrideRegion.id,
+            },
           },
-        },
-      );
+        );
 
-      const overridden = await readMarketingRegion();
-      expect(overridden.value?.id).toBe(overrideRegion.id);
+        // The marketing location still has its own default, so this is about
+        // which one wins rather than whether the override can be read at all.
+        const marketingRegion = await readMarketingRegion(project.id);
+        expect(marketingRegion.value?.id).toBe(overrideRegion.id);
+        expect(marketingRegion.value?.id).not.toBe(locationDefaultRegion.id);
+      });
     });
   });
 

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -928,6 +928,65 @@ describe('Project e2e', () => {
     });
   });
 
+  it('takes marketingRegion from the marketing location, and lets the override win', async () => {
+    await runAsAdmin(app, async () => {
+      const inheritedRegion = await createLocation(app);
+      const marketingLocation = await createLocation(app, {
+        defaultMarketingRegion: inheritedRegion.id,
+      });
+      const project = await createProject(app, {
+        marketingLocation: marketingLocation.id,
+        fieldRegion: fieldRegion.id,
+      });
+
+      const readMarketingRegion = async () => {
+        const result = await app.graphql.query(
+          graphql(`
+            query projectMarketingRegion($id: ID!) {
+              project(id: $id) {
+                marketingRegion {
+                  canRead
+                  value {
+                    id
+                  }
+                }
+              }
+            }
+          `),
+          { id: project.id },
+        );
+        return result.project.marketingRegion;
+      };
+
+      // Nothing overrides it, so it comes from the marketing location's default.
+      const inherited = await readMarketingRegion();
+      expect(inherited.canRead).toBe(true);
+      expect(inherited.value?.id).toBe(inheritedRegion.id);
+
+      const overrideRegion = await createLocation(app);
+      await app.graphql.mutate(
+        graphql(`
+          mutation setMarketingRegionOverride($input: UpdateProject!) {
+            updateProject(input: $input) {
+              project {
+                id
+              }
+            }
+          }
+        `),
+        {
+          input: {
+            id: project.id,
+            marketingRegionOverride: overrideRegion.id,
+          },
+        },
+      );
+
+      const overridden = await readMarketingRegion();
+      expect(overridden.value?.id).toBe(overrideRegion.id);
+    });
+  });
+
   // #727 create without mouStart, mouEnd, estimatedSubmission
   it('can create without mouStart, mouEnd and estimatedSubmission', async () => {
     const { createProject } = await app.graphql.mutate(


### PR DESCRIPTION
### Summary

A project's marketing region isn't stored — it's worked out when read: use the region someone set explicitly as an override, and otherwise inherit the one the project's marketing location points at. The Neo4j repository does exactly that. The Postgres one returns the override and stops, so any project relying on the inherited value answers with nothing.

Nothing errors when this happens. The field just comes back empty, which is why it survived the original port and two reviews.

The reason the compiler didn't catch it is the second half of this change. The repository built its result object, parked it in a variable typed as "could be anything", and then asserted it was a Project. That middle step throws away the real shape, so TypeScript never compares the object against what a Project is supposed to contain — a missing field costs nothing. Removing it makes this class of mistake a compile error instead of empty data, which is worth more than the single fix.

Two smaller things surfaced once that checking was back on, both in the prompt-response repository:

- The column holding a prompt's id was described as ordinary text, so it read back as an untyped string. It now carries the same id type the DTO uses.
- Which response variants are valid depends on the subtype the repository was built for, and that genuinely can't be proven from a text column. That one field is now narrowed deliberately, in place, rather than switching off checking for everything around it.

### Schema / DDL

No migration. The only schema-file change is a TypeScript type on an existing column (`prompt_variant_responses.prompt`), which changes neither the stored data nor the generated SQL.

### Validation performed

- Type-check clean, lint clean.
- New end-to-end test covering both halves of the rule: with no override the region is inherited from the marketing location, and setting an override replaces it.
- That test passes on Neo4j, which is the parity baseline, and on Postgres with this fix.
- **Negative check:** with the fix removed, the same test fails on Postgres and the assertion shows the field arriving as nothing. Removing the field is now also a compile error, so the mistake can't be made silently twice.
- Full project spec family, both engines: Postgres 43 passed / 0 failed, Neo4j 46 passed / 0 failed. The difference is the change-request suite, which is deliberately skipped under Postgres. Every project read goes through the query this touches, which is why the whole family was run and not just the new test.

### Reviewer cross-checks

- The inherited region is looked up only for live locations. Neo4j reaches it through an active relationship, so a deleted location contributes nothing there either — worth confirming that reading matches yours.
- The lookup is batched once per read rather than done per project, following the pattern this method already uses for memberships, workflow timestamps and pins.
- Precedence: an override always wins, including when the marketing location also carries a default.
- The narrowed variant field is the only place checking is bypassed, and only for that one field.

### Explicitly out of scope

- Seventeen other Postgres repositories still park their result object in an "anything" variable the same way. Sixteen of them need nothing but the deletion — that's measured, not assumed. Separate change, and it wants a quiet tree.
- One mismatch remains in the budget repository: the database allows its template file to be absent while the DTO claims the field is always present. Equally untrue on Neo4j, so it isn't a migration regression.
