### PR TITLE
Implement location attach/detach for Postgres (Organization, User, Language, Project)

### DIFF
--- a/src/components/location/location.drizzle.repository.ts
+++ b/src/components/location/location.drizzle.repository.ts
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon';
 import {
   generateId,
   type ID,
-  NotImplementedException,
+  NotFoundException,
   type PaginatedListType,
   ServerException,
   type UnsecuredDto,
@@ -18,7 +18,17 @@ import {
   type SortMap,
 } from '~/core/drizzle';
 import { DrizzleService } from '~/core/drizzle/drizzle.service';
-import { locations } from '~/core/drizzle/schema';
+import {
+  languageLocations,
+  languages,
+  locations,
+  organizationLocations,
+  organizations,
+  projectOtherLocations,
+  projects,
+  userLocations,
+  users,
+} from '~/core/drizzle/schema';
 import { type ResourceNameLike } from '~/core/resources';
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import { FileService } from '../file';
@@ -28,7 +38,6 @@ import {
   Location,
   type LocationFilters,
   type LocationListInput,
-  type LocationListOutput,
   type UpdateLocation,
 } from './dto';
 
@@ -145,37 +154,232 @@ export class LocationDrizzleRepository extends DrizzleDtoRepository<
     };
   }
 
-  // migration-todo: implement when location-node relationships are migrated to PG
-  addLocationToNode(
-    _label: ResourceNameLike,
-    _id: ID,
-    _rel: string,
-    _locationId: ID<'Location'>,
+  async addLocationToNode(
+    label: ResourceNameLike,
+    id: ID,
+    rel: string,
+    locationId: ID<'Location'>,
   ): Promise<DateTime | null> {
-    throw new NotImplementedException();
+    await this.assertLiveLocation(locationId);
+    await this.assertLiveResource(label, id);
+
+    if (label === 'Organization' && rel === 'locations') {
+      const inserted = await this.db
+        .insert(organizationLocations)
+        .values({ organizationId: id as ID<'Organization'>, locationId })
+        .onConflictDoNothing()
+        .returning();
+      return inserted.length > 0 ? DateTime.now() : null;
+    }
+    if (label === 'User' && rel === 'locations') {
+      const inserted = await this.db
+        .insert(userLocations)
+        .values({ userId: id as ID<'User'>, locationId })
+        .onConflictDoNothing()
+        .returning();
+      return inserted.length > 0 ? DateTime.now() : null;
+    }
+    if (label === 'Language' && rel === 'locations') {
+      const inserted = await this.db
+        .insert(languageLocations)
+        .values({ languageId: id as ID<'Language'>, locationId })
+        .onConflictDoNothing()
+        .returning();
+      return inserted.length > 0 ? DateTime.now() : null;
+    }
+    if (label === 'Project' && rel === 'otherLocations') {
+      const inserted = await this.db
+        .insert(projectOtherLocations)
+        .values({ projectId: id as ID<'Project'>, locationId })
+        .onConflictDoNothing()
+        .returning();
+      return inserted.length > 0 ? DateTime.now() : null;
+    }
+    throw new ServerException(`Unsupported location edge: ${label}.${rel}`);
   }
 
-  // migration-todo: implement when location-node relationships are migrated to PG
-  removeLocationFromNode(
-    _label: ResourceNameLike,
-    _id: ID,
-    _rel: string,
-    _locationId: ID<'Location'>,
+  async removeLocationFromNode(
+    label: ResourceNameLike,
+    id: ID,
+    rel: string,
+    locationId: ID<'Location'>,
   ): Promise<DateTime | null> {
-    throw new NotImplementedException();
+    await this.assertLiveLocation(locationId);
+    await this.assertLiveResource(label, id);
+
+    if (label === 'Organization' && rel === 'locations') {
+      const deleted = await this.db
+        .delete(organizationLocations)
+        .where(
+          and(
+            eq(organizationLocations.organizationId, id as ID<'Organization'>),
+            eq(organizationLocations.locationId, locationId),
+          ),
+        )
+        .returning();
+      return deleted.length > 0 ? DateTime.now() : null;
+    }
+    if (label === 'User' && rel === 'locations') {
+      const deleted = await this.db
+        .delete(userLocations)
+        .where(
+          and(
+            eq(userLocations.userId, id as ID<'User'>),
+            eq(userLocations.locationId, locationId),
+          ),
+        )
+        .returning();
+      return deleted.length > 0 ? DateTime.now() : null;
+    }
+    if (label === 'Language' && rel === 'locations') {
+      const deleted = await this.db
+        .delete(languageLocations)
+        .where(
+          and(
+            eq(languageLocations.languageId, id as ID<'Language'>),
+            eq(languageLocations.locationId, locationId),
+          ),
+        )
+        .returning();
+      return deleted.length > 0 ? DateTime.now() : null;
+    }
+    if (label === 'Project' && rel === 'otherLocations') {
+      const deleted = await this.db
+        .delete(projectOtherLocations)
+        .where(
+          and(
+            eq(projectOtherLocations.projectId, id as ID<'Project'>),
+            eq(projectOtherLocations.locationId, locationId),
+          ),
+        )
+        .returning();
+      return deleted.length > 0 ? DateTime.now() : null;
+    }
+    throw new ServerException(`Unsupported location edge: ${label}.${rel}`);
   }
 
-  // migration-todo: implement when location-node relationships are migrated
-  // to PG. Edges can't be written yet (addLocationToNode above throws), so an
-  // empty page is accurate for PG-resident resources — and it keeps reads
-  // (e.g. user.locations in e2e fragments) from hard-failing.
   async listLocationsFromNodeNoSecGroups(
-    _label: string,
-    _rel: string,
-    _id: ID,
-    _input: LocationListInput,
-  ): Promise<LocationListOutput> {
-    return EMPTY_PAGE;
+    label: string,
+    rel: string,
+    id: ID,
+    input: LocationListInput,
+  ): Promise<PaginatedListType<UnsecuredDto<Location>>> {
+    const linkedLocationIds =
+      label === 'Organization' && rel === 'locations'
+        ? this.db
+            .select({ id: organizationLocations.locationId })
+            .from(organizationLocations)
+            .where(
+              eq(
+                organizationLocations.organizationId,
+                id as ID<'Organization'>,
+              ),
+            )
+        : label === 'User' && rel === 'locations'
+          ? this.db
+              .select({ id: userLocations.locationId })
+              .from(userLocations)
+              .where(eq(userLocations.userId, id as ID<'User'>))
+          : label === 'Language' && rel === 'locations'
+            ? this.db
+                .select({ id: languageLocations.locationId })
+                .from(languageLocations)
+                .where(eq(languageLocations.languageId, id as ID<'Language'>))
+            : label === 'Project' && rel === 'otherLocations'
+              ? this.db
+                  .select({ id: projectOtherLocations.locationId })
+                  .from(projectOtherLocations)
+                  .where(
+                    eq(projectOtherLocations.projectId, id as ID<'Project'>),
+                  )
+              : null;
+    if (!linkedLocationIds) {
+      throw new ServerException(`Unsupported location edge: ${label}.${rel}`);
+    }
+
+    const conditions: SQL[] = [
+      isNull(locations.deletedAt),
+      inArray(locations.id, linkedLocationIds),
+    ];
+    if (!this.executor.applyReadFilter(this.resource, conditions)) {
+      return EMPTY_PAGE;
+    }
+    conditions.push(...locationFilterClauses(input.filter));
+
+    const { rows, total, hasMore } = await this.paginatedSelect({
+      predicate: and(...conditions),
+      orderBy: resolveOrderBy(input, locationSortColumns, locations.name),
+      page: input.page,
+      count: input.count,
+    });
+    return {
+      total,
+      items: rows.map((row) => this.toDto(row)),
+      hasMore,
+    };
+  }
+
+  /** Confirms `locationId` refers to a live Location, or throws. */
+  private async assertLiveLocation(locationId: ID<'Location'>): Promise<void> {
+    const [row] = await this.db
+      .select({ id: locations.id })
+      .from(locations)
+      .where(and(eq(locations.id, locationId), isNull(locations.deletedAt)));
+    if (!row) {
+      throw new NotFoundException('Location not found', 'location');
+    }
+  }
+
+  /** Confirms `id` refers to a live row of the resource named by `label`, or throws. */
+  private async assertLiveResource(
+    label: ResourceNameLike,
+    id: ID,
+  ): Promise<void> {
+    const rows =
+      label === 'Organization'
+        ? await this.db
+            .select({ id: organizations.id })
+            .from(organizations)
+            .where(
+              and(
+                eq(organizations.id, id as ID<'Organization'>),
+                isNull(organizations.deletedAt),
+              ),
+            )
+        : label === 'User'
+          ? await this.db
+              .select({ id: users.id })
+              .from(users)
+              .where(
+                and(eq(users.id, id as ID<'User'>), isNull(users.deletedAt)),
+              )
+          : label === 'Language'
+            ? await this.db
+                .select({ id: languages.id })
+                .from(languages)
+                .where(
+                  and(
+                    eq(languages.id, id as ID<'Language'>),
+                    isNull(languages.deletedAt),
+                  ),
+                )
+            : label === 'Project'
+              ? await this.db
+                  .select({ id: projects.id })
+                  .from(projects)
+                  .where(
+                    and(
+                      eq(projects.id, id as ID<'Project'>),
+                      isNull(projects.deletedAt),
+                    ),
+                  )
+              : null;
+    if (!rows) {
+      throw new ServerException(`Unsupported location edge resource: ${label}`);
+    }
+    if (rows.length === 0) {
+      throw new NotFoundException('Resource not found');
+    }
   }
 
   protected toDto(row: typeof locations.$inferSelect): UnsecuredDto<Location> {

--- a/src/core/drizzle/migrations/0038_add_location_edges.sql
+++ b/src/core/drizzle/migrations/0038_add_location_edges.sql
@@ -1,0 +1,28 @@
+-- Migration: add user_locations, language_locations, and project_other_locations
+-- junction tables, mirroring organization_locations (migration 0003).
+
+CREATE TABLE "user_locations" (
+  "user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "location_id" text NOT NULL REFERENCES "locations"("id") ON DELETE CASCADE,
+  PRIMARY KEY ("user_id", "location_id")
+);
+--> statement-breakpoint
+
+CREATE TABLE "language_locations" (
+  "language_id" text NOT NULL REFERENCES "languages"("id") ON DELETE CASCADE,
+  "location_id" text NOT NULL REFERENCES "locations"("id") ON DELETE CASCADE,
+  PRIMARY KEY ("language_id", "location_id")
+);
+--> statement-breakpoint
+
+CREATE TABLE "project_other_locations" (
+  "project_id" text NOT NULL REFERENCES "projects"("id") ON DELETE CASCADE,
+  "location_id" text NOT NULL REFERENCES "locations"("id") ON DELETE CASCADE,
+  PRIMARY KEY ("project_id", "location_id")
+);
+--> statement-breakpoint
+
+-- FK indexes on the right side of composite PKs (the leftmost column is already covered)
+CREATE INDEX "user_locations_location_id_idx" ON "user_locations" ("location_id");
+CREATE INDEX "language_locations_location_id_idx" ON "language_locations" ("location_id");
+CREATE INDEX "project_other_locations_location_id_idx" ON "project_other_locations" ("location_id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1753833600000,
       "tag": "0037_add_webhooks",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1753920000000,
+      "tag": "0038_add_location_edges",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -105,6 +105,7 @@ export const usersRelations = relations(users, ({ many, one }) => ({
   }),
   educations: many(educations),
   unavailabilities: many(unavailabilities),
+  locations: many(userLocations),
 }));
 
 export const userGlobalRoles = pgTable(
@@ -341,7 +342,38 @@ export const locations = pgTable(
   ],
 );
 
-export const locationsRelations = relations(locations, () => ({}));
+export const locationsRelations = relations(locations, ({ many }) => ({
+  users: many(userLocations),
+}));
+
+export const userLocations = pgTable(
+  'user_locations',
+  {
+    userId: text('user_id')
+      .$type<ID<'User'>>()
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    locationId: text('location_id')
+      .$type<ID<'Location'>>()
+      .notNull()
+      .references(() => locations.id, { onDelete: 'cascade' }),
+  },
+  (t) => [
+    primaryKey({ columns: [t.userId, t.locationId] }),
+    index('user_locations_location_id_idx').on(t.locationId),
+  ],
+);
+
+export const userLocationsRelations = relations(userLocations, ({ one }) => ({
+  user: one(users, {
+    fields: [userLocations.userId],
+    references: [users.id],
+  }),
+  location: one(locations, {
+    fields: [userLocations.locationId],
+    references: [locations.id],
+  }),
+}));
 
 // ─── Organizations ─────────────────────────────────────────────────────────
 
@@ -1366,7 +1398,40 @@ export const projectsRelations = relations(projects, ({ one, many }) => ({
   }),
   members: many(projectMembers),
   workflowEvents: many(projectWorkflowEvents),
+  otherLocations: many(projectOtherLocations),
 }));
