### PR TITLE
Assign department IDs to MultiplicationTranslation projects via their primary partner on Postgres

### DIFF
--- a/src/components/finance/department/neo4j.utils.ts
+++ b/src/components/finance/department/neo4j.utils.ts
@@ -3,17 +3,26 @@ import { node, type Pattern, type Query, relation } from 'cypher-query-builder';
 import { ACTIVE, apoc, collect, merge, variable } from '~/core/neo4j/query';
 import { type FinanceDepartmentIdBlockInput as Input } from './dto/id-blocks.input';
 
-const defaultRel = [
+// A fresh pair must be built on every use. cypher-query-builder's
+// useParameterBag() mutates a pattern's parameterBag reference in place
+// (parameter-container.ts), so a single shared instance reused across
+// separate query builds ends up carrying forward — and re-merging — the
+// previous build's accumulated parameters every time it's touched, which
+// silently doubles the query's parameter count on each reuse for the
+// lifetime of the process. A `const` array (even `as const`) only makes the
+// TypeScript type readonly; the underlying NodePattern/Relation instances
+// are still stateful and mutated by the library.
+const defaultRel = (): NonEmptyArray<Pattern> => [
   node('node'),
   relation('out', '', 'departmentIdBlock', ACTIVE),
-] as const;
+];
 interface Options {
   input?: NonEmptyArray<Pattern>;
   output?: string;
 }
 
 export const hydrate =
