### PR TITLE
Financial approver port

### DIFF
--- a/src/components/project/financial-approver/financial-approver.drizzle.repository.ts
+++ b/src/components/project/financial-approver/financial-approver.drizzle.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { many, type Many } from '@seedcompany/common';
-import { and, arrayOverlaps, eq, isNull } from 'drizzle-orm';
+import { and, arrayOverlaps, eq, isNull, sql } from 'drizzle-orm';
 import { type ID, type PublicOf, ServerException } from '~/common';
 import { DrizzleService } from '~/core/drizzle/drizzle.service';
 import { financialApprovers, users } from '~/core/drizzle/schema';
@@ -29,31 +29,53 @@ export class FinancialApproverDrizzleRepository implements PublicOf<FinancialApp
 
   async write(input: SetFinancialApprover) {
     if (input.projectTypes.length === 0) {
+      // Deliberately not conditioned on the user being live, unlike the write
+      // below. The Neo4j arm matches the live `User` label here too, so for a
+      // soft-deleted user it deletes nothing and the row survives — but that
+      // row is unreachable through read() on either engine, so matching Neo4j
+      // would mean deliberately keeping data nothing can see. Removing it is
+      // the better of two unobservable behaviours.
       await this.db.client
         .delete(financialApprovers)
         .where(eq(financialApprovers.userId, input.user));
       return null;
     }
 
-    // The FK alone cannot enforce this: a soft-deleted user's row never
-    // leaves, so the insert would succeed where the Neo4j arm's match on the
-    // live `User` label finds nothing and throws. Same check, same error.
-    const liveUser = await this.db.client
-      .select({ id: users.id })
-      .from(users)
-      .where(and(eq(users.id, input.user), isNull(users.deletedAt)));
-    if (!liveUser[0]) {
-      throw new ServerException('Failed to set financial approver.');
-    }
+    // Each value parameterized rather than inlined, and cast explicitly: the
+    // column is `project_type[]`, and a bare array parameter arrives untyped.
+    const typesLiteral = sql<
+      readonly [ProjectType, ...ProjectType[]]
+    >`array[${sql.join(
+      input.projectTypes.map((type) => sql`${type}`),
+      sql`, `,
+    )}]::"project_type"[]`;
 
-    await this.db.client
-      .insert(financialApprovers)
-      .values({ userId: input.user, projectTypes: input.projectTypes })
-      .onConflictDoUpdate({
-        target: financialApprovers.userId,
-        set: { projectTypes: input.projectTypes },
-      });
+    // ONE statement, deliberately. The foreign key cannot carry this: soft
+    // deletion never removes the user's row, so it is satisfied by a deleted
+    // user. Checking liveness in a separate SELECT first leaves a window — a
+    // user soft-deleted between the two statements gets an approver row
+    // written anyway — where the Neo4j arm, a single match-then-merge, has no
+    // such window. Selecting the row out of `users` closes it without needing
+    // a lock or a surrounding transaction: no live user, no row to insert,
+    // nothing written.
+    //
+    // Raw SQL rather than the query builder because drizzle's
+    // insert-from-select generics reject a projection that mixes a column with
+    // a SQL expression, which is exactly the shape wanted here.
+    await this.db.client.execute(sql`
+      insert into ${financialApprovers} ("user_id", "project_types")
+      select ${users.id}, ${typesLiteral}
+      from ${users}
+      where ${users.id} = ${input.user} and ${users.deletedAt} is null
+      on conflict ("user_id")
+        do update set "project_types" = excluded."project_types"
+    `);
 
+    // This now covers the not-live case as well as a failed write, which is
+    // why the liveness check above it is gone rather than merely moved:
+    // hydrated() inner-joins live users, so a user who was never live (nothing
+    // was written) and one deleted concurrently both land here, and raise the
+    // same error the Neo4j arm raises when its match finds nothing.
     const written = await this.hydrated().where(
       eq(financialApprovers.userId, input.user),
     );

--- a/src/components/project/financial-approver/financial-approver.drizzle.repository.ts
+++ b/src/components/project/financial-approver/financial-approver.drizzle.repository.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@nestjs/common';
+import { many, type Many } from '@seedcompany/common';
+import { and, arrayOverlaps, eq, isNull } from 'drizzle-orm';
+import { type ID, type PublicOf, ServerException } from '~/common';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { financialApprovers, users } from '~/core/drizzle/schema';
+import { type ProjectType } from '../dto/project-type.enum';
+import { type FinancialApprover, type SetFinancialApprover } from './dto';
+import { type FinancialApproverRepository } from './financial-approver.repository';
+
+@Injectable()
+export class FinancialApproverDrizzleRepository implements PublicOf<FinancialApproverRepository> {
+  constructor(private readonly db: DrizzleService) {}
+
+  async read(types?: Many<ProjectType>) {
+    const [first, ...rest] = types ? many(types) : [];
+    if (types && first === undefined) {
+      // An empty filter matches nothing — parity with the Neo4j/Gel arms,
+      // where it becomes an intersection with the empty set.
+      return [];
+    }
+    const rows = await this.hydrated().where(
+      first !== undefined
+        ? arrayOverlaps(financialApprovers.projectTypes, [first, ...rest])
+        : undefined,
+    );
+    return rows.map(toDto);
+  }
+
+  async write(input: SetFinancialApprover) {
+    if (input.projectTypes.length === 0) {
+      await this.db.client
+        .delete(financialApprovers)
+        .where(eq(financialApprovers.userId, input.user));
+      return null;
+    }
+
+    // The FK alone cannot enforce this: a soft-deleted user's row never
+    // leaves, so the insert would succeed where the Neo4j arm's match on the
+    // live `User` label finds nothing and throws. Same check, same error.
+    const liveUser = await this.db.client
+      .select({ id: users.id })
+      .from(users)
+      .where(and(eq(users.id, input.user), isNull(users.deletedAt)));
+    if (!liveUser[0]) {
+      throw new ServerException('Failed to set financial approver.');
+    }
+
+    await this.db.client
+      .insert(financialApprovers)
+      .values({ userId: input.user, projectTypes: input.projectTypes })
+      .onConflictDoUpdate({
+        target: financialApprovers.userId,
+        set: { projectTypes: input.projectTypes },
+      });
+
+    const written = await this.hydrated().where(
+      eq(financialApprovers.userId, input.user),
+    );
+    if (!written[0]) {
+      throw new ServerException('Failed to set financial approver.');
+    }
+    return toDto(written[0]);
+  }
+
+  private hydrated() {
+    return this.db.client
+      .select({
+        userId: financialApprovers.userId,
+        email: users.email,
+        projectTypes: financialApprovers.projectTypes,
+      })
+      .from(financialApprovers)
+      .innerJoin(
+        users,
+        // Live users only — the Neo4j arm matches the live `User` label, so a
+        // soft-deleted user's approver row disappears from read() there. This
+        // also protects the workflow notifier (which emails read()'s output)
+        // and the resolver's non-nullable user field (whose loader filters
+        // deleted users and would throw NotFound).
+        and(eq(users.id, financialApprovers.userId), isNull(users.deletedAt)),
+      );
+  }
+}
+
+const toDto = (row: {
+  userId: ID<'User'>;
+  email: string | null;
+  projectTypes: readonly [ProjectType, ...ProjectType[]];
+}): FinancialApprover => ({
+  user: { id: row.userId, email: row.email },
+  projectTypes: row.projectTypes,
+});

--- a/src/components/project/financial-approver/financial-approver.module.ts
+++ b/src/components/project/financial-approver/financial-approver.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { splitDb } from '~/core/database';
 import { FinancialApproverNeo4jRepository } from './financial-approver-neo4j.repository';
+import { FinancialApproverDrizzleRepository } from './financial-approver.drizzle.repository';
 import { FinancialApproverRepository } from './financial-approver.repository';
 import { FinancialApproverResolver } from './financial-approver.resolver';
 
@@ -9,6 +10,7 @@ import { FinancialApproverResolver } from './financial-approver.resolver';
     FinancialApproverResolver,
     splitDb(FinancialApproverRepository, {
       neo4j: FinancialApproverNeo4jRepository,
+      postgres: FinancialApproverDrizzleRepository,
     }),
   ],
   exports: [FinancialApproverRepository],

