### PR TITLE
Apply the pinned filter to the users list on Postgres

### DIFF
--- a/src/components/user/user.drizzle.repository.ts
+++ b/src/components/user/user.drizzle.repository.ts
@@ -30,7 +30,7 @@ import {
 import { PolicyExecutor } from '../authorization/policy/executor/policy-executor';
 import { FileService } from '../file';
 import { type FileId } from '../file/dto';
-import { pinnedByRequester } from '../pin/pinned-by-requester';
+import { pinnedByRequester, pinnedFilter } from '../pin/pinned-by-requester';
 import {
   type AssignOrganizationToUser,
   type CreatePerson,
@@ -240,7 +240,13 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
     if (!this.executor.applyReadFilter(this.resource, conditions)) {
       return EMPTY_PAGE;
     }
-    conditions.push(...userFilterClauses(this.db, input.filter));
+    conditions.push(
+      ...userFilterClauses(
+        this.db,
+        input.filter,
+        this.identity.currentMaybe?.userId,
+      ),
+    );
 
     const sortColumns = {
       fullName: [users.realFirstName, users.realLastName],
@@ -409,15 +415,21 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
  * `users` table. Reusable from sub-filters in other domains (e.g. FieldZone's
  * `director` filter) — the caller composes these with their own join/lookup.
  *
- * Note: `pinned` is not stored on the user row (per-requester state), so it is
- * intentionally not handled here — same migration-todo as the user list itself.
+ * `pinned` is per-requester state, so it needs `requesterId` — the user list
+ * passes it; sub-filter callers currently don't, and for them a `pinned`
+ * filter matches nothing (same as an anonymous requester — the semantics
+ * `pinnedFilter` already defines).
  */
 export const userFilterClauses = (
   db: DrizzleDb,
   filter: UserFilters | undefined,
+  requesterId?: ID<'User'>,
 ): SQL[] => {
   const conditions: SQL[] = [];
   if (!filter) return conditions;
+  if (filter.pinned != null) {
+    conditions.push(pinnedFilter(requesterId, users.id, filter.pinned));
+  }
   if (filter.id) conditions.push(eq(users.id, filter.id));
   if (filter.status) conditions.push(eq(users.status, filter.status));
   if (filter.name) {

--- a/test/pin.e2e-spec.ts
+++ b/test/pin.e2e-spec.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, it } from '@jest/globals';
 import { Role } from '~/common';
 import { graphql } from '~/graphql';
 import {
+  createPerson,
   createPin,
   createProject,
   createSession,
@@ -44,5 +45,40 @@ describe('Pin e2e', () => {
     const actual = result.project;
     expect(actual.id).toBe(project.id);
     expect(actual.pinned).toBe(true);
+  });
+
+  it('filters the users list to those pinned by the requester', async () => {
+    const pinnedPerson = await createPerson(app);
+    const unpinnedPerson = await createPerson(app);
+    await createPin(app, pinnedPerson.id, true);
+
+    const UsersByPinnedDoc = graphql(`
+      query usersByPinned($pinned: Boolean!) {
+        users(input: { count: 25, page: 1, filter: { pinned: $pinned } }) {
+          items {
+            id
+            pinned
+          }
+          total
+        }
+      }
+    `);
+
+    const pinnedOnly = await app.graphql.query(UsersByPinnedDoc, {
+      pinned: true,
+    });
+    // Only the person this requester pinned — the project pinned in the test
+    // above must not leak in, and nobody else is pinned.
+    expect(pinnedOnly.users.items.map((item) => item.id)).toEqual([
+      pinnedPerson.id,
+    ]);
+    expect(pinnedOnly.users.items[0]!.pinned).toBe(true);
+
+    const unpinned = await app.graphql.query(UsersByPinnedDoc, {
+      pinned: false,
+    });
+    const unpinnedIds = unpinned.users.items.map((item) => item.id);
+    expect(unpinnedIds).not.toContain(pinnedPerson.id);
+    expect(unpinnedIds).toContain(unpinnedPerson.id);
   });
 });


### PR DESCRIPTION
### Why

The People page's "Pinned" view silently returned everyone on pg-test. Under
Postgres, the users list was the one pinned-capable list that never wired the
`pinned` filter — Project, Language, and Partner all apply the shared
`pinnedFilter` EXISTS predicate, and the Neo4j arm filters users via
`filter.isPinned` — so this was an engine divergence on a live feature. Pinning
itself worked (the mutation writes, the pin indicator displays); only the list
filter was dropped on the floor. The skip was commented as deferred to a
migration-todo that was never actually recorded, and no test exercised the
filter, so the suite stayed green.

### How

- `userFilterClauses` now takes the requester (same shape as
  `languageFilterClauses`) and applies `pinnedFilter` when the filter is set.
- Sub-filter callers (field zone/region `director`, engagement `intern`, project
  member `user`) don't pass a requester, so a `pinned` value in those sub-filters
  matches nothing — the same semantics `pinnedFilter` already defines for
  anonymous requesters.
- New e2e in the pin spec locks the behavior on both engines: pin a person,
  `pinned: true` returns exactly them (a pinned project must not leak into the
  users list), `pinned: false` returns everyone else.
