### PR TITLE
[pg] Report live-query-invalidation's Postgres-only cases as skipped on Neo4j, not passed

### DIFF
--- a/test/live-query-invalidation.e2e-spec.ts
+++ b/test/live-query-invalidation.e2e-spec.ts
@@ -22,6 +22,10 @@ import {
 // The Drizzle repository base is only in play under postgres; under the other
 // engines their own bases already invalidate and are unchanged by this fix.
 const isPostgres = process.env.DATABASE === 'postgres';
+// Neo4j and Gel invalidate generically from their own bases (see the docblock
+// below), so these cases don't apply there. `it.skip` reports that honestly;
+// an early `return` inside the body would report the same run as PASSED.
+const itPostgresOnly = isPostgres ? it : it.skip;
 
 type Identifier = Parameters<LiveQueryStore['invalidate']>[0];
 
@@ -79,8 +83,7 @@ describe('Live-query invalidation (Drizzle base) e2e', () => {
   const watchInvalidations = () =>
     jest.spyOn(app.get(LiveQueryStore), 'invalidate');
 
-  it('invalidates the mutated resource on update', async () => {
-    if (!isPostgres) return;
+  itPostgresOnly('invalidates the mutated resource on update', async () => {
     const org = await createOrganization(app);
     const spy = watchInvalidations();
 
@@ -98,35 +101,39 @@ describe('Live-query invalidation (Drizzle base) e2e', () => {
     );
   });
 
-  it('invalidates the mutated resource on soft delete', async () => {
-    if (!isPostgres) return;
-    const org = await createOrganization(app);
-    const spy = watchInvalidations();
+  itPostgresOnly(
+    'invalidates the mutated resource on soft delete',
+    async () => {
+      const org = await createOrganization(app);
+      const spy = watchInvalidations();
 
-    await app.graphql.mutate(DeleteOrgDoc, { id: org.id });
+      await app.graphql.mutate(DeleteOrgDoc, { id: org.id });
 
-    expect(spy.mock.calls.map(([arg]) => keyOf(arg))).toContain(
-      `Organization:${org.id}`,
-    );
-  });
+      expect(spy.mock.calls.map(([arg]) => keyOf(arg))).toContain(
+        `Organization:${org.id}`,
+      );
+    },
+  );
 
   // The no-op guard in updateColumns() returns before touching the DB; it must
   // return before invalidating too, or every empty update wakes every live query
   // watching that resource for no reason.
-  it('does not invalidate when an update changes nothing', async () => {
-    if (!isPostgres) return;
-    const org = await createOrganization(app);
-    const spy = watchInvalidations();
+  itPostgresOnly(
+    'does not invalidate when an update changes nothing',
+    async () => {
+      const org = await createOrganization(app);
+      const spy = watchInvalidations();
 
-    // Same name it already has -> getActualChanges yields an empty change set.
-    await app.graphql.mutate(UpdateOrgDoc, {
-      input: { id: org.id, name: org.name.value ?? 'Org' },
-    });
+      // Same name it already has -> getActualChanges yields an empty change set.
+      await app.graphql.mutate(UpdateOrgDoc, {
+        input: { id: org.id, name: org.name.value ?? 'Org' },
+      });
 
-    expect(spy.mock.calls.map(([arg]) => keyOf(arg))).not.toContain(
-      `Organization:${org.id}`,
-    );
-  });
+      expect(spy.mock.calls.map(([arg]) => keyOf(arg))).not.toContain(
+        `Organization:${org.id}`,
+      );
+    },
+  );
 
   // Product hand-rolls its own writes, so it invalidates itself rather than
   // inheriting from the base. The interesting part is the KEY: the store keys on
@@ -134,19 +141,21 @@ describe('Live-query invalidation (Drizzle base) e2e', () => {
   // (DirectScriptureProduct, not Product). A generic `Product:` key would emit
   // something nothing subscribes to — an invalidation that exists and does
   // nothing, which is worse than none because it looks fixed.
-  it('invalidates a product under its concrete subtype, not the interface', async () => {
-    if (!isPostgres) return;
-    const product = await createDirectProduct(app, {
-      engagement: engagement.id,
-    });
-    const spy = watchInvalidations();
+  itPostgresOnly(
+    'invalidates a product under its concrete subtype, not the interface',
+    async () => {
+      const product = await createDirectProduct(app, {
+        engagement: engagement.id,
+      });
+      const spy = watchInvalidations();
 
-    await app.graphql.mutate(UpdateDirectProductDoc, { id: product.id });
+      await app.graphql.mutate(UpdateDirectProductDoc, { id: product.id });
 
-    const keys = spy.mock.calls.map(([arg]) => keyOf(arg));
-    expect(keys).toContain(`DirectScriptureProduct:${product.id}`);
-    expect(keys).not.toContain(`Product:${product.id}`);
-  });
+      const keys = spy.mock.calls.map(([arg]) => keyOf(arg));
+      expect(keys).toContain(`DirectScriptureProduct:${product.id}`);
+      expect(keys).not.toContain(`Product:${product.id}`);
+    },
+  );
 });
 
 const UpdateOrgDoc = graphql(`


### PR DESCRIPTION
#### Summary 

Four tests in `test/live-query-invalidation.e2e-spec.ts` only make sense when the app is running on Postgres — they check that certain writes tell any open live queries to refresh, a mechanism that's specific to how the Postgres path is built. On Neo4j, that mechanism doesn't apply, so these tests used to just exit immediately without checking anything.

The problem: exiting early like that still gets counted as a **pass**. So on Neo4j, the test run showed 4 green checkmarks for tests that verified nothing at all. That's misleading — a reviewer or a future engineer glancing at test results would reasonably assume those 4 things were confirmed working, when they were never checked.

This PR changes those 4 tests so that on Neo4j they're honestly labeled **skipped** instead of **passed**. Nothing about what's being tested changes, and nothing in the app itself changes — this is purely about test reporting telling the truth about what it did.

Branch `live-query-honest-skips`, off `develop`, one commit (`d879ddfc8`).

#### What's added

- A shared `itPostgresOnly` helper (`isPostgres ? it : it.skip`) at the top of the file, matching a convention already used elsewhere in the suite (`audit-log.e2e-spec.ts`, `file.e2e-spec.ts`) for tests that only apply to one database engine.
- The 4 affected tests now use `itPostgresOnly(...)` instead of `it(...)` with an `if (!isPostgres) return;` guard as their first line.

#### Validation performed

- `yarn type-check`: 0 errors.
- `yarn lint`: 0 warnings.
- Unit suite: 199 passed / 0 failed.
- e2e, both engines, read from Jest's own JSON output (not console text):
  - Neo4j: 4 skipped, 0 passed, 0 failed (previously: 4 passed, 0 skipped — the silent-green case this PR fixes).
  - Postgres: 4 passed, 0 skipped, 0 failed — same real assertions as before, unchanged.

#### Reviewer cross-checks

- Confirm the 4 tests' assertion bodies are byte-for-byte unchanged — only the `it(...)` → `itPostgresOnly(...)` wrapper and the removed early-return line should differ.
- Confirm `itPostgresOnly`'s definition matches the existing pattern in `audit-log.e2e-spec.ts` / `file.e2e-spec.ts` rather than introducing a second convention.

#### Explicitly out of scope

- Auditing the rest of the test suite for other places using the same early-return-instead-of-skip pattern. This PR fixes the one file already flagged; it doesn't claim to be a general sweep.
