### PR TITLE
Filter Partner.people by organization membership on Postgres

### DIFF
--- a/src/components/user/user.drizzle.repository.ts
+++ b/src/components/user/user.drizzle.repository.ts
@@ -22,6 +22,7 @@ import {
 import { type DrizzleDb, DrizzleService } from '~/core/drizzle/drizzle.service';
 import {
   engagements,
+  partners,
   userGlobalRoles,
   userOrganizations,
   users,
@@ -439,6 +440,19 @@ export const userFilterClauses = (
       .from(userGlobalRoles)
       .where(inArray(userGlobalRoles.role, filter.roles));
     conditions.push(inArray(users.id, roleSubq));
+  }
+  if (filter.partnerId) {
+    const partnerUserIdsSubq = db
+      .selectDistinct({ userId: userOrganizations.userId })
+      .from(userOrganizations)
+      .innerJoin(
+        partners,
+        eq(partners.organizationId, userOrganizations.organizationId),
+      )
+      .where(
+        and(eq(partners.id, filter.partnerId), isNull(partners.deletedAt)),
+      );
+    conditions.push(inArray(users.id, partnerUserIdsSubq));
   }
   return conditions;
 };

--- a/test/partner.e2e-spec.ts
+++ b/test/partner.e2e-spec.ts
@@ -190,6 +190,7 @@ describe('Partner e2e', () => {
     });
 
     const otherUser = await createPerson(app);
+    const unrelatedUser = await createPerson(app);
     await runAsAdmin(app, async () => {
       await app.graphql.mutate(AssignOrgToUserDoc, {
         org: org.id,
@@ -227,9 +228,9 @@ describe('Partner e2e', () => {
 
     const list = result.partner.people;
     expect(list.canRead).toBe(true);
-    expect(list.total).toBeGreaterThanOrEqual(2);
     const userIds = list.items.map((u) => u.id);
     expect(userIds).toEqual(expect.arrayContaining([poc.id, otherUser.id]));
+    expect(userIds).not.toContain(unrelatedUser.id);
     expect(result.partner.pointOfContact.value?.id).toBe(poc.id);
   });
 });


### PR DESCRIPTION
### Summary

A Partner has a "people" list — meant to show only the users who belong to that partner's organization. On Postgres, the filter that narrows that list down was simply missing: the code silently ignored it and returned every user in the system instead. So it looked like every user was a member of every partner.

There's an existing test for this list, but it only checked that the two people who *should* show up did show up — it never checked that someone unrelated was correctly left out. A list of "everyone" would pass that check just as easily as a correctly filtered one, so the bug was invisible to the test.

This branches off `develop` (1 commit, ~16 lines) and updates `user.drizzle.repository.ts` plus the existing `partner.e2e-spec.ts` coverage.

### What's in scope

- Adds the missing `partnerId` filter to the Postgres user query: a user counts as one of a partner's people if they belong to that partner's organization.
- Strengthens the existing "lists people on a partner" test to also assert that an unrelated user is excluded, not just that the expected ones are included.

### Design decisions

- Matched the existing Neo4j behavior exactly (user → organization → partner), rather than introducing a new relationship — this filter already existed and worked on the old database, it just never got carried over.

### Validation

- `yarn type-check` and `yarn lint` both clean.
- `test/partner.e2e-spec.ts` passes in full against Postgres (8/8), including the strengthened test that would have caught this bug.
