### PR TITLE
Implement Engagement name/engagedName/startDate/endDate filters on Postgres

### DIFF
--- a/src/components/engagement/engagement.drizzle.repository.ts
+++ b/src/components/engagement/engagement.drizzle.repository.ts
@@ -1,9 +1,23 @@
 import { Injectable } from '@nestjs/common';
-import { and, eq, inArray, isNull, sql, type SQL } from 'drizzle-orm';
+import {
+  and,
+  eq,
+  gt,
+  gte,
+  ilike,
+  inArray,
+  isNull,
+  lt,
+  lte,
+  or,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
 import { difference } from 'lodash';
 import { DateTime } from 'luxon';
 import {
   CalendarDate,
+  type DateFilter,
   DuplicateException,
   EnhancedResource,
   generateId,
@@ -21,6 +35,7 @@ import {
   catchUniqueViolation,
   DrizzleDtoRepository,
   EMPTY_PAGE,
+  escapeLikePattern,
   resolveOrderBy,
   type SortMap,
   subFilter,
@@ -495,14 +510,8 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
       modifiedAt: engagements.modifiedAt,
       type: engagements.type,
       // startDate/endDate coalesce with the project's mou window.
-      startDate: sql`coalesce(${engagements.startDateOverride}, (
-        select "p"."mou_start" from "projects" "p"
-        where "p"."id" = ${engagements.projectId}
-      ))`,
-      endDate: sql`coalesce(${engagements.endDateOverride}, (
-        select "p"."mou_end" from "projects" "p"
-        where "p"."id" = ${engagements.projectId}
-      ))`,
+      startDate: effectiveStartDate,
+      endDate: effectiveEndDate,
       // migration-todo: nameProjectFirst/nameProjectLast, sensitivity,
       // language.* / project.* delegated sorts, currentProgressReportDue.*.
       // Unknown keys fall back to createdAt.
@@ -861,17 +870,55 @@ export class EngagementDrizzleRepository extends DrizzleDtoRepository<
   }
 }
 
+// Neo4j falls back from an override to the project's MOU date when the
+// override isn't set; these mirror that COALESCE so sorting and filtering
+// see the same "effective" date on both engines.
+const effectiveStartDate = sql`coalesce(${engagements.startDateOverride}, (
+  select "p"."mou_start" from "projects" "p"
+  where "p"."id" = ${engagements.projectId}
+))`;
+const effectiveEndDate = sql`coalesce(${engagements.endDateOverride}, (
+  select "p"."mou_end" from "projects" "p"
+  where "p"."id" = ${engagements.projectId}
+))`;
+
+const engagementDateFilterConditions = (
+  effectiveDate: SQL,
+  fieldName: 'startDate' | 'endDate',
+  filter: DateFilter | undefined,
+): SQL[] => {
+  if (!filter) return [];
+  if (filter.isNull != null) {
+    throw new NotImplementedException(
+      `EngagementFilters.${fieldName}.isNull is not implemented for postgres yet`,
+    );
+  }
+  return [
+    ...(filter.after ? [gt(effectiveDate, filter.after.toISODate())] : []),
+    ...(filter.afterInclusive
+      ? [gte(effectiveDate, filter.afterInclusive.toISODate())]
+      : []),
+    ...(filter.before ? [lt(effectiveDate, filter.before.toISODate())] : []),
+    ...(filter.beforeInclusive
+      ? [lte(effectiveDate, filter.beforeInclusive.toISODate())]
+      : []),
+  ];
+};
+
+// Intern name-match, reused by both `name` (also matches the project and
+// language name) and `engagedName` (engaged entity only).
+const engagedEntityUserNameMatch = (term: string) =>
+  or(
+    ilike(users.realFirstName, term),
+    ilike(users.realLastName, term),
+    ilike(users.displayFirstName, term),
+    ilike(users.displayLastName, term),
+  )!;
+
 /**
- * Column-level WHERE clauses for `EngagementFilters`. Implemented: type,
- * status, project id, languageId, partnerId, marketable, milestoneReached,
- * milestonePlanned, usingAIAssistedTranslation. The rest THROW rather than
- * silently ignore (the discoverability convention — a silently-dropped filter
- * returns the full unfiltered set and nothing catches it).
- * migration-todo: implement the throwing ones as their domains land —
- * name/engagedName (language/user name joins), startDate/endDate ranges
- * (COALESCE with the project mou window), tool sub-filter (ToolUsage not
- * migrated). project/language/intern sub-filter composition is wired below,
- * now that Project/Language/User have all landed.
+ * Column-level WHERE clauses for `EngagementFilters`. All fields are
+ * implemented, including the project/language/intern sub-filter composition
+ * and the tool sub-filter (via `toolUsages`).
  */
 export const engagementFilterClauses = (
   db: DrizzleDb,
@@ -972,18 +1019,60 @@ export const engagementFilterClauses = (
       ),
     );
   }
