### PR TITLE
Default the users list to sorting by full name instead of id

### DIFF
--- a/src/components/user/dto/list-users.dto.ts
+++ b/src/components/user/dto/list-users.dto.ts
@@ -45,7 +45,7 @@ export abstract class UserFilters {
 export class UserListInput extends SortablePaginationInput<
   keyof User | 'fullName'
 >({
-  defaultSort: 'id',
+  defaultSort: 'fullName',
 }) {
   @FilterField(() => UserFilters)
   readonly filter?: UserFilters;

--- a/src/components/user/user.drizzle.repository.ts
+++ b/src/components/user/user.drizzle.repository.ts
@@ -242,11 +242,12 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
     conditions.push(...userFilterClauses(this.db, input.filter));
 
     const sortColumns = {
+      fullName: [users.realFirstName, users.realLastName],
       realLastName: [users.realLastName, users.realFirstName],
       displayLastName: [users.displayLastName, users.displayFirstName],
       realFirstName: [users.realFirstName, users.realLastName],
       displayFirstName: [users.displayFirstName, users.displayLastName],
-    } satisfies SortMap<keyof User>;
+    } satisfies SortMap<keyof User | 'fullName'>;
 
     const { rows, total, hasMore } = await this.paginatedSelect({
       predicate: and(...conditions),

--- a/src/components/user/user.gel.repository.ts
+++ b/src/components/user/user.gel.repository.ts
@@ -1,6 +1,17 @@
 import { Injectable } from '@nestjs/common';
-import { type ID, NotImplementedException, type PublicOf } from '~/common';
-import { disableAccessPolicies, e, RepoFor, type ScopeOf } from '~/core/gel';
+import {
+  type ID,
+  NotImplementedException,
+  type PublicOf,
+  type SortablePaginationInput,
+} from '~/common';
+import {
+  disableAccessPolicies,
+  e,
+  type OrderByExpression,
+  RepoFor,
+  type ScopeOf,
+} from '~/core/gel';
 import {
   type AssignOrganizationToUser,
   type CreatePerson,
@@ -76,6 +87,19 @@ export class UserGelRepository
     }));
 
     return this.db.run(query);
+  }
+
+  protected orderBy(
+    scope: ScopeOf<typeof e.User>,
+    input: SortablePaginationInput,
+  ): OrderByExpression {
+    if (input.sort === 'fullName') {
+      return [
+        { expression: scope.realFirstName, direction: input.order },
+        { expression: scope.realLastName, direction: input.order },
+      ];
+    }
+    return super.orderBy(scope, input);
   }
 
   protected listFilters(user: ScopeOf<typeof e.User>, input: UserListInput) {

--- a/src/core/drizzle/order-by.ts
+++ b/src/core/drizzle/order-by.ts
@@ -111,9 +111,9 @@ const NAME_COLUMNS: ReadonlySet<AnyPgColumn> = new Set<AnyPgColumn>([
  * non-text column cannot be collated at all (Postgres raises "collations are not
  * supported by type" for enum and uuid), so a wrong entry in the list fails loudly
  * instead of producing broken SQL at run time. Primary keys are excluded for the
- * same belt-and-braces reason — every id here is a `text` column, and the user
- * list's default sort key is its id, where collating would both reorder the list
- * and stop the ordering being read off the primary key index.
+ * same belt-and-braces reason — every id column here is `text`, and collating an
+ * id would both reorder a list by an opaque generated value and stop the ordering
+ * being read off the primary key index, for any list that falls back to id sorting.
  *
  * ⚠️ This can only inspect a COLUMN. A sort written as a raw `sql` expression has
  * no column to look up, so it falls through here and comes back uncollated — with

--- a/src/core/gel/index.ts
+++ b/src/core/gel/index.ts
@@ -5,6 +5,7 @@ export * from './gel.service';
 export { ExclusivityViolationError } from './errors/constraint-violation.error';
 export * from './common.repository';
 export * from './dto.repository';
+export type { OrderByExpression } from './generated-client/select';
 export * from './query-util/disable-access-policies.option';
 export * from './query-util/cast-to-enum';
 export * from '../database/transaction-retry.informer';

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -266,9 +266,24 @@ describe('User e2e', () => {
 
   it('lists users sorted by full name by default', async () => {
     const prefix = 'ZzzSortTest' + (await generateId());
-    await createPerson(app, { realFirstName: `${prefix}_Charlie` });
-    await createPerson(app, { realFirstName: `${prefix}_Alice` });
-    await createPerson(app, { realFirstName: `${prefix}_Bob` });
+    await createPerson(app, {
+      realFirstName: `${prefix}_Charlie`,
+      realLastName: 'Smith',
+    });
+    await createPerson(app, {
+      realFirstName: `${prefix}_Alice`,
+      realLastName: 'Smith',
+    });
+    // Same first name, different last names — verifies fullName sorting
+    // breaks ties on last name instead of stopping at first name.
+    await createPerson(app, {
+      realFirstName: `${prefix}_Bob`,
+      realLastName: 'Young',
+    });
+    await createPerson(app, {
+      realFirstName: `${prefix}_Bob`,
+      realLastName: 'Adams',
+    });
 
     const { users } = await app.graphql.query(
       graphql(`
@@ -278,6 +293,9 @@ describe('User e2e', () => {
               realFirstName {
                 value
               }
+              realLastName {
+                value
+              }
             }
           }
         }
@@ -285,10 +303,15 @@ describe('User e2e', () => {
       { prefix },
     );
 
-    expect(users.items.map((user) => user.realFirstName.value)).toEqual([
-      `${prefix}_Alice`,
-      `${prefix}_Bob`,
-      `${prefix}_Charlie`,
+    expect(
+      users.items.map(
+        (user) => `${user.realFirstName.value!} ${user.realLastName.value!}`,
+      ),
+    ).toEqual([
+      `${prefix}_Alice Smith`,
+      `${prefix}_Bob Adams`,
+      `${prefix}_Bob Young`,
+      `${prefix}_Charlie Smith`,
     ]);
   });
 

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { beforeAll, describe, expect, it } from '@jest/globals';
 import { times } from 'lodash';
-import { firstLettersOfWords, isValidId } from '~/common';
+import { firstLettersOfWords, generateId, isValidId } from '~/common';
 import { graphql, type InputOf, type VariablesOf } from '~/graphql';
 import { UserStatus } from '../src/components/user/dto';
 import {
@@ -262,6 +262,34 @@ describe('User e2e', () => {
       id: user.id,
     });
     expect(afterRemove.user.locations.items).toHaveLength(0);
+  });
+
+  it('lists users sorted by full name by default', async () => {
+    const prefix = 'ZzzSortTest' + (await generateId());
+    await createPerson(app, { realFirstName: `${prefix}_Charlie` });
+    await createPerson(app, { realFirstName: `${prefix}_Alice` });
+    await createPerson(app, { realFirstName: `${prefix}_Bob` });
+
+    const { users } = await app.graphql.query(
+      graphql(`
+        query ($prefix: String!) {
+          users(input: { count: 25, page: 1, filter: { name: $prefix } }) {
+            items {
+              realFirstName {
+                value
+              }
+            }
+          }
+        }
+      `),
+      { prefix },
+    );
+
+    expect(users.items.map((user) => user.realFirstName.value)).toEqual([
+      `${prefix}_Alice`,
+      `${prefix}_Bob`,
+      `${prefix}_Charlie`,
+    ]);
   });
 
   it('assign organization to user', async () => {


### PR DESCRIPTION
### Summary 

The user directory (the `users` list query) was sorting by an internal id — effectively random order, since that id has nothing to do with when someone was created or their name. Every other list in the app that has a name field (languages, organizations, locations, projects, etc.) already defaults to sorting by name; the user list was the one exception. Anyone browsing the full list of users would see them in a meaningless order and have to sort client-side or hunt for the person they wanted.

The fix flips the default to sort by full name (first name, then last name as a tiebreaker). The one wrinkle: this app is mid-migration between three different database implementations, and only the current one had "sort by name" actually built for the user list — the two newer implementations would have silently kept sorting by id even after the default changed, since they fall back silently instead of erroring on an unsupported sort. This PR builds that sorting logic into both of the newer implementations too, so the fix holds regardless of which database is active.

Branch `user-list-default-sort-by-name`, based directly on `develop`. Single commit, no dependencies on other in-flight work.

### What's added

- Changed the default sort key for the users list from `id` to `fullName`.
- Implemented full-name sorting (first name, then last name) on the two newer database implementations, matching what the current, live database already does.
- Exposed one small type from the shared data-access layer that was needed to express a two-column sort order — a one-line addition following the existing pattern for that layer's exports.
- Corrected a comment in the shared sorting helper that specifically referenced "the user list defaults to sorting by id," which is no longer true anywhere in the app.
- Added an end-to-end test: creates a few users with names deliberately out of alphabetical order and confirms the list comes back correctly sorted.

### Validation performed

- `yarn lint` — clean, zero warnings
- `yarn type-check` — clean
- `test/user.e2e-spec.ts` run against the current live database — 13/13 passed, including the new sort test
- `test/user.e2e-spec.ts` run against Postgres (one of the two newer implementations) — 13/13 passed, including the new sort test
- The third implementation (Gel) was verified by type-checking and by matching an existing, already-reviewed pattern elsewhere in the codebase (see below) — it isn't reachable in any environment currently in use, so there was no live database to test it against.

### Reviewer cross-checks

- The Gel-side change is currently unreachable code — nothing in this codebase is configured to route user list queries there today. It's included anyway because it's a real gap and this is the natural place to close it; worth confirming you agree that's the right call rather than leaving it for whenever Gel is actually wired up.
- The multi-column sort applies the same ascending/descending direction to both first and last name together, rather than letting them be independent. That matches the current live database's existing behavior.

### Explicitly out of scope

- There's a broader, separate issue: right now, requesting an unsupported or unrecognized sort key anywhere in the app silently falls back to sorting by id instead of returning an error. This PR only changes the User list's *default* value — it doesn't change that silent-fallback behavior, which affects many other lists beyond just users and deserves its own decision before being changed everywhere.
- This sorts by a person's real first/last name, not their display name (some users have a different display name set). That matches what the current live database already does — changing which name is used for sorting would be a separate, deliberate decision, not a byproduct of this fix.