+
+export const projectOtherLocations = pgTable(
+  'project_other_locations',
+  {
+    projectId: text('project_id')
+      .$type<ID<'Project'>>()
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    locationId: text('location_id')
+      .$type<ID<'Location'>>()
+      .notNull()
+      .references(() => locations.id, { onDelete: 'cascade' }),
+  },
+  (t) => [
+    primaryKey({ columns: [t.projectId, t.locationId] }),
+    index('project_other_locations_location_id_idx').on(t.locationId),
+  ],
+);
+
+export const projectOtherLocationsRelations = relations(
+  projectOtherLocations,
+  ({ one }) => ({
+    project: one(projects, {
+      fields: [projectOtherLocations.projectId],
+      references: [projects.id],
+    }),
+    location: one(locations, {
+      fields: [projectOtherLocations.locationId],
+      references: [locations.id],
+    }),
+  }),
+);
 
 export const projectMembersRelations = relations(projectMembers, ({ one }) => ({
   project: one(projects, {
@@ -1717,14 +1782,47 @@ export const languages = pgTable(
   ],
 );
 
-export const languagesRelations = relations(languages, ({ one }) => ({
+export const languagesRelations = relations(languages, ({ one, many }) => ({
   // 1:1 — the FK lives on ethnologue_languages.language_id (soft attachment;
   // see that table's comment for the future global-pool model).
   ethnologue: one(ethnologueLanguages, {
     fields: [languages.id],
     references: [ethnologueLanguages.languageId],
   }),
+  locations: many(languageLocations),
 }));
+
+export const languageLocations = pgTable(
+  'language_locations',
+  {
+    languageId: text('language_id')
+      .$type<ID<'Language'>>()
+      .notNull()
+      .references(() => languages.id, { onDelete: 'cascade' }),
+    locationId: text('location_id')
+      .$type<ID<'Location'>>()
+      .notNull()
+      .references(() => locations.id, { onDelete: 'cascade' }),
+  },
+  (t) => [
+    primaryKey({ columns: [t.languageId, t.locationId] }),
+    index('language_locations_location_id_idx').on(t.locationId),
+  ],
+);
+
+export const languageLocationsRelations = relations(
+  languageLocations,
+  ({ one }) => ({
+    language: one(languages, {
+      fields: [languageLocations.languageId],
+      references: [languages.id],
+    }),
+    location: one(locations, {
+      fields: [languageLocations.locationId],
+      references: [locations.id],
+    }),
+  }),
+);
 
 export const ethnologueLanguagesRelations = relations(
   ethnologueLanguages,

--- a/test/language.e2e-spec.ts
+++ b/test/language.e2e-spec.ts
@@ -7,6 +7,7 @@ import {
   createLanguage,
   createLanguageEngagement,
   createLanguageMinimal,
+  createLocation,
   createProject,
   createSession,
   createTestApp,
@@ -196,6 +197,57 @@ describe('Language e2e', () => {
         },
       )
       .expectError(errors.notFound());
+  });
+
+  it('adds and removes a location from a language', async () => {
+    const language = await createLanguage(app);
+    const location = await createLocation(app);
+
+    const LanguageLocations = graphql(`
+      query language($id: ID!) {
+        language(id: $id) {
+          locations {
+            items {
+              id
+            }
+          }
+        }
+      }
+    `);
+
+    await app.graphql.mutate(
+      graphql(`
+        mutation addLocationToLanguage($language: ID!, $location: ID!) {
+          addLocationToLanguage(language: $language, location: $location) {
+            id
+          }
+        }
+      `),
+      { language: language.id, location: location.id },
+    );
+
+    const afterAdd = await app.graphql.query(LanguageLocations, {
+      id: language.id,
+    });
+    expect(afterAdd.language.locations.items.map((l) => l.id)).toEqual([
+      location.id,
+    ]);
+
+    await app.graphql.mutate(
+      graphql(`
+        mutation removeLocationFromLanguage($language: ID!, $location: ID!) {
+          removeLocationFromLanguage(language: $language, location: $location) {
+            id
+          }
+        }
+      `),
+      { language: language.id, location: location.id },
+    );
+
+    const afterRemove = await app.graphql.query(LanguageLocations, {
+      id: language.id,
+    });
+    expect(afterRemove.language.locations.items).toHaveLength(0);
   });
 
   // LIST Languages

--- a/test/organization.e2e-spec.ts
+++ b/test/organization.e2e-spec.ts
@@ -4,12 +4,14 @@ import { times } from 'lodash';
 import { generateId, type ID, isValidId, Role } from '~/common';
 import { graphql } from '~/graphql';
 import {
+  createLocation,
   createOrganization,
   createSession,
   createTestApp,
   errors,
   fragments,
   registerUser,
+  runAsAdmin,
   type TestApp,
 } from './utility';
 
@@ -292,6 +294,62 @@ describe('Organization e2e', () => {
     );
 
     expect(actual.name.canEdit).toBe(true);
+  });
+
+  it('adds and removes a location from an organization', async () => {
+    const org = await createOrganization(app);
+    const location = await runAsAdmin(app, () => createLocation(app));
+
+    const OrgLocations = graphql(`
+      query org($id: ID!) {
+        organization(id: $id) {
+          locations {
+            items {
+              id
+            }
+          }
+        }
+      }
+    `);
+
+    await app.graphql.mutate(
+      graphql(`
+        mutation addLocationToOrganization($organization: ID!, $location: ID!) {
+          addLocationToOrganization(
+            organization: $organization
+            location: $location
+          ) {
+            id
+          }
+        }
+      `),
+      { organization: org.id, location: location.id },
+    );
+
+    const afterAdd = await app.graphql.query(OrgLocations, { id: org.id });
+    expect(afterAdd.organization.locations.items.map((l) => l.id)).toEqual([
+      location.id,
+    ]);
+
+    await app.graphql.mutate(
+      graphql(`
+        mutation removeLocationFromOrganization(
+          $organization: ID!
+          $location: ID!
+        ) {
+          removeLocationFromOrganization(
+            organization: $organization
+            location: $location
+          ) {
+            id
+          }
+        }
+      `),
+      { organization: org.id, location: location.id },
+    );
+
+    const afterRemove = await app.graphql.query(OrgLocations, { id: org.id });
+    expect(afterRemove.organization.locations.items).toHaveLength(0);
   });
 
   const Organizations = graphql(`

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -199,6 +199,64 @@ describe('Project e2e', () => {
     );
   });
 
+  it('adds and removes an other-location from a project', async () => {
+    const project = await createProject(app);
+    const location = await runAsAdmin(app, () => createLocation(app));
+
+    const ProjectOtherLocations = graphql(`
+      query project($id: ID!) {
+        project(id: $id) {
+          otherLocations {
+            items {
+              id
+            }
+          }
+        }
+      }
+    `);
+
+    await app.graphql.mutate(
+      graphql(`
+        mutation addOtherLocationToProject($project: ID!, $location: ID!) {
+          addOtherLocationToProject(project: $project, location: $location) {
+            project {
+              id
+            }
+          }
+        }
+      `),
+      { project: project.id, location: location.id },
+    );
+
+    const afterAdd = await app.graphql.query(ProjectOtherLocations, {
+      id: project.id,
+    });
+    expect(afterAdd.project.otherLocations.items.map((l) => l.id)).toEqual([
+      location.id,
+    ]);
+
+    await app.graphql.mutate(
+      graphql(`
+        mutation removeOtherLocationFromProject($project: ID!, $location: ID!) {
+          removeOtherLocationFromProject(
+            project: $project
+            location: $location
+          ) {
+            project {
+              id
+            }
+          }
+        }
+      `),
+      { project: project.id, location: location.id },
+    );
+
+    const afterRemove = await app.graphql.query(ProjectOtherLocations, {
+      id: project.id,
+    });
+    expect(afterRemove.project.otherLocations.items).toHaveLength(0);
+  });
+
   it('create & read project with budget and field region by id', async () => {
     const res = await app.graphql.mutate(
       graphql(

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -5,6 +5,7 @@ import { firstLettersOfWords, isValidId } from '~/common';
 import { graphql, type InputOf, type VariablesOf } from '~/graphql';
 import { UserStatus } from '../src/components/user/dto';
 import {
+  createLocation,
   createOrganization,
   createPerson,
   createSession,
@@ -208,6 +209,59 @@ describe('User e2e', () => {
     );
 
     expect(users.items.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('adds and removes a location from a user', async () => {
+    const user = await createPerson(app);
+    const location = await createLocation(app);
+
+    const UserLocations = graphql(`
+      query user($id: ID!) {
+        user(id: $id) {
+          locations {
+            items {
+              id
+            }
+          }
+        }
+      }
+    `);
+
+    await app.graphql.mutate(
+      graphql(`
+        mutation addLocationToUser($user: ID!, $location: ID!) {
+          addLocationToUser(user: $user, location: $location) {
+            user {
+              id
+            }
+          }
+        }
+      `),
+      { user: user.id, location: location.id },
+    );
+
+    const afterAdd = await app.graphql.query(UserLocations, { id: user.id });
+    expect(afterAdd.user.locations.items.map((l) => l.id)).toEqual([
+      location.id,
+    ]);
+
+    await app.graphql.mutate(
+      graphql(`
+        mutation removeLocationFromUser($user: ID!, $location: ID!) {
+          removeLocationFromUser(user: $user, location: $location) {
+            user {
+              id
+            }
+          }
+        }
+      `),
+      { user: user.id, location: location.id },
+    );
+
+    const afterRemove = await app.graphql.query(UserLocations, {
+      id: user.id,
+    });
+    expect(afterRemove.user.locations.items).toHaveLength(0);
   });
 
   it('assign organization to user', async () => {


### PR DESCRIPTION
### Summary 

Attaching or removing a location from an Organization, a User, a Language, or a Project (its "other locations" list — not its single primary/marketing location, which is a different, already-working mechanism) failed outright under the newer database. Viewing an existing list of locations on any of those four didn't error, but it silently came back empty regardless of what was actually attached.

This fixes both directions for all four. Attaching, removing, and viewing locations on any of these four record types now works the same way it already does on the current, live database.

Branch `location-node-edges-postgres`, based directly on `develop`. Single commit, no dependencies on other in-flight work.

### What's added

- Three new database tables (`user_locations`, `language_locations`, `project_other_locations`), matching the shape of a table for Organization that already existed in the schema but was never actually connected to anything
- Real attach/detach/list logic for all four record types, including checking that both the location and the record you're attaching it to actually exist and haven't been deleted before allowing the link — matching how the current live database already behaves
- An end-to-end test for each of the four: attach a location, confirm it shows up, remove it, confirm it's gone

### Validation performed

- `yarn lint` and `yarn type-check` — both clean
- New tests pass against both the current live database and the newer one
- Full existing test suites for all four affected areas re-run on both databases — nothing broken
- The project's schema consistency checks (every foreign key has an index, migration files are in order, etc.) — all pass

### Reviewer cross-checks

- The choice of four small tables (one per record type) instead of one shared table covering all cases was a deliberate call, made explicitly rather than defaulted to — worth confirming you're aligned with that reasoning rather than assuming it wasn't considered.
- While testing this, I found that attaching or removing a location from any of these four has **no permission check at all, on either database** — anyone logged in can do it to any record. That's a pre-existing gap, not something this change introduces or fixes, and it's already being tracked separately.

### Explicitly out of scope

- The permission-check gap above.
- The one-time data migration script (a separate, existing branch) needed a matching update so these same links carry over correctly when the real cutover happens — that's done as its own change on that branch, not part of this one.