--- a/src/core/drizzle/live-query-invalidation.spec.ts
+++ b/src/core/drizzle/live-query-invalidation.spec.ts
@@ -59,6 +59,14 @@ const EXEMPT: Record<string, string> = {
   // --- parity: verified the Neo4j counterpart has no invalidation either ---
   'src/components/pin/pin.drizzle.repository.ts':
     'parity — pin.repository.ts extends no invalidating base and never invalidates',
+  'src/components/project/financial-approver/financial-approver.drizzle.repository.ts':
+    'parity — financial-approver-neo4j.repository.ts extends CommonRepository but ' +
+    'writes with hand-built queries (merge / setValues / detachDelete), never one of ' +
+    'its invalidating methods, so Neo4j does not announce an approver change either. ' +
+    'Note the canonical `financial-approver.repository.ts` in this folder is the GEL ' +
+    'arm, not the Neo4j one — the Neo4j arm carries the `-neo4j` infix here, unlike ' +
+    'most domains. Adding invalidation to the Postgres arm alone would introduce a ' +
+    'divergence rather than remove one',
   'src/components/product-progress/product-progress.drizzle.repository.ts':
     'parity — product-progress.repository.ts extends no invalidating base',
   'src/components/progress-summary/progress-summary.drizzle.repository.ts':

--- a/src/core/drizzle/migrations/0039_add_financial_approvers.sql
+++ b/src/core/drizzle/migrations/0039_add_financial_approvers.sql
@@ -1,0 +1,21 @@
+-- Financial approvers: "user X approves finances for project type Y" — read by
+-- the project workflow to notify approvers on five financial-plan transitions
+-- (the FinancialApprovers notifier). Ported, not retired, per Rob 2026-08-24:
+-- without this table those notifications silently stop at cutover. 3 rows in
+-- production.
+--
+-- Neo4j models this as a ProjectTypeFinancialApprover node holding ONLY a
+-- projectTypes array, linked -[:financialApprover]-> User and merged
+-- one-per-user (Gel likewise makes the link exclusive). The node has no id and
+-- no timestamps, so the user is the row identity — hence user_id as the
+-- primary key and no id/created_at columns to carry.
+
+CREATE TABLE "financial_approvers" (
+  "user_id"        text PRIMARY KEY REFERENCES "users"("id"),
+  "project_types"  "project_type"[] NOT NULL,
+  -- An approver with no project types is a delete, not a row — the write path
+  -- removes the row when the list empties (matching Neo4j's detachDelete), so
+  -- the empty state is meaningless and the database refuses it outright.
+  CONSTRAINT "financial_approvers_types_not_empty"
+    CHECK (cardinality("project_types") > 0)
+);

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1753920000000,
       "tag": "0038_add_location_edges",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1754006400000,
+      "tag": "0039_add_financial_approvers",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -868,6 +868,50 @@ export const departmentIdBlocks = pgTable('department_id_blocks', {
     .default([]),
 });
 
+/**
+ * Finance-approver config: "user X approves finances for project type Y" —
+ * read by the project workflow to notify approvers on financial-plan
+ * transitions. Ported (not retired) per Rob 2026-08-24: without it those
+ * notifications silently stop at cutover.
+ *
+ * One row per user: Neo4j merges one ProjectTypeFinancialApprover node per
+ * [:financialApprover] user and Gel makes the link exclusive. The source node
+ * holds ONLY the projectTypes array — no id, no timestamps — so the user IS
+ * the row identity.
+ */
+export const financialApprovers = pgTable(
+  'financial_approvers',
+  {
+    userId: text('user_id')
+      .$type<ID<'User'>>()
+      .primaryKey()
+      .references(() => users.id),
+    projectTypes: projectTypeEnum('project_types')
+      .array()
+      .$type<readonly [ProjectType, ...ProjectType[]]>()
+      .notNull(),
+  },
+  (t) => [
+    // An approver with no project types is a delete, not a row — the write
+    // path removes the row when the list empties (matching Neo4j's
+    // detachDelete), and the DB refuses the meaningless state outright.
+    check(
+      'financial_approvers_types_not_empty',
+      sql`cardinality(${t.projectTypes}) > 0`,
+    ),
+  ],
+);
+
+export const financialApproversRelations = relations(
+  financialApprovers,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [financialApprovers.userId],
+      references: [users.id],
+    }),
+  }),
+);
+
 export const partners = pgTable(
   'partners',
   {


### PR DESCRIPTION
Why
Financial approvers ("user X approves finances for project type Y") are read by the
project workflow, which emails the matching approvers on five financial-plan
transitions. The module had Neo4j and Gel repositories but no Postgres one — so after
cutover those notifications would have silently stopped: no error, no failing test
(the feature has no e2e coverage on any engine), just emails that never send. The
cutover coverage check surfaced the data as unclaimed, and the call was to port the
feature rather than retire it.

How
New financial_approvers table (migration 0039). One row per user: the Neo4j node
holds only the projectTypes array — no id, no timestamps — so user_id is the
primary key. An empty type list is a delete, not a row (matching the existing
detachDelete behavior), and a CHECK refuses the meaningless empty state.
New Postgres repository wired as the module's postgres arm, keeping parity with
the other two arms where Postgres alone can't: soft deletion never removes a row,
so the foreign key can't mean "live user". read() joins users on
deleted_at IS NULL (the Neo4j arm's live-label match — and what keeps the
workflow notifier from emailing deleted users), write() verifies the user is
live before upserting (Neo4j's match finds nothing and throws; same check, same
error), and an empty type filter matches nothing rather than everything.
New ETL extractor carries the 3 production rows. The edge target is matched
label-free and classified in code, enum values are sanitized, and an empty or
absent type list drops the row with a log line — so a legacy data surprise is a
recorded drop, not an aborted load.
Notes
The feature has zero e2e coverage on any engine — noted in the test backlog rather
than addressed here, since the port changes no behavior on the current engine.