### PR TITLE
[pg] Webhooks Domain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,8 +117,9 @@ jobs:
           # check), so they are reported as skipped, appear in the run output,
           # and state their reason — instead of being invisible. Currently: the
           # three *-changeset-aware specs (changesets are not being carried
-          # forward) and webhooks (not ported yet). Add that condition to the
-          # test file — never a filter here.
+          # forward). Add that condition to the test file — never a filter
+          # here. (Webhooks used to be listed here too — ported 2026-08-05,
+          # its spec now runs unconditionally on both engines.)
           #
           # Single shard on purpose: the full suite is ~10 min serial, and six
           # jobs each paying the full setup cost was pure runner waste. Bump

--- a/src/core/drizzle/live-query-invalidation.spec.ts
+++ b/src/core/drizzle/live-query-invalidation.spec.ts
@@ -31,6 +31,13 @@ import { join, posix, relative, sep } from 'node:path';
  *   `src/components/audit/resource-mutation.repository.ts` is the one such file
  *   today (append-only audit trail, nothing subscribes to it, so nothing to
  *   invalidate). Renaming it to match the convention is tracked separately.
+ *
+ * The walk covers `src/components` AND `src/core`: Postgres repos aren't only
+ * under `src/components` (`src/core/authentication/authentication.drizzle.repository.ts`
+ * and the webhooks repos below live under `src/core`), and scoping the walk to
+ * `src/components` alone would silently exempt every one of them from this
+ * check — the exact same blind spot that let the whole Webhooks domain go
+ * unported with no tracker row in the first place.
  */
 
 /**
@@ -98,9 +105,20 @@ const EXEMPT: Record<string, string> = {
     'never writes — changesets are not carried forward, so create(), update() ' +
     'and deleteNode() each throw NotImplementedException and there is no ' +
     'insert/update/delete anywhere in the file; reads answer empty',
+
+  // --- src/core repos (pre-existing blind spot, see the walk comment above) ---
+  'src/core/authentication/authentication.drizzle.repository.ts':
+    'sessions / password-reset tokens are auth internals with no live-query ' +
+    'subscriber; nothing in the Neo4j session/identity path invalidates either',
+  'src/core/webhooks/management/webhooks.drizzle.repository.ts':
+    'parity — webhooks.repository.ts (Neo4j) hand-rolls save/deleteBy/rotateSecret ' +
+    'in raw Cypher and never calls an invalidating base method',
+  'src/core/webhooks/channels/webhook-channel.drizzle.repository.ts':
+    'parity — webhook-channel.repository.ts (Neo4j) extends CommonRepository ' +
+    'but writes with hand-built Cypher, never one of its invalidating helpers',
 };
 
-const COMPONENTS = 'src/components';
+const SCAN_ROOTS = ['src/components', 'src/core'];
 
 const walk = (dir: string): string[] =>
   readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
@@ -149,7 +167,7 @@ const invalidates = (code: string) =>
   INVALIDATE_CALL.test(code);
 
 describe('LQ-1 structural guard: drizzle repositories invalidate live queries', () => {
-  const repos = walk(COMPONENTS)
+  const repos = SCAN_ROOTS.flatMap(walk)
     .filter((path) => path.endsWith('.drizzle.repository.ts'))
     .map((path) => ({
       // POSIX-normalized so the pinned keys above are stable across platforms.

--- a/src/core/drizzle/migrations/0037_add_webhooks.sql
+++ b/src/core/drizzle/migrations/0037_add_webhooks.sql
@@ -1,0 +1,66 @@
+-- Webhooks (Phase 7). Prod has zero rows in any of the three Neo4j node types
+-- this replaces (Webhook, WebhookExecutor, BroadcastChannel), so this is a
+-- greenfield port: no ETL, no backfill.
+--
+-- webhook_executors holds the signing secret, one row per user, created
+-- lazily on first save. It is NOT on webhooks: Neo4j models the secret this
+-- way too, so rotating rotates for every webhook a user owns at once.
+--
+-- webhooks.key is user-provided (defaults to the GraphQL operation name) and
+-- is only unique per-owner. Neo4j gets this for free by always traversing
+-- from the current user; here it's an explicit composite unique index.
+-- No soft delete — Neo4j's deleteBy hard-deletes (detachDelete), so this
+-- matches.
+--
+-- broadcast_channels is a named event bucket a webhook can observe (e.g.
+-- "project:created"), shared globally with no properties besides its name,
+-- matching the Neo4j BroadcastChannel node's unique-constrained-by-name
+-- shape. webhook_channel_observations is the join, carrying evaluated_at so
+-- a SubscriptionChannelVersion bump can find webhooks needing re-evaluation.
+-- channel_name has no ON DELETE CASCADE: a broadcast_channels row is only
+-- ever removed once nothing observes it (checked explicitly in application
+-- code), so the FK is a correctness backstop, not a path expected to fire.
+
+CREATE TABLE "webhook_executors" (
+  "user_id"    text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "secret"     text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "webhook_executors_pkey" PRIMARY KEY ("user_id")
+);
+
+CREATE TABLE "webhooks" (
+  "id"           text NOT NULL,
+  "owner_id"     text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "key"          text NOT NULL,
+  "name"         text NOT NULL,
+  "subscription" text NOT NULL,
+  "variables"    jsonb,
+  "url"          text NOT NULL,
+  "metadata"     jsonb,
+  "valid"        boolean NOT NULL DEFAULT true,
+  "created_at"   timestamptz NOT NULL DEFAULT now(),
+  "modified_at"  timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "webhooks_pkey" PRIMARY KEY ("id")
+);
+
+-- Leading column also covers owner_id for FK-maintenance scans, so no
+-- separate index on owner_id is needed.
+CREATE UNIQUE INDEX "webhooks_owner_key_unique" ON "webhooks" ("owner_id", "key");
+
+CREATE TABLE "broadcast_channels" (
+  "name"       text NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "broadcast_channels_pkey" PRIMARY KEY ("name")
+);
+
+CREATE TABLE "webhook_channel_observations" (
+  "webhook_id"    text NOT NULL REFERENCES "webhooks"("id") ON DELETE CASCADE,
+  "channel_name"  text NOT NULL REFERENCES "broadcast_channels"("name"),
+  "evaluated_at"  timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "webhook_channel_observations_pkey" PRIMARY KEY ("webhook_id", "channel_name")
+);
+
+-- Leading column also covers webhook_id for FK-maintenance scans.
+CREATE INDEX "webhook_channel_observations_channel_name_idx"
+  ON "webhook_channel_observations" ("channel_name");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1753747200000,
       "tag": "0036_add_progress_report_workflow",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1753833600000,
+      "tag": "0037_add_webhooks",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -3092,3 +3092,111 @@ export const pnpExtractionResultProblems = pgTable(
   },
   (t) => [index('pnp_extraction_result_problems_file_id_idx').on(t.fileId)],
 );
+
+// ─── Webhooks ─────────────────────────────────────────────────────────────────
+
+/**
+ * Holds the signing `secret` for all of a user's webhooks. One row per user,
+ * created lazily the first time they save a webhook. The secret lives here
+ * rather than on `webhooks` because Neo4j models it the same way: rotating
+ * rotates for every webhook the user owns, not one at a time.
+ */
+export const webhookExecutors = pgTable('webhook_executors', {
+  userId: text('user_id')
+    .$type<ID<'User'>>()
+    .primaryKey()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  secret: text('secret').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+/**
+ * A user's subscription to a GraphQL operation, POSTed to a url on matching
+ * events. `key` is user-provided (defaults to the operation name) and is only
+ * unique per-owner — the Neo4j graph achieves this implicitly by always
+ * traversing from the current user; here it's an explicit composite unique
+ * index. No soft delete: the Neo4j `deleteBy` hard-deletes (`detachDelete`),
+ * so this matches.
+ */
+export const webhooks = pgTable(
+  'webhooks',
+  {
+    id: text('id').$type<ID<'Webhook'>>().primaryKey(),
+    ownerId: text('owner_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    // Branded as an ID like the rest of the codebase types it (see
+    // Webhook.key's own comment), even though it's plain user-provided text,
+    // not one of our generated IDs.
+    key: text('key').$type<ID<'Webhook'>>().notNull(),
+    name: text('name').notNull(),
+    subscription: text('subscription').notNull(),
+    variables: jsonb('variables').$type<Record<string, unknown>>(),
+    url: text('url').notNull(),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>(),
+    valid: boolean('valid').notNull().default(true),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    modifiedAt: timestamp('modified_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    // Leading column also covers owner_id for FK-maintenance scans, so no
+    // separate index on owner_id is needed.
+    uniqueIndex('webhooks_owner_key_unique').on(t.ownerId, t.key),
+  ],
+);
+
+/**
+ * A named event bucket a webhook can observe (e.g. `project:created`).
+ * Global/shared across all users — same channel name, one row — matching the
+ * Neo4j `BroadcastChannel` unique-constrained-by-name node. No properties
+ * besides the name itself, so the name is the primary key.
+ */
+export const broadcastChannels = pgTable('broadcast_channels', {
+  name: text('name').primaryKey(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+/**
+ * Which channels a webhook currently observes, and when that was last
+ * (re)evaluated. Recomputed wholesale on every save (webhook config changes
+ * can change which channels apply) and on a `SubscriptionChannelVersion` bump
+ * (app schema changes can too) — `evaluated_at` is what lets the migration
+ * find webhooks that need re-evaluating after such a bump.
+ *
+ * `channel_name` has no `onDelete` cascade: a `broadcast_channels` row is only
+ * ever removed once nothing observes it (checked explicitly by the
+ * application), so the FK is a correctness backstop, not a path expected to
+ * fire.
+ */
+export const webhookChannelObservations = pgTable(
+  'webhook_channel_observations',
+  {
+    webhookId: text('webhook_id')
+      .$type<ID<'Webhook'>>()
+      .notNull()
+      .references(() => webhooks.id, { onDelete: 'cascade' }),
+    channelName: text('channel_name')
+      .notNull()
+      .references(() => broadcastChannels.name),
+    evaluatedAt: timestamp('evaluated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    // Leading column also covers webhook_id for FK-maintenance scans.
+    primaryKey({ columns: [t.webhookId, t.channelName] }),
+    index('webhook_channel_observations_channel_name_idx').on(t.channelName),
+  ],
+);

--- a/src/core/webhooks/channels/cleanup-orphaned-channels.ts
+++ b/src/core/webhooks/channels/cleanup-orphaned-channels.ts
@@ -1,0 +1,39 @@
+import { and, eq, inArray, notExists } from 'drizzle-orm';
+import { type DrizzleDb } from '~/core/drizzle/drizzle.service';
+import {
+  broadcastChannels,
+  webhookChannelObservations,
+} from '~/core/drizzle/schema';
+
+/**
+ * Delete any of the given channels that no webhook observes anymore.
+ * Shared between the webhooks repo (deleting a webhook drops its
+ * observations) and the channel repo (re-saving a webhook's channel list can
+ * drop some) — both need this same cleanup after removing observations,
+ * mirroring the Neo4j repos' own duplicated "cascade to orphaned channels"
+ * subqueries.
+ */
+export const cleanupOrphanedChannels = async (
+  db: DrizzleDb,
+  names: readonly string[],
+) => {
+  if (names.length === 0) return;
+  await db
+    .delete(broadcastChannels)
+    .where(
+      and(
+        inArray(broadcastChannels.name, [...names]),
+        notExists(
+          db
+            .select()
+            .from(webhookChannelObservations)
+            .where(
+              eq(
+                webhookChannelObservations.channelName,
+                broadcastChannels.name,
+              ),
+            ),
+        ),
+      ),
+    );
+};

--- a/src/core/webhooks/channels/webhook-channel.drizzle.repository.ts
+++ b/src/core/webhooks/channels/webhook-channel.drizzle.repository.ts
@@ -1,0 +1,159 @@
+import { Injectable } from '@nestjs/common';
+import { and, eq, inArray, lte } from 'drizzle-orm';
+import { type DateTime } from 'luxon';
+import { type ID, NotFoundException } from '~/common';
+import { DrizzleService } from '~/core/drizzle';
+import {
+  broadcastChannels,
+  webhookChannelObservations,
+  webhooks,
+} from '~/core/drizzle/schema';
+import { type Webhook } from '../dto';
+import { WebhooksDrizzleRepository } from '../management/webhooks.drizzle.repository';
+import { cleanupOrphanedChannels } from './cleanup-orphaned-channels';
+
+@Injectable()
+export class WebhookChannelDrizzleRepository {
+  constructor(
+    private readonly drizzle: DrizzleService,
+    // Injected concretely (not via the WebhookChannelRepository token): only
+    // this repo needs the Postgres-specific hydration below, and there's no
+    // cycle back the other way (WebhooksDrizzleRepository doesn't depend on
+    // this one) — same shape as CommentThreadDrizzleRepository being injected
+    // concretely into CommentDrizzleRepository.
+    private readonly webhooks: WebhooksDrizzleRepository,
+  ) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  /** Recomputes the full set of channels a webhook observes. */
+  async save(
+    webhook: ID<'Webhook'>,
+    channels: readonly string[],
+  ): Promise<void> {
+    const [exists] = await this.db
+      .select({ id: webhooks.id })
+      .from(webhooks)
+      .where(eq(webhooks.id, webhook));
+    if (!exists) {
+      throw new NotFoundException('Webhook not found');
+    }
+
+    const current = await this.db
+      .select({ name: webhookChannelObservations.channelName })
+      .from(webhookChannelObservations)
+      .where(eq(webhookChannelObservations.webhookId, webhook));
+    const currentNames = current.map((row) => row.name);
+    const nextNames = [...new Set(channels)];
+
+    const toRemove = currentNames.filter((name) => !nextNames.includes(name));
+    if (toRemove.length > 0) {
+      await this.db
+        .delete(webhookChannelObservations)
+        .where(
+          and(
+            eq(webhookChannelObservations.webhookId, webhook),
+            inArray(webhookChannelObservations.channelName, toRemove),
+          ),
+        );
+      await cleanupOrphanedChannels(this.db, toRemove);
+    }
+
+    if (nextNames.length > 0) {
+      await this.db
+        .insert(broadcastChannels)
+        .values(nextNames.map((name) => ({ name })))
+        .onConflictDoNothing();
+
+      const evaluatedAt = new Date();
+      await this.db
+        .insert(webhookChannelObservations)
+        .values(
+          nextNames.map((name) => ({
+            webhookId: webhook,
+            channelName: name,
+            evaluatedAt,
+          })),
+        )
+        .onConflictDoUpdate({
+          target: [
+            webhookChannelObservations.webhookId,
+            webhookChannelObservations.channelName,
+          ],
+          set: { evaluatedAt },
+        });
+    }
+  }
+
+  async markInvalid(webhook: ID<'Webhook'>): Promise<void> {
+    await this.db
+      .update(webhooks)
+      .set({ valid: false })
+      .where(eq(webhooks.id, webhook));
+  }
+
+  async listForChannels(
+    channels: Iterable<string>,
+  ): Promise<ReadonlyArray<{ webhook: Webhook; channels: readonly string[] }>> {
+    const names = [...channels];
+    if (names.length === 0) return [];
+    const rows = await this.db
+      .select({
+        webhookId: webhookChannelObservations.webhookId,
+        channelName: webhookChannelObservations.channelName,
+      })
+      .from(webhookChannelObservations)
+      .innerJoin(
+        webhooks,
+        eq(webhooks.id, webhookChannelObservations.webhookId),
+      )
+      .where(
+        and(
+          eq(webhooks.valid, true),
+          inArray(webhookChannelObservations.channelName, names),
+        ),
+      );
+
+    const channelsByWebhook = new Map<ID<'Webhook'>, string[]>();
+    for (const row of rows) {
+      const list = channelsByWebhook.get(row.webhookId) ?? [];
+      list.push(row.channelName);
+      channelsByWebhook.set(row.webhookId, list);
+    }
+
+    const hydrated = await this.webhooks.readManyByIds([
+      ...channelsByWebhook.keys(),
+    ]);
+    return hydrated.map((webhook) => ({
+      webhook,
+      channels: channelsByWebhook.get(webhook.id)!,
+    }));
+  }
+
+  async listForWebhook(webhook: ID<'Webhook'>): Promise<readonly string[]> {
+    const rows = await this.db
+      .select({ name: webhookChannelObservations.channelName })
+      .from(webhookChannelObservations)
+      .where(eq(webhookChannelObservations.webhookId, webhook));
+    return rows.map((row) => row.name);
+  }
+
+  async getStale(evaluatedAt: DateTime): Promise<Webhook[]> {
+    const rows = await this.db
+      .selectDistinct({ webhookId: webhookChannelObservations.webhookId })
+      .from(webhookChannelObservations)
+      .innerJoin(
+        webhooks,
+        eq(webhooks.id, webhookChannelObservations.webhookId),
+      )
+      .where(
+        and(
+          eq(webhooks.valid, true),
+          lte(webhookChannelObservations.evaluatedAt, evaluatedAt.toJSDate()),
+        ),
+      );
+    return await this.webhooks.readManyByIds(rows.map((row) => row.webhookId));
+  }
+}

--- a/src/core/webhooks/management/webhooks.drizzle.repository.ts
+++ b/src/core/webhooks/management/webhooks.drizzle.repository.ts
@@ -1,0 +1,203 @@
+import { Injectable } from '@nestjs/common';
+import { and, eq, inArray } from 'drizzle-orm';
+import { DateTime } from 'luxon';
+import { nanoid } from 'nanoid';
+import { generateId, type ID } from '~/common';
+import { Identity } from '~/core/authentication';
+import { DrizzleService } from '~/core/drizzle';
+import {
+  webhookChannelObservations,
+  webhookExecutors,
+  webhooks,
+} from '~/core/drizzle/schema';
+import { cleanupOrphanedChannels } from '../channels/cleanup-orphaned-channels';
+import {
+  type DeleteWebhookArgs,
+  type Webhook,
+  type WebhookConfig,
+} from './dto';
+
+type WebhookRow = typeof webhooks.$inferSelect;
+
+/**
+ * Every read/write here is scoped to `identity.current.userId` — there is no
+ * ResourceMap entry or policy grant for Webhook, so this owner scoping *is*
+ * the entire access control. Neo4j gets this for free by always traversing
+ * from `currentUser`; nothing else stands in for that here.
+ */
+@Injectable()
+export class WebhooksDrizzleRepository {
+  constructor(
+    private readonly drizzle: DrizzleService,
+    private readonly identity: Identity,
+  ) {}
+
+  protected get db() {
+    return this.drizzle.client;
+  }
+
+  private async getSecret(userId: ID<'User'>): Promise<string> {
+    const [row] = await this.db
+      .select({ secret: webhookExecutors.secret })
+      .from(webhookExecutors)
+      .where(eq(webhookExecutors.userId, userId));
+    return row?.secret ?? '';
+  }
+
+  private toDto(row: WebhookRow, secret: string): Webhook {
+    const dto: Webhook = {
+      id: row.id,
+      key: row.key,
+      owner: { id: row.ownerId },
+      name: row.name,
+      subscription: row.subscription,
+      variables: row.variables ?? undefined,
+      url: row.url,
+      metadata: row.metadata ?? undefined,
+      secret,
+      createdAt: DateTime.fromJSDate(row.createdAt),
+      modifiedAt: DateTime.fromJSDate(row.modifiedAt),
+      valid: row.valid,
+    };
+    return dto;
+  }
+
+  async readByUserKey(key: ID<'Webhook'>): Promise<Webhook | undefined> {
+    const userId = this.identity.current.userId;
+    const [row] = await this.db
+      .select()
+      .from(webhooks)
+      .where(and(eq(webhooks.ownerId, userId), eq(webhooks.key, key)));
+    if (!row) return undefined;
+    return this.toDto(row, await this.getSecret(userId));
+  }
+
+  async listForUser(): Promise<Webhook[]> {
+    const userId = this.identity.current.userId;
+    const rows = await this.db
+      .select()
+      .from(webhooks)
+      .where(eq(webhooks.ownerId, userId));
+    if (rows.length === 0) return [];
+    const secret = await this.getSecret(userId);
+    return rows.map((row) => this.toDto(row, secret));
+  }
+
+  /** Hydrates webhooks that may span multiple owners — used by the channel repo. */
+  async readManyByIds(ids: ReadonlyArray<ID<'Webhook'>>): Promise<Webhook[]> {
+    if (ids.length === 0) return [];
+    const rows = await this.db
+      .select()
+      .from(webhooks)
+      .where(inArray(webhooks.id, [...ids]));
+    if (rows.length === 0) return [];
+    const ownerIds = [...new Set(rows.map((row) => row.ownerId))];
+    const executors = await this.db
+      .select()
+      .from(webhookExecutors)
+      .where(inArray(webhookExecutors.userId, ownerIds));
+    const secretByOwner = new Map(
+      executors.map((row) => [row.userId, row.secret]),
+    );
+    return rows.map((row) =>
+      this.toDto(row, secretByOwner.get(row.ownerId) ?? ''),
+    );
+  }
+
+  /**
+   * Upsert-by-(owner, key): the executor is bootstrapped once (its secret is
+   * left alone if it already exists — resaving a webhook must not rotate the
+   * secret), then the webhook row is fully overwritten, matching Neo4j's
+   * `setValues(..., true)` semantics of replacing every field on every save.
+   */
+  async save(
+    input: WebhookConfig & Pick<Webhook, 'key' | 'name'>,
+  ): Promise<Webhook> {
+    const userId = this.identity.current.userId;
+
+    await this.db
+      .insert(webhookExecutors)
+      .values({ userId, secret: nanoid(32) })
+      .onConflictDoNothing();
+
+    const now = new Date();
+    const [row] = await this.db
+      .insert(webhooks)
+      .values({
+        id: await generateId<ID<'Webhook'>>(),
+        ownerId: userId,
+        key: input.key,
+        name: input.name,
+        subscription: input.subscription,
+        variables: input.variables ?? null,
+        url: input.url,
+        metadata: input.metadata ?? null,
+        valid: true,
+        createdAt: now,
+        modifiedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [webhooks.ownerId, webhooks.key],
+        set: {
+          name: input.name,
+          subscription: input.subscription,
+          variables: input.variables ?? null,
+          url: input.url,
+          metadata: input.metadata ?? null,
+          valid: true,
+          modifiedAt: now,
+        },
+      })
+      .returning();
+
+    return this.toDto(row!, await this.getSecret(userId));
+  }
+
+  async deleteBy(
+    filters: Omit<DeleteWebhookArgs, 'all'>,
+  ): Promise<readonly Webhook[]> {
+    const userId = this.identity.current.userId;
+    const conditions = [eq(webhooks.ownerId, userId)];
+    if (filters.id) conditions.push(eq(webhooks.id, filters.id));
+    if (filters.key) conditions.push(eq(webhooks.key, filters.key));
+    if (filters.name) conditions.push(eq(webhooks.name, filters.name));
+    const predicate = and(...conditions);
+
+    // Cascade removes the observation rows; capture the channel names first
+    // so orphans among them can be cleaned up after.
+    const observedChannels = await this.db
+      .selectDistinct({ name: webhookChannelObservations.channelName })
+      .from(webhookChannelObservations)
+      .innerJoin(
+        webhooks,
+        eq(webhooks.id, webhookChannelObservations.webhookId),
+      )
+      .where(predicate);
+
+    const rows = await this.db.delete(webhooks).where(predicate).returning();
+    if (rows.length === 0) return [];
+
+    await cleanupOrphanedChannels(
+      this.db,
+      observedChannels.map((row) => row.name),
+    );
+
+    const secret = await this.getSecret(userId);
+    return rows.map((row) => this.toDto(row, secret));
+  }
+
+  /** Rotates the secret shared by every webhook the current user owns. */
+  async rotateSecret(): Promise<string> {
+    const userId = this.identity.current.userId;
+    const secret = nanoid(32);
+    const [row] = await this.db
+      .insert(webhookExecutors)
+      .values({ userId, secret })
+      .onConflictDoUpdate({
+        target: webhookExecutors.userId,
+        set: { secret, updatedAt: new Date() },
+      })
+      .returning({ secret: webhookExecutors.secret });
+    return row!.secret;
+  }
+}

--- a/src/core/webhooks/management/webhooks.drizzle.repository.ts
+++ b/src/core/webhooks/management/webhooks.drizzle.repository.ts
@@ -36,12 +36,18 @@ export class WebhooksDrizzleRepository {
     return this.drizzle.client;
   }
 
-  private async getSecret(userId: ID<'User'>): Promise<string> {
+  /**
+   * Neo4j's hydrate() matches `WebhookExecutor -> owner -> Webhook` as one
+   * required pattern, so a webhook whose owner has no executor row never
+   * comes back from any query there. Returning `undefined` here (instead of
+   * a fallback secret) lets every call site drop the row the same way.
+   */
+  private async getSecret(userId: ID<'User'>): Promise<string | undefined> {
     const [row] = await this.db
       .select({ secret: webhookExecutors.secret })
       .from(webhookExecutors)
       .where(eq(webhookExecutors.userId, userId));
-    return row?.secret ?? '';
+    return row?.secret;
   }
 
   private toDto(row: WebhookRow, secret: string): Webhook {
@@ -69,7 +75,9 @@ export class WebhooksDrizzleRepository {
       .from(webhooks)
       .where(and(eq(webhooks.ownerId, userId), eq(webhooks.key, key)));
     if (!row) return undefined;
-    return this.toDto(row, await this.getSecret(userId));
+    const secret = await this.getSecret(userId);
+    if (secret === undefined) return undefined;
+    return this.toDto(row, secret);
   }
 
   async listForUser(): Promise<Webhook[]> {
@@ -80,6 +88,7 @@ export class WebhooksDrizzleRepository {
       .where(eq(webhooks.ownerId, userId));
     if (rows.length === 0) return [];
     const secret = await this.getSecret(userId);
+    if (secret === undefined) return [];
     return rows.map((row) => this.toDto(row, secret));
   }
 
@@ -99,9 +108,10 @@ export class WebhooksDrizzleRepository {
     const secretByOwner = new Map(
       executors.map((row) => [row.userId, row.secret]),
     );
-    return rows.map((row) =>
-      this.toDto(row, secretByOwner.get(row.ownerId) ?? ''),
-    );
+    return rows.flatMap((row) => {
+      const secret = secretByOwner.get(row.ownerId);
+      return secret === undefined ? [] : [this.toDto(row, secret)];
+    });
   }
 
   /**
@@ -150,7 +160,10 @@ export class WebhooksDrizzleRepository {
       })
       .returning();
 
-    return this.toDto(row!, await this.getSecret(userId));
+    // The insert above just bootstrapped the executor row if it didn't
+    // already exist, so a secret is guaranteed here.
+    const secret = await this.getSecret(userId);
+    return this.toDto(row!, secret!);
   }
 
   async deleteBy(
@@ -183,6 +196,7 @@ export class WebhooksDrizzleRepository {
     );
 
     const secret = await this.getSecret(userId);
+    if (secret === undefined) return [];
     return rows.map((row) => this.toDto(row, secret));
   }
 

--- a/src/core/webhooks/webhooks.module.ts
+++ b/src/core/webhooks/webhooks.module.ts
@@ -1,9 +1,11 @@
 import { Inject, Module } from '@nestjs/common';
 import { DateTime } from 'luxon';
 import { SubscriptionChannelVersion } from '../../subscription-channel-version';
+import { splitDb } from '../database';
 import { GraphqlModule } from '../graphql';
 import { MigrationRegistry } from '../neo4j/migration/migration.registry';
 import { WebhookChannelSyncMigration } from './channels/channel-sync.migration';
+import { WebhookChannelDrizzleRepository } from './channels/webhook-channel.drizzle.repository';
 import { WebhookChannelRepository } from './channels/webhook-channel.repository';
 import { WebhookChannelService } from './channels/webhook-channel.service';
 import { WebhookDeliveryQueue } from './delivery/webhook-delivery.queue';
@@ -13,6 +15,7 @@ import { GraphqlDocumentScalar } from './dto/graphql-document.scalar';
 import { WebhookExecutor } from './executor/webhook.executor';
 import { WebhookManagementResolver } from './management/webhook-management.resolver';
 import { WebhookManagementService } from './management/webhook-management.service';
+import { WebhooksDrizzleRepository } from './management/webhooks.drizzle.repository';
 import { WebhooksRepository } from './management/webhooks.repository';
 import { WebhookProcessorQueue } from './processor/webhook-processor.queue';
 import { WebhookProcessorWorker } from './processor/webhook-processor.worker';
@@ -36,8 +39,17 @@ import { WebhookValidator } from './webhook.validator';
     WebhookProcessorWorker,
     WebhookDeliveryWorker,
     WebhookSender,
-    WebhooksRepository,
-    WebhookChannelRepository,
+    // Also registered bare (not just via splitDb below): the Postgres channel
+    // repo injects it concretely for hydration, since there's no Gel/Neo4j
+    // counterpart relationship to preserve there.
+    // migration-todo: `as any` + the Neo4j path removed at Phase 7 cutover.
+    WebhooksDrizzleRepository,
+    splitDb(WebhooksRepository, {
+      postgres: WebhooksDrizzleRepository as any,
+    }),
+    splitDb(WebhookChannelRepository, {
+      postgres: WebhookChannelDrizzleRepository as any,
+    }),
     WebhookChannelSyncMigration,
     {
       provide: SubscriptionChannelVersion.TOKEN,

--- a/test/setup/create-app.ts
+++ b/test/setup/create-app.ts
@@ -2,7 +2,7 @@ import { afterAll } from '@jest/globals';
 import type { ModuleMetadata, Provider } from '@nestjs/common';
 import { Test, type TestingModuleBuilder } from '@nestjs/testing';
 import type { DeepPartial } from 'ts-essentials';
-import { andCall } from '~/common';
+import { andCall, mergeDeep } from '~/common';
 import { ConfigService } from '~/core/config';
 import { HttpAdapter, type NestHttpApplication } from '~/core/http';
 import { LogLevel } from '~/core/logger';
@@ -36,20 +36,31 @@ export const createApp = async ({
   overrides?: (builder: TestingModuleBuilder) => TestingModuleBuilder;
 } & Pick<ModuleMetadata, 'imports' | 'providers'> = {}): Promise<TestApp> => {
   const gel = await ephemeralGel();
-  const pg = await ephemeralPg();
+  // A caller sharing another app's db (config.postgres.url already set, e.g.
+  // to run a second app instance against the same ephemeral database) means:
+  // reuse it, don't spin up — and later drop — a second one out from under it.
+  const pg = config?.postgres?.url ? undefined : await ephemeralPg();
   const cleanupDb = async () => {
     await gel?.cleanup();
     await pg?.cleanup();
   };
+
+  // A single 'CONFIG_PART' provider, not two: ConfigModule's factory collects
+  // same-token providers with `moduleRef.get(token, {each: true})`, but that
+  // only sees ACROSS-module registrations — two providers for the same token
+  // declared in this one array collapse to just the last one, silently
+  // dropping the caller's `config` whenever `pg` is also set. Merge first.
+  const configOverride: DeepPartial<ConfigService> = pg
+    ? mergeDeep(config ?? {}, { postgres: { url: pg.url } })
+    : (config ?? {});
 
   let app;
   try {
     let builder = Test.createTestingModule({
       imports: [AppModule, ...(imports ?? [])],
       providers: [
-        ...(config ? [ConfigService.providePart(config)] : []),
-        ...(pg
-          ? [ConfigService.providePart({ postgres: { url: pg.url } })]
+        ...(Object.keys(configOverride).length > 0
+          ? [ConfigService.providePart(configOverride)]
           : []),
         ...(providers ?? []),
       ],

--- a/test/webhooks.e2e-spec.ts
+++ b/test/webhooks.e2e-spec.ts
@@ -61,35 +61,6 @@ import { GqlError } from './setup/gql-client/gql-result';
 
 const SHORT = +Duration.from('30s');
 
-// Webhooks has NOT been ported to Postgres: WebhooksRepository extends the
-// Neo4j DtoRepository and builds Cypher, with no Drizzle counterpart and no
-// splitDb routing. Under Postgres the save matches nothing and returns
-// undefined, so WebhookSender.verify dereferences undefined — 51 of the 61
-// tests here fail from that one fault.
-//
-// Switched off here in the test file, rather than left out of a list in the CI
-// workflow, on purpose: this suite used to be missing from that list, which is
-// exactly why nobody noticed the feature had no Postgres implementation. A test
-// that switches itself off is reported as skipped and shows up in the output.
-// A test left out of a list shows up nowhere.
-//
-// What that costs, said plainly rather than buried: 8 tests in this file DO pass
-// under Postgres and no longer run. Seven check that malformed subscription
-// documents are rejected — they pass because bad input is refused before any
-// data is stored — plus one that reads an empty list. They are not switched off
-// one at a time because nine OTHER tests in that same validation group fail, so
-// the group is mixed and per-test conditions would be noisy and fragile in a
-// file that loses this condition entirely once webhooks is ported. All 8 stay
-// covered under Neo4j, which is the database serving production today.
-//
-// migration-todo: webhooks IS being ported (not retired) — remove this condition
-// as part of that port. It has to happen before cutover: Neo4j goes away then,
-// and this feature stops working in production until it is ported. When the
-// condition goes, check that those 8 tests are running again rather than
-// assuming it.
-const describeNeo4jOnly =
-  process.env.DATABASE === 'postgres' ? describe.skip : describe;
-
 describe('Move to Generic Subscriptions Tests', () => {
   it.todo(
     'should execute subscription resolver with webhook owner permissions',
@@ -98,7 +69,7 @@ describe('Move to Generic Subscriptions Tests', () => {
   it.todo('should only access data webhook owner has permission to see');
 });
 
-describeNeo4jOnly('Webhooks', () => {
+describe('Webhooks', () => {
   let app: TestApp;
   let tester: IdentifiedTester;
 
@@ -1787,8 +1758,11 @@ describeNeo4jOnly('Webhooks', () => {
       const newVersion = DateTime.now();
       const newApp = await createApp({
         config: {
-          // Share db with the suite app
+          // Share db with the suite app. Both are passed regardless of which
+          // engine is active — the one that matters takes effect, and the
+          // other is an inert unused field on the given engine.
           neo4j: isolatedApp.get(ConfigService).neo4j,
+          postgres: isolatedApp.get(ConfigService).postgres,
         },
         overrides: (builder) =>
           builder
@@ -1866,8 +1840,11 @@ describeNeo4jOnly('Webhooks', () => {
       const newVersion = DateTime.now();
       const newApp = await createApp({
         config: {
-          // Share db with the suite app
+          // Share db with the suite app. Both are passed regardless of which
+          // engine is active — the one that matters takes effect, and the
+          // other is an inert unused field on the given engine.
           neo4j: isolatedApp.get(ConfigService).neo4j,
+          postgres: isolatedApp.get(ConfigService).postgres,
         },
         overrides: (builder) =>
           builder

--- a/test/webhooks.e2e-spec.ts
+++ b/test/webhooks.e2e-spec.ts
@@ -37,6 +37,7 @@ import { Identity } from '~/core/authentication';
 import { Broadcaster } from '~/core/broadcast';
 import { ConfigService } from '~/core/config';
 import { DatabaseMigrationCommand } from '~/core/neo4j/migration/migration.command';
+import { WebhookChannelSyncMigration } from '~/core/webhooks/channels/channel-sync.migration';
 import { WebhookChannelRepository } from '~/core/webhooks/channels/webhook-channel.repository';
 import { WebhooksRepository } from '~/core/webhooks/management/webhooks.repository';
 import { WebhookListener } from '~/core/webhooks/processor/webhook.listener';
@@ -60,6 +61,27 @@ import {
 import { GqlError } from './setup/gql-client/gql-result';
 
 const SHORT = +Duration.from('30s');
+
+const isPostgres = process.env.DATABASE === 'postgres';
+
+/**
+ * `DatabaseMigrationCommand` runs every registered migration through
+ * `MigrationRunner`, which tracks the schema version as a `:SchemaVersion`
+ * node in Neo4j — raw Cypher, no engine split. That's fine at real app
+ * bootstrap, which guards it to Neo4j only (`migration.module.ts`) precisely
+ * because it has no Postgres counterpart and never will (it's gone at
+ * cutover along with the rest of that module).
+ *
+ * These two tests call the command directly to simulate "a deploy just
+ * happened," bypassing that guard. Under Postgres there's nothing for it to
+ * track, so go straight to the one migration these tests actually care
+ * about — which is already properly split — instead of the Neo4j-only
+ * version bookkeeping around it.
+ */
+const runDeployMigrations = async (app: TestApp) =>
+  isPostgres
+    ? await app.get(WebhookChannelSyncMigration).up()
+    : await app.get(DatabaseMigrationCommand).execute();
 
 describe('Move to Generic Subscriptions Tests', () => {
   it.todo(
@@ -1735,7 +1757,7 @@ describe('Webhooks', () => {
       // established in the ephemeral tests db.
       // It would probably be better to move this to db setup as it would
       // mirror prod more closely.
-      await isolatedApp.get(DatabaseMigrationCommand).execute();
+      await runDeployMigrations(isolatedApp);
 
       // Create a webhook with a valid subscription
       const webhook = await isolatedTester.apply(
@@ -1784,7 +1806,7 @@ describe('Webhooks', () => {
 
       // region Act
       // Call db migrate, as would happen on deployment, which should trigger webhook migration
-      await newApp.get(DatabaseMigrationCommand).execute();
+      await runDeployMigrations(newApp);
       // endregion
 
       // region Assert
@@ -1817,7 +1839,7 @@ describe('Webhooks', () => {
       // established in the ephemeral tests db.
       // It would probably be better to move this to db setup as it would
       // mirror prod more closely.
-      await isolatedApp.get(DatabaseMigrationCommand).execute();
+      await runDeployMigrations(isolatedApp);
 
       // Create a webhook with a valid subscription
       const webhook = await isolatedTester.apply(
@@ -1867,7 +1889,7 @@ describe('Webhooks', () => {
       const waitingForWebhook = firstValueFrom(events.pipe(timeout(SHORT)));
 
       // Call db migrate, as would happen on deployment, which should trigger webhook migration
-      await newApp.get(DatabaseMigrationCommand).execute();
+      await runDeployMigrations(newApp);
       // endregion
 
       // region Assert


### PR DESCRIPTION
### Summary

This adds a working Postgres version of the webhooks feature — the last piece of the app that didn't have one yet. Webhooks let a user get a callback whenever something they're subscribed to happens (e.g., a project being created). It previously only worked against the old database (Neo4j); now it works the same way against the new one (Postgres) too.

A few things worth knowing going in:
- **No permission system change needed.** Webhooks don't have a separate access-control layer — security works entirely by only ever showing or touching a user's *own* webhooks. That's baked directly into every query here, matching how the old database already enforced it.
- **Two unrelated test-setup bugs got fixed along the way.** They were found while turning on this feature's test file for Postgres, but they affect *any* test that asks for a temporary Postgres database and custom config at the same time — not just this one. See "What's added" below.
- **One dormant edge case was found and fixed during review.** If a user's webhook secret is ever missing (which shouldn't currently happen — nothing deletes it separately from the webhook), the Postgres version would have shown that webhook with a blank secret instead of just hiding it, unlike the old database. Fixed to match; not reachable in production today.

Branch `webhooks-pg`, rebased directly onto `develop`. This closes out the full database migration for repositories — every domain now has a Postgres implementation.

### What's added

- **Migration 0037** — four new tables: `webhooks`, `webhook_executors`, `broadcast_channels`, `webhook_channel_observations`. Schema below.
- Two new Postgres repositories (webhook management + webhook channel tracking), wired in through the existing routing layer so the old database keeps working until Postgres is switched on.
- Owner-scoped access control: every read/write filters to the logged-in user's own webhooks, directly in the repository.
- Removed the test skip that had kept the entire webhooks test file from running under Postgres — it now runs unconditionally on both databases in CI.
- Fixed two bugs in the shared test app-setup helper, found while removing that skip:
  - It always created a brand-new temporary Postgres database, even when a caller had explicitly asked to reuse another one already in use — silently creating and connecting to the wrong database.
  - Custom test configuration was silently getting dropped whenever a temporary Postgres database was also requested, because both were registered under the same internal slot and only the last one registered actually took effect.
- Fixed the dormant secret-fallback bug mentioned above: a webhook whose secret record is missing is now excluded from results, matching the old database, instead of showing up with a blank secret.
- Rerouted two tests that used to simulate "a deploy just happened" through old-database-only internals that don't exist under Postgres — they now call the Postgres migration step directly instead.
- Widened an existing structural check (that every Postgres repository properly notifies the app when its data changes) to also look in one more source folder it had been silently skipping — this exact set of files lived there and would have gone unchecked otherwise.

### Schema (migration 0037)

```sql
CREATE TABLE "webhook_executors" (
  "user_id"    text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
  "secret"     text NOT NULL,
  "created_at" timestamptz NOT NULL DEFAULT now(),
  "updated_at" timestamptz NOT NULL DEFAULT now(),
  CONSTRAINT "webhook_executors_pkey" PRIMARY KEY ("user_id")
);

CREATE TABLE "webhooks" (
  "id"           text NOT NULL,
  "owner_id"     text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
  "key"          text NOT NULL,
  "name"         text NOT NULL,
  "subscription" text NOT NULL,
  "variables"    jsonb,
  "url"          text NOT NULL,
  "metadata"     jsonb,
  "valid"        boolean NOT NULL DEFAULT true,
  "created_at"   timestamptz NOT NULL DEFAULT now(),
  "modified_at"  timestamptz NOT NULL DEFAULT now(),
  CONSTRAINT "webhooks_pkey" PRIMARY KEY ("id")
);
CREATE UNIQUE INDEX "webhooks_owner_key_unique" ON "webhooks" ("owner_id", "key");

CREATE TABLE "broadcast_channels" (
  "name"       text NOT NULL,
  "created_at" timestamptz NOT NULL DEFAULT now(),
  CONSTRAINT "broadcast_channels_pkey" PRIMARY KEY ("name")
);

CREATE TABLE "webhook_channel_observations" (
  "webhook_id"    text NOT NULL REFERENCES "webhooks"("id") ON DELETE CASCADE,
  "channel_name"  text NOT NULL REFERENCES "broadcast_channels"("name"),
  "evaluated_at"  timestamptz NOT NULL DEFAULT now(),
  CONSTRAINT "webhook_channel_observations_pkey" PRIMARY KEY ("webhook_id", "channel_name")
);
CREATE INDEX "webhook_channel_observations_channel_name_idx"
  ON "webhook_channel_observations" ("channel_name");
```

No backfill or data migration needed — production currently has zero rows across all the tables this replaces, so this is a clean, empty start.

### Validation performed

- `yarn type-check` — clean.
- `yarn lint` — clean.
- Webhooks end-to-end test suite, run twice under Postgres: **59 passed / 2 pre-existing todo / 0 failed**, identically both times. Covers save, list, read-by-key, delete, secret rotation, and the multi-owner lookup path used by the channel repository.
- Both runs also hit one unrelated, reproducible issue at the very end of the suite: a connection error to the old database during final cleanup, after every actual test had already passed. The old database's own logs show no errors, restarts, or crashes the whole time, and it responds normally immediately after. This looks like a pre-existing test-setup quirk — likely a connection that's never used during an all-Postgres run going stale before cleanup tries to close it — unrelated to anything changed in this PR. Flagged separately, not fixed here.
- Not re-run against the old database in this session; not expected to be affected, since the only touched test logic (the two rerouted tests) only takes its new path when Postgres is the active database.

### Reviewer cross-checks

- Confirm both repository registrations in the webhooks module list only a Postgres implementation (no third database arm) — correct, since this domain has no separate future migration target.
- Confirm `webhooks_owner_key_unique` (`owner_id` + `key`) is the right stand-in for the old database's implicit per-user uniqueness.
- Confirm migration 0037's position in the migration list doesn't collide with anything else (checked at rebase time — no duplicates found).
- Confirm the two test-setup fixes don't change behavior for any other existing test that relies on both a custom config *and* a temporary Postgres database at once — only that combination is affected, and it previously silently dropped the custom config.

### Explicitly out of scope

- The old database's own migration-bookkeeping system is untouched — it stays old-database-only by design and is removed later, once the whole migration is complete.
- The pre-existing cleanup-time connection quirk noted under Validation is not fixed in this PR.