-  const unimplemented = {
-    name: filter.name,
-    engagedName: filter.engagedName,
-    startDate: filter.startDate,
-    endDate: filter.endDate,
-  };
-  for (const [key, value] of Object.entries(unimplemented)) {
-    if (value !== undefined) {
-      throw new NotImplementedException(
-        `EngagementFilters.${key} is not implemented for postgres yet`,
+  if (filter.name) {
+    const term = `%${escapeLikePattern(filter.name)}%`;
+    const matchingProjectIds = db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(ilike(projects.name, term));
+    const matchingLanguageIds = db
+      .select({ id: languages.id })
+      .from(languages)
+      .where(
+        or(ilike(languages.name, term), ilike(languages.displayName, term)),
       );
-    }
+    const matchingInternIds = db
+      .select({ id: users.id })
+      .from(users)
+      .where(engagedEntityUserNameMatch(term));
+    conditions.push(
+      or(
+        inArray(engagements.projectId, matchingProjectIds),
+        inArray(engagements.languageId, matchingLanguageIds),
+        inArray(engagements.internId, matchingInternIds),
+      )!,
+    );
   }
+  if (filter.engagedName) {
+    const term = `%${escapeLikePattern(filter.engagedName)}%`;
+    const matchingLanguageIds = db
+      .select({ id: languages.id })
+      .from(languages)
+      .where(
+        or(ilike(languages.name, term), ilike(languages.displayName, term)),
+      );
+    const matchingInternIds = db
+      .select({ id: users.id })
+      .from(users)
+      .where(engagedEntityUserNameMatch(term));
+    conditions.push(
+      or(
+        inArray(engagements.languageId, matchingLanguageIds),
+        inArray(engagements.internId, matchingInternIds),
+      )!,
+    );
+  }
+  conditions.push(
+    ...engagementDateFilterConditions(
+      effectiveStartDate,
+      'startDate',
+      filter.startDate,
+    ),
+    ...engagementDateFilterConditions(
+      effectiveEndDate,
+      'endDate',
+      filter.endDate,
+    ),
+  );
   return conditions;
 };

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -3,7 +3,7 @@ import { beforeAll, describe, expect, it } from '@jest/globals';
 import { some } from 'lodash';
 import { DateTime, Interval } from 'luxon';
 import { CalendarDate, generateId, type ID, Role } from '~/common';
-import { graphql } from '~/graphql';
+import { graphql, type InputOf } from '~/graphql';
 import {
   EngagementStatus,
   InternshipPosition,
@@ -43,6 +43,26 @@ import {
   stepsFromEarlyConversationToBeforeActive,
   transitionProject,
 } from './utility/transition-project';
+
+const EngagementListDoc = graphql(`
+  query EngagementList($input: EngagementListInput) {
+    engagements(input: $input) {
+      items {
+        id
+      }
+      total
+    }
+  }
+`);
+const listEngagements = async (
+  app: TestApp,
+  input?: InputOf<typeof EngagementListDoc>,
+) => {
+  const { engagements } = await app.graphql.query(EngagementListDoc, {
+    input,
+  });
+  return engagements;
+};
 
 describe('Engagement e2e', () => {
   let app: TestApp;
@@ -1290,6 +1310,89 @@ describe('Engagement e2e', () => {
         message:
           'You do not have the permission to delete this language engagement',
       }),
+    );
+  });
+
+  it('filters engagements by name matching the project name', async () => {
+    const term = 'Zolt' + (await generateId());
+    const namedProject = await createProject(app, { name: `${term} project` });
+    const engagement = await createLanguageEngagement(app, {
+      project: namedProject.id,
+      language: language.id,
+    });
+
+    const result = await listEngagements(app, { filter: { name: term } });
+
+    expect(result.items.map((item) => item.id)).toContain(engagement.id);
+  });
+
+  it('filters engagements by name matching the engaged language name', async () => {
+    const term = 'Yenn' + (await generateId());
+    const namedLanguage = await runAsAdmin(
+      app,
+      async () => await createLanguage(app, { name: `${term} language` }),
+    );
+    const engagement = await createLanguageEngagement(app, {
+      project: project.id,
+      language: namedLanguage.id,
+    });
+
+    const result = await listEngagements(app, { filter: { name: term } });
+
+    expect(result.items.map((item) => item.id)).toContain(engagement.id);
+  });
+
+  it('filters engagements by engagedName, excluding project-name-only matches', async () => {
+    const term = 'Xylo' + (await generateId());
+    const namedProject = await createProject(app, { name: `${term} project` });
+    const nonMatchingEngagement = await createLanguageEngagement(app, {
+      project: namedProject.id,
+      language: language.id,
+    });
+
+    const namedLanguage = await runAsAdmin(
+      app,
+      async () => await createLanguage(app, { name: `${term} language` }),
+    );
+    const matchingEngagement = await createLanguageEngagement(app, {
+      project: project.id,
+      language: namedLanguage.id,
+    });
+
+    const result = await listEngagements(app, {
+      filter: { engagedName: term },
+    });
+
+    const ids = result.items.map((item) => item.id);
+    expect(ids).toContain(matchingEngagement.id);
+    expect(ids).not.toContain(nonMatchingEngagement.id);
+  });
+
+  it('filters engagements by startDate/endDate, falling back to the project mou window', async () => {
+    const farFutureProject = await createProject(app, {
+      mouStart: CalendarDate.fromISO('2075-01-01').toISO(),
+      mouEnd: CalendarDate.fromISO('2076-01-01').toISO(),
+    });
+    const engagement = await createLanguageEngagement(app, {
+      project: farFutureProject.id,
+      language: language.id,
+      startDateOverride: undefined,
+      endDateOverride: undefined,
+    });
+
+    const inRange = await listEngagements(app, {
+      filter: {
+        startDate: { afterInclusive: '2075-01-01' },
+        endDate: { beforeInclusive: '2076-01-01' },
+      },
+    });
+    expect(inRange.items.map((item) => item.id)).toContain(engagement.id);
+
+    const outOfRange = await listEngagements(app, {
+      filter: { startDate: { after: '2076-01-01' } },
+    });
+    expect(outOfRange.items.map((item) => item.id)).not.toContain(
+      engagement.id,
     );
   });
 });