-  ({ input = defaultRel, output }: Options = {}) =>
+  ({ input = defaultRel(), output }: Options = {}) =>
   (query: Query) =>
     query.subQuery(input[0].getNameString(), (sub) =>
       sub
@@ -33,7 +42,7 @@ export const createMaybe =
     !input ? query : query.apply(create(input, options));
 
 export const create =
-  (input: Input, { input: inputRel = defaultRel, output }: Options = {}) =>
+  (input: Input, { input: inputRel = defaultRel(), output }: Options = {}) =>
   (query: Query) =>
     query.subQuery(inputRel[0].getNameString(), (sub) =>
       sub
@@ -55,7 +64,7 @@ export const setMaybe =
 export const set =
   (
     input: Input | null,
-    { input: inputRel = defaultRel, output }: Options = {},
+    { input: inputRel = defaultRel(), output }: Options = {},
   ) =>
   (query: Query) =>
     input
@@ -68,7 +77,7 @@ export const set =
         );
 
 export const upsert =
-  (input: Input, { input: inputRel = defaultRel, output }: Options = {}) =>
+  (input: Input, { input: inputRel = defaultRel(), output }: Options = {}) =>
   (query: Query) =>
     query.subQuery(inputRel[0].getNameString(), (sub) =>
       sub

--- a/src/components/project/handlers/set-department-id.handler.ts
+++ b/src/components/project/handlers/set-department-id.handler.ts
@@ -1,10 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { isNull, node, not, relation } from 'cypher-query-builder';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, isNull as isNullColumn, sql } from 'drizzle-orm';
 import {
   ClientException,
   type ID,
-  NotImplementedException,
   ServerException,
   type UnsecuredDto,
 } from '~/common';
@@ -12,7 +11,7 @@ import { ConfigService } from '~/core/config';
 import { TransactionRetryInformer } from '~/core/database';
 import { DrizzleService } from '~/core/drizzle/drizzle.service';
 import { isUniqueViolation } from '~/core/drizzle/errors';
-import { projects } from '~/core/drizzle/schema';
+import { partners, partnerships, projects } from '~/core/drizzle/schema';
 import { OnHook } from '~/core/hooks';
 import { DatabaseService, UniquenessError } from '~/core/neo4j';
 import {
@@ -84,44 +83,85 @@ export class SetDepartmentId {
   }
 
   /**
-   * PG path — resolves the DepartmentIdBlock via the FK chain
-   * `project.primary_location_id → locations.funding_account_id →
-   * funding_accounts.department_id_block_id`, enumerates the block's
-   * `range int4multirange`, picks the smallest 5-digit-padded id that
-   * isn't already used, and UPDATEs `projects.department_id`. Catches PG
-   * unique violation 23505 on the partial-unique index and marks the
-   * transaction for retry — mirror of the Neo4j UniquenessError flow.
+   * PG path — resolves the DepartmentIdBlock via one of two FK chains,
+   * enumerates the block's `range int4multirange`, picks the smallest
+   * 5-digit-padded id that isn't already used, and UPDATEs
+   * `projects.department_id`. Catches PG unique violation 23505 on the
+   * partial-unique index and marks the transaction for retry — mirror of
+   * the Neo4j UniquenessError flow.
    *
-   * MultiplicationTranslation projects route via partnership → partner
-   * instead, but `partnerships` isn't migrated — throws NotImplementedException
-   * with a clear message until partnership-pg lands.
+   * MultiplicationTranslation projects route via
+   * `partnerships (primary) → partners.department_id_block_id`; everything
+   * else via `project.primary_location_id → locations.funding_account_id →
+   * funding_accounts.department_id_block_id`. `project.primaryPartnership`
+   * is a hard-coded null stub on the Postgres hydrate (unlike
+   * `primaryLocation`, which is real) — mirroring Neo4j's
+   * `!project.primaryPartnership` precondition check would false-positive
+   * for every Multiplication project. The primary-partnership branch below
+   * queries `partnerships`/`partners` directly instead.
    *
-   * `funding_accounts` (develop) + `department_id_blocks` (Partner) + `locations`
-   * are all present on the recut base, so the FK chain resolves. Raw SQL is used
-   * for the enumeration itself — `unnest(range)` + `lateral generate_series`
-   * over the `int4multirange` don't have a clean query-builder form.
+   * `funding_accounts` / `department_id_blocks` / `locations` / `partnerships` /
+   * `partners` are all present on the recut base, so both FK chains resolve.
+   * Raw SQL is used for the enumeration itself — `unnest(range)` + `lateral
+   * generate_series` over the `int4multirange` don't have a clean
+   * query-builder form.
    *
    * `external_department_ids` exclusion is dropped — that table is part of an
    * unmigrated domain. migration-todo: re-add the exclusion when that domain
    * ports (probably with the broader Finance/Admin work).
    */
   private async assignDepartmentIdPg(project: UnsecuredDto<Project>) {
-    if (project.type === 'MultiplicationTranslation') {
-      // migration-todo: implement the partnership → partner → block path
-      // when partnership-pg lands. Until then this branch never fires in
-      // production (DATABASE=postgres is dev-only), but it'd surface as a
-      // failed transition if hit. Mirror of the Neo4j repo's `holder` switch.
-      throw new NotImplementedException(
-        'SetDepartmentId for MultiplicationTranslation projects requires Partnership migration — pending.',
-      );
-    }
-    if (!project.primaryLocation) {
-      throw new ClientException(
-        'Project must have a primary location to continue',
-      );
+    const isMultiplication = project.type === 'MultiplicationTranslation';
+    const projectId = project.id;
+
+    let blockRangeJoin: ReturnType<typeof sql>;
+    if (isMultiplication) {
+      const [primaryPartner] = await this.drizzle.client
+        .select({ departmentIdBlockId: partners.departmentIdBlockId })
+        .from(partnerships)
+        .innerJoin(partners, eq(partners.id, partnerships.partnerId))
+        .where(
+          and(
+            eq(partnerships.projectId, projectId),
+            eq(partnerships.primary, true),
+            isNullColumn(partnerships.deletedAt),
+            isNullColumn(partners.deletedAt),
+          ),
+        )
+        .limit(1);
+      if (!primaryPartner) {
+        throw new ClientException(
+          'Project must have a partnership to continue',
+        );
+      }
+      if (!primaryPartner.departmentIdBlockId) {
+        throw new ClientException(
+          "Project's primary partner does not have a department ID blocks declared",
+        );
+      }
+      blockRangeJoin = sql`
+        join partnerships ps on ps.project_id = p.id
+          and ps."primary" = true
+          and ps.deleted_at is null
+        join partners pn on pn.id = ps.partner_id
+          and pn.deleted_at is null
+        join department_id_blocks b on b.id = pn.department_id_block_id
+      `;
+    } else {
+      if (!project.primaryLocation) {
+        throw new ClientException(
+          'Project must have a primary location to continue',
+        );
+      }
+      blockRangeJoin = sql`
+        join locations l on l.id = p.primary_location_id
+          and l.deleted_at is null
+        join funding_accounts fa on fa.id = l.funding_account_id
+          and fa.deleted_at is null
+        join department_id_blocks b on b.id = fa.department_id_block_id
+      `;
     }
 
-    const projectId = project.id;
     let nextId: string;
     try {
       const { rows } = await this.drizzle.client.execute<{ nextId: string }>(
@@ -129,11 +169,7 @@ export class SetDepartmentId {
           with block_range as (
             select b.range
             from projects p
-            join locations l on l.id = p.primary_location_id
-              and l.deleted_at is null
-            join funding_accounts fa on fa.id = l.funding_account_id
-              and fa.deleted_at is null
-            join department_id_blocks b on b.id = fa.department_id_block_id
+            ${blockRangeJoin}
             where p.id = ${projectId}
           ),
           enumerated as (

--- a/src/components/project/handlers/set-department-id.handler.ts
+++ b/src/components/project/handlers/set-department-id.handler.ts
@@ -173,10 +173,12 @@ export class SetDepartmentId {
             where p.id = ${projectId}
           ),
           enumerated as (
-            select case
-              when id < 10000 then lpad(id::text, 5, '0')
-              else id::text
-            end as dept_id
+            select
+              id,
+              case
+                when id < 10000 then lpad(id::text, 5, '0')
+                else id::text
+              end as dept_id
             from block_range,
                  unnest(block_range.range) as r,
                  lateral generate_series(lower(r), upper(r) - 1) as id
@@ -189,7 +191,7 @@ export class SetDepartmentId {
           )
           select dept_id as "nextId" from enumerated
           where dept_id not in (select department_id from used)
-          order by dept_id asc
+          order by id asc
           limit 1
         `,
       );

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -39,7 +39,10 @@ import {
   runAsAdmin,
   type TestApp,
 } from './utility';
-import { forceProjectTo } from './utility/transition-project';
+import {
+  forceProjectTo,
+  transitionProject,
+} from './utility/transition-project';
 
 const deleteProject =
   (app: TestApp) => async (id: ID | string | { id: ID | string }) =>
@@ -77,6 +80,22 @@ const ProjectListDoc = graphql(
   `,
   [fragments.project],
 );
+
+const readDepartmentId = async (app: TestApp, id: ID) => {
+  const { project } = await app.graphql.query(
+    graphql(`
+      query ProjectDepartmentId($id: ID!) {
+        project(id: $id) {
+          departmentId {
+            value
+          }
+        }
+      }
+    `),
+    { id },
+  );
+  return project.departmentId.value;
+};
 
 describe('Project e2e', () => {
   let app: TestApp;
@@ -1542,5 +1561,80 @@ describe('Project e2e', () => {
     const ids = partner.projects.items.map((p) => p.id);
     expect(ids).toContain(matchingProject.id);
     expect(ids).not.toContain(otherProject.id);
+  });
+
+  it('assigns a department id to a MultiplicationTranslation project via its primary partnership', async () => {
+    await runAsAdmin(app, async () => {
+      const partner = await createPartner(app, {
+        departmentIdBlock: { blocks: '500000-500009' },
+      });
+      const project = await createProject(app, {
+        type: ProjectType.MultiplicationTranslation,
+        fieldRegion: fieldRegion.id,
+      });
+      await createPartnership(app, {
+        project: project.id,
+        partner: partner.id,
+      });
+
+      await forceProjectTo(app, project.id, 'PendingFinanceConfirmation');
+      const departmentId = await readDepartmentId(app, project.id);
+
+      expect(departmentId).toBeTruthy();
+      expect(Number(departmentId)).toBeGreaterThanOrEqual(500000);
+      expect(Number(departmentId)).toBeLessThanOrEqual(500009);
+    });
+  });
+
+  it('does not assign the same department id to two MultiplicationTranslation projects sharing a partner', async () => {
+    await runAsAdmin(app, async () => {
+      const partner = await createPartner(app, {
+        departmentIdBlock: { blocks: '500100-500109' },
+      });
+
+      const createAndUpdateProject = async (name: string) => {
+        const project = await createProject(app, {
+          name,
+          type: ProjectType.MultiplicationTranslation,
+          fieldRegion: fieldRegion.id,
+        });
+        await createPartnership(app, {
+          project: project.id,
+          partner: partner.id,
+        });
+        // Not forceProjectTo here: it opens its own isolated admin session,
+        // which races with the shared app.graphql.authToken when two of
+        // these run concurrently under Promise.all below. The outer
+        // runAsAdmin already has us authenticated, so transition directly.
+        await transitionProject(app, {
+          project: project.id,
+          bypassTo: 'PendingFinanceConfirmation',
+        });
+        return await readDepartmentId(app, project.id);
+      };
+      const [departmentId1, departmentId2] = await Promise.all(
+        ['multi-1', 'multi-2'].map(
+          async (name) => await createAndUpdateProject(name),
+        ),
+      );
+
+      expect(departmentId1).not.toBe(departmentId2);
+    });
+  });
+
+  it('throws a clear error transitioning a MultiplicationTranslation project with no primary partnership', async () => {
+    await runAsAdmin(app, async () => {
+      const project = await createProject(app, {
+        type: ProjectType.MultiplicationTranslation,
+        fieldRegion: fieldRegion.id,
+      });
+
+      await expect(
+        forceProjectTo(app, project.id, 'PendingFinanceConfirmation'),
+      ).rejects.toThrowGqlError({
+        code: 'Client',
+        message: 'Project must have a partnership to continue',
+      });
+    });
   });
 });


### PR DESCRIPTION
### Summary 

Once a project reaches a certain step, it needs a finance tracking number ("department ID"). For most project types, that number comes from wherever the project's location is set up — the location is tied to a funding account, and each funding account has a reserved block of numbers to hand out one at a time.

One project type, MultiplicationTranslation, doesn't work through a location — its number is supposed to come from its funding partner instead. On Postgres, that path was never built: the code just gave up immediately and said "not implemented yet." Any Multiplication project that reached that step would fail outright. The leftover comment blamed this on Partnership support not existing yet — but that landed months ago, so this was just an unfinished corner, not a real blocker.

Two more things ended up in this branch alongside the main feature:

- **A numeric-ordering bug in how a number gets picked.** When choosing the next available department ID from a block, the code was sorting the candidates as *text*, not as numbers. Text sorting and number sorting agree almost all the time, but they disagree right at a length boundary — e.g. text sorting puts "10000" before "9999" because "1" sorts before "9", even though 9999 is smaller. That could cause the wrong ID to be picked once a block's numbers crossed a digit-length boundary. Fixed by sorting on the real integer value instead.
- **An unrelated, currently-live Neo4j-only bug**, found while chasing down a test that mysteriously hung for several minutes. A small piece of code that builds part of the Neo4j query for reading/writing a Partner's or FundingAccount's department-ID block was reusing one shared internal object across every call, for as long as the server process stays up. Neo4j's query-building library has a side effect where reusing that kind of object silently doubles some internal bookkeeping every time it's touched — so the more a running server used this code path, the slower it silently got, with no relation to how much actual data existed. Eventually it gets slow enough to look like a hang. This has nothing to do with Postgres and doesn't change any behavior — it's a pure performance fix scoped to Neo4j, which is still the live production database today.

Branches off `develop`, base `develop`, head `department-id-multiplication-partnership`.

### What's added

**Department ID via primary partnership (Postgres)** — `src/components/project/handlers/set-department-id.handler.ts`
- For Multiplication projects, resolves the project's main partner, finds that partner's reserved block of numbers, and picks the next unused one — same mechanism already used for the location path.
- Clear, specific errors when a Multiplication project has no primary partnership, or its partner has no number block declared, instead of the old generic "not implemented" message.
- Didn't reuse the project's `primaryPartnership` convenience field the way the original Neo4j logic did — on Postgres that field is currently hard-wired to always read empty, regardless of whether a real primary partnership exists. Copying that check as-is would have wrongly rejected every Multiplication project. The fix looks up the actual partnership/partner records directly instead.

**Numeric vs. text ordering fix** — same file
- The candidate-ID enumeration now carries the real integer id alongside the display string, and picks the next available ID by sorting on that integer instead of the zero-padded/unpadded text.

**Neo4j shared-object performance fix** — `src/components/finance/department/neo4j.utils.ts`
- A default node/relation pattern used by every `departmentIdBlock` read and write was a module-level constant, reused by reference for the life of the process. Changed it to a factory function that builds a fresh pair on every call, so nothing carries state across unrelated queries.
- Neo4j-only; has no effect on the Postgres path added above.

**Tests** — `test/project.e2e-spec.ts`
- 3 new tests covering the partnership-based assignment: assigning an ID through a partner, two projects sharing a partner getting different IDs, and the clear error when no partnership exists.

### Validation performed

- `yarn type-check` and `yarn lint`: clean.
- `test/project.e2e-spec.ts` against Postgres: 29/29 passing (covers the feature + ordering fix).
- `test/project.e2e-spec.ts` against Neo4j, full file: 33/33 passing in 53s. Before the shared-object fix, one of these tests hung for ~460 seconds and failed on timeout every time it was run; it now passes in ~4.6s.
- `funding-account`, `partner`, and `partnership` e2e suites against Neo4j: 27 passing, 2 skipped, 0 failing — checked because the shared-object fix touches code those domains also use.

### Reviewer cross-checks

- Confirm `defaultRel()` in `neo4j.utils.ts` is called (not referenced) at all four use sites (`hydrate`, `create`, `set`, `upsert`) — a missed call site would silently reintroduce the shared-instance bug at that one spot.
- The root-cause mechanism (a shared `node()`/`relation()` pattern object accumulating query-builder state across unrelated queries) is specific to how `cypher-query-builder` mutates pattern objects in place; verify the fix comment's explanation still reads as accurate if touching this file again.

### Explicitly out of scope

- `currentUser` in `src/core/neo4j/query/matching.ts` is a similarly-shaped shared singleton, reused across many other repositories (partnership, engagement, project-member, ceremony, language, progress-report, budget, organization, partner). It looks like it may be structurally immune to this exact bug for reasons specific to how its one property is built, but that was not independently confirmed. Flagged for a possible separate follow-up, not fixed here.
- No changes to the Postgres migration status or schema.
