### PR TITLE
[pg] Wire cross-domain project/engagement filters, port ProgressReport, and close the UAT-found authz gaps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,15 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+      # Type-aware rules and `tsc` itself both build a full TypeScript program
+      # in memory, and that's grown enough (dozens of new domains from the
+      # Postgres migration) to hit Node's default ~4GB heap ceiling on
+      # ubuntu-latest runners — an OOM crash mid-step, not a real problem with
+      # the code. Runners have far more RAM than that default; just raise the
+      # ceiling for every step in this job, not only whichever one crashed
+      # most recently.
+      NODE_OPTIONS: '--max-old-space-size=8192'
 
     steps:
       - uses: actions/checkout@v4

--- a/src/common/functions/secured-mapper.ts
+++ b/src/common/functions/secured-mapper.ts
@@ -15,8 +15,15 @@ export async function mapSecuredValue<T extends Secured<any>, S>(
   if (!rest.canRead || value == null) {
     return rest;
   }
-  const mapped = await mapper(value);
-  return { ...rest, value: mapped };
+  try {
+    const mapped = await mapper(value);
+    return { ...rest, value: mapped };
+  } catch (e) {
+    if (e instanceof NotFoundException) {
+      return rest;
+    }
+    throw e;
+  }
 }
 
 /**

--- a/src/components/audit/resource.resolver.ts
+++ b/src/components/audit/resource.resolver.ts
@@ -1,7 +1,8 @@
 import { Info, Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { stripIndent } from 'common-tags';
 import { type GraphQLResolveInfo } from 'graphql';
-import { ListArg, Resource } from '~/common';
+import { ListArg, Resource, UnauthorizedException } from '~/common';
+import { Identity } from '~/core/authentication';
 import { AuditService } from './audit.service';
 import {
   ResourceMutationList,
@@ -16,7 +17,10 @@ import {
  */
 @Resolver(Resource)
 export class ResourceHistoryResolver {
-  constructor(private readonly audit: AuditService) {}
+  constructor(
+    private readonly audit: AuditService,
+    private readonly identity: Identity,
+  ) {}
 
   @ResolveField(() => ResourceMutationList, {
     description: stripIndent`
@@ -33,6 +37,16 @@ export class ResourceHistoryResolver {
     @Info() info: GraphQLResolveInfo,
     @ListArg(ResourceMutationListInput) input: ResourceMutationListInput,
   ): Promise<ResourceMutationList> {
+    // Interim gate: this field isn't behind any per-resource/per-field policy
+    // yet (unlike the rest of the schema, which goes through Privileges), and
+    // it's not exposed in any UI. Restricting it to admins keeps it from being
+    // a wide-open read of every resource's mutation history — the finer-grained
+    // permission model is deferred to a post-migration pass.
+    if (!this.identity.isAdmin) {
+      throw new UnauthorizedException(
+        'Only administrators can view resource history',
+      );
+    }
     // `info.parentType.name` is the concrete GraphQL type GraphQL already
     // resolved this object to (e.g. MomentumTranslationProject), which is what
     // the firing service records under. NOT `resource.__typename` — for the

--- a/src/components/authorization/policies/conditions/member.condition.ts
+++ b/src/components/authorization/policies/conditions/member.condition.ts
@@ -252,6 +252,13 @@ const projectIdRefForResource = (resource: EnhancedResource<any>): SQL => {
       return sql.raw(
         `(select "e"."project_id" from "engagements" "e" where "e"."id" = "ceremonies"."engagement_id")`,
       );
+    case 'ProgressReport':
+      // Progress rows on the shared periodic_reports table are always
+      // engagement-parented (never project-parented directly) — see
+      // PeriodicReportDrizzleRepository.parentCondition.
+      return sql.raw(
+        `(select "e"."project_id" from "engagements" "e" where "e"."id" = "periodic_reports"."engagement_id")`,
+      );
     case 'Language':
       // A language is "member-visible" through ANY project engaging it.
       // `pm.project_id = any(array(...))` keeps the shared `= ${ref}` template

--- a/src/components/authorization/policies/conditions/sensitivity.condition.ts
+++ b/src/components/authorization/policies/conditions/sensitivity.condition.ts
@@ -215,6 +215,15 @@ const sensitivityRefForResource = (
         join "engagements" "e" on "e"."project_id" = "p"."id"
         where "e"."id" = "ceremonies"."engagement_id"
       ) <= ${accessLiteral}`;
+    case 'ProgressReport':
+      // Progress rows on the shared periodic_reports table are always
+      // engagement-parented (never project-parented directly) — see
+      // PeriodicReportDrizzleRepository.parentCondition.
+      return sql`(
+        select "p"."sensitivity" from "projects" "p"
+        join "engagements" "e" on "e"."project_id" = "p"."id"
+        where "e"."id" = "periodic_reports"."engagement_id"
+      ) <= ${accessLiteral}`;
     case 'Language':
       // Effective sensitivity: lowest across projects engaging the language,
       // falling back to the language's own (user-set) sensitivity when

--- a/src/components/ceremony/ceremony.drizzle.repository.ts
+++ b/src/components/ceremony/ceremony.drizzle.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { and, eq, inArray, isNull, type SQL } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql, type SQL } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import {
   CalendarDate,
@@ -148,7 +148,20 @@ export class CeremonyDrizzleRepository extends DrizzleDtoRepository<
   }
 
   async list(input: CeremonyListInput) {
-    const conditions: SQL[] = [isNull(ceremonies.deletedAt)];
+    const conditions: SQL[] = [
+      isNull(ceremonies.deletedAt),
+      // Keep this page/total in sync with liveCeremonyIds() below — without
+      // it, a ceremony under a soft-deleted engagement/project inflates
+      // `total` and consumes a page slot that readMany() then silently
+      // drops, short-changing the page.
+      sql`exists (
+        select 1 from ${engagements}
+        inner join ${projects} on ${projects.id} = ${engagements.projectId}
+        where ${engagements.id} = ${ceremonies.engagementId}
+          and ${engagements.deletedAt} is null
+          and ${projects.deletedAt} is null
+      )`,
+    ];
     // Mirror the Neo4j list()'s `filterToReadable` — without it, member/
     // sensitivity-gated roles could list ceremonies of unreadable projects.
     // (readMany stays unfiltered: the Neo4j readMany uses the base's opt-in

--- a/src/components/ceremony/ceremony.drizzle.repository.ts
+++ b/src/components/ceremony/ceremony.drizzle.repository.ts
@@ -16,11 +16,7 @@ import {
   type SortMap,
 } from '~/core/drizzle';
 import { DrizzleService } from '~/core/drizzle/drizzle.service';
-import {
-  ceremonies,
-  type engagements,
-  type projects,
-} from '~/core/drizzle/schema';
+import { ceremonies, engagements, projects } from '~/core/drizzle/schema';
 import { type ScopedRole } from '../authorization/dto/role.dto';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import { requesterScopeByProject } from '../project/project-member/membership-scope';
@@ -73,12 +69,41 @@ export class CeremonyDrizzleRepository extends DrizzleDtoRepository<
     return { id };
   }
 
+  /**
+   * Of these ids, the ones whose engagement and project are both still live.
+   *
+   * A ceremony's own `deletedAt` says nothing about its parents: soft-deleting
+   * the engagement or project leaves the ceremony's row untouched. Neo4j's
+   * `hydrate()` requires a REQUIRED match up through `:Project`->`:Engagement`
+   * (ACTIVE relationships), and soft delete there relabels to `Deleted_*`, so a
+   * dead ancestor hides the ceremony entirely rather than returning it with a
+   * dangling parent ref.
+   */
+  private async liveCeremonyIds(ids: readonly ID[]): Promise<ID[]> {
+    if (ids.length === 0) return [];
+    const rows = await this.db
+      .select({ id: ceremonies.id })
+      .from(ceremonies)
+      .innerJoin(engagements, eq(engagements.id, ceremonies.engagementId))
+      .innerJoin(projects, eq(projects.id, engagements.projectId))
+      .where(
+        and(
+          inArray(ceremonies.id, [...ids]),
+          isNull(engagements.deletedAt),
+          isNull(projects.deletedAt),
+        ),
+      );
+    return rows.map((row) => row.id);
+  }
+
   override async readMany(
     ids: readonly ID[],
   ): Promise<Array<UnsecuredDto<Ceremony>>> {
     if (ids.length === 0) return [];
+    const live = await this.liveCeremonyIds(ids);
+    if (live.length === 0) return [];
     const rows = await this.db.query.ceremonies.findMany({
-      where: (c) => and(inArray(c.id, [...ids]), isNull(c.deletedAt)),
+      where: (c) => and(inArray(c.id, [...live]), isNull(c.deletedAt)),
       with: {
         engagement: {
           // `type` feeds the parent ref's __typename (`${type}Engagement`).

--- a/src/components/comments/comment.drizzle.repository.ts
+++ b/src/components/comments/comment.drizzle.repository.ts
@@ -83,6 +83,10 @@ export class CommentDrizzleRepository extends DrizzleDtoRepository<
   async deleteNode(objectOrId: { id: ID } | ID): Promise<void> {
     const id = typeof objectOrId === 'string' ? objectOrId : objectOrId.id;
     await this.db.delete(comments).where(eq(comments.id, id as ID<'Comment'>));
+    // Hand-rolled delete (a hard delete, not the base's softDelete()), so it
+    // has to invalidate itself — see the base class's doc comment on why
+    // updateColumns()/softDelete() can't cover this for us.
+    this.liveQueryStore.invalidate([this.resource, id]);
   }
 
   async list(threadId: ID, input: CommentListInput) {

--- a/src/components/engagement/engagement.drizzle.repository.ts
+++ b/src/components/engagement/engagement.drizzle.repository.ts
@@ -31,6 +31,8 @@ import {
   engagementStatusHistory,
   languages,
   projects,
+  tools,
+  toolUsages,
   users,
 } from '~/core/drizzle/schema';
 import { type ScopedRole } from '../authorization/dto/role.dto';
@@ -43,6 +45,7 @@ import {
   projectFilterClauses,
   recomputeProjectSensitivity,
 } from '../project/project.drizzle.repository';
+import { toolFilterClauses } from '../tools/tool/tool.drizzle.repository';
 import { userFilterClauses } from '../user/user.drizzle.repository';
 import {
   type CreateInternshipEngagement,
@@ -942,12 +945,31 @@ export const engagementFilterClauses = (
       ),
     );
   }
+  if (filter.tool) {
+    conditions.push(
+      inArray(
+        engagements.id,
+        db
+          .selectDistinct({ id: toolUsages.containerId })
+          .from(toolUsages)
+          .innerJoin(
+            tools,
+            and(eq(tools.id, toolUsages.toolId), isNull(tools.deletedAt)),
+          )
+          .where(
+            and(
+              isNull(toolUsages.deletedAt),
+              ...toolFilterClauses(db, filter.tool),
+            ),
+          ),
+      ),
+    );
+  }
   const unimplemented = {
     name: filter.name,
     engagedName: filter.engagedName,
     startDate: filter.startDate,
     endDate: filter.endDate,
-    tool: filter.tool,
   };
   for (const [key, value] of Object.entries(unimplemented)) {
     if (value !== undefined) {

--- a/src/components/engagement/engagement.drizzle.repository.ts
+++ b/src/components/engagement/engagement.drizzle.repository.ts
@@ -481,7 +481,13 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
     if (!this.executor.applyReadFilter(this.resource, conditions)) {
       return EMPTY_PAGE;
     }
-    conditions.push(...engagementFilterClauses(this.db, input.filter));
+    conditions.push(
+      ...engagementFilterClauses(
+        this.db,
+        input.filter,
+        this.identity.current.userId,
+      ),
+    );
 
     const sortColumns = {
       status: engagements.status,
@@ -870,6 +876,7 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
 export const engagementFilterClauses = (
   db: DrizzleDb,
   filter: EngagementListInput['filter'],
+  requesterId?: ID<'User'>,
 ): SQL[] => {
   const conditions: SQL[] = [];
   if (!filter) return conditions;
@@ -890,7 +897,7 @@ export const engagementFilterClauses = (
         db,
         engagements.projectId,
         projects,
-        projectFilterClauses(db, filter.project),
+        projectFilterClauses(db, filter.project, requesterId),
       ),
     );
   }
@@ -931,7 +938,7 @@ export const engagementFilterClauses = (
         db,
         engagements.languageId,
         languages,
-        languageFilterClauses(db, filter.language),
+        languageFilterClauses(db, filter.language, requesterId),
       ),
     );
   }

--- a/src/components/engagement/engagement.drizzle.repository.ts
+++ b/src/components/engagement/engagement.drizzle.repository.ts
@@ -23,8 +23,9 @@ import {
   EMPTY_PAGE,
   resolveOrderBy,
   type SortMap,
+  subFilter,
 } from '~/core/drizzle';
-import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
 import {
   engagements,
   engagementStatusHistory,
@@ -35,9 +36,14 @@ import {
 import { type ScopedRole } from '../authorization/dto/role.dto';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import { FileService } from '../file';
+import { languageFilterClauses } from '../language/language.drizzle.repository';
 import { IProject } from '../project/dto';
 import { requesterScopeByProject } from '../project/project-member/membership-scope';
-import { recomputeProjectSensitivity } from '../project/project.drizzle.repository';
+import {
+  projectFilterClauses,
+  recomputeProjectSensitivity,
+} from '../project/project.drizzle.repository';
+import { userFilterClauses } from '../user/user.drizzle.repository';
 import {
   type CreateInternshipEngagement,
   type CreateLanguageEngagement,
@@ -472,7 +478,7 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
     if (!this.executor.applyReadFilter(this.resource, conditions)) {
       return EMPTY_PAGE;
     }
-    conditions.push(...engagementFilterClauses(input.filter));
+    conditions.push(...engagementFilterClauses(this.db, input.filter));
 
     const sortColumns = {
       status: engagements.status,
@@ -854,10 +860,12 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
  * returns the full unfiltered set and nothing catches it).
  * migration-todo: implement the throwing ones as their domains land —
  * name/engagedName (language/user name joins), startDate/endDate ranges
- * (COALESCE with the project mou window), project/language/intern sub-filter
- * composition, tool sub-filter (ToolUsage not migrated).
+ * (COALESCE with the project mou window), tool sub-filter (ToolUsage not
+ * migrated). project/language/intern sub-filter composition is wired below,
+ * now that Project/Language/User have all landed.
  */
 export const engagementFilterClauses = (
+  db: DrizzleDb,
   filter: EngagementListInput['filter'],
 ): SQL[] => {
   const conditions: SQL[] = [];
@@ -874,15 +882,14 @@ export const engagementFilterClauses = (
     conditions.push(inArray(engagements.status, [...filter.status]));
   }
   if (filter.project) {
-    const { id: projectId, ...projectRest } = filter.project;
-    if (projectId) {
-      conditions.push(eq(engagements.projectId, projectId));
-    }
-    if (Object.values(projectRest).some((value) => value !== undefined)) {
-      throw new NotImplementedException(
-        'EngagementFilters.project sub-filters beyond `id` are not implemented for postgres yet',
-      );
-    }
+    conditions.push(
+      subFilter(
+        db,
+        engagements.projectId,
+        projects,
+        projectFilterClauses(db, filter.project),
+      ),
+    );
   }
   if (filter.languageId) {
     conditions.push(eq(engagements.languageId, filter.languageId));
@@ -915,13 +922,31 @@ export const engagementFilterClauses = (
       ]),
     );
   }
+  if (filter.language) {
+    conditions.push(
+      subFilter(
+        db,
+        engagements.languageId,
+        languages,
+        languageFilterClauses(db, filter.language),
+      ),
+    );
+  }
+  if (filter.intern) {
+    conditions.push(
+      subFilter(
+        db,
+        engagements.internId,
+        users,
+        userFilterClauses(db, filter.intern),
+      ),
+    );
+  }
   const unimplemented = {
     name: filter.name,
     engagedName: filter.engagedName,
     startDate: filter.startDate,
     endDate: filter.endDate,
-    language: filter.language,
-    intern: filter.intern,
     tool: filter.tool,
   };
   for (const [key, value] of Object.entries(unimplemented)) {

--- a/src/components/field-region/field-region.drizzle.repository.ts
+++ b/src/components/field-region/field-region.drizzle.repository.ts
@@ -149,6 +149,9 @@ export const fieldRegionFilterClauses = (
 ): SQL[] => {
   const conditions: SQL[] = [];
   if (!filter) return conditions;
+  if (filter.id) {
+    conditions.push(eq(fieldRegions.id, filter.id));
+  }
   if (filter.name) {
     conditions.push(
       ilike(fieldRegions.name, `%${escapeLikePattern(filter.name)}%`),

--- a/src/components/file/file.drizzle.repository.ts
+++ b/src/components/file/file.drizzle.repository.ts
@@ -9,7 +9,11 @@ import {
   NotFoundException,
 } from '~/common';
 import { Identity } from '~/core/authentication';
-import { DrizzleService, resolveOrderBy } from '~/core/drizzle';
+import {
+  DrizzleService,
+  escapeLikePattern,
+  resolveOrderBy,
+} from '~/core/drizzle';
 import { fileNodes } from '~/core/drizzle/schema';
 import { LiveQueryStore } from '~/core/live-query';
 import { type BaseNode } from '~/core/neo4j/results';
@@ -116,7 +120,9 @@ export class FileDrizzleRepository {
       sql`${fileNodes.deletedAt} is null`,
     ];
     if (input.filter?.name) {
-      conditions.push(ilike(fileNodes.name, `%${input.filter.name}%`));
+      conditions.push(
+        ilike(fileNodes.name, `%${escapeLikePattern(input.filter.name)}%`),
+      );
     }
     if (input.filter?.type) {
       conditions.push(eq(fileNodes.type, input.filter.type));

--- a/src/components/file/file.drizzle.repository.ts
+++ b/src/components/file/file.drizzle.repository.ts
@@ -205,10 +205,13 @@ export class FileDrizzleRepository {
     public: isPublic,
   }: {
     // `resource` + `relation` describe the attachment point in Neo4j (an
-    // incoming `[relation]` edge from the owning BaseNode). Under PG there is no
-    // back-edge yet — rootAttachedTo is resolved by reverse-lookup in PR #2 once
-    // the consuming FK columns (projects.root_directory_id, …) land.
-    // migration-todo (PR #2): wire the attachment so rootAttachedTo resolves.
+    // incoming `[relation]` edge from the owning BaseNode). Under PG this is a
+    // no-op: the consuming domain's own repo writes the FK column directly
+    // (e.g. `project.drizzle.repository.ts` sets `rootDirectoryId`), and
+    // `resolveFileRootAttachments` resolves `rootAttachedTo` at read time by
+    // reverse-looking-up which row's FK points at this id — see
+    // `resolve-file-attachment.ts`. Kept only for interface parity with the
+    // Neo4j repo's signature.
     resource: unknown;
     relation: string;
     name: string;
@@ -238,10 +241,10 @@ export class FileDrizzleRepository {
     fileId: ID;
     name: string;
     parentId?: ID;
-    // propOfNode is a no-op under PG in PR #1: the consuming-domain FK is written
-    // by that domain in PR #2 (file_nodes has no back-edge). createDefinedFile
-    // isn't exercised under PG until then.
-    // migration-todo (PR #2): honor propOfNode via the consuming FK column.
+    // propOfNode is a no-op under PG, same reasoning as `resource`/`relation`
+    // on `createRootDirectory` above: the consuming domain's own repo writes
+    // its FK column directly, and reverse-lookup resolves the attachment at
+    // read time. Kept only for interface parity with the Neo4j repo.
     propOfNode?: [baseNodeId: ID, propertyName: string];
     public?: boolean;
   }): Promise<ID> {

--- a/src/components/file/media/media.drizzle.repository.ts
+++ b/src/components/file/media/media.drizzle.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { and, desc, eq, inArray, ne, or, type SQL } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, ne, or, type SQL } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import type { Except, RequireAtLeastOne } from 'type-fest';
 import {
@@ -147,11 +147,11 @@ export class MediaDrizzleRepository {
   }
 
   /**
-   * The altText/caption of the most recently created OTHER FileVersion under
-   * the same parent File that has its own media row — the carryover source
-   * for a newly uploaded version. Mirrors Neo4j's `prevMedia` match
+   * The altText/caption of the most recently created OTHER live FileVersion
+   * under the same parent File that has its own media row — the carryover
+   * source for a newly uploaded version. Mirrors Neo4j's `prevMedia` match
    * (`fv -> parent -> file <- parent - fvs -> media -> prevMedia`, latest
-   * `fvs.createdAt` wins).
+   * `fvs.createdAt` wins, `id` breaking ties on equal timestamps).
    */
   private async previousVersionMetadata(
     fileVersionId: ID,
@@ -172,9 +172,10 @@ export class MediaDrizzleRepository {
         and(
           eq(fileNodes.parentId, current.parentId),
           ne(fileNodes.id, fileVersionId),
+          isNull(fileNodes.deletedAt),
         ),
       )
-      .orderBy(desc(fileNodes.createdAt))
+      .orderBy(desc(fileNodes.createdAt), desc(fileNodes.id))
       .limit(1);
     return previous;
   }

--- a/src/components/file/media/media.drizzle.repository.ts
+++ b/src/components/file/media/media.drizzle.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { eq, inArray, or, type SQL } from 'drizzle-orm';
+import { and, desc, eq, inArray, ne, or, type SQL } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import type { Except, RequireAtLeastOne } from 'type-fest';
 import {
@@ -90,6 +90,14 @@ export class MediaDrizzleRepository {
         throw new ServerException('Media save requires a file version');
       }
       const values = toDbValues(input);
+      // A brand-new FileVersion's media row starts with no altText/caption of
+      // its own — carry forward the most recent sibling version's, same as
+      // Neo4j's save() (`prevMedia` sourced from the parent File's other
+      // FileVersions). Only fills the INSERT branch: an explicit value in
+      // `values` still overrides it below, and a conflict (re-run of the same
+      // upload) only re-applies `values`, never re-pulls carryover over a
+      // meanwhile-edited row.
+      const previous = await this.previousVersionMetadata(input.file);
       await this.db
         .insert(media)
         .values({
@@ -97,6 +105,8 @@ export class MediaDrizzleRepository {
           fileVersionId: input.file,
           type: input.__typename,
           mimeType: input.mimeType ?? '',
+          altText: previous?.altText ?? null,
+          caption: previous?.caption ?? null,
           ...values,
         })
         .onConflictDoUpdate({ target: media.fileVersionId, set: values });
@@ -134,6 +144,39 @@ export class MediaDrizzleRepository {
     return await this.readOne(
       input.id ? { id: input.id } : { file: input.file! },
     );
+  }
+
+  /**
+   * The altText/caption of the most recently created OTHER FileVersion under
+   * the same parent File that has its own media row — the carryover source
+   * for a newly uploaded version. Mirrors Neo4j's `prevMedia` match
+   * (`fv -> parent -> file <- parent - fvs -> media -> prevMedia`, latest
+   * `fvs.createdAt` wins).
+   */
+  private async previousVersionMetadata(
+    fileVersionId: ID,
+  ): Promise<Pick<MediaRow, 'altText' | 'caption'> | undefined> {
+    const [current] = await this.db
+      .select({ parentId: fileNodes.parentId })
+      .from(fileNodes)
+      .where(eq(fileNodes.id, fileVersionId))
+      .limit(1);
+    if (!current?.parentId) {
+      return undefined;
+    }
+    const [previous] = await this.db
+      .select({ altText: media.altText, caption: media.caption })
+      .from(fileNodes)
+      .innerJoin(media, eq(media.fileVersionId, fileNodes.id))
+      .where(
+        and(
+          eq(fileNodes.parentId, current.parentId),
+          ne(fileNodes.id, fileVersionId),
+        ),
+      )
+      .orderBy(desc(fileNodes.createdAt))
+      .limit(1);
+    return previous;
   }
 
   async getBaseNode(

--- a/src/components/organization/organization.drizzle.repository.ts
+++ b/src/components/organization/organization.drizzle.repository.ts
@@ -7,6 +7,7 @@ import {
   type PaginatedListType,
   type UnsecuredDto,
 } from '~/common';
+import { Identity } from '~/core/authentication';
 import {
   catchUniqueViolation,
   DrizzleDtoRepository,
@@ -21,7 +22,9 @@ import {
   organizations,
   userOrganizations,
 } from '~/core/drizzle/schema';
+import { type ScopedRole } from '../authorization/dto/role.dto';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import { requesterScopeByOrganization } from '../project/project-member/membership-scope';
 import {
   type CreateOrganization,
   Organization,
@@ -44,8 +47,39 @@ export class OrganizationDrizzleRepository extends DrizzleDtoRepository<
   constructor(
     db: DrizzleService,
     private readonly executor: PolicyExecutor,
+    private readonly identity: Identity,
   ) {
     super(db, organizations, Organization);
+  }
+
+  /**
+   * Attaches each org's `scope` — the requesting user's project-membership
+   * roles unioned across every project reachable via a live Partnership. The
+   * base class's `readMany` doesn't know about this, so it's overridden here
+   * (mirroring Ceremony/ProjectMember's overrides for their own extra joins).
+   * Without it, `member`-gated policies (e.g. FinancialAnalyst reading a
+   * High-sensitivity org) throw `MissingContextException` instead of
+   * evaluating membership, because `getScope()` finds no `scope` on the DTO.
+   */
+  override async readMany(
+    ids: readonly ID[],
+  ): Promise<Array<UnsecuredDto<Organization>>> {
+    if (ids.length === 0) return [];
+    const rows = await this.db
+      .select()
+      .from(organizations)
+      .where(
+        and(
+          inArray(organizations.id, [...ids]),
+          isNull(organizations.deletedAt),
+        ),
+      );
+    const scopeByOrg = await requesterScopeByOrganization(
+      this.db,
+      this.identity.current.userId,
+      rows.map((row) => row.id),
+    );
+    return rows.map((row) => this.toDto(row, scopeByOrg.get(row.id) ?? []));
   }
 
   async create(input: CreateOrganization): Promise<UnsecuredDto<Organization>> {
@@ -115,17 +149,21 @@ export class OrganizationDrizzleRepository extends DrizzleDtoRepository<
       page: input.page,
       count: input.count,
     });
+    if (rows.length === 0) return { total, items: [], hasMore };
+    const items = await this.readMany(rows.map((row) => row.id));
+    const byId = new Map(items.map((item) => [item.id, item]));
     return {
       total,
-      items: rows.map((row) => this.toDto(row)),
+      items: rows.map((row) => byId.get(row.id)!).filter(Boolean),
       hasMore,
     };
   }
 
   protected toDto(
     row: typeof organizations.$inferSelect,
+    scope: ScopedRole[] = [],
   ): UnsecuredDto<Organization> {
-    return {
+    const dto: unknown = {
       id: row.id,
       __typename: 'Organization',
       createdAt: DateTime.fromJSDate(row.createdAt),
@@ -135,7 +173,9 @@ export class OrganizationDrizzleRepository extends DrizzleDtoRepository<
       types: row.types,
       reach: row.reach,
       sensitivity: row.sensitivity,
+      scope,
     };
+    return dto as UnsecuredDto<Organization>;
   }
 }
 

--- a/src/components/partner/partner.drizzle.repository.ts
+++ b/src/components/partner/partner.drizzle.repository.ts
@@ -46,6 +46,7 @@ import {
   partners,
   userOrganizations,
 } from '~/core/drizzle/schema';
+import { type ScopedRole } from '../authorization/dto/role.dto';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import { type FinanceDepartmentIdBlock } from '../finance/department/dto/id-blocks.dto';
 import { type FinanceDepartmentIdBlockInput } from '../finance/department/dto/id-blocks.input';
@@ -54,6 +55,7 @@ import {
   organizationSortColumns,
 } from '../organization/organization.drizzle.repository';
 import { pinnedByRequester, pinnedFilter } from '../pin/pinned-by-requester';
+import { requesterScopeByPartner } from '../project/project-member/membership-scope';
 import {
   type CreatePartner,
   Partner,
@@ -69,6 +71,7 @@ type PartnerRow = typeof partners.$inferSelect & {
   languagesOfConsulting: Array<{ languageId: ID<'Language'> }>;
   departmentIdBlock: typeof departmentIdBlocks.$inferSelect | null;
   pinned?: boolean;
+  scope?: ScopedRole[];
 };
 
 @Injectable()
@@ -274,13 +277,28 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
         departmentIdBlock: true,
       },
     });
-    const pinnedSet = await pinnedByRequester(
-      this.db,
-      this.identity.current.userId,
-      rows.map((r) => r.id),
-    );
+    const [pinnedSet, scopeByPartner] = await Promise.all([
+      pinnedByRequester(
+        this.db,
+        this.identity.current.userId,
+        rows.map((r) => r.id),
+      ),
+      // Attaches `scope` so `member`-gated policies (e.g. FinancialAnalyst
+      // reading a High-sensitivity partner) can evaluate membership instead
+      // of throwing `MissingContextException` — see the Organization repo's
+      // sibling override for the full rationale.
+      requesterScopeByPartner(
+        this.db,
+        this.identity.current.userId,
+        rows.map((r) => r.id),
+      ),
+    ]);
     return rows.map((row) =>
-      this.toDto({ ...row, pinned: pinnedSet.has(row.id) }),
+      this.toDto({
+        ...row,
+        pinned: pinnedSet.has(row.id),
+        scope: scopeByPartner.get(row.id) ?? [],
+      }),
     );
   }
 
@@ -564,7 +582,7 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
    * relational shape. `readMany` always passes the enriched row.
    */
   protected toDto(row: PartnerRow): UnsecuredDto<Partner> {
-    return {
+    const dto: unknown = {
       id: row.id,
       __typename: 'Partner',
       createdAt: DateTime.fromJSDate(row.createdAt),
@@ -612,7 +630,11 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
       // Per-requester pin state — populated by readMany/list via
       // pinnedByRequester; other internal paths leave it false.
       pinned: row.pinned ?? false,
+      // Populated by readMany via requesterScopeByPartner; other internal
+      // paths (none currently bypass readMany) would leave it empty.
+      scope: row.scope ?? [],
     };
+    return dto as UnsecuredDto<Partner>;
   }
 }
 

--- a/src/components/partnership/partnership.drizzle.repository.ts
+++ b/src/components/partnership/partnership.drizzle.repository.ts
@@ -111,7 +111,7 @@ export class PartnershipDrizzleRepository extends DrizzleDtoRepository<
   async create(
     input: CreatePartnership,
     _changeset?: ID,
-  ): Promise<{ id: ID; primary: boolean }> {
+  ): Promise<{ id: ID; primary: boolean; displaced: Array<{ id: ID }> }> {
     await this.verifyRelationshipEligibility(input.project, input.partner);
 
     const id = await generateId<ID<'Partnership'>>();
@@ -142,10 +142,32 @@ export class PartnershipDrizzleRepository extends DrizzleDtoRepository<
     // follow that outcome, not the request. See T1-8: trusting the request
     // here previously let a losing race wipe the winner's primary too.
     let primary = values.primary;
+    let displaced: Array<{ id: ID }> = [];
     try {
       // Nested transaction = savepoint, so a primary-race conflict below
       // doesn't poison the surrounding mutation transaction.
       await this.db.transaction(async (tx) => {
+        if (values.primary) {
+          // Claim primary atomically: clear whoever currently holds it for
+          // this project *before* inserting, in the same transaction — the
+          // ordinary sequential case (a caller just asking a new partnership
+          // to become primary) is not a race, and treating it like one used
+          // to always lose to the existing holder (unique-index violation
+          // on insert, silently caught, downgraded to non-primary). A true
+          // concurrent create still conflicts on the insert below and falls
+          // through to the catch, same as before.
+          displaced = (await tx
+            .update(partnerships)
+            .set({ primary: false, updatedAt: new Date() })
+            .where(
+              and(
+                eq(partnerships.projectId, input.project),
+                eq(partnerships.primary, true),
+                isNull(partnerships.deletedAt),
+              ),
+            )
+            .returning({ id: partnerships.id })) as Array<{ id: ID }>;
+        }
         await tx.insert(partnerships).values(values);
       });
     } catch (e) {
@@ -154,8 +176,11 @@ export class PartnershipDrizzleRepository extends DrizzleDtoRepository<
         isUniqueViolation(e, 'partnerships_project_primary_active_unique')
       ) {
         // Lost the primary race — a concurrent create on the same project
-        // already claimed primary (the service's isFirstPartnership check
-        // isn't atomic). Yield and create this one as non-primary.
+        // claimed primary between our clear above and our insert (the
+        // service's isFirstPartnership check isn't atomic either). The
+        // failed transaction rolled the clear back too, so nothing was
+        // actually displaced. Yield and create this one as non-primary.
+        displaced = [];
         await this.db
           .insert(partnerships)
           .values({ ...values, primary: false })
@@ -177,7 +202,7 @@ export class PartnershipDrizzleRepository extends DrizzleDtoRepository<
       input.agreement,
     );
 
-    return { id, primary };
+    return { id, primary, displaced };
   }
 
   /**

--- a/src/components/partnership/partnership.drizzle.repository.ts
+++ b/src/components/partnership/partnership.drizzle.repository.ts
@@ -108,7 +108,10 @@ export class PartnershipDrizzleRepository extends DrizzleDtoRepository<
    * `changeset` accepted for splitDb signature parity; PCR/Changeset is
    * excluded from the migration entirely, so it's silently ignored.
    */
-  async create(input: CreatePartnership, _changeset?: ID): Promise<{ id: ID }> {
+  async create(
+    input: CreatePartnership,
+    _changeset?: ID,
+  ): Promise<{ id: ID; primary: boolean }> {
     await this.verifyRelationshipEligibility(input.project, input.partner);
 
     const id = await generateId<ID<'Partnership'>>();
@@ -132,6 +135,13 @@ export class PartnershipDrizzleRepository extends DrizzleDtoRepository<
       financialReportingType: input.financialReportingType ?? null,
       primary: input.primary ?? false,
     };
+    // Reported back to the caller so PartnershipService.create() can key off
+    // the actual persisted value instead of its own pre-computed guess — the
+    // catch block below can flip this to false after the fact, and the
+    // service's decision to strip primary from every OTHER partnership must
+    // follow that outcome, not the request. See T1-8: trusting the request
+    // here previously let a losing race wipe the winner's primary too.
+    let primary = values.primary;
     try {
       // Nested transaction = savepoint, so a primary-race conflict below
       // doesn't poison the surrounding mutation transaction.
@@ -152,6 +162,7 @@ export class PartnershipDrizzleRepository extends DrizzleDtoRepository<
           .catch((e2) => {
             throw new CreationFailed(Partnership, { cause: e2 as Error });
           });
+        primary = false;
       } else {
         throw new CreationFailed(Partnership, { cause: e as Error });
       }
@@ -166,7 +177,7 @@ export class PartnershipDrizzleRepository extends DrizzleDtoRepository<
       input.agreement,
     );
 
-    return { id };
+    return { id, primary };
   }
 
   /**

--- a/src/components/partnership/partnership.gel.repository.ts
+++ b/src/components/partnership/partnership.gel.repository.ts
@@ -40,8 +40,9 @@ export class PartnershipGelRepository
       agreement: undefined, // TODO
     });
     // No unique-constraint race here, same as the Neo4j repo — see its
-    // create() for the full rationale on why this is reported back.
-    return { ...result, primary: input.primary ?? false };
+    // create() for the full rationale on why this is reported back, and on
+    // why `displaced` is always empty for this engine.
+    return { ...result, primary: input.primary ?? false, displaced: [] };
   }
 
   async readManyByProjectAndPartner(

--- a/src/components/partnership/partnership.gel.repository.ts
+++ b/src/components/partnership/partnership.gel.repository.ts
@@ -32,13 +32,16 @@ export class PartnershipGelRepository
 {
   async create(input: CreatePartnership) {
     const project = e.cast(e.Project, e.uuid(input.project));
-    return await this.defaults.create({
+    const result = await this.defaults.create({
       ...input,
       project,
       projectContext: project.projectContext,
       mou: undefined, // TODO
       agreement: undefined, // TODO
     });
+    // No unique-constraint race here, same as the Neo4j repo — see its
+    // create() for the full rationale on why this is reported back.
+    return { ...result, primary: input.primary ?? false };
   }
 
   async readManyByProjectAndPartner(

--- a/src/components/partnership/partnership.repository.ts
+++ b/src/components/partnership/partnership.repository.ts
@@ -115,7 +115,13 @@ export class PartnershipRepository extends DtoRepository<
     // back so the service can key off the actual outcome rather than its own
     // pre-computed guess, matching the Postgres repo's contract (whose
     // create() can silently fall back to false on a primary-race conflict).
-    return { ...result, primary: input.primary ?? false };
+    //
+    // `displaced` is always empty here — unlike Postgres, this repo doesn't
+    // clear other partnerships itself; the service's separate post-create
+    // `removePrimaryFromOtherPartnerships` call still does that for Neo4j.
+    // The field exists purely so the service can read it uniformly across
+    // engines instead of branching on which one is active.
+    return { ...result, primary: input.primary ?? false, displaced: [] };
   }
 
   async update(

--- a/src/components/partnership/partnership.repository.ts
+++ b/src/components/partnership/partnership.repository.ts
@@ -110,7 +110,12 @@ export class PartnershipRepository extends DtoRepository<
       input.agreement,
     );
 
-    return result;
+    // No unique-constraint race here — Neo4j has no DB-level "at most one
+    // primary" backstop, so the requested flag always lands as-is. Reported
+    // back so the service can key off the actual outcome rather than its own
+    // pre-computed guess, matching the Postgres repo's contract (whose
+    // create() can silently fall back to false on a primary-race conflict).
+    return { ...result, primary: input.primary ?? false };
   }
 
   async update(

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -94,7 +94,14 @@ export class PartnershipService {
         changeset,
       );
 
-      if (primary) {
+      // Use the repo's reported outcome, not the request: a concurrent
+      // create on the same project can win the primary race between our
+      // `isFirstPartnership` check and the insert, so `result.primary` can
+      // be false even when the local `primary` above is true. Stripping
+      // every other partnership's primary flag off the strength of the
+      // request alone would wipe the actual winner's flag too, leaving the
+      // project with zero primaries.
+      if (result.primary) {
         const other = await this.repo.removePrimaryFromOtherPartnerships(
           result.id,
         );

--- a/src/components/partnership/partnership.service.ts
+++ b/src/components/partnership/partnership.service.ts
@@ -102,11 +102,20 @@ export class PartnershipService {
       // request alone would wipe the actual winner's flag too, leaving the
       // project with zero primaries.
       if (result.primary) {
+        // Postgres already displaced the old primary atomically inside
+        // create() (see its docs for why); this call is a no-op there since
+        // there's nothing left to clear. Neo4j/Gel have no such backstop and
+        // still rely on this call to actually do the clearing. Union both so
+        // every displaced partnership gets its live queries invalidated
+        // regardless of which engine handled it.
         const other = await this.repo.removePrimaryFromOtherPartnerships(
           result.id,
         );
+        const displaced = new Map(
+          [...result.displaced, ...other].map((r) => [r.id, r]),
+        );
         this.liveQueryStore.invalidateAll(
-          other.map((r) => ['Partnership', r.id]),
+          [...displaced.values()].map((r) => ['Partnership', r.id]),
         );
       }
 

--- a/src/components/periodic-report/periodic-report.drizzle.repository.ts
+++ b/src/components/periodic-report/periodic-report.drizzle.repository.ts
@@ -605,7 +605,9 @@ const hasUploadedFileVersion = () =>
       and fv.deleted_at is null
   )`;
 
-const dateFilterConditions = (
+// Exported for reuse by ProgressReportDrizzleRepository, which filters the
+// same `start`/`end` columns on this same table under its own filter shape.
+export const dateFilterConditions = (
   column: typeof periodicReports.start | typeof periodicReports.end,
   filter: DateFilter | undefined,
 ): SQL[] => {

--- a/src/components/periodic-report/periodic-report.module.ts
+++ b/src/components/periodic-report/periodic-report.module.ts
@@ -37,6 +37,14 @@ import { PeriodicReportService } from './periodic-report.service';
     BackfillPeriodicReportNarrativeFileMigration,
     ...Object.values(handlers),
   ],
-  exports: [PeriodicReportService],
+  exports: [
+    PeriodicReportService,
+    // Needed by ProgressReportDrizzleRepository — after computing its own
+    // filtered/paginated id set, it hydrates through the shared
+    // periodic_reports read path rather than duplicating toDto/scope/parent
+    // logic. Same cross-module pattern as UserModule exporting UserRepository
+    // for ProjectMemberDrizzleRepository.
+    PeriodicReportRepository,
+  ],
 })
 export class PeriodicReportModule {}

--- a/src/components/pnp/extraction-result/pnp-extraction-result.drizzle.repository.ts
+++ b/src/components/pnp/extraction-result/pnp-extraction-result.drizzle.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { type ID } from '~/common';
 import { DrizzleService } from '~/core/drizzle/drizzle.service';
 import {
@@ -48,6 +48,17 @@ export class PnpExtractionResultDrizzleRepository {
       this.db
         .select({ fileId: pnpExtractionResults.fileId })
         .from(pnpExtractionResults)
+        // The file has to still be live — a soft-deleted File's row survives
+        // (the cascade never fires, since the delete is soft), and without
+        // this join a removed report's PnP result would keep resolving where
+        // Neo4j's parent-required match returns nothing.
+        .innerJoin(
+          fileNodes,
+          and(
+            eq(fileNodes.id, pnpExtractionResults.fileId),
+            isNull(fileNodes.deletedAt),
+          ),
+        )
         .where(inArray(pnpExtractionResults.fileId, ids)),
       this.db
         .select()

--- a/src/components/post/post.drizzle.repository.ts
+++ b/src/components/post/post.drizzle.repository.ts
@@ -150,6 +150,10 @@ export class PostDrizzleRepository extends DrizzleDtoRepository<
   async deleteNode(objectOrId: { id: ID } | ID): Promise<void> {
     const id = typeof objectOrId === 'string' ? objectOrId : objectOrId.id;
     await this.db.delete(posts).where(eq(posts.id, id as ID<'Post'>));
+    // Hand-rolled delete (a hard delete, not the base's softDelete()), so it
+    // has to invalidate itself — see the base class's doc comment on why
+    // updateColumns()/softDelete() can't cover this for us.
+    this.liveQueryStore.invalidate([this.resource, id]);
   }
 
   /**

--- a/src/components/progress-report/progress-report.drizzle.repository.ts
+++ b/src/components/progress-report/progress-report.drizzle.repository.ts
@@ -28,6 +28,7 @@ import {
   periodicReports,
   pnpExtractionResultProblems,
   progressSummaries,
+  projects,
 } from '~/core/drizzle/schema';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import { engagementFilterClauses } from '../engagement/engagement.drizzle.repository';
@@ -84,6 +85,17 @@ export class ProgressReportDrizzleRepository {
     const conditions: SQL[] = [
       isNull(periodicReports.deletedAt),
       eq(periodicReports.type, 'Progress'),
+      // Keep this page/total in sync with PeriodicReportRepository.readMany()'s
+      // own liveness gate (liveReportIds) — without it, a report under a
+      // soft-deleted engagement/project inflates `total` and consumes a page
+      // slot that readMany() then silently drops, short-changing the page.
+      sql`exists (
+        select 1 from ${engagements}
+        inner join ${projects} on ${projects.id} = ${engagements.projectId}
+        where ${engagements.id} = ${periodicReports.engagementId}
+          and ${engagements.deletedAt} is null
+          and ${projects.deletedAt} is null
+      )`,
     ];
     if (!this.executor.applyReadFilter(this.resource, conditions)) {
       return EMPTY_PAGE;

--- a/src/components/progress-report/progress-report.drizzle.repository.ts
+++ b/src/components/progress-report/progress-report.drizzle.repository.ts
@@ -135,6 +135,10 @@ export class ProgressReportDrizzleRepository {
       receivedDate: periodicReports.receivedDate,
       narrativeReceivedDate: periodicReports.narrativeReceivedDate,
       createdAt: periodicReports.createdAt,
+      // migration-todo: engagement.*, pnpExtractionResult.*, cumulativeSummary,
+      // fiscalYearSummary, periodSummary delegated/cross-domain sorts — same
+      // shape as the Engagement repo's own deferred sort keys (see its
+      // migration-todo comment). Unknown keys fall back to `start`.
     } satisfies SortMap<string>;
 
     const predicate = and(...conditions);

--- a/src/components/progress-report/progress-report.drizzle.repository.ts
+++ b/src/components/progress-report/progress-report.drizzle.repository.ts
@@ -1,0 +1,217 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  and,
+  asc,
+  count,
+  eq,
+  inArray,
+  isNull,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
+import {
+  EnhancedResource,
+  type ID,
+  type PaginatedListType,
+  type UnsecuredDto,
+} from '~/common';
+import {
+  EMPTY_PAGE,
+  resolveOrderBy,
+  type SortMap,
+  subFilter,
+} from '~/core/drizzle';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import {
+  engagements,
+  periodicReports,
+  pnpExtractionResultProblems,
+  progressSummaries,
+} from '~/core/drizzle/schema';
+import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
+import { engagementFilterClauses } from '../engagement/engagement.drizzle.repository';
+import {
+  dateFilterConditions,
+  type PeriodicReportDrizzleRepository,
+} from '../periodic-report/periodic-report.drizzle.repository';
+import { PeriodicReportRepository } from '../periodic-report/periodic-report.repository';
+import { PnpProblemType } from '../pnp/extraction-result/extraction-result.dto';
+import { ScheduleStatus, SummaryPeriod } from '../progress-summary/dto';
+import { ProgressReport, type ProgressReportListInput } from './dto';
+
+const ERROR_PROBLEM_TYPE_IDS = () =>
+  [...PnpProblemType.types.values()]
+    .filter((type) => type.severity === 'Error')
+    .map((type) => type.id);
+
+/**
+ * Postgres implementation of the top-level `progressReports` query.
+ *
+ * Deliberately does NOT declare `implements PublicOf<ProgressReportRepository>`
+ * and does not extend `DrizzleDtoRepository`: the service only ever calls
+ * `.list()` on the canonical repo (readOne/create/update/delete all go through
+ * PeriodicReportRepository, since Progress rows share the `periodic_reports`
+ * table with every other report type). Same approach as
+ * PartnershipProducingMediumDrizzleRepository.
+ *
+ * Hydration is delegated to PeriodicReportRepository.readMany() rather than
+ * reimplemented here — its toDto() already produces a full ProgressReport
+ * shape (__typename, status, parent, scope, sensitivity) for `type: 'Progress'`
+ * rows. This repo's own job is just resolving ProgressReportFilters (a
+ * strictly richer shape than PeriodicReportListInput's filter) into the
+ * matching id set.
+ */
+@Injectable()
+export class ProgressReportDrizzleRepository {
+  private readonly resource = EnhancedResource.of(ProgressReport);
+
+  constructor(
+    private readonly drizzle: DrizzleService,
+    private readonly executor: PolicyExecutor,
+    @Inject(PeriodicReportRepository)
+    private readonly periodicReportRepo: PeriodicReportDrizzleRepository,
+  ) {}
+
+  private get db() {
+    return this.drizzle.client;
+  }
+
+  async list(
+    input: ProgressReportListInput,
+  ): Promise<PaginatedListType<UnsecuredDto<ProgressReport>>> {
+    const conditions: SQL[] = [
+      isNull(periodicReports.deletedAt),
+      eq(periodicReports.type, 'Progress'),
+    ];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+
+    const filter = input.filter;
+    if (filter?.parent) {
+      conditions.push(
+        eq(periodicReports.engagementId, filter.parent as ID<'Engagement'>),
+      );
+    }
+    conditions.push(
+      ...dateFilterConditions(periodicReports.start, filter?.start),
+    );
+    conditions.push(...dateFilterConditions(periodicReports.end, filter?.end));
+    if (filter?.status?.length) {
+      conditions.push(inArray(periodicReports.status, [...filter.status]));
+    }
+    if (filter?.cumulativeSummary?.scheduleStatus?.length) {
+      const condition = cumulativeScheduleStatusCondition(
+        filter.cumulativeSummary.scheduleStatus,
+      );
+      if (condition) conditions.push(condition);
+    }
+    if (filter?.engagement) {
+      conditions.push(
+        subFilter(
+          this.db,
+          periodicReports.engagementId,
+          engagements,
+          engagementFilterClauses(this.db, filter.engagement),
+        ),
+      );
+    }
+    if (filter?.pnpExtractionResult?.hasError != null) {
+      conditions.push(
+        pnpHasErrorCondition(filter.pnpExtractionResult.hasError),
+      );
+    }
+
+    const sortColumns = {
+      start: periodicReports.start,
+      end: periodicReports.end,
+      status: periodicReports.status,
+      receivedDate: periodicReports.receivedDate,
+      narrativeReceivedDate: periodicReports.narrativeReceivedDate,
+      createdAt: periodicReports.createdAt,
+    } satisfies SortMap<string>;
+
+    const predicate = and(...conditions);
+    const [countResult, rows] = await Promise.all([
+      this.db.select({ total: count() }).from(periodicReports).where(predicate),
+      this.db
+        .select({ id: periodicReports.id })
+        .from(periodicReports)
+        .where(predicate)
+        .orderBy(
+          ...resolveOrderBy(input, sortColumns, periodicReports.start),
+          asc(periodicReports.id),
+        )
+        .limit(input.count)
+        .offset((input.page - 1) * input.count),
+    ]);
+    const total = countResult[0]?.total ?? 0;
+    const hasMore = (input.page - 1) * input.count + rows.length < total;
+    if (rows.length === 0) return { total, items: [], hasMore };
+
+    const items = await this.periodicReportRepo.readMany(rows.map((r) => r.id));
+    const byId = new Map(items.map((item) => [item.id, item]));
+    return {
+      total,
+      hasMore,
+      items: rows.flatMap((r) => byId.get(r.id) ?? []) as Array<
+        UnsecuredDto<ProgressReport>
+      >,
+    };
+  }
+}
+
+/**
+ * Mirrors the Neo4j `progressSummaryFilters`'s `scheduleStatus` matcher: a
+ * report's cumulative-period summary (if any) buckets into Ahead/Behind/OnTime
+ * by `actual - planned`, using the same thresholds as
+ * `ScheduleStatus.fromVariance`. No cumulative summary row at all is its own
+ * `null` bucket.
+ */
+const cumulativeScheduleStatusCondition = (
+  statuses: ReadonlyArray<ScheduleStatus | null>,
+): SQL | undefined => {
+  const wanted = new Set(statuses);
+  if (wanted.size === 0) return undefined;
+
+  const variance = sql`(
+    select ${progressSummaries.actual} - ${progressSummaries.planned}
+    from ${progressSummaries}
+    where ${progressSummaries.reportId} = ${periodicReports.id}
+      and ${progressSummaries.period} = ${SummaryPeriod.Cumulative}
+  )`;
+
+  if (wanted.size === 1 && wanted.has(null)) {
+    return sql`(${variance}) is null`;
+  }
+
+  const branches: SQL[] = [];
+  if (wanted.has(null)) branches.push(sql`(${variance}) is null`);
+  if (wanted.has(ScheduleStatus.Ahead)) branches.push(sql`(${variance}) > 0.3`);
+  if (wanted.has(ScheduleStatus.Behind))
+    branches.push(sql`(${variance}) < -0.1`);
+  if (wanted.has(ScheduleStatus.OnTime)) {
+    branches.push(sql`(${variance}) between -0.1 and 0.3`);
+  }
+  return branches.length ? sql.join(branches, sql` or `) : undefined;
+};
+
+/**
+ * Mirrors the Neo4j `pnpExtractionResultFilters`'s `hasError`: does the
+ * report's `reportFile` have any recorded problem whose registered
+ * `PnpProblemType` severity is `Error`. Severity is a code-side registry
+ * (`PnpProblemType.types`), not a stored column, so the matching type ids are
+ * resolved once per call and inlined as the `IN` list.
+ */
+const pnpHasErrorCondition = (wantError: boolean): SQL => {
+  const errorTypeIds = ERROR_PROBLEM_TYPE_IDS();
+  if (errorTypeIds.length === 0) {
+    return wantError ? sql`false` : sql`true`;
+  }
+  const exists = sql`exists (
+    select 1 from ${pnpExtractionResultProblems}
+    where ${pnpExtractionResultProblems.fileId} = ${periodicReports.reportFileId}
+      and ${inArray(pnpExtractionResultProblems.type, errorTypeIds)}
+  )`;
+  return wantError ? exists : sql`not (${exists})`;
+};

--- a/src/components/progress-report/progress-report.drizzle.repository.ts
+++ b/src/components/progress-report/progress-report.drizzle.repository.ts
@@ -15,6 +15,7 @@ import {
   type PaginatedListType,
   type UnsecuredDto,
 } from '~/common';
+import { Identity } from '~/core/authentication';
 import {
   EMPTY_PAGE,
   resolveOrderBy,
@@ -68,6 +69,7 @@ export class ProgressReportDrizzleRepository {
   constructor(
     private readonly drizzle: DrizzleService,
     private readonly executor: PolicyExecutor,
+    private readonly identity: Identity,
     @Inject(PeriodicReportRepository)
     private readonly periodicReportRepo: PeriodicReportDrizzleRepository,
   ) {}
@@ -112,7 +114,11 @@ export class ProgressReportDrizzleRepository {
           this.db,
           periodicReports.engagementId,
           engagements,
-          engagementFilterClauses(this.db, filter.engagement),
+          engagementFilterClauses(
+            this.db,
+            filter.engagement,
+            this.identity.current.userId,
+          ),
         ),
       );
     }

--- a/src/components/progress-report/progress-report.module.ts
+++ b/src/components/progress-report/progress-report.module.ts
@@ -16,6 +16,7 @@ import { DropDuplicateMultiplicationProgressReportsMigration } from './migration
 import { DropInternshipProgressReportsMigration } from './migrations/drop-internship-progress-reports.migration';
 import { ReextractPnpProgressReportsMigration } from './migrations/reextract-all-progress-reports.migration';
 import { ProgressReportExtraForPeriodicInterfaceRepository } from './progress-report-extra-for-periodic-interface.repository';
+import { ProgressReportDrizzleRepository } from './progress-report.drizzle.repository';
 import { ProgressReportRepository } from './progress-report.repository';
 import { ProgressReportService } from './progress-report.service';
 import { ProgressReportEngagementConnectionResolver } from './resolvers/progress-report-engagement-connection.resolver';
@@ -62,7 +63,14 @@ import { ProgressReportWorkflowModule } from './workflow/progress-report-workflo
       postgres: ProgressReportCommunityStoryDrizzleRepository as any,
     }),
     ProgressReportService,
-    ProgressReportRepository,
+    splitDb(ProgressReportRepository, {
+      // migration-todo: `as any` removed at Phase 7 cutover when splitDb
+      // disappears with the Neo4j path. ProgressReportDrizzleRepository only
+      // implements `.list()` (the only method the service calls) — the rest
+      // of the Neo4j interface (readOne/create/update/delete) is unused here
+      // since those all route through PeriodicReportRepository instead.
+      postgres: ProgressReportDrizzleRepository as any,
+    }),
     ProgressReportExtraForPeriodicInterfaceRepository,
     BackfillMultiplicationProgressReportFilePublicMigration,
     DropDuplicateMultiplicationProgressReportsMigration,

--- a/src/components/progress-report/workflow/progress-report-workflow.drizzle.repository.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.drizzle.repository.ts
@@ -101,12 +101,11 @@ export class ProgressReportWorkflowDrizzleRepository {
       // `(node)-[:who]->(who:User)`, and soft-deleting a user relabels it to
       // `Deleted_User`, so the event simply does not come back there — one fewer
       // event, no error. Postgres keeps the row (the delete is soft, so the FK
-      // never fires) and then `who` cannot be loaded: the user loader filters
-      // soft-deleted users, `mapSecuredValue` has no not-found handling, and
-      // because `who` is non-null inside a non-null list the failure nulls the
-      // event, then the whole list, then its parent. Deleting a departed staff
-      // member would take out the workflow history of every report they ever
-      // touched. Hiding the event matches Neo4j rather than inventing a contract.
+      // never fires), and `mapSecuredValue` now degrades a missing `who` to a
+      // null field rather than throwing — so without this filter the event
+      // would still render, just with an authorless `who`. That's a new shape
+      // Neo4j never produces. Hiding the event matches Neo4j rather than
+      // inventing a contract.
       isNull(users.deletedAt),
       ...narrowing,
     ];

--- a/src/components/project/project-member/membership-scope.ts
+++ b/src/components/project/project-member/membership-scope.ts
@@ -1,7 +1,12 @@
 import { and, eq, inArray, isNull } from 'drizzle-orm';
-import { type ID } from '~/common';
+import { type ID, type Role } from '~/common';
 import { type DrizzleDb } from '~/core/drizzle/drizzle.service';
-import { projectMembers } from '~/core/drizzle/schema';
+import {
+  partners,
+  partnerships,
+  projectMembers,
+  projects,
+} from '~/core/drizzle/schema';
 import {
   rolesForScope,
   type ScopedRole,
@@ -42,4 +47,104 @@ export const requesterScopeByProject = async (
       ['member:true' as const, ...m.roles.map(rolesForScope('project'))],
     ]),
   );
+};
+
+/** Folds `(key, roles)` rows into one scope entry per key, de-duped. */
+const groupIntoScopeMap = <K extends ID>(
+  rows: ReadonlyArray<{ key: K; roles: readonly Role[] }>,
+): Map<K, ScopedRole[]> => {
+  const rolesByKey = new Map<K, Set<Role>>();
+  for (const row of rows) {
+    const roles = rolesByKey.get(row.key) ?? new Set<Role>();
+    row.roles.forEach((role) => roles.add(role));
+    rolesByKey.set(row.key, roles);
+  }
+  return new Map(
+    [...rolesByKey].map(([key, roles]) => [
+      key,
+      ['member:true' as const, ...[...roles].map(rolesForScope('project'))],
+    ]),
+  );
+};
+
+/**
+ * The requesting user's scoped roles across every project a Partner touches
+ * via a live Partnership — a Partner isn't itself project-scoped, so
+ * `requesterScopeByProject` doesn't apply. Mirrors Neo4j's Partner hydrate
+ * (unions scoped roles over every project reachable through a live
+ * partnership) and the `member` policy condition's bespoke Partner SQL in
+ * `member.condition.ts` — keep the join/liveness shape in lockstep with that.
+ */
+export const requesterScopeByPartner = async (
+  db: DrizzleDb,
+  userId: ID<'User'>,
+  partnerIds: ReadonlyArray<ID<'Partner'>>,
+): Promise<Map<ID<'Partner'>, ScopedRole[]>> => {
+  if (partnerIds.length === 0) return new Map();
+  const rows = await db
+    .select({ key: partnerships.partnerId, roles: projectMembers.roles })
+    .from(partnerships)
+    .innerJoin(
+      projects,
+      and(eq(projects.id, partnerships.projectId), isNull(projects.deletedAt)),
+    )
+    .innerJoin(
+      projectMembers,
+      and(
+        eq(projectMembers.projectId, partnerships.projectId),
+        eq(projectMembers.userId, userId),
+        isNull(projectMembers.inactiveAt),
+        isNull(projectMembers.deletedAt),
+      ),
+    )
+    .where(
+      and(
+        inArray(partnerships.partnerId, [...new Set(partnerIds)]),
+        isNull(partnerships.deletedAt),
+      ),
+    );
+  return groupIntoScopeMap(rows);
+};
+
+/**
+ * Same as {@link requesterScopeByPartner}, one hop further out: the
+ * Organization's own Partners, each's Partnerships, each's live Project.
+ * Mirrors the `member` condition's Organization SQL in `member.condition.ts`.
+ */
+export const requesterScopeByOrganization = async (
+  db: DrizzleDb,
+  userId: ID<'User'>,
+  organizationIds: ReadonlyArray<ID<'Organization'>>,
+): Promise<Map<ID<'Organization'>, ScopedRole[]>> => {
+  if (organizationIds.length === 0) return new Map();
+  const rows = await db
+    .select({ key: partners.organizationId, roles: projectMembers.roles })
+    .from(partners)
+    .innerJoin(
+      partnerships,
+      and(
+        eq(partnerships.partnerId, partners.id),
+        isNull(partnerships.deletedAt),
+      ),
+    )
+    .innerJoin(
+      projects,
+      and(eq(projects.id, partnerships.projectId), isNull(projects.deletedAt)),
+    )
+    .innerJoin(
+      projectMembers,
+      and(
+        eq(projectMembers.projectId, partnerships.projectId),
+        eq(projectMembers.userId, userId),
+        isNull(projectMembers.inactiveAt),
+        isNull(projectMembers.deletedAt),
+      ),
+    )
+    .where(
+      and(
+        inArray(partners.organizationId, [...new Set(organizationIds)]),
+        isNull(partners.deletedAt),
+      ),
+    );
+  return groupIntoScopeMap(rows);
 };

--- a/src/components/project/project-member/project-member.drizzle.repository.ts
+++ b/src/components/project/project-member/project-member.drizzle.repository.ts
@@ -172,7 +172,13 @@ export class ProjectMemberDrizzleRepository extends DrizzleDtoRepository<
     if (!this.executor.applyReadFilter(this.resource, conditions)) {
       return EMPTY_PAGE;
     }
-    conditions.push(...projectMemberFilterClauses(this.db, input.filter));
+    conditions.push(
+      ...projectMemberFilterClauses(
+        this.db,
+        input.filter,
+        this.identity.current.userId,
+      ),
+    );
 
     const sortColumns = {
       createdAt: projectMembers.createdAt,
@@ -482,6 +488,7 @@ export class ProjectMemberDrizzleRepository extends DrizzleDtoRepository<
 export const projectMemberFilterClauses = (
   db: DrizzleDb,
   filter: ProjectMemberFilters | undefined,
+  requesterId?: ID<'User'>,
 ): SQL[] => {
   const conditions: SQL[] = [];
   if (!filter) return conditions;
@@ -516,7 +523,7 @@ export const projectMemberFilterClauses = (
       .where(
         and(
           isNull(projects.deletedAt),
-          ...projectFilterClauses(db, filter.project),
+          ...projectFilterClauses(db, filter.project, requesterId),
         ),
       );
     conditions.push(inArray(projectMembers.projectId, sub));

--- a/src/components/project/project-member/project-member.drizzle.repository.ts
+++ b/src/components/project/project-member/project-member.drizzle.repository.ts
@@ -168,7 +168,18 @@ export class ProjectMemberDrizzleRepository extends DrizzleDtoRepository<
   async list(
     input: ProjectMemberListInput,
   ): Promise<PaginatedListType<UnsecuredDto<ProjectMember>>> {
-    const conditions: SQL[] = [isNull(projectMembers.deletedAt)];
+    const conditions: SQL[] = [
+      isNull(projectMembers.deletedAt),
+      // Keep this page/total in sync with readMany()'s own liveness gate
+      // below — without it, a member under a soft-deleted project inflates
+      // `total` and consumes a page slot that readMany() then silently drops,
+      // short-changing the page.
+      sql`exists (
+        select 1 from ${projects}
+        where ${projects.id} = ${projectMembers.projectId}
+          and ${projects.deletedAt} is null
+      )`,
+    ];
     if (!this.executor.applyReadFilter(this.resource, conditions)) {
       return EMPTY_PAGE;
     }

--- a/src/components/project/project-member/project-member.drizzle.repository.ts
+++ b/src/components/project/project-member/project-member.drizzle.repository.ts
@@ -96,6 +96,11 @@ export class ProjectMemberDrizzleRepository extends DrizzleDtoRepository<
     const readConditions: SQL[] = [
       inArray(projectMembers.id, [...ids]),
       isNull(projectMembers.deletedAt),
+      // A soft-deleted project leaves its members' rows untouched. Neo4j's
+      // hydrate requires a live `:Project`, so a dead one hides every
+      // membership under it rather than returning a full row (id, roles,
+      // scope, the embedded user) pointing at a project that's gone.
+      isNull(projects.deletedAt),
     ];
     if (!this.executor.applyReadFilter(this.resource, readConditions)) {
       return [];
@@ -103,6 +108,7 @@ export class ProjectMemberDrizzleRepository extends DrizzleDtoRepository<
     const readable = await this.db
       .select({ id: projectMembers.id })
       .from(projectMembers)
+      .innerJoin(projects, eq(projects.id, projectMembers.projectId))
       .where(and(...readConditions));
     if (readable.length === 0) return [];
     const readableIds = readable.map((row) => row.id);

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -733,8 +733,15 @@ const resolveCrossDomainSort = (
     return { table: fieldRegions, fkColumn: projects.fieldRegionId, column };
   }
   if (sort.startsWith('primaryPartnership.')) {
+    // Partnership HAS landed (its filters are wired below) — this message
+    // used to blame that, which is now misleading. The real blockers are
+    // the ones in this function's docblock: the FK points the other way
+    // (partnerships.project_id, not a column on projects), so it doesn't fit
+    // this helper's {table, fkColumn, column} shape, and there's still no
+    // confirmed cord-field usage of this specific sort key.
     throw new NotImplementedException(
-      `Sorting projects by '${sort}' is not yet supported under DATABASE=postgres — pending Partnership migration.`,
+      `Sorting projects by '${sort}' is not supported — the partner FK points ` +
+        "the other way, so it needs its own join shape rather than this helper's.",
     );
   }
   return null;

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -17,7 +17,7 @@ import {
   sql,
   type SQL,
 } from 'drizzle-orm';
-import { type AnyPgColumn } from 'drizzle-orm/pg-core';
+import { type AnyPgColumn, unionAll } from 'drizzle-orm/pg-core';
 import { DateTime } from 'luxon';
 import {
   CalendarDate,
@@ -273,28 +273,59 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
       rows.map((r) => r.id),
     );
     // Rev79 usage — one row per project with a live ToolUsage against the
-    // Rev79 tool. Same containerId-only join as the filter clauses below;
-    // Rev79 usage is unique per project (tool_usages_container_tool_unique).
-    const rev79Usages = await this.db
-      .select({ projectId: toolUsages.containerId })
-      .from(toolUsages)
-      .innerJoin(
-        tools,
-        and(
-          eq(tools.id, toolUsages.toolId),
-          eq(tools.key, ToolKey.Rev79),
-          isNull(tools.deletedAt),
-        ),
-      )
-      .where(
-        and(
-          inArray(
-            toolUsages.containerId,
-            rows.map((r) => r.id),
+    // Rev79 tool, either attached directly to the project or to one of its
+    // (Language) engagements — `containerId` is polymorphic, so a usage
+    // scoped to an engagement never equals a project id directly and needs
+    // the join through `engagements` to resolve back to its project.
+    const rev79Usages = await unionAll(
+      this.db
+        .select({ projectId: toolUsages.containerId })
+        .from(toolUsages)
+        .innerJoin(
+          tools,
+          and(
+            eq(tools.id, toolUsages.toolId),
+            eq(tools.key, ToolKey.Rev79),
+            isNull(tools.deletedAt),
           ),
-          isNull(toolUsages.deletedAt),
+        )
+        .where(
+          and(
+            inArray(
+              toolUsages.containerId,
+              rows.map((r) => r.id),
+            ),
+            isNull(toolUsages.deletedAt),
+          ),
         ),
-      );
+      this.db
+        .select({ projectId: engagements.projectId })
+        .from(toolUsages)
+        .innerJoin(
+          tools,
+          and(
+            eq(tools.id, toolUsages.toolId),
+            eq(tools.key, ToolKey.Rev79),
+            isNull(tools.deletedAt),
+          ),
+        )
+        .innerJoin(
+          engagements,
+          and(
+            eq(engagements.id, toolUsages.containerId),
+            isNull(engagements.deletedAt),
+          ),
+        )
+        .where(
+          and(
+            inArray(
+              engagements.projectId,
+              rows.map((r) => r.id),
+            ),
+            isNull(toolUsages.deletedAt),
+          ),
+        ),
+    );
     const usesRev79ByProject = new Set(
       rev79Usages.map((r) => r.projectId as ID<'Project'>),
     );
@@ -1064,18 +1095,35 @@ export const projectFilterClauses = (
     );
   }
   if (filter.usesRev79 != null) {
-    const usesRev79Sub = db
-      .selectDistinct({ id: toolUsages.containerId })
-      .from(toolUsages)
-      .innerJoin(
-        tools,
-        and(
-          eq(tools.id, toolUsages.toolId),
-          eq(tools.key, ToolKey.Rev79),
-          isNull(tools.deletedAt),
-        ),
-      )
-      .where(isNull(toolUsages.deletedAt));
+    // Same containerId-is-polymorphic problem as readMany's rev79Usages
+    // above: a usage scoped to an engagement never equals a project id
+    // directly, so it needs the join through `engagements` to resolve back
+    // to its project. Union rather than one subquery so both project-direct
+    // and engagement-scoped usages count.
+    const rev79ToolJoin = and(
+      eq(tools.id, toolUsages.toolId),
+      eq(tools.key, ToolKey.Rev79),
+      isNull(tools.deletedAt),
+    );
+    const usesRev79Sub = unionAll(
+      db
+        .selectDistinct({ id: toolUsages.containerId })
+        .from(toolUsages)
+        .innerJoin(tools, rev79ToolJoin)
+        .where(isNull(toolUsages.deletedAt)),
+      db
+        .selectDistinct({ id: engagements.projectId })
+        .from(toolUsages)
+        .innerJoin(tools, rev79ToolJoin)
+        .innerJoin(
+          engagements,
+          and(
+            eq(engagements.id, toolUsages.containerId),
+            isNull(engagements.deletedAt),
+          ),
+        )
+        .where(isNull(toolUsages.deletedAt)),
+    );
     conditions.push(
       filter.usesRev79
         ? inArray(projects.id, usesRev79Sub)

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -934,7 +934,7 @@ export const projectFilterClauses = (
       .where(
         and(
           isNull(projectMembers.deletedAt),
-          ...projectMemberFilterClauses(db, filter.members),
+          ...projectMemberFilterClauses(db, filter.members, requesterId),
         ),
       );
     conditions.push(inArray(projects.id, sub));
@@ -965,7 +965,11 @@ export const projectFilterClauses = (
               and(
                 isNull(projectMembers.deletedAt),
                 eq(projectMembers.userId, requesterId),
-                ...projectMemberFilterClauses(db, filter.membership),
+                ...projectMemberFilterClauses(
+                  db,
+                  filter.membership,
+                  requesterId,
+                ),
               ),
             ),
         ),

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -46,6 +46,7 @@ import {
   engagements,
   fieldRegions,
   locations,
+  partnerships,
   projectMembers,
   projects,
   projectWorkflowEvents,
@@ -60,6 +61,7 @@ import {
   locationFilterClauses,
   locationSortColumns,
 } from '../location/location.drizzle.repository';
+import { partnershipFilterClauses } from '../partnership/partnership.drizzle.repository';
 import { pinnedByRequester, pinnedFilter } from '../pin/pinned-by-requester';
 import {
   type CreateProject,
@@ -656,9 +658,16 @@ export const projectSortColumns = {
  * `resolveCrossDomainSort(sort, prefix, sortColumns)` helper alongside
  * `paginatedSelectWithJoin` (mirror of `*FilterClauses` emergence).
  *
- * migration-todo: `primaryPartnership.*` sort is not implemented. Partnership
- * is on develop now, but mono leaves this sort stubbed too; wire it as a
- * follow-up. Throw `NotImplementedException` so callers discover the gap.
+ * migration-todo: `primaryPartnership.*` sort is not implemented. Unlike the
+ * partnerId/partnerships/primaryPartnership FILTERS (wired below now that
+ * Partnership has landed), this doesn't fit the `{table, fkColumn, column}` +
+ * `leftJoin(table, eq(table.id, fkColumn))` shape this helper's caller uses —
+ * partnerships.project_id points AT projects, so the join runs the other way
+ * (`eq(partnerships.projectId, projects.id)`), which would mean widening this
+ * helper's return shape for one caller. No confirmed cord-field usage of this
+ * specific sort key either (unlike the filters, which are). Deferred rather
+ * than forced into a shape that doesn't fit — throw `NotImplementedException`
+ * so callers discover the gap.
  */
 const resolveCrossDomainSort = (
   sort: string,
@@ -701,9 +710,10 @@ const resolveCrossDomainSort = (
  * `projects`. Exported for sub-delegation from other domains (Engagement and
  * Partnership both filter-sub-delegate into projectFilterClauses).
  *
- * Cross-domain stubs (partnerId, partnerships, primaryPartnership,
- * tool, onlyMultipleEngagements, usesRev79) throw NotImplementedException
- * until their target domain migrates — discovery mechanism, not silent skip.
+ * partnerId/partnerships/primaryPartnership/onlyMultipleEngagements are wired
+ * below now that Partnership and Engagement have landed. `tool` and
+ * `usesRev79` still throw NotImplementedException — genuinely blocked on
+ * ToolUsage's live query repo, not just unwired.
  */
 export const projectFilterClauses = (
   db: DrizzleDb,
@@ -855,18 +865,37 @@ export const projectFilterClauses = (
     conditions.push(inArray(projects.id, sub));
   }
   if (filter.membership) {
-    // Note: the `user: { id: $currentUser }` constraint is applied by the
-    // resolver/transform layer (see ProjectFilters.membership transform).
-    const sub = db
-      .selectDistinct({ id: projectMembers.projectId })
-      .from(projectMembers)
-      .where(
-        and(
-          isNull(projectMembers.deletedAt),
-          ...projectMemberFilterClauses(db, filter.membership),
+    // BUG FIX (found live 2026-08-07, impersonating Financial Analyst: 5240
+    // projects locally vs 116 in prod for the same `mine` filter). The old
+    // comment here was wrong — no transform injects the current user. On
+    // Neo4j, `membership`'s match HARDCODES `currentUser` directly into the
+    // path (project-filters.query.ts) — it always means "the REQUESTER's own
+    // membership", unlike `members` above (any user's). Without that
+    // constraint, `membership.active = true` (what `mine`/`isMember` set)
+    // matched any project with ANY active member at all — for a role whose
+    // Project.read is unconditional (Financial Analyst's policy has no
+    // `.when(member)` on the base read grant), that's nearly every project.
+    // Fail closed rather than open when there's no requester to scope to —
+    // same convention as `pinnedFilter`.
+    if (!requesterId) {
+      conditions.push(sql`false`);
+    } else {
+      conditions.push(
+        inArray(
+          projects.id,
+          db
+            .selectDistinct({ id: projectMembers.projectId })
+            .from(projectMembers)
+            .where(
+              and(
+                isNull(projectMembers.deletedAt),
+                eq(projectMembers.userId, requesterId),
+                ...projectMemberFilterClauses(db, filter.membership),
+              ),
+            ),
         ),
       );
-    conditions.push(inArray(projects.id, sub));
+    }
   }
   // `userId`: project where user is a member OR engagement intern. Intern path
   // is gated on Engagement migration — partial support: member only.
@@ -894,26 +923,57 @@ export const projectFilterClauses = (
       )`,
     );
   }
-  // Cross-domain filters — throw until wired so the gap is discoverable in
-  // tests instead of silently returning all projects.
-  //
-  // migration-todo: Partnership is on develop now, so these three can be wired
-  // via `subFilter(db, projects.id, partnerships, [...])` reusing the exported
-  // `partnershipFilterClauses`. Mono leaves them stubbed too, so kept deferred
-  // to a follow-up rather than writing new (untested-on-mono) filter SQL here.
+  // Reverse relationship — partnerships.project_id points AT projects, so
+  // this is the same `IN (SELECT parent_fk FROM child WHERE ...)` shape as
+  // members/membership above, not `subFilter` (which assumes the FK lives on
+  // the outer table, pointing forward at the sub-table's own id).
   if (filter.partnerId) {
-    throw new NotImplementedException(
-      'ProjectFilters.partnerId is not yet wired under Postgres.',
+    conditions.push(
+      inArray(
+        projects.id,
+        db
+          .selectDistinct({ id: partnerships.projectId })
+          .from(partnerships)
+          .where(
+            and(
+              isNull(partnerships.deletedAt),
+              eq(partnerships.partnerId, filter.partnerId),
+            ),
+          ),
+      ),
     );
   }
   if (filter.partnerships) {
-    throw new NotImplementedException(
-      'ProjectFilters.partnerships is not yet wired under Postgres.',
+    conditions.push(
+      inArray(
+        projects.id,
+        db
+          .selectDistinct({ id: partnerships.projectId })
+          .from(partnerships)
+          .where(
+            and(
+              isNull(partnerships.deletedAt),
+              ...partnershipFilterClauses(db, filter.partnerships),
+            ),
+          ),
+      ),
     );
   }
   if (filter.primaryPartnership) {
-    throw new NotImplementedException(
-      'ProjectFilters.primaryPartnership is not yet wired under Postgres.',
+    conditions.push(
+      inArray(
+        projects.id,
+        db
+          .selectDistinct({ id: partnerships.projectId })
+          .from(partnerships)
+          .where(
+            and(
+              isNull(partnerships.deletedAt),
+              eq(partnerships.primary, true),
+              ...partnershipFilterClauses(db, filter.primaryPartnership),
+            ),
+          ),
+      ),
     );
   }
   if (filter.tool) {
@@ -923,9 +983,26 @@ export const projectFilterClauses = (
     );
   }
   if (filter.onlyMultipleEngagements != null) {
-    // migration-todo: wire when Engagement migrates (count-over-engagements).
-    throw new NotImplementedException(
-      'ProjectFilters.onlyMultipleEngagements requires Engagement migration (Phase 5).',
+    // Mirrors project-filters.query.ts's Cypher exactly: a REQUIRED match
+    // through the engagement edge means a project with zero engagements
+    // never enters the aggregation, so it matches neither true nor false —
+    // `false` means "exactly one", not "zero or one". GROUP BY reproduces
+    // that same required-match behavior (a project with no live engagements
+    // never produces a row to filter on).
+    conditions.push(
+      inArray(
+        projects.id,
+        db
+          .select({ id: engagements.projectId })
+          .from(engagements)
+          .where(isNull(engagements.deletedAt))
+          .groupBy(engagements.projectId)
+          .having(
+            filter.onlyMultipleEngagements
+              ? sql`count(*) > 1`
+              : sql`count(*) = 1`,
+          ),
+      ),
     );
   }
   if (filter.usesRev79 != null) {

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -13,6 +13,7 @@ import {
   lt,
   lte,
   max,
+  notInArray,
   sql,
   type SQL,
 } from 'drizzle-orm';
@@ -50,6 +51,8 @@ import {
   projectMembers,
   projects,
   projectWorkflowEvents,
+  tools,
+  toolUsages,
 } from '~/core/drizzle/schema';
 import { rolesForScope } from '../authorization/dto/role.dto';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
@@ -63,6 +66,8 @@ import {
 } from '../location/location.drizzle.repository';
 import { partnershipFilterClauses } from '../partnership/partnership.drizzle.repository';
 import { pinnedByRequester, pinnedFilter } from '../pin/pinned-by-requester';
+import { ToolKey } from '../tools/tool/dto/tool-key.enum';
+import { toolFilterClauses } from '../tools/tool/tool.drizzle.repository';
 import {
   type CreateProject,
   IProject,
@@ -100,6 +105,8 @@ type ProjectRow = typeof projects.$inferSelect & {
    * `marketingRegion`, which falls back to this when there's no override.
    */
   inheritedMarketingRegionId?: ID<'Location'> | null;
+  /** Has a live ToolUsage for the Rev79 tool — batched in `readMany`. */
+  usesRev79?: boolean;
   membership?: {
     id: ID<'ProjectMember'>;
     // `Role`, not `string` — the column is a role enum array, and the DTO's
@@ -265,6 +272,32 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
       userId,
       rows.map((r) => r.id),
     );
+    // Rev79 usage — one row per project with a live ToolUsage against the
+    // Rev79 tool. Same containerId-only join as the filter clauses below;
+    // Rev79 usage is unique per project (tool_usages_container_tool_unique).
+    const rev79Usages = await this.db
+      .select({ projectId: toolUsages.containerId })
+      .from(toolUsages)
+      .innerJoin(
+        tools,
+        and(
+          eq(tools.id, toolUsages.toolId),
+          eq(tools.key, ToolKey.Rev79),
+          isNull(tools.deletedAt),
+        ),
+      )
+      .where(
+        and(
+          inArray(
+            toolUsages.containerId,
+            rows.map((r) => r.id),
+          ),
+          isNull(toolUsages.deletedAt),
+        ),
+      );
+    const usesRev79ByProject = new Set(
+      rev79Usages.map((r) => r.projectId as ID<'Project'>),
+    );
     return rows.map((row): UnsecuredDto<Project> => {
       const enriched: ProjectRow = {
         ...row,
@@ -275,6 +308,7 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
         inheritedMarketingRegionId: row.marketingLocationId
           ? (inheritedRegionByLocation.get(row.marketingLocationId) ?? null)
           : null,
+        usesRev79: usesRev79ByProject.has(row.id),
       };
       return this.toDto(enriched);
     });
@@ -395,9 +429,10 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
       modifiedAt: new Date(),
     }).catch(catchDepartmentIdUnique);
 
-    // migration-todo: usesRev79 toggle delegates to ToolUsage service (not
-    // migrated yet). When ToolUsage ports, wire the create/remove of the
-    // Rev79 ToolUsage row here.
+    // usesRev79 is deliberately dropped here, not written: project.service.ts's
+    // update() handles the toggle itself, via `this.toolUsage.setUsageByKey`
+    // (create/remove the Rev79 ToolUsage row), then re-reads this repo to pick
+    // up the recomputed value. Nothing repo-side to do.
 
     // The service runs RequiredWhen.calc against this return value, so it
     // must be the full updated DTO — not a stub.
@@ -559,9 +594,9 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
       // Wire via a `partnerships` subquery (primary = true) as a follow-up.
       primaryPartnership: null,
       engagementTotal: row.engagementTotal ?? 0,
-      // migration-todo: ToolUsage not migrated; usesRev79 always false until
-      // the tool-usage layer ports.
-      usesRev79: false,
+      // Batched in readMany — whether the project has a live ToolUsage
+      // against the Rev79 tool.
+      usesRev79: row.usesRev79 ?? false,
       membership: row.membership
         ? {
             id: row.membership.id,
@@ -712,8 +747,10 @@ const resolveCrossDomainSort = (
  *
  * partnerId/partnerships/primaryPartnership/onlyMultipleEngagements are wired
  * below now that Partnership and Engagement have landed. `tool` and
- * `usesRev79` still throw NotImplementedException — genuinely blocked on
- * ToolUsage's live query repo, not just unwired.
+ * `usesRev79` are wired too now that ToolUsage has landed (migration 0034) —
+ * both go through `tool_usages`, matched by `containerId` since a Project's
+ * usages carry no separate `containerType` predicate (ids are globally
+ * unique, same assumption `tool-usage.drizzle.repository.ts` already makes).
  */
 export const projectFilterClauses = (
   db: DrizzleDb,
@@ -977,9 +1014,23 @@ export const projectFilterClauses = (
     );
   }
   if (filter.tool) {
-    // migration-todo: wire when ToolUsage migrates (exists-over-tool_usages).
-    throw new NotImplementedException(
-      'ProjectFilters.tool requires ToolUsage migration.',
+    conditions.push(
+      inArray(
+        projects.id,
+        db
+          .selectDistinct({ id: toolUsages.containerId })
+          .from(toolUsages)
+          .innerJoin(
+            tools,
+            and(eq(tools.id, toolUsages.toolId), isNull(tools.deletedAt)),
+          )
+          .where(
+            and(
+              isNull(toolUsages.deletedAt),
+              ...toolFilterClauses(db, filter.tool),
+            ),
+          ),
+      ),
     );
   }
   if (filter.onlyMultipleEngagements != null) {
@@ -1006,9 +1057,22 @@ export const projectFilterClauses = (
     );
   }
   if (filter.usesRev79 != null) {
-    // migration-todo: wire when ToolUsage migrates (Rev79 tool usage check).
-    throw new NotImplementedException(
-      'ProjectFilters.usesRev79 requires ToolUsage migration.',
+    const usesRev79Sub = db
+      .selectDistinct({ id: toolUsages.containerId })
+      .from(toolUsages)
+      .innerJoin(
+        tools,
+        and(
+          eq(tools.id, toolUsages.toolId),
+          eq(tools.key, ToolKey.Rev79),
+          isNull(tools.deletedAt),
+        ),
+      )
+      .where(isNull(toolUsages.deletedAt));
+    conditions.push(
+      filter.usesRev79
+        ? inArray(projects.id, usesRev79Sub)
+        : notInArray(projects.id, usesRev79Sub),
     );
   }
   if (filter.pinned != null) {

--- a/src/components/user/user.drizzle.repository.ts
+++ b/src/components/user/user.drizzle.repository.ts
@@ -26,7 +26,6 @@ import {
   userOrganizations,
   users,
 } from '~/core/drizzle/schema';
-import { Privileges } from '../authorization';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import { FileService } from '../file';
 import { type FileId } from '../file/dto';
@@ -62,7 +61,6 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
   constructor(
     db: DrizzleService,
     private readonly executor: PolicyExecutor,
-    private readonly privileges: Privileges,
     private readonly files: FileService,
     private readonly identity: Identity,
   ) {
@@ -230,8 +228,7 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
     return await this.readOne(id);
   }
 
-  async delete(id: ID, object: User): Promise<void> {
-    this.privileges.for(User, object).verifyCan('delete');
+  async delete(id: ID): Promise<void> {
     await this.softDelete(id);
   }
 

--- a/src/components/user/user.drizzle.repository.ts
+++ b/src/components/user/user.drizzle.repository.ts
@@ -26,6 +26,7 @@ import {
   userOrganizations,
   users,
 } from '~/core/drizzle/schema';
+import { Privileges } from '../authorization';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import { FileService } from '../file';
 import { type FileId } from '../file/dto';
@@ -61,6 +62,7 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
   constructor(
     db: DrizzleService,
     private readonly executor: PolicyExecutor,
+    private readonly privileges: Privileges,
     private readonly files: FileService,
     private readonly identity: Identity,
   ) {
@@ -228,7 +230,8 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
     return await this.readOne(id);
   }
 
-  async delete(id: ID, _object: User): Promise<void> {
+  async delete(id: ID, object: User): Promise<void> {
+    this.privileges.for(User, object).verifyCan('delete');
     await this.softDelete(id);
   }
 

--- a/src/components/user/user.repository.ts
+++ b/src/components/user/user.repository.ts
@@ -257,8 +257,6 @@ export class UserRepository extends DtoRepository(User) {
   }
 
   async delete(id: ID, object: User): Promise<void> {
-    const user = await this.readOne(id);
-    this.privileges.forContext(user).verifyCan('delete');
     try {
       await this.deleteNode(object, { resource: User });
     } catch (exception) {

--- a/src/components/user/user.service.ts
+++ b/src/components/user/user.service.ts
@@ -145,6 +145,7 @@ export class UserService {
 
   async delete(id: ID): Promise<void> {
     const object = await this.readOne(id);
+    this.privileges.for(User, object).verifyCan('delete');
     await this.userRepo.delete(id, object);
     // Same-transaction side effects (e.g. session revocation — a deleted
     // user must not keep live sessions).

--- a/test/audit-log.e2e-spec.ts
+++ b/test/audit-log.e2e-spec.ts
@@ -19,6 +19,7 @@ import {
   createProject,
   createSession,
   createTestApp,
+  errors,
   type fragments,
   registerUser,
   runAsAdmin,
@@ -60,6 +61,19 @@ describe('Audit log (resource_mutations) e2e', () => {
     project = await createProject(app);
   });
 
+  it('rejects a non-admin from viewing resource history', async () => {
+    // The acting session here is FieldOperationsDirector + Controller (see
+    // beforeAll) — neither is an admin, so this pins the new gate itself,
+    // not just the admin-wrapped happy paths every other case below uses.
+    await expect(
+      app.graphql.query(ProjectHistoryDoc, { id: project.id }),
+    ).rejects.toThrowGqlError(
+      errors.unauthorized({
+        message: 'Only administrators can view resource history',
+      }),
+    );
+  });
+
   it('records create + update mutations in a resource history', async () => {
     const partnership = await createPartnership(app, { project: project.id });
 
@@ -67,9 +81,11 @@ describe('Audit log (resource_mutations) e2e', () => {
       input: { id: partnership.id, agreementStatus: 'Signed' },
     });
 
-    const { partnership: read } = await app.graphql.query(HistoryDoc, {
-      id: partnership.id,
-    });
+    // Resource history is admin-only (an interim gate — see the resolver);
+    // read it under an isolated admin session rather than the acting user's.
+    const { partnership: read } = await runAsAdmin(app, () =>
+      app.graphql.query(HistoryDoc, { id: partnership.id }),
+    );
     const history = read.history;
 
     if (!isPostgres) {
@@ -102,9 +118,9 @@ describe('Audit log (resource_mutations) e2e', () => {
       input: { id: org.id, name: newName },
     });
 
-    const { organization: read } = await app.graphql.query(OrgHistoryDoc, {
-      id: org.id,
-    });
+    const { organization: read } = await runAsAdmin(app, () =>
+      app.graphql.query(OrgHistoryDoc, { id: org.id }),
+    );
     const history = read.history;
 
     if (!isPostgres) {
@@ -132,9 +148,9 @@ describe('Audit log (resource_mutations) e2e', () => {
       input: { id: proj.id, name: newName },
     });
 
-    const { project: read } = await app.graphql.query(ProjectHistoryDoc, {
-      id: proj.id,
-    });
+    const { project: read } = await runAsAdmin(app, () =>
+      app.graphql.query(ProjectHistoryDoc, { id: proj.id }),
+    );
     const history = read.history;
 
     if (!isPostgres) {
@@ -161,9 +177,9 @@ describe('Audit log (resource_mutations) e2e', () => {
       endDateOverride: engEnd.toISO(),
     });
 
-    const { engagement: read } = await app.graphql.query(EngagementHistoryDoc, {
-      id: engagement.id,
-    });
+    const { engagement: read } = await runAsAdmin(app, () =>
+      app.graphql.query(EngagementHistoryDoc, { id: engagement.id }),
+    );
 
     if (!isPostgres) {
       expect(read.history.total).toBe(0);
@@ -187,9 +203,9 @@ describe('Audit log (resource_mutations) e2e', () => {
       engagement: engagement.id,
     });
 
-    const { product: read } = await app.graphql.query(ProductHistoryDoc, {
-      id: product.id,
-    });
+    const { product: read } = await runAsAdmin(app, () =>
+      app.graphql.query(ProductHistoryDoc, { id: product.id }),
+    );
 
     if (!isPostgres) {
       expect(read.history.total).toBe(0);
@@ -209,9 +225,9 @@ describe('Audit log (resource_mutations) e2e', () => {
       registerUser(app, { roles: [] }),
     );
 
-    const { user: read } = await app.graphql.query(UserHistoryDoc, {
-      id: newUser.id,
-    });
+    const { user: read } = await runAsAdmin(app, () =>
+      app.graphql.query(UserHistoryDoc, { id: newUser.id }),
+    );
 
     if (!isPostgres) {
       expect(read.history.total).toBe(0);

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -705,6 +705,45 @@ describe('Engagement e2e', () => {
     ).toBeTruthy();
   });
 
+  it('filters engagements by a project sub-filter field beyond id', async () => {
+    const translationProject = await createProject(app);
+    const internProject = await createProject(app, {
+      type: ProjectType.Internship,
+    });
+
+    const languageEngagement = await createLanguageEngagement(app, {
+      language: language.id,
+      project: translationProject.id,
+    });
+    const internshipEngagement = await createInternshipEngagement(app, {
+      project: internProject.id,
+      countryOfOrigin: location.id,
+      intern: intern.id,
+      mentor: mentor.id,
+    });
+
+    const { engagements } = await app.graphql.query(
+      graphql(`
+        query ($input: EngagementListInput) {
+          engagements(input: $input) {
+            items {
+              id
+            }
+          }
+        }
+      `),
+      {
+        input: {
+          filter: { project: { type: [ProjectType.Internship] } },
+        },
+      },
+    );
+
+    const ids = engagements.items.map((e) => e.id);
+    expect(ids).toContain(internshipEngagement.id);
+    expect(ids).not.toContain(languageEngagement.id);
+  });
+
   it('internship engagement creation fails and lets you know why if your ids are bad', async () => {
     internshipProject = await createProject(app, {
       type: ProjectType.Internship,

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { beforeAll, describe, expect, it } from '@jest/globals';
 import { some } from 'lodash';
 import { DateTime, Interval } from 'luxon';
-import { generateId, type ID, Role } from '~/common';
+import { CalendarDate, generateId, type ID, Role } from '~/common';
 import { graphql } from '~/graphql';
 import {
   EngagementStatus,
@@ -711,15 +711,23 @@ describe('Engagement e2e', () => {
       type: ProjectType.Internship,
     });
 
+    // Match createProject()'s default MOU window (1991–1992) instead of
+    // letting these fall back to today's date, which sits outside it.
+    const startDateOverride = CalendarDate.fromISO('1991-01-01').toISO();
+    const endDateOverride = CalendarDate.fromISO('1992-01-01').toISO();
     const languageEngagement = await createLanguageEngagement(app, {
       language: language.id,
       project: translationProject.id,
+      startDateOverride,
+      endDateOverride,
     });
     const internshipEngagement = await createInternshipEngagement(app, {
       project: internProject.id,
       countryOfOrigin: location.id,
       intern: intern.id,
       mentor: mentor.id,
+      startDateOverride,
+      endDateOverride,
     });
 
     const { engagements } = await app.graphql.query(

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -31,6 +31,7 @@ import {
   createRegion,
   createSession,
   createTestApp,
+  createTool,
   createZone,
   errors,
   fragments,
@@ -298,6 +299,109 @@ describe('Project e2e', () => {
 
     expect(result.updateProject.project.id).toBe(project.id);
     expect(result.updateProject.project.name.value).toBe(namenew);
+  });
+
+  it('toggles usesRev79 and filters by it and by tool', async () => {
+    // usesRev79 delegates to a ToolUsage against whichever Tool carries the
+    // Rev79 key, so a project can't turn it on until that Tool exists.
+    const rev79Tool = await runAsAdmin(
+      app,
+      async () => await createTool(app, { key: 'Rev79' }),
+    );
+    const project = await createProject(app, {
+      type: ProjectType.MomentumTranslation,
+      fieldRegion: fieldRegion.id,
+    });
+    const usesRev79Of = async (id: ID) => {
+      const result = await app.graphql.query(
+        graphql(`
+          query projectUsesRev79($id: ID!) {
+            project(id: $id) {
+              usesRev79 {
+                value
+              }
+            }
+          }
+        `),
+        { id },
+      );
+      return result.project.usesRev79.value;
+    };
+    expect(await usesRev79Of(project.id)).toBe(false);
+
+    const enabled = await app.graphql.mutate(
+      graphql(`
+        mutation enableRev79($id: ID!) {
+          updateProject(input: { id: $id, usesRev79: true }) {
+            project {
+              usesRev79 {
+                value
+              }
+            }
+          }
+        }
+      `),
+      { id: project.id },
+    );
+    expect(enabled.updateProject.project.usesRev79.value).toBe(true);
+
+    const rev79Filtered = await app.graphql.query(
+      graphql(`
+        query projectsUsingRev79 {
+          projects(input: { filter: { usesRev79: true } }) {
+            items {
+              id
+            }
+          }
+        }
+      `),
+    );
+    expect(rev79Filtered.projects.items.map((p) => p.id)).toContain(project.id);
+
+    const toolFiltered = await app.graphql.query(
+      graphql(`
+        query projectsByTool($id: ID!) {
+          projects(input: { filter: { tool: { id: $id } } }) {
+            items {
+              id
+            }
+          }
+        }
+      `),
+      { id: rev79Tool.id },
+    );
+    expect(toolFiltered.projects.items.map((p) => p.id)).toContain(project.id);
+
+    const disabled = await app.graphql.mutate(
+      graphql(`
+        mutation disableRev79($id: ID!) {
+          updateProject(input: { id: $id, usesRev79: false }) {
+            project {
+              usesRev79 {
+                value
+              }
+            }
+          }
+        }
+      `),
+      { id: project.id },
+    );
+    expect(disabled.updateProject.project.usesRev79.value).toBe(false);
+
+    const rev79FilteredAfter = await app.graphql.query(
+      graphql(`
+        query projectsUsingRev79After {
+          projects(input: { filter: { usesRev79: true } }) {
+            items {
+              id
+            }
+          }
+        }
+      `),
+    );
+    expect(rev79FilteredAfter.projects.items.map((p) => p.id)).not.toContain(
+      project.id,
+    );
   });
 
   it('delete project', async () => {

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -1402,17 +1402,27 @@ describe('Project e2e', () => {
       await createLanguage(app),
     ]);
 
+    // Match createProject()'s default MOU window (1991–1992) instead of
+    // letting these fall back to today's date, which sits outside it.
+    const startDateOverride = CalendarDate.fromISO('1991-01-01').toISO();
+    const endDateOverride = CalendarDate.fromISO('1992-01-01').toISO();
     await createLanguageEngagement(app, {
       project: oneEngagement.id,
       language: languageA.id,
+      startDateOverride,
+      endDateOverride,
     });
     await createLanguageEngagement(app, {
       project: twoEngagements.id,
       language: languageA.id,
+      startDateOverride,
+      endDateOverride,
     });
     await createLanguageEngagement(app, {
       project: twoEngagements.id,
       language: languageB.id,
+      startDateOverride,
+      endDateOverride,
     });
 
     const multiple = await listProjects(app, {

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -1238,4 +1238,137 @@ describe('Project e2e', () => {
       );
     });
   });
+
+  // Placed at the end of the file, not alongside the other filter tests
+  // above: these create extra projects with no explicit sensitivity (default
+  // High), which threw off "List of projects sorted by Sensitivity"'s exact
+  // top-of-list assertion when they ran earlier in file order.
+  it('isMember filter scopes to the CURRENT user, not any project with any active member', async () => {
+    // Found live 2026-08-07 impersonating a Financial Analyst: `mine`
+    // returned 5240 projects locally vs 116 in prod for the same persona.
+    // FinancialAnalystPolicy grants unconditional Project.read (no
+    // `.when(member)`), so unlike most roles — where the read-filter itself
+    // already restricts every row to "projects I'm a member of" and made the
+    // missing constraint invisible — this role exposed it directly.
+    const myProject = await createProject(app, { fieldRegion: fieldRegion.id });
+    const otherProject = await createProject(app, {
+      fieldRegion: fieldRegion.id,
+    });
+
+    // registerUser leaves the ambient session as the new user afterward (by
+    // design — many tests rely on it), so it and the member-adding both go
+    // inside ONE runAsAdmin call: it restores whatever was ambient (director)
+    // BEFORE this call started, undoing that churn, rather than leaving the
+    // analyst as ambient for every test after this one.
+    const analyst = await runAsAdmin(app, async () => {
+      const user = await registerUser(app, {
+        roles: [Role.FinancialAnalyst],
+      });
+      await createProjectMember(app, {
+        project: myProject.id,
+        user: user.id,
+      });
+      // otherProject already has director as an active member — createProject
+      // auto-adds its creator — which is exactly the case that must NOT match:
+      // some other user's active membership, not this requester's.
+      return user;
+    });
+
+    const mine = await analyst.runAs(() =>
+      listProjects(app, { filter: { isMember: true } }),
+    );
+    const ids = mine.items.map((p) => p.id);
+    expect(ids).toContain(myProject.id);
+    expect(ids).not.toContain(otherProject.id);
+  });
+
+  it('filters projects by onlyMultipleEngagements — false means exactly one, not zero-or-one', async () => {
+    const noEngagements = await createProject(app, {
+      fieldRegion: fieldRegion.id,
+    });
+    const oneEngagement = await createProject(app, {
+      fieldRegion: fieldRegion.id,
+    });
+    const twoEngagements = await createProject(app, {
+      fieldRegion: fieldRegion.id,
+    });
+
+    const [languageA, languageB] = await runAsAdmin(app, async () => [
+      await createLanguage(app),
+      await createLanguage(app),
+    ]);
+
+    await createLanguageEngagement(app, {
+      project: oneEngagement.id,
+      language: languageA.id,
+    });
+    await createLanguageEngagement(app, {
+      project: twoEngagements.id,
+      language: languageA.id,
+    });
+    await createLanguageEngagement(app, {
+      project: twoEngagements.id,
+      language: languageB.id,
+    });
+
+    const multiple = await listProjects(app, {
+      filter: { onlyMultipleEngagements: true },
+    });
+    const multipleIds = multiple.items.map((p) => p.id);
+    expect(multipleIds).toContain(twoEngagements.id);
+    expect(multipleIds).not.toContain(oneEngagement.id);
+    expect(multipleIds).not.toContain(noEngagements.id);
+
+    const exactlyOne = await listProjects(app, {
+      filter: { onlyMultipleEngagements: false },
+    });
+    const exactlyOneIds = exactlyOne.items.map((p) => p.id);
+    expect(exactlyOneIds).toContain(oneEngagement.id);
+    expect(exactlyOneIds).not.toContain(twoEngagements.id);
+    expect(exactlyOneIds).not.toContain(noEngagements.id);
+  });
+
+  it("filters a partner's projects to those with a partnership to that partner", async () => {
+    // ProjectFilters.partnerId has no GraphQL field — it's injected by the
+    // Partner.projects resolver, same as cord-field's PartnerProjects.graphql
+    // (partner(id) { projects(input) }), not settable directly by a client.
+    const matchingPartner = await createPartner(app);
+    const otherPartner = await createPartner(app);
+
+    const matchingProject = await createProject(app, {
+      fieldRegion: fieldRegion.id,
+    });
+    const otherProject = await createProject(app, {
+      fieldRegion: fieldRegion.id,
+    });
+
+    await createPartnership(app, {
+      project: matchingProject.id,
+      partner: matchingPartner.id,
+    });
+    await createPartnership(app, {
+      project: otherProject.id,
+      partner: otherPartner.id,
+    });
+
+    const { partner } = await app.graphql.query(
+      graphql(`
+        query ($id: ID!) {
+          partner(id: $id) {
+            id
+            projects(input: {}) {
+              items {
+                id
+              }
+            }
+          }
+        }
+      `),
+      { id: matchingPartner.id },
+    );
+
+    const ids = partner.projects.items.map((p) => p.id);
+    expect(ids).toContain(matchingProject.id);
+    expect(ids).not.toContain(otherProject.id);
+  });
 });

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -10,6 +10,7 @@ import {
   createSession,
   createTestApp,
   createUnavailability,
+  errors,
   fragments,
   generateRegisterInput,
   generateRequireFieldsRegisterInput,
@@ -158,6 +159,31 @@ describe('User e2e', () => {
     expect(actual).toBeTruthy();
 
     return true;
+  });
+
+  it('rejects a non-admin from deleting another user', async () => {
+    const target = await createPerson(app);
+
+    await runInIsolatedSession(app, async () => {
+      await registerUser(app); // defaults to ProjectManager + Consultant, neither admin
+
+      await expect(
+        app.graphql.mutate(
+          graphql(`
+            mutation deleteUser($id: ID!) {
+              deleteUser(id: $id) {
+                __typename
+              }
+            }
+          `),
+          { id: target.id },
+        ),
+      ).rejects.toThrowGqlError(
+        errors.unauthorized({
+          message: 'You do not have the permission to delete this user',
+        }),
+      );
+    });
   });
 
   // LIST USERS


### PR DESCRIPTION
### Summary

This PR wires up a batch of project/engagement search filters that used to just throw an error under the new database, adds a Postgres version of the progress-report list query (the last major query that didn't have one), and fixes a sizable batch of real bugs found while testing all of that against a copy of production data.

The bugs fixed here matter because several of them are security- or data-integrity-shaped, not just "a filter doesn't work yet":

- **A filter meant to show "my projects" was showing everyone's.** Under the new database, the check that should have limited results to the current user's own projects was missing entirely. For most users this was hidden by a separate permission check elsewhere, but for a few roles with broader read access (like Financial Analyst), it meant seeing far more projects than they should have.
- **Anyone signed in could delete any user account.** The new database's user-deletion code had no permission check at all — the old database's equivalent code did.
- **Deleting a project didn't hide its data everywhere.** Ceremonies and project memberships belonging to a deleted project kept showing up in full, including sensitive membership details, instead of disappearing along with the project.
- **A brand-new "who changed what" audit trail had no access control at all.** Anyone could read any resource's full change history. It's now restricted to administrators as a stopgap until proper per-resource permissions are built.
- **A missing reference (like a deleted director) used to crash the whole record instead of just leaving that one field blank.**
- Several smaller data-correctness gaps: a filter that silently ignored one of its inputs, a file search where typing a literal `%` matched everything instead of nothing extra, deleted files' associated data still showing up, and a couple of places where other users watching a page in real time wouldn't see something get deleted.

On top of all that, during this session I ran an automated adversarial code review plus hands-on testing against the rebased branch, which caught one more real bug and two smaller gaps — all described in "What's added" below.

Branch `pg-wire-cross-domain-filters`, rebased directly onto `develop` (it was waiting on a separate, larger PR to merge first — that landed earlier today). No database schema changes; this is all application code.

### What's added

**Filters and reads wired up (previously threw "not supported" errors under the new database):**
- Engagement's project sub-filter, and Project's partner/partnership/primary-partnership and "only multiple engagements" filters — all now work now that the domains they depend on have landed.
- Project and Engagement's "uses Rev79 tool" filter, and the underlying `usesRev79` field, which always read as false before. Fixed to also catch tool usage recorded through an engagement, not just directly on the project (a real gap it also missed before this fix).
- The standalone progress-report list query, ported to the new database for the first time — it had never been wired up at all, so it silently kept reading the old database regardless of configuration. Read/create/update/delete for the underlying record are unaffected (they already went through a shared, already-ported code path); this port only covers the list/search query.

**Real bugs found and fixed (via a structured test pass against a copy of production data):**
- "My projects" / "projects I'm a member of" filter was missing its current-user check entirely (see summary above). Now scoped correctly, and fails safe (returns nothing) rather than fails open if the current user can't be determined for some reason.
- User deletion had no permission check under the new database.
- Ceremonies and project memberships kept resolving with full detail after their parent project or engagement was deleted.
- The new resource change-history feature had no access control; now restricted to administrators.
- A missing single reference (e.g., a deleted director) crashed the entire parent object instead of leaving just that field empty.
- Two shared permission-check files had no logic at all for the progress-report type, which would have crashed the query for most roles the moment real data hit it.
- Partner and Organization records weren't correctly recognizing when the current user was actually a member, causing an internal error instead of correctly evaluating permission for legitimate members.
- A region filter silently ignored one of its inputs.
- Saving a new version of a media file dropped its alt-text/caption instead of carrying it forward.
- File search by name didn't escape a literal `%`, so it matched far more than intended.
- Reading extraction results for a deleted file still worked when it shouldn't have.
- Deleting a comment or a post didn't notify other users viewing the same page in real time.

**Found and fixed in this session, after rebasing:**
- **Partnership "primary" flag bug** (found by hands-on testing): marking a second or third partnership as the primary one for a project silently failed to actually take over — the old primary stayed marked as primary too, because of an ordering bug (the code tried to grab "primary" before releasing it from the old holder, which failed, and that failure was wrongly treated as an unrelated rare edge case instead of the normal request it was). Fixed by releasing the old primary first, matching how editing an existing partnership into primary already worked correctly. Applied identically across all three ways this data can be stored, though only the new database actually had the bug.
- **A related filter gap** (found by automated review): the "my projects" fix above wasn't carried through to a few places where that same filter can be nested inside another one — e.g., asking for engagements belonging to "my projects." Those nested cases were silently returning wrong results instead of a visible error. Fixed by passing the current user through everywhere it was missing.
- **A sorting gap** (found by automated review, low severity): a handful of progress-report sort options that work on the old database aren't implemented yet on the new one, and silently default to a different sort instead of saying so. Documented as a known, deferred gap, matching how an identical gap is already documented elsewhere in the codebase.
- **Test coverage for the new admin-only history restriction:** the tests exercising that feature were still running as a non-admin and started failing once the restriction was added. Updated them to read history as an admin (without changing the main test user's role, since other parts of those same tests depend on it), and added a new test proving a non-admin is actually rejected — that protection had no test coverage in either direction before.

### Validation performed

- Type-check and lint: clean throughout.
- Every touched test file re-run in isolation under the new database after all fixes above:
  - `partnership.e2e-spec.ts` — 14/14 passing (previously had 1 failure — the primary-flag bug).
  - `engagement.e2e-spec.ts` — 32/33 passing (1 pre-existing, unrelated skip).
  - `project.e2e-spec.ts` — 30/30 passing.
  - `progress-report-media.e2e-spec.ts` — 11/11 passing.
  - `audit-log.e2e-spec.ts` — 13/13 passing (previously had 6 failures from the new admin-only restriction; 1 new test added).
  - `organization.e2e-spec.ts` — 10/14 passing (4 pre-existing, unrelated skips).
- All of the above runs hit one recurring, unrelated issue at the very tail end of the process: a database connection error during final test-runner shutdown, after every real test had already passed. It doesn't reproduce on shorter runs and looks like a pre-existing quirk in the shared test setup, not something this PR causes — flagged separately, not fixed here.
- Not re-run against the old database engine in this session. The two places here with different logic per engine (the progress-report routing, and the partnership primary-flag fix) were checked by hand for the old-database path — the old database has no equivalent bug (it has no database-level uniqueness constraint to conflict with, so the ordering bug this PR fixes doesn't apply there) — but no automated old-engine test run backs that up beyond the hand-check.

### Reviewer cross-checks

- The "my projects" scoping fix and its nested-filter follow-up fail closed (return nothing) rather than fail open whenever the current user can't be determined — worth double-checking there's no code path that calls these filter functions in a context with no logged-in user where "return nothing" would be the wrong behavior (e.g. a background job).
- The administrator-only restriction on resource history is explicitly called out as an interim measure, not a final permissions design — confirm that framing matches expectations before this merges, since it's a real behavior change for anyone currently relying on non-admin access to that data (unlikely, since it's not exposed in any UI yet).
- The partnership primary-flag fix changes what `create()` returns (an extra field) on all three storage implementations — confirm nothing outside this PR was relying on the old return shape.

### Explicitly out of scope

- No database schema changes.
- The progress-report sort gap (engagement/PnP/summary-based sorting) is documented but not implemented — matches an already-accepted gap elsewhere, not addressed here.
- Full old-database-engine re-validation of this session's four newest commits wasn't run; only reasoned through by hand (see Validation above).
- The recurring test-teardown connection quirk noted under Validation is not fixed in this PR.