--- a/test/engagement.e2e-spec.ts
+++ b/test/engagement.e2e-spec.ts
@@ -1320,10 +1320,13 @@ describe('Engagement e2e', () => {
       project: namedProject.id,
       language: language.id,
     });
+    const unrelatedEngagement = await createLanguageEngagement(app);
 
     const result = await listEngagements(app, { filter: { name: term } });
 
-    expect(result.items.map((item) => item.id)).toContain(engagement.id);
+    const ids = result.items.map((item) => item.id);
+    expect(ids).toContain(engagement.id);
+    expect(ids).not.toContain(unrelatedEngagement.id);
   });
 
   it('filters engagements by name matching the engaged language name', async () => {
@@ -1336,10 +1339,13 @@ describe('Engagement e2e', () => {
       project: project.id,
       language: namedLanguage.id,
     });
+    const unrelatedEngagement = await createLanguageEngagement(app);
 
     const result = await listEngagements(app, { filter: { name: term } });
 
-    expect(result.items.map((item) => item.id)).toContain(engagement.id);
+    const ids = result.items.map((item) => item.id);
+    expect(ids).toContain(engagement.id);
+    expect(ids).not.toContain(unrelatedEngagement.id);
   });
 
   it('filters engagements by engagedName, excluding project-name-only matches', async () => {


### PR DESCRIPTION
### Summary

The engagement list screen lets people search and narrow results — by typing a name, or picking a date range. Four of those search options were completely broken on the new database: searching by name, searching by the specific language or person on the engagement, and filtering by start or end date. Any attempt to use them just failed outright with a "not implemented" error.

An engagement is either tied to a language (translation work) or a person (an internship). The "name" search is supposed to match the project's name, OR the language's name, OR the person's name — whichever applies. There's also a narrower version that only matches the language or person, deliberately leaving the project name out, for when someone wants "the engagement with this specific language" without also pulling in every engagement whose project happens to share that word.

The date filters are trickier because an engagement's start and end dates are often not set directly — they fall back to the dates of the project it belongs to. Filtering "engagements starting after such-and-such date" has to check the engagement's own date first and fall back to the project's date, or it would wrongly skip engagements that never got their own override.

This branches off `develop` (1 commit, ~230 lines) and updates `engagement.drizzle.repository.ts`.

### What's in scope

- `name` and `engagedName` filters, matching against project/language/intern name text.
- `startDate`/`endDate` range filters, using the same project-date fallback that engagement sorting already relies on — filtering and sorting now agree on what an engagement's "real" date is, instead of risking two different answers.

### Design decisions

- The date fallback logic is pulled out into a shared piece of code used by both sorting and filtering, rather than duplicating it — they need to answer the exact same question ("what's this engagement's actual date?") and drifting apart would produce inconsistent results between the two.
- The name searches don't rely on the data being joined together in one query — the engagement, project, language, and person all live in separate lookups. Each name filter runs a small lookup first (which projects/languages/people match this text?) and then matches engagements against those results.

### Validation

- `yarn type-check` and `yarn lint` both clean.
- `test/engagement.e2e-spec.ts` passes in full against Postgres (35/36, the 1 skip pre-existing and unrelated), including 4 new tests covering each filter.
