### PR TITLE
External department id port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ package-lock.json
 
 # local configuration
 .env.local
+.env.migration
 .pg.local/
 .env.*.local
 logging.yml

--- a/src/components/admin/admin.drizzle.service.ts
+++ b/src/components/admin/admin.drizzle.service.ts
@@ -7,6 +7,7 @@ import { ModuleRef } from '@nestjs/core';
 import { LazyGetter as Once } from 'lazy-get-decorator';
 import { CryptoService } from '~/core/authentication/crypto.service';
 import { ConfigService } from '~/core/config';
+import { isPgRefreshInvocation } from '~/core/drizzle/refresh/is-pg-refresh-invocation';
 import { ILogger, Logger } from '~/core/logger';
 import { AdminDrizzleRepository } from './admin.drizzle.repository';
 import { AdminRepository } from './admin.repository';
@@ -25,6 +26,13 @@ export class AdminDrizzleService implements OnApplicationBootstrap {
   }
 
   async onApplicationBootstrap(): Promise<void> {
+    // Skip when `pg refresh` is running: it wipes and reloads the whole
+    // database, these rows included. Doing it here too is a race — startup
+    // doesn't wait for this work, so an insert can land in the schema the
+    // command just rebuilt and then collide with the same id coming from
+    // the reload, stopping it partway with the old data already gone.
+    if (isPgRefreshInvocation()) return;
+
     const finishing = this.repo.finishing(async () => {
       await this.setupRootUser();
       await this.setupDefaultOrg();

--- a/src/components/file/file.drizzle.repository.ts
+++ b/src/components/file/file.drizzle.repository.ts
@@ -369,7 +369,13 @@ export class FileDrizzleRepository {
   }
 
   async delete(fileNode: FileNode): Promise<void> {
-    // Soft-delete the node and its whole subtree.
+    // Soft-delete the node and its whole subtree. DELIBERATE divergence from
+    // Neo4j, which soft-deletes only the target node and leaves descendants
+    // alive-but-detached (fetchable by direct ID). Accepted as the new truth
+    // 2026-07-14 (pre-cutover audit F1): nothing app-side reads descendants of
+    // a deleted directory, and cascade matches user expectation. S3 objects
+    // are untouched either way. Delete e2e legs (currently it.skip) get ported
+    // at cutover validation.
     const deleted = await this.db.execute<{ id: ID; type: FileNodeType }>(sql`
       WITH RECURSIVE subtree AS (
         SELECT id FROM ${fileNodes} WHERE id = ${fileNode.id}

--- a/src/components/project/financial-approver/financial-approver.drizzle.repository.ts
+++ b/src/components/project/financial-approver/financial-approver.drizzle.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { many, type Many } from '@seedcompany/common';
-import { and, arrayOverlaps, eq, isNull } from 'drizzle-orm';
+import { and, arrayOverlaps, eq, isNull, sql } from 'drizzle-orm';
 import { type ID, type PublicOf, ServerException } from '~/common';
 import { DrizzleService } from '~/core/drizzle/drizzle.service';
 import { financialApprovers, users } from '~/core/drizzle/schema';
@@ -29,31 +29,53 @@ export class FinancialApproverDrizzleRepository implements PublicOf<FinancialApp
 
   async write(input: SetFinancialApprover) {
     if (input.projectTypes.length === 0) {
+      // Deliberately not conditioned on the user being live, unlike the write
+      // below. The Neo4j arm matches the live `User` label here too, so for a
+      // soft-deleted user it deletes nothing and the row survives — but that
+      // row is unreachable through read() on either engine, so matching Neo4j
+      // would mean deliberately keeping data nothing can see. Removing it is
+      // the better of two unobservable behaviours.
       await this.db.client
         .delete(financialApprovers)
         .where(eq(financialApprovers.userId, input.user));
       return null;
     }
 
-    // The FK alone cannot enforce this: a soft-deleted user's row never
-    // leaves, so the insert would succeed where the Neo4j arm's match on the
-    // live `User` label finds nothing and throws. Same check, same error.
-    const liveUser = await this.db.client
-      .select({ id: users.id })
-      .from(users)
-      .where(and(eq(users.id, input.user), isNull(users.deletedAt)));
-    if (!liveUser[0]) {
-      throw new ServerException('Failed to set financial approver.');
-    }
+    // Each value parameterized rather than inlined, and cast explicitly: the
+    // column is `project_type[]`, and a bare array parameter arrives untyped.
+    const typesLiteral = sql<
+      readonly [ProjectType, ...ProjectType[]]
+    >`array[${sql.join(
+      input.projectTypes.map((type) => sql`${type}`),
+      sql`, `,
+    )}]::"project_type"[]`;
 
-    await this.db.client
-      .insert(financialApprovers)
-      .values({ userId: input.user, projectTypes: input.projectTypes })
-      .onConflictDoUpdate({
-        target: financialApprovers.userId,
-        set: { projectTypes: input.projectTypes },
-      });
+    // ONE statement, deliberately. The foreign key cannot carry this: soft
+    // deletion never removes the user's row, so it is satisfied by a deleted
+    // user. Checking liveness in a separate SELECT first leaves a window — a
+    // user soft-deleted between the two statements gets an approver row
+    // written anyway — where the Neo4j arm, a single match-then-merge, has no
+    // such window. Selecting the row out of `users` closes it without needing
+    // a lock or a surrounding transaction: no live user, no row to insert,
+    // nothing written.
+    //
+    // Raw SQL rather than the query builder because drizzle's
+    // insert-from-select generics reject a projection that mixes a column with
+    // a SQL expression, which is exactly the shape wanted here.
+    await this.db.client.execute(sql`
+      insert into ${financialApprovers} ("user_id", "project_types")
+      select ${users.id}, ${typesLiteral}
+      from ${users}
+      where ${users.id} = ${input.user} and ${users.deletedAt} is null
+      on conflict ("user_id")
+        do update set "project_types" = excluded."project_types"
+    `);
 
+    // This now covers the not-live case as well as a failed write, which is
+    // why the liveness check above it is gone rather than merely moved:
+    // hydrated() inner-joins live users, so a user who was never live (nothing
+    // was written) and one deleted concurrently both land here, and raise the
+    // same error the Neo4j arm raises when its match finds nothing.
     const written = await this.hydrated().where(
       eq(financialApprovers.userId, input.user),
     );

--- a/src/components/project/financial-approver/financial-approver.drizzle.repository.ts
+++ b/src/components/project/financial-approver/financial-approver.drizzle.repository.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@nestjs/common';
+import { many, type Many } from '@seedcompany/common';
+import { and, arrayOverlaps, eq, isNull } from 'drizzle-orm';
+import { type ID, type PublicOf, ServerException } from '~/common';
+import { DrizzleService } from '~/core/drizzle/drizzle.service';
+import { financialApprovers, users } from '~/core/drizzle/schema';
+import { type ProjectType } from '../dto/project-type.enum';
+import { type FinancialApprover, type SetFinancialApprover } from './dto';
+import { type FinancialApproverRepository } from './financial-approver.repository';
+
+@Injectable()
+export class FinancialApproverDrizzleRepository implements PublicOf<FinancialApproverRepository> {
+  constructor(private readonly db: DrizzleService) {}
+
+  async read(types?: Many<ProjectType>) {
+    const [first, ...rest] = types ? many(types) : [];
+    if (types && first === undefined) {
+      // An empty filter matches nothing — parity with the Neo4j/Gel arms,
+      // where it becomes an intersection with the empty set.
+      return [];
+    }
+    const rows = await this.hydrated().where(
+      first !== undefined
+        ? arrayOverlaps(financialApprovers.projectTypes, [first, ...rest])
+        : undefined,
+    );
+    return rows.map(toDto);
+  }
+
+  async write(input: SetFinancialApprover) {
+    if (input.projectTypes.length === 0) {
+      await this.db.client
+        .delete(financialApprovers)
+        .where(eq(financialApprovers.userId, input.user));
+      return null;
+    }
+
+    // The FK alone cannot enforce this: a soft-deleted user's row never
+    // leaves, so the insert would succeed where the Neo4j arm's match on the
+    // live `User` label finds nothing and throws. Same check, same error.
+    const liveUser = await this.db.client
+      .select({ id: users.id })
+      .from(users)
+      .where(and(eq(users.id, input.user), isNull(users.deletedAt)));
+    if (!liveUser[0]) {
+      throw new ServerException('Failed to set financial approver.');
+    }
+
+    await this.db.client
+      .insert(financialApprovers)
+      .values({ userId: input.user, projectTypes: input.projectTypes })
+      .onConflictDoUpdate({
+        target: financialApprovers.userId,
+        set: { projectTypes: input.projectTypes },
+      });
+
+    const written = await this.hydrated().where(
+      eq(financialApprovers.userId, input.user),
+    );
+    if (!written[0]) {
+      throw new ServerException('Failed to set financial approver.');
+    }
+    return toDto(written[0]);
+  }
+
+  private hydrated() {
+    return this.db.client
+      .select({
+        userId: financialApprovers.userId,
+        email: users.email,
+        projectTypes: financialApprovers.projectTypes,
+      })
+      .from(financialApprovers)
+      .innerJoin(
+        users,
+        // Live users only — the Neo4j arm matches the live `User` label, so a
+        // soft-deleted user's approver row disappears from read() there. This
+        // also protects the workflow notifier (which emails read()'s output)
+        // and the resolver's non-nullable user field (whose loader filters
+        // deleted users and would throw NotFound).
+        and(eq(users.id, financialApprovers.userId), isNull(users.deletedAt)),
+      );
+  }
+}
+
+const toDto = (row: {
+  userId: ID<'User'>;
+  email: string | null;
+  projectTypes: readonly [ProjectType, ...ProjectType[]];
+}): FinancialApprover => ({
+  user: { id: row.userId, email: row.email },
+  projectTypes: row.projectTypes,
+});

--- a/src/components/project/financial-approver/financial-approver.module.ts
+++ b/src/components/project/financial-approver/financial-approver.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { splitDb } from '~/core/database';
 import { FinancialApproverNeo4jRepository } from './financial-approver-neo4j.repository';
+import { FinancialApproverDrizzleRepository } from './financial-approver.drizzle.repository';
 import { FinancialApproverRepository } from './financial-approver.repository';
 import { FinancialApproverResolver } from './financial-approver.resolver';
 
@@ -9,6 +10,7 @@ import { FinancialApproverResolver } from './financial-approver.resolver';
     FinancialApproverResolver,
     splitDb(FinancialApproverRepository, {
       neo4j: FinancialApproverNeo4jRepository,
+      postgres: FinancialApproverDrizzleRepository,
     }),
   ],
   exports: [FinancialApproverRepository],

--- a/src/components/project/handlers/set-department-id.handler.ts
+++ b/src/components/project/handlers/set-department-id.handler.ts
@@ -106,9 +106,10 @@ export class SetDepartmentId {
    * generate_series` over the `int4multirange` don't have a clean
    * query-builder form.
    *
-   * `external_department_ids` exclusion is dropped — that table is part of an
-   * unmigrated domain. migration-todo: re-add the exclusion when that domain
-   * ports (probably with the broader Finance/Admin work).
+   * `external_department_ids` — the IDs Intacct already holds — is unioned into
+   * the used set exactly as the Neo4j path does. It is a flat reservation list
+   * with no owner and no lifecycle, so it needs no domain of its own; see
+   * migration 0040.
    */
   private async assignDepartmentIdPg(project: UnsecuredDto<Project>) {
     const isMultiplication = project.type === 'MultiplicationTranslation';
@@ -186,8 +187,12 @@ export class SetDepartmentId {
           used as (
             select department_id from projects
             where department_id is not null and deleted_at is null
-            -- migration-todo: also exclude external_department_ids when that
-            -- table migrates (likely Admin domain).
+            -- Same union the Neo4j path builds: an ID Intacct already holds is
+            -- as unavailable as one a project already has. Dropping this arm is
+            -- silent — CORD cannot see an Intacct collision, and the unique
+            -- index on projects.department_id will not catch one either.
+            union
+            select department_id from external_department_ids
           )
           select dept_id as "nextId" from enumerated
           where dept_id not in (select department_id from used)

--- a/src/components/user/user.drizzle.repository.ts
+++ b/src/components/user/user.drizzle.repository.ts
@@ -1,5 +1,14 @@
 import { Injectable } from '@nestjs/common';
-import { and, eq, ilike, inArray, isNull, or, type SQL } from 'drizzle-orm';
+import {
+  and,
+  eq,
+  ilike,
+  inArray,
+  isNull,
+  or,
+  type SQL,
+  sql,
+} from 'drizzle-orm';
 import { groupBy } from 'lodash';
 import { DateTime } from 'luxon';
 import {
@@ -13,6 +22,7 @@ import {
 import { Identity } from '~/core/authentication';
 import {
   catchUniqueViolation,
+  collateDisplayOrder,
   DrizzleDtoRepository,
   EMPTY_PAGE,
   escapeLikePattern,
@@ -243,7 +253,29 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
     conditions.push(...userFilterClauses(this.db, input.filter));
 
     const sortColumns = {
-      fullName: [users.realFirstName, users.realLastName],
+      // ONE concatenated string, not two columns with a tiebreaker. Neo4j's
+      // matching sorter is `coalesce(realFirstName,"") + coalesce(realLastName,"")`
+      // (multiPropsAsSortString in user.repository.ts), and ordering by that is
+      // not the same as ordering by first name then last name — they disagree
+      // whenever one first name is a prefix of another, which real names do
+      // constantly:
+      //   concatenated  -> "annabrown" < "annsmith"  => Anna Brown, Ann Smith
+      //   two columns   -> "Ann"       < "Anna"      => Ann Smith, Anna Brown
+      // Same for Jon/Jonathan, Dan/Daniel, Sam/Samuel. No separator between the
+      // two, and coalesce to '' rather than leaving NULL, both to match Neo4j.
+      //
+      // ⚠️ Deliberately still COLLATED, which Neo4j is NOT for this key: `fullName`
+      // is a resolver field, not a `@NameField` DTO field, so `DbSort.get` finds no
+      // transformer and Neo4j orders it by raw code points — capitals before lower
+      // case, accented initials after `z`. Matching that exactly would mean
+      // `collate "C"`; keeping display_order was chosen instead (2026-08-19) so the
+      // list reads the way people expect and agrees with every other name sort in
+      // this app. The residual ordering difference is a registered known delta in
+      // the shadow-diff suppression registry — do not "fix" it by dropping the
+      // collation without moving that entry too.
+      fullName: collateDisplayOrder(
+        sql`coalesce(${users.realFirstName}, '') || coalesce(${users.realLastName}, '')`,
+      ),
       realLastName: [users.realLastName, users.realFirstName],
       displayLastName: [users.displayLastName, users.displayFirstName],
       realFirstName: [users.realFirstName, users.realLastName],

--- a/src/core/cutover-coverage.run.ts
+++ b/src/core/cutover-coverage.run.ts
@@ -1,0 +1,150 @@
+/**
+ * Coverage check for the cutover ETL: the SOURCE graph enumerates itself, and
+ * everything it names — every label, relationship type and property key — must
+ * be claimed in cutover/coverage-manifest.ts. Exits 1 on anything unclaimed, on
+ * any open `review` question, and on any source-vs-target count gap that does
+ * not match a written-down shortfall.
+ *
+ * This is the inverse of every other cutover check: reconciliation, verify and
+ * shadow-diff all enumerate from OUR lists and so can only confirm what someone
+ * already thought of. This run answers the remaining question — "did we tell
+ * the ETL about everything?" — from the source's side.
+ *
+ * Unlike cutover-verify.run (Postgres-only), this needs BOTH databases:
+ *   NEO4J_URL      — the source graph (.env.local points at the prodcopy)
+ *   POSTGRES_URL   — the loaded target to count against
+ *
+ *   POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/cord_cutover_verify \
+ *     yarn start --entryFile core/cutover-coverage.run
+ *
+ * READ-ONLY BY CONSTRUCTION, same guards as cutover-verify.run and cutover.run:
+ * root-object sync and index creation are writes into the SOURCE graph, and
+ * under DATABASE=postgres the DrizzleMigrator would issue DDL against the
+ * TARGET it is about to count — so the engine is forced to neo4j (nothing here
+ * reads through a repository, so the engine has no legitimate effect), and both
+ * bootstrap write paths are switched off before ConfigService reads env.
+ *
+ * Exit codes: 0 every name claimed and every count explained; 1 otherwise.
+ */
+import { NestFactory } from '@nestjs/core';
+import { exit } from 'node:process';
+import '../polyfills';
+
+async function bootstrap() {
+  process.argv.push('console');
+
+  process.env.DB_ROOT_OBJECTS_SYNC = 'false';
+  process.env.DB_CREATE_INDEXES = 'false';
+  process.env.DATABASE = 'neo4j';
+
+  const { AppModule } = await import('../app.module');
+  const { ConfigService } = await import('~/core/config');
+  const { DrizzleService } = await import('~/core/drizzle/drizzle.service');
+  const { DatabaseService } = await import('~/core/neo4j');
+  const { runCutoverCoverage } = await import('./cutover/coverage');
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn'],
+  });
+  // CLI script — its output IS the interface. Same as cutover-verify.run.ts.
+  // eslint-disable-next-line no-console
+  const log = (msg: string) => console.log(msg);
+  let report: Awaited<ReturnType<typeof runCutoverCoverage>> | undefined;
+  try {
+    await app.init();
+    const config = app.get(ConfigService);
+    const drizzle = app.get(DrizzleService);
+    const neo4j = app.get(DatabaseService);
+
+    if (!config.postgres.url) {
+      throw new Error(
+        'POSTGRES_URL is required (the loaded database to count).',
+      );
+    }
+    log(
+      `\nCutover coverage — source ${config.neo4j.url} → ` +
+        `target ${new URL(config.postgres.url).pathname.slice(1)}\n`,
+    );
+    report = await runCutoverCoverage(neo4j, drizzle.client, log);
+  } finally {
+    await app.close();
+  }
+
+  // ── The full label ledger: every name, its count, and its claim ────────────
+  log('\n─── Labels (source count · claim · target check) ───');
+  const width = Math.max(...report.labelRows.map((row) => row.label.length));
+  for (const row of report.labelRows) {
+    const counts =
+      row.expected != null && row.actual != null
+        ? ` → expected ${row.expected}, holds ${row.actual} ${row.ok ? '✓' : '✗'}`
+        : '';
+    log(
+      `  ${row.label.padEnd(width)} ${String(row.sourceCount).padStart(9)}  ` +
+        `${row.kind}${counts}`,
+    );
+  }
+  if (report.staleManifest.length > 0) {
+    log(
+      `\n  ℹ ${report.staleManifest.length} manifest entr(ies) name things this source does not ` +
+        `enumerate — expected across snapshots (scrub markers, retired names): ` +
+        report.staleManifest.join(', '),
+    );
+  }
+
+  log(
+    `\n${report.checksRun} checks — ${report.sourceLabeledNodes.toLocaleString()} ` +
+      `labeled source nodes accounted for against ` +
+      `${report.targetRows.toLocaleString()} counted target rows.`,
+  );
+
+  const list = (
+    findings: ReadonlyArray<{
+      axis: string;
+      name: string;
+      detail: string;
+      count?: number;
+    }>,
+  ) => {
+    for (const finding of findings) {
+      const count =
+        finding.count != null ? ` [${finding.count.toLocaleString()}]` : '';
+      log(
+        `  · ${finding.axis} \`${finding.name}\`${count} — ${finding.detail}`,
+      );
+    }
+  };
+
+  if (report.clean) {
+    log(
+      '\n✓ Every name the source enumerates is claimed, no review questions are ' +
+        'open, and every counted gap matches its written-down reason.\n',
+    );
+    exit();
+  }
+  if (report.unclaimed.length > 0) {
+    log(
+      `\n✗ UNCLAIMED — ${report.unclaimed.length} name(s) the source has and the manifest does not:\n`,
+    );
+    list(report.unclaimed);
+  }
+  if (report.reviews.length > 0) {
+    log(
+      `\n✗ OPEN DECISIONS — ${report.reviews.length} review question(s) blocking (answer, then reclassify):\n`,
+    );
+    list(report.reviews);
+  }
+  if (report.countMismatches.length > 0) {
+    log(
+      `\n✗ UNEXPLAINED COUNT GAPS — ${report.countMismatches.length} label(s):\n`,
+    );
+    list(report.countMismatches);
+  }
+  log('');
+  exit(1);
+}
+
+void bootstrap().catch((err: unknown) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+});

--- a/src/core/cutover-verify.run.ts
+++ b/src/core/cutover-verify.run.ts
@@ -1,0 +1,127 @@
+/**
+ * Post-load check that a cutover ETL result HOLDS TOGETHER.
+ *
+ * Reads only Postgres, and only what the database cannot enforce for itself:
+ * references with no foreign key behind them, live rows whose target is
+ * soft-deleted, foreign keys pointing at the right table but the wrong subtype,
+ * duplicate or NULL array elements. See cutover/verify.ts for why each of those
+ * is unenforceable and what the two report sections mean.
+ *
+ * Runs after `cutover.run` against the SAME target database. It reads no Neo4j
+ * data, so it can be pointed at a load long after the source is gone — and it
+ * writes nothing, so it is safe against the live target mid-cutover.
+ *
+ * The run forces `DATABASE=neo4j` on itself, which is what keeps it READ-ONLY.
+ * `DrizzleService` connects whenever POSTGRES_URL is set regardless of engine,
+ * but `DrizzleMigrator.onModuleInit` applies pending migrations whenever the
+ * engine IS postgres — so booting the obvious way produces a verifier that
+ * writes DDL to the database it is about to certify. Against an empty target it
+ * would create the schema and then find nothing wrong with it. (The row census
+ * inside `runCutoverVerify` is the other half of that guard: it refuses a
+ * database with no rows rather than passing it.)
+ *
+ * Usage — only POSTGRES_URL matters:
+ *   POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/cord_cutover \
+ *     yarn start --entryFile core/cutover-verify.run
+ *
+ * Exit codes: 0 clean, 1 the load violates an invariant (or the run threw).
+ * The watchlist never affects the exit code — it reports source oddities the
+ * load carried faithfully, which are not reasons to stop.
+ */
+import { NestFactory } from '@nestjs/core';
+import { exit } from 'node:process';
+import '../polyfills';
+
+async function bootstrap() {
+  process.argv.push('console');
+
+  // A verifier must not change what it is measuring. Booting the AppModule runs
+  // AdminService.onApplicationBootstrap, which writes the root user into
+  // whichever database is primary — so a "clean" run would be certifying rows it
+  // had just created. Same guards, same reasoning, as cutover.run.ts and
+  // shadow-diff.run.ts. Set before the AppModule import below, since
+  // ConfigService reads env once.
+  process.env.DB_ROOT_OBJECTS_SYNC = 'false';
+  process.env.DB_CREATE_INDEXES = 'false';
+  // And the third write path, which is the one that actually fired: under
+  // `DATABASE=postgres`, DrizzleMigrator.onModuleInit applies pending migrations
+  // to the target — DDL, issued by the tool that is about to certify it. Forced
+  // rather than left to the caller because, unlike cutover.run.ts, nothing here
+  // reads through a repository, so the engine has no legitimate effect on the
+  // result. EnvironmentService seeds itself from process.env and dotenv does not
+  // override what is already set, so this beats a DATABASE=postgres in .env.local.
+  process.env.DATABASE = 'neo4j';
+
+  const { AppModule } = await import('../app.module');
+  const { ConfigService } = await import('~/core/config');
+  const { DrizzleService } = await import('~/core/drizzle/drizzle.service');
+  const { runCutoverVerify } = await import('./cutover/verify');
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn'],
+  });
+  // CLI script — its output IS the interface. Same as scrub.run.ts.
+  // eslint-disable-next-line no-console
+  const log = (msg: string) => console.log(msg);
+  let report: Awaited<ReturnType<typeof runCutoverVerify>> | undefined;
+  try {
+    await app.init();
+    const config = app.get(ConfigService);
+    const drizzle = app.get(DrizzleService);
+
+    if (!config.postgres.url) {
+      throw new Error(
+        'POSTGRES_URL is required (the loaded database to check).',
+      );
+    }
+    log(
+      `\nCutover verify — ${new URL(config.postgres.url).pathname.slice(1)}\n`,
+    );
+    report = await runCutoverVerify(drizzle.client, log);
+  } finally {
+    await app.close();
+  }
+
+  const table = (
+    rows: ReadonlyArray<{ check: string; detail: string; count: number }>,
+  ) => {
+    const width = Math.max(...rows.map((row) => row.check.length));
+    for (const row of rows) {
+      log(
+        `  ${row.check.padEnd(width)}  ${String(row.count).padStart(9)}  ${
+          row.detail
+        }`,
+      );
+    }
+  };
+
+  if (report.watchlist.length > 0) {
+    log(
+      `\nWatchlist — carried faithfully from the source, not load defects:\n`,
+    );
+    table(report.watchlist);
+  }
+
+  log(
+    `\n${report.checksRun} checks over ` +
+      `${report.rowsChecked.toLocaleString()} rows.`,
+  );
+  if (report.clean) {
+    log(
+      '✓ No violations — every invariant the database cannot enforce holds.\n',
+    );
+    exit();
+  }
+  log(
+    `\n⚠ ${report.violations.length} VIOLATION(S) — this load is not usable:\n`,
+  );
+  table(report.violations);
+  log('');
+  exit(1);
+}
+
+void bootstrap().catch((err: unknown) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+});

--- a/src/core/cutover.run.ts
+++ b/src/core/cutover.run.ts
@@ -103,6 +103,7 @@ async function bootstrap() {
           moduleRef,
           dryRun: flags.dryRun,
           batchSize: flags.batchSize,
+          notHydrated: new Map(),
           log,
         },
         extractors,

--- a/src/core/cutover.run.ts
+++ b/src/core/cutover.run.ts
@@ -1,0 +1,122 @@
+/**
+ * One-time Neo4j → Postgres data migration (cutover ETL).
+ *
+ * Reads every entity out of Neo4j (the current production DB) through the
+ * proven Neo4j repositories and inserts it into the corresponding Postgres
+ * (Drizzle) tables — ID-preserving, no service/hook side-effects. See
+ * src/core/cutover/README.md for the full design.
+ *
+ * Boots with `DATABASE=neo4j` so `splitDb` resolves the NEO4J repositories
+ * (the readers); `POSTGRES_URL` is the WRITE target (DrizzleService connects
+ * whenever the url is set, regardless of engine). The target's schema is
+ * applied here (migrations) before loading, so it can point at an empty DB.
+ *
+ * Usage (see README for the cutover runbook — freeze, load, validate, flip):
+ *   # dry-run: read + map everything, write nothing (surfaces mapping errors)
+ *   POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/cord_cutover \
+ *     yarn start --entryFile core/cutover.run -- --dry-run
+ *
+ *   # real load of one domain
+ *   POSTGRES_URL=... yarn start --entryFile core/cutover.run -- --only=tool
+ *
+ *   # full load
+ *   POSTGRES_URL=... yarn start --entryFile core/cutover.run
+ *
+ * Flags: --dry-run | --only=a,b,c | --batch=N | --no-migrate
+ */
+import { NestFactory } from '@nestjs/core';
+import { migrate } from 'drizzle-orm/node-postgres/migrator';
+import path from 'node:path';
+import { exit } from 'node:process';
+import '../polyfills';
+
+const parseFlags = (argv: readonly string[]) => {
+  const get = (name: string) =>
+    argv.find((a) => a.startsWith(`--${name}=`))?.split('=')[1];
+  const has = (name: string) => argv.includes(`--${name}`);
+  return {
+    dryRun: has('dry-run'),
+    migrate: !has('no-migrate'),
+    only: get('only')?.split(',').filter(Boolean),
+    batchSize: get('batch') ? Number(get('batch')) : 500,
+  };
+};
+
+async function bootstrap() {
+  // Capture cutover flags, THEN push 'console' so ConfigService.isCli is true
+  // (DataLoaders resolve against CLI_CONTEXT_ID, scheduler off) — same trick as
+  // pg-seed.run.ts / repl.ts.
+  const flags = parseFlags(process.argv.slice(2));
+  process.argv.push('console');
+
+  // AppModule FIRST, then dynamic imports (circular-dep ordering).
+  const { AppModule } = await import('../app.module');
+  const { ModuleRef } = await import('@nestjs/core');
+  const { ConfigService } = await import('~/core/config');
+  const { DrizzleService } = await import('~/core/drizzle/drizzle.service');
+  const { DatabaseService } = await import('~/core/neo4j');
+  const { SessionManager } =
+    await import('~/core/authentication/session/session.manager');
+  const { runCutover } = await import('./cutover/cutover.harness');
+  const { extractors } = await import('./cutover/extractors');
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn'],
+  });
+  // eslint-disable-next-line no-console
+  const log = (msg: string) => console.log(msg);
+  try {
+    await app.init();
+
+    const config = app.get(ConfigService);
+    const drizzle = app.get(DrizzleService);
+    const neo4j = app.get(DatabaseService);
+    const sessions = app.get(SessionManager);
+    const moduleRef = app.get(ModuleRef);
+
+    if (!config.postgres.url) {
+      throw new Error('POSTGRES_URL is required (the cutover write target).');
+    }
+    log(
+      `\nCutover ETL — engine=${config.databaseEngine} (Neo4j source) → ` +
+        `Postgres target ${new URL(config.postgres.url).pathname}\n`,
+    );
+
+    // The migrator only auto-runs under engine=postgres; we boot as neo4j, so
+    // apply the target schema here (unless it's already migrated).
+    if (flags.migrate && !flags.dryRun) {
+      log('Applying target schema (migrations)…');
+      await migrate(drizzle.client, {
+        migrationsFolder: path.join(
+          process.cwd(),
+          'src/core/drizzle/migrations',
+        ),
+      });
+    }
+
+    const rootSession = await sessions.lazySessionForRootUser();
+    await sessions.asUser(rootSession, async () => {
+      await runCutover(
+        {
+          neo4j,
+          db: drizzle.client,
+          moduleRef,
+          dryRun: flags.dryRun,
+          batchSize: flags.batchSize,
+          log,
+        },
+        extractors,
+        { only: flags.only },
+      );
+    });
+  } finally {
+    await app.close();
+  }
+  exit();
+}
+
+void bootstrap().catch((err: unknown) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+});

--- a/src/core/cutover.run.ts
+++ b/src/core/cutover.run.ts
@@ -11,18 +11,32 @@
  * whenever the url is set, regardless of engine). The target's schema is
  * applied here (migrations) before loading, so it can point at an empty DB.
  *
+ * `DATABASE=neo4j` is MANDATORY on every invocation below and is not a default —
+ * `.env`/`.env.local` commonly set it to postgres, and with that in effect
+ * `splitDb` resolves the DRIZZLE repositories, so every read hydrates from the
+ * EMPTY TARGET instead of the source. Ids still enumerate from Neo4j via raw
+ * Cypher, so the run loads zero rows and reconciles `0 == 0 == 0 ✓` — an empty
+ * migration that declares success. The banner prints `engine=`: check it.
+ *
  * Usage (see README for the cutover runbook — freeze, load, validate, flip):
  *   # dry-run: read + map everything, write nothing (surfaces mapping errors)
+ *   DATABASE=neo4j \
  *   POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/cord_cutover \
  *     yarn start --entryFile core/cutover.run -- --dry-run
  *
  *   # real load of one domain
- *   POSTGRES_URL=... yarn start --entryFile core/cutover.run -- --only=tool
+ *   DATABASE=neo4j POSTGRES_URL=... \
+ *     yarn start --entryFile core/cutover.run -- --only=tool
  *
- *   # full load
- *   POSTGRES_URL=... yarn start --entryFile core/cutover.run
+ *   # full load (--batch=100 at production volume: 500 exceeds Neo4j's
+ *   # dbms.memory.transaction.total.max)
+ *   DATABASE=neo4j POSTGRES_URL=... \
+ *     yarn start --entryFile core/cutover.run -- --batch=100
  *
- * Flags: --dry-run | --only=a,b,c | --batch=N | --no-migrate
+ * Flags: --dry-run | --only=a,b,c | --batch=N | --no-migrate | --strict
+ *
+ * Exit codes: 0 clean, 1 a table MISMATCHed (a write did not land) or the run
+ * threw, 2 under --strict when rows were lost but nothing broke.
  */
 import { NestFactory } from '@nestjs/core';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
@@ -34,11 +48,27 @@ const parseFlags = (argv: readonly string[]) => {
   const get = (name: string) =>
     argv.find((a) => a.startsWith(`--${name}=`))?.split('=')[1];
   const has = (name: string) => argv.includes(`--${name}`);
+  // A bad --batch must not be allowed through: `chunk(ids, NaN)` yields no
+  // chunks at all, so the run would read and insert NOTHING and still reconcile,
+  // and a value large enough overruns the driver's 65,535 bind parameters
+  // mid-load. Fail here instead, where the message can say why.
+  const rawBatch = get('batch');
+  let batchSize = 500;
+  if (rawBatch != null) {
+    batchSize = Number(rawBatch);
+    if (!Number.isInteger(batchSize) || batchSize < 1 || batchSize > 1000) {
+      throw new Error(
+        `--batch must be a whole number between 1 and 1000 (got ${rawBatch}). ` +
+          `Use --batch=100 at production volume.`,
+      );
+    }
+  }
   return {
     dryRun: has('dry-run'),
     migrate: !has('no-migrate'),
+    strict: has('strict'),
     only: get('only')?.split(',').filter(Boolean),
-    batchSize: get('batch') ? Number(get('batch')) : 500,
+    batchSize,
   };
 };
 
@@ -48,6 +78,19 @@ async function bootstrap() {
   // pg-seed.run.ts / repl.ts.
   const flags = parseFlags(process.argv.slice(2));
   process.argv.push('console');
+
+  // The ETL must never WRITE to the source graph. Booting the full AppModule
+  // starts AdminService.onApplicationBootstrap, which outside jest runs
+  // `setupRootObjects()` in the BACKGROUND (unawaited) against Neo4j — and if
+  // this box's ROOT_USER/PASSWORD_SECRET differ from production's, it rewrites
+  // the root user's email and password hash. That is a write into the graph the
+  // runbook has just frozen, it races the user extractor's read, and it would
+  // break root login on the Neo4j rollback path. The flag defaults to TRUE
+  // whenever NODE_ENV is not development, which is exactly the cutover box.
+  // Set before the AppModule import below, since ConfigService reads env once.
+  process.env.DB_ROOT_OBJECTS_SYNC = 'false';
+  // Same reasoning for index creation: it is DDL against the source.
+  process.env.DB_CREATE_INDEXES = 'false';
 
   // AppModule FIRST, then dynamic imports (circular-dep ordering).
   const { AppModule } = await import('../app.module');
@@ -65,6 +108,7 @@ async function bootstrap() {
   });
   // eslint-disable-next-line no-console
   const log = (msg: string) => console.log(msg);
+  let result: Awaited<ReturnType<typeof runCutover>> | undefined;
   try {
     await app.init();
 
@@ -95,8 +139,8 @@ async function bootstrap() {
     }
 
     const rootSession = await sessions.lazySessionForRootUser();
-    await sessions.asUser(rootSession, async () => {
-      await runCutover(
+    result = await sessions.asUser(rootSession, async () => {
+      return await runCutover(
         {
           neo4j,
           db: drizzle.client,
@@ -112,6 +156,19 @@ async function bootstrap() {
     });
   } finally {
     await app.close();
+  }
+
+  // A MISMATCH means a write did not land — the load is broken, so say so in the
+  // exit code rather than only in scrollback. Row LOSS is different: guard drops
+  // are expected and documented (a soft-deleted parent takes its children), so
+  // it stays a success by default and only fails under --strict.
+  if (!result?.allOk) {
+    log('\nExiting 1 — a table MISMATCHed, so the load is not usable.');
+    exit(1);
+  }
+  if (flags.strict && result.totalLost > 0) {
+    log(`\nExiting 2 (--strict) — ${result.totalLost} row(s) did not make it.`);
+    exit(2);
   }
   exit();
 }

--- a/src/core/cutover/README.md
+++ b/src/core/cutover/README.md
@@ -33,6 +33,9 @@ here (migrations run) before loading, so it can point at an empty DB.
   TRUNCATE targets, run each extractor, reconcile row counts.
 - `extractors/*.extractor.ts` — one per domain (`extractors/index.ts` registry).
 - `../cutover.run.ts` — the entry point (boot + arg parsing + target migration).
+- `verify.ts` — the post-load check, run through `../cutover-verify.run.ts`.
+  Reads only Postgres and only what the database cannot enforce for itself; the
+  complement to reconciliation, which counts rows but never looks at the result.
 
 ## Running
 
@@ -228,8 +231,24 @@ Locally it reads 8 keys / 0 duplicates, and production reads 3,430 / 0.
    "Not hydrated" block empty. The process now exits non-zero on a MISMATCH, and
    `--strict` also fails the run when any row was lost, so this step can be
    automated rather than read by eye.
-4. Flip `DATABASE=postgres`; smoke-test.
-5. Keep Neo4j as read-only fallback for a few days, then tear down.
+4. **Run `core/cutover-verify.run` against the target and require exit 0.**
+   Reconciliation proves everything arrived; it cannot prove what arrived is
+   coherent, because it only ever compares its own two numbers. This reads the
+   loaded database instead — dangling references with no FK behind them, live rows
+   whose target is soft-deleted, foreign keys landing on the wrong subtype. Only
+   `POSTGRES_URL` is needed; the run forces `DATABASE=neo4j` on itself so the
+   migrator cannot write DDL to the database it is certifying.
+
+   ```
+   POSTGRES_URL=... yarn start --entryFile core/cutover-verify.run
+   ```
+
+   Read the verdict line, not just the exit code: it prints how many rows were
+   checked, and "no violations" over a database that never loaded would otherwise
+   look identical to a perfect load. The watchlist section is expected to be
+   non-empty and never affects the exit code.
+5. Flip `DATABASE=postgres`; smoke-test.
+6. Keep Neo4j as read-only fallback for a few days, then tear down.
 
 Rollback is instant at any point before the flip: Neo4j is untouched — and the
 run deliberately disables root-object sync and index creation so that stays true

--- a/src/core/cutover/README.md
+++ b/src/core/cutover/README.md
@@ -101,9 +101,26 @@ conflict — **investigate, don't ignore**.
 
 ## Pre-flight: `preflight-enums.cypher` — RUN THIS AGAINST PROD FIRST
 
-39 read-only legs, one per stored enum value that has to fit a Postgres enum. The
-allowed lists are generated from `drizzle/schema`, so they cannot drift from it by
-hand-editing.
+40 read-only legs covering stored enum values that have to fit a Postgres enum.
+
+⚠ **The allowed lists are hand-maintained, and the leg list is NOT complete.**
+This section used to claim the lists were "generated from `drizzle/schema`, so they
+cannot drift" — there is no generator, and they can. Two consequences to hold:
+
+- Each leg's allowed list is a copy of a `pgEnum`'s values at the time it was
+  written. Re-check a leg against `schema/index.ts` before trusting it.
+- Columns with **no leg at all** are the bigger gap, because a missing leg looks
+  exactly like a clean one. Known-missing: `projects.type`,
+  `department_id_blocks.programs`, `engagements.using_ai_assisted_translation`,
+  `products.methodology`, `products.progress_step_measurement`,
+  `product_completion_descriptions.methodology`,
+  `partnership_producing_mediums.medium`, `project_workflow_events.to_step`.
+  Add them before relying on this as a full sweep.
+
+A leg was added for `Engagement.status (superseded/history)`: the live-status leg
+scans `{active: true}` only, so it cannot see the retired values that
+`engagement_status_history` now migrates — a status retired years ago exists
+nowhere else.
 
 ```bash
 # against a local container
@@ -138,8 +155,18 @@ wrong, not that the data is empty.
 
 ## Pre-flight: `preflight-uniques.cypher` — RUN THIS AGAINST PROD FIRST
 
-22 read-only legs, one per Postgres unique index that can shed rows, Tier 1 (root
-entities, where a drop takes a subtree) then Tier 2 (junctions, one row each).
+22 read-only legs, Tier 1 (root entities, where a drop takes a subtree) then Tier 2
+(junctions, one row each).
+
+⚠ **Not one leg per shed-capable index — eight enforced unique indexes have no leg**,
+and a missing leg is indistinguishable from a clean one. Missing:
+`periodic_reports_live_interval_unique`, `media_file_version_id_unique`,
+`prompt_variant_response_entries_response_variant_active_unique`,
+`product_progress_product_report_variant_unique`, `step_progress_progress_step_unique`,
+`tool_usages`' natural key, and the two `user_organizations` /
+`progress_report_media` variant keys. Five of those shed a row at load with only an
+unattributed read-vs-inserted gap to show for it. Worth closing before the prod
+dry-run; until then, do not read a clean sweep as "no duplicates anywhere".
 
 ```bash
 docker exec -i <neo4j-container> cypher-shell -u neo4j -p <pw> --format plain \
@@ -180,13 +207,83 @@ Locally it reads 8 keys / 0 duplicates, and production reads 3,430 / 0.
 
 ## Cutover runbook (production)
 
-1. Freeze Neo4j writes (maintenance window) + take a final snapshot.
-2. Point `POSTGRES_URL` at the fresh target; run the full load.
-3. Check the reconciliation report — every table `✓`, no dropped-row gaps.
+> **The harness REFUSES to read an unscrubbed production-scale graph, and that is
+> not bypassable from the command line.** `runCutover` calls `checkScrubGate`
+> before anything else (in the harness, not the entry point, so no caller can skip
+> it), and it rejects any graph of ≥1,000,000 nodes that carries no current
+> `DataProvenance` scrub marker. Production is ~22M nodes. Discovering this inside
+> the maintenance window means burning the window, so settle the source question
+> BEFORE the freeze — either run against a scrubbed copy, or agree the marker
+> story for the real load in advance. Do not add an env-var bypass.
+
+0. **Run the pre-flight probes** (below) against production and read the results.
+   These size the losses in advance; several classes are invisible until they have
+   already happened.
+1. Freeze Neo4j writes (maintenance window) + take a final snapshot. The event
+   tables grow continuously, so a copy taken while writes continue will not match
+   what was validated.
+2. Point `POSTGRES_URL` at the fresh target; run the full load with
+   `DATABASE=neo4j` and `--batch=100`.
+3. Check the reconciliation report — every table `✓`, no dropped-row gaps, and the
+   "Not hydrated" block empty. The process now exits non-zero on a MISMATCH, and
+   `--strict` also fails the run when any row was lost, so this step can be
+   automated rather than read by eye.
 4. Flip `DATABASE=postgres`; smoke-test.
 5. Keep Neo4j as read-only fallback for a few days, then tear down.
 
-Rollback is instant at any point before the flip: Neo4j is untouched.
+Rollback is instant at any point before the flip: Neo4j is untouched — and the
+run deliberately disables root-object sync and index creation so that stays true
+(booting the AppModule would otherwise write to the source graph in the
+background).
+
+### Cheap probes worth running at immediate pre-flight
+
+All are O(1) or near it, and each answers "is there data here we do not migrate,
+or that would stop the load?"
+
+```cypher
+// Field zones / regions: director and zone are OPTIONAL in Neo4j and NOT NULL in
+// Postgres, so a missing one stops the load. The extractors now fail fast naming
+// the ids rather than letting the driver reject a null mid-run. These are small
+// tables, so this should read 0 -- the point is to know before the window.
+// `scanned` is reported so a 0 cannot be confused with a query that matched
+// nothing.
+MATCH (z:FieldZone)
+WITH count(z) AS total,
+     sum(CASE WHEN EXISTS { MATCH (z)-[:director { active: true }]->(:User) } THEN 0 ELSE 1 END) AS broken
+RETURN 'FieldZone.director' AS check, total AS scanned, broken AS wouldFailLoad
+UNION ALL
+MATCH (r:FieldRegion)
+WITH count(r) AS total,
+     sum(CASE WHEN EXISTS { MATCH (r)-[:director { active: true }]->(:User) } THEN 0 ELSE 1 END) AS broken
+RETURN 'FieldRegion.director' AS check, total AS scanned, broken AS wouldFailLoad
+UNION ALL
+MATCH (r:FieldRegion)
+WITH count(r) AS total,
+     sum(CASE WHEN EXISTS { MATCH (r)-[:zone { active: true }]->(:FieldZone) } THEN 0 ELSE 1 END) AS broken
+RETURN 'FieldRegion.zone' AS check, total AS scanned, broken AS wouldFailLoad
+```
+
+⚠ The region-to-zone relationship is `:zone`, NOT `:fieldZone` -- `fieldZone` is
+the DTO field name only. Matching the DTO name here would report a clean 0 while
+scanning nothing.
+
+```cypher
+// Webhooks: no extractor exists because prod has no webhook data (2026-08-18).
+// This is a point-in-time fact — if the feature gets used before the flip, that
+// data would be silently left behind.
+MATCH (n:Webhook) RETURN count(n);
+
+// Tool-usage containers: container_type is NOT NULL and is resolved through
+// resolveParentTypes, which covers only progress report / engagement / project /
+// partner / language / user. A usage on any other resource type is DROPPED. This
+// reports what container types actually exist, so the gap can be sized before the
+// load rather than counted in its warnings.
+MATCH (:ToolUsage)-[:container]->(c)
+RETURN [l IN labels(c) WHERE NOT l STARTS WITH 'Deleted_' AND l <> 'BaseNode'] AS containerLabels,
+       count(*) AS usages
+ORDER BY usages DESC;
+```
 
 ## Findings (surfaced by the real-load validation — real cutover concerns)
 
@@ -330,8 +427,13 @@ whole time.
 - **`resource_mutations`** — the audit log. Postgres-only surface with no
   Neo4j counterpart to read; starts empty and accumulates from the first
   post-flip mutation. Writing an extractor for it isn't hard, it's impossible.
+- **The four webhook tables** (migration 0037) — **prod carries no webhook data**
+  (confirmed 2026-08-18), so there is nothing to move. Deliberately skipped-empty
+  rather than uncovered, and the same category as `known-language`: unproven code
+  that would move zero rows costs nothing at cutover. ⚠ Point-in-time, so the
+  count probe in the runbook above is worth one second at immediate pre-flight.
 
-Do not chase 58/58 — the three above cannot and should not be filled from
+Do not chase 58/58 — the items above cannot and should not be filled from
 Neo4j.
 
 ## Thin/unexercised paths worth a second look with real data

--- a/src/core/cutover/README.md
+++ b/src/core/cutover/README.md
@@ -139,6 +139,36 @@ Rollback is instant at any point before the flip: Neo4j is untouched.
    being mistaken for a clean load. **Fix the root before the dry run**, and
    re-measure downstream after: the deeper waves are where the loss shows up,
    and they did not exist when finding #3 was first written.
+7. **A repository can be the wrong reader — read its `hydrate`/`readMany` first.**
+   `PostRepository.readMany` applies `filterAuthorized()`, which is not a policy
+   check but hardcoded Cypher requiring the current user to be a **member** of the
+   post's parent. A root session cannot satisfy a graph traversal, so every
+   `Membership`-shareability post would be silently dropped — the read stat counts
+   only what came back. Post is therefore read by raw Cypher.
+   The distinction that keeps this narrow: every *other* filtered repository uses
+   `privileges.filterToReadable()`, which root's global grants DO satisfy —
+   confirmed empirically, since project / engagement / language each read their
+   full node count through `readMany`. **Local data cannot catch this class:** all
+   8 local posts are `Internal`, so the filter drops nothing here; a prod run is
+   where it would have bitten.
+   Same family, different mechanism: `CommentThreadRepository.hydrate` returns only
+   `[comments[0], comments[-1]]`, so reading comments through the *thread* repo
+   would migrate two per thread and discard the middle of every conversation.
+8. **Edge-stored domains need their own guard.** Pins and known languages have no
+   node label to enumerate — they are `(:User)-[:pinned]->(:BaseNode)` and
+   `(:User)-[:knownLanguage { value }]->(:Language)`. `warnIfLabelUnknown` cannot
+   see a relationship type, so a misspelled one returns zero rows and reconciles ✓
+   — the ethnologue failure in a dimension the existing guard is blind to.
+   `warnIfRelTypeUnknown` closes it and earned its place on its first run:
+   `knownLanguage` has **zero** edges locally, so a correct query and a typo
+   produce byte-identical output and nothing else could distinguish them.
+9. **Alias every expression column in a raw `sql` leg.** `resolveParentTypes`
+   shipped with `AS t` on only its first leg; Postgres names an unaliased
+   expression `?column?`, so five of six legs mapped their ids to `undefined`.
+   That still created the map KEY, which defeated the `keepLanded` guard built
+   from `.keys()` and then failed on a NOT NULL discriminator. Caught by a real
+   run — invisible to a dry-run, which never inserts. The helper now skips falsy
+   values so an alias slip can only lose a row loudly, never write a null.
 
 ## Domains covered (firm / merged to develop)
 
@@ -149,7 +179,8 @@ departmentIdBlock · fieldZone · fieldRegion · location · organization
 re-assert 2-pass) · projectMember · partnership · engagement (+ status history,
 ceremonies) · product (+ producibles, completion descriptions) · periodic-report
 · prompt-variant-response (+ entries) · product-progress (+ step progress) ·
-progress-summary · notification (+ recipients) · budget (+ budget_records).
+progress-summary · notification (+ recipients) · budget (+ budget_records) ·
+pin · known-language · comment (+ threads) · post.
 
 **Deliberately NOT migrated (transient):** `auth_sessions`,
 `auth_password_reset_tokens` — users re-authenticate post-cutover.
@@ -162,8 +193,8 @@ progress-summary · notification (+ recipients) · budget (+ budget_records).
   metadata only.) Note `periodic_reports.report_file_id`/`narrative_file_id`
   ARE already populated with the ids this wave will insert — they're plain text
   with no FK, so they cost nothing to carry early and save a backfill.
-- **The leaves** — pins, known languages, comments/comment threads, posts,
-  progress-report media, PnP extraction results.
+- **progress-report media + PnP extraction results** — both are file-keyed, so
+  they belong with the File wave rather than with the other leaves.
 - **ProgressReportWorkflowEvent** (192 nodes locally) and
   **ProgressReportVarianceExplanation** (2) have **no Postgres table yet** —
   neither domain is ported, so there is nowhere to load them. A progress

--- a/src/core/cutover/README.md
+++ b/src/core/cutover/README.md
@@ -36,6 +36,11 @@ here (migrations run) before loading, so it can point at an empty DB.
 - `verify.ts` — the post-load check, run through `../cutover-verify.run.ts`.
   Reads only Postgres and only what the database cannot enforce for itself; the
   complement to reconciliation, which counts rows but never looks at the result.
+- `coverage-manifest.ts` + `coverage.ts` — the coverage check, run through
+  `../cutover-coverage.run.ts`. The SOURCE enumerates itself and every label,
+  relationship type and property key must be claimed with a disposition; migrated
+  labels are also counted source-vs-target with written-down shortfalls. The only
+  check that can catch a domain or field nobody thought to migrate.
 
 ## Running
 
@@ -224,9 +229,16 @@ Locally it reads 8 keys / 0 duplicates, and production reads 3,430 / 0.
    already happened.
 1. Freeze Neo4j writes (maintenance window) + take a final snapshot. The event
    tables grow continuously, so a copy taken while writes continue will not match
-   what was validated.
+   what was validated. **Stop the app first and let the BullMQ queues drain** —
+   two reasons: the workers deliver whatever Redis still holds, and the ETL
+   process itself boots the full app module, so its own run would start
+   processing any jobs left in the queue it is pointed at.
 2. Point `POSTGRES_URL` at the fresh target; run the full load with
-   `DATABASE=neo4j` and `--batch=100`.
+   `DATABASE=neo4j` and `--batch=100`, and give node a real heap:
+   `NODE_OPTIONS=--max-old-space-size=12288` — the file domain (1.5M nodes) blows
+   the default ~4GB heap, and `yarn start` has been seen swallowing that crash's
+   exit code, so judge the load by its final reconciliation summary, never by
+   `$?` alone.
 3. Check the reconciliation report — every table `✓`, no dropped-row gaps, and the
    "Not hydrated" block empty. The process now exits non-zero on a MISMATCH, and
    `--strict` also fails the run when any row was lost, so this step can be
@@ -247,8 +259,24 @@ Locally it reads 8 keys / 0 duplicates, and production reads 3,430 / 0.
    checked, and "no violations" over a database that never loaded would otherwise
    look identical to a perfect load. The watchlist section is expected to be
    non-empty and never affects the exit code.
-5. Flip `DATABASE=postgres`; smoke-test.
-6. Keep Neo4j as read-only fallback for a few days, then tear down.
+5. **Run `core/cutover-coverage.run` against BOTH databases and require exit 0.**
+   The inverse of every check above: instead of confirming what our lists name,
+   the SOURCE enumerates itself (`db.labels()`, `db.relationshipTypes()`,
+   `db.propertyKeys()`) and every name must be claimed in
+   `cutover/coverage-manifest.ts` — so a domain, edge, or FIELD nobody thought
+   about cannot slip through silently. It also counts every migrated label from
+   the source's side against the target table, requiring any gap to match the
+   manifest's written-down shortfall. Shortfall counts are snapshot-pinned on
+   purpose: on a fresh snapshot the run goes red until each delta's REASON is
+   re-verified — that is the designed behavior, not noise. Open `review` entries
+   (undecided exclusions) also fail the run.
+
+   ```
+   POSTGRES_URL=... yarn start --entryFile core/cutover-coverage.run
+   ```
+
+6. Flip `DATABASE=postgres`; smoke-test.
+7. Keep Neo4j as read-only fallback for a few days, then tear down.
 
 Rollback is instant at any point before the flip: Neo4j is untouched — and the
 run deliberately disables root-object sync and index creation so that stays true

--- a/src/core/cutover/README.md
+++ b/src/core/cutover/README.md
@@ -98,6 +98,43 @@ loading, so dry-runs and retries start clean. Inserts use `onConflictDoNothing`.
 `read`/`pgCount` gap means `onConflictDoNothing` dropped rows on a UNIQUE
 conflict — **investigate, don't ignore**.
 
+## Pre-flight: `preflight-enums.cypher` — RUN THIS AGAINST PROD FIRST
+
+39 read-only legs, one per stored enum value that has to fit a Postgres enum. The
+allowed lists are generated from `drizzle/schema`, so they cannot drift from it by
+hand-editing.
+
+```bash
+# against a local container
+docker exec -i <neo4j-container> cypher-shell -u neo4j -p <pw> --format plain \
+  < src/core/cutover/preflight-enums.cypher
+
+# against a remote (prod/staged) instance, using a container's client binary so
+# nothing needs installing locally — `-a` targets the address
+docker exec -i <neo4j-container> cypher-shell -a neo4j+s://<host> -u <user> -p <pw> \
+  --format plain < src/core/cutover/preflight-enums.cypher
+```
+
+Rows are ordered so anything wrong is at the top. Two signals:
+
+- **`wouldDrop` non-empty** — the source holds a value the target enum does not
+  declare. For a sanitised column the row still lands *without* that value, which
+  no row count can show. For an unsanitised one the cast fails and the load stops.
+- **`distinctValues = 0`** — the leg matched nothing. Treat as a WRONG LEG first
+  and an empty domain second. That convention immediately caught one: media
+  category is stored **on the node**, and the leg was written as a `Property` node
+  walk, so it read 0 while holding values.
+
+Storage shape is stated per row because a sweep that only walks `Property` nodes
+misses every enum held on the node itself (progress summary period, step progress
+step, workflow event status, media category) or on a relationship (known-language
+proficiency). All three shapes exist; only the first is obvious.
+
+Expected on production, from a value dump taken 2026-08-05: every leg above should
+report `distinctValues > 0` **except** possibly `KnownLanguage.proficiency`, which
+is the one leg no run has yet exercised. A zero anywhere else means the leg is
+wrong, not that the data is empty.
+
 ## Pre-flight: `preflight-uniques.cypher` — RUN THIS AGAINST PROD FIRST
 
 22 read-only legs, one per Postgres unique index that can shed rows, Tier 1 (root
@@ -185,11 +222,15 @@ Rollback is instant at any point before the flip: Neo4j is untouched.
    findings have now blamed a name column that turned out innocent (see the
    language case in finding #6 / migration 0030). A per-constraint pre-flight
    query is the instrument; a plausible guess is not.
-4. **Legacy/renamed enum values.** Neo4j `organizations.types` carries
-   `TranslationOrganization`, absent from the PG `organization_type` enum.
-   `sanitizeEnum` currently **drops** unknowns (logged). **migration-todo:** some
-   are renames that should MAP (likely `TranslationOrganization` → `Translation`)
-   — replace the drop with an explicit per-enum value map once the team decides.
+4. **Legacy/renamed enum values — CHECKED AND CLEAR.** `sanitizeEnum` drops
+   values the target pgEnum does not declare, which raised the question of
+   whether any stored value is a rename that should be mapped instead. Every
+   enum-bearing property in production was compared against the pgEnum that
+   receives it: **no stored value would be dropped.** The one renamed value that
+   prompted the concern turned out to exist only in local test data. No value map
+   is needed. Note the reverse case, though: enum columns whose extractor does
+   not call `sanitizeEnum` cast straight through, so an unknown value there fails
+   the load instead of being dropped — a different failure to recognise.
 5. **`deleted_at` rows.** `readMany` returns live rows only; soft-deleted nodes
    aren't carried. Confirm that's intended per domain before cutover.
 6. **A drop at the root is not a drop of one row — measure the subtree.** The

--- a/src/core/cutover/README.md
+++ b/src/core/cutover/README.md
@@ -119,9 +119,22 @@ Rollback is instant at any point before the flip: Neo4j is untouched.
    migrate soft-deleted parents too, or scrub these refs. NOT-NULL dangling FKs
    (e.g. a partner's org) can't be nulled — they'd need the parent migrated or
    the row skipped.
-3. **Dropped rows on UNIQUE conflicts.** Dev Neo4j has duplicate live location
-   names → `onConflictDoNothing` dropped 9 (reconciliation flagged read 26 /
-   pgCount 17). Prod needs dedup or the partial-unique relaxed.
+3. **Dropped rows on UNIQUE conflicts.** `onConflictDoNothing` drops 9 locations
+   (reconciliation flags read 26 / pgCount 17). Prod needs dedup or the
+   partial-unique relaxed.
+   **Corrected 2026-07-30 — this finding named the wrong column for weeks.** The
+   culprit is `locations_iso_alpha3_active_unique`, NOT
+   `locations_name_active_unique`: live location names have **zero** duplicates
+   locally (26 distinct over 26 rows), while `iso_alpha3` has 3 distinct non-null
+   values spread over 12 rows — exactly the 9 drops observed. The index carries no
+   `NULLS NOT DISTINCT`, so Postgres treats NULLs as distinct and the 19 null-coded
+   locations do not collide; only the non-null groups do, which is why the non-null
+   count matches the drop count precisely.
+   The general lesson is bigger than the typo: **attribute a drop to a named
+   constraint by measuring that constraint's key, not by assuming.** Two of these
+   findings have now blamed a name column that turned out innocent (see the
+   language case in finding #6 / migration 0030). A per-constraint pre-flight
+   query is the instrument; a plausible guess is not.
 4. **Legacy/renamed enum values.** Neo4j `organizations.types` carries
    `TranslationOrganization`, absent from the PG `organization_type` enum.
    `sanitizeEnum` currently **drops** unknowns (logged). **migration-todo:** some

--- a/src/core/cutover/README.md
+++ b/src/core/cutover/README.md
@@ -175,7 +175,22 @@ Rollback is instant at any point before the flip: Neo4j is untouched.
    `warnIfRelTypeUnknown` closes it and earned its place on its first run:
    `knownLanguage` has **zero** edges locally, so a correct query and a typo
    produce byte-identical output and nothing else could distinguish them.
-9. **Alias every expression column in a raw `sql` leg.** `resolveParentTypes`
+9. **🔴 A dropped row can break a whole LIST QUERY, not just lose data (ETH1).**
+   The worst consequence found so far, and it is qualitatively different from
+   finding #6's subtree arithmetic. The 2 `ethnologue_languages` rows dropped to
+   the `code` / `provisional_code` unique indexes leave their 2 languages with no
+   ethnologue row — and the Postgres language repo treats that as a hard
+   invariant: *"Language iaJWie869fn has no attached EthnologueLanguage —
+   create-flow invariant violated"*. Neo4j tolerates the same shape and answers
+   normally. Measured by the shadow-diff run of 2026-07-30: this **fails
+   `languages.list` outright for an Administrator** — the entire query, not one
+   row — plus `engagement.byId` for any engagement on an affected language.
+   So the ordering of consequences for a unique-dup drop is: (1) the row, (2) its
+   subtree, (3) **any query whose result set would have contained it, if a
+   downstream repo asserts an invariant the source never enforced.** Prod exposure
+   is unmeasured; the `ethnologue.code` / `provisionalCode` legs of the unique
+   pre-flight are what size it, and they must be run before the dry-run window.
+10. **Alias every expression column in a raw `sql` leg.** `resolveParentTypes`
    shipped with `AS t` on only its first leg; Postgres names an unaliased
    expression `?column?`, so five of six legs mapped their ids to `undefined`.
    That still created the map KEY, which defeated the `keepLanded` guard built

--- a/src/core/cutover/README.md
+++ b/src/core/cutover/README.md
@@ -35,19 +35,56 @@ here (migrations run) before loading, so it can point at an empty DB.
 
 ## Running
 
+**`DATABASE=neo4j` IS MANDATORY, not optional.** It is what makes `splitDb`
+resolve the Neo4j repositories — the readers. Omit it and, if your env sets
+`DATABASE=postgres`, `readMany` hydrates from the *target* Postgres instead of
+the source: ids still enumerate from Neo4j (raw Cypher), so every domain reports
+"N enumerated but NOT hydrated" and loads **zero rows**, and reconciliation says
+`0 == 0 == 0 ✓`. A completely empty migration that reports success. The banner
+line prints `engine=` — **check it says `neo4j` before trusting any run.**
+
 ```bash
-# dry-run: read + map everything, write nothing (surfaces mapping errors)
-POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/cord_cutover \
+# dry-run: read + map only. Writes NOTHING and its ✓ is tautological
+# (see "What a dry-run does and does not prove" below).
+DATABASE=neo4j POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/cord_cutover \
   yarn start --entryFile core/cutover.run -- --dry-run
 
 # real load of one domain
-POSTGRES_URL=... yarn start --entryFile core/cutover.run -- --only=tool
+DATABASE=neo4j POSTGRES_URL=... yarn start --entryFile core/cutover.run -- --only=tool
 
 # full load (migrates the target first, then loads)
-POSTGRES_URL=... yarn start --entryFile core/cutover.run
+DATABASE=neo4j POSTGRES_URL=... yarn start --entryFile core/cutover.run
 ```
 
 Flags: `--dry-run` · `--only=a,b,c` · `--batch=N` (default 500) · `--no-migrate`.
+
+### What a dry-run does and does not prove
+
+`--dry-run` validates **reads, hydration and mapping**. It does **not** touch the
+database: `bulkInsert` returns early before inserting, and the harness sets
+`count = inserted` with `ok = true` unconditionally, so its ✓ column *cannot
+fail*. It therefore proves nothing about NOT NULL, CHECK, FK or unique-index
+satisfaction.
+
+Every new wave needs a **real run against a throwaway database** to be called
+verified — that is the only thing that exercises the constraints. Two real FK
+bugs (`auth_identities`, `user_organizations`) and three unique-drop mismatches
+were invisible to dry-runs and surfaced on the first real scratch run.
+
+```bash
+psql -U postgres -c 'DROP DATABASE IF EXISTS cutover_scratch'
+psql -U postgres -c 'CREATE DATABASE cutover_scratch'
+DATABASE=neo4j POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/cutover_scratch \
+  yarn start --entryFile core/cutover.run
+```
+
+### `--only` and the CASCADE truncate
+
+The truncate is `TRUNCATE <targets> RESTART IDENTITY CASCADE`, so it also empties
+tables holding an FK *to* a target even when that table belongs to an unselected
+extractor. `--only=language` alone wipes `ethnologue_languages` (its
+`language_id` references `languages.id`) and then has nothing to backfill. Select
+dependencies explicitly: `--only=ethnologue,language`.
 
 The load is **idempotent**: it TRUNCATEs every target table (CASCADE) before
 loading, so dry-runs and retries start clean. Inserts use `onConflictDoNothing`.

--- a/src/core/cutover/README.md
+++ b/src/core/cutover/README.md
@@ -98,6 +98,39 @@ loading, so dry-runs and retries start clean. Inserts use `onConflictDoNothing`.
 `read`/`pgCount` gap means `onConflictDoNothing` dropped rows on a UNIQUE
 conflict — **investigate, don't ignore**.
 
+## Pre-flight: `preflight-uniques.cypher` — RUN THIS AGAINST PROD FIRST
+
+22 read-only legs, one per Postgres unique index that can shed rows, Tier 1 (root
+entities, where a drop takes a subtree) then Tier 2 (junctions, one row each).
+
+```bash
+docker exec -i <neo4j-container> cypher-shell -u neo4j -p <pw> --format plain \
+  < src/core/cutover/preflight-uniques.cypher
+```
+
+Columns: `scannedKeys` (distinct live key values — **zero means a BROKEN LEG, not a
+clean result**), `dupGroups`, `rowsWouldDrop`. On a Tier 1 row read
+`rowsWouldDrop` as a **subtree**, not a row count — see findings #6 and #9.
+
+Three conventions in this file exist because each one caught a real bug:
+
+- **Aggregate to scalars first, attach the leg's label literal after.** A literal
+  in the aggregating clause is a grouping key, and a grouping key over zero input
+  rows yields zero output rows — so a clean leg would vanish and read exactly like
+  a broken pattern.
+- **`scannedKeys: 0` is a broken leg.** That convention immediately caught one:
+  the `user_organizations` primary check tested `r.primary = true` on the
+  `organization` edge, but primary is a **separate `primaryOrganization` relationship
+  type**.
+- **Never group by `labels(n)[i]`.** For producibles `labels(n)[0]` is `"BaseNode"`
+  (`["BaseNode","Story","Producible"]`), so grouping by it would fold a Film and a
+  Story sharing a name into one group and report a **false** duplicate. Use an
+  explicit `CASE WHEN n:Film …`.
+
+Validated against local data: every leg matches real rows, and its predictions
+reproduce what the loader actually drops (`iso_alpha3` → 9 locations, ethnologue
+`code` + `provisional_code` → 2). Locally only those two constraints are dirty.
+
 ## Cutover runbook (production)
 
 1. Freeze Neo4j writes (maintenance window) + take a final snapshot.

--- a/src/core/cutover/README.md
+++ b/src/core/cutover/README.md
@@ -71,9 +71,13 @@ verified — that is the only thing that exercises the constraints. Two real FK
 bugs (`auth_identities`, `user_organizations`) and three unique-drop mismatches
 were invisible to dry-runs and surfaced on the first real scratch run.
 
+Each statement needs its own `-c`: you cannot DROP/CREATE a database inside a
+multi-statement (implicitly transactional) batch. There is no local `psql` on the
+dev machine — it lives in the compose container.
+
 ```bash
-psql -U postgres -c 'DROP DATABASE IF EXISTS cutover_scratch'
-psql -U postgres -c 'CREATE DATABASE cutover_scratch'
+docker exec cord-api-v3-postgres-1 psql -U postgres -c 'DROP DATABASE IF EXISTS cutover_scratch'
+docker exec cord-api-v3-postgres-1 psql -U postgres -c 'CREATE DATABASE cutover_scratch'
 DATABASE=neo4j POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/cutover_scratch \
   yarn start --entryFile core/cutover.run
 ```
@@ -125,15 +129,27 @@ Rollback is instant at any point before the flip: Neo4j is untouched.
    — replace the drop with an explicit per-enum value map once the team decides.
 5. **`deleted_at` rows.** `readMany` returns live rows only; soft-deleted nodes
    aren't carried. Confirm that's intended per domain before cutover.
+6. **A drop at the root is not a drop of one row — measure the subtree.** The
+   19 languages lost to finding #3 locally cost, transitively: 32
+   LanguageEngagements → 32 ceremonies → 88 products → **514 periodic reports**
+   → 148 product-progress rows → 605 step-progress rows → 18 progress
+   summaries. Roughly 1,400 rows from 19. Per-table reconciliation reports each
+   of these as its own ⚠, which reads like seven unrelated problems rather than
+   one; the "counts reconcile but N dropped" summary line exists to stop that
+   being mistaken for a clean load. **Fix the root before the dry run**, and
+   re-measure downstream after: the deeper waves are where the loss shows up,
+   and they did not exist when finding #3 was first written.
 
 ## Domains covered (firm / merged to develop)
 
 user (+ global_roles, educations, unavailabilities, system_agents,
-auth_identities) · tool · fundingAccount · ethnologue · departmentIdBlock ·
-fieldZone · fieldRegion · location · organization (+ 2 junctions) · partner
-(+ 3 junctions) · project (+ workflow events, step re-assert 2-pass) ·
-projectMember · partnership · notification (+ recipients) · budget
-(+ budget_records).
+auth_identities) · tool · fundingAccount · ethnologue · language ·
+departmentIdBlock · fieldZone · fieldRegion · location · organization
+(+ 2 junctions) · partner (+ 3 junctions) · project (+ workflow events, step
+re-assert 2-pass) · projectMember · partnership · engagement (+ status history,
+ceremonies) · product (+ producibles, completion descriptions) · periodic-report
+· prompt-variant-response (+ entries) · product-progress (+ step progress) ·
+progress-summary · notification (+ recipients) · budget (+ budget_records).
 
 **Deliberately NOT migrated (transient):** `auth_sessions`,
 `auth_password_reset_tokens` — users re-authenticate post-cutover.
@@ -142,11 +158,18 @@ projectMember · partnership · notification (+ recipients) · budget
 
 - **File + Media** — deferred. `file_nodes` is a single-table tree needing a
   topological insert (parents before children) + a two-pass for the denormalized
-  `latest_version_id`; Media's app-level port isn't on develop. Wants its own
-  focused pass. (S3 blobs never migrate — metadata only.)
-- **Language / Engagement** and all later-wave domains — add an extractor here
-  as each lands on develop (that's the "build the data script incrementally"
-  plan). New extractors just implement `Extractor` and register in `index.ts`;
-  the harness handles ordering + reconciliation.
-- **`ethnologue_languages.language_id`** — left null (deferred FK); backfill in
-  the Language wave.
+  `latest_version_id`. Wants its own focused pass. (S3 blobs never migrate —
+  metadata only.) Note `periodic_reports.report_file_id`/`narrative_file_id`
+  ARE already populated with the ids this wave will insert — they're plain text
+  with no FK, so they cost nothing to carry early and save a backfill.
+- **The leaves** — pins, known languages, comments/comment threads, posts,
+  progress-report media, PnP extraction results.
+- **ProgressReportWorkflowEvent** (192 nodes locally) and
+  **ProgressReportVarianceExplanation** (2) have **no Postgres table yet** —
+  neither domain is ported, so there is nowhere to load them. A progress
+  report's *current* `status` carries over; its transition history does not.
+  Add extractors when those domains land.
+- **ProgressReportHighlight** exists as a code path in the
+  prompt-variant-response extractor but has **zero instances locally**, so that
+  branch is written and unexercised. Same class as OtherProduct / Film /
+  EthnoArt and `engagement_status_history` — needs a real dataset to validate.

--- a/src/core/cutover/README.md
+++ b/src/core/cutover/README.md
@@ -1,0 +1,115 @@
+# Cutover ETL — Neo4j → Postgres
+
+One-time data migration run at cutover: reads every entity out of **Neo4j** (the
+production DB) and inserts it into the corresponding **Postgres** (Drizzle)
+tables, **ID-preserving**, with **no service/hook side-effects**. Separate from
+the schema migrations (those build empty tables; this fills them).
+
+> Status: **draft covering the firm (already-merged-to-develop) domains.** Built
+> + validated end-to-end against a local Neo4j (`yarn` dev DB). NOT yet run
+> against production data. See _Findings_ and _Not covered yet_.
+
+## Strategy
+
+Direct extract → transform → load, **not** replay through the services (which
+would regenerate ids, fire hooks, and re-run today's validators on legacy data).
+Each entity is read **through its existing Neo4j repository** so the proven
+`hydrate()` assembles the full `UnsecuredDto` (fields live in `Property`-node
+relationships — a raw `MATCH (n) RETURN n` won't hydrate them). The row is then
+mapped to the Drizzle shape and bulk-inserted.
+
+Boots with `DATABASE=neo4j` so `splitDb` resolves the **Neo4j** repositories
+(the readers); `POSTGRES_URL` is the **write target** (`DrizzleService` connects
+whenever the url is set, regardless of engine). The target schema is applied
+here (migrations run) before loading, so it can point at an empty DB.
+
+## Layout
+
+- `cutover.types.ts` — `CutoverContext`, `Extractor` interface, stats.
+- `cutover.helpers.ts` — `readAllViaRepo`, `bulkInsert`, `cypher`, value mappers
+  (`ts`/`dateStr`/`linkId`/`orDefault`/`sanitizeEnum`).
+- `cutover.harness.ts` — `runCutover`: topological order by `dependsOn`,
+  TRUNCATE targets, run each extractor, reconcile row counts.
+- `extractors/*.extractor.ts` — one per domain (`extractors/index.ts` registry).
+- `../cutover.run.ts` — the entry point (boot + arg parsing + target migration).
+
+## Running
+
+```bash
+# dry-run: read + map everything, write nothing (surfaces mapping errors)
+POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/cord_cutover \
+  yarn start --entryFile core/cutover.run -- --dry-run
+
+# real load of one domain
+POSTGRES_URL=... yarn start --entryFile core/cutover.run -- --only=tool
+
+# full load (migrates the target first, then loads)
+POSTGRES_URL=... yarn start --entryFile core/cutover.run
+```
+
+Flags: `--dry-run` · `--only=a,b,c` · `--batch=N` (default 500) · `--no-migrate`.
+
+The load is **idempotent**: it TRUNCATEs every target table (CASCADE) before
+loading, so dry-runs and retries start clean. Inserts use `onConflictDoNothing`.
+
+**Reconciliation** (printed at the end): `read` = rows pulled from Neo4j,
+`inserted` = rows sent to Postgres, `pgCount` = rows actually present. A
+`read`/`pgCount` gap means `onConflictDoNothing` dropped rows on a UNIQUE
+conflict — **investigate, don't ignore**.
+
+## Cutover runbook (production)
+
+1. Freeze Neo4j writes (maintenance window) + take a final snapshot.
+2. Point `POSTGRES_URL` at the fresh target; run the full load.
+3. Check the reconciliation report — every table `✓`, no dropped-row gaps.
+4. Flip `DATABASE=postgres`; smoke-test.
+5. Keep Neo4j as read-only fallback for a few days, then tear down.
+
+Rollback is instant at any point before the flip: Neo4j is untouched.
+
+## Findings (surfaced by the real-load validation — real cutover concerns)
+
+1. **Null in NOT-NULL columns.** Legacy rows can lack a `Property` the DTO types
+   as non-null (`users.status`, `partners.active`/`globalInnovationsClient`).
+   Handled with `orDefault(...)` → the schema default. Audit for more before prod.
+2. **Dangling references (live → deleted).** A live row can reference a
+   soft-deleted/absent target (`locations.defaultMarketingRegion`). The self-FK
+   two-pass skips targets not actually present. **Open decision for prod:**
+   migrate soft-deleted parents too, or scrub these refs. NOT-NULL dangling FKs
+   (e.g. a partner's org) can't be nulled — they'd need the parent migrated or
+   the row skipped.
+3. **Dropped rows on UNIQUE conflicts.** Dev Neo4j has duplicate live location
+   names → `onConflictDoNothing` dropped 9 (reconciliation flagged read 26 /
+   pgCount 17). Prod needs dedup or the partial-unique relaxed.
+4. **Legacy/renamed enum values.** Neo4j `organizations.types` carries
+   `TranslationOrganization`, absent from the PG `organization_type` enum.
+   `sanitizeEnum` currently **drops** unknowns (logged). **migration-todo:** some
+   are renames that should MAP (likely `TranslationOrganization` → `Translation`)
+   — replace the drop with an explicit per-enum value map once the team decides.
+5. **`deleted_at` rows.** `readMany` returns live rows only; soft-deleted nodes
+   aren't carried. Confirm that's intended per domain before cutover.
+
+## Domains covered (firm / merged to develop)
+
+user (+ global_roles, educations, unavailabilities, system_agents,
+auth_identities) · tool · fundingAccount · ethnologue · departmentIdBlock ·
+fieldZone · fieldRegion · location · organization (+ 2 junctions) · partner
+(+ 3 junctions).
+
+**Deliberately NOT migrated (transient):** `auth_sessions`,
+`auth_password_reset_tokens` — users re-authenticate post-cutover.
+
+## Not covered yet (add as domains land / as follow-ups)
+
+- **File + Media** — deferred. `file_nodes` is a single-table tree needing a
+  topological insert (parents before children) + a two-pass for the denormalized
+  `latest_version_id`; Media's app-level port isn't on develop. Wants its own
+  focused pass. (S3 blobs never migrate — metadata only.)
+- **Project / Partnership** and all later-wave domains — add an extractor here
+  as each lands on develop (that's the "build the data script incrementally"
+  plan). New extractors just implement `Extractor` and register in `index.ts`;
+  the harness handles ordering + reconciliation.
+- **`ethnologue_languages.language_id`** — left null (deferred FK); backfill in
+  the Language wave.
+- **`users.isRoot`** — defaulted false; the admin bootstrap re-establishes root
+  on first postgres boot, or detect the Neo4j root by configured email.

--- a/src/core/cutover/README.md
+++ b/src/core/cutover/README.md
@@ -128,8 +128,17 @@ Three conventions in this file exist because each one caught a real bug:
   explicit `CASE WHEN n:Film …`.
 
 Validated against local data: every leg matches real rows, and its predictions
-reproduce what the loader actually drops (`iso_alpha3` → 9 locations, ethnologue
-`code` + `provisional_code` → 2). Locally only those two constraints are dirty.
+reproduced what the loader actually dropped (`iso_alpha3` → 9 locations,
+ethnologue `code` + `provisional_code` → 2).
+
+**Those three legs no longer predict anything.** Migration 0030 dropped their
+unique indexes — along with the language `name` / `display_name` pair — because
+Neo4j never enforced any of them, so Postgres was rejecting data the source
+accepts. Their legs are relabelled `RELAXED 0030, informational` and kept for the
+duplicate count alone. A ROLV-code leg was added in the same pass: it is the one
+language unique still enforced, and it had no leg at all, so the instrument was
+measuring three constraints that no longer drop and missing the one that does.
+Locally it reads 8 keys / 0 duplicates, and production reads 3,430 / 0.
 
 ## Cutover runbook (production)
 
@@ -152,9 +161,17 @@ Rollback is instant at any point before the flip: Neo4j is untouched.
    migrate soft-deleted parents too, or scrub these refs. NOT-NULL dangling FKs
    (e.g. a partner's org) can't be nulled — they'd need the parent migrated or
    the row skipped.
-3. **Dropped rows on UNIQUE conflicts.** `onConflictDoNothing` drops 9 locations
-   (reconciliation flags read 26 / pgCount 17). Prod needs dedup or the
-   partial-unique relaxed.
+3. **Dropped rows on UNIQUE conflicts.** ✅ **CLOSED by migration 0030** — the five
+   offending indexes are gone (language `name` + `display_name`, ethnologue `code`
+   + `provisional_code`, `locations.iso_alpha3`), because Neo4j never enforced any
+   of them. A full local load now reports `locations 26/26`, `languages 69/69` and
+   `ethnologue_languages 69/69`, where it previously shed 9 locations and 19
+   languages plus their ~1,400-row subtree. Total drops on that dataset fell from
+   ~1,500 to 206, and every remaining drop is a genuine soft-deleted-parent case
+   rather than a constraint the source does not have.
+   *History, kept because the reasoning is the lesson:*
+   `onConflictDoNothing` dropped 9 locations (reconciliation flagged read 26 /
+   pgCount 17).
    **Corrected 2026-07-30 — this finding named the wrong column for weeks.** The
    culprit is `locations_iso_alpha3_active_unique`, NOT
    `locations_name_active_unique`: live location names have **zero** duplicates

--- a/src/core/cutover/README.md
+++ b/src/core/cutover/README.md
@@ -292,20 +292,30 @@ Rollback is instant at any point before the flip: Neo4j is untouched.
 
 ## Domains covered (firm / merged to develop)
 
-**55 of 58 Postgres tables, which is the ceiling — see below.**
+**58 of 61 Postgres tables, which is the ceiling — see below.**
+
+(2026-08-14: `user_locations`, `language_locations`, and
+`project_other_locations` are three NEW junction tables — the app-side
+`addLocationToNode`/`removeLocationFromNode` gap they fill was found and
+fixed on `location-node-edges-postgres`, not yet on develop. This count and
+the extractors below assume that migration has landed; until this branch is
+rebased past it, `userLocation`/`language`/`project`'s new Cypher legs
+reference tables that don't exist in the schema on disk yet — see those
+commits for detail.)
 
 user (+ global_roles, educations, unavailabilities, system_agents,
-auth_identities) · tool · fundingAccount · ethnologue · language ·
+auth_identities) · **userLocation** (`user_locations`) · tool ·
+fundingAccount · ethnologue · language (+ **locations** junction) ·
 departmentIdBlock · fieldZone · fieldRegion · location · organization
 (+ 2 junctions) · partner (+ 3 junctions) · project (+ workflow events, step
-re-assert 2-pass) · projectMember · partnership · engagement (+ status history,
-ceremonies) · product (+ producibles, completion descriptions) · periodic-report
-· prompt-variant-response (+ entries) · product-progress (+ step progress) ·
-progress-summary · notification (+ recipients) · budget (+ budget_records) ·
-pin · known-language · comment (+ threads) · post · file (+ media, PnP
-extraction results + problems, progress-report media) · tool-usage ·
-progress-report-workflow-event · progress-report-variance-explanation ·
-partnership-producing-medium.
+re-assert 2-pass, **otherLocations** junction) · projectMember · partnership ·
+engagement (+ status history, ceremonies) · product (+ producibles, completion
+descriptions) · periodic-report · prompt-variant-response (+ entries) ·
+product-progress (+ step progress) · progress-summary · notification
+(+ recipients) · budget (+ budget_records) · pin · known-language · comment
+(+ threads) · post · file (+ media, PnP extraction results + problems,
+progress-report media) · tool-usage · progress-report-workflow-event ·
+progress-report-variance-explanation · partnership-producing-medium.
 
 `project.rootDirectoryId` and `engagement.{pnpId,growthPlanId}` are backfilled
 from the DTO fields the live repos already hydrate (`rootDirectory` relation,

--- a/src/core/cutover/README.md
+++ b/src/core/cutover/README.md
@@ -94,7 +94,9 @@ Rollback is instant at any point before the flip: Neo4j is untouched.
 user (+ global_roles, educations, unavailabilities, system_agents,
 auth_identities) · tool · fundingAccount · ethnologue · departmentIdBlock ·
 fieldZone · fieldRegion · location · organization (+ 2 junctions) · partner
-(+ 3 junctions).
+(+ 3 junctions) · project (+ workflow events, step re-assert 2-pass) ·
+projectMember · partnership · notification (+ recipients) · budget
+(+ budget_records).
 
 **Deliberately NOT migrated (transient):** `auth_sessions`,
 `auth_password_reset_tokens` — users re-authenticate post-cutover.
@@ -105,11 +107,9 @@ fieldZone · fieldRegion · location · organization (+ 2 junctions) · partner
   topological insert (parents before children) + a two-pass for the denormalized
   `latest_version_id`; Media's app-level port isn't on develop. Wants its own
   focused pass. (S3 blobs never migrate — metadata only.)
-- **Project / Partnership** and all later-wave domains — add an extractor here
+- **Language / Engagement** and all later-wave domains — add an extractor here
   as each lands on develop (that's the "build the data script incrementally"
   plan). New extractors just implement `Extractor` and register in `index.ts`;
   the harness handles ordering + reconciliation.
 - **`ethnologue_languages.language_id`** — left null (deferred FK); backfill in
   the Language wave.
-- **`users.isRoot`** — defaulted false; the admin bootstrap re-establishes root
-  on first postgres boot, or detect the Neo4j root by configured email.

--- a/src/core/cutover/README.md
+++ b/src/core/cutover/README.md
@@ -5,9 +5,10 @@ production DB) and inserts it into the corresponding **Postgres** (Drizzle)
 tables, **ID-preserving**, with **no service/hook side-effects**. Separate from
 the schema migrations (those build empty tables; this fills them).
 
-> Status: **draft covering the firm (already-merged-to-develop) domains.** Built
-> + validated end-to-end against a local Neo4j (`yarn` dev DB). NOT yet run
-> against production data. See _Findings_ and _Not covered yet_.
+> Status: **all 55 loadable tables covered (the 3 remaining are uncoverable by
+> design — see below).** Built + validated end-to-end against a local Neo4j
+> (`yarn` dev DB). NOT yet run against production data. See _Findings_ and
+> _Not covered_.
 
 ## Strategy
 
@@ -291,6 +292,8 @@ Rollback is instant at any point before the flip: Neo4j is untouched.
 
 ## Domains covered (firm / merged to develop)
 
+**55 of 58 Postgres tables, which is the ceiling — see below.**
+
 user (+ global_roles, educations, unavailabilities, system_agents,
 auth_identities) · tool · fundingAccount · ethnologue · language ·
 departmentIdBlock · fieldZone · fieldRegion · location · organization
@@ -299,26 +302,30 @@ re-assert 2-pass) · projectMember · partnership · engagement (+ status histor
 ceremonies) · product (+ producibles, completion descriptions) · periodic-report
 · prompt-variant-response (+ entries) · product-progress (+ step progress) ·
 progress-summary · notification (+ recipients) · budget (+ budget_records) ·
-pin · known-language · comment (+ threads) · post.
+pin · known-language · comment (+ threads) · post · file (+ media, PnP
+extraction results + problems, progress-report media) · tool-usage ·
+progress-report-workflow-event · progress-report-variance-explanation ·
+partnership-producing-medium.
 
-**Deliberately NOT migrated (transient):** `auth_sessions`,
-`auth_password_reset_tokens` — users re-authenticate post-cutover.
+`project.rootDirectoryId` and `engagement.{pnpId,growthPlanId}` are backfilled
+from the DTO fields the live repos already hydrate (`rootDirectory` relation,
+`props.pnp`/`props.growthPlan`) now that `file` is a declared dependency of
+both — no separate second pass needed, the id was sitting on the row the
+whole time.
 
-## Not covered yet (add as domains land / as follow-ups)
+## Not covered (by design — this is the correct end state, not a gap)
 
-- **File + Media** — deferred. `file_nodes` is a single-table tree needing a
-  topological insert (parents before children) + a two-pass for the denormalized
-  `latest_version_id`. Wants its own focused pass. (S3 blobs never migrate —
-  metadata only.) Note `periodic_reports.report_file_id`/`narrative_file_id`
-  ARE already populated with the ids this wave will insert — they're plain text
-  with no FK, so they cost nothing to carry early and save a backfill.
-- **progress-report media + PnP extraction results** — both are file-keyed, so
-  they belong with the File wave rather than with the other leaves.
-- **ProgressReportWorkflowEvent** (192 nodes locally) and
-  **ProgressReportVarianceExplanation** (2) have **no Postgres table yet** —
-  neither domain is ported, so there is nowhere to load them. A progress
-  report's *current* `status` carries over; its transition history does not.
-  Add extractors when those domains land.
+- **`auth_sessions`, `auth_password_reset_tokens`** — transient; users
+  re-authenticate post-cutover.
+- **`resource_mutations`** — the audit log. Postgres-only surface with no
+  Neo4j counterpart to read; starts empty and accumulates from the first
+  post-flip mutation. Writing an extractor for it isn't hard, it's impossible.
+
+Do not chase 58/58 — the three above cannot and should not be filled from
+Neo4j.
+
+## Thin/unexercised paths worth a second look with real data
+
 - **ProgressReportHighlight** exists as a code path in the
   prompt-variant-response extractor but has **zero instances locally**, so that
   branch is written and unexercised. Same class as OtherProduct / Film /

--- a/src/core/cutover/coverage-manifest.ts
+++ b/src/core/cutover/coverage-manifest.ts
@@ -1,0 +1,1588 @@
+/**
+ * Cutover coverage manifest — every name the SOURCE graph can enumerate about
+ * itself, and what the ETL does with it.
+ *
+ * WHY THIS EXISTS. Every other cutover check enumerates from OUR list: the
+ * reconciliation counts the rows the extractors read, the verifier walks the
+ * Postgres schema, the shadow-diff replays operations someone wrote down. All of
+ * them can only confirm what someone already thought of. This file flips the
+ * direction: Neo4j enumerates itself — `db.labels()`, `db.relationshipTypes()`,
+ * `db.propertyKeys()` — and every name it returns must be claimed here with a
+ * disposition. The coverage run FAILS on anything the source names that this
+ * file does not, so a domain, field, or edge nobody thought about cannot slip
+ * through silently. Same shape as the scrub's `assertFullyClassified` and the
+ * verifier's `assertEveryUnenforcedColumnIsClassified`, built for the same
+ * reason: an allowlist tells you what you forgot; a blocklist never does.
+ *
+ * THE FIVE DISPOSITIONS:
+ *  - `migrated`         — carried. For labels: names the extractor and target
+ *                         table, and the run compares the SOURCE node count
+ *                         against the Postgres row count, requiring any gap to
+ *                         match the entry's written-down `shortfall`.
+ *  - `structural`       — an interface/marker label or a duplicate edge whose
+ *                         information is carried implicitly by the target
+ *                         schema's shape.
+ *  - `property-storage` — Neo4j's field storage, not an entity: the `*Name`/
+ *                         `*Status`-style labels on `Property` records. The
+ *                         VALUE such a record holds is claimed by the
+ *                         relationship type pointing at it.
+ *  - `excluded`         — deliberately not carried, with the reason written
+ *                         down. An exclusion without a reason is not a decision.
+ *  - `review`           — BLOCKS the run. An unanswered question is not a
+ *                         default to excluded. (The scrub's rule, kept.)
+ *
+ * PROPERTY KEYS ARE THE HIGHEST-VALUE AXIS. A property no extractor reads means
+ * every row still arrives, every table still reconciles, and a column is
+ * silently empty — nothing else in the pipeline can see that class.
+ *
+ * SOFT-DELETED LABELS. Neo4j soft-delete PREFIXES labels (`Deleted_Project`,
+ * and a twice-deleted record is `Deleted_Deleted_Property`). One rule, applied
+ * by the checker, covers them: a `Deleted_`-prefixed label with no entry of its
+ * own is claimed as "the soft-deleted counterpart of <base>, not carried — the
+ * ETL is live-only", PROVIDED the fully-stripped base label has an entry here.
+ * An explicit entry always wins over the rule — `Deleted_VariantResponse` below
+ * is carried on purpose, and says so.
+ *
+ * COUNTS ARE SNAPSHOT-PINNED, DELIBERATELY. Every `shortfall` count below was
+ * measured and root-caused against the 2026-08-24 production copy, loaded from
+ * current HEAD into `cord_cutover_r2` (2026-08-24; supersedes the 2026-08-20
+ * `cord_cutover_verify` load, which predates the creator-fallback fix and
+ * migrations 0039/0040). On a newer snapshot the numbers WILL drift and the run
+ * WILL go red — that is the designed behavior: an unexplained delta blocks
+ * until someone re-verifies the reason still holds and updates the number.
+ * Never update a count without re-verifying its reason.
+ *
+ * WHEN THE RUN FAILS ON AN UNCLAIMED NAME: do not guess from the name. Probe
+ * what carries it (`MATCH (n) WHERE n.<key> IS NOT NULL RETURN labels(n),
+ * count(*)` — or the targeted equivalents in this file's history), find the
+ * reader in `src/`, and write a disposition whose reason states what you
+ * measured. Every `excluded` entry below cites its evidence.
+ */
+
+export interface ExpectedShortfall {
+  /** Source rows that verifiably do NOT arrive. */
+  readonly count: number;
+  /** The verified cause — not a guess, and never just "dropped". */
+  readonly reason: string;
+}
+
+export type Disposition =
+  | {
+      readonly kind: 'migrated';
+      /** Where it lands: `table.column`, a table's rows, or how it is derived. */
+      readonly to?: string;
+      /** Labels: the extractor that carries it (its `name`). */
+      readonly extractor?: string;
+      /** Labels: count this Postgres table against the source node count. */
+      readonly table?: string;
+      /** Labels: SQL predicate narrowing `table` to this label's rows. */
+      readonly where?: string;
+      /** Labels: OTHER source labels whose nodes land in the same counted rows. */
+      readonly plusLabels?: readonly string[];
+      /** Labels: the written-down explanation for source-vs-target count gaps. */
+      readonly shortfall?: readonly ExpectedShortfall[];
+    }
+  | { readonly kind: 'structural'; readonly why: string }
+  | { readonly kind: 'property-storage'; readonly why: string }
+  | { readonly kind: 'excluded'; readonly reason: string }
+  | { readonly kind: 'review'; readonly question: string };
+
+const structural = (why: string): Disposition => ({ kind: 'structural', why });
+const propertyStorage = (why: string): Disposition => ({
+  kind: 'property-storage',
+  why,
+});
+const excluded = (reason: string): Disposition => ({
+  kind: 'excluded',
+  reason,
+});
+const review = (question: string): Disposition => ({
+  kind: 'review',
+  question,
+});
+/** A relationship type or property key whose value is carried — says where. */
+const carried = (to: string): Disposition => ({ kind: 'migrated', to });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AXIS 1 — node labels (199 in the 2026-08-24 production copy; 127 live).
+// `Deleted_*` labels are covered by the checker's live-only rule unless they
+// have an explicit entry here.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const labels: Readonly<Record<string, Disposition>> = {
+  // ── Interface / marker labels — carried implicitly ─────────────────────────
+  BaseNode: structural('the universal interface label every entity carries'),
+  Actor: structural('interface over User + SystemAgent (2,376 + 2 = 2,378)'),
+  AnonUser: structural(
+    'marker on the anonymous user; the node itself migrates via its User label',
+  ),
+  RootUser: structural(
+    'marker on the root user; carried as users.is_root = true (the user extractor reads this label)',
+  ),
+  DefaultOrganization: structural(
+    'marker on the config-referenced default organization; the node migrates via Organization',
+  ),
+  Commentable: structural(
+    'interface — resources that can hold comment threads',
+  ),
+  Postable: structural('interface — resources that can hold posts'),
+  Producible: structural(
+    'interface — but in Neo4j PRODUCTS carry it too, so it must never be enumerated: ' +
+      'MATCH (n:Producible) would insert every Product into producibles. Rows are ' +
+      'counted by the concrete labels Film/Story/EthnoArt',
+  ),
+  BaseFile: structural(
+    'marker on a subset of File/FileVersion nodes (138,838 + 64,618 measured 2026-08-24); rows migrate via FileNode',
+  ),
+  FileNode: {
+    kind: 'migrated',
+    extractor: 'file',
+    table: 'file_nodes',
+    to: 'the single-table Directory/File/FileVersion tree',
+    shortfall: [
+      {
+        count: 89,
+        reason:
+          '88 Files + 1 FileVersion whose createdBy user is absent or soft-deleted — ' +
+          'created_by_id is NOT NULL (measured 2026-08-24; zero versions are missing mime/size)',
+      },
+    ],
+  },
+  TemporalMedia: structural('interface over Video + Audio media'),
+  VisualMedia: structural('interface over Image media (+ video stills)'),
+  Engagement: {
+    kind: 'migrated',
+    extractor: 'engagement',
+    table: 'engagements',
+    to: 'single-table inheritance over Language/Internship engagements',
+    shortfall: [
+      {
+        count: 11,
+        reason:
+          'live engagements under a soft-deleted project (9 language + 2 internship) — the ' +
+          'project never lands and engagements.project_id is NOT NULL (measured against the ' +
+          'graph 2026-08-24)',
+      },
+    ],
+  },
+  PeriodicReport: {
+    kind: 'migrated',
+    extractor: 'periodic-report',
+    table: 'periodic_reports',
+    to: 'one table over Financial/Narrative/Progress reports',
+    shortfall: [
+      {
+        count: 6897,
+        reason:
+          'no live owner — the report hangs off a soft-deleted engagement or project ' +
+          '(verified against the graph 2026-08-20)',
+      },
+      {
+        count: 114,
+        reason:
+          'a LIVE engagement under a soft-deleted project — the dead ancestor is two levels up, ' +
+          'so a direct-parent check misses these (verified 2026-08-20)',
+      },
+    ],
+  },
+  Project: {
+    kind: 'migrated',
+    extractor: 'project',
+    table: 'projects',
+    to: 'single-table inheritance over the project subtypes',
+  },
+  PromptVariantResponse: {
+    kind: 'migrated',
+    extractor: 'prompt-variant-response',
+    table: 'prompt_variant_responses',
+    to: 'interface over the three prompt-response types; rows split by resource_type',
+    shortfall: [
+      {
+        count: 35,
+        reason:
+          'responses under soft-deleted or never-landing reports — 5 with a dead parent edge, ' +
+          '30 under live-labeled reports that never land (measured 2026-08-24)',
+      },
+    ],
+  },
+  Notification: {
+    kind: 'migrated',
+    extractor: 'notification',
+    table: 'notifications',
+    to: 'single-table inheritance over notification subtypes',
+  },
+
+  // ── Entities with their own extractor + table ──────────────────────────────
+  User: {
+    kind: 'migrated',
+    extractor: 'user',
+    table: 'users',
+    to: 'users rows (AnonUser and RootUser both carry this label too)',
+  },
+  SystemAgent: {
+    kind: 'migrated',
+    extractor: 'user',
+    table: 'system_agents',
+    to: 'system_agents rows (the retired duplicate Anonymous agent is Deleted_SystemAgent)',
+  },
+  Education: {
+    kind: 'migrated',
+    extractor: 'user',
+    table: 'educations',
+  },
+  Unavailability: {
+    kind: 'migrated',
+    extractor: 'user',
+    table: 'unavailabilities',
+  },
+  Tool: { kind: 'migrated', extractor: 'tool', table: 'tools' },
+  ToolUsage: {
+    kind: 'migrated',
+    extractor: 'tool-usage',
+    table: 'tool_usages',
+    shortfall: [
+      {
+        count: 4,
+        reason:
+          'usages under a soft-deleted container — container_type is NOT NULL and a dead ' +
+          'container never resolves (measured 2026-08-24; zero usages lack a creator)',
+      },
+    ],
+  },
+  FundingAccount: {
+    kind: 'migrated',
+    extractor: 'fundingAccount',
+    table: 'funding_accounts',
+  },
+  DepartmentIdBlock: {
+    kind: 'migrated',
+    extractor: 'departmentIdBlock',
+    table: 'department_id_blocks',
+  },
+  EthnologueLanguage: {
+    kind: 'migrated',
+    extractor: 'ethnologue',
+    table: 'ethnologue_languages',
+  },
+  Language: { kind: 'migrated', extractor: 'language', table: 'languages' },
+  FieldZone: { kind: 'migrated', extractor: 'fieldZone', table: 'field_zones' },
+  FieldRegion: {
+    kind: 'migrated',
+    extractor: 'fieldRegion',
+    table: 'field_regions',
+  },
+  Location: { kind: 'migrated', extractor: 'location', table: 'locations' },
+  Organization: {
+    kind: 'migrated',
+    extractor: 'organization',
+    table: 'organizations',
+  },
+  Partner: { kind: 'migrated', extractor: 'partner', table: 'partners' },
+  ProjectMember: {
+    kind: 'migrated',
+    extractor: 'projectMember',
+    table: 'project_members',
+    shortfall: [
+      {
+        count: 129,
+        reason:
+          'members of soft-deleted projects/users — hydrate-drops, verified against the graph 2026-08-20',
+      },
+      {
+        count: 8,
+        reason:
+          'duplicate (project, user) memberships collapse to one row each — merged with roles ' +
+          'unioned since commit 602601755 (before it, the unique index conflict-dropped one; ' +
+          'the row count is identical either way, so this holds for this database regardless of ' +
+          'which load produced it)',
+      },
+    ],
+  },
+  Partnership: {
+    kind: 'migrated',
+    extractor: 'partnership',
+    table: 'partnerships',
+    shortfall: [
+      {
+        count: 25,
+        reason:
+          'live partnership with a live partner AND org, but hydrate() matches the soft-deleted ' +
+          "project's props without optional:true, so readMany never returns them (verified 2026-08-20)",
+      },
+    ],
+  },
+  Budget: {
+    kind: 'migrated',
+    extractor: 'budget',
+    table: 'budgets',
+    shortfall: [
+      {
+        count: 46,
+        reason:
+          'budgets of soft-deleted projects (project_id is a NOT NULL FK) — verified 2026-08-20',
+      },
+    ],
+  },
+  BudgetRecord: {
+    kind: 'migrated',
+    extractor: 'budget',
+    table: 'budget_records',
+    shortfall: [
+      {
+        count: 45,
+        reason:
+          'records under the 46 budgets of soft-deleted projects — the budget never lands and ' +
+          'budget_id is NOT NULL (measured 2026-08-24; zero records have a dangling org or ' +
+          'missing fiscalYear)',
+      },
+    ],
+  },
+  Ceremony: {
+    kind: 'migrated',
+    extractor: 'engagement',
+    table: 'ceremonies',
+    shortfall: [
+      {
+        count: 11,
+        reason:
+          'ceremonies whose engagement is soft-deleted or never landed (engagement_id is a ' +
+          'NOT NULL FK) — verified 2026-08-20',
+      },
+    ],
+  },
+  LanguageEngagement: {
+    kind: 'migrated',
+    extractor: 'engagement',
+    table: 'engagements',
+    where: "type = 'Language'",
+    shortfall: [
+      {
+        count: 9,
+        reason:
+          'its share of the 11 engagements under soft-deleted projects (measured 2026-08-24; ' +
+          'zero language engagements have a dead or missing language)',
+      },
+    ],
+  },
+  InternshipEngagement: {
+    kind: 'migrated',
+    extractor: 'engagement',
+    table: 'engagements',
+    where: "type = 'Internship'",
+    shortfall: [
+      {
+        count: 2,
+        reason:
+          'its share of the 11 engagements under soft-deleted projects (measured 2026-08-24; ' +
+          'zero internships have a dead or missing intern)',
+      },
+    ],
+  },
+  TranslationProject: {
+    kind: 'migrated',
+    extractor: 'project',
+    table: 'projects',
+    where: "type IN ('MomentumTranslation', 'MultiplicationTranslation')",
+  },
+  MomentumTranslationProject: {
+    kind: 'migrated',
+    extractor: 'project',
+    table: 'projects',
+    where: "type = 'MomentumTranslation'",
+  },
+  MultiplicationTranslationProject: {
+    kind: 'migrated',
+    extractor: 'project',
+    table: 'projects',
+    where: "type = 'MultiplicationTranslation'",
+  },
+  InternshipProject: {
+    kind: 'migrated',
+    extractor: 'project',
+    table: 'projects',
+    where: "type = 'Internship'",
+  },
+  ProjectWorkflowEvent: {
+    kind: 'migrated',
+    extractor: 'project',
+    table: 'project_workflow_events',
+    shortfall: [
+      {
+        count: 11,
+        reason:
+          'events under soft-deleted projects (measured 2026-08-24; zero events have actor or ' +
+          'step problems)',
+      },
+    ],
+  },
+  // A second label carried by 5,758 of the 27,535 ProjectWorkflowEvent nodes —
+  // the older events, from before the concrete label existed on its own. Found
+  // by this check's first run (it was unclaimed), which is the mechanism working.
+  WorkflowEvent: structural(
+    'co-label on the 5,758 older ProjectWorkflowEvent nodes; those rows migrate via ' +
+      'ProjectWorkflowEvent (measured 2026-08-24)',
+  ),
+  FinancialReport: {
+    kind: 'migrated',
+    extractor: 'periodic-report',
+    table: 'periodic_reports',
+    where: "type = 'Financial'",
+    shortfall: [
+      {
+        count: 14,
+        reason:
+          'reports whose [:report] parent edge points at a soft-deleted project (measured 2026-08-24)',
+      },
+    ],
+  },
+  NarrativeReport: {
+    kind: 'migrated',
+    extractor: 'periodic-report',
+    table: 'periodic_reports',
+    where: "type = 'Narrative'",
+    shortfall: [
+      {
+        count: 263,
+        reason:
+          'parent edge points at a soft-deleted project (measured 2026-08-24)',
+      },
+      {
+        count: 13,
+        reason:
+          'all 13 hang off ONE corrupt node (5e1e0c9b70c6ff879e61353d): a 2020-era internship ' +
+          'project that lost its Project labels but kept BaseNode and its properties. The app ' +
+          'cannot see it either — every read anchors on :Project — so these reports are already ' +
+          'invisible today (measured 2026-08-24)',
+      },
+    ],
+  },
+  ProgressReport: {
+    kind: 'migrated',
+    extractor: 'periodic-report',
+    table: 'periodic_reports',
+    where: "type = 'Progress'",
+    shortfall: [
+      {
+        count: 6620,
+        reason:
+          'parent edge points at a soft-deleted engagement (measured 2026-08-24)',
+      },
+      {
+        count: 101,
+        reason:
+          'reports on the 11 LIVE engagements under soft-deleted projects — the engagement ' +
+          'never lands, so its reports cannot either (measured 2026-08-24)',
+      },
+    ],
+  },
+  Product: {
+    kind: 'migrated',
+    extractor: 'product',
+    table: 'products',
+    to: 'single-table inheritance over the product subtypes',
+    shortfall: [
+      {
+        count: 1878,
+        reason:
+          'products with no live Project→Engagement→Product chain — verified against the graph 2026-08-20',
+      },
+    ],
+  },
+  DirectScriptureProduct: {
+    kind: 'migrated',
+    extractor: 'product',
+    table: 'products',
+    where: "type = 'DirectScripture'",
+    shortfall: [
+      {
+        count: 1062,
+        reason:
+          'its share of the 1,878 products with no live Project→Engagement chain (the interface ' +
+          'total was verified against the graph 2026-08-20; the per-type split is this check’s ' +
+          'own measurement, 2026-08-24)',
+      },
+    ],
+  },
+  DerivativeScriptureProduct: {
+    kind: 'migrated',
+    extractor: 'product',
+    table: 'products',
+    where: "type = 'Derivative'",
+    shortfall: [
+      {
+        count: 812,
+        reason:
+          'its share of the 1,878 chain-dead products — see DirectScriptureProduct',
+      },
+    ],
+  },
+  OtherProduct: {
+    kind: 'migrated',
+    extractor: 'product',
+    table: 'products',
+    where: "type = 'Other'",
+    shortfall: [
+      {
+        count: 4,
+        reason:
+          'its share of the 1,878 chain-dead products — see DirectScriptureProduct',
+      },
+    ],
+  },
+  Film: {
+    kind: 'migrated',
+    extractor: 'product',
+    table: 'producibles',
+    where: "type = 'Film'",
+  },
+  Story: {
+    kind: 'migrated',
+    extractor: 'product',
+    table: 'producibles',
+    where: "type = 'Story'",
+  },
+  EthnoArt: {
+    kind: 'migrated',
+    extractor: 'product',
+    table: 'producibles',
+    where: "type = 'EthnoArt'",
+  },
+  ProductCompletionDescription: {
+    kind: 'migrated',
+    extractor: 'product',
+    table: 'product_completion_descriptions',
+    to: 'deduplicated on (value, methodology) — the source stores repeats',
+    shortfall: [
+      {
+        count: 65,
+        reason:
+          'source duplicates — 3,941 nodes hold 3,876 distinct (value, methodology) pairs, ' +
+          'and the target keeps one row per pair (measured 2026-08-24)',
+      },
+    ],
+  },
+  ProductProgress: {
+    kind: 'migrated',
+    extractor: 'product-progress',
+    table: 'product_progress',
+    shortfall: [
+      {
+        count: 19535,
+        reason:
+          'progress nodes missing a live product or report edge — soft-deleted parents ' +
+          '(measured 2026-08-24)',
+      },
+      {
+        count: 283,
+        reason:
+          'progress under live-labeled parents that never LAND (their product or report was ' +
+          'itself dropped): 364,705 − 19,535 = 345,170 read, 344,887 landed (derived 2026-08-24)',
+      },
+    ],
+  },
+  StepProgress: {
+    kind: 'migrated',
+    extractor: 'product-progress',
+    table: 'step_progress',
+    shortfall: [
+      {
+        count: 81332,
+        reason:
+          'steps under the 19,535 progress nodes with soft-deleted parents (measured 2026-08-24)',
+      },
+      {
+        count: 1332,
+        reason:
+          'steps under the 283 progress rows that never land: 1,560,484 − 81,332 = 1,479,152 ' +
+          'on a live path, 1,477,820 landed (derived 2026-08-24; zero steps lack an active ' +
+          'inbound step edge)',
+      },
+    ],
+  },
+  ProgressSummary: {
+    kind: 'migrated',
+    extractor: 'progress-summary',
+    table: 'progress_summaries',
+    shortfall: [
+      {
+        count: 13,
+        reason:
+          'summaries whose report edge points at a soft-deleted report (measured 2026-08-24)',
+      },
+      {
+        count: 60,
+        reason:
+          'summaries under LIVE-labeled reports that never land (the unlanded-report class ' +
+          'behind the PeriodicReport shortfall) (measured 2026-08-24)',
+      },
+    ],
+  },
+  Comment: { kind: 'migrated', extractor: 'comment', table: 'comments' },
+  CommentThread: {
+    kind: 'migrated',
+    extractor: 'comment',
+    table: 'comment_threads',
+  },
+  Post: {
+    kind: 'migrated',
+    extractor: 'post',
+    table: 'posts',
+    shortfall: [
+      {
+        count: 2,
+        reason:
+          'posts failing a required read join — a soft-deleted parent or creator, or a missing ' +
+          'type/shareability/body property (measured 2026-08-24)',
+      },
+    ],
+  },
+  CommentViaMentionNotification: {
+    kind: 'migrated',
+    extractor: 'notification',
+    table: 'notifications',
+    where: "type = 'CommentViaMention'",
+  },
+  Directory: {
+    kind: 'migrated',
+    extractor: 'file',
+    table: 'file_nodes',
+    where: "type = 'Directory'",
+  },
+  File: {
+    kind: 'migrated',
+    extractor: 'file',
+    table: 'file_nodes',
+    where: "type = 'File'",
+    shortfall: [
+      {
+        count: 88,
+        reason:
+          'files whose createdBy user is absent or soft-deleted — created_by_id is NOT NULL ' +
+          '(measured 2026-08-24)',
+      },
+    ],
+  },
+  FileVersion: {
+    kind: 'migrated',
+    extractor: 'file',
+    table: 'file_nodes',
+    where: "type = 'FileVersion'",
+    shortfall: [
+      {
+        count: 1,
+        reason:
+          'one version with an absent/soft-deleted createdBy user, same rule as File ' +
+          '(measured 2026-08-24 — zero versions are missing mimeType or size)',
+      },
+    ],
+  },
+  Media: {
+    kind: 'migrated',
+    extractor: 'media',
+    table: 'media',
+    shortfall: [
+      {
+        count: 5,
+        reason:
+          'media on FileVersions that never land (dead or missing createdBy user) — ' +
+          'file_version_id is a real FK (measured 2026-08-24; zero duplicate media per version)',
+      },
+    ],
+  },
+  Image: {
+    kind: 'migrated',
+    extractor: 'media',
+    table: 'media',
+    where: "type = 'Image'",
+    shortfall: [
+      {
+        count: 5,
+        reason:
+          'all 5 of the unlanded-FileVersion media are images (measured 2026-08-24)',
+      },
+    ],
+  },
+  Video: {
+    kind: 'migrated',
+    extractor: 'media',
+    table: 'media',
+    where: "type = 'Video'",
+  },
+  Audio: {
+    kind: 'migrated',
+    extractor: 'media',
+    table: 'media',
+    where: "type = 'Audio'",
+  },
+  PnpExtractionResult: {
+    kind: 'migrated',
+    extractor: 'pnpExtractionResult',
+    table: 'pnp_extraction_results',
+  },
+  ProgressReportMedia: {
+    kind: 'migrated',
+    extractor: 'progressReportMedia',
+    table: 'progress_report_media',
+    shortfall: [
+      {
+        count: 3,
+        reason:
+          'media slots under reports that never land (the unlanded-report class) ' +
+          '(measured 2026-08-24; zero slots fail the report/variant-group/creator joins)',
+      },
+    ],
+  },
+  ProgressReportVarianceExplanation: {
+    kind: 'migrated',
+    extractor: 'progress-report-variance-explanation',
+    table: 'progress_report_variance_explanations',
+    shortfall: [
+      {
+        count: 2,
+        reason:
+          'explanations whose report edge points at a soft-deleted report (measured 2026-08-24)',
+      },
+      {
+        count: 4,
+        reason:
+          'explanations under reports that never land (measured 2026-08-24)',
+      },
+    ],
+  },
+  ProgressReportWorkflowEvent: {
+    kind: 'migrated',
+    extractor: 'progress-report-workflow-event',
+    table: 'progress_report_workflow_events',
+    shortfall: [
+      {
+        count: 12,
+        reason:
+          'events whose report edge points at a soft-deleted report (measured 2026-08-24)',
+      },
+      {
+        count: 47,
+        reason:
+          'events under reports that never land (measured 2026-08-24; zero events lack a who edge)',
+      },
+    ],
+  },
+  ProgressReportCommunityStory: {
+    kind: 'migrated',
+    extractor: 'prompt-variant-response',
+    table: 'prompt_variant_responses',
+    where: "resource_type = 'ProgressReportCommunityStory'",
+    shortfall: [
+      {
+        count: 17,
+        reason:
+          'its share of the 35 responses under dead/never-landing reports (measured 2026-08-24)',
+      },
+    ],
+  },
+  ProgressReportHighlight: {
+    kind: 'migrated',
+    extractor: 'prompt-variant-response',
+    table: 'prompt_variant_responses',
+    where: "resource_type = 'ProgressReportHighlight'",
+  },
+  ProgressReportTeamNews: {
+    kind: 'migrated',
+    extractor: 'prompt-variant-response',
+    table: 'prompt_variant_responses',
+    where: "resource_type = 'ProgressReportTeamNews'",
+    shortfall: [
+      {
+        count: 18,
+        reason:
+          'its share of the 35 responses under dead/never-landing reports (measured 2026-08-24)',
+      },
+    ],
+  },
+  VariantResponse: {
+    kind: 'migrated',
+    extractor: 'prompt-variant-response',
+    table: 'prompt_variant_response_entries',
+    plusLabels: ['Deleted_VariantResponse'],
+    to: 'live answers; superseded answers arrive too, with deleted_at set — see Deleted_VariantResponse',
+    shortfall: [
+      {
+        count: 63,
+        reason:
+          'every answer under the 34 never-landing responses (of the 35 responses whose parent ' +
+          'report or creator never lands, 34 have answers). Verified by joining graph-side ' +
+          'per-response answer counts against the loaded prompt_variant_responses ids ' +
+          '(2026-08-24, cord_cutover_r2). Creator-side losses are ZERO since the property ' +
+          'fallback fix: all 86 distinct property-creator ids resolve to loaded users. (The ' +
+          'pre-fix figure was 56 — measured through the old required-edge join, which hid the ' +
+          '7 property-mechanism answers under these same dead parents)',
+      },
+    ],
+  },
+  // Explicit override of the live-only rule: superseded answers are CARRIED,
+  // because the source models "superseded" with a deletedAt stamp and the
+  // partial unique index on (response_id, variant) is scoped WHERE deleted_at
+  // IS NULL — the history is legal and wanted. Counted with VariantResponse.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  Deleted_VariantResponse: {
+    kind: 'migrated',
+    extractor: 'prompt-variant-response',
+    to:
+      'prompt_variant_response_entries rows with deleted_at set (the answer history). 5,368 of ' +
+      'the 9,995 carry the creator as a property instead of an edge; the extractor falls back ' +
+      'to it since 2026-08-24 — loads older than that dropped them (see the VariantResponse ' +
+      'shortfall and the `creator` property-key entry)',
+  },
+  VariantGroup: structural(
+    'grouping node for progress-report media variants; its id survives as ' +
+      'progress_report_media.variant_group_id (a bare NOT NULL text column, no table of its own)',
+  ),
+
+  // ── Property storage — Neo4j field records, claimed by their link types ────
+  Property: propertyStorage(
+    'Neo4j stores each field as its own attached record whose payload is always `value`; ' +
+      'the 9,984,914 live records are the field values of everything above',
+  ),
+  // Explicit rather than rule-derived, because a subset IS read: the
+  // engagement extractor reads DEACTIVATED status rels — whose target a
+  // supersede relabels to Deleted_Property — to build engagement_status_history.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  Deleted_Property: propertyStorage(
+    'superseded/deleted field records. Mostly not carried (live-only), EXCEPT the engagement ' +
+      'status history: deactivated [:status] rels are read label-free, so the 13,558 superseded ' +
+      'status records under live engagements become engagement_status_history rows',
+  ),
+  BudgetStatus: propertyStorage('budgets.status values'),
+  EngagementStatus: propertyStorage(
+    'engagements.status values + the superseded ones behind engagement_status_history',
+  ),
+  ProjectStatus: propertyStorage(
+    'the stored project status; Postgres does not carry it as data — projects.status is ' +
+      'GENERATED from step, deriving the same value the source derived when writing it',
+  ),
+  ProjectStep: propertyStorage('projects.step values'),
+  ProjectName: propertyStorage('projects.name values'),
+  UserName: propertyStorage(
+    'user name-field values (users.real_/display_ names)',
+  ),
+  OrgName: propertyStorage('organizations.name values'),
+  LocationName: propertyStorage('locations.name values'),
+  LocationType: propertyStorage('locations.type values'),
+  LanguageName: propertyStorage('languages.name values'),
+  LanguageDisplayName: propertyStorage('languages.display_name values'),
+  FieldRegionName: propertyStorage('field_regions.name values'),
+  FieldZoneName: propertyStorage('field_zones.name values'),
+  FilmName: propertyStorage('producibles.name values (films)'),
+  StoryName: propertyStorage('producibles.name values (stories)'),
+  EthnoArtName: propertyStorage('producibles.name values (ethno art)'),
+  ToolName: propertyStorage('tools.name values'),
+  FundingAccountName: propertyStorage('funding_accounts.name values'),
+  FundingAccountNumber: propertyStorage(
+    'funding_accounts.account_number values',
+  ),
+  EmailAddress: propertyStorage('users.email values'),
+  IsoAlpha3: propertyStorage('locations.iso_alpha3 values'),
+  RegistryOfLanguageVarietiesCode: propertyStorage(
+    'languages.registry_of_language_varieties_code values',
+  ),
+  InternPosition: propertyStorage('engagements.position values'),
+  ProductMedium: propertyStorage('products.mediums values'),
+  ProductMethodology: propertyStorage('products.methodology values'),
+  ProductPurpose: propertyStorage('products.purposes values'),
+  DepartmentId: propertyStorage('projects.department_id values'),
+  ScriptureRange: propertyStorage(
+    'verse-id ranges; carried as the {start, end} pairs inside the scripture_references jsonb columns',
+  ),
+  UnspecifiedScripturePortion: propertyStorage(
+    'products.unspecified_scripture_book / _total_verses values',
+  ),
+
+  // ── Deliberately not carried — each with its evidence ──────────────────────
+  RegistryOfDialectsCode: excluded(
+    'renamed to registryOfLanguageVarietiesCode by an app migration (rename-rod-to-rolv). ' +
+      'ZERO live nodes remain (22 Deleted_); the 58 surviving edges are the retired history of ' +
+      'that rename — every one points at a Deleted_Property or is inactive (measured 2026-08-24)',
+  ),
+  DuplicateProjectDepartmentId: excluded(
+    'quarantined duplicate department-id records: 7 property nodes {createdAt, value} that were ' +
+      'relabelled OUT of DepartmentId so each project keeps one value; the surviving DepartmentId ' +
+      'record is what migrates (probed 2026-08-24)',
+  ),
+  PnpProblemType: excluded(
+    'the extraction-problem-type registry: 16 nodes {id, name, severity} mirrored from ' +
+      'code-defined problem types. Problems carry the type ID into ' +
+      'pnp_extraction_result_problems.type; name and severity live in the application registry',
+  ),
+  SchemaVersion: excluded(
+    "Neo4j's own schema-version marker (one node, {value}); Postgres versions its schema " +
+      'through drizzle migrations',
+  ),
+  DataProvenance: excluded(
+    "the scrub tooling's provenance marker on this COPY ({scrubbedAt, scrubbedValues, " +
+      'deletedKeys, classificationHash}); absent from real production and not application data',
+  ),
+  Webhook: excluded(
+    'zero nodes in the source; the webhooks tables start empty',
+  ),
+  BroadcastChannel: excluded(
+    'zero nodes in the source; the broadcast_channels table starts empty',
+  ),
+  Changeset: excluded(
+    'zero nodes in the source — the changeset feature holds no live changesets, and ' +
+      'changeset-pending values are not carried anyway (reads are live-view only)',
+  ),
+  ProjectChangeRequest: excluded(
+    'zero nodes in the source; same feature family as Changeset',
+  ),
+  Song: excluded(
+    'zero nodes; not among the producible types the app defines today (Film/Story/EthnoArt)',
+  ),
+  LiteracyMaterial: excluded('zero nodes; retired producible type, as Song'),
+  LiteracyName: excluded(
+    'zero nodes; the name storage for the retired type above',
+  ),
+  SongName: excluded('zero nodes; the name storage for the retired type above'),
+
+  // ── Decided drops (Rob, 2026-08-24) ─────────────────────────────────────────
+  Token: excluded(
+    '4,175,608 session tokens ({value, createdAt, active}) — every session ends at cutover and ' +
+      'users re-authenticate with their existing password (auth_sessions deliberately starts ' +
+      'empty). Decided: drop (Rob, 2026-08-24)',
+  ),
+  EmailToken: excluded(
+    '147 password-reset tokens ({value, createdOn}) — every outstanding reset link breaks at ' +
+      'cutover; anyone mid-reset requests a new email. Decided: drop (Rob, 2026-08-24)',
+  ),
+
+  // ── Still open — blocks the run until the team answers ─────────────────────
+  ExternalDepartmentId: review(
+    '565 fully DISCONNECTED nodes (zero edges in or out), each {name, departmentId} — an ' +
+      'org-name → 5-digit finance-department-code directory imported in a single moment ' +
+      '(2025-09-22T21:05:53Z; the names read as scrubbed fakes in this copy, real in prod; ' +
+      'codes like 00000/00010/00020). Nothing in src/ reads the label — likely the finance ' +
+      'system’s department list imported around the department-id-block work. Rob is asking ' +
+      'the team whether it is superseded (2026-08-24)',
+  ),
+
+  // ── Decided ports (Rob, 2026-08-24) ─────────────────────────────────────────
+  ProjectTypeFinancialApprover: {
+    kind: 'migrated',
+    extractor: 'financial-approver',
+    table: 'financial_approvers',
+    to:
+      'financial_approvers — one row per user (the source node holds ONLY the projectTypes ' +
+      'array, so the user is the row identity). Ported, not retired: the project workflow ' +
+      'notifies these approvers on five transitions (Rob, 2026-08-24)',
+  },
+  PnpData: {
+    kind: 'migrated',
+    extractor: 'pnp-data',
+    table: 'pnp_data',
+    to:
+      'pnp_data (ARCHIVE — no app reader): per-quarter figures on language engagements, the ' +
+      'retired predecessor of ProgressSummary. Carried verbatim, importer bugs included ' +
+      '(15 year-0 rows). Archived rather than dropped (Rob, 2026-08-24)',
+    shortfall: [
+      {
+        count: 1,
+        reason:
+          'the one node whose owning engagement is soft-deleted — the engagement never lands ' +
+          'and engagement_id is NOT NULL (measured 2026-08-24; the other 69 owning engagements ' +
+          'all land, verified by the 104/105 load into cord_cutover_r2)',
+      },
+    ],
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AXIS 2 — relationship types (207). For a property link (an edge pointing at
+// a Property record), `migrated` means the VALUE lands in the named column(s).
+// For an entity edge, the connection survives as a foreign key or junction row.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const relationshipTypes: Readonly<Record<string, Disposition>> = {
+  // ── People / users ──────────────────────────────────────────────────────────
+  realFirstName: carried('users.real_first_name'),
+  realLastName: carried('users.real_last_name'),
+  displayFirstName: carried('users.display_first_name'),
+  displayLastName: carried('users.display_last_name'),
+  email: carried('users.email'),
+  phone: carried('users.phone'),
+  about: carried('users.about'),
+  timezone: carried('users.timezone'),
+  gender: carried('users.gender'),
+  title: carried('users.title / products.title (OtherProduct)'),
+  roles: carried('user_global_roles rows / project_members.roles'),
+  education: carried('educations.user_id (the User→Education edge)'),
+  degree: carried('educations.degree'),
+  major: carried('educations.major'),
+  institution: carried('educations.institution'),
+  unavailability: carried(
+    'unavailabilities.user_id (the User→Unavailability edge)',
+  ),
+  password: carried('auth_identities.password_hash'),
+  pinned: carried('pins rows (edge-stored: user, resource, createdAt)'),
+  locations: carried(
+    'user_locations / organization_locations / language_locations junction rows',
+  ),
+  organization: carried(
+    'user_organizations rows / partners.organization_id / budget_records.organization_id',
+  ),
+  primaryOrganization: carried('user_organizations.primary'),
+
+  // ── Projects ────────────────────────────────────────────────────────────────
+  name: carried(
+    'the name column of each owning entity (projects, languages, orgs, …) and file_nodes.name',
+  ),
+  step: carried(
+    'projects.step (the property records) and step_progress rows (the ProductProgress→StepProgress edges)',
+  ),
+  status: carried(
+    'the status columns: users, budgets, engagements (+ engagement_status_history from ' +
+      'deactivated rels), periodic_reports. projects.status is GENERATED from step in Postgres',
+  ),
+  stepChangedAt: carried(
+    'derived, not stored: the Postgres read side serves stepChangedAt from the latest ' +
+      'project_workflow_events.at per project (project.drizzle.repository)',
+  ),
+  mouStart: carried('projects.mou_start'),
+  mouEnd: carried('projects.mou_end'),
+  initialMouEnd: carried('projects.initial_mou_end'),
+  estimatedSubmission: carried('projects.estimated_submission'),
+  financialReportReceivedAt: carried('projects.financial_report_received_at'),
+  financialReportPeriod: carried('projects.financial_report_period'),
+  departmentId: carried('projects.department_id'),
+  rev79ProjectId: carried('projects.rev79_project_id'),
+  presetInventory: carried('projects.preset_inventory'),
+  tags: carried('projects.tags / languages.tags'),
+  sensitivity: carried(
+    'projects.sensitivity + projects.own_sensitivity / languages.sensitivity',
+  ),
+  primaryLocation: carried('projects.primary_location_id'),
+  marketingLocation: carried('projects.marketing_location_id'),
+  fieldRegion: carried('projects.field_region_id'),
+  owningOrganization: carried('projects.owning_organization_id'),
+  rootDirectory: carried('projects.root_directory_id'),
+  member: structural(
+    'the Project→ProjectMember edge; survives as project_members.project_id',
+  ),
+  user: structural(
+    'the ProjectMember→User (and sibling) edges; survive as the user_id foreign keys',
+  ),
+  inactiveAt: carried('project_members.inactive_at'),
+  workflowEvent: structural(
+    'the parent→event edges; survive as project_workflow_events.project_id / ' +
+      'progress_report_workflow_events.report_id',
+  ),
+  who: carried(
+    'project_workflow_events.who / .who_system_agent_id and progress_report_workflow_events.who',
+  ),
+  modifiedAt: carried(
+    'the modified_at / updated_at columns, where the source stores modification time as a property record',
+  ),
+
+  // ── Engagements ─────────────────────────────────────────────────────────────
+  engagement: structural(
+    'the Project→Engagement edge; survives as engagements.project_id',
+  ),
+  language: carried('engagements.language_id'),
+  intern: carried('engagements.intern_id'),
+  mentor: carried('engagements.mentor_id'),
+  countryOfOrigin: carried('engagements.country_of_origin_id'),
+  position: carried('engagements.position'),
+  methodologies: carried('engagements.methodologies'),
+  startDateOverride: carried('engagements.start_date_override'),
+  endDateOverride: carried('engagements.end_date_override'),
+  initialEndDate: carried('engagements.initial_end_date'),
+  completeDate: carried('engagements.complete_date'),
+  disbursementCompleteDate: carried('engagements.disbursement_complete_date'),
+  statusModifiedAt: carried('engagements.status_modified_at'),
+  lastSuspendedAt: carried('engagements.last_suspended_at'),
+  lastReactivatedAt: carried('engagements.last_reactivated_at'),
+  paratextRegistryId: carried('engagements.paratext_registry_id'),
+  rev79CommunityId: carried('engagements.rev79_community_id'),
+  webId: carried('engagements.web_id'),
+  firstScripture: carried('engagements.first_scripture'),
+  lukePartnership: carried('engagements.luke_partnership'),
+  openToInvestorVisit: carried('engagements.open_to_investor_visit'),
+  sentPrintingDate: carried('engagements.sent_printing_date'),
+  historicGoal: carried('engagements.historic_goal'),
+  milestonePlanned: carried('engagements.milestone_planned'),
+  milestoneReached: carried('engagements.milestone_reached'),
+  usingAIAssistedTranslation: carried(
+    'engagements.using_ai_assisted_translation',
+  ),
+  marketable: carried('engagements.marketable'),
+  pnp: carried('engagements.pnp_id (DefinedFile placeholder id)'),
+  pnpNode: structural('duplicate edge to the same File the pnp link names'),
+  growthPlan: carried(
+    'engagements.growth_plan_id (DefinedFile placeholder id)',
+  ),
+  growthPlanNode: structural(
+    'duplicate edge to the same File the growthPlan link names',
+  ),
+  ceremony: structural(
+    'the Engagement→Ceremony edge; survives as ceremonies.engagement_id',
+  ),
+  actualDate: carried('ceremonies.actual_date'),
+  estimatedDate: carried('ceremonies.estimated_date'),
+  planned: carried('ceremonies.planned'),
+  description: carried(
+    'the description columns: engagements (rich text), products, tools, unavailabilities',
+  ),
+
+  // ── Decided 2026-08-24 ──────────────────────────────────────────────────────
+  communicationsCompleteDate: excluded(
+    'a RETIRED engagement field nothing in src/ reads or writes — and all 35 live-labeled ' +
+      'records hold NULL (count(p.value) = 0, probed 2026-08-24), so dropping it loses ' +
+      'literally nothing. Decided: drop (Rob, 2026-08-24)',
+  ),
+  pnpData: carried(
+    'pnp_data rows — the owning edge becomes pnp_data.engagement_id (the archive table)',
+  ),
+  token: excluded(
+    'the User→Token session edges (223,387) — dropped with the Token label (Rob, 2026-08-24)',
+  ),
+
+  // ── Languages ───────────────────────────────────────────────────────────────
+  displayName: carried('languages.display_name'),
+  displayNamePronunciation: carried('languages.display_name_pronunciation'),
+  isDialect: carried('languages.is_dialect'),
+  isSignLanguage: carried('languages.is_sign_language'),
+  signLanguageCode: carried('languages.sign_language_code'),
+  leastOfThese: carried('languages.least_of_these'),
+  leastOfTheseReason: carried('languages.least_of_these_reason'),
+  populationOverride: carried('languages.population_override'),
+  registryOfLanguageVarietiesCode: carried(
+    'languages.registry_of_language_varieties_code',
+  ),
+  registryOfDialectsCode: excluded(
+    'the retired pre-rename field (renamed to registryOfLanguageVarietiesCode by an app ' +
+      'migration); all 58 surviving edges are the rename’s retired history — every one is ' +
+      'inactive or points at a Deleted_Property (measured 2026-08-24)',
+  ),
+  sponsorEstimatedEndDate: carried('languages.sponsor_estimated_end_date'),
+  hasExternalFirstScripture: carried('languages.has_external_first_scripture'),
+  isAvailableForReporting: carried('languages.is_available_for_reporting'),
+  ethnologue: structural(
+    'the Language→EthnologueLanguage edge; survives as ethnologue_languages.language_id (backfilled)',
+  ),
+  code: carried('ethnologue_languages.code'),
+  provisionalCode: carried('ethnologue_languages.provisional_code'),
+  population: carried('ethnologue_languages.population'),
+
+  // ── Field zones / regions / locations / funding ─────────────────────────────
+  zone: carried('field_regions.field_zone_id'),
+  director: carried('field_zones.director_id / field_regions.director_id'),
+  fundingAccount: carried('locations.funding_account_id'),
+  defaultFieldRegion: carried('locations.default_field_region_id'),
+  defaultMarketingRegion: carried('locations.default_marketing_region_id'),
+  isoAlpha3: carried('locations.iso_alpha3'),
+  mapImage: carried('locations.map_image_id (DefinedFile placeholder id)'),
+  mapImageNode: structural(
+    'duplicate edge to the same File the mapImage link names',
+  ),
+  accountNumber: carried('funding_accounts.account_number'),
+  departmentIdBlock: carried(
+    'funding_accounts.department_id_block_id / partners.department_id_block_id',
+  ),
+
+  // ── Organizations / partners / partnerships ─────────────────────────────────
+  acronym: carried('organizations.acronym'),
+  address: carried('organizations.address / partners.address'),
+  reach: carried('organizations.reach'),
+  types: carried('organizations.types / partners.types / partnerships.types'),
+  active: carried(
+    'partners.active (a property link, unlike the `active` EDGE FLAG below)',
+  ),
+  pmcEntityCode: carried('partners.pmc_entity_code'),
+  globalInnovationsClient: carried('partners.global_innovations_client'),
+  pointOfContact: carried('partners.point_of_contact_id'),
+  startDate: carried('partners.start_date / tool_usages.start_date'),
+  approvedPrograms: carried('partners.approved_programs'),
+  financialReportingTypes: carried('partners.financial_reporting_types'),
+  fieldRegions: carried('partner_field_regions junction rows'),
+  countries: carried('partner_countries junction rows'),
+  partner: carried('partnerships.partner_id'),
+  partnership: structural(
+    'the Project→Partnership edge; survives as partnerships.project_id',
+  ),
+  agreementStatus: carried('partnerships.agreement_status'),
+  mouStatus: carried('partnerships.mou_status'),
+  mou: carried('partnerships.mou_id (DefinedFile placeholder id)'),
+  mouNode: structural('duplicate edge to the same File the mou link names'),
+  agreement: carried('partnerships.agreement_id (DefinedFile placeholder id)'),
+  agreementNode: structural(
+    'duplicate edge to the same File the agreement link names',
+  ),
+  mouStartOverride: carried('partnerships.mou_start_override'),
+  mouEndOverride: carried('partnerships.mou_end_override'),
+  financialReportingType: carried('partnerships.financial_reporting_type'),
+  primary: carried('partnerships.primary'),
+  PartnershipProducingMedium: carried(
+    'partnership_producing_mediums rows (edge-stored; medium + createdAt live on the edge)',
+  ),
+
+  // ── Budgets ─────────────────────────────────────────────────────────────────
+  budget: structural('the Project→Budget edge; survives as budgets.project_id'),
+  universalTemplateFile: carried(
+    'budgets.universal_template_file_id (DefinedFile placeholder id)',
+  ),
+  universalTemplateFileNode: structural(
+    'duplicate edge to the same File the universalTemplateFile link names',
+  ),
+  record: structural(
+    'the Budget→BudgetRecord edge; survives as budget_records.budget_id',
+  ),
+  fiscalYear: carried('budget_records.fiscal_year'),
+  amount: carried('budget_records.amount'),
+  initialAmount: carried('budget_records.initial_amount'),
+  preApprovedAmount: carried('budget_records.pre_approved_amount'),
+
+  // ── Products / producibles / progress ───────────────────────────────────────
+  product: structural(
+    'the Engagement→Product edge; survives as products.engagement_id',
+  ),
+  mediums: carried('products.mediums'),
+  purposes: carried('products.purposes'),
+  methodology: carried('products.methodology'),
+  steps: carried('products.steps'),
+  describeCompletion: carried('products.describe_completion'),
+  placeholderDescription: carried('products.placeholder_description'),
+  progressStepMeasurement: carried('products.progress_step_measurement'),
+  progressTarget: carried('products.progress_target'),
+  produces: carried('products.produces_id'),
+  isOverriding: carried(
+    'encoded into products.scripture_references_override: null means not overriding',
+  ),
+  composite: carried('products.composite'),
+  totalVerses: carried('products.total_verses'),
+  totalVerseEquivalents: carried('products.total_verse_equivalents'),
+  scriptureReferences: carried(
+    'products.scripture_references / producibles.scripture_references (jsonb verse ranges)',
+  ),
+  scriptureReferencesOverride: carried(
+    'products.scripture_references_override',
+  ),
+  unspecifiedScripture: carried(
+    'products.unspecified_scripture_book + _total_verses',
+  ),
+  progress: structural(
+    'the Product→ProductProgress and PeriodicReport→ProductProgress edges; survive as ' +
+      'product_progress.product_id / .report_id',
+  ),
+  completed: carried('step_progress.completed'),
+
+  // ── Reports and their attachments ───────────────────────────────────────────
+  report: structural(
+    'the parent→PeriodicReport edge; survives as periodic_reports.project_id / .engagement_id',
+  ),
+  start: carried('periodic_reports.start / unavailabilities.start'),
+  end: carried('periodic_reports.end / unavailabilities.end'),
+  type: carried(
+    'the discriminators stored as property records: periodic_reports.type, ceremonies.type, posts.type',
+  ),
+  receivedDate: carried('periodic_reports.received_date'),
+  skippedReason: carried('periodic_reports.skipped_reason'),
+  reportFile: carried(
+    'periodic_reports.report_file_id (DefinedFile placeholder id)',
+  ),
+  reportFileNode: structural(
+    'duplicate edge to the same File the reportFile link names',
+  ),
+  narrativeFile: carried(
+    'periodic_reports.narrative_file_id (DefinedFile placeholder id)',
+  ),
+  narrativeFileNode: structural(
+    'duplicate edge to the same File the narrativeFile link names',
+  ),
+  narrativeReceivedDate: carried('periodic_reports.narrative_received_date'),
+  summary: carried(
+    'progress_summaries rows (period/planned/actual sit on the target node)',
+  ),
+  varianceExplanation: carried('progress_report_variance_explanations rows'),
+  reasons: carried('progress_report_variance_explanations.reasons'),
+  comments: carried('progress_report_variance_explanations.comments'),
+  child: structural(
+    'parent→child edges (report→media, variant-group→media, prompt-response→answer); ' +
+      'survive as report_id / variant_group_id / response_id',
+  ),
+  prompt: carried('prompt_variant_responses.prompt'),
+
+  // ── Comments / posts / notifications / pins ─────────────────────────────────
+  commentThread: structural(
+    'the parent→CommentThread edge; survives as comment_threads.parent_id + parent_type',
+  ),
+  comment: structural(
+    'the CommentThread→Comment and Notification→Comment edges; survive as comments.thread_id ' +
+      'and notifications.comment_id',
+  ),
+  body: carried('posts.body (plain text) / comments.body (rich text jsonb)'),
+  shareability: carried('posts.shareability'),
+  post: structural(
+    'the parent→Post edge; survives as posts.parent_id + parent_type',
+  ),
+  creator: carried(
+    'the creator_id columns (posts, comments, threads, tool usages, prompt responses, media slots, notifications)',
+  ),
+
+  // ── Files / media / PnP extraction ──────────────────────────────────────────
+  parent: carried('file_nodes.parent_id (the file tree)'),
+  createdBy: carried('file_nodes.created_by_id'),
+  public: carried(
+    'file_nodes.public (tri-state; null inherits from the parent)',
+  ),
+  mimeType: carried('file_nodes.mime_type (file versions)'),
+  size: carried('file_nodes.size (file versions)'),
+  media: structural(
+    'the FileVersion→Media edge; survives as media.file_version_id',
+  ),
+  photo: carried('users.photo_id (DefinedFile placeholder id)'),
+  photoNode: structural('duplicate edge to the same File the photo link names'),
+  fileNode: carried(
+    'progress_report_media.file_id (DefinedFile placeholder id)',
+  ),
+  pnpExtractionResult: structural(
+    'the File→PnpExtractionResult edge; survives as pnp_extraction_results.file_id',
+  ),
+  problem: carried(
+    'pnp_extraction_result_problems rows ({id, source, context} live on the edge; type is the target node’s id)',
+  ),
+
+  // ── Tools ───────────────────────────────────────────────────────────────────
+  key: carried('tools.key'),
+  aiBased: carried('tools.ai_based'),
+  uses: structural(
+    'the container→ToolUsage edge; survives as tool_usages.container_id + container_type',
+  ),
+  tool: carried('tool_usages.tool_id'),
+
+  // ── Department-id / finance config ──────────────────────────────────────────
+  financialApprover: carried(
+    'financial_approvers.user_id — the edge target IS the row identity (ported, Rob 2026-08-24)',
+  ),
+
+  // ── Neo4j-side mechanics, deliberately not carried ──────────────────────────
+  canDelete: excluded(
+    'Neo4j-side delete-permission flag written on every entity (1,280,074 records); Postgres ' +
+      'derives delete rights from the policy engine, so there is nothing to carry',
+  ),
+  changeset: excluded(
+    'changeset bookkeeping edges on engagement property records (591, incl. 46 on deleted ' +
+      'engagements). The graph holds ZERO Changeset nodes, and changeset-pending values are not ' +
+      'carried — reads are live-view only (probed 2026-08-24)',
+  ),
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AXIS 3 — property keys (85). The least obvious axis and the one that catches
+// FIELD-level loss. `db.propertyKeys()` returns every key EVER minted, so a key
+// can be claimed `excluded` on the measured fact that nothing carries it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const propertyKeys: Readonly<Record<string, Disposition>> = {
+  // ── The core storage mechanics ─────────────────────────────────────────────
+  value: carried(
+    'the payload every field record holds; lands in the column its LINK names — see the ' +
+      'relationship-type manifest, which claims each link',
+  ),
+  id: carried(
+    'the id columns — ids are preserved verbatim across the migration',
+  ),
+  createdAt: carried(
+    'the created_at columns (nodes) and edge timestamps (pins, junctions)',
+  ),
+  modifiedAt: carried(
+    'the modified_at / updated_at columns where stored directly on a node',
+  ),
+  deletedAt: carried(
+    'deleted_at where the target table keeps history (prompt_variant_response_entries); ' +
+      'otherwise the marker of rows the live-only rule excludes',
+  ),
+  active: propertyStorage(
+    'the liveness flag on relationships — Neo4j’s way of superseding a value without ' +
+      'deleting it. Postgres has no equivalent because current-vs-history is modeled in rows',
+  ),
+  sortValue: propertyStorage(
+    'a derived sort key on Property records; Postgres re-derives ordering with collation and indexes',
+  ),
+  // Soft-delete renames a field record's id/value to deleted_id/deleted_value.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  deleted_id: propertyStorage(
+    'the id of a soft-deleted field record (renamed on delete)',
+  ),
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  deleted_value: propertyStorage(
+    'the value of a soft-deleted field record (renamed on delete); not carried — live-only',
+  ),
+  property: excluded(
+    'zero occurrences on any node or relationship (full scans 2026-08-24) — a token-store ' +
+      'ghost from an older schema',
+  ),
+
+  // ── Values living directly on nodes/edges, and where they land ─────────────
+  name: carried(
+    'system_agents.name (+ PnpProblemType registry names, which live in code)',
+  ),
+  status: carried('project/progress-report workflow event status columns'),
+  step: carried('step_progress.step'),
+  to: carried(
+    'project_workflow_events.to_step (from_step is derived while loading)',
+  ),
+  transition: carried('the workflow events’ transition_key columns'),
+  notes: carried('the workflow events’ notes columns (rich text jsonb)'),
+  variant: carried(
+    'prompt_variant_response_entries.variant / progress_report_media.variant / product_progress.variant',
+  ),
+  response: carried(
+    'prompt_variant_response_entries.response (rich text jsonb)',
+  ),
+  period: carried('progress_summaries.period'),
+  planned: carried('progress_summaries.planned'),
+  actual: carried('progress_summaries.actual'),
+  category: carried('progress_report_media.category'),
+  medium: carried('partnership_producing_mediums.medium (lives on the edge)'),
+  methodology: carried('product_completion_descriptions.methodology'),
+  lastUsedAt: carried('product_completion_descriptions.last_used_at'),
+  type: carried(
+    'media.type, notifications.type, and the engagement/project type discriminators',
+  ),
+  mimeType: carried(
+    'media.mime_type (direct property; file versions store theirs as a field record)',
+  ),
+  caption: carried('media.caption'),
+  duration: carried('media.duration'),
+  height: carried('media.height'),
+  width: carried('media.width'),
+  message: carried('notifications.message'),
+  readAt: carried(
+    'notification_recipients.read_at (on the recipient edge; zero edges in prod today)',
+  ),
+  start: carried(
+    'the {start, end} verse bounds inside the scripture_references jsonb',
+  ),
+  end: carried('as start — the other verse bound'),
+  book: carried('products.unspecified_scripture_book'),
+  totalVerses: carried('products.unspecified_scripture_total_verses'),
+  blocks: carried('department_id_blocks.range (JSON ranges → int4multirange)'),
+  programs: carried('department_id_blocks.programs'),
+  departmentId: carried('projects.department_id (where stored directly)'),
+  key: carried('tools.key (where stored directly)'),
+  source: carried('pnp_extraction_result_problems.source'),
+  context: carried(
+    'pnp_extraction_result_problems.context (JSON string → jsonb)',
+  ),
+  severity: excluded(
+    'lives only on the 16 PnpProblemType registry nodes ({id, name, severity}); the registry ' +
+      'is code-defined in Postgres, problems carry only the type id (probed 2026-08-24)',
+  ),
+  roles: carried(
+    'system_agents.roles / user_global_roles / project_members.roles (where stored directly)',
+  ),
+  pnpIndex: carried('products.pnp_index'),
+
+  // ── Scrub tooling markers — exist only on this copy, never in production ───
+  scrubbedAt: excluded(
+    'scrub provenance marker on the DataProvenance node of this COPY',
+  ),
+  scrubbedValues: excluded('scrub provenance marker, as scrubbedAt'),
+  deletedKeys: excluded('scrub provenance marker, as scrubbedAt'),
+  classificationHash: excluded('scrub provenance marker, as scrubbedAt'),
+
+  // ── Dead 2021-migration artifacts (the scrub deletes these outright) ───────
+  '87SixId': excluded(
+    'join key for the Aug-2021 import from 87Six, the system Cord v3 replaced; nothing reads it',
+  ),
+  v2User: excluded(
+    'old-system actor id from the same 2021 import; nothing reads it',
+  ),
+  v2Timestamp: excluded('old-system timestamp from the same 2021 import'),
+  finalReportMigration: excluded(
+    'rollback marker from the 2021 effort; one distinct value',
+  ),
+  postMigration: excluded(
+    'rollback marker from the 2021 effort; never reverted',
+  ),
+  commentDescription: excluded('87Six leftovers; verified 0 live values'),
+  commentPrayerNeeds: excluded('87Six leftovers; verified 0 live values'),
+  commentProposalComments: excluded('87Six leftovers; verified 0 live values'),
+  migrated: excluded('migration bookkeeping marker; not data'),
+  migration: excluded('migration bookkeeping marker; not data'),
+  primarySchemaUpdateAt: excluded(
+    'schema bookkeeping on the SchemaVersion node',
+  ),
+
+  // ── Sessions / credentials — dropped with the Token/EmailToken decisions ───
+  createdOn: excluded(
+    'lives only on EmailToken nodes — dropped with EmailToken (Rob, 2026-08-24)',
+  ),
+  valid: excluded(
+    'zero occurrences on any node or relationship (full scans 2026-08-24); token-store ghost',
+  ),
+  token: excluded(
+    'zero occurrences on any node or relationship (full scans 2026-08-24) — session tokens ' +
+      'store their value under `value`; this key is a token-store ghost',
+  ),
+  secret: excluded(
+    'webhook signing secrets — zero occurrences (webhooks hold zero nodes in the source)',
+  ),
+  subscription: excluded(
+    'webhook GraphQL documents — zero occurrences, as secret',
+  ),
+  url: excluded('webhook target URLs — zero occurrences, as secret'),
+
+  // ── Measured-dead keys, each probed 2026-08-24 ─────────────────────────────
+  powers: excluded(
+    'the pre-policy-engine authorization grants, stored on 1,243 live User nodes. The current ' +
+      'system computes powers from code-defined policies (authorization.resolver reads ' +
+      'privileges.powers, never this property); no repository reads it',
+  ),
+  originalParentId: excluded(
+    'pre-move parent bookkeeping on 705 live FileVersions (+626 Property records); ZERO ' +
+      'references in src/ outside the scrub classification — the live tree is carried via parent edges',
+  ),
+  creator: carried(
+    'prompt_variant_response_entries.creator_id — the OLD creator mechanism (a creator id ' +
+      'stored as a node property, on 5,368 retired answers with no [:creator] edge). The ' +
+      'extractor coalesces edge-then-property since 2026-08-24, after cutover-coverage caught ' +
+      'the required-edge join dropping 54% of the answer history (Rob: fix, 2026-08-24). The ' +
+      '91 occurrences on deleted media slots stay uncarried — live-only',
+  ),
+  hadNaN: excluded(
+    'a "spreadsheet cell was NaN" marker the old PnP importer stamped on progress field ' +
+      'records; 1 live occurrence (59 on deleted records); nothing reads it',
+  ),
+  read: excluded(
+    'the pre-readAt read-state key; zero occurrences on any node or relationship — production ' +
+      'has zero notification recipient edges at all',
+  ),
+  edit: excluded(
+    'zero occurrences on any node or relationship (full scans 2026-08-24)',
+  ),
+  role: excluded(
+    'zero occurrences on any node or relationship (full scans 2026-08-24)',
+  ),
+  countError: excluded(
+    'the OLD denormalized PnP-extraction schema; save() clears it ({result: {}}), and full ' +
+      'scans 2026-08-24 found zero occurrences — problems now live on edges',
+  ),
+  countNotice: excluded('as countError — zero occurrences'),
+  countWarning: excluded('as countError — zero occurrences'),
+  hasError: excluded('as countError — zero occurrences'),
+  hasNotice: excluded('as countError — zero occurrences'),
+  hasWarning: excluded('as countError — zero occurrences'),
+  problems: excluded(
+    'as countError — zero occurrences; problems live on [:problem] edges',
+  ),
+
+  // ── PnpData figures — archived with the PnpData label (Rob, 2026-08-24) ────
+  quarter: carried('pnp_data.quarter'),
+  year: carried('pnp_data.year'),
+  progressActual: carried('pnp_data.progress_actual'),
+  progressPlanned: carried('pnp_data.progress_planned'),
+  variance: carried('pnp_data.variance'),
+
+  // ── Config nodes ────────────────────────────────────────────────────────────
+  projectTypes: carried(
+    'financial_approvers.project_types (ported with the label, Rob 2026-08-24)',
+  ),
+};

--- a/src/core/cutover/coverage-manifest.ts
+++ b/src/core/cutover/coverage-manifest.ts
@@ -99,6 +99,18 @@ const excluded = (reason: string): Disposition => ({
   kind: 'excluded',
   reason,
 });
+/**
+ * Currently unused, and deliberately kept.
+ *
+ * As of 2026-08-25 every name the source enumerates has a decided disposition —
+ * ExternalDepartmentId was the last one under review, and it is now ported. So
+ * this helper has no call sites, which is the good state rather than dead code:
+ * `review` is one of the five dispositions, the checker still refuses to pass on
+ * it, and the next unclaimed name that turns up needs it to be here. Deleting it
+ * would quietly make "I don't know yet" harder to express than "excluded", which
+ * is exactly the pressure this file exists to resist.
+ */
+// eslint-disable-next-line @seedcompany/no-unused-vars
 const review = (question: string): Disposition => ({
   kind: 'review',
   question,
@@ -956,15 +968,33 @@ export const labels: Readonly<Record<string, Disposition>> = {
       'cutover; anyone mid-reset requests a new email. Decided: drop (Rob, 2026-08-24)',
   ),
 
-  // ── Still open — blocks the run until the team answers ─────────────────────
-  ExternalDepartmentId: review(
-    '565 fully DISCONNECTED nodes (zero edges in or out), each {name, departmentId} — an ' +
-      'org-name → 5-digit finance-department-code directory imported in a single moment ' +
-      '(2025-09-22T21:05:53Z; the names read as scrubbed fakes in this copy, real in prod; ' +
-      'codes like 00000/00010/00020). Nothing in src/ reads the label — likely the finance ' +
-      'system’s department list imported around the department-id-block work. Rob is asking ' +
-      'the team whether it is superseded (2026-08-24)',
-  ),
+  ExternalDepartmentId: {
+    kind: 'migrated',
+    extractor: 'external-department-id',
+    table: 'external_department_ids',
+    to:
+      'external_department_ids — the department IDs Intacct already holds, which must never ' +
+      'be assigned to a CORD project. 565 nodes, one bulk import (2025-09-22T21:05:53Z). ' +
+      'PORTED (Rob, 2026-08-25, after the team confirmed Intacct is still in use and the ' +
+      'reservations still stand). ' +
+      // The correction matters more than the disposition. This entry previously
+      // read "Nothing in src/ reads the label", and that was simply wrong: the
+      // department-ID allocator unions these into the unavailable set on every
+      // assignment and has since 2025-09. The nodes ARE fully disconnected, and
+      // that is what made them look retired — but a reservation list has
+      // nothing to connect to, so disconnected was the correct shape, not a
+      // symptom. The lesson for future entries: "no edges" and "no readers" are
+      // different claims, and only the second is evidence of being retired.
+      'CORRECTION to the earlier entry, which said nothing in src/ read this label: ' +
+      'set-department-id.handler.ts reads it on every department-ID assignment. The ' +
+      'exclusion was missing from the Postgres arm and is restored in migration 0040 — ' +
+      'measured before fixing, 389 of the 565 codes sit inside blocks projects are assigned ' +
+      'from, and 2 of 13 blocks would have handed out a different ID than Neo4j on their ' +
+      'next project. ' +
+      'Separately open, and NOT a cutover item: the list is a one-shot manual load with no ' +
+      'refresh path (its importer was never merged to develop), so it is stale against ' +
+      'Intacct. Owner of the Intacct side to decide re-export vs real integration.',
+  },
 
   // ── Decided ports (Rob, 2026-08-24) ─────────────────────────────────────────
   ProjectTypeFinancialApprover: {
@@ -1467,7 +1497,14 @@ export const propertyKeys: Readonly<Record<string, Disposition>> = {
   totalVerses: carried('products.unspecified_scripture_total_verses'),
   blocks: carried('department_id_blocks.range (JSON ranges → int4multirange)'),
   programs: carried('department_id_blocks.programs'),
-  departmentId: carried('projects.department_id (where stored directly)'),
+  // Two different nodes carry this key and both are migrated: the Property
+  // record behind a project's departmentId, and the ExternalDepartmentId
+  // reservation nodes. Named here because a single property-key entry cannot
+  // say "per label", and one destination would have hidden the other.
+  departmentId: carried(
+    'projects.department_id (where stored directly), and ' +
+      'external_department_ids.department_id for the ExternalDepartmentId nodes',
+  ),
   key: carried('tools.key (where stored directly)'),
   source: carried('pnp_extraction_result_problems.source'),
   context: carried(

--- a/src/core/cutover/coverage-manifest.ts
+++ b/src/core/cutover/coverage-manifest.ts
@@ -47,7 +47,10 @@
  * measured and root-caused against the 2026-08-24 production copy, loaded from
  * current HEAD into `cord_cutover_r2` (2026-08-24; supersedes the 2026-08-20
  * `cord_cutover_verify` load, which predates the creator-fallback fix and
- * migrations 0039/0040). On a newer snapshot the numbers WILL drift and the run
+ * migration 0039). That load also built a `pnp_data` table, from a migration
+ * since withdrawn — see the PnpData entry. It is harmless: nothing counts a
+ * table the schema no longer declares, so no reload is owed on its account.
+ * On a newer snapshot the numbers WILL drift and the run
  * WILL go red — that is the designed behavior: an unexplained delta blocks
  * until someone re-verifies the reason still holds and updates the number.
  * Never update a count without re-verifying its reason.
@@ -973,24 +976,23 @@ export const labels: Readonly<Record<string, Disposition>> = {
       'array, so the user is the row identity). Ported, not retired: the project workflow ' +
       'notifies these approvers on five transitions (Rob, 2026-08-24)',
   },
-  PnpData: {
-    kind: 'migrated',
-    extractor: 'pnp-data',
-    table: 'pnp_data',
-    to:
-      'pnp_data (ARCHIVE — no app reader): per-quarter figures on language engagements, the ' +
-      'retired predecessor of ProgressSummary. Carried verbatim, importer bugs included ' +
-      '(15 year-0 rows). Archived rather than dropped (Rob, 2026-08-24)',
-    shortfall: [
-      {
-        count: 1,
-        reason:
-          'the one node whose owning engagement is soft-deleted — the engagement never lands ' +
-          'and engagement_id is NOT NULL (measured 2026-08-24; the other 69 owning engagements ' +
-          'all land, verified by the 104/105 load into cord_cutover_r2)',
-      },
-    ],
-  },
+  PnpData: excluded(
+    '105 nodes of per-quarter planned/actual figures written onto language engagements by the ' +
+      'pre-2022 PnP importer — the retired predecessor of ProgressSummary. Nothing in src/ reads ' +
+      'or writes them. Dropped, and this entry states what that gives up rather than pretending ' +
+      'it is nothing: 90 rows carry a real year (2020-2021) and the other 15 are importer junk ' +
+      '(year and quarter both 0; 6 of the 90 also have an unstamped quarter). They are NOT ' +
+      'duplicates of the modern model — checked 2026-08-24 by joining each (engagement, fiscal ' +
+      'quarter) to its ProgressReport: only 31 of the 90 have modern ProgressSummary figures at ' +
+      'all (just 56 even have the report), and sampled covered rows disagree in value (the ' +
+      'modern numbers are later re-extractions, on a 0-1 scale where these are 0-100). So this ' +
+      'is a real loss of ~90 historical figures, taken knowingly: management confirmed the ' +
+      'legacy figures are not needed (Rob, 2026-08-25), superseding the 2026-08-24 decision to ' +
+      'archive them into a pnp_data table. The archive work (migration 0040 + pnp-data.extractor) ' +
+      'was written and is recoverable at tag archive/pnp-data if that call is ever reversed. ' +
+      'NOTE: this is the retired PnpData label ONLY. The live PnP extraction model is untouched ' +
+      '— PnpExtractionResult, engagements.pnp_id, and products.pnp_index all still migrate.',
+  ),
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1136,8 +1138,8 @@ export const relationshipTypes: Readonly<Record<string, Disposition>> = {
       'records hold NULL (count(p.value) = 0, probed 2026-08-24), so dropping it loses ' +
       'literally nothing. Decided: drop (Rob, 2026-08-24)',
   ),
-  pnpData: carried(
-    'pnp_data rows — the owning edge becomes pnp_data.engagement_id (the archive table)',
+  pnpData: excluded(
+    'the LanguageEngagement→PnpData edges — dropped with the PnpData label (Rob, 2026-08-25)',
   ),
   token: excluded(
     'the User→Token session edges (223,387) — dropped with the Token label (Rob, 2026-08-24)',
@@ -1574,12 +1576,15 @@ export const propertyKeys: Readonly<Record<string, Disposition>> = {
     'as countError — zero occurrences; problems live on [:problem] edges',
   ),
 
-  // ── PnpData figures — archived with the PnpData label (Rob, 2026-08-24) ────
-  quarter: carried('pnp_data.quarter'),
-  year: carried('pnp_data.year'),
-  progressActual: carried('pnp_data.progress_actual'),
-  progressPlanned: carried('pnp_data.progress_planned'),
-  variance: carried('pnp_data.variance'),
+  // ── PnpData figures — dropped with the PnpData label (Rob, 2026-08-25) ─────
+  // All five live ONLY on PnpData nodes: no other extractor reads any of them,
+  // and the modern equivalents are separate keys on ProgressSummary/Product.
+  // The figures themselves are the loss the PnpData label entry describes.
+  quarter: excluded('a PnpData figure — dropped with that label'),
+  year: excluded('a PnpData figure — dropped with that label'),
+  progressActual: excluded('a PnpData figure — dropped with that label'),
+  progressPlanned: excluded('a PnpData figure — dropped with that label'),
+  variance: excluded('a PnpData figure — dropped with that label'),
 
   // ── Config nodes ────────────────────────────────────────────────────────────
   projectTypes: carried(

--- a/src/core/cutover/coverage.ts
+++ b/src/core/cutover/coverage.ts
@@ -1,0 +1,399 @@
+import { sql } from 'drizzle-orm';
+import { type DrizzleDb } from '~/core/drizzle/drizzle.service';
+import { type DatabaseService } from '~/core/neo4j';
+import {
+  type Disposition,
+  labels as labelManifest,
+  propertyKeys as propertyKeyManifest,
+  relationshipTypes as relationshipTypeManifest,
+} from './coverage-manifest';
+
+/**
+ * Cutover coverage check — the SOURCE enumerates itself, and everything it
+ * names must be claimed in coverage-manifest.ts. See that file's header for the
+ * why; this file is the mechanics.
+ *
+ * Three checks, all fail-closed:
+ *
+ * 1. **Claims.** `db.labels()`, `db.relationshipTypes()` and `db.propertyKeys()`
+ *    are compared against the manifest. Anything unlisted is a violation — and
+ *    so is anything listed as `review`, because an unanswered question is not a
+ *    default to excluded.
+ * 2. **Counts, from the source's side.** For every `migrated` label naming a
+ *    table, the SOURCE node count (via Neo4j's count store, so this is O(1) per
+ *    label, not a scan) must equal the Postgres row count plus the entry's
+ *    written-down shortfall. This is independent of the ETL's own
+ *    reconciliation, which only ever compares the ETL's two numbers.
+ * 3. **Census.** A source that enumerates nothing, or a target with no rows,
+ *    fails outright rather than passing everything vacuously — the same guard
+ *    `cutover-verify` carries, for the same reason: every check here counts
+ *    problems, and an empty database has none.
+ *
+ * ## Two Cypher traps this file works around, both hit while building it
+ *
+ * - `RETURN 'X' AS name, count(n)` makes the constant a GROUPING key, so a
+ *   label with zero nodes yields ZERO ROWS, not a zero count — ten labels
+ *   silently vanished from the first count query. Aggregate first
+ *   (`WITH count(n) AS n`), then attach the constant.
+ * - Counting by re-matching each label over the graph
+ *   (`WHERE label IN labels(n)`) scans 22M nodes per label and times out.
+ *   One `UNION ALL` of per-label `MATCH (n:X)` counts hits the count store.
+ */
+
+export interface CoverageFinding {
+  readonly axis: 'label' | 'relationship type' | 'property key';
+  readonly name: string;
+  readonly detail: string;
+  /** Source occurrences, where the axis has a cheap count (labels, rel types). */
+  readonly count?: number;
+}
+
+export interface LabelCountRow {
+  readonly label: string;
+  readonly sourceCount: number;
+  /** The disposition kind, or 'live-only rule' for rule-claimed Deleted_* labels. */
+  readonly kind: string;
+  /** For counted labels: source − shortfall (+ plusLabels), what Postgres must hold. */
+  readonly expected?: number;
+  readonly actual?: number;
+  readonly ok?: boolean;
+}
+
+export interface CoverageReport {
+  /** Names the source enumerates that the manifest does not claim. Violations. */
+  readonly unclaimed: readonly CoverageFinding[];
+  /** Open `review` questions present in this source. Violations until answered. */
+  readonly reviews: readonly CoverageFinding[];
+  /** Counted labels whose source-vs-target gap is not the written-down one. */
+  readonly countMismatches: readonly CoverageFinding[];
+  /** Every label with its source count and how it is claimed — the full ledger. */
+  readonly labelRows: readonly LabelCountRow[];
+  /** Manifest names this source does not enumerate (fine — informational). */
+  readonly staleManifest: readonly string[];
+  /** Sum over per-label counts. Multi-label nodes count once per label; census only. */
+  readonly sourceLabeledNodes: number;
+  /** Sum over the counted Postgres tables. */
+  readonly targetRows: number;
+  /** Claim sweeps (one per name) + count comparisons. */
+  readonly checksRun: number;
+  readonly clean: boolean;
+}
+
+/** Structural slice of DatabaseService this check needs — a raw Cypher read. */
+type SourceGraph = Pick<DatabaseService, 'query'>;
+
+const enumerate = async (
+  neo4j: SourceGraph,
+  procedure: string,
+  column: string,
+): Promise<string[]> => {
+  const rows = await neo4j
+    .query<
+      Record<string, string>
+    >(`CALL ${procedure}() YIELD ${column} RETURN ${column}`)
+    .run();
+  return rows.map((row) => row[column]!);
+};
+
+/**
+ * Only plain identifier names may be interpolated into the generated count
+ * query. Nothing in either database mints names outside this set; refusing here
+ * beats discovering what a backtick in a label does to a UNION of 199 queries.
+ */
+const assertPlainName = (name: string) => {
+  if (!/^[A-Za-z0-9_]+$/.test(name)) {
+    throw new Error(
+      `Coverage: the source enumerated a name this check refuses to ` +
+        `interpolate into a query: "${name}"`,
+    );
+  }
+};
+
+/** Count-store counts for every label, one query. See the header for the traps. */
+const countLabels = async (
+  neo4j: SourceGraph,
+  labels: readonly string[],
+): Promise<ReadonlyMap<string, number>> => {
+  if (labels.length === 0) return new Map();
+  labels.forEach(assertPlainName);
+  const union = labels
+    .map(
+      (label) =>
+        `MATCH (n:\`${label}\`) WITH count(n) AS n RETURN '${label}' AS name, n`,
+    )
+    .join(' UNION ALL ');
+  const rows = await neo4j.query<{ name: string; n: number }>(union).run();
+  return new Map(rows.map((row) => [row.name, Number(row.n)]));
+};
+
+/** Count-store counts for every relationship type, one query. */
+const countRelationshipTypes = async (
+  neo4j: SourceGraph,
+  types: readonly string[],
+): Promise<ReadonlyMap<string, number>> => {
+  if (types.length === 0) return new Map();
+  types.forEach(assertPlainName);
+  const union = types
+    .map(
+      (type) =>
+        `MATCH ()-[r:\`${type}\`]->() WITH count(r) AS n RETURN '${type}' AS name, n`,
+    )
+    .join(' UNION ALL ');
+  const rows = await neo4j.query<{ name: string; n: number }>(union).run();
+  return new Map(rows.map((row) => [row.name, Number(row.n)]));
+};
+
+const pgCount = async (
+  db: DrizzleDb,
+  table: string,
+  where?: string,
+): Promise<number> => {
+  if (!/^[a-z0-9_]+$/.test(table)) {
+    throw new Error(
+      `Coverage: refusing to count a non-identifier table "${table}"`,
+    );
+  }
+  const result = await db.execute<{ n: number }>(
+    sql.raw(
+      `SELECT count(*)::int AS n FROM "${table}"${where ? ` WHERE ${where}` : ''}`,
+    ),
+  );
+  return Number(result.rows[0]?.n ?? 0);
+};
+
+/**
+ * The live-only rule for soft-deleted labels. Neo4j soft-delete PREFIXES labels
+ * (and stacks: `Deleted_Deleted_Property`), so match the prefix at any depth —
+ * the same depth-proofing lesson as the scrub's `isFieldRecord`. The rule only
+ * claims a label whose fully-stripped BASE is itself in the manifest; a
+ * `Deleted_` label over an unknown base stays unclaimed and fails the run.
+ */
+const stripDeleted = (label: string) => label.replace(/^(?:Deleted_)+/, '');
+
+const resolveLabelClaim = (
+  label: string,
+): { disposition: Disposition; kind: string } | null => {
+  const explicit = labelManifest[label];
+  if (explicit) return { disposition: explicit, kind: explicit.kind };
+  if (label.startsWith('Deleted_') && labelManifest[stripDeleted(label)]) {
+    return {
+      disposition: {
+        kind: 'excluded',
+        reason: `soft-deleted ${stripDeleted(label)} — the ETL is live-only`,
+      },
+      kind: 'live-only rule',
+    };
+  }
+  return null;
+};
+
+export const runCutoverCoverage = async (
+  neo4j: SourceGraph,
+  db: DrizzleDb,
+  log: (msg: string) => void,
+): Promise<CoverageReport> => {
+  const [sourceLabels, sourceRelTypes, sourcePropertyKeys] = await Promise.all([
+    enumerate(neo4j, 'db.labels', 'label'),
+    enumerate(neo4j, 'db.relationshipTypes', 'relationshipType'),
+    enumerate(neo4j, 'db.propertyKeys', 'propertyKey'),
+  ]);
+  log(
+    `Source enumerates ${sourceLabels.length} labels, ` +
+      `${sourceRelTypes.length} relationship types, ` +
+      `${sourcePropertyKeys.length} property keys.`,
+  );
+  if (sourceLabels.length === 0 || sourceRelTypes.length === 0) {
+    // An empty enumeration means the wrong (or an empty) graph, and every claim
+    // below would pass over nothing. That must never read as coverage.
+    throw new Error(
+      'Coverage refused: the source graph enumerates no labels or no ' +
+        'relationship types — this is not a database with data to account for.',
+    );
+  }
+
+  const labelCounts = await countLabels(neo4j, sourceLabels);
+  const relTypeCounts = await countRelationshipTypes(neo4j, sourceRelTypes);
+  const sourceLabeledNodes = [...labelCounts.values()].reduce(
+    (sum, n) => sum + n,
+    0,
+  );
+  if (sourceLabeledNodes === 0) {
+    throw new Error(
+      'Coverage refused: every label counts zero nodes — an empty source ' +
+        'trivially satisfies every claim, which must never read as coverage.',
+    );
+  }
+
+  const unclaimed: CoverageFinding[] = [];
+  const reviews: CoverageFinding[] = [];
+  const countMismatches: CoverageFinding[] = [];
+  const labelRows: LabelCountRow[] = [];
+  let checksRun = 0;
+  let targetRows = 0;
+
+  // ── Axis 1: labels — claims and counts ─────────────────────────────────────
+  for (const label of [...sourceLabels].sort((a, b) => a.localeCompare(b))) {
+    checksRun++;
+    const sourceCount = labelCounts.get(label) ?? 0;
+    const claim = resolveLabelClaim(label);
+    if (!claim) {
+      unclaimed.push({
+        axis: 'label',
+        name: label,
+        count: sourceCount,
+        detail: `${sourceCount} node(s) with no disposition — nobody has decided what happens to these`,
+      });
+      labelRows.push({ label, sourceCount, kind: 'UNCLAIMED' });
+      continue;
+    }
+    const { disposition } = claim;
+    if (disposition.kind === 'review') {
+      reviews.push({
+        axis: 'label',
+        name: label,
+        count: sourceCount,
+        detail: disposition.question,
+      });
+      labelRows.push({ label, sourceCount, kind: 'review' });
+      continue;
+    }
+
+    if (disposition.kind === 'migrated' && disposition.table) {
+      checksRun++;
+      const plus = (disposition.plusLabels ?? []).reduce(
+        (sum, other) => sum + (labelCounts.get(other) ?? 0),
+        0,
+      );
+      const shortfall = (disposition.shortfall ?? []).reduce(
+        (sum, entry) => sum + entry.count,
+        0,
+      );
+      const expected = sourceCount + plus - shortfall;
+      const actual = await pgCount(db, disposition.table, disposition.where);
+      targetRows += actual;
+      const ok = actual === expected;
+      if (!ok) {
+        const target =
+          disposition.table +
+          (disposition.where ? ` WHERE ${disposition.where}` : '');
+        countMismatches.push({
+          axis: 'label',
+          name: label,
+          count: sourceCount,
+          detail:
+            `source ${sourceCount}${plus ? ` (+${plus} via ${disposition.plusLabels!.join('+')})` : ''}` +
+            ` − ${shortfall} explained = ${expected} expected, but ${target} holds ${actual} ` +
+            `(off by ${actual - expected}). Either rows were lost without a written-down reason, ` +
+            `or a recorded shortfall no longer matches this snapshot — re-verify its cause ` +
+            `before touching the number`,
+        });
+      }
+      labelRows.push({
+        label,
+        sourceCount,
+        kind: claim.kind,
+        expected,
+        actual,
+        ok,
+      });
+      continue;
+    }
+
+    labelRows.push({ label, sourceCount, kind: claim.kind });
+  }
+
+  // ── Axis 2: relationship types — claims ────────────────────────────────────
+  for (const type of [...sourceRelTypes].sort((a, b) => a.localeCompare(b))) {
+    checksRun++;
+    const count = relTypeCounts.get(type) ?? 0;
+    const disposition = relationshipTypeManifest[type];
+    if (!disposition) {
+      unclaimed.push({
+        axis: 'relationship type',
+        name: type,
+        count,
+        detail: `${count} edge(s) with no disposition — a connection or stored field nobody has accounted for`,
+      });
+      continue;
+    }
+    if (disposition.kind === 'review') {
+      reviews.push({
+        axis: 'relationship type',
+        name: type,
+        count,
+        detail: disposition.question,
+      });
+    }
+  }
+
+  // ── Axis 3: property keys — claims ─────────────────────────────────────────
+  // The highest-value axis: a key nobody claims is a FIELD that arrives empty
+  // while every row count still reconciles. No cheap per-key count exists
+  // (the count store does not cover properties), so this axis is claims-only —
+  // which is why every `excluded` entry in the manifest cites a measured probe.
+  for (const key of [...sourcePropertyKeys].sort((a, b) =>
+    a.localeCompare(b),
+  )) {
+    checksRun++;
+    const disposition = propertyKeyManifest[key];
+    if (!disposition) {
+      unclaimed.push({
+        axis: 'property key',
+        name: key,
+        detail:
+          'no disposition — if any extractor misses this field, every row still arrives and a ' +
+          'column is silently empty. Probe what carries it before classifying',
+      });
+      continue;
+    }
+    if (disposition.kind === 'review') {
+      reviews.push({
+        axis: 'property key',
+        name: key,
+        detail: disposition.question,
+      });
+    }
+  }
+
+  if (targetRows === 0) {
+    throw new Error(
+      'Coverage refused: the counted Postgres tables hold zero rows — this is ' +
+        'not a loaded database, and nothing meaningful was compared.',
+    );
+  }
+
+  // Manifest entries this source does not enumerate. Not a violation — the
+  // manifest may know more than one snapshot (scrub markers exist only on
+  // copies; retired names disappear once their token store is rebuilt).
+  const sourceNames = {
+    labels: new Set(sourceLabels),
+    relationshipTypes: new Set(sourceRelTypes),
+    propertyKeys: new Set(sourcePropertyKeys),
+  };
+  const staleManifest = [
+    ...Object.keys(labelManifest)
+      .filter((name) => !sourceNames.labels.has(name))
+      .map((name) => `label ${name}`),
+    ...Object.keys(relationshipTypeManifest)
+      .filter((name) => !sourceNames.relationshipTypes.has(name))
+      .map((name) => `relationship type ${name}`),
+    ...Object.keys(propertyKeyManifest)
+      .filter((name) => !sourceNames.propertyKeys.has(name))
+      .map((name) => `property key ${name}`),
+  ];
+
+  return {
+    unclaimed,
+    reviews,
+    countMismatches,
+    labelRows,
+    staleManifest,
+    sourceLabeledNodes,
+    targetRows,
+    checksRun,
+    clean:
+      unclaimed.length === 0 &&
+      reviews.length === 0 &&
+      countMismatches.length === 0,
+  };
+};

--- a/src/core/cutover/cutover.harness.ts
+++ b/src/core/cutover/cutover.harness.ts
@@ -66,7 +66,7 @@ export const runCutover = async (
   // Allows a small unmarked graph through (local test data) and refuses a
   // production-scale one that carries no scrub marker. See scrub/provenance.ts.
   const gate = await checkScrubGate(ctx.neo4j);
-  if (!gate.allowed) {
+  if (!gate.allowed && !ctx.allowProductionSource) {
     throw new Error(`Cutover refused — ${gate.reason}`);
   }
   ctx.log(`Source: ${gate.reason}`);

--- a/src/core/cutover/cutover.harness.ts
+++ b/src/core/cutover/cutover.harness.ts
@@ -1,0 +1,122 @@
+import { sql } from 'drizzle-orm';
+import {
+  type CutoverContext,
+  type Extractor,
+  type TableStat,
+} from './cutover.types';
+
+/**
+ * Topologically order extractors by their `dependsOn` (parents before
+ * children). Throws on an unknown dependency or a cycle.
+ */
+const orderExtractors = (extractors: readonly Extractor[]): Extractor[] => {
+  const byName = new Map(extractors.map((e) => [e.name, e]));
+  const ordered: Extractor[] = [];
+  const state = new Map<string, 'visiting' | 'done'>();
+
+  const visit = (e: Extractor) => {
+    const s = state.get(e.name);
+    if (s === 'done') return;
+    if (s === 'visiting') {
+      throw new Error(`Cutover: dependency cycle involving "${e.name}"`);
+    }
+    state.set(e.name, 'visiting');
+    for (const dep of e.dependsOn ?? []) {
+      const depE = byName.get(dep);
+      if (!depE) {
+        throw new Error(`Cutover: "${e.name}" depends on unknown "${dep}"`);
+      }
+      visit(depE);
+    }
+    state.set(e.name, 'done');
+    ordered.push(e);
+  };
+
+  for (const e of extractors) visit(e);
+  return ordered;
+};
+
+/** `SELECT count(*)` for a Postgres table. */
+const pgCount = async (ctx: CutoverContext, table: string): Promise<number> => {
+  const res = await ctx.db.execute<{ n: number }>(
+    sql.raw(`SELECT count(*)::int AS n FROM "${table}"`),
+  );
+  return res.rows[0]?.n ?? 0;
+};
+
+/**
+ * Run the cutover ETL.
+ *
+ * 1. Order extractors by dependency.
+ * 2. (unless dry-run) TRUNCATE every target table up front — CASCADE + reverse
+ *    order makes the load idempotent so dry-runs / retries start clean.
+ * 3. Run each extractor.
+ * 4. Reconcile: compare rows-read vs rows-inserted vs the live `count(*)`.
+ */
+export const runCutover = async (
+  ctx: CutoverContext,
+  extractors: readonly Extractor[],
+  opts: { only?: readonly string[] } = {},
+): Promise<void> => {
+  const ordered = orderExtractors(extractors);
+  const selected = opts.only?.length
+    ? ordered.filter((e) => opts.only!.includes(e.name))
+    : ordered;
+
+  if (selected.length === 0) {
+    ctx.log('Cutover: no extractors selected.');
+    return;
+  }
+
+  ctx.log(
+    `\nCutover ${ctx.dryRun ? '(DRY RUN — no writes)' : ''}\n` +
+      `Domains: ${selected.map((e) => e.name).join(' → ')}\n`,
+  );
+
+  // Truncate target tables first (idempotent load). CASCADE handles FK order;
+  // we truncate the full set the selected extractors own.
+  if (!ctx.dryRun) {
+    const tables = [...new Set(selected.flatMap((e) => e.targetTables))];
+    const quoted = tables.map((t) => `"${t}"`).join(', ');
+    ctx.log(`Truncating ${tables.length} target tables…`);
+    await ctx.db.execute(
+      sql.raw(`TRUNCATE ${quoted} RESTART IDENTITY CASCADE`),
+    );
+  }
+
+  const results = new Map<string, Record<string, TableStat>>();
+  for (const e of selected) {
+    ctx.log(`\n▶ ${e.name}`);
+    const started = process.hrtime.bigint();
+    const stats = await e.run(ctx);
+    const ms = Number(process.hrtime.bigint() - started) / 1e6;
+    results.set(e.name, stats);
+    for (const [table, s] of Object.entries(stats)) {
+      ctx.log(`    ${table}: read ${s.read}, inserted ${s.inserted}`);
+    }
+    ctx.log(`    (${ms.toFixed(0)}ms)`);
+  }
+
+  // Reconciliation report.
+  ctx.log('\n─── Reconciliation ───');
+  ctx.log('  table                              read  inserted   pgCount  ok');
+  let allOk = true;
+  for (const e of selected) {
+    for (const table of e.targetTables) {
+      const s = results.get(e.name)?.[table] ?? { read: 0, inserted: 0 };
+      const count = ctx.dryRun ? s.inserted : await pgCount(ctx, table);
+      const ok = ctx.dryRun || count === s.inserted;
+      if (!ok) allOk = false;
+      ctx.log(
+        `  ${table.padEnd(34)} ${String(s.read).padStart(5)} ` +
+          `${String(s.inserted).padStart(9)} ${String(count).padStart(9)}  ` +
+          `${ok ? '✓' : '✗ MISMATCH'}`,
+      );
+    }
+  }
+  ctx.log(
+    `\nCutover ${ctx.dryRun ? 'dry-run' : 'load'} complete — ${
+      allOk ? 'all tables reconciled ✓' : 'MISMATCHES above ✗'
+    }`,
+  );
+};

--- a/src/core/cutover/cutover.harness.ts
+++ b/src/core/cutover/cutover.harness.ts
@@ -142,14 +142,35 @@ export const runCutover = async (
       );
     }
   }
+  // Rows lost during hydration, which the table above cannot show: they are
+  // gone before `read` counts them, so their tables tick ✓. Reported as its own
+  // block, keyed by node label rather than table, because that is the only
+  // thing known at the point the row disappears.
+  const totalNotHydrated = [...ctx.notHydrated.values()].reduce(
+    (sum, n) => sum + n,
+    0,
+  );
+  if (totalNotHydrated > 0) {
+    ctx.log(
+      '\n─── Not hydrated (found in Neo4j, never reached the mapper) ───\n' +
+        '  These do NOT appear in the table above — their tables read ✓.',
+    );
+    for (const [label, count] of ctx.notHydrated) {
+      ctx.log(`  ${label.padEnd(34)} ${String(count).padStart(5)}`);
+    }
+  }
+
+  const totalLost = totalDropped + totalNotHydrated;
   ctx.log(
     `\nCutover ${ctx.dryRun ? 'dry-run' : 'load'} complete — ${
       !allOk
         ? 'MISMATCHES above ✗'
-        : totalDropped > 0
-          ? `counts reconcile, but ${totalDropped} row(s) were DROPPED — see the ⚠ lines and the per-domain warnings above. ` +
-            'A root-entity drop takes its whole subtree with it; do not treat this as a clean load.'
-          : 'all tables reconciled, zero rows dropped ✓'
+        : totalLost > 0
+          ? `counts reconcile, but ${totalLost} row(s) did not make it: ` +
+            `${totalDropped} dropped by a guard, ${totalNotHydrated} lost while reading. ` +
+            'See the ⚠ lines and the per-domain warnings above. A root-entity drop takes ' +
+            'its whole subtree with it; do not treat this as a clean load.'
+          : 'all tables reconciled, zero rows lost ✓'
     }`,
   );
 };

--- a/src/core/cutover/cutover.harness.ts
+++ b/src/core/cutover/cutover.harness.ts
@@ -54,11 +54,19 @@ const pgCount = async (ctx: CutoverContext, table: string): Promise<number> => {
  * 3. Run each extractor.
  * 4. Reconcile: compare rows-read vs rows-inserted vs the live `count(*)`.
  */
+export interface CutoverResult {
+  /** False when a table's inserted count disagreed with its live `count(*)`. */
+  allOk: boolean;
+  totalDropped: number;
+  totalNotHydrated: number;
+  totalLost: number;
+}
+
 export const runCutover = async (
   ctx: CutoverContext,
   extractors: readonly Extractor[],
   opts: { only?: readonly string[] } = {},
-): Promise<void> => {
+): Promise<CutoverResult> => {
   // Scrub gate, checked here rather than at the entry point because THIS is the
   // thing that reads the graph in bulk and persists what it reads. An entry-point
   // check is bypassed by any other caller; this one is not.
@@ -72,13 +80,32 @@ export const runCutover = async (
   ctx.log(`Source: ${gate.reason}`);
 
   const ordered = orderExtractors(extractors);
+  // An unknown --only name is a typo, not a request for nothing. Silently
+  // running the subset that DID match is the worst outcome: `--only=user,engagment`
+  // would load users, print a clean reconciliation, and never mention that the
+  // domain the operator actually cared about was skipped.
+  if (opts.only?.length) {
+    const known = new Set(ordered.map((e) => e.name));
+    const unknown = opts.only.filter((name) => !known.has(name));
+    if (unknown.length > 0) {
+      throw new Error(
+        `Cutover: --only names no such extractor: ${unknown.join(', ')}. ` +
+          `Known: ${ordered.map((e) => e.name).join(', ')}`,
+      );
+    }
+  }
   const selected = opts.only?.length
     ? ordered.filter((e) => opts.only!.includes(e.name))
     : ordered;
 
   if (selected.length === 0) {
     ctx.log('Cutover: no extractors selected.');
-    return;
+    return {
+      allOk: true,
+      totalDropped: 0,
+      totalNotHydrated: 0,
+      totalLost: 0,
+    };
   }
 
   ctx.log(
@@ -173,4 +200,10 @@ export const runCutover = async (
           : 'all tables reconciled, zero rows lost ✓'
     }`,
   );
+
+  // Returned rather than only printed, so the caller can set an exit code. A
+  // load that MISMATCHed used to end in exit 0 exactly like a clean one, which
+  // makes the run unusable as an automated gate and puts the entire weight of
+  // catching a broken load on someone reading scrollback.
+  return { allOk, totalDropped, totalNotHydrated, totalLost };
 };

--- a/src/core/cutover/cutover.harness.ts
+++ b/src/core/cutover/cutover.harness.ts
@@ -1,4 +1,5 @@
 import { sql } from 'drizzle-orm';
+import { checkScrubGate } from '../scrub/provenance';
 import {
   type CutoverContext,
   type Extractor,
@@ -58,6 +59,18 @@ export const runCutover = async (
   extractors: readonly Extractor[],
   opts: { only?: readonly string[] } = {},
 ): Promise<void> => {
+  // Scrub gate, checked here rather than at the entry point because THIS is the
+  // thing that reads the graph in bulk and persists what it reads. An entry-point
+  // check is bypassed by any other caller; this one is not.
+  //
+  // Allows a small unmarked graph through (local test data) and refuses a
+  // production-scale one that carries no scrub marker. See scrub/provenance.ts.
+  const gate = await checkScrubGate(ctx.neo4j);
+  if (!gate.allowed) {
+    throw new Error(`Cutover refused — ${gate.reason}`);
+  }
+  ctx.log(`Source: ${gate.reason}`);
+
   const ordered = orderExtractors(extractors);
   const selected = opts.only?.length
     ? ordered.filter((e) => opts.only!.includes(e.name))

--- a/src/core/cutover/cutover.harness.ts
+++ b/src/core/cutover/cutover.harness.ts
@@ -101,22 +101,42 @@ export const runCutover = async (
   ctx.log('\n─── Reconciliation ───');
   ctx.log('  table                              read  inserted   pgCount  ok');
   let allOk = true;
+  let totalDropped = 0;
   for (const e of selected) {
     for (const table of e.targetTables) {
       const s = results.get(e.name)?.[table] ?? { read: 0, inserted: 0 };
       const count = ctx.dryRun ? s.inserted : await pgCount(ctx, table);
-      const ok = ctx.dryRun || count === s.inserted;
-      if (!ok) allOk = false;
+      // TWO distinct failures, deliberately not collapsed:
+      //  · inserted ≠ pgCount → a write did not land. Broken.
+      //  · read ≠ inserted    → rows were DROPPED (unique conflict, guard skip).
+      //    Not corrupt, but it is silent data loss and must never read as ✓.
+      //    `inserted` counts what Postgres actually wrote, so it equals pgCount
+      //    on a healthy run — which means the drop signal lives in read-vs-
+      //    inserted and nowhere else.
+      const countMatches = ctx.dryRun || count === s.inserted;
+      const dropped = ctx.dryRun ? 0 : s.read - s.inserted;
+      if (!countMatches) allOk = false;
+      totalDropped += Math.max(0, dropped);
+      const verdict = !countMatches
+        ? '✗ MISMATCH'
+        : dropped > 0
+          ? `⚠ DROPPED ${dropped}`
+          : '✓';
       ctx.log(
         `  ${table.padEnd(34)} ${String(s.read).padStart(5)} ` +
           `${String(s.inserted).padStart(9)} ${String(count).padStart(9)}  ` +
-          `${ok ? '✓' : '✗ MISMATCH'}`,
+          verdict,
       );
     }
   }
   ctx.log(
     `\nCutover ${ctx.dryRun ? 'dry-run' : 'load'} complete — ${
-      allOk ? 'all tables reconciled ✓' : 'MISMATCHES above ✗'
+      !allOk
+        ? 'MISMATCHES above ✗'
+        : totalDropped > 0
+          ? `counts reconcile, but ${totalDropped} row(s) were DROPPED — see the ⚠ lines and the per-domain warnings above. ` +
+            'A root-entity drop takes its whole subtree with it; do not treat this as a clean load.'
+          : 'all tables reconciled, zero rows dropped ✓'
     }`,
   );
 };

--- a/src/core/cutover/cutover.helpers.ts
+++ b/src/core/cutover/cutover.helpers.ts
@@ -147,10 +147,27 @@ export const readAllViaRepo = async <T extends { id: ID }>(
   repoClass: Type<{
     readMany: (ids: readonly ID[]) => Promise<ReadonlyArray<UnsecuredDto<T>>>;
   }>,
-): Promise<Array<UnsecuredDto<T>>> => {
+): Promise<Array<UnsecuredDto<T>>> =>
+  await readAllRowsViaRepo<UnsecuredDto<T>>(ctx, label, repoClass);
+
+/**
+ * Same as {@link readAllViaRepo}, but for repositories whose `readMany` returns
+ * a purpose-built ROW type rather than an `UnsecuredDto<T>` — Product's
+ * `HydratedProductRow` is the case in point (it carries `isOverriding` and raw
+ * ScriptureRange nodes the DTO does not have). Kept as a sibling rather than
+ * loosening `readAllViaRepo`'s generic, which would silently change what the ten
+ * existing `readAllViaRepo<Foo>()` call sites resolve to.
+ */
+export const readAllRowsViaRepo = async <TRow extends { id: ID }>(
+  ctx: CutoverContext,
+  label: string,
+  repoClass: Type<{
+    readMany: (ids: readonly ID[]) => Promise<readonly TRow[]>;
+  }>,
+): Promise<TRow[]> => {
   const repo = ctx.moduleRef.get(repoClass, { strict: false });
   const ids = await fetchIds(ctx, label);
-  const out: Array<UnsecuredDto<T>> = [];
+  const out: TRow[] = [];
   for (const ids_ of chunk(ids, ctx.batchSize)) {
     out.push(...(await repo.readMany(ids_)));
   }
@@ -159,7 +176,7 @@ export const readAllViaRepo = async <T extends { id: ID }>(
   // deactivated by its Partner's soft-delete). Reconciliation can't catch it —
   // the read stat counts hydrated DTOs — so surface the delta here.
   if (out.length !== ids.length) {
-    const hydrated = new Set<string>(out.map((dto) => String(dto.id)));
+    const hydrated = new Set<string>(out.map((row) => String(row.id)));
     const missing = ids.filter((id) => !hydrated.has(id));
     ctx.log(
       `    ⚠ ${label}: ${missing.length} node(s) enumerated but NOT hydrated by readMany ` +

--- a/src/core/cutover/cutover.helpers.ts
+++ b/src/core/cutover/cutover.helpers.ts
@@ -1,5 +1,5 @@
 import { type Type } from '@nestjs/common';
-import { sql } from 'drizzle-orm';
+import { getTableName, sql } from 'drizzle-orm';
 import { type PgTable } from 'drizzle-orm/pg-core';
 import { DateTime } from 'luxon';
 import {
@@ -305,6 +305,22 @@ export const recordReadLoss = (
  * `onConflictDoNothing` (idempotent re-runs). No-op write in dry-run — the
  * mapping still runs, so mapping errors still surface. Returns rows written
  * (or would-be-written in dry-run).
+ *
+ * ## Why a conflict now WARNS
+ *
+ * `onConflictDoNothing` is what makes a re-run idempotent, and it is also a
+ * silencer: a row rejected for violating a unique constraint leaves no trace
+ * except a smaller `inserted`. The reader then has to work out, from a
+ * subtraction, that something was refused — and which rows, and why, is nowhere.
+ *
+ * That is not hypothetical. `system_agents` read 3 and inserted 2 for weeks,
+ * carried in the notes as "cause unconfirmed". It turned out two agents shared
+ * the name `Anonymous` while the column is UNIQUE, so Postgres dropped one and
+ * said nothing. Every table here has the same exposure. Naming the table and the
+ * count turns a subtraction someone has to notice into a line someone can read.
+ *
+ * Deliberately a warning and not an error: a conflict is legitimate on a re-run
+ * over an already-loaded table, which is the whole point of the clause.
  */
 export const bulkInsert = async <T extends PgTable>(
   ctx: CutoverContext,
@@ -321,6 +337,15 @@ export const bulkInsert = async <T extends PgTable>(
     // simply false. Only the pgCount comparison caught it; now both agree.
     const res = await ctx.db.insert(table).values(c).onConflictDoNothing();
     n += (res as { rowCount?: number | null }).rowCount ?? c.length;
+  }
+  const refused = rows.length - n;
+  if (refused > 0) {
+    ctx.log(
+      `    ⚠ ${getTableName(table)}: Postgres refused ${refused} of ` +
+        `${rows.length} row(s) on a conflict — a duplicate primary key, or a ` +
+        `unique constraint the source data does not satisfy. Expected on a ` +
+        `re-run over a loaded table; on a fresh load it is a real finding.`,
+    );
   }
   return n;
 };

--- a/src/core/cutover/cutover.helpers.ts
+++ b/src/core/cutover/cutover.helpers.ts
@@ -10,8 +10,14 @@ export const chunk = <T>(items: readonly T[], size: number): T[][] =>
   );
 
 /**
- * Enumerate the ids of every node with `label`. Backticks the label so dotted
- * labels (e.g. `Ethnologue.Language`, `File.Version`) work.
+ * Enumerate the ids of every node with `label`.
+ *
+ * `label` must be an actual NEO4J label — PascalCase, no dots. The label is
+ * backticked so a dotted name is syntactically legal, which is precisely the
+ * trap: `Ethnologue.Language` and `File.Version` are **Gel** module paths and
+ * match nothing. This docblock used to cite them as working examples; it was
+ * wrong and the ethnologue extractor shipped that way, migrating zero rows with
+ * a green ✓. See {@link warnIfLabelUnknown}.
  *
  * migration-todo: this reads ALL nodes including soft-deleted ones if the
  * Neo4j model keeps them. The per-domain hydrate/readMany typically filters to
@@ -24,7 +30,45 @@ export const fetchIds = async (
   const rows = await ctx.neo4j
     .query<{ id: ID }>(`MATCH (n:\`${label}\`) RETURN n.id AS id`)
     .run();
+  if (rows.length === 0) {
+    await warnIfLabelUnknown(ctx, label);
+  }
   return rows.map((r) => r.id);
+};
+
+/** Labels actually in use in the source graph. Fetched once per run. */
+let knownLabels: ReadonlySet<string> | undefined;
+
+/**
+ * A wrong label is the worst failure this harness has, because it is SILENT:
+ * `MATCH (n:\`Nope\`)` returns zero rows exactly like an empty domain, so the
+ * extractor reports 0 and reconciliation confirms 0 == 0 == 0 with a ✓.
+ *
+ * This actually happened — `ethnologue` queried `Ethnologue.Language`, which is
+ * the **Gel** module path (`e.Ethnologue.Language`) and not a Neo4j label. The
+ * whole domain migrated as zero rows and every check passed. The docblock on
+ * this file even suggested `File.Version` as an example, so later waves would
+ * have inherited it.
+ *
+ * Warn rather than throw: a genuinely empty domain whose label was never created
+ * also yields zero, and that is legitimate. The point is to make the ambiguity
+ * loud instead of invisible.
+ */
+const warnIfLabelUnknown = async (ctx: CutoverContext, label: string) => {
+  knownLabels ??= new Set(
+    (
+      await ctx.neo4j
+        .query<{ label: string }>('CALL db.labels() YIELD label RETURN label')
+        .run()
+    ).map((row) => row.label),
+  );
+  if (!knownLabels.has(label)) {
+    ctx.log(
+      `    ⚠⚠ label "${label}" is NOT in db.labels() and matched 0 nodes — either the domain is ` +
+        `genuinely empty, or the label is wrong. Neo4j labels are PascalCase with NO dots; a Gel ` +
+        `module path (e.g. "Ethnologue.Language", "File.Version") silently matches nothing.`,
+    );
+  }
 };
 
 /**
@@ -48,6 +92,40 @@ export const liveTargetIds = async (
     .select({ id: table.id })
     .from(table);
   return new Set(rows.map((row) => String(row.id)));
+};
+
+/**
+ * Drop junction/child rows whose referenced parent never LANDED in Postgres.
+ *
+ * This is the harness's most common real-load failure and it is a HARD one — a
+ * `*_fkey` violation aborts the whole run. It happens because junctions are read
+ * with raw Cypher over ALL nodes of a label, which is a superset of what landed:
+ * `readMany` silently omits nodes with broken required rels, and
+ * `onConflictDoNothing` drops unique-conflicts. Neither is visible to the
+ * junction query.
+ *
+ * Pass one entry per FK column. Returns the surviving rows plus a skip count to
+ * log — never drop silently.
+ *
+ * Found by a real (non-dry) scratch-DB run: dry-run cannot surface this class at
+ * all, because it never inserts.
+ */
+export const keepLanded = <T>(
+  rows: readonly T[],
+  refs: ReadonlyArray<
+    readonly [
+      landed: ReadonlySet<string>,
+      idOf: (row: T) => string | null | undefined,
+    ]
+  >,
+): { kept: T[]; skipped: number } => {
+  const kept = rows.filter((row) =>
+    refs.every(([landed, idOf]) => {
+      const id = idOf(row);
+      return id != null && landed.has(id);
+    }),
+  );
+  return { kept, skipped: rows.length - kept.length };
 };
 
 /** Run an arbitrary read Cypher and return the rows (junction extraction). */
@@ -108,8 +186,12 @@ export const bulkInsert = async <T extends PgTable>(
   if (ctx.dryRun) return rows.length;
   let n = 0;
   for (const c of chunk(rows, ctx.batchSize)) {
-    await ctx.db.insert(table).values(c).onConflictDoNothing();
-    n += c.length;
+    // Count what Postgres ACTUALLY wrote, not what we handed it. Adding
+    // `c.length` here reported attempted-not-written, so a unique-conflict drop
+    // showed as `inserted 69` against `pgCount 50` and the "inserted" column was
+    // simply false. Only the pgCount comparison caught it; now both agree.
+    const res = await ctx.db.insert(table).values(c).onConflictDoNothing();
+    n += (res as { rowCount?: number | null }).rowCount ?? c.length;
   }
   return n;
 };

--- a/src/core/cutover/cutover.helpers.ts
+++ b/src/core/cutover/cutover.helpers.ts
@@ -239,9 +239,19 @@ export const readAllRowsViaRepo = async <TRow extends { id: ID }>(
       label,
       (ctx.notHydrated.get(label) ?? 0) + missing.length,
     );
+    // The dominant cause is a DELETED ANCESTOR, not corruption, and saying so
+    // matters because this block reads alarming otherwise. Measured on production
+    // 2026-08-19: of 7,011 unhydrated PeriodicReports, 6,897 hang off a
+    // soft-deleted engagement or project, and all 1,878 unhydrated Products lack a
+    // live Project→Engagement→Product chain. Those rows SHOULD NOT migrate — it is
+    // the live-only policy arriving through a channel no counter tracks. Hydrates
+    // reach further up the tree than their own node: PeriodicReport's requires a
+    // reachable live `:Project`, so deleting a project silently makes every report
+    // under every one of its engagements unreadable.
     ctx.log(
       `    ⚠ ${label}: ${missing.length} of ${ids.length} node(s) enumerated but NOT hydrated ` +
-        `by readMany (broken required rels — prod-finding #2 class): ${missing
+        `by readMany. Expected cause is a soft-deleted ancestor (the hydrate requires the ` +
+        `whole chain live), which is correct to drop — anything else is a real finding: ${missing
           .slice(0, 10)
           .join(', ')}${missing.length > 10 ? ', …' : ''}`,
     );
@@ -260,6 +270,34 @@ export const readAllRowsViaRepo = async <TRow extends { id: ID }>(
     }
   }
   return out;
+};
+
+/**
+ * Record rows lost while READING, for extractors that read with raw Cypher.
+ *
+ * `readAllViaRepo`/`readAllRowsViaRepo` get this for free, but a raw-Cypher
+ * extractor loses rows in a way no counter sees: its MATCH inner-joins the
+ * things it needs (a creator, a parent, a required property), so a node missing
+ * any of them never enters the result set at all. `read` then counts what came
+ * back, which equals `inserted`, so the table reconciles ✓ and the run-end
+ * summary can claim "zero rows lost" while rows were lost — the exact failure
+ * mode the hydrate-drop guard was added to close for repo-backed reads.
+ *
+ * Enumerate the label separately, compare, and pass the shortfall here so it
+ * joins the same total. Logging alone is not enough: an inline ⚠ scrolls past
+ * and the footer still says clean.
+ */
+export const recordReadLoss = (
+  ctx: CutoverContext,
+  label: string,
+  lost: number,
+  reason: string,
+): void => {
+  if (lost <= 0) return;
+  ctx.notHydrated.set(label, (ctx.notHydrated.get(label) ?? 0) + lost);
+  ctx.log(
+    `    ⚠ ${label}: ${lost} node(s) enumerated but never read — ${reason}`,
+  );
 };
 
 /**

--- a/src/core/cutover/cutover.helpers.ts
+++ b/src/core/cutover/cutover.helpers.ts
@@ -223,17 +223,40 @@ export const readAllRowsViaRepo = async <TRow extends { id: ID }>(
   }
   // Hydrate-drop guard (finding #8): readMany silently omits nodes whose
   // required matches fail (e.g. a partnership whose [:partner] rel was
-  // deactivated by its Partner's soft-delete). Reconciliation can't catch it —
-  // the read stat counts hydrated DTOs — so surface the delta here.
+  // deactivated by its Partner's soft-delete).
+  //
+  // These rows are lost BEFORE an extractor counts anything, so the per-table
+  // read stat — which counts hydrated DTOs — equals inserted and the table
+  // reconciles with a clean ✓ while rows are missing. Logging the delta is not
+  // enough on its own: a real load ticked ✓ on tables that were short a
+  // noticeable fraction of their source rows. So record it on the context too,
+  // and let the harness add it to the run's total.
   if (out.length !== ids.length) {
     const hydrated = new Set<string>(out.map((row) => String(row.id)));
     const missing = ids.filter((id) => !hydrated.has(id));
+    ctx.notHydrated.set(
+      label,
+      (ctx.notHydrated.get(label) ?? 0) + missing.length,
+    );
     ctx.log(
-      `    ⚠ ${label}: ${missing.length} node(s) enumerated but NOT hydrated by readMany ` +
-        `(broken required rels — prod-finding #2 class): ${missing
+      `    ⚠ ${label}: ${missing.length} of ${ids.length} node(s) enumerated but NOT hydrated ` +
+        `by readMany (broken required rels — prod-finding #2 class): ${missing
           .slice(0, 10)
           .join(', ')}${missing.length > 10 ? ', …' : ''}`,
     );
+    // Every node failing is a different problem from some nodes failing: it is
+    // what hydrating against the wrong database looks like. The readers come
+    // from `splitDb`, so `DATABASE` has to be neo4j — set it to postgres and
+    // every repository resolves to Drizzle and reads the empty target instead.
+    // Called out separately because the message above reads like a data-quality
+    // finding, which is the wrong place to start looking.
+    if (missing.length === ids.length) {
+      ctx.log(
+        `    🔴 ${label}: NONE of the ${ids.length} node(s) hydrated. Check that ` +
+          `DATABASE=neo4j (so the Neo4j repositories are the readers) before ` +
+          `treating this as a data problem.`,
+      );
+    }
   }
   return out;
 };
@@ -264,14 +287,21 @@ export const bulkInsert = async <T extends PgTable>(
 };
 
 /**
- * Keep only enum values the target pgEnum actually declares. Real Neo4j data
- * can carry legacy/renamed enum values (e.g. `TranslationOrganization`) that
- * the Postgres enum rejects.
+ * Keep only enum values the target pgEnum actually declares, returning
+ * `{ kept, dropped }` so callers can warn about what fell out.
  *
- * migration-todo: this DROPS unknown values (data loss). Some are renames that
- * should MAP, not drop (likely `TranslationOrganization` → `Translation`).
- * Replace with an explicit value-map per enum once the team decides. Returns
- * `{ kept, dropped }` so callers can warn.
+ * This DROPS unknown values rather than mapping them. That was written as a
+ * placeholder against the possibility of renamed values in the source, on the
+ * evidence of a local database that carried one. **A production check has since
+ * compared every stored value of every enum-bearing property against the pgEnum
+ * that receives it, and found no value that would be dropped** — the renamed
+ * value existed only in local test data. So there is no value map to write, and
+ * a warning from here means either new data or a source other than production.
+ *
+ * Worth knowing about the opposite case: enum columns whose extractor does NOT
+ * call this cast the value straight through, so an unrecognised value there
+ * fails the whole load rather than being dropped and reported. The two failure
+ * modes are both fine, but they look completely different when they happen.
  */
 export const sanitizeEnum = <T extends string>(
   values: readonly string[],

--- a/src/core/cutover/cutover.helpers.ts
+++ b/src/core/cutover/cutover.helpers.ts
@@ -1,6 +1,12 @@
 import { type Type } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
 import { type PgTable } from 'drizzle-orm/pg-core';
-import { type CalendarDate, type ID, type UnsecuredDto } from '~/common';
+import {
+  type CalendarDate,
+  type ID,
+  RichTextDocument,
+  type UnsecuredDto,
+} from '~/common';
 import { type CutoverContext, type TableStat } from './cutover.types';
 
 /** Split an array into fixed-size chunks. */
@@ -67,6 +73,50 @@ const warnIfLabelUnknown = async (ctx: CutoverContext, label: string) => {
       `    ⚠⚠ label "${label}" is NOT in db.labels() and matched 0 nodes — either the domain is ` +
         `genuinely empty, or the label is wrong. Neo4j labels are PascalCase with NO dots; a Gel ` +
         `module path (e.g. "Ethnologue.Language", "File.Version") silently matches nothing.`,
+    );
+  }
+};
+
+/** Relationship types actually in use in the source graph. Fetched once per run. */
+let knownRelTypes: ReadonlySet<string> | undefined;
+
+/**
+ * The {@link warnIfLabelUnknown} guard, for RELATIONSHIP types.
+ *
+ * The label guard covers nodes only, and several domains are stored purely as
+ * edges — `(:User)-[:pinned]->(:BaseNode)`,
+ * `(:User)-[:knownLanguage { value }]->(:Language)`. A misspelled rel type in a
+ * raw `cypher()` query returns zero rows exactly like an empty domain and
+ * reconciles `0 == 0 == 0 ✓`: the same silent failure as the ethnologue label
+ * bug, in a dimension the existing guard cannot see.
+ *
+ * This is not hypothetical. `knownLanguage` has **zero** edges in the local
+ * graph, so a correct query and a typo produce byte-identical output, and
+ * nothing else in the harness can tell them apart.
+ *
+ * Warns rather than throws — a genuinely empty domain whose rel type was never
+ * minted also yields zero, and that is legitimate.
+ */
+export const warnIfRelTypeUnknown = async (
+  ctx: CutoverContext,
+  relType: string,
+) => {
+  knownRelTypes ??= new Set(
+    (
+      await ctx.neo4j
+        .query<{
+          relationshipType: string;
+        }>(
+          'CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType',
+        )
+        .run()
+    ).map((row) => row.relationshipType),
+  );
+  if (!knownRelTypes.has(relType)) {
+    ctx.log(
+      `    ⚠⚠ relationship type "${relType}" is NOT in db.relationshipTypes() and matched 0 rows — ` +
+        `either the domain is genuinely empty, or the type name is wrong. Node labels have their own ` +
+        `guard (warnIfLabelUnknown); edge-stored domains like pins and known languages need this one.`,
     );
   }
 };
@@ -285,6 +335,95 @@ export const dateStr = (d: ISODateish): string | null => {
  */
 export const orDefault = <T>(value: T | null | undefined, fallback: T): T =>
   value ?? fallback;
+
+/**
+ * The stored rich-text value → the plain object a `jsonb` column takes.
+ *
+ * Neo4j stores rich text as a NUL-delimited tagged string
+ * (`'\0RichText\0' + JSON` — see RichTextDocument.serializedPrefix). The Neo4j
+ * read transformer (`core/neo4j/transformer.ts`) parses it back into a
+ * RichTextDocument on the way out, so the first branch is the normal path; the
+ * serialized branch covers a value the transformer did not reach (nested inside
+ * a map, say).
+ *
+ * Handling that second case is not optional politeness. **Postgres text and
+ * jsonb cannot store a NUL byte at all**, so letting the serialized form through
+ * is a hard insert failure, not a cosmetically-wrong row.
+ *
+ * `undefined` = present but unusable (the caller decides: null the column, or
+ * drop the row if it is NOT NULL); `null` = genuinely empty at the source.
+ */
+export const richText = (value: unknown): object | null | undefined => {
+  if (value == null) return null;
+  if (RichTextDocument.isSerialized(value)) {
+    try {
+      return { ...RichTextDocument.fromSerialized(value) };
+    } catch {
+      return undefined;
+    }
+  }
+  if (typeof value === 'object') return { ...value };
+  return undefined;
+};
+
+/**
+ * Batched mirror of `resolveResourceBaseNode` (`~/core/drizzle`): resolve
+ * polymorphic parent ids to the **concrete typename** the read path expects in
+ * a `parent_type` discriminator column (`comment_threads`, `posts`).
+ *
+ * Why mirror instead of reusing it: that function issues six queries per id, and
+ * these domains resolve one parent per row. This resolves the whole distinct set
+ * in six queries total.
+ *
+ * Why not read the Neo4j labels instead: `labels(parent)` is unordered and
+ * carries interface noise — a project comes back as
+ * `["BaseNode","Project","MomentumTranslationProject"]` and a language as
+ * `["BaseNode","Language","Commentable"]`, so neither the first nor the last
+ * entry is the answer. The PG read path rebuilds the parent as
+ * `labels: [parent_type, 'BaseNode']`, so the column must hold exactly the
+ * string the resolver would have produced.
+ *
+ * ⚠ The precedence order below MUST match `resolveResourceBaseNode`'s
+ * (user → language → partner → project → engagement → progressReport). An id
+ * absent from the returned map either did not land or is soft-deleted, which
+ * makes this double as the landed-parent guard.
+ */
+export const resolveParentTypes = async (
+  ctx: CutoverContext,
+  ids: readonly string[],
+): Promise<Map<string, string>> => {
+  const out = new Map<string, string>();
+  const distinct = [...new Set(ids)];
+  if (distinct.length === 0) return out;
+  const list = sql.join(
+    distinct.map((id) => sql`${id}`),
+    sql`, `,
+  );
+  // Lowest precedence first, so a higher-precedence match overwrites it.
+  // EVERY leg must alias the type expression `AS t`. Postgres names an
+  // unaliased expression `?column?`, so a missing alias makes `row.t` undefined
+  // — and `out.set(id, undefined)` still creates the KEY, which silently defeats
+  // any `keepLanded` guard built from `.keys()` and then fails downstream on a
+  // NOT NULL discriminator. That is exactly how this shipped the first time; the
+  // filter below is the structural backstop so an alias slip can only ever lose
+  // a row loudly, never write a null.
+  const legs = [
+    sql`SELECT id, 'ProgressReport' AS t FROM periodic_reports WHERE id IN (${list}) AND type = 'Progress'`,
+    sql`SELECT id, type || 'Engagement' AS t FROM engagements WHERE id IN (${list}) AND deleted_at IS NULL`,
+    sql`SELECT id, type || 'Project' AS t FROM projects WHERE id IN (${list}) AND deleted_at IS NULL`,
+    sql`SELECT id, 'Partner' AS t FROM partners WHERE id IN (${list}) AND deleted_at IS NULL`,
+    sql`SELECT id, 'Language' AS t FROM languages WHERE id IN (${list}) AND deleted_at IS NULL`,
+    sql`SELECT id, 'User' AS t FROM users WHERE id IN (${list}) AND deleted_at IS NULL`,
+  ];
+  for (const leg of legs) {
+    const res = await ctx.db.execute<{ id: string; t: string }>(leg);
+    for (const row of res.rows) {
+      if (!row.t) continue;
+      out.set(row.id, row.t);
+    }
+  }
+  return out;
+};
 
 /** LinkTo<T> | { id } | null → the id string, or null. */
 export const linkId = <T extends string>(

--- a/src/core/cutover/cutover.helpers.ts
+++ b/src/core/cutover/cutover.helpers.ts
@@ -76,6 +76,20 @@ export const readAllViaRepo = async <T extends { id: ID }>(
   for (const ids_ of chunk(ids, ctx.batchSize)) {
     out.push(...(await repo.readMany(ids_)));
   }
+  // Hydrate-drop guard (finding #8): readMany silently omits nodes whose
+  // required matches fail (e.g. a partnership whose [:partner] rel was
+  // deactivated by its Partner's soft-delete). Reconciliation can't catch it —
+  // the read stat counts hydrated DTOs — so surface the delta here.
+  if (out.length !== ids.length) {
+    const hydrated = new Set<string>(out.map((dto) => String(dto.id)));
+    const missing = ids.filter((id) => !hydrated.has(id));
+    ctx.log(
+      `    ⚠ ${label}: ${missing.length} node(s) enumerated but NOT hydrated by readMany ` +
+        `(broken required rels — prod-finding #2 class): ${missing
+          .slice(0, 10)
+          .join(', ')}${missing.length > 10 ? ', …' : ''}`,
+    );
+  }
   return out;
 };
 

--- a/src/core/cutover/cutover.helpers.ts
+++ b/src/core/cutover/cutover.helpers.ts
@@ -1,0 +1,159 @@
+import { type Type } from '@nestjs/common';
+import { type PgTable } from 'drizzle-orm/pg-core';
+import { type CalendarDate, type ID, type UnsecuredDto } from '~/common';
+import { type CutoverContext, type TableStat } from './cutover.types';
+
+/** Split an array into fixed-size chunks. */
+export const chunk = <T>(items: readonly T[], size: number): T[][] =>
+  Array.from({ length: Math.ceil(items.length / size) }, (_, i) =>
+    items.slice(i * size, i * size + size),
+  );
+
+/**
+ * Enumerate the ids of every node with `label`. Backticks the label so dotted
+ * labels (e.g. `Ethnologue.Language`, `File.Version`) work.
+ *
+ * migration-todo: this reads ALL nodes including soft-deleted ones if the
+ * Neo4j model keeps them. The per-domain hydrate/readMany typically filters to
+ * live rows; verify deleted-row handling against a real Neo4j before cutover.
+ */
+export const fetchIds = async (
+  ctx: CutoverContext,
+  label: string,
+): Promise<ID[]> => {
+  const rows = await ctx.neo4j
+    .query<{ id: ID }>(`MATCH (n:\`${label}\`) RETURN n.id AS id`)
+    .run();
+  return rows.map((r) => r.id);
+};
+
+/** Run an arbitrary read Cypher and return the rows (junction extraction). */
+export const cypher = async <T>(
+  ctx: CutoverContext,
+  query: string,
+): Promise<T[]> => {
+  return [...(await ctx.neo4j.query<T>(query).run())];
+};
+
+/**
+ * Read every node of `label` through its canonical (Neo4j) repository, so the
+ * proven `hydrate()` assembles the full `UnsecuredDto`. Resolves the repo from
+ * the container, enumerates ids, then batches `readMany`.
+ */
+export const readAllViaRepo = async <T extends { id: ID }>(
+  ctx: CutoverContext,
+  label: string,
+  repoClass: Type<{
+    readMany: (ids: readonly ID[]) => Promise<ReadonlyArray<UnsecuredDto<T>>>;
+  }>,
+): Promise<Array<UnsecuredDto<T>>> => {
+  const repo = ctx.moduleRef.get(repoClass, { strict: false });
+  const ids = await fetchIds(ctx, label);
+  const out: Array<UnsecuredDto<T>> = [];
+  for (const ids_ of chunk(ids, ctx.batchSize)) {
+    out.push(...(await repo.readMany(ids_)));
+  }
+  return out;
+};
+
+/**
+ * Insert rows into a Postgres table, chunked, ID-preserving,
+ * `onConflictDoNothing` (idempotent re-runs). No-op write in dry-run — the
+ * mapping still runs, so mapping errors still surface. Returns rows written
+ * (or would-be-written in dry-run).
+ */
+export const bulkInsert = async <T extends PgTable>(
+  ctx: CutoverContext,
+  table: T,
+  rows: ReadonlyArray<T['$inferInsert']>,
+): Promise<number> => {
+  if (rows.length === 0) return 0;
+  if (ctx.dryRun) return rows.length;
+  let n = 0;
+  for (const c of chunk(rows, ctx.batchSize)) {
+    await ctx.db.insert(table).values(c).onConflictDoNothing();
+    n += c.length;
+  }
+  return n;
+};
+
+/**
+ * Keep only enum values the target pgEnum actually declares. Real Neo4j data
+ * can carry legacy/renamed enum values (e.g. `TranslationOrganization`) that
+ * the Postgres enum rejects.
+ *
+ * migration-todo: this DROPS unknown values (data loss). Some are renames that
+ * should MAP, not drop (likely `TranslationOrganization` → `Translation`).
+ * Replace with an explicit value-map per enum once the team decides. Returns
+ * `{ kept, dropped }` so callers can warn.
+ */
+export const sanitizeEnum = <T extends string>(
+  values: readonly string[],
+  allowed: readonly T[],
+): { kept: T[]; dropped: string[] } => {
+  const allowedSet = new Set<string>(allowed);
+  const kept: T[] = [];
+  const dropped: string[] = [];
+  for (const v of values) {
+    if (allowedSet.has(v)) kept.push(v as T);
+    else dropped.push(v);
+  }
+  return { kept, dropped };
+};
+
+/** `read` and `inserted` are usually equal (onConflictDoNothing aside). */
+export const stat = (read: number, inserted: number): TableStat => ({
+  read,
+  inserted,
+});
+
+/**
+ * Single-table stats result: `{ [table]: { read, inserted } }`. The key is a
+ * variable (not a snake_case literal), which keeps the naming-convention +
+ * no-useless-computed-key lint rules happy.
+ */
+export const one = (
+  table: string,
+  read: number,
+  inserted: number,
+): Record<string, TableStat> => ({ [table]: { read, inserted } });
+
+// ─── Value mappers ───────────────────────────────────────────────────────────
+// UnsecuredDto dates are Luxon; Postgres `timestamp` columns (mode 'date')
+// take a JS Date, `date` columns (mode 'string') take an ISO date string.
+
+type Luxonish = { toJSDate: () => Date } | null | undefined;
+type ISODateish =
+  | CalendarDate
+  | { toISO: () => string | null }
+  | null
+  | undefined;
+
+/** Luxon DateTime → JS Date for `timestamp` columns. */
+export const ts = (dt: Luxonish): Date | null => (dt ? dt.toJSDate() : null);
+
+/** Non-null variant for NOT NULL timestamp columns (e.g. createdAt). */
+export const tsReq = (dt: { toJSDate: () => Date }): Date => dt.toJSDate();
+
+/** CalendarDate / DateTime → 'YYYY-MM-DD' for `date` columns. */
+export const dateStr = (d: ISODateish): string | null => {
+  if (!d) return null;
+  const iso = d.toISO();
+  return iso ? iso.slice(0, 10) : null;
+};
+
+/**
+ * Coalesce a value that the DTO *types* as non-null but which real Neo4j data
+ * can still hold null for (a Property node was never written). Mirrors the
+ * column's schema default so the NOT NULL insert succeeds.
+ */
+export const orDefault = <T>(value: T | null | undefined, fallback: T): T =>
+  value ?? fallback;
+
+/** LinkTo<T> | { id } | null → the id string, or null. */
+export const linkId = <T extends string>(
+  link: { id: ID<T> } | ID<T> | null | undefined,
+): ID<T> | null => {
+  if (!link) return null;
+  return typeof link === 'string' ? link : link.id;
+};

--- a/src/core/cutover/cutover.helpers.ts
+++ b/src/core/cutover/cutover.helpers.ts
@@ -27,6 +27,29 @@ export const fetchIds = async (
   return rows.map((r) => r.id);
 };
 
+/**
+ * The set of ids that actually LANDED in a Postgres target table — the truth
+ * source for dangling-FK guards. Neo4j liveness isn't enough: a live source
+ * row can be silently dropped by `onConflictDoNothing` (unique-dup class,
+ * prod-finding #3), and anything referencing it must be nulled/dropped too.
+ *
+ * Dry-run inserts nothing, so fall back to the Neo4j id set there — mapped
+ * counts can differ slightly from a real run when dups exist.
+ */
+export const liveTargetIds = async (
+  ctx: CutoverContext,
+  label: string,
+  table: PgTable & { id: any },
+): Promise<ReadonlySet<string>> => {
+  if (ctx.dryRun) {
+    return new Set(await fetchIds(ctx, label));
+  }
+  const rows: Array<{ id: unknown }> = await ctx.db
+    .select({ id: table.id })
+    .from(table);
+  return new Set(rows.map((row) => String(row.id)));
+};
+
 /** Run an arbitrary read Cypher and return the rows (junction extraction). */
 export const cypher = async <T>(
   ctx: CutoverContext,

--- a/src/core/cutover/cutover.helpers.ts
+++ b/src/core/cutover/cutover.helpers.ts
@@ -1,6 +1,7 @@
 import { type Type } from '@nestjs/common';
 import { sql } from 'drizzle-orm';
 import { type PgTable } from 'drizzle-orm/pg-core';
+import { DateTime } from 'luxon';
 import {
   type CalendarDate,
   type ID,
@@ -338,22 +339,86 @@ export const one = (
 // UnsecuredDto dates are Luxon; Postgres `timestamp` columns (mode 'date')
 // take a JS Date, `date` columns (mode 'string') take an ISO date string.
 
-type Luxonish = { toJSDate: () => Date } | null | undefined;
+type Luxonish = { toJSDate: () => Date } | Date | string | null | undefined;
 type ISODateish =
   | CalendarDate
   | { toISO: () => string | null }
+  | Date
+  | string
   | null
   | undefined;
 
+/**
+ * Anything date-shaped that production actually holds → a JS Date.
+ *
+ * ⚠ NOT every stored timestamp is a temporal type. `ProjectMember.inactiveAt`
+ * is a ZONED DATETIME for the overwhelming majority of rows and a plain STRING
+ * for a handful — so the driver hands back a Luxon DateTime most of the time and
+ * a bare string the rest, and a truthiness check alone then calls `.toJSDate()`
+ * on a string and throws. Found by the first load at production volume; no local
+ * dataset contains the string form.
+ *
+ * A string is converted rather than dropped: the target column is a timestamp,
+ * and the value is a real date that happens to be stored in the wrong type.
+ */
+const toDate = (value: Luxonish): Date | null => {
+  if (value == null) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === 'string') {
+    // Neo4j's `toString()` on a zoned datetime appends the zone in brackets
+    // (`2020-01-01T00:00:00Z[UTC]`), which neither `new Date()` nor Luxon's ISO
+    // parser accepts. Roughly half of one edge-stored domain's timestamps carry
+    // it and the rest do not, so the format parses fine right up until it does
+    // not. Strip the suffix; the offset ahead of it already fixes the instant.
+    const parsed = DateTime.fromISO(value.replace(/\[[^\]]*\]$/, ''));
+    if (!parsed.isValid) {
+      throw new Error(
+        `Cannot read a timestamp from a string (${parsed.invalidReason ?? 'invalid'})`,
+      );
+    }
+    return parsed.toJSDate();
+  }
+  // A Luxon value can be INVALID (`isValid === false`) and still answer
+  // `toJSDate()` — with a Date whose time is NaN. Postgres then fails at
+  // serialization, far from the field that caused it, as `RangeError: Invalid
+  // time value`. Refuse it here, and name the shape received so the stack points
+  // at the extractor field rather than at the driver.
+  const asDate = value.toJSDate();
+  // migration-todo: an unusable value becomes null here and is therefore
+  // INVISIBLE — nothing counts it. Thread the context through so the harness can
+  // report a per-field tally, the way it reports rows that failed to hydrate.
+  // Returning null rather than throwing is deliberate: one malformed timestamp
+  // should not abort a twenty-domain load, and `tsReq` still refuses when the
+  // column cannot take a null.
+  return Number.isNaN(asDate.getTime()) ? null : asDate;
+};
+
 /** Luxon DateTime → JS Date for `timestamp` columns. */
-export const ts = (dt: Luxonish): Date | null => (dt ? dt.toJSDate() : null);
+export const ts = (dt: Luxonish): Date | null => toDate(dt);
 
 /** Non-null variant for NOT NULL timestamp columns (e.g. createdAt). */
-export const tsReq = (dt: { toJSDate: () => Date }): Date => dt.toJSDate();
+export const tsReq = (dt: NonNullable<Luxonish>): Date => {
+  const date = toDate(dt);
+  if (!date) {
+    throw new Error('Required timestamp was empty');
+  }
+  return date;
+};
 
 /** CalendarDate / DateTime → 'YYYY-MM-DD' for `date` columns. */
 export const dateStr = (d: ISODateish): string | null => {
   if (!d) return null;
+  // Same mixed-storage problem as `toDate` above: a date column's source value
+  // may arrive as a bare string rather than a temporal type.
+  if (typeof d === 'string') {
+    const parsed = DateTime.fromISO(d);
+    return parsed.isValid ? parsed.toISODate() : null;
+  }
+  if (d instanceof Date) {
+    return DateTime.fromJSDate(d).toISODate();
+  }
   const iso = d.toISO();
   return iso ? iso.slice(0, 10) : null;
 };

--- a/src/core/cutover/cutover.types.ts
+++ b/src/core/cutover/cutover.types.ts
@@ -32,6 +32,13 @@ export interface CutoverContext {
   readonly notHydrated: Map<string, number>;
   /** Read/insert chunk size. */
   readonly batchSize: number;
+  /**
+   * When true, bypass the scrub gate that normally refuses a production-scale
+   * Neo4j graph without a scrub marker. Set this for the real cutover, where
+   * loading production data is the entire point. Leave it false (the default)
+   * for ongoing QA refreshes, which should always run against scrubbed data.
+   */
+  readonly allowProductionSource?: boolean;
   readonly log: (msg: string) => void;
 }
 

--- a/src/core/cutover/cutover.types.ts
+++ b/src/core/cutover/cutover.types.ts
@@ -1,0 +1,55 @@
+import { type ModuleRef } from '@nestjs/core';
+import { type DrizzleDb } from '~/core/drizzle/drizzle.service';
+import { type DatabaseService } from '~/core/neo4j';
+
+/**
+ * Shared context handed to every {@link Extractor}. Holds both live DB handles
+ * (Neo4j = source, Drizzle/Postgres = target) plus run options.
+ *
+ * The harness boots with `DATABASE=neo4j` (so `splitDb` resolves the *Neo4j*
+ * repositories, which are the proven readers) AND `POSTGRES_URL` set (so
+ * `DrizzleService` connects to the *target* regardless of engine). See
+ * cutover.run.ts + README.md.
+ */
+export interface CutoverContext {
+  /** Source: raw Cypher (`.query(...).run()`) for id enumeration + junctions. */
+  readonly neo4j: DatabaseService;
+  /** Target: raw Drizzle insert (`db.insert(table).values(...)`). */
+  readonly db: DrizzleDb;
+  /** Resolves the canonical (Neo4j) domain repositories for hydration. */
+  readonly moduleRef: ModuleRef;
+  /** When true: read + map (to surface errors) but do NOT write or truncate. */
+  readonly dryRun: boolean;
+  /** Read/insert chunk size. */
+  readonly batchSize: number;
+  readonly log: (msg: string) => void;
+}
+
+export interface TableStat {
+  /** Rows read (and mapped) from Neo4j. */
+  read: number;
+  /** Rows inserted into Postgres (0 in dry-run). */
+  inserted: number;
+}
+
+/**
+ * One domain's ETL. Reads its entities out of Neo4j, maps them to the Drizzle
+ * row shape, and inserts them — ID-preserving, no service/hook side-effects.
+ *
+ * Extractors are pure data movers: no business validation, no security. The
+ * harness orders them by {@link dependsOn}, truncates {@link targetTables}
+ * up front (unless dry-run), then runs each and reconciles row counts.
+ */
+export interface Extractor {
+  /** Unique domain name (used for ordering + `--only`). */
+  readonly name: string;
+  /**
+   * Postgres tables this extractor fills, in insert (dependency) order. Used
+   * by the harness for truncate + row-count reconciliation.
+   */
+  readonly targetTables: readonly string[];
+  /** Names of extractors that must run before this one (FK dependencies). */
+  readonly dependsOn?: readonly string[];
+  /** Returns per-table {read, inserted} stats. */
+  run: (ctx: CutoverContext) => Promise<Record<string, TableStat>>;
+}

--- a/src/core/cutover/cutover.types.ts
+++ b/src/core/cutover/cutover.types.ts
@@ -20,6 +20,16 @@ export interface CutoverContext {
   readonly moduleRef: ModuleRef;
   /** When true: read + map (to surface errors) but do NOT write or truncate. */
   readonly dryRun: boolean;
+  /**
+   * Nodes found in Neo4j that never reached the mapper, keyed by node label.
+   * Written by `readAllRowsViaRepo`, reported by the harness.
+   *
+   * Lives here rather than in {@link TableStat} because the loss happens while
+   * reading, before the extractor knows which table the row would have filled —
+   * which is also why these rows are invisible to per-table reconciliation and
+   * have to be totalled separately.
+   */
+  readonly notHydrated: Map<string, number>;
   /** Read/insert chunk size. */
   readonly batchSize: number;
   readonly log: (msg: string) => void;

--- a/src/core/cutover/extractors/budget.extractor.ts
+++ b/src/core/cutover/extractors/budget.extractor.ts
@@ -145,8 +145,8 @@ export const budgetExtractor: Extractor = {
           amount: rec.amount,
           initialAmount: rec.initialAmount,
           preApprovedAmount: rec.preApprovedAmount,
-          createdAt: new Date(rec.createdAt),
-          updatedAt: new Date(rec.createdAt),
+          createdAt: tsReq(rec.createdAt),
+          updatedAt: tsReq(rec.createdAt),
           deletedAt: null,
         },
       ];

--- a/src/core/cutover/extractors/budget.extractor.ts
+++ b/src/core/cutover/extractors/budget.extractor.ts
@@ -6,6 +6,7 @@ import {
   organizations,
   projects,
 } from '~/core/drizzle/schema';
+import { isBaseNode } from '~/core/neo4j/results';
 import { BudgetRepository } from '../../../components/budget/budget.repository';
 import { type Budget, type BudgetStatus } from '../../../components/budget/dto';
 import {
@@ -58,7 +59,14 @@ export const budgetExtractor: Extractor = {
 
     const budgetRows = dtos.flatMap((dto) => {
       // `parent` is the raw project node (readMany merges the Cypher variable
-      // directly), so the id sits under `properties`.
+      // directly), so the id sits under `properties`. This extractor only ever
+      // reads through the Neo4j repo, so it's always a raw node here — the
+      // `BaseNode | LinkToUnknown` union on the DTO type is for other engines.
+      if (!isBaseNode(dto.parent)) {
+        throw new Error(
+          `Expected budget ${dto.id}'s parent to be a raw Neo4j node`,
+        );
+      }
       const projectId = dto.parent.properties.id;
       if (!projectId || !liveProjects.has(projectId)) {
         droppedDangling++;

--- a/src/core/cutover/extractors/budget.extractor.ts
+++ b/src/core/cutover/extractors/budget.extractor.ts
@@ -1,0 +1,171 @@
+import { type ID } from '~/common';
+import {
+  budgetRecords,
+  budgets,
+  budgetStatusEnum,
+  organizations,
+  projects,
+} from '~/core/drizzle/schema';
+import { BudgetRepository } from '../../../components/budget/budget.repository';
+import { type Budget, type BudgetStatus } from '../../../components/budget/dto';
+import {
+  bulkInsert,
+  cypher,
+  linkId,
+  liveTargetIds,
+  readAllViaRepo,
+  stat,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor, type TableStat } from '../cutover.types';
+
+/**
+ * Budget + BudgetRecord. Budgets read through the repo's proven readMany;
+ * records go pure Cypher — `BudgetRecordRepository`'s hydrate requires a bound
+ * `project` variable (its inherited readMany can't run standalone) and the
+ * record props are plain Property nodes, so an explicit per-prop match is the
+ * whole hydrate. `universal_template_file_id` is a deferred FK (plain text) —
+ * the Neo4j file ID carries over now and becomes a real reference when the
+ * File wave migrates `file_nodes` with the same IDs (same as
+ * partnerships.mou_id).
+ *
+ * Changeset-pending record values are NOT carried — reads are live-view only,
+ * consistent with every other extractor (changesets don't migrate).
+ */
+export const budgetExtractor: Extractor = {
+  name: 'budget',
+  targetTables: ['budgets', 'budget_records'],
+  dependsOn: ['project', 'organization'],
+  async run(ctx) {
+    const out: Record<string, TableStat> = {};
+
+    const dtos = await readAllViaRepo<Budget>(ctx, 'Budget', BudgetRepository);
+
+    const statuses = budgetStatusEnum.enumValues as readonly string[];
+    const unknownStatuses = new Set<string>();
+    const statusOr = (value: string | null | undefined): BudgetStatus => {
+      if (value && statuses.includes(value)) {
+        // Runtime-validated against the pgEnum just above.
+        return value as BudgetStatus;
+      }
+      if (value) unknownStatuses.add(value);
+      return 'Pending' as BudgetStatus;
+    };
+
+    // Prod-finding #2 guard: project_id is NOT NULL — drop dangling rows + log.
+    const liveProjects = await liveTargetIds(ctx, 'Project', projects);
+    let droppedDangling = 0;
+
+    const budgetRows = dtos.flatMap((dto) => {
+      // `parent` is the raw project node (readMany merges the Cypher variable
+      // directly), so the id sits under `properties`.
+      const projectId = dto.parent.properties.id;
+      if (!projectId || !liveProjects.has(projectId)) {
+        droppedDangling++;
+        return [];
+      }
+      return [
+        {
+          id: dto.id,
+          projectId,
+          status: statusOr(dto.status),
+          // Deferred FK — File wave makes it real (IDs are preserved).
+          universalTemplateFileId: linkId(dto.universalTemplateFile),
+          createdAt: tsReq(dto.createdAt),
+          updatedAt: tsReq(dto.createdAt),
+          deletedAt: null,
+        },
+      ];
+    });
+    if (unknownStatuses.size) {
+      ctx.log(
+        `    ⚠ defaulted unknown budget status value(s) to Pending: ${[
+          ...unknownStatuses,
+        ].join(', ')} — migration-todo: map, don't default`,
+      );
+    }
+    if (droppedDangling) {
+      ctx.log(
+        `    ⚠ dropped ${droppedDangling} budget(s) with dangling project refs (NOT NULL FK — prod-finding #2)`,
+      );
+    }
+    out.budgets = stat(dtos.length, await bulkInsert(ctx, budgets, budgetRows));
+
+    // Records: guard budget_id against what THIS run just mapped (a dropped
+    // budget drops its records), organization_id against PG truth.
+    const insertedBudgetIds = new Set<string>(budgetRows.map((row) => row.id));
+    const liveOrgs = await liveTargetIds(ctx, 'Organization', organizations);
+
+    const records = await cypher<{
+      id: ID<'BudgetRecord'>;
+      budgetId: ID<'Budget'>;
+      organizationId: ID<'Organization'> | null;
+      fiscalYear: number | null;
+      amount: number | null;
+      initialAmount: number | null;
+      preApprovedAmount: number | null;
+      createdAt: string;
+    }>(
+      ctx,
+      `MATCH (budget:Budget)-[:record {active: true}]->(node:BudgetRecord)
+       OPTIONAL MATCH (node)-[:organization {active: true}]->(org:Organization)
+       OPTIONAL MATCH (node)-[:fiscalYear {active: true}]->(fy:Property)
+       OPTIONAL MATCH (node)-[:amount {active: true}]->(amount:Property)
+       OPTIONAL MATCH (node)-[:initialAmount {active: true}]->(initial:Property)
+       OPTIONAL MATCH (node)-[:preApprovedAmount {active: true}]->(pre:Property)
+       RETURN node.id AS id, budget.id AS budgetId, org.id AS organizationId,
+              toFloat(fy.value) AS fiscalYear, toFloat(amount.value) AS amount,
+              toFloat(initial.value) AS initialAmount,
+              toFloat(pre.value) AS preApprovedAmount,
+              toString(node.createdAt) AS createdAt`,
+    );
+
+    let droppedDanglingRecords = 0;
+    let droppedNullFiscalYear = 0;
+    const recordRows = records.flatMap((rec) => {
+      if (
+        !insertedBudgetIds.has(rec.budgetId) ||
+        !rec.organizationId ||
+        !liveOrgs.has(rec.organizationId)
+      ) {
+        droppedDanglingRecords++;
+        return [];
+      }
+      if (rec.fiscalYear == null) {
+        // NOT NULL with no sensible default (and part of the partial unique).
+        droppedNullFiscalYear++;
+        return [];
+      }
+      return [
+        {
+          id: rec.id,
+          budgetId: rec.budgetId,
+          organizationId: rec.organizationId,
+          fiscalYear: Math.round(rec.fiscalYear),
+          amount: rec.amount,
+          initialAmount: rec.initialAmount,
+          preApprovedAmount: rec.preApprovedAmount,
+          createdAt: new Date(rec.createdAt),
+          updatedAt: new Date(rec.createdAt),
+          deletedAt: null,
+        },
+      ];
+    });
+    if (droppedDanglingRecords) {
+      ctx.log(
+        `    ⚠ dropped ${droppedDanglingRecords} budget record(s) with dangling budget/organization refs (NOT NULL FKs — prod-finding #2)`,
+      );
+    }
+    if (droppedNullFiscalYear) {
+      ctx.log(
+        `    ⚠ dropped ${droppedNullFiscalYear} budget record(s) with no fiscalYear property (NOT NULL, no default — prod-finding #1 class)`,
+      );
+    }
+    out.budget_records = stat(
+      records.length,
+      await bulkInsert(ctx, budgetRecords, recordRows),
+    );
+
+    return out;
+  },
+};

--- a/src/core/cutover/extractors/comment.extractor.ts
+++ b/src/core/cutover/extractors/comment.extractor.ts
@@ -1,0 +1,165 @@
+import { type ID } from '~/common';
+import { comments, commentThreads, users } from '~/core/drizzle/schema';
+import { CommentRepository } from '../../../components/comments/comment.repository';
+import { type Comment } from '../../../components/comments/dto';
+import {
+  bulkInsert,
+  cypher,
+  fetchIds,
+  keepLanded,
+  liveTargetIds,
+  readAllViaRepo,
+  resolveParentTypes,
+  richText,
+  stat,
+  ts,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor, type TableStat } from '../cutover.types';
+
+/**
+ * Comment threads + comments. `(parent:BaseNode)-[:commentThread]->(:CommentThread)`,
+ * `(thread)-[:comment { active }]->(:Comment)`, each with a `[:creator]->(:User)`.
+ *
+ * Threads are read by raw Cypher, comments through their repository — the split is
+ * deliberate. `CommentThreadRepository.hydrate` returns only
+ * `[comments[0], comments[-1]]` (first + latest, all the UI needs), so using it
+ * would migrate two comments per thread and silently discard the middle of every
+ * conversation. `CommentRepository.hydrate` has no such narrowing and no
+ * authorization filter, so it is safe to read through.
+ *
+ * `parent_type` holds the CONCRETE typename and is resolved from the landed
+ * Postgres rows, not from Neo4j labels — see {@link resolveParentTypes} for why the
+ * labels can't be used. That resolution doubles as the parent guard: `parent_id` is
+ * FK-less (parents span tables), so nothing would fail on a dangling thread; it
+ * would just be permanently unreachable, since every read arrives via the parent.
+ * A thread with no resolvable parent is therefore dropped rather than orphaned.
+ *
+ * `comments.body` is jsonb and NOT NULL, so an unparseable rich-text body has to
+ * drop the row — there is no null to fall back to. Loud, since a lost comment is
+ * lost user content.
+ */
+export const commentExtractor: Extractor = {
+  name: 'comment',
+  targetTables: ['comment_threads', 'comments'],
+  dependsOn: ['user', 'project', 'language', 'partner', 'periodic-report'],
+  async run(ctx) {
+    const out: Record<string, TableStat> = {};
+
+    // ── comment_threads ───────────────────────────────────────────────────────
+    const threadRows = await cypher<{
+      id: ID<'CommentThread'>;
+      parentId: ID;
+      creatorId: ID<'User'>;
+      createdAt: string;
+    }>(
+      ctx,
+      `MATCH (parent:BaseNode)-[:commentThread { active: true }]->(thread:CommentThread)
+       MATCH (thread)-[:creator]->(creator:User)
+       RETURN thread.id AS id, parent.id AS parentId, creator.id AS creatorId,
+              toString(thread.createdAt) AS createdAt`,
+    );
+    // `parent:BaseNode` excludes threads under a soft-deleted parent (relabelled
+    // `Deleted_BaseNode`) — 1 of 28 locally, under a deleted project. Enumerate
+    // separately so that loss is stated rather than inferred.
+    const allThreadIds = await fetchIds(ctx, 'CommentThread');
+    if (allThreadIds.length !== threadRows.length) {
+      ctx.log(
+        `    ⚠ CommentThread: ${allThreadIds.length} node(s) enumerated but ${threadRows.length} had a live ` +
+          `parent + creator — ${allThreadIds.length - threadRows.length} hang off a soft-deleted parent`,
+      );
+    }
+
+    const landedUsers = await liveTargetIds(ctx, 'User', users);
+    const parentTypes = await resolveParentTypes(
+      ctx,
+      threadRows.map((row) => row.parentId),
+    );
+    const threadsKept = keepLanded(threadRows, [
+      [landedUsers, (row) => row.creatorId],
+      [new Set(parentTypes.keys()), (row) => row.parentId],
+    ]);
+    if (threadsKept.skipped > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${threadsKept.skipped} thread(s) whose creator never landed, or whose parent is not ` +
+          `a live migrated resource (unreachable rather than invalid — parent_id is FK-less)`,
+      );
+    }
+
+    out.comment_threads = stat(
+      threadRows.length,
+      await bulkInsert(
+        ctx,
+        commentThreads,
+        threadsKept.kept.map((row) => ({
+          id: row.id,
+          parentId: row.parentId,
+          parentType: parentTypes.get(row.parentId)!,
+          creatorId: row.creatorId,
+          createdAt: new Date(row.createdAt),
+        })),
+      ),
+    );
+
+    // ── comments ──────────────────────────────────────────────────────────────
+    const dtos = await readAllViaRepo<Comment>(
+      ctx,
+      'Comment',
+      CommentRepository,
+    );
+
+    const landedThreads = new Set<string>(
+      threadsKept.kept.map((row) => row.id),
+    );
+    const unparsedBodies: string[] = [];
+    const commentValues = dtos.flatMap((comment) => {
+      const dto = comment as unknown as Record<string, any>;
+      const threadId = dto.thread as ID<'CommentThread'> | undefined;
+      const creatorId = dto.creator as ID<'User'> | undefined;
+      if (
+        !threadId ||
+        !landedThreads.has(threadId) ||
+        !creatorId ||
+        !landedUsers.has(creatorId)
+      ) {
+        return [];
+      }
+      const body = richText(dto.body);
+      if (!body) {
+        unparsedBodies.push(comment.id);
+        return [];
+      }
+      return [
+        {
+          id: comment.id,
+          threadId,
+          creatorId,
+          body: body as any,
+          createdAt: tsReq(comment.createdAt),
+          modifiedAt: ts(dto.modifiedAt) ?? tsReq(comment.createdAt),
+        },
+      ];
+    });
+    const droppedForParent =
+      dtos.length - commentValues.length - unparsedBodies.length;
+    if (droppedForParent > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${droppedForParent} comment(s) whose thread or creator never landed (both FKs)`,
+      );
+    }
+    if (unparsedBodies.length > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${unparsedBodies.length} comment(s) whose rich-text body could not be parsed into ` +
+          `jsonb, which is NOT NULL here so there is no null to fall back to — this is lost user content: ` +
+          `${unparsedBodies.slice(0, 10).join(', ')}`,
+      );
+    }
+
+    out.comments = stat(
+      dtos.length,
+      await bulkInsert(ctx, comments, commentValues),
+    );
+
+    return out;
+  },
+};

--- a/src/core/cutover/extractors/comment.extractor.ts
+++ b/src/core/cutover/extractors/comment.extractor.ts
@@ -96,7 +96,7 @@ export const commentExtractor: Extractor = {
           parentId: row.parentId,
           parentType: parentTypes.get(row.parentId)!,
           creatorId: row.creatorId,
-          createdAt: new Date(row.createdAt),
+          createdAt: tsReq(row.createdAt),
         })),
       ),
     );

--- a/src/core/cutover/extractors/comment.extractor.ts
+++ b/src/core/cutover/extractors/comment.extractor.ts
@@ -9,6 +9,7 @@ import {
   keepLanded,
   liveTargetIds,
   readAllViaRepo,
+  recordReadLoss,
   resolveParentTypes,
   richText,
   stat,
@@ -63,12 +64,13 @@ export const commentExtractor: Extractor = {
     // `Deleted_BaseNode`) — 1 of 28 locally, under a deleted project. Enumerate
     // separately so that loss is stated rather than inferred.
     const allThreadIds = await fetchIds(ctx, 'CommentThread');
-    if (allThreadIds.length !== threadRows.length) {
-      ctx.log(
-        `    ⚠ CommentThread: ${allThreadIds.length} node(s) enumerated but ${threadRows.length} had a live ` +
-          `parent + creator — ${allThreadIds.length - threadRows.length} hang off a soft-deleted parent`,
-      );
-    }
+    recordReadLoss(
+      ctx,
+      'CommentThread',
+      allThreadIds.length - threadRows.length,
+      `${threadRows.length} of ${allThreadIds.length} had a live parent + creator, ` +
+        `the rest hang off a soft-deleted parent or creator`,
+    );
 
     const landedUsers = await liveTargetIds(ctx, 'User', users);
     const parentTypes = await resolveParentTypes(

--- a/src/core/cutover/extractors/department-id-block.extractor.ts
+++ b/src/core/cutover/extractors/department-id-block.extractor.ts
@@ -1,0 +1,48 @@
+import { type ID } from '~/common';
+import { type IntRange } from '~/core/drizzle/int4-multirange';
+import { departmentIdBlocks } from '~/core/drizzle/schema';
+import { type ProjectType } from '../../../components/project/dto/project-type.enum';
+import { bulkInsert, cypher, one } from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+interface BlockRow {
+  id: ID;
+  /** JSON string of inclusive ranges `[{start,end}]` (apoc-stored on the node). */
+  blocks: string | null;
+  programs: string[] | null;
+}
+
+const parseBlocks = (json: string | null): IntRange[] => {
+  if (!json) return [];
+  const parsed: unknown = JSON.parse(json);
+  return Array.isArray(parsed) ? (parsed as IntRange[]) : [];
+};
+
+/**
+ * DepartmentIdBlock — persistent blocks (the ones Partner/Project reference; the
+ * FundingAccount-derived block is computed at read-time, never stored). Read
+ * raw (no DTO readMany path): the Neo4j node keeps `blocks` as a JSON string of
+ * inclusive `{start,end}` ranges, which map straight onto the `int4multirange`
+ * column (its codec re-encodes inclusive → half-open).
+ */
+export const departmentIdBlockExtractor: Extractor = {
+  name: 'departmentIdBlock',
+  targetTables: ['department_id_blocks'],
+  async run(ctx) {
+    const rows = await cypher<BlockRow>(
+      ctx,
+      `MATCH (n:DepartmentIdBlock)
+       RETURN n.id AS id, n.blocks AS blocks, n.programs AS programs`,
+    );
+    const mapped = rows.map((r) => ({
+      id: r.id,
+      range: parseBlocks(r.blocks),
+      programs: (r.programs ?? []) as ProjectType[],
+    }));
+    return one(
+      'department_id_blocks',
+      rows.length,
+      await bulkInsert(ctx, departmentIdBlocks, mapped),
+    );
+  },
+};

--- a/src/core/cutover/extractors/engagement.extractor.ts
+++ b/src/core/cutover/extractors/engagement.extractor.ts
@@ -287,34 +287,109 @@ export const engagementExtractor: Extractor = {
     );
 
     // ── engagement_status_history ────────────────────────────────────────────
-    // Neo4j keeps status history as DEACTIVATED `status` property rels
-    // (`deactivateProperty` flips active:false and stamps deletedAt); the live
+    // Neo4j keeps status history as DEACTIVATED `status` property rels; the live
     // status is the one active rel. Newest-first ordering is the consumer's job
     // (the rules engine's BackTo transitions read this table), so just carry the
     // timestamps faithfully.
+    //
+    // DO NOT put a `:Property` label filter on the target node. Superseding a
+    // property relabels its node — `deactivateProperty` and `commitChangesetProps`
+    // both call `prefixNodeLabelsWithDeleted`, which REMOVES every label and
+    // re-adds it prefixed — so a superseded status node is `Deleted_Property` and
+    // matches `:Property` never again. This mirrors the app's own Neo4j read in
+    // `engagement.rules.ts` (`getPreviousStatus`), which is label-free for the same
+    // reason and defines what "previous statuses" means here.
+    //
+    // MEASURED ON PRODUCTION 2026-08-19, because the filter's cost is not obvious
+    // from reading it — it does not read zero, it reads a misleading minority:
+    //   13,558 rows on `Deleted_Property` (superseded — invisible to the filter)
+    //      903 rows on a bare `Property`  (visible to the filter)
+    // and 5,136 of 8,235 engagements have history while the filtered query finds
+    // it for only 502 of them. So the filtered read carried ~6% of the history and
+    // reconciled ✓, because read and inserted agree when the read itself is short.
+    //
+    // The 903 bare-`Property` rows are NOT pending changeset drafts — production
+    // has zero of those (no row had a `:changeset` edge). The full label census
+    // splits them, and the split is readable because `createProperty` gives a
+    // property its domain label (`EngagementStatus`) only when it is created
+    // OUTSIDE a changeset:
+    //   ["Deleted_Property","Deleted_EngagementStatus"] 12,893 — ordinary history
+    //   ["Deleted_Property"]                               665 — began as a
+    //       changeset proposal, was committed, later superseded — still history
+    //   ["Property","EngagementStatus"]                    401 — deactivated but
+    //       never relabelled, i.e. history predating the label-prefixing behaviour
+    //   ["Property"]                                       502 — began as a
+    //       changeset proposal and was never committed (rejecting a changeset
+    //       removes the `:changeset` edge but leaves the node)
+    // Only that last group is arguably not history. It is carried anyway, because
+    // Neo4j's own `getPreviousStatus` counts it and the cutover's job is to agree
+    // with the source, not to improve on it — but it is counted and reported so
+    // the question can be settled post-cutover on a real number.
+    //
+    // `deletedAt` is stamped on the property NODE, never on the rel, so `at`
+    // comes from `p.deletedAt` — the moment the status was superseded, which is
+    // what the Postgres write side records going forward (the drizzle repo
+    // inserts the OLD status and lets `at` default to now at change time). The
+    // remaining arms are begin-time fallbacks for rows that predate that.
     const historyRows = await cypher<{
       engagementId: ID<'Engagement'>;
       status: string;
       at: string | null;
+      neverCommitted: boolean;
     }>(
       ctx,
-      `MATCH (e:Engagement)-[r:status { active: false }]->(p:Property)
+      `MATCH (e:Engagement)-[r:status { active: false }]->(p)
        RETURN e.id AS engagementId, p.value AS status,
-              toString(coalesce(r.deletedAt, r.createdAt, p.createdAt)) AS at`,
+              toString(coalesce(p.deletedAt, r.createdAt, p.createdAt)) AS at,
+              (NOT p:Deleted_Property AND NOT p:EngagementStatus) AS neverCommitted`,
     );
     const landedEngagements = await liveTargetIds(
       ctx,
       'Engagement',
       engagements,
     );
+    // Statuses that only ever existed as an uncommitted changeset proposal — see
+    // the label census above. Carried, not dropped, so Postgres agrees with the
+    // source, but counted so the "should a rejected proposal count as history"
+    // question can be answered post-cutover against a real number (502 in prod).
+    const neverCommitted = historyRows.filter(
+      (row) => row.neverCommitted,
+    ).length;
+    if (neverCommitted > 0) {
+      ctx.log(
+        `    ℹ ${neverCommitted} status-history row(s) only ever existed as an uncommitted ` +
+          `changeset proposal — carried because Neo4j's own BackTo read counts them too ` +
+          `(engagement.rules.ts getPreviousStatus). migration-todo(post-cutover): decide ` +
+          `whether a rejected proposal belongs in an engagement's status history.`,
+      );
+    }
+
     const knownStatuses = new Set<string>(engagementStatusEnum.enumValues);
-    const history = keepLanded(
-      historyRows.filter((row) => knownStatuses.has(row.status)),
-      [[landedEngagements, (row) => row.engagementId]],
+    const typedHistory = historyRows.filter((row) =>
+      knownStatuses.has(row.status),
     );
+    const untypedStatuses = historyRows.length - typedHistory.length;
+    if (untypedStatuses > 0) {
+      const offenders = [
+        ...new Set(
+          historyRows
+            .filter((row) => !knownStatuses.has(row.status))
+            .map((row) => String(row.status)),
+        ),
+      ];
+      ctx.log(
+        `    ⚠ DROPPED ${untypedStatuses} status-history row(s) carrying a status outside ` +
+          `engagement_status: ${offenders.slice(0, 10).join(', ')}` +
+          (offenders.length > 10 ? ', …' : ''),
+      );
+    }
+
+    const history = keepLanded(typedHistory, [
+      [landedEngagements, (row) => row.engagementId],
+    ]);
     if (history.skipped > 0) {
       ctx.log(
-        `    ⚠ skipped ${history.skipped} status-history row(s) whose engagement never landed`,
+        `    ⚠ DROPPED ${history.skipped} status-history row(s) whose engagement never landed`,
       );
     }
     out.engagement_status_history = stat(

--- a/src/core/cutover/extractors/engagement.extractor.ts
+++ b/src/core/cutover/extractors/engagement.extractor.ts
@@ -310,7 +310,14 @@ export const engagementExtractor: Extractor = {
           status: row.status as any,
           // `at` is NOT NULL with a defaultNow(); a history rel with no usable
           // timestamp is better dated now than dropped.
-          at: row.at ? new Date(row.at) : new Date(),
+          //
+          // Must go through `ts`, NOT `new Date(row.at)`. Raw Cypher results are
+          // still passed through the connection's transformer, so `at` arrives as
+          // a Luxon value — and `new Date(<object>)` yields an INVALID date rather
+          // than failing, which Postgres only rejects later, as a RangeError from
+          // deep inside the driver. This path has no rows locally, so it went
+          // unexercised until a production-volume load.
+          at: ts(row.at) ?? new Date(),
         })),
       ),
     );

--- a/src/core/cutover/extractors/engagement.extractor.ts
+++ b/src/core/cutover/extractors/engagement.extractor.ts
@@ -5,6 +5,7 @@ import {
   engagements,
   engagementStatusEnum,
   engagementStatusHistory,
+  fileNodes,
   languages,
   locations,
   productMethodologyEnum,
@@ -55,13 +56,16 @@ import { type Extractor, type TableStat } from '../cutover.types';
  * rather than the DTO's `__typename` string, which is prefixed `default::` for
  * Gel's benefit and is a fragile thing to parse.
  *
- * `pnp_id` / `growth_plan_id` stay null — deferred FKs to file_nodes, populated
- * by the File wave (Phase 7).
+ * `pnp_id` / `growth_plan_id` are backfilled from the same `pnp`/`growthPlan`
+ * properties the live repo already hydrates (`props.pnp` / `props.growthPlan` —
+ * plain DefinedFile placeholder ids, not a graph relationship). `file` is added
+ * to `dependsOn` so file_nodes has landed by the time these are checked for
+ * liveness.
  */
 export const engagementExtractor: Extractor = {
   name: 'engagement',
   targetTables: ['engagements', 'engagement_status_history', 'ceremonies'],
-  dependsOn: ['project', 'language', 'user', 'location'],
+  dependsOn: ['project', 'language', 'user', 'location', 'file'],
   async run(ctx) {
     const out: Record<string, TableStat> = {};
 
@@ -80,6 +84,7 @@ export const engagementExtractor: Extractor = {
     const landedLanguages = await liveTargetIds(ctx, 'Language', languages);
     const landedUsers = await liveTargetIds(ctx, 'User', users);
     const landedLocations = await liveTargetIds(ctx, 'Location', locations);
+    const landedFileNodes = await liveTargetIds(ctx, 'FileNode', fileNodes);
 
     const droppedForProject: string[] = [];
     const droppedForLanguage: string[] = [];
@@ -87,6 +92,14 @@ export const engagementExtractor: Extractor = {
     const nulledEnums = new Set<string>();
     let nulledMentors = 0;
     let nulledCountries = 0;
+    let nulledFileRefs = 0;
+    const liveFileRefOrNull = (id: ID | null): ID | null => {
+      if (id && !landedFileNodes.has(id)) {
+        nulledFileRefs++;
+        return null;
+      }
+      return id;
+    };
 
     const rows = dtos.flatMap((eng) => {
       const isLanguage = languageEngagementIds.has(eng.id);
@@ -178,8 +191,7 @@ export const engagementExtractor: Extractor = {
           paratextRegistryId:
             (lang.paratextRegistryId as string | null) ?? null,
           rev79CommunityId: (lang.rev79CommunityId as string | null) ?? null,
-          // Deferred FK — the File wave fills these.
-          pnpId: null,
+          pnpId: liveFileRefOrNull(linkId(lang.pnp)),
           sentPrintingDate: dateStr(lang.sentPrintingDate),
           historicGoal: (lang.historicGoal as string | null) ?? null,
           milestonePlanned: orDefault(
@@ -198,7 +210,7 @@ export const engagementExtractor: Extractor = {
           position: lang.position ?? null,
           methodologies: methodologies.kept as any,
           countryOfOriginId,
-          growthPlanId: null,
+          growthPlanId: liveFileRefOrNull(linkId(lang.growthPlan)),
           marketable: orDefault(lang.marketable as boolean, false),
           webId: (lang.webId as string | null) ?? null,
 
@@ -231,6 +243,11 @@ export const engagementExtractor: Extractor = {
     if (nulledMentors > 0 || nulledCountries > 0) {
       ctx.log(
         `    ⚠ nulled ${nulledMentors} mentor + ${nulledCountries} countryOfOrigin ref(s) whose target never landed`,
+      );
+    }
+    if (nulledFileRefs > 0) {
+      ctx.log(
+        `    ⚠ nulled ${nulledFileRefs} pnp/growthPlan ref(s) whose file never landed`,
       );
     }
     if (nulledEnums.size > 0) {

--- a/src/core/cutover/extractors/engagement.extractor.ts
+++ b/src/core/cutover/extractors/engagement.extractor.ts
@@ -1,0 +1,378 @@
+import { type ID } from '~/common';
+import {
+  ceremonies,
+  ceremonyTypeEnum,
+  engagements,
+  engagementStatusEnum,
+  engagementStatusHistory,
+  languages,
+  locations,
+  productMethodologyEnum,
+  projects,
+  users,
+} from '~/core/drizzle/schema';
+import { CeremonyRepository } from '../../../components/ceremony/ceremony.repository';
+import { type Ceremony } from '../../../components/ceremony/dto';
+import { type Engagement } from '../../../components/engagement/dto';
+import { EngagementRepository } from '../../../components/engagement/engagement.repository';
+import {
+  bulkInsert,
+  cypher,
+  dateStr,
+  fetchIds,
+  keepLanded,
+  linkId,
+  liveTargetIds,
+  orDefault,
+  readAllViaRepo,
+  sanitizeEnum,
+  stat,
+  ts,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor, type TableStat } from '../cutover.types';
+
+/**
+ * Engagement cluster — engagements (single-table inheritance over
+ * LanguageEngagement / InternshipEngagement) + engagement_status_history +
+ * ceremonies (1:1).
+ *
+ * This wave has more ways to fail than any before it, because `engagements`
+ * carries a type-shape CHECK on top of five FKs to tables that legitimately drop
+ * rows:
+ *
+ *   engagements_type_shape_chk:
+ *     Language   ⟹ language_id NOT NULL AND intern_id IS NULL
+ *     Internship ⟹ intern_id   NOT NULL AND language_id IS NULL
+ *
+ * So for a Language engagement whose language never landed there is no
+ * null-and-continue option — the CHECK forbids it and the row must be DROPPED.
+ * Same for an Internship whose intern never landed. That is real data loss, so
+ * both are counted and logged with ids rather than absorbed. `mentor_id` and
+ * `country_of_origin_id` ARE nullable, so those get nulled instead.
+ *
+ * Type comes from the Neo4j label (`LanguageEngagement` / `InternshipEngagement`)
+ * rather than the DTO's `__typename` string, which is prefixed `default::` for
+ * Gel's benefit and is a fragile thing to parse.
+ *
+ * `pnp_id` / `growth_plan_id` stay null — deferred FKs to file_nodes, populated
+ * by the File wave (Phase 7).
+ */
+export const engagementExtractor: Extractor = {
+  name: 'engagement',
+  targetTables: ['engagements', 'engagement_status_history', 'ceremonies'],
+  dependsOn: ['project', 'language', 'user', 'location'],
+  async run(ctx) {
+    const out: Record<string, TableStat> = {};
+
+    const dtos = await readAllViaRepo<Engagement>(
+      ctx,
+      'Engagement',
+      EngagementRepository,
+    );
+
+    // Label-driven discriminator — see the docblock.
+    const languageEngagementIds = new Set<string>(
+      await fetchIds(ctx, 'LanguageEngagement'),
+    );
+
+    const landedProjects = await liveTargetIds(ctx, 'Project', projects);
+    const landedLanguages = await liveTargetIds(ctx, 'Language', languages);
+    const landedUsers = await liveTargetIds(ctx, 'User', users);
+    const landedLocations = await liveTargetIds(ctx, 'Location', locations);
+
+    const droppedForProject: string[] = [];
+    const droppedForLanguage: string[] = [];
+    const droppedForIntern: string[] = [];
+    const nulledEnums = new Set<string>();
+    let nulledMentors = 0;
+    let nulledCountries = 0;
+
+    const rows = dtos.flatMap((eng) => {
+      const isLanguage = languageEngagementIds.has(eng.id);
+      const projectId = eng.project?.id;
+      if (!projectId || !landedProjects.has(projectId)) {
+        droppedForProject.push(eng.id);
+        return [];
+      }
+
+      // migration-todo: the DTO splits Language/Internship fields by subtype, so
+      // reading the other half needs a cast. The shape is guaranteed by the
+      // label check above.
+      const lang = eng as unknown as Record<string, any>;
+
+      const languageId = isLanguage
+        ? (linkId(lang.language as { id: ID<'Language'> } | null) ?? null)
+        : null;
+      if (isLanguage && (!languageId || !landedLanguages.has(languageId))) {
+        droppedForLanguage.push(eng.id);
+        return [];
+      }
+
+      const internId = !isLanguage
+        ? (linkId(lang.intern as { id: ID<'User'> } | null) ?? null)
+        : null;
+      if (!isLanguage && (!internId || !landedUsers.has(internId))) {
+        droppedForIntern.push(eng.id);
+        return [];
+      }
+
+      let mentorId = !isLanguage
+        ? (linkId(lang.mentor as { id: ID<'User'> } | null) ?? null)
+        : null;
+      if (mentorId && !landedUsers.has(mentorId)) {
+        mentorId = null;
+        nulledMentors++;
+      }
+      let countryOfOriginId = !isLanguage
+        ? (linkId(lang.countryOfOrigin as { id: ID<'Location'> } | null) ??
+          null)
+        : null;
+      if (countryOfOriginId && !landedLocations.has(countryOfOriginId)) {
+        countryOfOriginId = null;
+        nulledCountries++;
+      }
+
+      const status = sanitizeEnum(
+        [orDefault(eng.status as string, 'InDevelopment')],
+        engagementStatusEnum.enumValues,
+      );
+      if (status.dropped.length > 0) {
+        for (const value of status.dropped) nulledEnums.add(`status=${value}`);
+      }
+      const methodologies = sanitizeEnum(
+        [...((lang.methodologies as string[] | undefined) ?? [])],
+        productMethodologyEnum.enumValues,
+      );
+      for (const value of methodologies.dropped) {
+        nulledEnums.add(`methodology=${value}`);
+      }
+
+      const type: 'Language' | 'Internship' = isLanguage
+        ? 'Language'
+        : 'Internship';
+      return [
+        {
+          id: eng.id,
+          projectId,
+          type,
+          // A legacy status outside the enum falls back to the column default
+          // rather than aborting the chunk.
+          status: status.kept[0] ?? ('InDevelopment' as const),
+          statusModifiedAt: ts(eng.statusModifiedAt),
+          lastSuspendedAt: ts(eng.lastSuspendedAt),
+          lastReactivatedAt: ts(eng.lastReactivatedAt),
+          completeDate: dateStr(eng.completeDate),
+          disbursementCompleteDate: dateStr(eng.disbursementCompleteDate),
+          startDateOverride: dateStr(lang.startDateOverride),
+          endDateOverride: dateStr(lang.endDateOverride),
+          initialEndDate: dateStr(eng.initialEndDate),
+          description: eng.description ?? null,
+
+          // ── LanguageEngagement ──
+          languageId,
+          firstScripture: (lang.firstScripture as boolean | null) ?? null,
+          lukePartnership: (lang.lukePartnership as boolean | null) ?? null,
+          openToInvestorVisit:
+            (lang.openToInvestorVisit as boolean | null) ?? null,
+          paratextRegistryId:
+            (lang.paratextRegistryId as string | null) ?? null,
+          rev79CommunityId: (lang.rev79CommunityId as string | null) ?? null,
+          // Deferred FK — the File wave fills these.
+          pnpId: null,
+          sentPrintingDate: dateStr(lang.sentPrintingDate),
+          historicGoal: (lang.historicGoal as string | null) ?? null,
+          milestonePlanned: orDefault(
+            lang.milestonePlanned,
+            'Unknown' as const,
+          ),
+          milestoneReached: (lang.milestoneReached as boolean | null) ?? null,
+          usingAIAssistedTranslation: orDefault(
+            lang.usingAIAssistedTranslation,
+            'Unknown' as const,
+          ),
+
+          // ── InternshipEngagement ──
+          internId,
+          mentorId,
+          position: lang.position ?? null,
+          methodologies: methodologies.kept as any,
+          countryOfOriginId,
+          growthPlanId: null,
+          marketable: orDefault(lang.marketable as boolean, false),
+          webId: (lang.webId as string | null) ?? null,
+
+          createdAt: tsReq(eng.createdAt),
+          modifiedAt: tsReq(eng.modifiedAt),
+          updatedAt: tsReq(eng.modifiedAt),
+          deletedAt: null,
+        },
+      ];
+    });
+
+    for (const [reason, ids] of [
+      ['their project never landed', droppedForProject],
+      [
+        'they are a LanguageEngagement whose language never landed (type-shape CHECK forbids a null language_id)',
+        droppedForLanguage,
+      ],
+      [
+        'they are an InternshipEngagement whose intern never landed (type-shape CHECK forbids a null intern_id)',
+        droppedForIntern,
+      ],
+    ] as const) {
+      if (ids.length > 0) {
+        ctx.log(
+          `    ⚠ DROPPED ${ids.length} engagement(s) because ${reason}: ` +
+            `${ids.slice(0, 10).join(', ')}${ids.length > 10 ? ', …' : ''}`,
+        );
+      }
+    }
+    if (nulledMentors > 0 || nulledCountries > 0) {
+      ctx.log(
+        `    ⚠ nulled ${nulledMentors} mentor + ${nulledCountries} countryOfOrigin ref(s) whose target never landed`,
+      );
+    }
+    if (nulledEnums.size > 0) {
+      ctx.log(
+        `    ⚠ dropped unknown engagement enum value(s): ${[...nulledEnums].join(', ')} — migration-todo: map, don't drop`,
+      );
+    }
+
+    // Live-unique pre-warning: (project, language) and (project, intern) are
+    // unique among live rows, and everything here is live.
+    for (const [label, key] of [
+      ['(project, language)', (r: (typeof rows)[number]) => r.languageId],
+      ['(project, intern)', (r: (typeof rows)[number]) => r.internId],
+    ] as const) {
+      const seen = new Map<string, ID>();
+      const collisions: string[] = [];
+      for (const row of rows) {
+        const other = key(row);
+        if (other == null) continue;
+        const composite = `${row.projectId}::${other}`;
+        const first = seen.get(composite);
+        if (first) collisions.push(`${row.id} (dup of ${first})`);
+        else seen.set(composite, row.id);
+      }
+      if (collisions.length > 0) {
+        ctx.log(
+          `    ⚠ ${collisions.length} engagement(s) collide on the ${label} live-unique index and will be ` +
+            `DROPPED by onConflictDoNothing: ${collisions.slice(0, 10).join(', ')}` +
+            (collisions.length > 10 ? ', …' : ''),
+        );
+      }
+    }
+
+    out.engagements = stat(
+      dtos.length,
+      await bulkInsert(ctx, engagements, rows),
+    );
+
+    // ── engagement_status_history ────────────────────────────────────────────
+    // Neo4j keeps status history as DEACTIVATED `status` property rels
+    // (`deactivateProperty` flips active:false and stamps deletedAt); the live
+    // status is the one active rel. Newest-first ordering is the consumer's job
+    // (the rules engine's BackTo transitions read this table), so just carry the
+    // timestamps faithfully.
+    const historyRows = await cypher<{
+      engagementId: ID<'Engagement'>;
+      status: string;
+      at: string | null;
+    }>(
+      ctx,
+      `MATCH (e:Engagement)-[r:status { active: false }]->(p:Property)
+       RETURN e.id AS engagementId, p.value AS status,
+              toString(coalesce(r.deletedAt, r.createdAt, p.createdAt)) AS at`,
+    );
+    const landedEngagements = await liveTargetIds(
+      ctx,
+      'Engagement',
+      engagements,
+    );
+    const knownStatuses = new Set<string>(engagementStatusEnum.enumValues);
+    const history = keepLanded(
+      historyRows.filter((row) => knownStatuses.has(row.status)),
+      [[landedEngagements, (row) => row.engagementId]],
+    );
+    if (history.skipped > 0) {
+      ctx.log(
+        `    ⚠ skipped ${history.skipped} status-history row(s) whose engagement never landed`,
+      );
+    }
+    out.engagement_status_history = stat(
+      historyRows.length,
+      await bulkInsert(
+        ctx,
+        engagementStatusHistory,
+        history.kept.map((row) => ({
+          engagementId: row.engagementId,
+          status: row.status as any,
+          // `at` is NOT NULL with a defaultNow(); a history rel with no usable
+          // timestamp is better dated now than dropped.
+          at: row.at ? new Date(row.at) : new Date(),
+        })),
+      ),
+    );
+
+    // ── ceremonies (1:1 with engagement) ────────────────────────────────────
+    const ceremonyDtos = await readAllViaRepo<Ceremony>(
+      ctx,
+      'Ceremony',
+      CeremonyRepository,
+    );
+    const ceremonyPairs = await cypher<{
+      cid: ID<'Ceremony'>;
+      eid: ID<'Engagement'>;
+    }>(
+      ctx,
+      `MATCH (e:Engagement)-[:ceremony { active: true }]->(c:Ceremony)
+       RETURN c.id AS cid, e.id AS eid`,
+    );
+    const engagementOf = new Map(ceremonyPairs.map((p) => [p.cid, p.eid]));
+    const knownCeremonyTypes = new Set<string>(ceremonyTypeEnum.enumValues);
+    let ceremoniesWithoutEngagement = 0;
+    let ceremoniesBadType = 0;
+    const ceremonyRows = ceremonyDtos.flatMap((cer) => {
+      const engagementId = engagementOf.get(cer.id);
+      if (!engagementId || !landedEngagements.has(engagementId)) {
+        // engagement_id is NOT NULL, so an orphan ceremony cannot be written.
+        ceremoniesWithoutEngagement++;
+        return [];
+      }
+      if (!knownCeremonyTypes.has(cer.type)) {
+        ceremoniesBadType++;
+        return [];
+      }
+      return [
+        {
+          id: cer.id,
+          engagementId,
+          type: cer.type,
+          planned: orDefault(cer.planned, false),
+          estimatedDate: dateStr(cer.estimatedDate),
+          actualDate: dateStr(cer.actualDate),
+          createdAt: tsReq(cer.createdAt),
+          updatedAt: tsReq(cer.createdAt),
+          deletedAt: null,
+        },
+      ];
+    });
+    if (ceremoniesWithoutEngagement > 0) {
+      ctx.log(
+        `    ⚠ skipped ${ceremoniesWithoutEngagement} ceremony(ies) with no landed engagement (engagement_id is NOT NULL)`,
+      );
+    }
+    if (ceremoniesBadType > 0) {
+      ctx.log(
+        `    ⚠ skipped ${ceremoniesBadType} ceremony(ies) with a type outside the ceremony_type enum`,
+      );
+    }
+    out.ceremonies = stat(
+      ceremonyDtos.length,
+      await bulkInsert(ctx, ceremonies, ceremonyRows),
+    );
+
+    return out;
+  },
+};

--- a/src/core/cutover/extractors/ethnologue.extractor.ts
+++ b/src/core/cutover/extractors/ethnologue.extractor.ts
@@ -19,7 +19,12 @@ export const ethnologueExtractor: Extractor = {
   async run(ctx) {
     const dtos = await readAllViaRepo<EthnologueLanguage>(
       ctx,
-      'Ethnologue.Language',
+      // The Neo4j label is `EthnologueLanguage`. It was `Ethnologue.Language`
+      // here — the GEL module path (`e.Ethnologue.Language`), which is not a
+      // Neo4j label at all, so this extractor read ZERO rows and reconciliation
+      // reported ✓ because 0 read = 0 inserted = 0 count. See the label guard in
+      // cutover.helpers.fetchIds, added so a wrong label can't be silent again.
+      'EthnologueLanguage',
       EthnologueLanguageRepository,
     );
     // CHECK-constraint guard (audit ETH1, prod-finding #1 class): the PG

--- a/src/core/cutover/extractors/ethnologue.extractor.ts
+++ b/src/core/cutover/extractors/ethnologue.extractor.ts
@@ -22,17 +22,40 @@ export const ethnologueExtractor: Extractor = {
       'Ethnologue.Language',
       EthnologueLanguageRepository,
     );
+    // CHECK-constraint guard (audit ETH1, prod-finding #1 class): the PG
+    // format/range CHECKs have no Neo4j counterpart and DTO validators only
+    // guarded NEW writes — one legacy bad value would abort a whole insert
+    // chunk. The CHECKs are NULL-tolerant, so null + log instead of dropping.
+    const CODE_RE = /^[a-z]{3}$/;
+    let nulledValues = 0;
+    const conform = (value: string | null | undefined): string | null => {
+      if (value == null) return null;
+      if (CODE_RE.test(value)) return value;
+      nulledValues++;
+      return null;
+    };
+
     // EthnologueLanguage is an embedded value type (no Resource createdAt on
     // the Neo4j side); let the table's createdAt/updatedAt defaults apply.
-    const rows = dtos.map((e) => ({
-      id: e.id,
-      languageId: null,
-      code: e.code ?? null,
-      provisionalCode: e.provisionalCode ?? null,
-      name: e.name ?? null,
-      population: e.population ?? null,
-      deletedAt: null,
-    }));
+    const rows = dtos.map((e) => {
+      const population =
+        e.population != null && e.population >= 0 ? e.population : null;
+      if (e.population != null && population == null) nulledValues++;
+      return {
+        id: e.id,
+        languageId: null,
+        code: conform(e.code),
+        provisionalCode: conform(e.provisionalCode),
+        name: e.name ?? null,
+        population,
+        deletedAt: null,
+      };
+    });
+    if (nulledValues) {
+      ctx.log(
+        `    ⚠ nulled ${nulledValues} ethnologue value(s) violating PG CHECK constraints (bad code format / negative population — audit ETH1)`,
+      );
+    }
     return one(
       'ethnologue_languages',
       dtos.length,

--- a/src/core/cutover/extractors/ethnologue.extractor.ts
+++ b/src/core/cutover/extractors/ethnologue.extractor.ts
@@ -1,0 +1,42 @@
+import { ethnologueLanguages } from '~/core/drizzle/schema';
+import { type EthnologueLanguage } from '../../../components/language/dto';
+import { EthnologueLanguageRepository } from '../../../components/language/ethnologue-language/ethnologue-language.repository';
+import { bulkInsert, one, readAllViaRepo } from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * EthnologueLanguage — leaf (code, provisionalCode, name, population).
+ *
+ * migration-todo: `language_id` is left null here. It's a deferred plain-text
+ * column (no FK) until Language migrates; the id lives on the Neo4j *Language*
+ * side (`(Language)-[:ethnologue]->(Ethnologue.Language)`), so backfill it in
+ * the Language wave's extractor (or a reverse-lookup pass) once `languages` is
+ * on Postgres.
+ */
+export const ethnologueExtractor: Extractor = {
+  name: 'ethnologue',
+  targetTables: ['ethnologue_languages'],
+  async run(ctx) {
+    const dtos = await readAllViaRepo<EthnologueLanguage>(
+      ctx,
+      'Ethnologue.Language',
+      EthnologueLanguageRepository,
+    );
+    // EthnologueLanguage is an embedded value type (no Resource createdAt on
+    // the Neo4j side); let the table's createdAt/updatedAt defaults apply.
+    const rows = dtos.map((e) => ({
+      id: e.id,
+      languageId: null,
+      code: e.code ?? null,
+      provisionalCode: e.provisionalCode ?? null,
+      name: e.name ?? null,
+      population: e.population ?? null,
+      deletedAt: null,
+    }));
+    return one(
+      'ethnologue_languages',
+      dtos.length,
+      await bulkInsert(ctx, ethnologueLanguages, rows),
+    );
+  },
+};

--- a/src/core/cutover/extractors/external-department-id.extractor.ts
+++ b/src/core/cutover/extractors/external-department-id.extractor.ts
@@ -1,0 +1,119 @@
+import { type ID } from '~/common';
+import { externalDepartmentIds } from '~/core/drizzle/schema';
+import {
+  bulkInsert,
+  cypher,
+  fetchIds,
+  recordReadLoss,
+  stat,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor, type TableStat } from '../cutover.types';
+
+/**
+ * ExternalDepartmentId — the department IDs that already exist in Intacct, the
+ * accounting system, and so must never be handed out to a CORD project.
+ *
+ * Carried, not dropped (Rob, 2026-08-25, after confirming with the team that
+ * Intacct is still in use and the reservations still stand). These nodes are
+ * fully disconnected — no edges in either direction — which is exactly what
+ * made them look retired on a first pass. They are not: the department-ID
+ * allocator has unioned them into the unavailable set since 2025-09, and
+ * measured against this snapshot, 389 of the 565 sit inside blocks projects are
+ * assigned from, with two of thirteen blocks landing on a different ID without
+ * them.
+ *
+ * No `dependsOn`. A reservation list has nothing to depend on: nothing points
+ * at these rows and they point at nothing, so there is no landing check to make
+ * and no row can be orphaned by another domain failing.
+ *
+ * The source `id` is deliberately not carried. It is an `apoc.create.uuid()`
+ * value invented by the one-off import, referenced by nothing; the department
+ * ID is the identity and the target's primary key. It is still read here, so
+ * that enumeration can be reconciled against what was actually hydrated.
+ */
+interface Row {
+  id: ID;
+  departmentId: string | null;
+  name: string | null;
+  createdAt: unknown;
+}
+
+export const externalDepartmentIdExtractor: Extractor = {
+  name: 'external-department-id',
+  targetTables: ['external_department_ids'],
+  async run(ctx) {
+    const out: Record<string, TableStat> = {};
+
+    // Enumerate first, read second, and compare. Without this a mistyped label
+    // returns zero rows and reconciles as a clean 0 == 0 == 0 — the failure
+    // this harness treats as its worst, because it is completely silent.
+    const enumerated = await fetchIds(ctx, 'ExternalDepartmentId');
+
+    const rows = await cypher<Row>(
+      ctx,
+      `MATCH (n:ExternalDepartmentId)
+       RETURN n.id AS id, n.departmentId AS departmentId,
+              n.name AS name, n.createdAt AS createdAt`,
+    );
+    recordReadLoss(
+      ctx,
+      'ExternalDepartmentId',
+      enumerated.length - rows.length,
+      'enumerated by label but not returned by the property read',
+    );
+
+    // A row with no code reserves nothing and cannot be a primary key. None
+    // exist in the current snapshot; classified in code anyway so a future
+    // import that writes a blank is a logged drop rather than an aborted run.
+    const usable: Array<{
+      departmentId: string;
+      name: string;
+      createdAt: Date;
+    }> = [];
+    const seen = new Set<string>();
+    let droppedBlank = 0;
+    let droppedDuplicate = 0;
+    for (const row of rows) {
+      const code = row.departmentId?.trim();
+      if (!code) {
+        droppedBlank++;
+        continue;
+      }
+      // department_id is the primary key, so a duplicate would be silently
+      // swallowed by onConflictDoNothing and show up only as a smaller insert
+      // count. The source has none today (565 codes, 565 distinct); counting
+      // them here means a future re-import says so out loud.
+      if (seen.has(code)) {
+        droppedDuplicate++;
+        continue;
+      }
+      seen.add(code);
+      usable.push({
+        departmentId: code,
+        // The Intacct department name. Not unique — one name legitimately
+        // covers three codes — so it is carried as data, never as a key.
+        name: row.name?.trim() ?? '',
+        createdAt: tsReq(row.createdAt as Parameters<typeof tsReq>[0]),
+      });
+    }
+    if (droppedBlank > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${droppedBlank} external department id(s) with no code`,
+      );
+    }
+    if (droppedDuplicate > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${droppedDuplicate} duplicate external department id(s) — ` +
+          `the code is the primary key, so only the first of each is kept`,
+      );
+    }
+
+    out.external_department_ids = stat(
+      rows.length,
+      await bulkInsert(ctx, externalDepartmentIds, usable),
+    );
+
+    return out;
+  },
+};

--- a/src/core/cutover/extractors/field-region.extractor.ts
+++ b/src/core/cutover/extractors/field-region.extractor.ts
@@ -1,0 +1,39 @@
+import { fieldRegions } from '~/core/drizzle/schema';
+import { type FieldRegion } from '../../../components/field-region/dto';
+import { FieldRegionRepository } from '../../../components/field-region/field-region.repository';
+import {
+  bulkInsert,
+  linkId,
+  one,
+  readAllViaRepo,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/** FieldRegion — (name, fieldZone, director→user). Both FKs NOT NULL. */
+export const fieldRegionExtractor: Extractor = {
+  name: 'fieldRegion',
+  targetTables: ['field_regions'],
+  dependsOn: ['fieldZone', 'user'],
+  async run(ctx) {
+    const dtos = await readAllViaRepo<FieldRegion>(
+      ctx,
+      'FieldRegion',
+      FieldRegionRepository,
+    );
+    const rows = dtos.map((r) => ({
+      id: r.id,
+      name: r.name,
+      fieldZoneId: linkId(r.fieldZone)!,
+      directorId: linkId(r.director)!,
+      createdAt: tsReq(r.createdAt),
+      updatedAt: tsReq(r.createdAt),
+      deletedAt: null,
+    }));
+    return one(
+      'field_regions',
+      dtos.length,
+      await bulkInsert(ctx, fieldRegions, rows),
+    );
+  },
+};

--- a/src/core/cutover/extractors/field-region.extractor.ts
+++ b/src/core/cutover/extractors/field-region.extractor.ts
@@ -21,6 +21,23 @@ export const fieldRegionExtractor: Extractor = {
       'FieldRegion',
       FieldRegionRepository,
     );
+    // Both links are OPTIONAL-matched by the hydrate and both columns are NOT
+    // NULL — same trap as the field zone above, and the same reasoning for failing
+    // instead of dropping: a region carries its projects with it.
+    const incomplete = dtos.filter(
+      (r) => !linkId(r.fieldZone) || !linkId(r.director),
+    );
+    if (incomplete.length > 0) {
+      throw new Error(
+        `Cutover: ${incomplete.length} FieldRegion(s) are missing a live field zone or ` +
+          `director, and both columns are NOT NULL: ${incomplete
+            .map((r) => r.id)
+            .join(
+              ', ',
+            )}. Fix in Neo4j before loading — dropping them here would ` +
+          `take every project beneath them.`,
+      );
+    }
     const rows = dtos.map((r) => ({
       id: r.id,
       name: r.name,

--- a/src/core/cutover/extractors/field-zone.extractor.ts
+++ b/src/core/cutover/extractors/field-zone.extractor.ts
@@ -1,0 +1,38 @@
+import { fieldZones } from '~/core/drizzle/schema';
+import { type FieldZone } from '../../../components/field-zone/dto';
+import { FieldZoneRepository } from '../../../components/field-zone/field-zone.repository';
+import {
+  bulkInsert,
+  linkId,
+  one,
+  readAllViaRepo,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/** FieldZone — (name, director→user). directorId is NOT NULL. */
+export const fieldZoneExtractor: Extractor = {
+  name: 'fieldZone',
+  targetTables: ['field_zones'],
+  dependsOn: ['user'],
+  async run(ctx) {
+    const dtos = await readAllViaRepo<FieldZone>(
+      ctx,
+      'FieldZone',
+      FieldZoneRepository,
+    );
+    const rows = dtos.map((z) => ({
+      id: z.id,
+      name: z.name,
+      directorId: linkId(z.director)!,
+      createdAt: tsReq(z.createdAt),
+      updatedAt: tsReq(z.createdAt),
+      deletedAt: null,
+    }));
+    return one(
+      'field_zones',
+      dtos.length,
+      await bulkInsert(ctx, fieldZones, rows),
+    );
+  },
+};

--- a/src/core/cutover/extractors/field-zone.extractor.ts
+++ b/src/core/cutover/extractors/field-zone.extractor.ts
@@ -21,6 +21,30 @@ export const fieldZoneExtractor: Extractor = {
       'FieldZone',
       FieldZoneRepository,
     );
+    // `director` is OPTIONAL-matched by the repository's hydrate, so a zone whose
+    // director user was soft-deleted arrives as null — and `director_id` is NOT
+    // NULL. Written unchecked (it used to be `linkId(z.director)!`) that becomes a
+    // null-violation raised from inside the driver, naming a column and nothing
+    // else, part-way through the load.
+    //
+    // Deliberately fails the run rather than dropping the row: a FieldZone sits at
+    // the root of the dependency graph, so dropping one silently takes its field
+    // regions, their projects and everything below. There are only a handful of
+    // zones, and a director-less zone is a source-data fix, not a shape the load
+    // should quietly absorb.
+    const directorless = dtos.filter((z) => !linkId(z.director));
+    if (directorless.length > 0) {
+      throw new Error(
+        `Cutover: ${directorless.length} FieldZone(s) have no live director, and ` +
+          `field_zones.director_id is NOT NULL: ${directorless
+            .map((z) => z.id)
+            .join(
+              ', ',
+            )}. Assign a director (or restore the deleted user) in Neo4j ` +
+          `before loading — dropping them here would take every field region and ` +
+          `project beneath them.`,
+      );
+    }
     const rows = dtos.map((z) => ({
       id: z.id,
       name: z.name,

--- a/src/core/cutover/extractors/file.extractor.ts
+++ b/src/core/cutover/extractors/file.extractor.ts
@@ -161,7 +161,7 @@ const toNum = (value: unknown): number | null => {
 const rowKey = (row: RawFileNode) =>
   [row.parentId, row.name, row.createdById, row.public, row.mimeType, row.size]
     .map((value) => (value == null ? '' : String(value)))
-    .join(' ');
+    .join('\u0000');
 
 /** When this row's NAME was written; 0 when the source never stamped it. */
 const nameWrittenAt = (row: RawFileNode) =>

--- a/src/core/cutover/extractors/file.extractor.ts
+++ b/src/core/cutover/extractors/file.extractor.ts
@@ -1,0 +1,338 @@
+import { sql } from 'drizzle-orm';
+import { type ID } from '~/common';
+import { fileNodes, users } from '~/core/drizzle/schema';
+import {
+  bulkInsert,
+  chunk,
+  cypher,
+  keepLanded,
+  liveTargetIds,
+  one,
+} from '../cutover.helpers';
+import { type CutoverContext, type Extractor } from '../cutover.types';
+
+/**
+ * FileNode — the single-table Directory / File / FileVersion tree.
+ *
+ * ## Why this reads raw Cypher instead of going through FileRepository
+ *
+ * Every other extractor uses {@link readAllViaRepo} because the proven
+ * `hydrate()` assembles the DTO for us. **This one must not.** `hydrateFile()`
+ * (file.repository.ts:189-215) opens with `matchLatestVersion()`, which is a
+ * REQUIRED `.match()` on `(node)<-[:parent ACTIVE]-(:FileVersion)`. A File with
+ * no versions therefore does not hydrate at all — and version-less Files are not
+ * an edge case, they are the normal resting state of every `DefinedFile`
+ * placeholder (`createDefinedFile` makes the File row before any upload).
+ * The local graph has ~7,559 File nodes against ~372 FileVersions, so reading
+ * through the repository would silently shed the overwhelming majority of the
+ * table and reconcile as a clean ✓ — the {@link warnIfLabelUnknown} failure mode,
+ * one layer up.
+ *
+ * Reading raw is also strictly MORE faithful here: `hydrateFile`/`hydrateDirectory`
+ * merge `{ public: false }` as a DTO default, while the column is deliberately
+ * tri-state (`null` = inherit from parent). The raw Property value preserves that.
+ *
+ * ## Insert order
+ *
+ * `parent_id` and `latest_version_id` are both self-FKs, so one flat insert
+ * cannot work:
+ *
+ * 1. Rows are sorted by **tree depth** (roots first) and inserted in that order,
+ *    so a child never precedes its parent. Depth is computed from the parent map,
+ *    with cycle protection — a cycle is impossible in the Neo4j model but a
+ *    corrupt one would otherwise hang this loop rather than fail.
+ * 2. `latest_version_id` is a **second pass**, because it points at a FileVersion
+ *    that is itself a row in this table and cannot exist until step 1 finishes.
+ *    Computed in JS from the landed set (max `createdAt` per File), then written
+ *    with chunked `UPDATE … FROM (VALUES …)` — a per-row UPDATE would be one
+ *    round trip per File, which is the wrong shape for the largest table here.
+ *
+ * ## Soft-delete
+ *
+ * LIVE-ONLY, for free: `deleteBaseNode` relabels to `Deleted_FileNode`, so
+ * `MATCH (n:FileNode)` excludes soft-deleted nodes without a predicate. Same
+ * reason a soft-deleted parent yields `parentId = null` (its label is gone AND
+ * the inbound `parent` rel was deactivated) — those become roots, and the count
+ * is logged rather than left silent.
+ *
+ * ## Rows this DROPS (loudly — never silently)
+ *
+ * - **FileVersion with no `mimeType` or `size`.** The `file_nodes_shape` CHECK
+ *   requires both to be NOT NULL for that type. Dropping is deliberate over
+ *   defaulting: inventing `application/octet-stream`/`0` would fabricate
+ *   user-visible metadata for a version that cannot be served correctly anyway.
+ *   The drop fans out correctly on its own — the `latest_version_id` pass and the
+ *   media extractor both build from {@link liveTargetIds}, i.e. what LANDED.
+ * - **Any node whose `createdBy` user did not land.** `created_by_id` is NOT NULL
+ *   with an FK; there is nothing to write.
+ *
+ * A missing `name` is treated differently — defaulted, not dropped — because
+ * dropping a Directory would orphan its whole subtree, and a blank name is
+ * cosmetic and fixable in-app. Both counts are logged; check them against a real
+ * Neo4j on the first prod-shaped run before trusting either policy.
+ *
+ * ## Local-graph count check (2026-08-03)
+ *
+ * 8,275 `:FileNode` — 7,559 File / 345 Directory / 372 FileVersion, which sums to
+ * 8,276, i.e. ONE more than the interface label. The extra is a single junk node
+ * `{id: '$p'}` labelled `[BaseNode, File]` — an unsubstituted query parameter that
+ * got persisted — with **zero** relationships in either direction and no
+ * `FileNode` label. Matching on `:FileNode` excludes it, and since nothing
+ * references it the exclusion cannot orphan anything; it also has no `createdBy`,
+ * so it could never satisfy `created_by_id` regardless. Recorded so the arithmetic
+ * gap does not get re-investigated. Worth a look on the prod graph: any extractor
+ * that enumerates by a SUBTYPE label rather than the interface label would pick
+ * junk like this up (the queries here and in the media/PnP extractors all require
+ * an edge, so they cannot).
+ */
+
+interface RawFileNode {
+  id: ID;
+  type: 'Directory' | 'File' | 'FileVersion' | null;
+  name: string | null;
+  public: boolean | null;
+  mimeType: string | null;
+  size: number | null;
+  parentId: ID | null;
+  createdById: ID<'User'> | null;
+  createdAt: { toJSDate: () => Date } | null;
+}
+
+const READ = `
+  MATCH (n:FileNode)
+  OPTIONAL MATCH (n)-[:parent { active: true }]->(p:FileNode)
+  OPTIONAL MATCH (n)-[:createdBy { active: true }]->(cb:User)
+  OPTIONAL MATCH (n)-[:name { active: true }]->(nameProp:Property)
+  OPTIONAL MATCH (n)-[:public { active: true }]->(pubProp:Property)
+  OPTIONAL MATCH (n)-[:mimeType { active: true }]->(mimeProp:Property)
+  OPTIONAL MATCH (n)-[:size { active: true }]->(sizeProp:Property)
+  RETURN n.id AS id,
+         [l IN labels(n) WHERE l IN ['Directory', 'File', 'FileVersion']][0] AS type,
+         nameProp.value AS name,
+         pubProp.value AS public,
+         mimeProp.value AS mimeType,
+         sizeProp.value AS size,
+         p.id AS parentId,
+         cb.id AS createdById,
+         n.createdAt AS createdAt
+`;
+
+/** Neo4j may hand back an Integer wrapper rather than a JS number. */
+const toNum = (value: unknown): number | null => {
+  if (value == null) return null;
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') return Number(value);
+  if (typeof (value as { toNumber?: unknown }).toNumber === 'function') {
+    return (value as { toNumber: () => number }).toNumber();
+  }
+  return Number(value);
+};
+
+/**
+ * Depth of each node in the parent tree, so inserts can be ordered roots-first.
+ * A parent outside `byId` (soft-deleted, or dropped upstream) counts as a root.
+ * Memoized and iterative rather than recursive — directory nesting is unbounded,
+ * and a corrupt cycle must terminate rather than blow the stack.
+ *
+ * `cycles` collects any node that walked into a loop, so the caller can report it
+ * instead of letting the insert die on a bare `*_fkey` violation.
+ */
+const depthOf = (
+  byId: ReadonlyMap<ID, RawFileNode>,
+  cache: Map<ID, number>,
+  cycles: Set<ID>,
+  start: ID,
+): number => {
+  const path: ID[] = [];
+  const seen = new Set<ID>();
+  let cursor: ID | undefined = start;
+  while (cursor != null && cache.get(cursor) == null && !seen.has(cursor)) {
+    seen.add(cursor);
+    path.push(cursor);
+    // Annotated: without it TS reports a control-flow circularity between this
+    // const and the `cursor` reassignment below (TS7022).
+    const parentId: ID | null | undefined = byId.get(cursor)?.parentId;
+    cursor = parentId != null && byId.has(parentId) ? parentId : undefined;
+  }
+  // `base` is the depth of the walked path's PARENT, so the first node unwound
+  // lands at base + 1. A run off the top of the tree gives -1, i.e. root = 0.
+  let base: number;
+  if (cursor == null) {
+    base = -1;
+  } else {
+    const cached = cache.get(cursor);
+    if (cached != null) {
+      base = cached;
+    } else {
+      // Cursor is in `seen` → we walked into a cycle.
+      cycles.add(start);
+      base = -1;
+    }
+  }
+  for (const id of [...path].reverse()) {
+    base++;
+    cache.set(id, base);
+  }
+  return cache.get(start)!;
+};
+
+/** Write `latest_version_id` in chunks: one statement per chunk, not per row. */
+const writeLatestVersions = async (
+  ctx: CutoverContext,
+  pairs: ReadonlyArray<readonly [fileId: ID, versionId: ID]>,
+) => {
+  for (const batch of chunk(pairs, ctx.batchSize)) {
+    // Explicit ::text casts: a bare parameter inside VALUES has unknown type, and
+    // joining it against a text column then fails with "could not determine data
+    // type". A dry run cannot surface this — it never issues the statement.
+    const values = sql.join(
+      batch.map(
+        ([fileId, versionId]) => sql`(${fileId}::text, ${versionId}::text)`,
+      ),
+      sql`, `,
+    );
+    await ctx.db.execute(sql`
+      UPDATE file_nodes AS f
+      SET latest_version_id = v.version_id
+      FROM (VALUES ${values}) AS v(file_id, version_id)
+      WHERE f.id = v.file_id
+    `);
+  }
+};
+
+export const fileExtractor: Extractor = {
+  name: 'file',
+  targetTables: ['file_nodes'],
+  dependsOn: ['user'],
+  async run(ctx) {
+    const raw = await cypher<RawFileNode>(ctx, READ);
+    const userIds = await liveTargetIds(ctx, 'User', users);
+
+    const typeless = raw.filter((row) => row.type == null);
+    if (typeless.length > 0) {
+      ctx.log(
+        `    ⚠ ${typeless.length} FileNode(s) carry none of Directory/File/FileVersion — dropped`,
+      );
+    }
+    const typed = raw.filter(
+      (row): row is RawFileNode & { type: NonNullable<RawFileNode['type']> } =>
+        row.type != null,
+    );
+
+    // CHECK file_nodes_shape: FileVersion requires mime_type + size NOT NULL.
+    const shapeless = typed.filter(
+      (row) =>
+        row.type === 'FileVersion' &&
+        (row.mimeType == null || row.size == null),
+    );
+    if (shapeless.length > 0) {
+      ctx.log(
+        `    ⚠ ${shapeless.length} FileVersion(s) missing mimeType and/or size — DROPPED ` +
+          `(file_nodes_shape CHECK requires both): ${shapeless
+            .slice(0, 10)
+            .map((row) => row.id)
+            .join(', ')}${shapeless.length > 10 ? ', …' : ''}`,
+      );
+    }
+    const shaped = typed.filter(
+      (row) =>
+        !(
+          row.type === 'FileVersion' &&
+          (row.mimeType == null || row.size == null)
+        ),
+    );
+
+    const unnamed = shaped.filter((row) => row.name == null);
+    if (unnamed.length > 0) {
+      ctx.log(
+        `    ⚠ ${unnamed.length} FileNode(s) have no name Property — defaulted to '(unnamed)' ` +
+          `rather than dropped (dropping a Directory orphans its subtree)`,
+      );
+    }
+
+    const { kept, skipped } = keepLanded(shaped, [
+      [userIds, (row) => row.createdById],
+    ]);
+    if (skipped > 0) {
+      ctx.log(
+        `    ⚠ ${skipped} FileNode(s) skipped — createdBy user absent or did not land ` +
+          `(created_by_id is NOT NULL)`,
+      );
+    }
+
+    const byId = new Map(kept.map((row) => [row.id, row]));
+    const orphaned = kept.filter(
+      (row) => row.parentId != null && !byId.has(row.parentId),
+    ).length;
+    if (orphaned > 0) {
+      ctx.log(
+        `    ⚠ ${orphaned} FileNode(s) point at a parent that is absent (soft-deleted or dropped) ` +
+          `— inserted as roots with parent_id null`,
+      );
+    }
+
+    const depthCache = new Map<ID, number>();
+    const cycles = new Set<ID>();
+    const ordered = [...kept].sort(
+      (a, b) =>
+        depthOf(byId, depthCache, cycles, a.id) -
+        depthOf(byId, depthCache, cycles, b.id),
+    );
+    if (cycles.size > 0) {
+      ctx.log(
+        `    ⚠⚠ ${cycles.size} FileNode(s) sit in a parent CYCLE — depth ordering cannot ` +
+          `satisfy the self-FK and the insert will fail on file_nodes_parent_id_fkey. ` +
+          `Ids: ${[...cycles].slice(0, 10).join(', ')}`,
+      );
+    }
+
+    const undated = kept.filter((row) => row.createdAt == null).length;
+    if (undated > 0) {
+      ctx.log(
+        `    ⚠ ${undated} FileNode(s) have no createdAt — every BaseNode should carry one; ` +
+          `falling back to the epoch, which is visible in the data rather than silent`,
+      );
+    }
+
+    const isVersion = (row: RawFileNode) => row.type === 'FileVersion';
+    const rows = ordered.map((row) => ({
+      id: row.id,
+      type: row.type,
+      name: row.name ?? '(unnamed)',
+      public: row.public ?? null,
+      parentId:
+        row.parentId != null && byId.has(row.parentId) ? row.parentId : null,
+      createdById: row.createdById!,
+      // The CHECK confines these to FileVersion — a File carrying a stray
+      // mimeType/size Property must still write null, or the insert aborts.
+      mimeType: isVersion(row) ? row.mimeType : null,
+      size: isVersion(row) ? toNum(row.size) : null,
+      // Second pass; see the docblock.
+      latestVersionId: null,
+      createdAt: row.createdAt ? row.createdAt.toJSDate() : new Date(0),
+      deletedAt: null,
+    }));
+
+    const inserted = await bulkInsert(ctx, fileNodes, rows);
+
+    // Pass 2: latest_version_id = the newest LANDED FileVersion under each File.
+    if (!ctx.dryRun) {
+      const landed = await liveTargetIds(ctx, 'FileNode', fileNodes);
+      const newest = new Map<ID, { id: ID; at: number }>();
+      for (const row of kept) {
+        if (!isVersion(row) || row.parentId == null) continue;
+        if (!landed.has(row.id) || !landed.has(row.parentId)) continue;
+        const at = row.createdAt ? row.createdAt.toJSDate().getTime() : 0;
+        const held = newest.get(row.parentId);
+        if (!held || at > held.at) newest.set(row.parentId, { id: row.id, at });
+      }
+      const pairs = [...newest].map(
+        ([fileId, latest]) => [fileId, latest.id] as const,
+      );
+      await writeLatestVersions(ctx, pairs);
+      ctx.log(`    ✓ latest_version_id set on ${pairs.length} File(s)`);
+    }
+
+    return one('file_nodes', rows.length, inserted);
+  },
+};

--- a/src/core/cutover/extractors/file.extractor.ts
+++ b/src/core/cutover/extractors/file.extractor.ts
@@ -334,6 +334,11 @@ export const fileExtractor: Extractor = {
       ctx.log(`    ✓ latest_version_id set on ${pairs.length} File(s)`);
     }
 
-    return one('file_nodes', rows.length, inserted);
+    // `read` is the count BEFORE the typeless / shapeless / unlanded-creator
+    // filters above, so every one of those drops shows up as a read-vs-inserted
+    // gap in the reconciliation table. Passing `rows.length` (the post-filter
+    // count) would make read equal inserted and print ✓ on a table that shed
+    // rows, while the ⚠ lines above said otherwise.
+    return one('file_nodes', raw.length, inserted);
   },
 };

--- a/src/core/cutover/extractors/file.extractor.ts
+++ b/src/core/cutover/extractors/file.extractor.ts
@@ -56,6 +56,25 @@ import { type CutoverContext, type Extractor } from '../cutover.types';
  * the inbound `parent` rel was deactivated) — those become roots, and the count
  * is logged rather than left silent.
  *
+ * ## The read fans out, so rows are NOT nodes
+ *
+ * Every `OPTIONAL MATCH` below multiplies rows when a node holds more than one
+ * ACTIVE edge of that type, and production holds plenty: 164 FileNodes have 2–5
+ * active `parent` rels and 72 have 2+ active `name` rels, which is 284 duplicate
+ * rows on a 1.56M-row read. That is bad data in Neo4j — a property written
+ * without deactivating the old one — not a query bug, and it cannot be fixed
+ * here. Only some of it costs anything: all 164 duplicate parents point at the
+ * SAME directory, so collapsing them loses nothing, while 52 of the 72 duplicate
+ * names genuinely disagree and one of the two has to be dropped.
+ *
+ * It has to be handled here anyway, because the duplicates used to travel all
+ * the way to the insert and get swallowed by `onConflictDoNothing`. That made
+ * `read` an inflated ROW count while `inserted` was a NODE count, so the
+ * reconciliation table subtracted two different units: the 2026-08-19 prod run
+ * reported 373 file_nodes dropped when the real loss was 89. Collapsing the
+ * fan-out up front makes both columns count nodes, and gives the ambiguity its
+ * own warning instead of letting a conflict clause hide it.
+ *
  * ## Rows this DROPS (loudly — never silently)
  *
  * - **FileVersion with no `mimeType` or `size`.** The `file_nodes_shape` CHECK
@@ -97,13 +116,15 @@ interface RawFileNode {
   parentId: ID | null;
   createdById: ID<'User'> | null;
   createdAt: { toJSDate: () => Date } | null;
+  /** When the NAME was written — only used to break a name conflict. */
+  nameCreatedAt: { toJSDate: () => Date } | null;
 }
 
 const READ = `
   MATCH (n:FileNode)
   OPTIONAL MATCH (n)-[:parent { active: true }]->(p:FileNode)
   OPTIONAL MATCH (n)-[:createdBy { active: true }]->(cb:User)
-  OPTIONAL MATCH (n)-[:name { active: true }]->(nameProp:Property)
+  OPTIONAL MATCH (n)-[nameRel:name { active: true }]->(nameProp:Property)
   OPTIONAL MATCH (n)-[:public { active: true }]->(pubProp:Property)
   OPTIONAL MATCH (n)-[:mimeType { active: true }]->(mimeProp:Property)
   OPTIONAL MATCH (n)-[:size { active: true }]->(sizeProp:Property)
@@ -115,7 +136,8 @@ const READ = `
          sizeProp.value AS size,
          p.id AS parentId,
          cb.id AS createdById,
-         n.createdAt AS createdAt
+         n.createdAt AS createdAt,
+         nameRel.createdAt AS nameCreatedAt
 `;
 
 /** Neo4j may hand back an Integer wrapper rather than a JS number. */
@@ -127,6 +149,124 @@ const toNum = (value: unknown): number | null => {
     return (value as { toNumber: () => number }).toNumber();
   }
   return Number(value);
+};
+
+/**
+ * Total order over the fields the fan-out can vary, so the row kept for a
+ * duplicated node is the SAME row on every run. Neo4j returns the rows of a
+ * fan-out in no defined order, so picking "the first one" would let a file land
+ * in one folder during a rehearsal and a different folder at cutover — a
+ * difference nothing downstream could explain.
+ */
+const rowKey = (row: RawFileNode) =>
+  [row.parentId, row.name, row.createdById, row.public, row.mimeType, row.size]
+    .map((value) => (value == null ? '' : String(value)))
+    .join(' ');
+
+/** When this row's NAME was written; 0 when the source never stamped it. */
+const nameWrittenAt = (row: RawFileNode) =>
+  row.nameCreatedAt ? row.nameCreatedAt.toJSDate().getTime() : 0;
+
+/**
+ * Pick the surviving row for a node whose duplicates DISAGREE.
+ *
+ * The app's own rule decides it: `createFileVersion` ends by renaming the File
+ * to the version just uploaded (file.service.ts, "Change the file's name to
+ * match the latest version name"). So a File carrying several live names is a
+ * rename history that was never retired, and the right name is the one matching
+ * its newest FileVersion. Measured on the production copy 2026-08-20: that name
+ * is present among the competing values for 49 of the 52 conflicting Files.
+ *
+ * Falls back to the most recently WRITTEN name for the other 3, where the latest
+ * version's name is not among the candidates at all. Deliberately not the
+ * alphabetically-first value, and deliberately not the newest name property
+ * everywhere: the newest name agrees with the app's rule in only 30 of the 52,
+ * so using it alone would get 22 of them wrong.
+ */
+const resolveConflict = (
+  rows: readonly RawFileNode[],
+  latestVersionName: string | undefined,
+): { row: RawFileNode; fromVersion: boolean } => {
+  if (latestVersionName != null) {
+    const match = rows.find((row) => row.name === latestVersionName);
+    if (match) return { row: match, fromVersion: true };
+  }
+  // `rows` arrives in the stable rowKey order, and `>` keeps the incumbent, so
+  // a tie on the timestamp still resolves the same way on every run.
+  const newest = rows.reduce((best, row) =>
+    nameWrittenAt(row) > nameWrittenAt(best) ? row : best,
+  );
+  return { row: newest, fromVersion: false };
+};
+
+/**
+ * Collapse the read's fan-out to one row per node — see the docblock.
+ *
+ * Splits the duplicates into two very different populations, because lumping
+ * them together over-reports the problem by 4x. A node with two ACTIVE `parent`
+ * edges pointing at the SAME directory loses nothing when collapsed; a node with
+ * two ACTIVE `name` properties holding DIFFERENT strings loses one of them, for
+ * good. Measured on the production copy 2026-08-20: 164 nodes have duplicate
+ * parent edges and every single one repeats the same target, while 72 have
+ * duplicate names of which 52 genuinely disagree.
+ */
+const collapseFanOut = (raw: readonly RawFileNode[]) => {
+  const groups = new Map<ID, RawFileNode[]>();
+  for (const row of raw) {
+    const held = groups.get(row.id);
+    if (held) held.push(row);
+    else groups.set(row.id, [row]);
+  }
+
+  // A provisional representative for every node, chosen deterministically. Only
+  // needed to build the version index below — a FileVersion can itself be
+  // duplicated, and its own name conflict (if any) is resolved on its own turn.
+  const byRowKey = (a: RawFileNode, b: RawFileNode) =>
+    rowKey(a).localeCompare(rowKey(b));
+  const provisional = [...groups.values()].map((group) =>
+    group.length === 1 ? group[0]! : [...group].sort(byRowKey)[0]!,
+  );
+
+  // Newest FileVersion name per parent File — the value {@link resolveConflict}
+  // prefers. Built from the whole read, not just the conflicting nodes, because
+  // the version that carries the right name is usually not itself in conflict.
+  const latestVersionName = new Map<ID, { name: string; at: number }>();
+  for (const row of provisional) {
+    if (
+      row.type !== 'FileVersion' ||
+      row.parentId == null ||
+      row.name == null
+    ) {
+      continue;
+    }
+    const at = row.createdAt ? row.createdAt.toJSDate().getTime() : 0;
+    const held = latestVersionName.get(row.parentId);
+    if (!held || at > held.at) {
+      latestVersionName.set(row.parentId, { name: row.name, at });
+    }
+  }
+
+  const conflicting: ID[] = [];
+  const namedFromVersion: ID[] = [];
+  let repeated = 0;
+  const nodes: RawFileNode[] = [];
+  for (const [id, group] of groups) {
+    if (group.length === 1) {
+      nodes.push(group[0]!);
+      continue;
+    }
+    const sorted = [...group].sort(byRowKey);
+    if (rowKey(sorted[0]!) === rowKey(sorted.at(-1)!)) {
+      repeated++;
+      nodes.push(sorted[0]!);
+      continue;
+    }
+    conflicting.push(id);
+    const picked = resolveConflict(sorted, latestVersionName.get(id)?.name);
+    if (picked.fromVersion) namedFromVersion.push(id);
+    nodes.push(picked.row);
+  }
+  return { nodes, conflicting, repeated, namedFromVersion };
 };
 
 /**
@@ -209,13 +349,38 @@ export const fileExtractor: Extractor = {
     const raw = await cypher<RawFileNode>(ctx, READ);
     const userIds = await liveTargetIds(ctx, 'User', users);
 
-    const typeless = raw.filter((row) => row.type == null);
+    // Before ANY count is taken — see the fan-out section of the docblock.
+    const { nodes, conflicting, repeated, namedFromVersion } =
+      collapseFanOut(raw);
+    if (repeated > 0) {
+      ctx.log(
+        `    ℹ ${repeated} FileNode(s) carry a duplicate ACTIVE edge whose copies ` +
+          `all agree (the same parent directory named twice, say) — collapsed to ` +
+          `one row, nothing lost.`,
+      );
+    }
+    if (conflicting.length > 0) {
+      const guessed = conflicting.length - namedFromVersion.length;
+      ctx.log(
+        `    ⚠ ${conflicting.length} FileNode(s) hold two or more ACTIVE values ` +
+          `that DISAGREE — a file carrying several live names because an upload ` +
+          `renamed it without retiring the previous name. Postgres stores one ` +
+          `name, so ${namedFromVersion.length} took the name of their newest ` +
+          `FileVersion, which is the rule the app itself applies on upload. The ` +
+          `other ${guessed} had no candidate matching their newest version and ` +
+          `fell back to the most recently written name — those are the guesses. ` +
+          `Ids: ${conflicting.slice(0, 10).join(', ')}` +
+          `${conflicting.length > 10 ? ', …' : ''}`,
+      );
+    }
+
+    const typeless = nodes.filter((row) => row.type == null);
     if (typeless.length > 0) {
       ctx.log(
         `    ⚠ ${typeless.length} FileNode(s) carry none of Directory/File/FileVersion — dropped`,
       );
     }
-    const typed = raw.filter(
+    const typed = nodes.filter(
       (row): row is RawFileNode & { type: NonNullable<RawFileNode['type']> } =>
         row.type != null,
     );
@@ -339,6 +504,11 @@ export const fileExtractor: Extractor = {
     // gap in the reconciliation table. Passing `rows.length` (the post-filter
     // count) would make read equal inserted and print ✓ on a table that shed
     // rows, while the ⚠ lines above said otherwise.
-    return one('file_nodes', raw.length, inserted);
+    //
+    // `nodes.length`, NOT `raw.length`: `inserted` is what Postgres wrote, i.e.
+    // a count of nodes, so `read` has to be nodes too or the subtraction is
+    // between two different units. `raw.length` counted fan-out rows and made
+    // this table report 373 dropped against a real loss of 89.
+    return one('file_nodes', nodes.length, inserted);
   },
 };

--- a/src/core/cutover/extractors/file.extractor.ts
+++ b/src/core/cutover/extractors/file.extractor.ts
@@ -8,6 +8,7 @@ import {
   keepLanded,
   liveTargetIds,
   one,
+  ts,
 } from '../cutover.helpers';
 import { type CutoverContext, type Extractor } from '../cutover.types';
 
@@ -309,7 +310,7 @@ export const fileExtractor: Extractor = {
       size: isVersion(row) ? toNum(row.size) : null,
       // Second pass; see the docblock.
       latestVersionId: null,
-      createdAt: row.createdAt ? row.createdAt.toJSDate() : new Date(0),
+      createdAt: ts(row.createdAt) ?? new Date(0),
       deletedAt: null,
     }));
 

--- a/src/core/cutover/extractors/financial-approver.extractor.ts
+++ b/src/core/cutover/extractors/financial-approver.extractor.ts
@@ -1,0 +1,105 @@
+import { type ID } from '~/common';
+import {
+  financialApprovers,
+  projectTypeEnum,
+  users,
+} from '~/core/drizzle/schema';
+import { type ProjectType } from '../../../components/project/dto/project-type.enum';
+import {
+  bulkInsert,
+  cypher,
+  keepLanded,
+  liveTargetIds,
+  sanitizeEnum,
+  stat,
+} from '../cutover.helpers';
+import { type Extractor, type TableStat } from '../cutover.types';
+
+/**
+ * ProjectTypeFinancialApprover — finance-approver config ("user X approves
+ * finances for project type Y"), read by the project workflow to notify
+ * approvers on financial-plan transitions. Ported, not retired, per Rob
+ * 2026-08-24: without it those notifications silently stop at cutover.
+ *
+ * The source node holds ONLY the projectTypes array — no id, no timestamps —
+ * and is merged one-per-user, so the user id is the row identity (and the
+ * table's primary key). The edge target is matched label-free and classified
+ * in code, so an approver pointing at a soft-deleted or never-landed user is a
+ * logged drop, not a silent Cypher filter.
+ */
+interface Row {
+  userId: ID<'User'>;
+  // Raw from Cypher: a field Neo4j never wrote arrives null, and values are
+  // only trusted after sanitizeEnum — an unrecognised one would otherwise
+  // fail the enum cast and abort the whole load.
+  projectTypes: readonly string[] | null;
+}
+
+export const financialApproverExtractor: Extractor = {
+  name: 'financial-approver',
+  targetTables: ['financial_approvers'],
+  dependsOn: ['user'],
+  async run(ctx) {
+    const out: Record<string, TableStat> = {};
+
+    const landedUsers = await liveTargetIds(ctx, 'User', users);
+
+    const rows = await cypher<Row>(
+      ctx,
+      `MATCH (n:ProjectTypeFinancialApprover)-[:financialApprover { active: true }]->(user)
+       RETURN user.id AS userId, n.projectTypes AS projectTypes`,
+    );
+
+    const kept = keepLanded(rows, [[landedUsers, (row) => row.userId]]);
+    if (kept.skipped > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${kept.skipped} financial approver(s) whose user never landed`,
+      );
+    }
+
+    // Sanitize before the enum cast and the non-empty CHECK get a say — a bad
+    // legacy value or an empty/absent array would abort the whole run here.
+    // An empty list means "no row" (the write path models it as a delete).
+    const usable: Array<{
+      userId: ID<'User'>;
+      projectTypes: readonly [ProjectType, ...ProjectType[]];
+    }> = [];
+    const droppedValues: string[] = [];
+    let droppedEmpty = 0;
+    for (const row of kept.kept) {
+      const types = sanitizeEnum(
+        [...(row.projectTypes ?? [])],
+        projectTypeEnum.enumValues,
+      );
+      droppedValues.push(...types.dropped);
+      const [firstType, ...restTypes] = types.kept;
+      if (firstType === undefined) {
+        droppedEmpty++;
+        continue;
+      }
+      usable.push({
+        userId: row.userId,
+        projectTypes: [firstType, ...restTypes],
+      });
+    }
+    if (droppedValues.length > 0) {
+      ctx.log(
+        `    ⚠ dropped ${droppedValues.length} unrecognised project type value(s): ` +
+          droppedValues.join(', '),
+      );
+    }
+    if (droppedEmpty > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${droppedEmpty} financial approver(s) with no valid project types — ` +
+          `an empty list means no row, matching the write path's delete-on-empty`,
+      );
+    }
+
+    out.financial_approvers = stat(
+      rows.length,
+      await bulkInsert(ctx, financialApprovers, usable),
+    );
+
+    return out;
+  },
+};

--- a/src/core/cutover/extractors/funding-account.extractor.ts
+++ b/src/core/cutover/extractors/funding-account.extractor.ts
@@ -1,0 +1,31 @@
+import { fundingAccounts } from '~/core/drizzle/schema';
+import { type FundingAccount } from '../../../components/funding-account/dto';
+import { FundingAccountRepository } from '../../../components/funding-account/funding-account.repository';
+import { bulkInsert, one, readAllViaRepo, tsReq } from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/** FundingAccount — leaf domain (id, name, accountNumber). */
+export const fundingAccountExtractor: Extractor = {
+  name: 'fundingAccount',
+  targetTables: ['funding_accounts'],
+  async run(ctx) {
+    const dtos = await readAllViaRepo<FundingAccount>(
+      ctx,
+      'FundingAccount',
+      FundingAccountRepository,
+    );
+    const rows = dtos.map((f) => ({
+      id: f.id,
+      name: f.name,
+      accountNumber: f.accountNumber,
+      createdAt: tsReq(f.createdAt),
+      updatedAt: tsReq(f.createdAt),
+      deletedAt: null,
+    }));
+    return one(
+      'funding_accounts',
+      dtos.length,
+      await bulkInsert(ctx, fundingAccounts, rows),
+    );
+  },
+};

--- a/src/core/cutover/extractors/funding-account.extractor.ts
+++ b/src/core/cutover/extractors/funding-account.extractor.ts
@@ -1,23 +1,46 @@
+import { type ID } from '~/common';
 import { fundingAccounts } from '~/core/drizzle/schema';
 import { type FundingAccount } from '../../../components/funding-account/dto';
 import { FundingAccountRepository } from '../../../components/funding-account/funding-account.repository';
-import { bulkInsert, one, readAllViaRepo, tsReq } from '../cutover.helpers';
+import {
+  bulkInsert,
+  cypher,
+  one,
+  readAllViaRepo,
+  tsReq,
+} from '../cutover.helpers';
 import { type Extractor } from '../cutover.types';
 
-/** FundingAccount — leaf domain (id, name, accountNumber). */
+/**
+ * FundingAccount (id, name, accountNumber) + its department-id-block FK —
+ * resolved via the fa→block rel like the partner extractor (audit finding
+ * FUNDINGACCOUNT-1: the column landed with migration 0014, after this
+ * extractor was first written; without it SetDepartmentId's PG join finds
+ * zero rows for every migrated account).
+ */
 export const fundingAccountExtractor: Extractor = {
   name: 'fundingAccount',
   targetTables: ['funding_accounts'],
+  dependsOn: ['departmentIdBlock'],
   async run(ctx) {
     const dtos = await readAllViaRepo<FundingAccount>(
       ctx,
       'FundingAccount',
       FundingAccountRepository,
     );
+
+    const blockPairs = await cypher<{ fid: ID; bid: ID }>(
+      ctx,
+      `MATCH (f:FundingAccount)-[:departmentIdBlock { active: true }]->(b:DepartmentIdBlock)
+       RETURN f.id AS fid, b.id AS bid`,
+    );
+    const blockByAccount = new Map(blockPairs.map((row) => [row.fid, row.bid]));
+
     const rows = dtos.map((f) => ({
       id: f.id,
       name: f.name,
       accountNumber: f.accountNumber,
+      departmentIdBlockId: blockByAccount.get(f.id) ?? null,
       createdAt: tsReq(f.createdAt),
       updatedAt: tsReq(f.createdAt),
       deletedAt: null,

--- a/src/core/cutover/extractors/index.ts
+++ b/src/core/cutover/extractors/index.ts
@@ -5,8 +5,12 @@ import { fieldRegionExtractor } from './field-region.extractor';
 import { fieldZoneExtractor } from './field-zone.extractor';
 import { fundingAccountExtractor } from './funding-account.extractor';
 import { locationExtractor } from './location.extractor';
+import { notificationExtractor } from './notification.extractor';
 import { organizationExtractor } from './organization.extractor';
 import { partnerExtractor } from './partner.extractor';
+import { partnershipExtractor } from './partnership.extractor';
+import { projectMemberExtractor } from './project-member.extractor';
+import { projectExtractor } from './project.extractor';
 import { toolExtractor } from './tool.extractor';
 import { userExtractor } from './user.extractor';
 
@@ -14,8 +18,9 @@ import { userExtractor } from './user.extractor';
  * All firm-domain extractors, in no particular order — the harness
  * topologically sorts by each extractor's `dependsOn`.
  *
- * Covers the domains already merged to develop. Project / Partnership / File
- * (tree) / and the rest of the waves drop in here as they land (see README.md).
+ * Covers the domains already merged to develop. File (tree) / Budget /
+ * Language / Engagement and the rest of the waves drop in here as they land
+ * (see README.md).
  */
 export const extractors: readonly Extractor[] = [
   userExtractor,
@@ -28,4 +33,8 @@ export const extractors: readonly Extractor[] = [
   locationExtractor,
   organizationExtractor,
   partnerExtractor,
+  projectExtractor,
+  projectMemberExtractor,
+  partnershipExtractor,
+  notificationExtractor,
 ];

--- a/src/core/cutover/extractors/index.ts
+++ b/src/core/cutover/extractors/index.ts
@@ -15,6 +15,7 @@ import { mediaExtractor } from './media.extractor';
 import { notificationExtractor } from './notification.extractor';
 import { organizationExtractor } from './organization.extractor';
 import { partnerExtractor } from './partner.extractor';
+import { partnershipProducingMediumExtractor } from './partnership-producing-medium.extractor';
 import { partnershipExtractor } from './partnership.extractor';
 import { periodicReportExtractor } from './periodic-report.extractor';
 import { pinExtractor } from './pin.extractor';
@@ -23,10 +24,13 @@ import { postExtractor } from './post.extractor';
 import { productProgressExtractor } from './product-progress.extractor';
 import { productExtractor } from './product.extractor';
 import { progressReportMediaExtractor } from './progress-report-media.extractor';
+import { progressReportVarianceExplanationExtractor } from './progress-report-variance-explanation.extractor';
+import { progressReportWorkflowEventExtractor } from './progress-report-workflow-event.extractor';
 import { progressSummaryExtractor } from './progress-summary.extractor';
 import { projectMemberExtractor } from './project-member.extractor';
 import { projectExtractor } from './project.extractor';
 import { promptVariantResponseExtractor } from './prompt-variant-response.extractor';
+import { toolUsageExtractor } from './tool-usage.extractor';
 import { toolExtractor } from './tool.extractor';
 import { userExtractor } from './user.extractor';
 
@@ -34,12 +38,12 @@ import { userExtractor } from './user.extractor';
  * All firm-domain extractors, in no particular order — the harness
  * topologically sorts by each extractor's `dependsOn`.
  *
- * Covers every domain merged to develop, File + Media + PnP included.
- *
- * Still outstanding, and NOT writable here: the four tables that exist only on
- * `pg-app-enablement` — `tool_usages`, `progress_report_workflow_events`,
- * `progress_report_variance_explanations`, `partnership_producing_mediums`. Their
- * schema is not in this branch, so an extractor importing it would not compile.
+ * Covers every domain merged to develop, File + Media + PnP included, plus the four
+ * tables that arrive with the app-enablement branch this now sits on:
+ * `tool_usages`, `progress_report_workflow_events`,
+ * `progress_report_variance_explanations` and `partnership_producing_mediums`. Those
+ * four could not be written before — their schema was not in this branch, so an
+ * extractor importing it would not compile.
  *
  * Three tables are intentionally never filled and need no extractor:
  * `auth_sessions` + `auth_password_reset_tokens` (transient — users re-authenticate
@@ -78,4 +82,8 @@ export const extractors: readonly Extractor[] = [
   mediaExtractor,
   pnpExtractionResultExtractor,
   progressReportMediaExtractor,
+  partnershipProducingMediumExtractor,
+  toolUsageExtractor,
+  progressReportVarianceExplanationExtractor,
+  progressReportWorkflowEventExtractor,
 ];

--- a/src/core/cutover/extractors/index.ts
+++ b/src/core/cutover/extractors/index.ts
@@ -1,4 +1,5 @@
 import { type Extractor } from '../cutover.types';
+import { budgetExtractor } from './budget.extractor';
 import { departmentIdBlockExtractor } from './department-id-block.extractor';
 import { ethnologueExtractor } from './ethnologue.extractor';
 import { fieldRegionExtractor } from './field-region.extractor';
@@ -18,8 +19,8 @@ import { userExtractor } from './user.extractor';
  * All firm-domain extractors, in no particular order — the harness
  * topologically sorts by each extractor's `dependsOn`.
  *
- * Covers the domains already merged to develop. File (tree) / Budget /
- * Language / Engagement and the rest of the waves drop in here as they land
+ * Covers the domains already merged to develop. File (tree) / Language /
+ * Engagement and the rest of the waves drop in here as they land
  * (see README.md).
  */
 export const extractors: readonly Extractor[] = [
@@ -37,4 +38,5 @@ export const extractors: readonly Extractor[] = [
   projectMemberExtractor,
   partnershipExtractor,
   notificationExtractor,
+  budgetExtractor,
 ];

--- a/src/core/cutover/extractors/index.ts
+++ b/src/core/cutover/extractors/index.ts
@@ -4,6 +4,7 @@ import { commentExtractor } from './comment.extractor';
 import { departmentIdBlockExtractor } from './department-id-block.extractor';
 import { engagementExtractor } from './engagement.extractor';
 import { ethnologueExtractor } from './ethnologue.extractor';
+import { externalDepartmentIdExtractor } from './external-department-id.extractor';
 import { fieldRegionExtractor } from './field-region.extractor';
 import { fieldZoneExtractor } from './field-zone.extractor';
 import { fileExtractor } from './file.extractor';
@@ -61,6 +62,10 @@ export const extractors: readonly Extractor[] = [
   ethnologueExtractor,
   languageExtractor,
   departmentIdBlockExtractor,
+  // No dependencies in either direction — a flat reservation list. Placed next
+  // to the block extractor because they are read together by the allocator, not
+  // because either needs the other.
+  externalDepartmentIdExtractor,
   fieldZoneExtractor,
   fieldRegionExtractor,
   locationExtractor,

--- a/src/core/cutover/extractors/index.ts
+++ b/src/core/cutover/extractors/index.ts
@@ -1,11 +1,13 @@
 import { type Extractor } from '../cutover.types';
 import { budgetExtractor } from './budget.extractor';
+import { commentExtractor } from './comment.extractor';
 import { departmentIdBlockExtractor } from './department-id-block.extractor';
 import { engagementExtractor } from './engagement.extractor';
 import { ethnologueExtractor } from './ethnologue.extractor';
 import { fieldRegionExtractor } from './field-region.extractor';
 import { fieldZoneExtractor } from './field-zone.extractor';
 import { fundingAccountExtractor } from './funding-account.extractor';
+import { knownLanguageExtractor } from './known-language.extractor';
 import { languageExtractor } from './language.extractor';
 import { locationExtractor } from './location.extractor';
 import { notificationExtractor } from './notification.extractor';
@@ -13,6 +15,8 @@ import { organizationExtractor } from './organization.extractor';
 import { partnerExtractor } from './partner.extractor';
 import { partnershipExtractor } from './partnership.extractor';
 import { periodicReportExtractor } from './periodic-report.extractor';
+import { pinExtractor } from './pin.extractor';
+import { postExtractor } from './post.extractor';
 import { productProgressExtractor } from './product-progress.extractor';
 import { productExtractor } from './product.extractor';
 import { progressSummaryExtractor } from './progress-summary.extractor';
@@ -26,8 +30,10 @@ import { userExtractor } from './user.extractor';
  * All firm-domain extractors, in no particular order — the harness
  * topologically sorts by each extractor's `dependsOn`.
  *
- * Covers the domains already merged to develop. File (tree) / Engagement and
- * the rest of the waves drop in here as they land (see README.md).
+ * Covers the domains already merged to develop. File + Media is the remaining
+ * wave (it wants its own pass — see README.md), plus extractors for
+ * ProgressReportWorkflowEvent / VarianceExplanation once those domains have
+ * Postgres tables.
  */
 export const extractors: readonly Extractor[] = [
   userExtractor,
@@ -52,4 +58,8 @@ export const extractors: readonly Extractor[] = [
   progressSummaryExtractor,
   notificationExtractor,
   budgetExtractor,
+  pinExtractor,
+  knownLanguageExtractor,
+  commentExtractor,
+  postExtractor,
 ];

--- a/src/core/cutover/extractors/index.ts
+++ b/src/core/cutover/extractors/index.ts
@@ -1,0 +1,31 @@
+import { type Extractor } from '../cutover.types';
+import { departmentIdBlockExtractor } from './department-id-block.extractor';
+import { ethnologueExtractor } from './ethnologue.extractor';
+import { fieldRegionExtractor } from './field-region.extractor';
+import { fieldZoneExtractor } from './field-zone.extractor';
+import { fundingAccountExtractor } from './funding-account.extractor';
+import { locationExtractor } from './location.extractor';
+import { organizationExtractor } from './organization.extractor';
+import { partnerExtractor } from './partner.extractor';
+import { toolExtractor } from './tool.extractor';
+import { userExtractor } from './user.extractor';
+
+/**
+ * All firm-domain extractors, in no particular order — the harness
+ * topologically sorts by each extractor's `dependsOn`.
+ *
+ * Covers the domains already merged to develop. Project / Partnership / File
+ * (tree) / and the rest of the waves drop in here as they land (see README.md).
+ */
+export const extractors: readonly Extractor[] = [
+  userExtractor,
+  toolExtractor,
+  fundingAccountExtractor,
+  ethnologueExtractor,
+  departmentIdBlockExtractor,
+  fieldZoneExtractor,
+  fieldRegionExtractor,
+  locationExtractor,
+  organizationExtractor,
+  partnerExtractor,
+];

--- a/src/core/cutover/extractors/index.ts
+++ b/src/core/cutover/extractors/index.ts
@@ -12,6 +12,7 @@ import { notificationExtractor } from './notification.extractor';
 import { organizationExtractor } from './organization.extractor';
 import { partnerExtractor } from './partner.extractor';
 import { partnershipExtractor } from './partnership.extractor';
+import { productExtractor } from './product.extractor';
 import { projectMemberExtractor } from './project-member.extractor';
 import { projectExtractor } from './project.extractor';
 import { toolExtractor } from './tool.extractor';
@@ -40,6 +41,7 @@ export const extractors: readonly Extractor[] = [
   projectMemberExtractor,
   partnershipExtractor,
   engagementExtractor,
+  productExtractor,
   notificationExtractor,
   budgetExtractor,
 ];

--- a/src/core/cutover/extractors/index.ts
+++ b/src/core/cutover/extractors/index.ts
@@ -7,6 +7,7 @@ import { ethnologueExtractor } from './ethnologue.extractor';
 import { fieldRegionExtractor } from './field-region.extractor';
 import { fieldZoneExtractor } from './field-zone.extractor';
 import { fileExtractor } from './file.extractor';
+import { financialApproverExtractor } from './financial-approver.extractor';
 import { fundingAccountExtractor } from './funding-account.extractor';
 import { knownLanguageExtractor } from './known-language.extractor';
 import { languageExtractor } from './language.extractor';
@@ -69,6 +70,7 @@ export const extractors: readonly Extractor[] = [
   projectMemberExtractor,
   partnershipExtractor,
   engagementExtractor,
+  financialApproverExtractor,
   productExtractor,
   periodicReportExtractor,
   promptVariantResponseExtractor,

--- a/src/core/cutover/extractors/index.ts
+++ b/src/core/cutover/extractors/index.ts
@@ -32,6 +32,7 @@ import { projectExtractor } from './project.extractor';
 import { promptVariantResponseExtractor } from './prompt-variant-response.extractor';
 import { toolUsageExtractor } from './tool-usage.extractor';
 import { toolExtractor } from './tool.extractor';
+import { userLocationExtractor } from './user-location.extractor';
 import { userExtractor } from './user.extractor';
 
 /**
@@ -53,6 +54,7 @@ import { userExtractor } from './user.extractor';
  */
 export const extractors: readonly Extractor[] = [
   userExtractor,
+  userLocationExtractor,
   toolExtractor,
   fundingAccountExtractor,
   ethnologueExtractor,

--- a/src/core/cutover/extractors/index.ts
+++ b/src/core/cutover/extractors/index.ts
@@ -1,10 +1,12 @@
 import { type Extractor } from '../cutover.types';
 import { budgetExtractor } from './budget.extractor';
 import { departmentIdBlockExtractor } from './department-id-block.extractor';
+import { engagementExtractor } from './engagement.extractor';
 import { ethnologueExtractor } from './ethnologue.extractor';
 import { fieldRegionExtractor } from './field-region.extractor';
 import { fieldZoneExtractor } from './field-zone.extractor';
 import { fundingAccountExtractor } from './funding-account.extractor';
+import { languageExtractor } from './language.extractor';
 import { locationExtractor } from './location.extractor';
 import { notificationExtractor } from './notification.extractor';
 import { organizationExtractor } from './organization.extractor';
@@ -19,15 +21,15 @@ import { userExtractor } from './user.extractor';
  * All firm-domain extractors, in no particular order — the harness
  * topologically sorts by each extractor's `dependsOn`.
  *
- * Covers the domains already merged to develop. File (tree) / Language /
- * Engagement and the rest of the waves drop in here as they land
- * (see README.md).
+ * Covers the domains already merged to develop. File (tree) / Engagement and
+ * the rest of the waves drop in here as they land (see README.md).
  */
 export const extractors: readonly Extractor[] = [
   userExtractor,
   toolExtractor,
   fundingAccountExtractor,
   ethnologueExtractor,
+  languageExtractor,
   departmentIdBlockExtractor,
   fieldZoneExtractor,
   fieldRegionExtractor,
@@ -37,6 +39,7 @@ export const extractors: readonly Extractor[] = [
   projectExtractor,
   projectMemberExtractor,
   partnershipExtractor,
+  engagementExtractor,
   notificationExtractor,
   budgetExtractor,
 ];

--- a/src/core/cutover/extractors/index.ts
+++ b/src/core/cutover/extractors/index.ts
@@ -12,9 +12,13 @@ import { notificationExtractor } from './notification.extractor';
 import { organizationExtractor } from './organization.extractor';
 import { partnerExtractor } from './partner.extractor';
 import { partnershipExtractor } from './partnership.extractor';
+import { periodicReportExtractor } from './periodic-report.extractor';
+import { productProgressExtractor } from './product-progress.extractor';
 import { productExtractor } from './product.extractor';
+import { progressSummaryExtractor } from './progress-summary.extractor';
 import { projectMemberExtractor } from './project-member.extractor';
 import { projectExtractor } from './project.extractor';
+import { promptVariantResponseExtractor } from './prompt-variant-response.extractor';
 import { toolExtractor } from './tool.extractor';
 import { userExtractor } from './user.extractor';
 
@@ -42,6 +46,10 @@ export const extractors: readonly Extractor[] = [
   partnershipExtractor,
   engagementExtractor,
   productExtractor,
+  periodicReportExtractor,
+  promptVariantResponseExtractor,
+  productProgressExtractor,
+  progressSummaryExtractor,
   notificationExtractor,
   budgetExtractor,
 ];

--- a/src/core/cutover/extractors/index.ts
+++ b/src/core/cutover/extractors/index.ts
@@ -6,19 +6,23 @@ import { engagementExtractor } from './engagement.extractor';
 import { ethnologueExtractor } from './ethnologue.extractor';
 import { fieldRegionExtractor } from './field-region.extractor';
 import { fieldZoneExtractor } from './field-zone.extractor';
+import { fileExtractor } from './file.extractor';
 import { fundingAccountExtractor } from './funding-account.extractor';
 import { knownLanguageExtractor } from './known-language.extractor';
 import { languageExtractor } from './language.extractor';
 import { locationExtractor } from './location.extractor';
+import { mediaExtractor } from './media.extractor';
 import { notificationExtractor } from './notification.extractor';
 import { organizationExtractor } from './organization.extractor';
 import { partnerExtractor } from './partner.extractor';
 import { partnershipExtractor } from './partnership.extractor';
 import { periodicReportExtractor } from './periodic-report.extractor';
 import { pinExtractor } from './pin.extractor';
+import { pnpExtractionResultExtractor } from './pnp-extraction-result.extractor';
 import { postExtractor } from './post.extractor';
 import { productProgressExtractor } from './product-progress.extractor';
 import { productExtractor } from './product.extractor';
+import { progressReportMediaExtractor } from './progress-report-media.extractor';
 import { progressSummaryExtractor } from './progress-summary.extractor';
 import { projectMemberExtractor } from './project-member.extractor';
 import { projectExtractor } from './project.extractor';
@@ -30,10 +34,18 @@ import { userExtractor } from './user.extractor';
  * All firm-domain extractors, in no particular order — the harness
  * topologically sorts by each extractor's `dependsOn`.
  *
- * Covers the domains already merged to develop. File + Media is the remaining
- * wave (it wants its own pass — see README.md), plus extractors for
- * ProgressReportWorkflowEvent / VarianceExplanation once those domains have
- * Postgres tables.
+ * Covers every domain merged to develop, File + Media + PnP included.
+ *
+ * Still outstanding, and NOT writable here: the four tables that exist only on
+ * `pg-app-enablement` — `tool_usages`, `progress_report_workflow_events`,
+ * `progress_report_variance_explanations`, `partnership_producing_mediums`. Their
+ * schema is not in this branch, so an extractor importing it would not compile.
+ *
+ * Three tables are intentionally never filled and need no extractor:
+ * `auth_sessions` + `auth_password_reset_tokens` (transient — users re-authenticate
+ * post-cutover, see README) and `resource_mutations` (the audit log is a
+ * Postgres-only surface with no Neo4j counterpart to read; it starts empty and
+ * accumulates from the first mutation after the flip).
  */
 export const extractors: readonly Extractor[] = [
   userExtractor,
@@ -62,4 +74,8 @@ export const extractors: readonly Extractor[] = [
   knownLanguageExtractor,
   commentExtractor,
   postExtractor,
+  fileExtractor,
+  mediaExtractor,
+  pnpExtractionResultExtractor,
+  progressReportMediaExtractor,
 ];

--- a/src/core/cutover/extractors/known-language.extractor.ts
+++ b/src/core/cutover/extractors/known-language.extractor.ts
@@ -12,6 +12,7 @@ import {
   liveTargetIds,
   one,
   sanitizeEnum,
+  ts,
   warnIfRelTypeUnknown,
 } from '../cutover.helpers';
 import { type Extractor } from '../cutover.types';
@@ -91,7 +92,7 @@ export const knownLanguageExtractor: Extractor = {
           userId: row.userId,
           languageId: row.languageId,
           proficiency: proficiency.kept[0],
-          createdAt: row.createdAt ? new Date(row.createdAt) : new Date(),
+          createdAt: ts(row.createdAt) ?? new Date(),
         },
       ];
     });

--- a/src/core/cutover/extractors/known-language.extractor.ts
+++ b/src/core/cutover/extractors/known-language.extractor.ts
@@ -1,0 +1,111 @@
+import { type ID } from '~/common';
+import {
+  knownLanguages,
+  languageProficiencyEnum,
+  languages,
+  users,
+} from '~/core/drizzle/schema';
+import {
+  bulkInsert,
+  cypher,
+  keepLanded,
+  liveTargetIds,
+  one,
+  sanitizeEnum,
+  warnIfRelTypeUnknown,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * KnownLanguages — which languages a user knows, at what proficiency.
+ *
+ * Edge-stored like pins, but with the proficiency ON the edge:
+ * `(:User)-[:knownLanguage { active, createdAt, value }]->(:Language)`, where
+ * `value` is the proficiency. There is no node to enumerate.
+ *
+ * ⚠ **This domain has ZERO edges in the local graph — the rel type is not even in
+ * `db.relationshipTypes()`.** So a correct query and a typo'd one produce
+ * byte-identical output, and reconciliation says `0 == 0 == 0 ✓` either way. The
+ * rel-type guard is the only thing standing between those two outcomes here, which
+ * is precisely why it was added. The type name is taken from
+ * KnownLanguageRepository.create, not guessed.
+ *
+ * Unlike pins, the edge DOES carry `active` — removal deactivates rather than
+ * deletes (KnownLanguageRepository.delete sets `rel.active = false`), so the
+ * filter is load-bearing: without it, every proficiency a user ever had would be
+ * migrated as current.
+ *
+ * The PK spans all three columns because a user may legitimately know one language
+ * at more than one proficiency — the Neo4j create only replaces the exact
+ * (user, language, proficiency) edge.
+ */
+export const knownLanguageExtractor: Extractor = {
+  name: 'known-language',
+  targetTables: ['known_languages'],
+  dependsOn: ['user', 'language'],
+  async run(ctx) {
+    const rows = await cypher<{
+      userId: ID<'User'>;
+      languageId: ID<'Language'>;
+      proficiency: string | null;
+      createdAt: string | null;
+    }>(
+      ctx,
+      `MATCH (user:User)-[rel:knownLanguage { active: true }]->(language:Language)
+       RETURN user.id AS userId, language.id AS languageId,
+              rel.value AS proficiency, toString(rel.createdAt) AS createdAt`,
+    );
+    if (rows.length === 0) {
+      await warnIfRelTypeUnknown(ctx, 'knownLanguage');
+    }
+
+    const landedUsers = await liveTargetIds(ctx, 'User', users);
+    const landedLanguages = await liveTargetIds(ctx, 'Language', languages);
+    const kept = keepLanded(rows, [
+      [landedUsers, (row) => row.userId],
+      [landedLanguages, (row) => row.languageId],
+    ]);
+    if (kept.skipped > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${kept.skipped} known-language row(s) whose user or language never landed ` +
+          `(both FKs) — language drops are the unique-dup cascade, see README finding #6`,
+      );
+    }
+
+    const seen = new Set<string>();
+    const droppedProficiencies = new Set<string>();
+    const values = kept.kept.flatMap((row) => {
+      const proficiency = sanitizeEnum(
+        [String(row.proficiency)],
+        languageProficiencyEnum.enumValues,
+      );
+      if (!proficiency.kept[0]) {
+        droppedProficiencies.add(String(row.proficiency));
+        return [];
+      }
+      const key = `${row.userId}::${row.languageId}::${proficiency.kept[0]}`;
+      if (seen.has(key)) return [];
+      seen.add(key);
+      return [
+        {
+          userId: row.userId,
+          languageId: row.languageId,
+          proficiency: proficiency.kept[0],
+          createdAt: row.createdAt ? new Date(row.createdAt) : new Date(),
+        },
+      ];
+    });
+    if (droppedProficiencies.size > 0) {
+      ctx.log(
+        `    ⚠ DROPPED row(s) with a proficiency outside the language_proficiency enum: ` +
+          `${[...droppedProficiencies].join(', ')} — migration-todo: map, don't drop`,
+      );
+    }
+
+    return one(
+      'known_languages',
+      rows.length,
+      await bulkInsert(ctx, knownLanguages, values),
+    );
+  },
+};

--- a/src/core/cutover/extractors/language.extractor.ts
+++ b/src/core/cutover/extractors/language.extractor.ts
@@ -1,0 +1,197 @@
+import { eq, inArray } from 'drizzle-orm';
+import { type ID } from '~/common';
+import { ethnologueLanguages, languages } from '~/core/drizzle/schema';
+import { type Language } from '../../../components/language/dto';
+import { LanguageRepository } from '../../../components/language/language.repository';
+import {
+  bulkInsert,
+  dateStr,
+  orDefault,
+  readAllViaRepo,
+  stat,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * Language — the FK root for Engagement, and the wave that closes the
+ * `ethnologue_languages.language_id` deferral the ethnologue extractor left
+ * open (its comment points here).
+ *
+ * Only STORED columns are written. `presetInventory`, `usesAIAssistance`,
+ * `firstScriptureEngagement` and `effectiveSensitivity` all appear on the
+ * hydrated DTO but are DERIVED from engaged projects at read time and have no
+ * column — writing them would invent state.
+ *
+ * `sensitivity` is the user-settable column, NOT the computed one. The Neo4j
+ * hydrate merges `props`, so `dto.sensitivity` is the stored property;
+ * `effectiveSensitivity` is a separate DTO field the hydrate computes in a
+ * subquery. Getting these backwards would silently overwrite each language's
+ * own setting with the lowest sensitivity across its projects.
+ *
+ * ⚠ `--only=language` ALONE IS UNSAFE. The harness truncates target tables with
+ * CASCADE, and `ethnologue_languages.language_id` references `languages.id`, so
+ * truncating `languages` truncates the ethnologue rows this wave then wants to
+ * backfill. Use `--only=ethnologue,language`.
+ */
+export const languageExtractor: Extractor = {
+  name: 'language',
+  targetTables: ['languages'],
+  dependsOn: ['ethnologue'],
+  async run(ctx) {
+    const dtos = await readAllViaRepo<Language>(
+      ctx,
+      'Language',
+      LanguageRepository,
+    );
+
+    // NOT NULL guard (prod-finding #1 class: null-in-NOT-NULL). `name` and
+    // `displayName` are NOT NULL with no schema default, and Language is an FK
+    // PARENT of engagements — dropping a row here would orphan real work. So
+    // fall back to the sibling name field (one of the pair is almost always
+    // present), and only as a last resort to the id, which is visible in the UI
+    // and trivially correctable by a data fix. Never silent.
+    let namesFilled = 0;
+    let idFallbacks = 0;
+    const nameOf = (
+      primary: string | null | undefined,
+      sibling: string | null | undefined,
+      id: ID,
+    ): string => {
+      if (primary) return primary;
+      namesFilled++;
+      if (sibling) return sibling;
+      idFallbacks++;
+      return id;
+    };
+
+    const rows = dtos.map((lang) => ({
+      id: lang.id,
+      name: nameOf(lang.name, lang.displayName, lang.id),
+      displayName: nameOf(lang.displayName, lang.name, lang.id),
+      displayNamePronunciation: lang.displayNamePronunciation ?? null,
+      // Stored value — see the docblock. NOT effectiveSensitivity.
+      sensitivity: orDefault(lang.sensitivity, 'High'),
+      isDialect: orDefault(lang.isDialect, false),
+      populationOverride: lang.populationOverride ?? null,
+      registryOfLanguageVarietiesCode:
+        lang.registryOfLanguageVarietiesCode ?? null,
+      leastOfThese: orDefault(lang.leastOfThese, false),
+      leastOfTheseReason: lang.leastOfTheseReason ?? null,
+      isSignLanguage: orDefault(lang.isSignLanguage, false),
+      signLanguageCode: lang.signLanguageCode ?? null,
+      sponsorEstimatedEndDate: dateStr(lang.sponsorEstimatedEndDate),
+      hasExternalFirstScripture: orDefault(
+        lang.hasExternalFirstScripture,
+        false,
+      ),
+      tags: lang.tags ? [...lang.tags] : [],
+      isAvailableForReporting: orDefault(lang.isAvailableForReporting, false),
+      createdAt: tsReq(lang.createdAt),
+      // Language carries no modifiedAt (Resource gives only createdAt), so
+      // updatedAt mirrors it — same as fieldZone/fieldRegion/location.
+      updatedAt: tsReq(lang.createdAt),
+      deletedAt: null,
+    }));
+    if (namesFilled > 0) {
+      ctx.log(
+        `    ⚠ ${namesFilled} language name/displayName value(s) were null under a NOT NULL column — ` +
+          `filled from the sibling field` +
+          (idFallbacks > 0
+            ? `, and ${idFallbacks} from the id because BOTH were null (needs a data fix)`
+            : ''),
+      );
+    }
+
+    // Unique-dup pre-warning (prod-finding #3 class). Three partial uniques
+    // scope to live rows, and every row this wave writes is live — so any
+    // duplicate among them is silently swallowed by onConflictDoNothing and the
+    // reconciliation count alone won't say which. Surface it before inserting.
+    for (const [label, key] of [
+      ['name', (r: (typeof rows)[number]) => r.name],
+      ['displayName', (r: (typeof rows)[number]) => r.displayName],
+      [
+        'registryOfLanguageVarietiesCode',
+        (r: (typeof rows)[number]) => r.registryOfLanguageVarietiesCode,
+      ],
+    ] as const) {
+      const seen = new Map<string, ID>();
+      const collisions: string[] = [];
+      for (const row of rows) {
+        const value = key(row);
+        if (value == null) continue;
+        const first = seen.get(value);
+        if (first) collisions.push(`${row.id} (dup of ${first})`);
+        else seen.set(value, row.id);
+      }
+      if (collisions.length > 0) {
+        ctx.log(
+          `    ⚠ ${collisions.length} language(s) collide on the ${label} live-unique index and will be ` +
+            `DROPPED by onConflictDoNothing: ${collisions.slice(0, 10).join(', ')}` +
+            (collisions.length > 10 ? ', …' : ''),
+        );
+      }
+    }
+
+    const inserted = await bulkInsert(ctx, languages, rows);
+
+    // Pass 2 — close the ethnologue deferral. The FK lives on the OTHER table
+    // (ethnologue_languages.language_id), which the ethnologue extractor owns,
+    // so this is an UPDATE and `ethnologue_languages` is deliberately NOT in
+    // targetTables: declaring it would truncate it twice and double-count it in
+    // reconciliation. The extra stat key below is logged but not reconciled.
+    let linked = 0;
+    let danglingEthnologue = 0;
+    const pairs = dtos.flatMap((lang) => {
+      const ethId = lang.ethnologue?.id;
+      return ethId ? [{ languageId: lang.id, ethId }] : [];
+    });
+    if (!ctx.dryRun && pairs.length > 0) {
+      // Only target ethnologue rows that actually landed, and languages that
+      // actually landed — either side can be missing via onConflictDoNothing.
+      const presentEth = new Set(
+        (
+          await ctx.db
+            .select({ id: ethnologueLanguages.id })
+            .from(ethnologueLanguages)
+            .where(
+              inArray(
+                ethnologueLanguages.id,
+                pairs.map((p) => p.ethId),
+              ),
+            )
+        ).map((row) => row.id),
+      );
+      const presentLangs = new Set(
+        (await ctx.db.select({ id: languages.id }).from(languages)).map(
+          (row) => row.id,
+        ),
+      );
+      for (const pair of pairs) {
+        if (!presentEth.has(pair.ethId) || !presentLangs.has(pair.languageId)) {
+          danglingEthnologue++;
+          continue;
+        }
+        await ctx.db
+          .update(ethnologueLanguages)
+          .set({ languageId: pair.languageId })
+          .where(eq(ethnologueLanguages.id, pair.ethId));
+        linked++;
+      }
+      if (danglingEthnologue > 0) {
+        ctx.log(
+          `    ⚠ ${danglingEthnologue} ethnologue↔language link(s) skipped — one side never landed`,
+        );
+      }
+    }
+
+    return {
+      languages: stat(dtos.length, inserted),
+      // Not a target table — reported for visibility, not reconciled.
+      'ethnologue_languages.language_id (backfill)': stat(
+        pairs.length,
+        ctx.dryRun ? 0 : linked,
+      ),
+    };
+  },
+};

--- a/src/core/cutover/extractors/language.extractor.ts
+++ b/src/core/cutover/extractors/language.extractor.ts
@@ -103,13 +103,18 @@ export const languageExtractor: Extractor = {
       );
     }
 
-    // Unique-dup pre-warning (prod-finding #3 class). Three partial uniques
-    // scope to live rows, and every row this wave writes is live — so any
-    // duplicate among them is silently swallowed by onConflictDoNothing and the
-    // reconciliation count alone won't say which. Surface it before inserting.
+    // Unique-dup pre-warning (prod-finding #3 class). The ROLV code is the one
+    // remaining partial unique on this table, it scopes to live rows, and every
+    // row this wave writes is live — so a duplicate among them is silently
+    // swallowed by onConflictDoNothing and the reconciliation count alone won't
+    // say which. Surface it before inserting.
+    //
+    // `name` and `displayName` were checked here too until migration 0030 dropped
+    // their unique indexes. Leaving them in printed "19 language(s) … will be
+    // DROPPED" on every run while all 69 loaded fine — a warning that is not true
+    // is worse than no warning, because it teaches the reader to skim the ⚠ lines
+    // that are.
     for (const [label, key] of [
-      ['name', (r: (typeof rows)[number]) => r.name],
-      ['displayName', (r: (typeof rows)[number]) => r.displayName],
       [
         'registryOfLanguageVarietiesCode',
         (r: (typeof rows)[number]) => r.registryOfLanguageVarietiesCode,

--- a/src/core/cutover/extractors/language.extractor.ts
+++ b/src/core/cutover/extractors/language.extractor.ts
@@ -1,11 +1,20 @@
 import { eq, inArray } from 'drizzle-orm';
 import { type ID } from '~/common';
-import { ethnologueLanguages, languages } from '~/core/drizzle/schema';
+import {
+  ethnologueLanguages,
+  languageLocations,
+  languages,
+  locations,
+} from '~/core/drizzle/schema';
 import { type Language } from '../../../components/language/dto';
 import { LanguageRepository } from '../../../components/language/language.repository';
 import {
   bulkInsert,
+  cypher,
   dateStr,
+  keepLanded,
+  liveTargetIds,
+  one,
   orDefault,
   readAllViaRepo,
   stat,
@@ -32,12 +41,12 @@ import { type Extractor } from '../cutover.types';
  * ⚠ `--only=language` ALONE IS UNSAFE. The harness truncates target tables with
  * CASCADE, and `ethnologue_languages.language_id` references `languages.id`, so
  * truncating `languages` truncates the ethnologue rows this wave then wants to
- * backfill. Use `--only=ethnologue,language`.
+ * backfill. Use `--only=ethnologue,location,language`.
  */
 export const languageExtractor: Extractor = {
   name: 'language',
-  targetTables: ['languages'],
-  dependsOn: ['ethnologue'],
+  targetTables: ['languages', 'language_locations'],
+  dependsOn: ['ethnologue', 'location'],
   async run(ctx) {
     const dtos = await readAllViaRepo<Language>(
       ctx,
@@ -190,8 +199,33 @@ export const languageExtractor: Extractor = {
       }
     }
 
+    // ── language_locations ─────────────────────────────────────────────────
+    // Mirrors organization.extractor.ts's `organization_locations` junction —
+    // same relationship name (`locations`), same landed-both-sides guard.
+    const locPairs = await cypher<{ languageId: ID; locationId: ID }>(
+      ctx,
+      `MATCH (lang:Language)-[:locations { active: true }]->(l:Location)
+       RETURN lang.id AS languageId, l.id AS locationId`,
+    );
+    const landedLanguages = await liveTargetIds(ctx, 'Language', languages);
+    const landedLocations = await liveTargetIds(ctx, 'Location', locations);
+    const locRows = keepLanded(locPairs, [
+      [landedLanguages, (row) => row.languageId],
+      [landedLocations, (row) => row.locationId],
+    ]);
+    if (locRows.skipped > 0) {
+      ctx.log(
+        `    ⚠ skipped ${locRows.skipped} language_locations row(s) — language or location never landed`,
+      );
+    }
+
     return {
       languages: stat(dtos.length, inserted),
+      ...one(
+        'language_locations',
+        locPairs.length,
+        await bulkInsert(ctx, languageLocations, locRows.kept),
+      ),
       // Not a target table — reported for visibility, not reconciled.
       'ethnologue_languages.language_id (backfill)': stat(
         pairs.length,

--- a/src/core/cutover/extractors/location.extractor.ts
+++ b/src/core/cutover/extractors/location.extractor.ts
@@ -46,7 +46,9 @@ export const locationExtractor: Extractor = {
     // Pass 2: self-ref marketing region. Guard against targets that aren't
     // actually in the table — a live location can point at a soft-deleted
     // marketing region, OR its row was dropped by onConflictDoNothing on a
-    // UNIQUE (dup name/iso) conflict. Query the present ids, not the read set.
+    // UNIQUE conflict. Only `name` can conflict now: migration 0030 dropped the
+    // iso_alpha3 unique, which is what the 9 local drops used to be. Query the
+    // present ids, not the read set.
     // See README "Dangling references & dropped rows".
     if (!ctx.dryRun) {
       const migrated = new Set(

--- a/src/core/cutover/extractors/location.extractor.ts
+++ b/src/core/cutover/extractors/location.extractor.ts
@@ -1,0 +1,78 @@
+import { eq } from 'drizzle-orm';
+import { locations } from '~/core/drizzle/schema';
+import { type Location } from '../../../components/location/dto';
+import { LocationRepository } from '../../../components/location/location.repository';
+import {
+  bulkInsert,
+  linkId,
+  readAllViaRepo,
+  stat,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * Location — (name, type, isoAlpha3, fundingAccount, defaultFieldRegion,
+ * defaultMarketingRegion→self, mapImage). `mapImageId` is plain text (no FK).
+ *
+ * `defaultMarketingRegionId` is a self-FK, so it's set in a second UPDATE pass
+ * after all rows exist (avoids insert-order violations).
+ */
+export const locationExtractor: Extractor = {
+  name: 'location',
+  targetTables: ['locations'],
+  dependsOn: ['fundingAccount', 'fieldRegion'],
+  async run(ctx) {
+    const dtos = await readAllViaRepo<Location>(
+      ctx,
+      'Location',
+      LocationRepository,
+    );
+    const rows = dtos.map((l) => ({
+      id: l.id,
+      name: l.name,
+      type: l.type,
+      isoAlpha3: l.isoAlpha3 ?? null,
+      fundingAccountId: linkId(l.fundingAccount),
+      defaultFieldRegionId: linkId(l.defaultFieldRegion),
+      defaultMarketingRegionId: null,
+      mapImageId: linkId(l.mapImage),
+      createdAt: tsReq(l.createdAt),
+      updatedAt: tsReq(l.createdAt),
+      deletedAt: null,
+    }));
+    const inserted = await bulkInsert(ctx, locations, rows);
+
+    // Pass 2: self-ref marketing region. Guard against targets that aren't
+    // actually in the table — a live location can point at a soft-deleted
+    // marketing region, OR its row was dropped by onConflictDoNothing on a
+    // UNIQUE (dup name/iso) conflict. Query the present ids, not the read set.
+    // See README "Dangling references & dropped rows".
+    if (!ctx.dryRun) {
+      const migrated = new Set(
+        (await ctx.db.select({ id: locations.id }).from(locations)).map(
+          (r) => r.id,
+        ),
+      );
+      let dangling = 0;
+      for (const l of dtos) {
+        const mkt = linkId(l.defaultMarketingRegion);
+        if (!mkt) continue;
+        if (!migrated.has(mkt)) {
+          dangling++;
+          continue;
+        }
+        await ctx.db
+          .update(locations)
+          .set({ defaultMarketingRegionId: mkt })
+          .where(eq(locations.id, l.id));
+      }
+      if (dangling > 0) {
+        ctx.log(
+          `    ⚠ ${dangling} location(s) had a dangling defaultMarketingRegion — left null`,
+        );
+      }
+    }
+    return { locations: stat(dtos.length, inserted) };
+  },
+};

--- a/src/core/cutover/extractors/media.extractor.ts
+++ b/src/core/cutover/extractors/media.extractor.ts
@@ -6,6 +6,7 @@ import {
   keepLanded,
   liveTargetIds,
   one,
+  ts,
   warnIfRelTypeUnknown,
 } from '../cutover.helpers';
 import { type Extractor } from '../cutover.types';
@@ -149,7 +150,7 @@ export const mediaExtractor: Extractor = {
       width: row.width ?? null,
       height: row.height ?? null,
       duration: row.duration ?? null,
-      createdAt: row.createdAt ? row.createdAt.toJSDate() : new Date(0),
+      createdAt: ts(row.createdAt) ?? new Date(0),
     }));
 
     const inserted = await bulkInsert(ctx, media, rows);

--- a/src/core/cutover/extractors/media.extractor.ts
+++ b/src/core/cutover/extractors/media.extractor.ts
@@ -154,6 +154,8 @@ export const mediaExtractor: Extractor = {
     }));
 
     const inserted = await bulkInsert(ctx, media, rows);
-    return one('media', rows.length, inserted);
+    // PRE-drop count, so the unlanded-file-version, unknown-type and mimeless
+    // drops above show as a read-vs-inserted gap rather than reconciling ✓.
+    return one('media', raw.length, inserted);
   },
 };

--- a/src/core/cutover/extractors/media.extractor.ts
+++ b/src/core/cutover/extractors/media.extractor.ts
@@ -1,0 +1,158 @@
+import { type ID } from '~/common';
+import { fileNodes, media } from '~/core/drizzle/schema';
+import {
+  bulkInsert,
+  cypher,
+  keepLanded,
+  liveTargetIds,
+  one,
+  warnIfRelTypeUnknown,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * Media — the image/video/audio metadata hanging off a FileVersion.
+ *
+ * Read raw rather than through `MediaRepository.readMany`: that method's
+ * `hydrate()` (media.repository.ts:48-78) attaches a required
+ * `MATCH (resource:BaseNode)-[rel]->(root)` to resolve `attachedTo`, which is a
+ * GraphQL concern the table does not store — and a Media whose root directory is
+ * not attached to anything would drop out of the read while still needing to
+ * migrate.
+ *
+ * Unlike almost every other edge in the graph, `[:media]` carries **no `active`
+ * flag** — the read path matches it bare (`relation('out', '', 'media')`), so this
+ * query must not filter on one either. Filtering would return zero rows and
+ * reconcile as a clean ✓.
+ *
+ * Media properties are denormalized directly onto the node (no Property nodes),
+ * because `save()` writes them with `setValues({ node: … })`.
+ *
+ * `mime_type` is NOT NULL here but is only written when the caller supplies a
+ * `__typename`, so older rows can lack it. Rather than drop those, fall back to
+ * the owning FileVersion's own `mimeType` Property — the same value the upload
+ * recorded, and the reason a Media exists at all.
+ */
+
+interface RawMedia {
+  id: ID;
+  type: string | null;
+  fileVersionId: ID;
+  mimeType: string | null;
+  fallbackMimeType: string | null;
+  altText: string | null;
+  caption: string | null;
+  width: number | null;
+  height: number | null;
+  duration: number | null;
+  createdAt: { toJSDate: () => Date } | null;
+}
+
+const READ = `
+  MATCH (fv:FileVersion)-[:media]->(m:Media)
+  OPTIONAL MATCH (fv)-[:mimeType { active: true }]->(fvMime:Property)
+  RETURN m.id AS id,
+         m.type AS type,
+         fv.id AS fileVersionId,
+         m.mimeType AS mimeType,
+         fvMime.value AS fallbackMimeType,
+         m.altText AS altText,
+         m.caption AS caption,
+         m.width AS width,
+         m.height AS height,
+         m.duration AS duration,
+         m.createdAt AS createdAt
+`;
+
+const MEDIA_TYPES = ['Image', 'Video', 'Audio'] as const;
+
+export const mediaExtractor: Extractor = {
+  name: 'media',
+  targetTables: ['media'],
+  dependsOn: ['file'],
+  async run(ctx) {
+    await warnIfRelTypeUnknown(ctx, 'media');
+    const raw = await cypher<RawMedia>(ctx, READ);
+    // What LANDED in file_nodes, not what Neo4j holds: the file extractor drops
+    // FileVersions missing mimeType/size, and this is where that fans out.
+    const landedFileNodes = await liveTargetIds(ctx, 'FileNode', fileNodes);
+
+    const { kept, skipped } = keepLanded(raw, [
+      [landedFileNodes, (row) => row.fileVersionId],
+    ]);
+    if (skipped > 0) {
+      ctx.log(
+        `    ⚠ ${skipped} Media row(s) skipped — their FileVersion did not land ` +
+          `(dropped by the file extractor, or soft-deleted)`,
+      );
+    }
+
+    const allowedTypes = new Set<string>(MEDIA_TYPES);
+    const typed = kept.filter((row) => allowedTypes.has(row.type ?? ''));
+    if (typed.length !== kept.length) {
+      const offending = [
+        ...new Set(
+          kept
+            .filter((row) => !allowedTypes.has(row.type ?? ''))
+            .map((row) => row.type ?? '(null)'),
+        ),
+      ];
+      ctx.log(
+        `    ⚠ ${kept.length - typed.length} Media row(s) carry a type the media_type enum ` +
+          `rejects — DROPPED (media.type is NOT NULL). Values seen: ${offending.join(', ')}`,
+      );
+    }
+
+    const mimeless = typed.filter(
+      (row) => (row.mimeType ?? row.fallbackMimeType) == null,
+    );
+    if (mimeless.length > 0) {
+      ctx.log(
+        `    ⚠ ${mimeless.length} Media row(s) have no mimeType and their FileVersion has none ` +
+          `either — DROPPED; media.mime_type is NOT NULL`,
+      );
+    }
+    const withMime = typed.filter(
+      (row) => (row.mimeType ?? row.fallbackMimeType) != null,
+    );
+
+    // media_file_version_id_unique: one Media per FileVersion. `save()` MERGEs,
+    // so a duplicate should be impossible — keep the newest and say so rather
+    // than letting onConflictDoNothing pick arbitrarily.
+    const byFileVersion = new Map<ID, RawMedia>();
+    let duplicates = 0;
+    for (const row of withMime) {
+      const held = byFileVersion.get(row.fileVersionId);
+      if (!held) {
+        byFileVersion.set(row.fileVersionId, row);
+        continue;
+      }
+      duplicates++;
+      const heldAt = held.createdAt?.toJSDate().getTime() ?? 0;
+      const rowAt = row.createdAt?.toJSDate().getTime() ?? 0;
+      if (rowAt > heldAt) byFileVersion.set(row.fileVersionId, row);
+    }
+    if (duplicates > 0) {
+      ctx.log(
+        `    ⚠ ${duplicates} FileVersion(s) carry more than one Media — kept the newest ` +
+          `(media_file_version_id_unique allows one)`,
+      );
+    }
+
+    const rows = [...byFileVersion.values()].map((row) => ({
+      id: row.id,
+      type: row.type as (typeof MEDIA_TYPES)[number],
+      fileVersionId: row.fileVersionId,
+      mimeType: (row.mimeType ?? row.fallbackMimeType)!,
+      altText: row.altText ?? null,
+      caption: row.caption ?? null,
+      width: row.width ?? null,
+      height: row.height ?? null,
+      duration: row.duration ?? null,
+      createdAt: row.createdAt ? row.createdAt.toJSDate() : new Date(0),
+    }));
+
+    const inserted = await bulkInsert(ctx, media, rows);
+    return one('media', rows.length, inserted);
+  },
+};

--- a/src/core/cutover/extractors/notification.extractor.ts
+++ b/src/core/cutover/extractors/notification.extractor.ts
@@ -1,11 +1,18 @@
 import { type ID } from '~/common';
 import {
+  comments,
   notificationRecipients,
   notifications,
   notificationTypeEnum,
   users,
 } from '~/core/drizzle/schema';
-import { bulkInsert, cypher, liveTargetIds, stat } from '../cutover.helpers';
+import {
+  bulkInsert,
+  cypher,
+  liveTargetIds,
+  stat,
+  warnIfRelTypeUnknown,
+} from '../cutover.helpers';
 import { type Extractor, type TableStat } from '../cutover.types';
 
 /**
@@ -15,17 +22,27 @@ import { type Extractor, type TableStat } from '../cutover.types';
  * `[:comment]` rel for mentions, `readAt` on the `[:recipient]` rel.
  *
  * Rows that would violate the `notifications_shape` CHECK (unknown type, or a
- * mention whose comment rel is gone) are dropped + logged — comments aren't a
- * PG domain yet, so `comment_id` is a deferred FK carrying the Neo4j id.
+ * mention whose comment rel is gone) are dropped + logged.
+ *
+ * `comment_id` is a REAL FK to `comments`, added with the Comments migration
+ * (0024) — after this extractor was first written, when the docblock could still
+ * say "comments aren't a PG domain yet, so it's a deferred FK". Two consequences
+ * that the original version missed, both load-aborting:
+ *  - `dependsOn` must include `comment`, or the topological sort is free to run
+ *    this extractor at its registration position (ahead of `comment`) and every
+ *    mention violates the FK against an empty table.
+ *  - A mention whose comment never landed must be DROPPED, not nulled: the
+ *    `notifications_shape` CHECK requires `comment_id IS NOT NULL` for that type.
  */
 export const notificationExtractor: Extractor = {
   name: 'notification',
   targetTables: ['notifications', 'notification_recipients'],
-  dependsOn: ['user'],
+  dependsOn: ['user', 'comment'],
   async run(ctx) {
     const out: Record<string, TableStat> = {};
 
     const userIds = await liveTargetIds(ctx, 'User', users);
+    const landedComments = await liveTargetIds(ctx, 'Comment', comments);
 
     const nodes = await cypher<{
       id: ID;
@@ -45,6 +62,7 @@ export const notificationExtractor: Extractor = {
 
     const knownTypes = new Set<string>(notificationTypeEnum.enumValues);
     let droppedShape = 0;
+    let droppedForComment = 0;
     let nulledCreators = 0;
     const rows = nodes.flatMap((n) => {
       const shapeOk =
@@ -54,6 +72,14 @@ export const notificationExtractor: Extractor = {
           n.message == null);
       if (!knownTypes.has(n.type) || !shapeOk) {
         droppedShape++;
+        return [];
+      }
+      // Drop rather than null: comment_id FKs to comments, and the shape CHECK
+      // requires it non-null for a mention, so there is no salvageable row. A
+      // comment goes missing when its thread's parent was soft-deleted or its
+      // creator never landed — see comment.extractor's own guards.
+      if (n.commentId && !landedComments.has(n.commentId)) {
+        droppedForComment++;
         return [];
       }
       // creator FK is ON DELETE SET NULL semantics — SystemAgent/absent
@@ -77,6 +103,11 @@ export const notificationExtractor: Extractor = {
         `    ⚠ dropped ${droppedShape} notification(s) failing the shape check (unknown type / missing message / dangling comment)`,
       );
     }
+    if (droppedForComment) {
+      ctx.log(
+        `    ⚠ DROPPED ${droppedForComment} mention notification(s) whose comment never landed (comment_id FK + shape CHECK)`,
+      );
+    }
     if (nulledCreators) {
       ctx.log(
         `    ⚠ nulled ${nulledCreators} SystemAgent/absent notification creator(s)`,
@@ -98,6 +129,13 @@ export const notificationExtractor: Extractor = {
        RETURN n.id AS notificationId, u.id AS userId,
               toString(r.readAt) AS readAt`,
     );
+    // Edge-stored, so a wrong type name reconciles 0 == 0 == 0 with a ✓. Prod
+    // has notifications but ZERO `recipient` edges, which is exactly the
+    // ambiguity this guard exists to name: `db.relationshipTypes()` decides
+    // whether the domain is empty or the query is broken.
+    if (recipients.length === 0) {
+      await warnIfRelTypeUnknown(ctx, 'recipient');
+    }
     const recipientRows = recipients.flatMap((r) =>
       insertedIds.has(r.notificationId) && userIds.has(r.userId)
         ? [

--- a/src/core/cutover/extractors/notification.extractor.ts
+++ b/src/core/cutover/extractors/notification.extractor.ts
@@ -11,6 +11,8 @@ import {
   cypher,
   liveTargetIds,
   stat,
+  ts,
+  tsReq,
   warnIfRelTypeUnknown,
 } from '../cutover.helpers';
 import { type Extractor, type TableStat } from '../cutover.types';
@@ -91,7 +93,7 @@ export const notificationExtractor: Extractor = {
         {
           id: n.id,
           type: n.type as (typeof notificationTypeEnum.enumValues)[number],
-          createdAt: new Date(n.createdAt),
+          createdAt: tsReq(n.createdAt),
           creatorId,
           message: n.message,
           commentId: n.commentId,
@@ -142,7 +144,7 @@ export const notificationExtractor: Extractor = {
             {
               notificationId: r.notificationId,
               userId: r.userId,
-              readAt: r.readAt ? new Date(r.readAt) : null,
+              readAt: ts(r.readAt),
             },
           ]
         : [],

--- a/src/core/cutover/extractors/notification.extractor.ts
+++ b/src/core/cutover/extractors/notification.extractor.ts
@@ -1,0 +1,119 @@
+import { type ID } from '~/common';
+import {
+  notificationRecipients,
+  notifications,
+  notificationTypeEnum,
+  users,
+} from '~/core/drizzle/schema';
+import { bulkInsert, cypher, liveTargetIds, stat } from '../cutover.helpers';
+import { type Extractor, type TableStat } from '../cutover.types';
+
+/**
+ * Notifications + per-recipient read state. Pure Cypher — there's no
+ * readMany-all repo surface (lists are per-recipient), and the node props are
+ * direct (no Property nodes): `type` discriminator + `message` on the node,
+ * `[:comment]` rel for mentions, `readAt` on the `[:recipient]` rel.
+ *
+ * Rows that would violate the `notifications_shape` CHECK (unknown type, or a
+ * mention whose comment rel is gone) are dropped + logged — comments aren't a
+ * PG domain yet, so `comment_id` is a deferred FK carrying the Neo4j id.
+ */
+export const notificationExtractor: Extractor = {
+  name: 'notification',
+  targetTables: ['notifications', 'notification_recipients'],
+  dependsOn: ['user'],
+  async run(ctx) {
+    const out: Record<string, TableStat> = {};
+
+    const userIds = await liveTargetIds(ctx, 'User', users);
+
+    const nodes = await cypher<{
+      id: ID;
+      type: string;
+      createdAt: string;
+      message: string | null;
+      creatorId: ID | null;
+      commentId: ID | null;
+    }>(
+      ctx,
+      `MATCH (n:Notification)
+       OPTIONAL MATCH (n)-[:creator]->(c)
+       OPTIONAL MATCH (n)-[:comment]->(cm:Comment)
+       RETURN n.id AS id, n.type AS type, toString(n.createdAt) AS createdAt,
+              n.message AS message, c.id AS creatorId, cm.id AS commentId`,
+    );
+
+    const knownTypes = new Set<string>(notificationTypeEnum.enumValues);
+    let droppedShape = 0;
+    let nulledCreators = 0;
+    const rows = nodes.flatMap((n) => {
+      const shapeOk =
+        (n.type === 'System' && n.message != null && n.commentId == null) ||
+        (n.type === 'CommentViaMention' &&
+          n.commentId != null &&
+          n.message == null);
+      if (!knownTypes.has(n.type) || !shapeOk) {
+        droppedShape++;
+        return [];
+      }
+      // creator FK is ON DELETE SET NULL semantics — SystemAgent/absent
+      // creators null out rather than dropping the notification.
+      const creatorId =
+        n.creatorId && userIds.has(n.creatorId) ? n.creatorId : null;
+      if (n.creatorId && !creatorId) nulledCreators++;
+      return [
+        {
+          id: n.id,
+          type: n.type as (typeof notificationTypeEnum.enumValues)[number],
+          createdAt: new Date(n.createdAt),
+          creatorId,
+          message: n.message,
+          commentId: n.commentId,
+        },
+      ];
+    });
+    if (droppedShape) {
+      ctx.log(
+        `    ⚠ dropped ${droppedShape} notification(s) failing the shape check (unknown type / missing message / dangling comment)`,
+      );
+    }
+    if (nulledCreators) {
+      ctx.log(
+        `    ⚠ nulled ${nulledCreators} SystemAgent/absent notification creator(s)`,
+      );
+    }
+    out.notifications = stat(
+      nodes.length,
+      await bulkInsert(ctx, notifications, rows),
+    );
+
+    const insertedIds = new Set(rows.map((row) => row.id));
+    const recipients = await cypher<{
+      notificationId: ID;
+      userId: ID;
+      readAt: string | null;
+    }>(
+      ctx,
+      `MATCH (n:Notification)-[r:recipient]->(u:User)
+       RETURN n.id AS notificationId, u.id AS userId,
+              toString(r.readAt) AS readAt`,
+    );
+    const recipientRows = recipients.flatMap((r) =>
+      insertedIds.has(r.notificationId) && userIds.has(r.userId)
+        ? [
+            {
+              notificationId: r.notificationId,
+              userId: r.userId,
+              readAt: r.readAt ? new Date(r.readAt) : null,
+            },
+          ]
+        : [],
+    );
+    out.notification_recipients = stat(
+      recipients.length,
+      await bulkInsert(ctx, notificationRecipients, recipientRows),
+    );
+
+    return out;
+  },
+};

--- a/src/core/cutover/extractors/organization.extractor.ts
+++ b/src/core/cutover/extractors/organization.extractor.ts
@@ -119,17 +119,64 @@ export const organizationExtractor: Extractor = {
       userId: ID;
       orgId: ID;
       primary: boolean;
+      primaryAt: string | null;
     }>(
       ctx,
       `MATCH (u:User)-[:organization { active: true }]->(o:Organization)
+       OPTIONAL MATCH (u)-[pr:primaryOrganization { active: true }]->(o)
        RETURN u.id AS userId, o.id AS orgId,
-              exists((u)-[:primaryOrganization { active: true }]->(o)) AS primary`,
+              pr IS NOT NULL AS primary,
+              toString(pr.createdAt) AS primaryAt`,
     );
+
+    // A user can carry MORE THAN ONE active primaryOrganization rel. The Neo4j
+    // write side only deactivates the previous primary when the new assignment
+    // targets the SAME organization (`user.repository.ts` binds `org` to the org
+    // being assigned before matching the rel to deactivate), so changing a user's
+    // primary from A to B leaves both rels active.
+    //
+    // Postgres has `user_organizations_one_primary_per_user` (unique on user_id
+    // WHERE primary), and bulkInsert's onConflictDoNothing has no conflict target,
+    // so the loser would not merely lose its flag — the ENTIRE membership row is
+    // discarded and the user silently loses that organization.
+    //
+    // Keep the most recently assigned primary (the intended current one) and
+    // demote the rest to ordinary memberships, so every membership survives.
+    // Ties break on organization id purely so the choice is reproducible.
+    const primariesByUser = new Map<string, typeof userOrgs>();
+    for (const row of userOrgs) {
+      if (!row.primary) continue;
+      const list = primariesByUser.get(row.userId) ?? [];
+      list.push(row);
+      primariesByUser.set(row.userId, list);
+    }
+    const demoted = new Set<string>();
+    let multiPrimaryUsers = 0;
+    for (const [userId, list] of primariesByUser) {
+      if (list.length < 2) continue;
+      multiPrimaryUsers++;
+      // Non-empty by the length check above.
+      const winner = [...list].sort((a, b) => {
+        const at = (a.primaryAt ?? '').localeCompare(b.primaryAt ?? '');
+        return at !== 0 ? -at : a.orgId.localeCompare(b.orgId);
+      })[0]!;
+      for (const row of list) {
+        if (row.orgId !== winner.orgId) demoted.add(`${userId}::${row.orgId}`);
+      }
+    }
+    if (multiPrimaryUsers) {
+      ctx.log(
+        `    ⚠ ${multiPrimaryUsers} user(s) had multiple active primaryOrganization rels — ` +
+          `kept the most recent as primary and demoted ${demoted.size} to ordinary membership(s), ` +
+          `which preserves every membership row`,
+      );
+    }
+
     const userOrgRows = keepLanded(
       userOrgs.map((r) => ({
         userId: r.userId,
         organizationId: r.orgId,
-        primary: r.primary,
+        primary: r.primary && !demoted.has(`${r.userId}::${r.orgId}`),
       })),
       [
         [landedUsers, (row) => row.userId],

--- a/src/core/cutover/extractors/organization.extractor.ts
+++ b/src/core/cutover/extractors/organization.extractor.ts
@@ -15,6 +15,7 @@ import {
   cypher,
   keepLanded,
   liveTargetIds,
+  orDefault,
   readAllViaRepo,
   sanitizeEnum,
   stat,
@@ -50,9 +51,18 @@ export const organizationExtractor: Extractor = {
     );
     const droppedEnums = new Set<string>();
     const rows = dtos.map((o) => {
-      const types = sanitizeEnum([...o.types], organizationTypeEnum.enumValues);
+      // orDefault, not a bare spread: the DTO types these as arrays but Neo4j
+      // has no Property node when the field was never written, so the value
+      // arrives undefined and spreading it throws — which aborts the WHOLE run,
+      // not just this row. Confirmed locally: the DefaultOrganization that
+      // setupRootObjects creates (id hardcoded in config.service.ts) is written
+      // with a `name` and nothing else, so it has neither of these.
+      const types = sanitizeEnum(
+        [...orDefault(o.types, [])],
+        organizationTypeEnum.enumValues,
+      );
       const reach = sanitizeEnum(
-        [...o.reach],
+        [...orDefault(o.reach, [])],
         organizationReachEnum.enumValues,
       );
       [...types.dropped, ...reach.dropped].forEach((d) => droppedEnums.add(d));

--- a/src/core/cutover/extractors/organization.extractor.ts
+++ b/src/core/cutover/extractors/organization.extractor.ts
@@ -1,16 +1,20 @@
 import { type ID } from '~/common';
 import {
+  locations,
   organizationLocations,
   organizationReachEnum,
   organizations,
   organizationTypeEnum,
   userOrganizations,
+  users,
 } from '~/core/drizzle/schema';
 import { type Organization } from '../../../components/organization/dto';
 import { OrganizationRepository } from '../../../components/organization/organization.repository';
 import {
   bulkInsert,
   cypher,
+  keepLanded,
+  liveTargetIds,
   readAllViaRepo,
   sanitizeEnum,
   stat,
@@ -82,13 +86,26 @@ export const organizationExtractor: Extractor = {
       `MATCH (o:Organization)-[:locations { active: true }]->(l:Location)
        RETURN o.id AS orgId, l.id AS locId`,
     );
+    // Both junctions below FK to parents that can be absent — see keepLanded.
+    const landedOrgs = await liveTargetIds(ctx, 'Organization', organizations);
+    const landedLocs = await liveTargetIds(ctx, 'Location', locations);
+    const landedUsers = await liveTargetIds(ctx, 'User', users);
+
+    const orgLocRows = keepLanded(
+      orgLocs.map((r) => ({ organizationId: r.orgId, locationId: r.locId })),
+      [
+        [landedOrgs, (row) => row.organizationId],
+        [landedLocs, (row) => row.locationId],
+      ],
+    );
+    if (orgLocRows.skipped > 0) {
+      ctx.log(
+        `    ⚠ skipped ${orgLocRows.skipped} organization_locations row(s) — org or location never landed`,
+      );
+    }
     out.organization_locations = stat(
       orgLocs.length,
-      await bulkInsert(
-        ctx,
-        organizationLocations,
-        orgLocs.map((r) => ({ organizationId: r.orgId, locationId: r.locId })),
-      ),
+      await bulkInsert(ctx, organizationLocations, orgLocRows.kept),
     );
 
     const userOrgs = await cypher<{
@@ -101,17 +118,25 @@ export const organizationExtractor: Extractor = {
        RETURN u.id AS userId, o.id AS orgId,
               exists((u)-[:primaryOrganization { active: true }]->(o)) AS primary`,
     );
+    const userOrgRows = keepLanded(
+      userOrgs.map((r) => ({
+        userId: r.userId,
+        organizationId: r.orgId,
+        primary: r.primary,
+      })),
+      [
+        [landedUsers, (row) => row.userId],
+        [landedOrgs, (row) => row.organizationId],
+      ],
+    );
+    if (userOrgRows.skipped > 0) {
+      ctx.log(
+        `    ⚠ skipped ${userOrgRows.skipped} user_organizations row(s) — user or org never landed`,
+      );
+    }
     out.user_organizations = stat(
       userOrgs.length,
-      await bulkInsert(
-        ctx,
-        userOrganizations,
-        userOrgs.map((r) => ({
-          userId: r.userId,
-          organizationId: r.orgId,
-          primary: r.primary,
-        })),
-      ),
+      await bulkInsert(ctx, userOrganizations, userOrgRows.kept),
     );
 
     return out;

--- a/src/core/cutover/extractors/organization.extractor.ts
+++ b/src/core/cutover/extractors/organization.extractor.ts
@@ -71,9 +71,16 @@ export const organizationExtractor: Extractor = {
         deletedAt: null,
       };
     });
+    // Kept as a guard, not as an outstanding task: production carries no value
+    // that either enum rejects (checked against the source before the real
+    // load). A hit here means data this check has not seen, so it is worth
+    // saying out loud — the organization row still lands, only the value is
+    // lost, which no row count can show.
     if (droppedEnums.size) {
       ctx.log(
-        `    ⚠ dropped unknown organization enum value(s): ${[...droppedEnums].join(', ')} — migration-todo: map, don't drop`,
+        `    ⚠ dropped unknown organization type/reach value(s): ${[
+          ...droppedEnums,
+        ].join(', ')} — the org row still landed WITHOUT them`,
       );
     }
     out.organizations = stat(

--- a/src/core/cutover/extractors/organization.extractor.ts
+++ b/src/core/cutover/extractors/organization.extractor.ts
@@ -1,0 +1,119 @@
+import { type ID } from '~/common';
+import {
+  organizationLocations,
+  organizationReachEnum,
+  organizations,
+  organizationTypeEnum,
+  userOrganizations,
+} from '~/core/drizzle/schema';
+import { type Organization } from '../../../components/organization/dto';
+import { OrganizationRepository } from '../../../components/organization/organization.repository';
+import {
+  bulkInsert,
+  cypher,
+  readAllViaRepo,
+  sanitizeEnum,
+  stat,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor, type TableStat } from '../cutover.types';
+
+/**
+ * Organization + its two junctions.
+ *  - organization_locations: (Organization)-[:locations]->(Location)
+ *  - user_organizations: (User)-[:organization]->(Organization); `primary` is
+ *    a SECOND rel (`primaryOrganization`) to the same org.
+ *
+ * migration-todo: the `one primary org per user` partial-unique index will
+ * reject dirty data (a user flagged primary on two orgs). Verify on a live
+ * Neo4j; onConflictDoNothing does not cover unique-index violations.
+ */
+export const organizationExtractor: Extractor = {
+  name: 'organization',
+  targetTables: [
+    'organizations',
+    'organization_locations',
+    'user_organizations',
+  ],
+  dependsOn: ['user', 'location'],
+  async run(ctx) {
+    const out: Record<string, TableStat> = {};
+
+    const dtos = await readAllViaRepo<Organization>(
+      ctx,
+      'Organization',
+      OrganizationRepository,
+    );
+    const droppedEnums = new Set<string>();
+    const rows = dtos.map((o) => {
+      const types = sanitizeEnum([...o.types], organizationTypeEnum.enumValues);
+      const reach = sanitizeEnum(
+        [...o.reach],
+        organizationReachEnum.enumValues,
+      );
+      [...types.dropped, ...reach.dropped].forEach((d) => droppedEnums.add(d));
+      return {
+        id: o.id,
+        name: o.name,
+        acronym: o.acronym ?? null,
+        address: o.address ?? null,
+        types: types.kept,
+        reach: reach.kept,
+        // migration-todo: sensitivity is denormalized from linked projects;
+        // reads 'High' until Project migrates + a recompute pass runs.
+        sensitivity: o.sensitivity,
+        createdAt: tsReq(o.createdAt),
+        updatedAt: tsReq(o.createdAt),
+        deletedAt: null,
+      };
+    });
+    if (droppedEnums.size) {
+      ctx.log(
+        `    ⚠ dropped unknown organization enum value(s): ${[...droppedEnums].join(', ')} — migration-todo: map, don't drop`,
+      );
+    }
+    out.organizations = stat(
+      dtos.length,
+      await bulkInsert(ctx, organizations, rows),
+    );
+
+    const orgLocs = await cypher<{ orgId: ID; locId: ID }>(
+      ctx,
+      `MATCH (o:Organization)-[:locations { active: true }]->(l:Location)
+       RETURN o.id AS orgId, l.id AS locId`,
+    );
+    out.organization_locations = stat(
+      orgLocs.length,
+      await bulkInsert(
+        ctx,
+        organizationLocations,
+        orgLocs.map((r) => ({ organizationId: r.orgId, locationId: r.locId })),
+      ),
+    );
+
+    const userOrgs = await cypher<{
+      userId: ID;
+      orgId: ID;
+      primary: boolean;
+    }>(
+      ctx,
+      `MATCH (u:User)-[:organization { active: true }]->(o:Organization)
+       RETURN u.id AS userId, o.id AS orgId,
+              exists((u)-[:primaryOrganization { active: true }]->(o)) AS primary`,
+    );
+    out.user_organizations = stat(
+      userOrgs.length,
+      await bulkInsert(
+        ctx,
+        userOrganizations,
+        userOrgs.map((r) => ({
+          userId: r.userId,
+          organizationId: r.orgId,
+          primary: r.primary,
+        })),
+      ),
+    );
+
+    return out;
+  },
+};

--- a/src/core/cutover/extractors/partner.extractor.ts
+++ b/src/core/cutover/extractors/partner.extractor.ts
@@ -1,0 +1,143 @@
+import { type ID } from '~/common';
+import {
+  financialReportingTypeEnum,
+  partnerCountries,
+  partnerFieldRegions,
+  partnerLanguagesOfConsulting,
+  partners,
+  partnerTypeEnum,
+  projectTypeEnum,
+} from '~/core/drizzle/schema';
+import { type Partner } from '../../../components/partner/dto';
+import { PartnerRepository } from '../../../components/partner/partner.repository';
+import {
+  bulkInsert,
+  cypher,
+  dateStr,
+  linkId,
+  orDefault,
+  readAllViaRepo,
+  sanitizeEnum,
+  stat,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor, type TableStat } from '../cutover.types';
+
+/**
+ * Partner + its three junctions (field_regions, countries, languagesOfConsulting).
+ * `departmentIdBlockId` is resolved via the partner→block rel (the DTO's nested
+ * block doesn't surface the node id). Language ids are plain text (deferred FK).
+ */
+export const partnerExtractor: Extractor = {
+  name: 'partner',
+  targetTables: [
+    'partners',
+    'partner_field_regions',
+    'partner_countries',
+    'partner_languages_of_consulting',
+  ],
+  dependsOn: [
+    'organization',
+    'user',
+    'departmentIdBlock',
+    'fieldRegion',
+    'location',
+  ],
+  async run(ctx) {
+    const out: Record<string, TableStat> = {};
+
+    const dtos = await readAllViaRepo<Partner>(
+      ctx,
+      'Partner',
+      PartnerRepository,
+    );
+
+    // partner → departmentIdBlock node id (FK), resolved separately.
+    const blockPairs = await cypher<{ pid: ID; bid: ID }>(
+      ctx,
+      `MATCH (p:Partner)-[:departmentIdBlock { active: true }]->(b:DepartmentIdBlock)
+       RETURN p.id AS pid, b.id AS bid`,
+    );
+    const blockByPartner = new Map(blockPairs.map((r) => [r.pid, r.bid]));
+
+    const droppedEnums = new Set<string>();
+    const rows = dtos.map((p) => {
+      const types = sanitizeEnum([...p.types], partnerTypeEnum.enumValues);
+      const frt = sanitizeEnum(
+        [...p.financialReportingTypes],
+        financialReportingTypeEnum.enumValues,
+      );
+      const programs = sanitizeEnum(
+        [...p.approvedPrograms],
+        projectTypeEnum.enumValues,
+      );
+      [...types.dropped, ...frt.dropped, ...programs.dropped].forEach((d) =>
+        droppedEnums.add(d),
+      );
+      return {
+        id: p.id,
+        organizationId: linkId(p.organization)!,
+        pointOfContactId: linkId(p.pointOfContact),
+        types: types.kept,
+        financialReportingTypes: frt.kept,
+        pmcEntityCode: p.pmcEntityCode ?? null,
+        // NOT NULL (default false) — legacy rows may lack the Property.
+        globalInnovationsClient: orDefault(p.globalInnovationsClient, false),
+        active: orDefault(p.active, false),
+        address: p.address ?? null,
+        // Plain text (deferred FK) — may reference not-yet-migrated languages.
+        languageOfWiderCommunicationId: linkId(p.languageOfWiderCommunication),
+        languageOfReportingId: linkId(p.languageOfReporting),
+        startDate: dateStr(p.startDate),
+        approvedPrograms: programs.kept,
+        departmentIdBlockId: blockByPartner.get(p.id) ?? null,
+        // migration-todo: denormalized from projects; 'High' until Project migrates.
+        sensitivity: p.sensitivity,
+        createdAt: tsReq(p.createdAt),
+        updatedAt: tsReq(p.createdAt),
+        deletedAt: null,
+      };
+    });
+    if (droppedEnums.size) {
+      ctx.log(
+        `    ⚠ dropped unknown partner enum value(s): ${[...droppedEnums].join(', ')} — migration-todo: map, don't drop`,
+      );
+    }
+    out.partners = stat(dtos.length, await bulkInsert(ctx, partners, rows));
+
+    const frRows = dtos.flatMap((p) =>
+      p.fieldRegions.flatMap((fr) => {
+        const fieldRegionId = linkId(fr);
+        return fieldRegionId ? [{ partnerId: p.id, fieldRegionId }] : [];
+      }),
+    );
+    out.partner_field_regions = stat(
+      frRows.length,
+      await bulkInsert(ctx, partnerFieldRegions, frRows),
+    );
+
+    const countryRows = dtos.flatMap((p) =>
+      p.countries.flatMap((c) => {
+        const locationId = linkId(c);
+        return locationId ? [{ partnerId: p.id, locationId }] : [];
+      }),
+    );
+    out.partner_countries = stat(
+      countryRows.length,
+      await bulkInsert(ctx, partnerCountries, countryRows),
+    );
+
+    const locRows = dtos.flatMap((p) =>
+      p.languagesOfConsulting.flatMap((l) => {
+        const languageId = linkId(l);
+        return languageId ? [{ partnerId: p.id, languageId }] : [];
+      }),
+    );
+    out.partner_languages_of_consulting = stat(
+      locRows.length,
+      await bulkInsert(ctx, partnerLanguagesOfConsulting, locRows),
+    );
+
+    return out;
+  },
+};

--- a/src/core/cutover/extractors/partner.extractor.ts
+++ b/src/core/cutover/extractors/partner.extractor.ts
@@ -94,7 +94,9 @@ export const partnerExtractor: Extractor = {
         // migration-todo: denormalized from projects; 'High' until Project migrates.
         sensitivity: p.sensitivity,
         createdAt: tsReq(p.createdAt),
-        updatedAt: tsReq(p.createdAt),
+        // S7 (decided 2026-07-14): carry Neo4j's computed modifiedAt (max
+        // property timestamp) — history-accurate + BI-continuous.
+        updatedAt: tsReq(p.modifiedAt),
         deletedAt: null,
       };
     });

--- a/src/core/cutover/extractors/partner.extractor.ts
+++ b/src/core/cutover/extractors/partner.extractor.ts
@@ -1,12 +1,17 @@
 import { type ID } from '~/common';
 import {
+  departmentIdBlocks,
+  fieldRegions,
   financialReportingTypeEnum,
+  locations,
+  organizations,
   partnerCountries,
   partnerFieldRegions,
   partnerLanguagesOfConsulting,
   partners,
   partnerTypeEnum,
   projectTypeEnum,
+  users,
 } from '~/core/drizzle/schema';
 import { type Partner } from '../../../components/partner/dto';
 import { PartnerRepository } from '../../../components/partner/partner.repository';
@@ -14,7 +19,9 @@ import {
   bulkInsert,
   cypher,
   dateStr,
+  keepLanded,
   linkId,
+  liveTargetIds,
   orDefault,
   readAllViaRepo,
   sanitizeEnum,
@@ -60,8 +67,42 @@ export const partnerExtractor: Extractor = {
     );
     const blockByPartner = new Map(blockPairs.map((r) => [r.pid, r.bid]));
 
+    // Prod-finding #2 guards. Every FK below points at a table that legitimately
+    // sheds rows (hydrate-drops upstream, unique-conflict drops, soft-deleted
+    // parents), and the read here is a superset of what LANDED — so each one is
+    // checked against Postgres truth, not against Neo4j liveness.
+    //   organization_id is NOT NULL, so a partner whose organization did not land
+    //     must be DROPPED. It was previously written as `linkId(p.organization)!`,
+    //     and that assertion is not merely cosmetic: the repository OPTIONAL-matches
+    //     the organization, so a soft-deleted one yields null, and the `!` carried
+    //     it into a NOT NULL column to abort the entire load.
+    //   point_of_contact_id and department_id_block_id are nullable, so a missing
+    //     target is nulled and logged rather than costing the whole partner.
+    const landedOrgs = await liveTargetIds(ctx, 'Organization', organizations);
+    const landedUsers = await liveTargetIds(ctx, 'User', users);
+    const landedBlocks = await liveTargetIds(
+      ctx,
+      'DepartmentIdBlock',
+      departmentIdBlocks,
+    );
+    let droppedForOrganization = 0;
+    let nulledContacts = 0;
+    let nulledBlocks = 0;
+
     const droppedEnums = new Set<string>();
-    const rows = dtos.map((p) => {
+    const rows = dtos.flatMap((p) => {
+      const organizationId = linkId(p.organization);
+      if (!organizationId || !landedOrgs.has(organizationId)) {
+        droppedForOrganization++;
+        return [];
+      }
+      const pointOfContactId = linkId(p.pointOfContact);
+      const contactLanded =
+        pointOfContactId && landedUsers.has(pointOfContactId);
+      if (pointOfContactId && !contactLanded) nulledContacts++;
+      const blockId = blockByPartner.get(p.id) ?? null;
+      const blockLanded = blockId && landedBlocks.has(blockId);
+      if (blockId && !blockLanded) nulledBlocks++;
       const types = sanitizeEnum([...p.types], partnerTypeEnum.enumValues);
       const frt = sanitizeEnum(
         [...p.financialReportingTypes],
@@ -76,8 +117,8 @@ export const partnerExtractor: Extractor = {
       );
       return {
         id: p.id,
-        organizationId: linkId(p.organization)!,
-        pointOfContactId: linkId(p.pointOfContact),
+        organizationId,
+        pointOfContactId: contactLanded ? pointOfContactId : null,
         types: types.kept,
         financialReportingTypes: frt.kept,
         pmcEntityCode: p.pmcEntityCode ?? null,
@@ -90,7 +131,7 @@ export const partnerExtractor: Extractor = {
         languageOfReportingId: linkId(p.languageOfReporting),
         startDate: dateStr(p.startDate),
         approvedPrograms: programs.kept,
-        departmentIdBlockId: blockByPartner.get(p.id) ?? null,
+        departmentIdBlockId: blockLanded ? blockId : null,
         // migration-todo: denormalized from projects; 'High' until Project migrates.
         sensitivity: p.sensitivity,
         createdAt: tsReq(p.createdAt),
@@ -105,39 +146,95 @@ export const partnerExtractor: Extractor = {
         `    ⚠ dropped unknown partner enum value(s): ${[...droppedEnums].join(', ')} — migration-todo: map, don't drop`,
       );
     }
+    if (droppedForOrganization) {
+      ctx.log(
+        `    ⚠ DROPPED ${droppedForOrganization} partner(s) whose organization never landed — organization_id is NOT NULL`,
+      );
+    }
+    if (nulledContacts) {
+      ctx.log(
+        `    ⚠ nulled pointOfContact on ${nulledContacts} partner(s) whose contact user never landed`,
+      );
+    }
+    if (nulledBlocks) {
+      ctx.log(
+        `    ⚠ nulled departmentIdBlock on ${nulledBlocks} partner(s) whose block never landed`,
+      );
+    }
     out.partners = stat(dtos.length, await bulkInsert(ctx, partners, rows));
 
-    const frRows = dtos.flatMap((p) =>
-      p.fieldRegions.flatMap((fr) => {
-        const fieldRegionId = linkId(fr);
-        return fieldRegionId ? [{ partnerId: p.id, fieldRegionId }] : [];
-      }),
+    // Junction guards. The partner side is read back from Postgres rather than
+    // reused from `rows`, so a partner dropped just above OR dropped by
+    // onConflictDoNothing is caught here instead of failing the insert. The
+    // far side of each junction is a NOT NULL FK, so a missing target drops the
+    // junction row (there is nothing to null).
+    const landedPartners = await liveTargetIds(ctx, 'Partner', partners);
+    const landedRegions = await liveTargetIds(ctx, 'FieldRegion', fieldRegions);
+    const landedLocations = await liveTargetIds(ctx, 'Location', locations);
+
+    const frRows = keepLanded(
+      dtos.flatMap((p) =>
+        p.fieldRegions.flatMap((fr) => {
+          const fieldRegionId = linkId(fr);
+          return fieldRegionId ? [{ partnerId: p.id, fieldRegionId }] : [];
+        }),
+      ),
+      [
+        [landedPartners, (row) => row.partnerId],
+        [landedRegions, (row) => row.fieldRegionId],
+      ],
     );
+    if (frRows.skipped) {
+      ctx.log(
+        `    ⚠ DROPPED ${frRows.skipped} partner_field_regions row(s) — partner or field region never landed`,
+      );
+    }
     out.partner_field_regions = stat(
-      frRows.length,
-      await bulkInsert(ctx, partnerFieldRegions, frRows),
+      frRows.kept.length + frRows.skipped,
+      await bulkInsert(ctx, partnerFieldRegions, frRows.kept),
     );
 
-    const countryRows = dtos.flatMap((p) =>
-      p.countries.flatMap((c) => {
-        const locationId = linkId(c);
-        return locationId ? [{ partnerId: p.id, locationId }] : [];
-      }),
+    const countryRows = keepLanded(
+      dtos.flatMap((p) =>
+        p.countries.flatMap((c) => {
+          const locationId = linkId(c);
+          return locationId ? [{ partnerId: p.id, locationId }] : [];
+        }),
+      ),
+      [
+        [landedPartners, (row) => row.partnerId],
+        [landedLocations, (row) => row.locationId],
+      ],
     );
+    if (countryRows.skipped) {
+      ctx.log(
+        `    ⚠ DROPPED ${countryRows.skipped} partner_countries row(s) — partner or location never landed`,
+      );
+    }
     out.partner_countries = stat(
-      countryRows.length,
-      await bulkInsert(ctx, partnerCountries, countryRows),
+      countryRows.kept.length + countryRows.skipped,
+      await bulkInsert(ctx, partnerCountries, countryRows.kept),
     );
 
-    const locRows = dtos.flatMap((p) =>
-      p.languagesOfConsulting.flatMap((l) => {
-        const languageId = linkId(l);
-        return languageId ? [{ partnerId: p.id, languageId }] : [];
-      }),
+    // `language_id` here is deliberately plain text with no FK (the docblock's
+    // deferred-FK note), so only the partner side can be guarded.
+    const locRows = keepLanded(
+      dtos.flatMap((p) =>
+        p.languagesOfConsulting.flatMap((l) => {
+          const languageId = linkId(l);
+          return languageId ? [{ partnerId: p.id, languageId }] : [];
+        }),
+      ),
+      [[landedPartners, (row) => row.partnerId]],
     );
+    if (locRows.skipped) {
+      ctx.log(
+        `    ⚠ DROPPED ${locRows.skipped} partner_languages_of_consulting row(s) whose partner never landed`,
+      );
+    }
     out.partner_languages_of_consulting = stat(
-      locRows.length,
-      await bulkInsert(ctx, partnerLanguagesOfConsulting, locRows),
+      locRows.kept.length + locRows.skipped,
+      await bulkInsert(ctx, partnerLanguagesOfConsulting, locRows.kept),
     );
 
     return out;

--- a/src/core/cutover/extractors/partner.extractor.ts
+++ b/src/core/cutover/extractors/partner.extractor.ts
@@ -103,13 +103,19 @@ export const partnerExtractor: Extractor = {
       const blockId = blockByPartner.get(p.id) ?? null;
       const blockLanded = blockId && landedBlocks.has(blockId);
       if (blockId && !blockLanded) nulledBlocks++;
-      const types = sanitizeEnum([...p.types], partnerTypeEnum.enumValues);
+      // orDefault, not a bare spread — see the organization extractor: the DTO
+      // types these as arrays, but a field Neo4j never wrote arrives undefined
+      // and spreading it throws, ending the whole run rather than this row.
+      const types = sanitizeEnum(
+        [...orDefault(p.types, [])],
+        partnerTypeEnum.enumValues,
+      );
       const frt = sanitizeEnum(
-        [...p.financialReportingTypes],
+        [...orDefault(p.financialReportingTypes, [])],
         financialReportingTypeEnum.enumValues,
       );
       const programs = sanitizeEnum(
-        [...p.approvedPrograms],
+        [...orDefault(p.approvedPrograms, [])],
         projectTypeEnum.enumValues,
       );
       [...types.dropped, ...frt.dropped, ...programs.dropped].forEach((d) =>

--- a/src/core/cutover/extractors/partnership-producing-medium.extractor.ts
+++ b/src/core/cutover/extractors/partnership-producing-medium.extractor.ts
@@ -11,6 +11,7 @@ import {
   keepLanded,
   liveTargetIds,
   one,
+  ts,
   warnIfRelTypeUnknown,
 } from '../cutover.helpers';
 import { type Extractor } from '../cutover.types';
@@ -160,7 +161,7 @@ export const partnershipProducingMediumExtractor: Extractor = {
           engagementId: row.engagementId,
           medium: row.medium as ProductMedium,
           partnershipId: row.partnershipId,
-          createdAt: row.createdAt ? new Date(row.createdAt) : new Date(),
+          createdAt: ts(row.createdAt) ?? new Date(),
         },
       ];
     });

--- a/src/core/cutover/extractors/partnership-producing-medium.extractor.ts
+++ b/src/core/cutover/extractors/partnership-producing-medium.extractor.ts
@@ -1,0 +1,192 @@
+import { type ID } from '~/common';
+import {
+  engagements,
+  partnershipProducingMediums,
+  partnerships,
+} from '~/core/drizzle/schema';
+import { type ProductMedium } from '../../../components/product/dto';
+import {
+  bulkInsert,
+  cypher,
+  keepLanded,
+  liveTargetIds,
+  one,
+  warnIfRelTypeUnknown,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * Partnership producing mediums — which partnership is responsible for producing
+ * each medium (print, audio, video …) on a language engagement.
+ *
+ * Edge-stored with the payload ON the edge, which makes it the odd one of the four.
+ * There is no node and therefore no label to enumerate: the whole record is
+ * `(:LanguageEngagement)-[:PartnershipProducingMedium { active, medium, createdAt }]->(:Partnership)`,
+ * where the relationship TYPE is the resource name and `medium` is a relationship
+ * property. Hence the explicit rel-type guard — a misspelling returns zero rows and
+ * reconciles as a clean ✓.
+ *
+ * Only `active: true` edges are carried. Neo4j does not delete a reassignment, it
+ * sets `active: false` and stamps `deletedAt`, so the inactive edges are the history
+ * of previous assignments. Postgres deliberately does not model that history: the
+ * table is a pure assignment with a composite primary key of
+ * `(engagement_id, medium)` and no `deleted_at`, decided when the domain was ported
+ * on the grounds that the audit trail now covers the "who changed this" need.
+ * Carrying inactive edges here would violate that primary key.
+ *
+ * Both columns are real foreign keys, and only a live `LanguageEngagement` source
+ * is carried — the label the repository requires. Everything else is read anyway
+ * and reported, rather than filtered out in the Cypher where it would leave no
+ * trace; see the classification step for why those are two different things.
+ */
+export const partnershipProducingMediumExtractor: Extractor = {
+  name: 'partnership-producing-medium',
+  targetTables: ['partnership_producing_mediums'],
+  dependsOn: ['engagement', 'partnership'],
+  async run(ctx) {
+    const rows = await cypher<{
+      engagementId: ID<'Engagement'>;
+      medium: string | null;
+      partnershipId: ID<'Partnership'>;
+      createdAt: string | null;
+      isLanguageEngagement: boolean;
+      sourceDeleted: boolean;
+    }>(
+      ctx,
+      // Deliberately NOT `(eng:LanguageEngagement)`. That exact-label match is what
+      // the repository requires, and matching it here would be defensible — but it
+      // would also make this extractor blind to every edge hanging off anything
+      // else, which is the harness's worst failure shape: rows never read, so read
+      // and inserted agree and the table reconciles with a clean tick while real
+      // rows go missing. A production probe found a substantial set of exactly those
+      // edges, so this is a live concern rather than a theoretical one. Read every
+      // edge and let the classification below account for each one out loud.
+      `MATCH (eng)-[rel:PartnershipProducingMedium { active: true }]->(partnership:Partnership)
+       RETURN eng.id AS engagementId,
+              rel.medium AS medium,
+              partnership.id AS partnershipId,
+              toString(rel.createdAt) AS createdAt,
+              'LanguageEngagement' IN labels(eng) AS isLanguageEngagement,
+              any(l IN labels(eng) WHERE l STARTS WITH 'Deleted_') AS sourceDeleted`,
+    );
+    if (rows.length === 0) {
+      await warnIfRelTypeUnknown(ctx, 'PartnershipProducingMedium');
+    }
+
+    // Account for every edge whose source is not a live LanguageEngagement, rather
+    // than never reading it. Two distinct causes with opposite meanings, so they are
+    // reported separately:
+    //
+    // - `sourceDeleted` — the engagement was removed. Soft delete prefixes every
+    //   label, so `LanguageEngagement` becomes `Deleted_LanguageEngagement`. Correct
+    //   to skip (the ETL is live-only) and expected in any real database.
+    // - live but not a LanguageEngagement — should be impossible. The repository
+    //   only ever creates these from a LanguageEngagement, so this means either an
+    //   older code path made them or the data has drifted. A production probe found
+    //   none of these, so this branch is a guard against drift rather than a known
+    //   case — which is exactly why it logs loudly instead of being left out.
+    const foreign = rows.filter((row) => !row.isLanguageEngagement);
+    const foreignDeleted = foreign.filter((row) => row.sourceDeleted).length;
+    const foreignLive = foreign.length - foreignDeleted;
+    if (foreignDeleted > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${foreignDeleted} producing-medium assignment(s) under a ` +
+          `soft-deleted engagement — correct, the ETL carries live rows only`,
+      );
+    }
+    if (foreignLive > 0) {
+      ctx.log(
+        `    🔴 DROPPED ${foreignLive} producing-medium assignment(s) whose source is ` +
+          `LIVE but carries no \`LanguageEngagement\` label. The repository only ` +
+          `creates these from a language engagement, so this should not be possible — ` +
+          `investigate the source edges before trusting this table.`,
+      );
+    }
+
+    const languageEngagementRows = rows.filter(
+      (row) => row.isLanguageEngagement,
+    );
+
+    const landedEngagements = await liveTargetIds(
+      ctx,
+      'LanguageEngagement',
+      engagements,
+    );
+    const landedPartnerships = await liveTargetIds(
+      ctx,
+      'Partnership',
+      partnerships,
+    );
+    const kept = keepLanded(languageEngagementRows, [
+      [landedEngagements, (row) => row.engagementId],
+      [landedPartnerships, (row) => row.partnershipId],
+    ]);
+    if (kept.skipped > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${kept.skipped} producing-medium assignment(s) whose engagement ` +
+          `or partnership never landed (both are real FKs, either would abort the load)`,
+      );
+    }
+
+    // From the column, so it cannot drift from what Postgres accepts.
+    const allowedMediums = new Set<string>(
+      partnershipProducingMediums.medium.enumValues,
+    );
+
+    // Composite PK (engagement_id, medium). Neo4j's own `merge` plus the deactivate
+    // step should make two active edges for one pair impossible, so a duplicate here
+    // means that invariant has slipped — report it rather than letting the PK abort
+    // the run.
+    const seen = new Set<string>();
+    const duplicated: string[] = [];
+    const badMedium: string[] = [];
+    const undated: string[] = [];
+    const values = kept.kept.flatMap((row) => {
+      // NOT NULL enum. An edge with no medium, or one the enum no longer lists,
+      // would abort the load on a cast error.
+      if (!row.medium || !allowedMediums.has(row.medium)) {
+        badMedium.push(`${row.engagementId}:${row.medium ?? 'null'}`);
+        return [];
+      }
+      const key = `${row.engagementId}::${row.medium}`;
+      if (seen.has(key)) {
+        duplicated.push(key);
+        return [];
+      }
+      seen.add(key);
+      if (!row.createdAt) undated.push(key);
+      return [
+        {
+          engagementId: row.engagementId,
+          medium: row.medium as ProductMedium,
+          partnershipId: row.partnershipId,
+          createdAt: row.createdAt ? new Date(row.createdAt) : new Date(),
+        },
+      ];
+    });
+    if (badMedium.length > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${badMedium.length} assignment(s) whose medium is missing or ` +
+          `not a value the \`product_medium\` enum lists (NOT NULL enum column)`,
+      );
+    }
+    if (duplicated.length > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${duplicated.length} duplicate (engagement, medium) pair(s) — ` +
+          `two ACTIVE edges existed for one pair, which the merge/deactivate pair in ` +
+          `PartnershipProducingMediumRepository.update is meant to prevent. Kept the ` +
+          `first of each; investigate the source edges.`,
+      );
+    }
+    if (undated.length > 0) {
+      ctx.log(
+        `    ⚠ ${undated.length} assignment(s) had no createdAt under a NOT NULL ` +
+          `column — stamped now(). \`createdAt\` is set only ON CREATE, so an edge ` +
+          `predating that code can lack it.`,
+      );
+    }
+
+    const inserted = await bulkInsert(ctx, partnershipProducingMediums, values);
+    return one('partnership_producing_mediums', rows.length, inserted);
+  },
+};

--- a/src/core/cutover/extractors/partnership.extractor.ts
+++ b/src/core/cutover/extractors/partnership.extractor.ts
@@ -72,7 +72,13 @@ export const partnershipExtractor: Extractor = {
         droppedDangling++;
         return [];
       }
-      const types = sanitizeEnum([...p.types], partnerTypeEnum.enumValues);
+      // orDefault, not a bare spread — see the organization extractor: a field
+      // Neo4j never wrote arrives undefined despite the DTO's array type, and
+      // spreading it ends the whole run rather than dropping this row.
+      const types = sanitizeEnum(
+        [...orDefault(p.types, [])],
+        partnerTypeEnum.enumValues,
+      );
       types.dropped.forEach((value) => dropped.add(value));
       const frt =
         p.financialReportingType &&

--- a/src/core/cutover/extractors/partnership.extractor.ts
+++ b/src/core/cutover/extractors/partnership.extractor.ts
@@ -1,0 +1,122 @@
+import {
+  financialReportingTypeEnum,
+  partners,
+  partnershipAgreementStatusEnum,
+  partnerships,
+  partnerTypeEnum,
+  projects,
+} from '~/core/drizzle/schema';
+import {
+  type Partnership,
+  type PartnershipAgreementStatus,
+} from '../../../components/partnership/dto';
+import { PartnershipRepository } from '../../../components/partnership/partnership.repository';
+import {
+  bulkInsert,
+  dateStr,
+  linkId,
+  liveTargetIds,
+  one,
+  orDefault,
+  readAllViaRepo,
+  sanitizeEnum,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * Partnership. `mou_id`/`agreement_id` are deferred FKs (plain text) — the
+ * Neo4j file IDs carry over now and become real references when the File wave
+ * migrates `file_nodes` with the same IDs. mouStart/mouEnd (non-override) are
+ * project-derived — not columns.
+ */
+export const partnershipExtractor: Extractor = {
+  name: 'partnership',
+  targetTables: ['partnerships'],
+  dependsOn: ['project', 'partner'],
+  async run(ctx) {
+    const dtos = await readAllViaRepo<Partnership>(
+      ctx,
+      'Partnership',
+      PartnershipRepository,
+    );
+
+    const agreementStatuses =
+      partnershipAgreementStatusEnum.enumValues as readonly string[];
+    const dropped = new Set<string>();
+    const statusOr = (
+      value: string | null | undefined,
+    ): PartnershipAgreementStatus => {
+      if (value && agreementStatuses.includes(value)) {
+        // Runtime-validated against the pgEnum just above.
+        return value as PartnershipAgreementStatus;
+      }
+      if (value) dropped.add(value);
+      return 'NotAttached' as PartnershipAgreementStatus;
+    };
+
+    // Prod-finding #2 guard: both FKs are NOT NULL — drop dangling rows + log.
+    const liveProjects = await liveTargetIds(ctx, 'Project', projects);
+    const livePartners = await liveTargetIds(ctx, 'Partner', partners);
+    let droppedDangling = 0;
+
+    const rows = dtos.flatMap((p) => {
+      const projectId = linkId(p.project);
+      const partnerId = linkId(p.partner);
+      if (
+        !projectId ||
+        !liveProjects.has(projectId) ||
+        !partnerId ||
+        !livePartners.has(partnerId)
+      ) {
+        droppedDangling++;
+        return [];
+      }
+      const types = sanitizeEnum([...p.types], partnerTypeEnum.enumValues);
+      types.dropped.forEach((value) => dropped.add(value));
+      const frt =
+        p.financialReportingType &&
+        (financialReportingTypeEnum.enumValues as readonly string[]).includes(
+          p.financialReportingType,
+        )
+          ? p.financialReportingType
+          : null;
+      if (p.financialReportingType && !frt) {
+        dropped.add(p.financialReportingType);
+      }
+      return {
+        id: p.id,
+        projectId,
+        partnerId,
+        agreementStatus: statusOr(p.agreementStatus),
+        mouStatus: statusOr(p.mouStatus),
+        // Deferred FKs — File wave makes these real (IDs are preserved).
+        mouId: linkId(p.mou),
+        agreementId: linkId(p.agreement),
+        mouStartOverride: dateStr(p.mouStartOverride),
+        mouEndOverride: dateStr(p.mouEndOverride),
+        types: types.kept,
+        financialReportingType: frt,
+        primary: orDefault(p.primary, false),
+        createdAt: tsReq(p.createdAt),
+        updatedAt: tsReq(p.createdAt),
+        deletedAt: null,
+      };
+    });
+    if (dropped.size) {
+      ctx.log(
+        `    ⚠ dropped unknown partnership enum value(s): ${[...dropped].join(', ')} — migration-todo: map, don't drop`,
+      );
+    }
+    if (droppedDangling) {
+      ctx.log(
+        `    ⚠ dropped ${droppedDangling} partnership(s) with dangling project/partner refs (NOT NULL FKs — prod-finding #2)`,
+      );
+    }
+    return one(
+      'partnerships',
+      dtos.length,
+      await bulkInsert(ctx, partnerships, rows),
+    );
+  },
+};

--- a/src/core/cutover/extractors/periodic-report.extractor.ts
+++ b/src/core/cutover/extractors/periodic-report.extractor.ts
@@ -1,0 +1,219 @@
+import { type ID } from '~/common';
+import {
+  engagements,
+  periodicReports,
+  progressReportStatusEnum,
+  projects,
+  reportTypeEnum,
+} from '~/core/drizzle/schema';
+import { type PeriodicReport } from '../../../components/periodic-report/dto';
+import { PeriodicReportRepository } from '../../../components/periodic-report/periodic-report.repository';
+import {
+  bulkInsert,
+  cypher,
+  dateStr,
+  liveTargetIds,
+  one,
+  readAllViaRepo,
+  sanitizeEnum,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * PeriodicReport — one table over FinancialReport / NarrativeReport /
+ * ProgressReport, which in Neo4j are three labels sharing the `:PeriodicReport`
+ * one (2450 locally: 92 + 396 + 1962).
+ *
+ * Two shape CHECKs decide every drop here, and neither offers a null-and-carry-on
+ * option:
+ *
+ *   periodic_reports_parent_shape_chk:
+ *     Financial | Narrative ⟹ project_id NOT NULL AND engagement_id IS NULL
+ *     Progress              ⟹ engagement_id NOT NULL AND project_id IS NULL
+ *   periodic_reports_status_shape_chk:
+ *     (type = 'Progress') = (status IS NOT NULL)
+ *
+ * Ids are NOT generated — they are sha256(parent:type:start:end) in both engines
+ * (deterministicReportId), so preserving them is what keeps a re-sync idempotent
+ * rather than duplicating every interval. Two reports can only collide on the PK
+ * if they share all four dimensions, which is the intended dedup.
+ *
+ * `report_file_id` / `narrative_file_id` ARE populated, unlike the other
+ * deferred-FK file columns in this harness: they are plain text with no FK (the
+ * S4 class), and the ids carried here are the same File node ids the File wave
+ * will insert. Nulling them would need a whole backfill pass later for nothing.
+ * Until File runs they simply point at rows that do not exist yet, which reads as
+ * "no file uploaded" — see hasUploadedFileVersion in the drizzle repo.
+ *
+ * `periodic_reports` has NO deleted_at: deletion is real. So there is no
+ * soft-deleted state to carry over, and a report whose parent was soft-deleted in
+ * Neo4j has nowhere to land — see the parent note below.
+ */
+export const periodicReportExtractor: Extractor = {
+  name: 'periodic-report',
+  targetTables: ['periodic_reports'],
+  dependsOn: ['project', 'engagement'],
+  async run(ctx) {
+    const dtos = await readAllViaRepo<PeriodicReport>(
+      ctx,
+      'PeriodicReport',
+      PeriodicReportRepository,
+    );
+
+    // Parent id + kind by raw Cypher rather than off the hydrated DTO, whose
+    // `parent` is a raw Neo4j node rather than a LinkTo. Matching `parent:BaseNode`
+    // also excludes reports hanging off a SOFT-DELETED parent (Neo4j relabels to
+    // `Deleted_BaseNode`) — 67 progress reports under deleted engagements locally.
+    // That is the same set the repo's hydrate drops, so the two agree by
+    // construction and the readMany guard already reports the count.
+    const parents = new Map<string, { id: ID; isEngagement: boolean }>();
+    const parentRows = await cypher<{
+      id: ID;
+      parentId: ID;
+      isEngagement: boolean;
+    }>(
+      ctx,
+      `MATCH (parent:BaseNode)-[:report { active: true }]->(n:PeriodicReport)
+       RETURN n.id AS id, parent.id AS parentId, parent:Engagement AS isEngagement`,
+    );
+    for (const row of parentRows) {
+      parents.set(row.id, { id: row.parentId, isEngagement: row.isEngagement });
+    }
+
+    const landedProjects = await liveTargetIds(ctx, 'Project', projects);
+    const landedEngagements = await liveTargetIds(
+      ctx,
+      'Engagement',
+      engagements,
+    );
+
+    const droppedForParent: string[] = [];
+    const droppedForShape: string[] = [];
+    const droppedForInterval: string[] = [];
+    const droppedForType: string[] = [];
+    const defaultedStatuses: string[] = [];
+    const droppedEnums = new Set<string>();
+
+    const rows = dtos.flatMap((report) => {
+      const dto = report as unknown as Record<string, any>;
+
+      const typeResult = sanitizeEnum(
+        [String(dto.type)],
+        reportTypeEnum.enumValues,
+      );
+      for (const value of typeResult.dropped) {
+        droppedEnums.add(`type=${value}`);
+      }
+      const type = typeResult.kept[0];
+      if (!type) {
+        droppedForType.push(report.id);
+        return [];
+      }
+      const isProgress = type === 'Progress';
+
+      const parent = parents.get(report.id);
+      if (!parent) {
+        droppedForParent.push(report.id);
+        return [];
+      }
+      // The parent-shape CHECK ties the FK column to the type, so a Progress
+      // report under a Project (or a Financial under an Engagement) cannot be
+      // written either way round. Aborting the whole load on one bad row is
+      // worse than dropping it loudly.
+      if (isProgress !== parent.isEngagement) {
+        droppedForShape.push(report.id);
+        return [];
+      }
+      const landed = isProgress ? landedEngagements : landedProjects;
+      if (!landed.has(parent.id)) {
+        droppedForParent.push(report.id);
+        return [];
+      }
+
+      const start = dateStr(dto.start);
+      const end = dateStr(dto.end);
+      if (!start || !end) {
+        droppedForInterval.push(report.id);
+        return [];
+      }
+
+      // status is ProgressReport-only and NOT NULL for it, per the status-shape
+      // CHECK. Every progress report carries one today; default rather than drop
+      // if one ever doesn't, since NotStarted is what merge() writes at creation.
+      let status: string | null = null;
+      if (isProgress) {
+        const raw = dto.status ? String(dto.status) : null;
+        if (!raw) {
+          defaultedStatuses.push(report.id);
+        }
+        const result = sanitizeEnum(
+          [raw ?? 'NotStarted'],
+          progressReportStatusEnum.enumValues,
+        );
+        for (const value of result.dropped) {
+          droppedEnums.add(`status=${value}`);
+        }
+        status = result.kept[0] ?? 'NotStarted';
+      }
+
+      return [
+        {
+          id: report.id,
+          type: type as any,
+          projectId: isProgress ? null : (parent.id as ID<'Project'>),
+          engagementId: isProgress ? (parent.id as ID<'Engagement'>) : null,
+          start,
+          end,
+          receivedDate: dateStr(dto.receivedDate),
+          skippedReason: (dto.skippedReason as string | null) ?? null,
+          reportFileId: (dto.reportFile as ID<'File'> | null) ?? null,
+          narrativeFileId: (dto.narrativeFile as ID<'File'> | null) ?? null,
+          narrativeReceivedDate: dateStr(dto.narrativeReceivedDate),
+          status: status as any,
+          createdAt: tsReq(report.createdAt),
+          updatedAt: tsReq(report.createdAt),
+        },
+      ];
+    });
+
+    const warnDropped = (label: string, ids: readonly string[]) => {
+      if (ids.length === 0) return;
+      ctx.log(
+        `    ⚠ DROPPED ${ids.length} report(s) ${label}: ` +
+          `${ids.slice(0, 10).join(', ')}${ids.length > 10 ? ', …' : ''}`,
+      );
+    };
+    warnDropped(
+      'whose parent project/engagement never landed',
+      droppedForParent,
+    );
+    warnDropped(
+      'whose type disagreed with their parent kind (parent-shape CHECK)',
+      droppedForShape,
+    );
+    warnDropped(
+      'missing a start or end date (both NOT NULL)',
+      droppedForInterval,
+    );
+    warnDropped('with an unrecognized report type', droppedForType);
+    if (defaultedStatuses.length > 0) {
+      ctx.log(
+        `    ⚠ ${defaultedStatuses.length} progress report(s) had no status under a CHECK that ` +
+          `requires one — defaulted to NotStarted: ${defaultedStatuses.slice(0, 10).join(', ')}`,
+      );
+    }
+    if (droppedEnums.size > 0) {
+      ctx.log(
+        `    ⚠ dropped unknown periodic-report enum value(s): ${[...droppedEnums].join(', ')} ` +
+          `— migration-todo: map, don't drop`,
+      );
+    }
+
+    return one(
+      'periodic_reports',
+      dtos.length,
+      await bulkInsert(ctx, periodicReports, rows),
+    );
+  },
+};

--- a/src/core/cutover/extractors/pin.extractor.ts
+++ b/src/core/cutover/extractors/pin.extractor.ts
@@ -7,6 +7,7 @@ import {
   liveTargetIds,
   one,
   resolveParentTypes,
+  ts,
   warnIfRelTypeUnknown,
 } from '../cutover.helpers';
 import { type Extractor } from '../cutover.types';
@@ -71,7 +72,7 @@ export const pinExtractor: Extractor = {
         {
           userId: row.userId,
           resourceId: row.resourceId,
-          createdAt: row.createdAt ? new Date(row.createdAt) : new Date(),
+          createdAt: ts(row.createdAt) ?? new Date(),
         },
       ];
     });

--- a/src/core/cutover/extractors/pin.extractor.ts
+++ b/src/core/cutover/extractors/pin.extractor.ts
@@ -1,0 +1,111 @@
+import { type ID } from '~/common';
+import { pins, users } from '~/core/drizzle/schema';
+import {
+  bulkInsert,
+  cypher,
+  keepLanded,
+  liveTargetIds,
+  one,
+  resolveParentTypes,
+  warnIfRelTypeUnknown,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * Pins — per-user bookmarks over arbitrary resources.
+ *
+ * Edge-stored, not node-stored: `(:User)-[:pinned { createdAt }]->(:BaseNode)`.
+ * There is no `Pinned` label to enumerate, which is why this reads a raw edge and
+ * guards the rel type explicitly ({@link warnIfRelTypeUnknown}) — a misspelled
+ * type would return zero rows and reconcile ✓.
+ *
+ * `resource_id` is deliberately FK-less because `Pinnable` carries `@DbLabel(null)`
+ * — literally any BaseNode can be pinned, so the targets span every table. That
+ * has a consequence for the guard below: a pin whose target has not landed cannot
+ * fail an insert, so dropping it would be *choosing* to lose a user's bookmark for
+ * no constraint reason. Those are carried and counted instead. The `user_id` FK is
+ * real, so a pin whose owner never landed must go.
+ *
+ * The edge has no `active` flag — unpinning DELETEs it (PinRepository.remove), so
+ * every edge present is a live pin. Nothing to filter.
+ */
+export const pinExtractor: Extractor = {
+  name: 'pin',
+  targetTables: ['pins'],
+  dependsOn: ['user'],
+  async run(ctx) {
+    const rows = await cypher<{
+      userId: ID<'User'>;
+      resourceId: ID;
+      createdAt: string | null;
+    }>(
+      ctx,
+      `MATCH (user:User)-[rel:pinned]->(target:BaseNode)
+       RETURN user.id AS userId, target.id AS resourceId, toString(rel.createdAt) AS createdAt`,
+    );
+    if (rows.length === 0) {
+      await warnIfRelTypeUnknown(ctx, 'pinned');
+    }
+
+    const landedUsers = await liveTargetIds(ctx, 'User', users);
+    const kept = keepLanded(rows, [[landedUsers, (row) => row.userId]]);
+    if (kept.skipped > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${kept.skipped} pin(s) whose owning user never landed (user_id FK)`,
+      );
+    }
+
+    // Composite PK (user_id, resource_id). Neo4j's `merge` makes a duplicate edge
+    // impossible, so this is belt-and-braces — but a dup would otherwise be
+    // absorbed by onConflictDoNothing and show only as an unexplained count gap.
+    const seen = new Set<string>();
+    const undated: string[] = [];
+    const values = kept.kept.flatMap((row) => {
+      const key = `${row.userId}::${row.resourceId}`;
+      if (seen.has(key)) return [];
+      seen.add(key);
+      // NOT NULL with a now() default. `add()` sets createdAt only ON CREATE, so
+      // an edge predating that code could lack it.
+      if (!row.createdAt) undated.push(key);
+      return [
+        {
+          userId: row.userId,
+          resourceId: row.resourceId,
+          createdAt: row.createdAt ? new Date(row.createdAt) : new Date(),
+        },
+      ];
+    });
+    if (undated.length > 0) {
+      ctx.log(
+        `    ⚠ ${undated.length} pin(s) had no createdAt under a NOT NULL column — stamped now()`,
+      );
+    }
+
+    const inserted = await bulkInsert(ctx, pins, values);
+
+    // Reported, never dropped — see the docblock. Worth surfacing because a large
+    // count here means pins reference a domain the ETL has not reached yet, which
+    // no constraint will ever tell us. Deliberately hedged: resolveParentTypes
+    // covers the six migrated pinnable tables, not every possible Pinnable, so an
+    // unresolved target is "not found among those" rather than proof of a dangling
+    // pin.
+    if (!ctx.dryRun && values.length > 0) {
+      const resolved = await resolveParentTypes(
+        ctx,
+        values.map((row) => row.resourceId),
+      );
+      const unresolved = values.filter(
+        (row) => !resolved.has(row.resourceId),
+      ).length;
+      if (unresolved > 0) {
+        ctx.log(
+          `    ⚠ ${unresolved} pin(s) target a resource not found among the migrated pinnable tables ` +
+            `(user/language/partner/project/engagement/progress report). CARRIED, not dropped — ` +
+            `resource_id is FK-less, so nothing fails; they are simply inert until that domain lands.`,
+        );
+      }
+    }
+
+    return one('pins', rows.length, inserted);
+  },
+};

--- a/src/core/cutover/extractors/pnp-extraction-result.extractor.ts
+++ b/src/core/cutover/extractors/pnp-extraction-result.extractor.ts
@@ -141,6 +141,10 @@ export const pnpExtractionResultExtractor: Extractor = {
 
     let unusableContext = 0;
     let incomplete = 0;
+    // Counted BEFORE any drop below, so the reconciliation's read-vs-inserted gap
+    // reflects the problems that existed rather than the ones that survived.
+    let problemsSeen = 0;
+    let droppedForFile = 0;
     const problemRows: Array<{
       id: ID;
       fileId: ID<'File'>;
@@ -149,9 +153,14 @@ export const pnpExtractionResultExtractor: Extractor = {
       context: Record<string, unknown>;
     }> = [];
     for (const row of kept) {
-      if (!landedResultFiles.has(row.fileId)) continue;
+      const fileLanded = landedResultFiles.has(row.fileId);
       for (const problem of row.problems) {
         if (problem.id == null && problem.type == null) continue; // the null map
+        problemsSeen++;
+        if (!fileLanded) {
+          droppedForFile++;
+          continue;
+        }
         if (
           problem.id == null ||
           problem.type == null ||
@@ -192,11 +201,15 @@ export const pnpExtractionResultExtractor: Extractor = {
       problemRows,
     );
 
-    out.pnp_extraction_results = stat(resultRows.length, resultsInserted);
-    out.pnp_extraction_result_problems = stat(
-      problemRows.length,
-      problemsInserted,
-    );
+    if (droppedForFile > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${droppedForFile} PnP problem(s) whose extraction-result file never landed`,
+      );
+    }
+    // Both reads are PRE-drop counts — see the file extractor for why the
+    // post-filter count would make a lossy table reconcile ✓.
+    out.pnp_extraction_results = stat(raw.length, resultsInserted);
+    out.pnp_extraction_result_problems = stat(problemsSeen, problemsInserted);
     return out;
   },
 };

--- a/src/core/cutover/extractors/pnp-extraction-result.extractor.ts
+++ b/src/core/cutover/extractors/pnp-extraction-result.extractor.ts
@@ -1,0 +1,201 @@
+import { type ID } from '~/common';
+import {
+  fileNodes,
+  pnpExtractionResultProblems,
+  pnpExtractionResults,
+} from '~/core/drizzle/schema';
+import {
+  bulkInsert,
+  cypher,
+  keepLanded,
+  liveTargetIds,
+  stat,
+  warnIfRelTypeUnknown,
+} from '../cutover.helpers';
+import { type Extractor, type TableStat } from '../cutover.types';
+
+/**
+ * PnpExtractionResult + its problems — the outcome of parsing an uploaded PnP
+ * spreadsheet.
+ *
+ * Two things about the Neo4j shape drive this extractor:
+ *
+ * 1. **The result node holds no properties at all.** `save()` does
+ *    `.setVariables({ result: '{}' })` to clear the old denormalized schema
+ *    (pnp-extraction-result.neo4j.repository.ts:93), so the node carries neither
+ *    an `id` nor a `createdAt`. The Postgres table matches on the id front — its
+ *    primary key IS `file_id`, one result per File — but `created_at` is NOT NULL
+ *    with no source to read. **The owning File's `createdAt` is used**, which is
+ *    the closest defensible stand-in: a result is created by uploading a version
+ *    of that file, so it cannot predate it. Flagged rather than hidden — if
+ *    result timestamps ever matter, they have to come from somewhere else.
+ * 2. **Problem data lives on the relationship, not a node.** Each problem is
+ *    `(result)-[:problem { id, source, context }]->(:PnpProblemType)`, so `type`
+ *    comes from the target node's id while everything else comes from the edge.
+ *    `context` is stored as a JSON *string* via `apoc.convert.toJson`, so it must
+ *    be parsed on the way into a `jsonb` column.
+ *
+ * Neither `[:pnpExtractionResult]` nor `[:problem]` carries an `active` flag —
+ * `save()` hard-`delete`s the old problem edges instead of deactivating them — so
+ * this query must not filter on one.
+ */
+
+interface RawProblem {
+  id: ID | null;
+  source: string | null;
+  context: string | null;
+  type: string | null;
+}
+
+interface RawResult {
+  fileId: ID<'File'>;
+  fileCreatedAt: { toJSDate: () => Date } | null;
+  problems: RawProblem[];
+}
+
+const READ = `
+  MATCH (file:File)-[:pnpExtractionResult]->(result:PnpExtractionResult)
+  OPTIONAL MATCH (result)-[problemRel:problem]->(type:PnpProblemType)
+  RETURN file.id AS fileId,
+         file.createdAt AS fileCreatedAt,
+         collect({
+           id: problemRel.id,
+           source: problemRel.source,
+           context: problemRel.context,
+           type: type.id
+         }) AS problems
+`;
+
+/** The stored JSON string → the object a `jsonb` NOT NULL column takes. */
+const parseContext = (
+  value: string | null,
+): Record<string, unknown> | undefined => {
+  if (value == null) return {};
+  try {
+    const parsed: unknown = JSON.parse(value);
+    // A bare array or scalar is legal JSON but not the type-specific render input
+    // the column is declared to hold, so treat it as unusable rather than write it.
+    return parsed !== null &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const pnpExtractionResultExtractor: Extractor = {
+  name: 'pnpExtractionResult',
+  targetTables: ['pnp_extraction_results', 'pnp_extraction_result_problems'],
+  dependsOn: ['file'],
+  async run(ctx) {
+    const out: Record<string, TableStat> = {};
+    await warnIfRelTypeUnknown(ctx, 'pnpExtractionResult');
+    await warnIfRelTypeUnknown(ctx, 'problem');
+    const raw = await cypher<RawResult>(ctx, READ);
+    const landedFileNodes = await liveTargetIds(ctx, 'FileNode', fileNodes);
+
+    const { kept, skipped } = keepLanded(raw, [
+      [landedFileNodes, (row) => row.fileId],
+    ]);
+    if (skipped > 0) {
+      ctx.log(
+        `    ⚠ ${skipped} PnpExtractionResult(s) skipped — their File did not land ` +
+          `(file_id is the primary key and carries the FK)`,
+      );
+    }
+
+    const undated = kept.filter((row) => row.fileCreatedAt == null).length;
+    if (undated > 0) {
+      ctx.log(
+        `    ⚠ ${undated} result(s) whose File has no createdAt — created_at falls back to the epoch`,
+      );
+    }
+
+    const resultRows = kept.map((row) => ({
+      fileId: row.fileId,
+      createdAt: row.fileCreatedAt ? row.fileCreatedAt.toJSDate() : new Date(0),
+    }));
+    const resultsInserted = await bulkInsert(
+      ctx,
+      pnpExtractionResults,
+      resultRows,
+    );
+
+    // `collect()` over an OPTIONAL MATCH that found nothing still yields one
+    // all-null map, because a map literal is itself non-null. Those are absences,
+    // not problems.
+    // Cannot use liveTargetIds here: this table's primary key is `file_id`, not
+    // `id`, so the helper's `table.id` projection does not exist.
+    const landedResultFiles = ctx.dryRun
+      ? new Set(resultRows.map((row) => String(row.fileId)))
+      : new Set(
+          (
+            await ctx.db
+              .select({ fileId: pnpExtractionResults.fileId })
+              .from(pnpExtractionResults)
+          ).map((row) => String(row.fileId)),
+        );
+
+    let unusableContext = 0;
+    let incomplete = 0;
+    const problemRows: Array<{
+      id: ID;
+      fileId: ID<'File'>;
+      type: string;
+      source: string;
+      context: Record<string, unknown>;
+    }> = [];
+    for (const row of kept) {
+      if (!landedResultFiles.has(row.fileId)) continue;
+      for (const problem of row.problems) {
+        if (problem.id == null && problem.type == null) continue; // the null map
+        if (
+          problem.id == null ||
+          problem.type == null ||
+          problem.source == null
+        ) {
+          incomplete++;
+          continue;
+        }
+        const context = parseContext(problem.context);
+        if (context === undefined) {
+          unusableContext++;
+          continue;
+        }
+        problemRows.push({
+          id: problem.id,
+          fileId: row.fileId,
+          type: problem.type,
+          source: problem.source,
+          context,
+        });
+      }
+    }
+    if (incomplete > 0) {
+      ctx.log(
+        `    ⚠ ${incomplete} problem edge(s) missing id, type or source — DROPPED (all three NOT NULL)`,
+      );
+    }
+    if (unusableContext > 0) {
+      ctx.log(
+        `    ⚠ ${unusableContext} problem edge(s) whose context is not a JSON object — DROPPED ` +
+          `(context is jsonb NOT NULL and the render input must be a map)`,
+      );
+    }
+
+    const problemsInserted = await bulkInsert(
+      ctx,
+      pnpExtractionResultProblems,
+      problemRows,
+    );
+
+    out.pnp_extraction_results = stat(resultRows.length, resultsInserted);
+    out.pnp_extraction_result_problems = stat(
+      problemRows.length,
+      problemsInserted,
+    );
+    return out;
+  },
+};

--- a/src/core/cutover/extractors/pnp-extraction-result.extractor.ts
+++ b/src/core/cutover/extractors/pnp-extraction-result.extractor.ts
@@ -10,6 +10,7 @@ import {
   keepLanded,
   liveTargetIds,
   stat,
+  ts,
   warnIfRelTypeUnknown,
 } from '../cutover.helpers';
 import { type Extractor, type TableStat } from '../cutover.types';
@@ -115,7 +116,7 @@ export const pnpExtractionResultExtractor: Extractor = {
 
     const resultRows = kept.map((row) => ({
       fileId: row.fileId,
-      createdAt: row.fileCreatedAt ? row.fileCreatedAt.toJSDate() : new Date(0),
+      createdAt: ts(row.fileCreatedAt) ?? new Date(0),
     }));
     const resultsInserted = await bulkInsert(
       ctx,

--- a/src/core/cutover/extractors/post.extractor.ts
+++ b/src/core/cutover/extractors/post.extractor.ts
@@ -14,6 +14,7 @@ import {
   one,
   resolveParentTypes,
   sanitizeEnum,
+  tsReq,
 } from '../cutover.helpers';
 import { type Extractor } from '../cutover.types';
 
@@ -126,8 +127,8 @@ export const postExtractor: Extractor = {
           type: type.kept[0],
           shareability: shareability.kept[0],
           body: row.body,
-          createdAt: new Date(row.createdAt),
-          modifiedAt: new Date(row.modifiedAt ?? row.createdAt),
+          createdAt: tsReq(row.createdAt),
+          modifiedAt: tsReq(row.modifiedAt ?? row.createdAt),
         },
       ];
     });

--- a/src/core/cutover/extractors/post.extractor.ts
+++ b/src/core/cutover/extractors/post.extractor.ts
@@ -1,0 +1,149 @@
+import { type ID } from '~/common';
+import {
+  posts,
+  postShareabilityEnum,
+  postTypeEnum,
+  users,
+} from '~/core/drizzle/schema';
+import {
+  bulkInsert,
+  cypher,
+  fetchIds,
+  keepLanded,
+  liveTargetIds,
+  one,
+  resolveParentTypes,
+  sanitizeEnum,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * Posts — notes / stories / prayers attached to a Language, Partner or Project.
+ *
+ * ⚠ **Read by raw Cypher, NOT through PostRepository — this is the one repository
+ * in the harness that must not be used.** `PostRepository.readMany` applies
+ * `filterAuthorized()`, and that filter is not a policy check the root session can
+ * satisfy: it is hardcoded Cypher requiring the current user to be a *member* of
+ * the post's parent —
+ * `(node)<-[:post]-(:BaseNode)-[:member]-(:BaseNode)-[:user]->(:User { id: $currentUser })`.
+ * There is no privileges escape in a raw graph pattern, so every
+ * `Membership`-shareability post whose parent the root user isn't a member of would
+ * be dropped. Silently: the read stat counts what came back.
+ *
+ * The distinction that makes this the only case: other repositories filter with
+ * `privileges.filterToReadable()`, which root's global grants DO satisfy — proven
+ * empirically, since project/engagement/language all read their full node counts
+ * through readMany. Post's is a membership traversal, not a grant.
+ *
+ * It also cannot be caught locally: all 8 local posts are `Internal`, so the filter
+ * currently drops nothing here. A prod run is where it would have bitten.
+ *
+ * `parent_type` resolution and the FK-less-parent guard work exactly as in the
+ * comment extractor. `posts.body` is plain `text` (Post.body is a SecuredString,
+ * not rich text) so it needs no jsonb conversion — unlike comments.
+ */
+export const postExtractor: Extractor = {
+  name: 'post',
+  targetTables: ['posts'],
+  dependsOn: ['user', 'project', 'language', 'partner'],
+  async run(ctx) {
+    const rows = await cypher<{
+      id: ID<'Post'>;
+      parentId: ID;
+      creatorId: ID<'User'>;
+      type: string | null;
+      shareability: string | null;
+      body: string | null;
+      createdAt: string;
+      modifiedAt: string | null;
+    }>(
+      ctx,
+      `MATCH (parent:BaseNode)-[:post { active: true }]->(post:Post)
+       MATCH (post)-[:creator]->(creator:User)
+       MATCH (post)-[:type { active: true }]->(type:Property)
+       MATCH (post)-[:shareability { active: true }]->(shareability:Property)
+       MATCH (post)-[:body { active: true }]->(body:Property)
+       OPTIONAL MATCH (post)-[:modifiedAt { active: true }]->(modifiedAt:Property)
+       RETURN post.id AS id, parent.id AS parentId, creator.id AS creatorId,
+              type.value AS type, shareability.value AS shareability, body.value AS body,
+              toString(post.createdAt) AS createdAt, toString(modifiedAt.value) AS modifiedAt`,
+    );
+    // Every match above is required, so a post missing any of them vanishes from
+    // the result exactly like an empty domain. Enumerate to make that visible.
+    const allIds = await fetchIds(ctx, 'Post');
+    if (allIds.length !== rows.length) {
+      ctx.log(
+        `    ⚠ Post: ${allIds.length} node(s) enumerated but ${rows.length} matched the parent + creator + ` +
+          `type/shareability/body joins — ${allIds.length - rows.length} lost to a soft-deleted parent or a ` +
+          `missing required property`,
+      );
+    }
+
+    const landedUsers = await liveTargetIds(ctx, 'User', users);
+    const parentTypes = await resolveParentTypes(
+      ctx,
+      rows.map((row) => row.parentId),
+    );
+    const kept = keepLanded(rows, [
+      [landedUsers, (row) => row.creatorId],
+      [new Set(parentTypes.keys()), (row) => row.parentId],
+    ]);
+    if (kept.skipped > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${kept.skipped} post(s) whose creator never landed, or whose parent is not a live ` +
+          `migrated resource (unreachable rather than invalid — parent_id is FK-less)`,
+      );
+    }
+
+    const droppedEnums = new Set<string>();
+    const droppedForShape: string[] = [];
+    const values = kept.kept.flatMap((row) => {
+      const type = sanitizeEnum([String(row.type)], postTypeEnum.enumValues);
+      const shareability = sanitizeEnum(
+        [String(row.shareability)],
+        postShareabilityEnum.enumValues,
+      );
+      for (const [label, result] of [
+        ['type', type],
+        ['shareability', shareability],
+      ] as const) {
+        for (const value of result.dropped) {
+          droppedEnums.add(`${label}=${value}`);
+        }
+      }
+      // All three are NOT NULL with no sensible default: a post with no body or an
+      // unrecognized type is not a post.
+      if (!type.kept[0] || !shareability.kept[0] || row.body == null) {
+        droppedForShape.push(row.id);
+        return [];
+      }
+      return [
+        {
+          id: row.id,
+          parentId: row.parentId,
+          parentType: parentTypes.get(row.parentId)!,
+          creatorId: row.creatorId,
+          type: type.kept[0],
+          shareability: shareability.kept[0],
+          body: row.body,
+          createdAt: new Date(row.createdAt),
+          modifiedAt: new Date(row.modifiedAt ?? row.createdAt),
+        },
+      ];
+    });
+    if (droppedForShape.length > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${droppedForShape.length} post(s) missing a body or carrying an unrecognized ` +
+          `type/shareability (all three NOT NULL): ${droppedForShape.slice(0, 10).join(', ')}`,
+      );
+    }
+    if (droppedEnums.size > 0) {
+      ctx.log(
+        `    ⚠ unknown post enum value(s): ${[...droppedEnums].join(', ')} — migration-todo: map, don't drop. ` +
+          `Note 'ProjectTeam' IS a legal shareability (deprecated alias for Membership, stored verbatim)`,
+      );
+    }
+
+    return one('posts', rows.length, await bulkInsert(ctx, posts, values));
+  },
+};

--- a/src/core/cutover/extractors/post.extractor.ts
+++ b/src/core/cutover/extractors/post.extractor.ts
@@ -12,6 +12,7 @@ import {
   keepLanded,
   liveTargetIds,
   one,
+  recordReadLoss,
   resolveParentTypes,
   sanitizeEnum,
   tsReq,
@@ -72,13 +73,13 @@ export const postExtractor: Extractor = {
     // Every match above is required, so a post missing any of them vanishes from
     // the result exactly like an empty domain. Enumerate to make that visible.
     const allIds = await fetchIds(ctx, 'Post');
-    if (allIds.length !== rows.length) {
-      ctx.log(
-        `    ⚠ Post: ${allIds.length} node(s) enumerated but ${rows.length} matched the parent + creator + ` +
-          `type/shareability/body joins — ${allIds.length - rows.length} lost to a soft-deleted parent or a ` +
-          `missing required property`,
-      );
-    }
+    recordReadLoss(
+      ctx,
+      'Post',
+      allIds.length - rows.length,
+      `${rows.length} of ${allIds.length} matched the parent + creator + type/shareability/body joins, ` +
+        `the rest are lost to a soft-deleted parent or creator, or a missing required property`,
+    );
 
     const landedUsers = await liveTargetIds(ctx, 'User', users);
     const parentTypes = await resolveParentTypes(

--- a/src/core/cutover/extractors/product-progress.extractor.ts
+++ b/src/core/cutover/extractors/product-progress.extractor.ts
@@ -1,0 +1,168 @@
+import { type ID } from '~/common';
+import {
+  periodicReports,
+  productProgress,
+  products,
+  productStepEnum,
+  stepProgress,
+} from '~/core/drizzle/schema';
+import {
+  bulkInsert,
+  cypher,
+  fetchIds,
+  keepLanded,
+  liveTargetIds,
+  sanitizeEnum,
+  stat,
+} from '../cutover.helpers';
+import { type Extractor, type TableStat } from '../cutover.types';
+
+/**
+ * ProductProgress + StepProgress — reported completion per
+ * (product, report, variant), with one step row per step actually reported.
+ *
+ * No repository read here, deliberately. ProductProgressRepository has no
+ * `readMany(ids)` — every read is keyed by (product, report, variant) and its
+ * hydrate SYNTHESIZES placeholder step rows for the product's declared-but-
+ * unreported steps (product-progress.repository.ts hydrateOne). Those
+ * placeholders are a read-time convenience, not stored data, and going through
+ * that path would invent step rows the source never had. So this reads the nodes
+ * directly.
+ *
+ * `completed` is nullable and very often null — 788 of 1391 step rows locally.
+ * A step row with no value is meaningful (the step was touched, no figure
+ * recorded), so those are carried rather than skipped.
+ *
+ * Both FKs are NOT NULL, so a progress row whose product or report never landed
+ * has to be dropped. Neo4j keeps progress hanging off soft-deleted parents
+ * (locally 5 under deleted products, 1 under a deleted report), and the product
+ * wave itself drops rows, so this is a real and recurring class.
+ */
+export const productProgressExtractor: Extractor = {
+  name: 'product-progress',
+  targetTables: ['product_progress', 'step_progress'],
+  dependsOn: ['product', 'periodic-report'],
+  async run(ctx) {
+    const out: Record<string, TableStat> = {};
+
+    // ── product_progress ──────────────────────────────────────────────────────
+    const progressRows = await cypher<{
+      id: ID;
+      productId: ID<'Product'>;
+      reportId: ID;
+      variant: string;
+      createdAt: string;
+    }>(
+      ctx,
+      `MATCH (product:Product)-[:progress { active: true }]->(progress:ProductProgress)
+             <-[:progress { active: true }]-(report:PeriodicReport)
+       RETURN progress.id AS id, product.id AS productId, report.id AS reportId,
+              progress.variant AS variant, toString(progress.createdAt) AS createdAt`,
+    );
+    // Enumerate independently: the match above is an inner join through two
+    // required edges, so nodes whose product or report is soft-deleted simply
+    // vanish from it. Without this the loss reconciles ✓.
+    const allProgressIds = await fetchIds(ctx, 'ProductProgress');
+    if (allProgressIds.length !== progressRows.length) {
+      ctx.log(
+        `    ⚠ ProductProgress: ${allProgressIds.length} node(s) enumerated but ${progressRows.length} ` +
+          `had both a live product and a live report — ${allProgressIds.length - progressRows.length} hang off ` +
+          `a soft-deleted parent`,
+      );
+    }
+
+    const landedProducts = await liveTargetIds(ctx, 'Product', products);
+    const landedReports = await liveTargetIds(
+      ctx,
+      'PeriodicReport',
+      periodicReports,
+    );
+    const progressKept = keepLanded(progressRows, [
+      [landedProducts, (row) => row.productId],
+      [landedReports, (row) => row.reportId],
+    ]);
+    if (progressKept.skipped > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${progressKept.skipped} progress row(s) whose product or report never landed ` +
+          `(both FKs are NOT NULL) — their step rows go with them`,
+      );
+    }
+
+    out.product_progress = stat(
+      progressRows.length,
+      await bulkInsert(
+        ctx,
+        productProgress,
+        progressKept.kept.map((row) => ({
+          id: row.id,
+          productId: row.productId,
+          reportId: row.reportId,
+          variant: row.variant,
+          createdAt: new Date(row.createdAt),
+          updatedAt: new Date(row.createdAt),
+        })),
+      ),
+    );
+
+    // ── step_progress ─────────────────────────────────────────────────────────
+    const stepRows = await cypher<{
+      id: ID;
+      progressId: ID;
+      step: string;
+      completed: number | null;
+      createdAt: string;
+    }>(
+      ctx,
+      `MATCH (progress:ProductProgress)-[:step { active: true }]->(step:StepProgress)
+       OPTIONAL MATCH (step)-[:completed { active: true }]->(value:Property)
+       RETURN step.id AS id, progress.id AS progressId, step.step AS step,
+              value.value AS completed, toString(step.createdAt) AS createdAt`,
+    );
+
+    // Built from what this extractor just kept rather than via liveTargetIds,
+    // whose dry-run fallback would enumerate the dropped parents too.
+    const landedProgress = new Set<string>(
+      progressKept.kept.map((row) => row.id),
+    );
+    const stepsKept = keepLanded(stepRows, [
+      [landedProgress, (row) => row.progressId],
+    ]);
+    if (stepsKept.skipped > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${stepsKept.skipped} step row(s) belonging to a dropped progress row`,
+      );
+    }
+
+    const droppedSteps: string[] = [];
+    const stepValues = stepsKept.kept.flatMap((row) => {
+      const step = sanitizeEnum([row.step], productStepEnum.enumValues);
+      if (!step.kept[0]) {
+        droppedSteps.push(`${row.id} (${row.step})`);
+        return [];
+      }
+      return [
+        {
+          id: row.id,
+          progressId: row.progressId,
+          step: step.kept[0],
+          completed: row.completed == null ? null : Number(row.completed),
+          createdAt: new Date(row.createdAt),
+          updatedAt: new Date(row.createdAt),
+        },
+      ];
+    });
+    if (droppedSteps.length > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${droppedSteps.length} step row(s) naming a step outside the product_step enum: ` +
+          `${droppedSteps.slice(0, 10).join(', ')} — migration-todo: map, don't drop`,
+      );
+    }
+
+    out.step_progress = stat(
+      stepRows.length,
+      await bulkInsert(ctx, stepProgress, stepValues),
+    );
+
+    return out;
+  },
+};

--- a/src/core/cutover/extractors/product-progress.extractor.ts
+++ b/src/core/cutover/extractors/product-progress.extractor.ts
@@ -14,6 +14,7 @@ import {
   liveTargetIds,
   sanitizeEnum,
   stat,
+  tsReq,
 } from '../cutover.helpers';
 import { type Extractor, type TableStat } from '../cutover.types';
 
@@ -98,8 +99,8 @@ export const productProgressExtractor: Extractor = {
           productId: row.productId,
           reportId: row.reportId,
           variant: row.variant,
-          createdAt: new Date(row.createdAt),
-          updatedAt: new Date(row.createdAt),
+          createdAt: tsReq(row.createdAt),
+          updatedAt: tsReq(row.createdAt),
         })),
       ),
     );
@@ -146,8 +147,8 @@ export const productProgressExtractor: Extractor = {
           progressId: row.progressId,
           step: step.kept[0],
           completed: row.completed == null ? null : Number(row.completed),
-          createdAt: new Date(row.createdAt),
-          updatedAt: new Date(row.createdAt),
+          createdAt: tsReq(row.createdAt),
+          updatedAt: tsReq(row.createdAt),
         },
       ];
     });

--- a/src/core/cutover/extractors/product-progress.extractor.ts
+++ b/src/core/cutover/extractors/product-progress.extractor.ts
@@ -12,6 +12,7 @@ import {
   fetchIds,
   keepLanded,
   liveTargetIds,
+  recordReadLoss,
   sanitizeEnum,
   stat,
   tsReq,
@@ -64,13 +65,13 @@ export const productProgressExtractor: Extractor = {
     // required edges, so nodes whose product or report is soft-deleted simply
     // vanish from it. Without this the loss reconciles ✓.
     const allProgressIds = await fetchIds(ctx, 'ProductProgress');
-    if (allProgressIds.length !== progressRows.length) {
-      ctx.log(
-        `    ⚠ ProductProgress: ${allProgressIds.length} node(s) enumerated but ${progressRows.length} ` +
-          `had both a live product and a live report — ${allProgressIds.length - progressRows.length} hang off ` +
-          `a soft-deleted parent`,
-      );
-    }
+    recordReadLoss(
+      ctx,
+      'ProductProgress',
+      allProgressIds.length - progressRows.length,
+      `${progressRows.length} of ${allProgressIds.length} had both a live product and a live ` +
+        `report, the rest hang off a soft-deleted parent`,
+    );
 
     const landedProducts = await liveTargetIds(ctx, 'Product', products);
     const landedReports = await liveTargetIds(
@@ -120,17 +121,38 @@ export const productProgressExtractor: Extractor = {
               value.value AS completed, toString(step.createdAt) AS createdAt`,
     );
 
-    // Built from what this extractor just kept rather than via liveTargetIds,
-    // whose dry-run fallback would enumerate the dropped parents too.
-    const landedProgress = new Set<string>(
-      progressKept.kept.map((row) => row.id),
-    );
+    // In a REAL run this must be Postgres truth, not the pre-insert kept set:
+    // `product_progress_product_report_variant_unique` can conflict-drop a row
+    // that `progressKept` believes landed, and its step rows would then pass this
+    // guard and FK-abort the whole load. Dry-run is the only case where the kept
+    // set is right — nothing was inserted, and liveTargetIds' own dry-run
+    // fallback enumerates every Neo4j node including the parents just dropped.
+    const landedProgress = ctx.dryRun
+      ? new Set<string>(progressKept.kept.map((row) => row.id))
+      : await liveTargetIds(ctx, 'ProductProgress', productProgress);
     const stepsKept = keepLanded(stepRows, [
       [landedProgress, (row) => row.progressId],
     ]);
     if (stepsKept.skipped > 0) {
+      // Split by CAUSE. The step read above anchors on `(progress:ProductProgress)`
+      // with no liveness constraint, so it returns steps for every progress node in
+      // the graph — including the ones the progress read inner-joined away because
+      // their product or report is soft-deleted. Those are the overwhelming
+      // majority, and reporting the whole gap as "belonging to a dropped progress
+      // row" points at the wrong thing: on the 2026-08-19 production run it read as
+      // 82,664 steps lost to 283 dropped rows (292 each, against an average of 4.3)
+      // when in fact ~19,535 unread progress nodes accounted for nearly all of it.
+      const readProgressIds = new Set(progressRows.map((row) => row.id));
+      const lostToSoftDeletedParent = stepRows.filter(
+        (row) =>
+          !landedProgress.has(row.progressId) &&
+          !readProgressIds.has(row.progressId),
+      ).length;
+      const lostToGuard = stepsKept.skipped - lostToSoftDeletedParent;
       ctx.log(
-        `    ⚠ DROPPED ${stepsKept.skipped} step row(s) belonging to a dropped progress row`,
+        `    ⚠ DROPPED ${stepsKept.skipped} step row(s): ${lostToSoftDeletedParent} under a progress ` +
+          `node whose product or report is soft-deleted (never read — the live-only policy working), ` +
+          `${lostToGuard} under a progress row this wave dropped or that failed to land`,
       );
     }
 

--- a/src/core/cutover/extractors/product.extractor.ts
+++ b/src/core/cutover/extractors/product.extractor.ts
@@ -24,6 +24,7 @@ import {
   readAllRowsViaRepo,
   sanitizeEnum,
   stat,
+  ts,
   tsReq,
 } from '../cutover.helpers';
 import { type Extractor, type TableStat } from '../cutover.types';
@@ -89,7 +90,7 @@ export const productExtractor: Extractor = {
           id: row.id,
           type,
           name: row.name,
-          createdAt: new Date(row.createdAt),
+          createdAt: tsReq(row.createdAt),
         });
       }
     }
@@ -381,8 +382,8 @@ export const productExtractor: Extractor = {
         descKept.map((row) => ({
           value: row.value,
           methodology: row.methodology as any,
-          lastUsedAt: row.lastUsedAt ? new Date(row.lastUsedAt) : new Date(),
-          createdAt: row.createdAt ? new Date(row.createdAt) : new Date(),
+          lastUsedAt: ts(row.lastUsedAt) ?? new Date(),
+          createdAt: ts(row.createdAt) ?? new Date(),
         })),
       ),
     );

--- a/src/core/cutover/extractors/product.extractor.ts
+++ b/src/core/cutover/extractors/product.extractor.ts
@@ -1,0 +1,411 @@
+import { type ID } from '~/common';
+import {
+  engagements,
+  producibles,
+  producibleTypeEnum,
+  productCompletionDescriptions,
+  productMediumEnum,
+  productMethodologyEnum,
+  productPurposeEnum,
+  products,
+  productStepEnum,
+  progressMeasurementEnum,
+} from '~/core/drizzle/schema';
+import {
+  type HydratedProductRow,
+  ProductRepository,
+} from '../../../components/product/product.repository';
+import {
+  bulkInsert,
+  cypher,
+  fetchIds,
+  liveTargetIds,
+  orDefault,
+  readAllRowsViaRepo,
+  sanitizeEnum,
+  stat,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor, type TableStat } from '../cutover.types';
+
+/** A verse-id range exactly as both engines store it. */
+interface VerseRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * Product family — producibles (Film/Story/EthnoArt in one table) + products
+ * (single-table inheritance over Direct/Derivative/Other) +
+ * product_completion_descriptions.
+ *
+ * ⚠ DO NOT ENUMERATE THE `Producible` LABEL. In Neo4j, **Products carry it too** —
+ * locally `MATCH (n:Producible)` returns 477 nodes of which 444 are Products
+ * (411 DirectScriptureProduct + 33 DerivativeScriptureProduct) and only 33 are
+ * real producibles. Reading that label would insert every Product into the
+ * `producibles` table. Producibles are enumerated by their CONCRETE labels
+ * instead. This is the same family of trap as the ethnologue label bug, inverted:
+ * the label exists and matches too much rather than nothing.
+ *
+ * Scripture ranges are read STRAIGHT off the `ScriptureRange` nodes, whose
+ * `start`/`end` are already the verse-id integers the jsonb columns want. Going
+ * through the DTO instead would mean a lossy round trip out to
+ * book/chapter/verse and back via ScriptureRange.fromReferences.
+ *
+ * `products_type_shape_chk` forces drops rather than nulls, as with engagements:
+ *   DirectScripture ⟹ produces_id NULL     AND title NULL
+ *   Derivative      ⟹ produces_id NOT NULL AND title NULL
+ *   Other           ⟹ title NOT NULL       AND produces_id NULL
+ */
+export const productExtractor: Extractor = {
+  name: 'product',
+  targetTables: ['producibles', 'products', 'product_completion_descriptions'],
+  dependsOn: ['engagement'],
+  async run(ctx) {
+    const out: Record<string, TableStat> = {};
+
+    // ── producibles ─────────────────────────────────────────────────────────
+    // Concrete labels only — see the docblock.
+    const producibleRows: Array<{
+      id: ID;
+      type: 'Film' | 'Story' | 'EthnoArt';
+      name: string;
+      createdAt: Date;
+    }> = [];
+    for (const type of producibleTypeEnum.enumValues) {
+      const rows = await cypher<{ id: ID; name: string; createdAt: string }>(
+        ctx,
+        `MATCH (p:\`${type}\`)-[:name { active: true }]->(n:Property)
+         RETURN p.id AS id, n.value AS name, toString(p.createdAt) AS createdAt`,
+      );
+      // A label with no nodes is fine here (Film/EthnoArt are empty locally),
+      // but an unknown label would also be silent — fetchIds' guard covers the
+      // repo-driven paths, so assert the label is real by enumerating it too.
+      if (rows.length === 0) {
+        await fetchIds(ctx, type);
+      }
+      for (const row of rows) {
+        producibleRows.push({
+          id: row.id,
+          type,
+          name: row.name,
+          createdAt: new Date(row.createdAt),
+        });
+      }
+    }
+    // Producibles are read by raw Cypher (no repo), so fetch their ranges the
+    // same way — one batched query, then group by owner. Products get theirs off
+    // the hydrated row instead.
+    const producibleIds = new Set<string>(producibleRows.map((row) => row.id));
+    const producibleRefs = new Map<string, VerseRange[]>();
+    if (producibleIds.size > 0) {
+      const refRows = await cypher<{
+        ownerId: ID;
+        start: number;
+        end: number;
+      }>(
+        ctx,
+        `MATCH (o)-[:scriptureReferences { active: true }]->(s:ScriptureRange)
+         WHERE o:Film OR o:Story OR o:EthnoArt
+         RETURN o.id AS ownerId, s.start AS start, s.end AS end`,
+      );
+      for (const row of refRows) {
+        if (!producibleIds.has(row.ownerId)) continue;
+        const list = producibleRefs.get(row.ownerId) ?? [];
+        list.push({ start: Number(row.start), end: Number(row.end) });
+        producibleRefs.set(row.ownerId, list);
+      }
+      for (const list of producibleRefs.values()) {
+        list.sort((a, b) => a.start - b.start || a.end - b.end);
+      }
+    }
+    out.producibles = stat(
+      producibleRows.length,
+      await bulkInsert(
+        ctx,
+        producibles,
+        producibleRows.map((row) => ({
+          id: row.id,
+          type: row.type,
+          name: row.name,
+          scriptureReferences: producibleRefs.get(row.id) ?? [],
+          createdAt: row.createdAt,
+          updatedAt: row.createdAt,
+          deletedAt: null,
+        })),
+      ),
+    );
+
+    // ── products ────────────────────────────────────────────────────────────
+    // HydratedProductRow, not UnsecuredDto<Product> — it carries `isOverriding`
+    // and the raw ScriptureRange nodes, both of which the DTO drops.
+    const dtos = await readAllRowsViaRepo<HydratedProductRow>(
+      ctx,
+      'Product',
+      ProductRepository,
+    );
+    const derivativeIds = new Set<string>(
+      await fetchIds(ctx, 'DerivativeScriptureProduct'),
+    );
+    const otherIds = new Set<string>(await fetchIds(ctx, 'OtherProduct'));
+
+    const landedEngagements = await liveTargetIds(
+      ctx,
+      'Engagement',
+      engagements,
+    );
+    // Can't use liveTargetIds here: its dry-run fallback takes ONE label, and
+    // producibles span three (with `Producible` itself unusable — it matches
+    // Products). Build from what this extractor just wrote instead.
+    const landedProducibles = ctx.dryRun
+      ? new Set<string>(producibleRows.map((row) => row.id))
+      : new Set(
+          (await ctx.db.select({ id: producibles.id }).from(producibles)).map(
+            (row) => String(row.id),
+          ),
+        );
+
+    const droppedForEngagement: string[] = [];
+    const droppedForProduces: string[] = [];
+    const untitledOther: string[] = [];
+    const unpairedUnspecified: string[] = [];
+    const droppedEnums = new Set<string>();
+
+    const productRows = dtos.flatMap((prod) => {
+      const dto = prod as unknown as Record<string, any>;
+      const engagementId = dto.engagement as ID<'Engagement'> | undefined;
+      if (!engagementId || !landedEngagements.has(engagementId)) {
+        droppedForEngagement.push(prod.id);
+        return [];
+      }
+
+      const isDerivative = derivativeIds.has(prod.id);
+      const isOther = otherIds.has(prod.id);
+      const type: 'DirectScripture' | 'Derivative' | 'Other' = isDerivative
+        ? 'Derivative'
+        : isOther
+          ? 'Other'
+          : 'DirectScripture';
+
+      // Derivative REQUIRES produces_id — the CHECK gives no null option.
+      let producesId: ID | null = null;
+      if (isDerivative) {
+        producesId = (dto.produces?.id as ID | undefined) ?? null;
+        if (!producesId || !landedProducibles.has(producesId)) {
+          droppedForProduces.push(prod.id);
+          return [];
+        }
+      }
+
+      // Other REQUIRES a title. Rather than drop the row (products are the FK
+      // parent of product_progress, so a drop loses real progress history), fill
+      // a visible marker and shout — same call as the Language name fallback.
+      let title: string | null = isOther
+        ? ((dto.title as string | null) ?? null)
+        : null;
+      if (isOther && !title) {
+        title = `(untitled product ${prod.id})`;
+        untitledOther.push(prod.id);
+      }
+
+      // products_unspecified_scripture_chk: both columns or neither.
+      let unspecifiedBook =
+        (dto.unspecifiedScripture?.book as string | null) ?? null;
+      let unspecifiedVerses =
+        (dto.unspecifiedScripture?.totalVerses as number | null) ?? null;
+      if ((unspecifiedBook == null) !== (unspecifiedVerses == null)) {
+        unspecifiedBook = null;
+        unspecifiedVerses = null;
+        unpairedUnspecified.push(prod.id);
+      }
+
+      const mediums = sanitizeEnum(
+        [...((dto.mediums as string[] | undefined) ?? [])],
+        productMediumEnum.enumValues,
+      );
+      const purposes = sanitizeEnum(
+        [...((dto.purposes as string[] | undefined) ?? [])],
+        productPurposeEnum.enumValues,
+      );
+      const steps = sanitizeEnum(
+        [...((dto.steps as string[] | undefined) ?? [])],
+        productStepEnum.enumValues,
+      );
+      const methodology = dto.methodology
+        ? sanitizeEnum(
+            [dto.methodology as string],
+            productMethodologyEnum.enumValues,
+          )
+        : { kept: [], dropped: [] as string[] };
+      const measurement = sanitizeEnum(
+        [orDefault(dto.progressStepMeasurement as string, 'Percent')],
+        progressMeasurementEnum.enumValues,
+      );
+      for (const [label, result] of [
+        ['medium', mediums],
+        ['purpose', purposes],
+        ['step', steps],
+        ['methodology', methodology],
+        ['progressStepMeasurement', measurement],
+      ] as const) {
+        for (const value of result.dropped) {
+          droppedEnums.add(`${label}=${value}`);
+        }
+      }
+
+      // The hydrate already returns the OWN list under `scriptureReferences`,
+      // picking the right relationship per subtype (`scriptureReferences` for
+      // direct, `scriptureReferencesOverride` for derivative) — see
+      // product.repository.ts:229-239. So this is the own list either way.
+      const ownRanges = rangesOf(dto.scriptureReferences);
+      // For a derivative, null (NOT []) is what encodes "not overriding": the
+      // column REPLACES Neo4j's isOverriding flag, so an empty array would mean
+      // "overriding with nothing" and would hide the producible's references.
+      const override = isDerivative
+        ? dto.isOverriding
+          ? ownRanges
+          : null
+        : null;
+
+      return [
+        {
+          id: prod.id,
+          engagementId,
+          type: type,
+          mediums: mediums.kept as any,
+          purposes: purposes.kept as any,
+          methodology: (methodology.kept[0] as any) ?? null,
+          steps: steps.kept as any,
+          describeCompletion: (dto.describeCompletion as string | null) ?? null,
+          placeholderDescription:
+            (dto.placeholderDescription as string | null) ?? null,
+          progressStepMeasurement: (measurement.kept[0] as any) ?? 'Percent',
+          progressTarget: orDefault(dto.progressTarget as number, 100),
+          scriptureReferences: isDerivative ? [] : ownRanges,
+          scriptureReferencesOverride: override,
+          unspecifiedScriptureBook: unspecifiedBook,
+          unspecifiedScriptureTotalVerses: unspecifiedVerses,
+          totalVerses: orDefault(dto.totalVerses as number, 0),
+          totalVerseEquivalents: orDefault(
+            dto.totalVerseEquivalents as number,
+            0,
+          ),
+          producesId,
+          composite: isDerivative
+            ? ((dto.composite as boolean | null) ?? null)
+            : null,
+          title,
+          description: isOther
+            ? ((dto.description as string | null) ?? null)
+            : null,
+          pnpIndex: (dto.pnpIndex as number | null) ?? null,
+          createdAt: tsReq(prod.createdAt),
+          updatedAt: tsReq(prod.createdAt),
+          deletedAt: null,
+        },
+      ];
+    });
+
+    if (droppedForEngagement.length > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${droppedForEngagement.length} product(s) whose engagement never landed: ` +
+          `${droppedForEngagement.slice(0, 10).join(', ')}${droppedForEngagement.length > 10 ? ', …' : ''}`,
+      );
+    }
+    if (droppedForProduces.length > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${droppedForProduces.length} derivative product(s) whose producible never landed ` +
+          `(type-shape CHECK forbids a null produces_id): ` +
+          `${droppedForProduces.slice(0, 10).join(', ')}${droppedForProduces.length > 10 ? ', …' : ''}`,
+      );
+    }
+    if (untitledOther.length > 0) {
+      ctx.log(
+        `    ⚠ ${untitledOther.length} OtherProduct(s) had no title under a CHECK that requires one — ` +
+          `filled with a visible marker, needs a data fix: ${untitledOther.slice(0, 10).join(', ')}`,
+      );
+    }
+    if (unpairedUnspecified.length > 0) {
+      ctx.log(
+        `    ⚠ ${unpairedUnspecified.length} product(s) had only one half of the unspecified-scripture pair ` +
+          `(book XOR totalVerses) — both nulled to satisfy the CHECK: ${unpairedUnspecified.slice(0, 10).join(', ')}`,
+      );
+    }
+    if (droppedEnums.size > 0) {
+      ctx.log(
+        `    ⚠ dropped unknown product enum value(s): ${[...droppedEnums].join(', ')} — migration-todo: map, don't drop`,
+      );
+    }
+
+    out.products = stat(
+      dtos.length,
+      await bulkInsert(ctx, products, productRows),
+    );
+
+    // ── product_completion_descriptions ─────────────────────────────────────
+    // Suggestion store, not a domain entity: id is a bigserial, so let Postgres
+    // assign it and dedupe on (value, methodology).
+    const descRows = await cypher<{
+      value: string;
+      methodology: string;
+      lastUsedAt: string | null;
+      createdAt: string | null;
+    }>(
+      ctx,
+      `MATCH (d:ProductCompletionDescription)
+       RETURN d.value AS value, d.methodology AS methodology,
+              toString(d.lastUsedAt) AS lastUsedAt, toString(d.createdAt) AS createdAt`,
+    );
+    const knownMethodologies = new Set<string>(
+      productMethodologyEnum.enumValues,
+    );
+    const seenDesc = new Set<string>();
+    const descKept = descRows.filter((row) => {
+      if (!row.value || !knownMethodologies.has(row.methodology)) return false;
+      const key = `${row.value}::${row.methodology}`;
+      if (seenDesc.has(key)) return false;
+      seenDesc.add(key);
+      return true;
+    });
+    if (descKept.length !== descRows.length) {
+      ctx.log(
+        `    ⚠ skipped ${descRows.length - descKept.length} completion description(s) — blank value, ` +
+          `unknown methodology, or a (value, methodology) duplicate`,
+      );
+    }
+    out.product_completion_descriptions = stat(
+      descRows.length,
+      await bulkInsert(
+        ctx,
+        productCompletionDescriptions,
+        descKept.map((row) => ({
+          value: row.value,
+          methodology: row.methodology as any,
+          lastUsedAt: row.lastUsedAt ? new Date(row.lastUsedAt) : new Date(),
+          createdAt: row.createdAt ? new Date(row.createdAt) : new Date(),
+        })),
+      ),
+    );
+
+    return out;
+  },
+};
+
+/**
+ * ScriptureRange nodes → the plain `{start, end}` verse-id pairs the jsonb
+ * columns hold. Both engines already store verse ids, so this is a shape unwrap
+ * (`node.properties`), NOT a conversion — deliberately avoiding a round trip out
+ * to book/chapter/verse and back through ScriptureRange.fromReferences.
+ *
+ * Sorted so a re-run produces byte-identical jsonb.
+ */
+const rangesOf = (nodes: unknown): VerseRange[] => {
+  const list = Array.isArray(nodes) ? nodes : [];
+  return list
+    .map((node: any) => {
+      const props = node?.properties ?? node ?? {};
+      return { start: Number(props.start), end: Number(props.end) };
+    })
+    .filter((r) => Number.isFinite(r.start) && Number.isFinite(r.end))
+    .sort((a, b) => a.start - b.start || a.end - b.end);
+};

--- a/src/core/cutover/extractors/progress-report-media.extractor.ts
+++ b/src/core/cutover/extractors/progress-report-media.extractor.ts
@@ -167,6 +167,8 @@ export const progressReportMediaExtractor: Extractor = {
           `Neo4j has no equivalent constraint for`,
       );
     }
-    return one('progress_report_media', rows.length, inserted);
+    // PRE-drop count, so the variantless / unknown-category / dangling-file-ref
+    // drops above show as a read-vs-inserted gap rather than reconciling ✓.
+    return one('progress_report_media', raw.length, inserted);
   },
 };

--- a/src/core/cutover/extractors/progress-report-media.extractor.ts
+++ b/src/core/cutover/extractors/progress-report-media.extractor.ts
@@ -12,6 +12,7 @@ import {
   keepLanded,
   liveTargetIds,
   one,
+  ts,
   warnIfRelTypeUnknown,
 } from '../cutover.helpers';
 import { type Extractor } from '../cutover.types';
@@ -154,7 +155,7 @@ export const progressReportMediaExtractor: Extractor = {
           ? row.fileId
           : null,
       creatorId: row.creatorId,
-      createdAt: row.createdAt ? row.createdAt.toJSDate() : new Date(0),
+      createdAt: ts(row.createdAt) ?? new Date(0),
       deletedAt: null,
     }));
 

--- a/src/core/cutover/extractors/progress-report-media.extractor.ts
+++ b/src/core/cutover/extractors/progress-report-media.extractor.ts
@@ -1,0 +1,171 @@
+import { type ID } from '~/common';
+import {
+  fileNodes,
+  periodicReports,
+  progressReportMedia,
+  users,
+} from '~/core/drizzle/schema';
+import { type MediaCategory } from '../../../components/progress-report/media/media-category.enum';
+import {
+  bulkInsert,
+  cypher,
+  keepLanded,
+  liveTargetIds,
+  one,
+  warnIfRelTypeUnknown,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * ProgressReportMedia — the per-variant media slots on a progress report.
+ *
+ * Stored as a node whose scalar props sit directly on it (`variant`, `category`),
+ * wired by four ACTIVE edges:
+ *
+ * - `(report:ProgressReport)-[:child]->(node)` — the owning report
+ * - `(vg:VariantGroup)-[:child]->(node)` — the variant group, which has no table
+ *   of its own; `variant_group_id` is a bare NOT NULL text column, no FK
+ * - `(node)-[:fileNode]->(file:File)` — the DefinedFile placeholder, optional
+ * - `(node)-[:creator]->(:User)`
+ *
+ * Read raw rather than through the repository: `ProgressReportMediaRepository`
+ * exposes only `list(report, args)` and a featured-media lookup — both are
+ * paginated, report-scoped views, so there is no all-rows read to borrow. Its
+ * `hydrate()` also resolves the attached `Media` through the file's latest
+ * version, which this table does not store.
+ *
+ * Both parent edges are required matches, mirroring the read path: a media row
+ * with no report or no variant group cannot be represented (`report_id` and
+ * `variant_group_id` are both NOT NULL), so it drops out here exactly as it would
+ * from `list()`.
+ *
+ * `file_id` deliberately has **no FK** in Postgres (the DefinedFile placeholder is
+ * created after this row), which means a stale id here would be invisible to the
+ * database and surface as a dangling-reference read bug instead. So it is nulled
+ * when the File did not land, rather than carried across.
+ */
+
+interface RawReportMedia {
+  id: ID;
+  reportId: ID<'ProgressReport'>;
+  variant: string | null;
+  category: string | null;
+  variantGroupId: ID<'ProgressReportMediaVariantGroup'>;
+  fileId: ID<'File'> | null;
+  creatorId: ID<'User'>;
+  createdAt: { toJSDate: () => Date } | null;
+}
+
+const READ = `
+  MATCH (report:ProgressReport)-[:child { active: true }]->(m:ProgressReportMedia)
+  MATCH (vg:VariantGroup)-[:child { active: true }]->(m)
+  MATCH (m)-[:creator { active: true }]->(creator:User)
+  OPTIONAL MATCH (m)-[:fileNode { active: true }]->(file:File)
+  RETURN m.id AS id,
+         report.id AS reportId,
+         m.variant AS variant,
+         m.category AS category,
+         vg.id AS variantGroupId,
+         file.id AS fileId,
+         creator.id AS creatorId,
+         m.createdAt AS createdAt
+`;
+
+const CATEGORIES = [
+  'Team',
+  'WorkInProgress',
+  'CommunityEngagement',
+  'LifeInCommunity',
+  'Events',
+  'SceneryLandscape',
+  'Other',
+] as const;
+
+export const progressReportMediaExtractor: Extractor = {
+  name: 'progressReportMedia',
+  targetTables: ['progress_report_media'],
+  dependsOn: ['user', 'periodic-report', 'file'],
+  async run(ctx) {
+    await warnIfRelTypeUnknown(ctx, 'fileNode');
+    const raw = await cypher<RawReportMedia>(ctx, READ);
+    const [reportIds, userIds, landedFileNodes] = await Promise.all([
+      liveTargetIds(ctx, 'PeriodicReport', periodicReports),
+      liveTargetIds(ctx, 'User', users),
+      liveTargetIds(ctx, 'FileNode', fileNodes),
+    ]);
+
+    const { kept, skipped } = keepLanded(raw, [
+      [reportIds, (row) => row.reportId],
+      [userIds, (row) => row.creatorId],
+    ]);
+    if (skipped > 0) {
+      ctx.log(
+        `    ⚠ ${skipped} ProgressReportMedia row(s) skipped — report or creator did not land ` +
+          `(report_id and creator_id are both NOT NULL with FKs)`,
+      );
+    }
+
+    const variantless = kept.filter((row) => row.variant == null).length;
+    if (variantless > 0) {
+      ctx.log(
+        `    ⚠ ${variantless} row(s) have no variant — DROPPED (variant is NOT NULL and is half ` +
+          `of the (variant_group, variant) unique key)`,
+      );
+    }
+    const withVariant = kept.filter((row) => row.variant != null);
+
+    const allowed = new Set<string>(CATEGORIES);
+    const unknownCategories = [
+      ...new Set(
+        withVariant
+          .filter((row) => row.category != null && !allowed.has(row.category))
+          .map((row) => row.category!),
+      ),
+    ];
+    if (unknownCategories.length > 0) {
+      ctx.log(
+        `    ⚠ category value(s) the progress_report_media_category enum rejects — NULLED, not ` +
+          `dropped (the column is nullable and the row is still meaningful): ` +
+          unknownCategories.join(', '),
+      );
+    }
+
+    const droppedFileRefs = withVariant.filter(
+      (row) => row.fileId != null && !landedFileNodes.has(row.fileId),
+    ).length;
+    if (droppedFileRefs > 0) {
+      ctx.log(
+        `    ⚠ ${droppedFileRefs} row(s) point at a File that did not land — file_id NULLED ` +
+          `(no FK would have caught this; a stale id reads as a dangling reference)`,
+      );
+    }
+
+    const rows = withVariant.map((row) => ({
+      id: row.id,
+      reportId: row.reportId,
+      variant: row.variant!,
+      category:
+        row.category != null && allowed.has(row.category)
+          ? (row.category as MediaCategory)
+          : null,
+      variantGroupId: row.variantGroupId,
+      fileId:
+        row.fileId != null && landedFileNodes.has(row.fileId)
+          ? row.fileId
+          : null,
+      creatorId: row.creatorId,
+      createdAt: row.createdAt ? row.createdAt.toJSDate() : new Date(0),
+      deletedAt: null,
+    }));
+
+    const inserted = await bulkInsert(ctx, progressReportMedia, rows);
+    if (inserted < rows.length) {
+      ctx.log(
+        `    ⚠ ${rows.length - inserted} row(s) not written — likely a duplicate ` +
+          `(variant_group_id, variant) pair, which the partial unique index rejects and ` +
+          `Neo4j has no equivalent constraint for`,
+      );
+    }
+    return one('progress_report_media', rows.length, inserted);
+  },
+};

--- a/src/core/cutover/extractors/progress-report-variance-explanation.extractor.ts
+++ b/src/core/cutover/extractors/progress-report-variance-explanation.extractor.ts
@@ -35,6 +35,24 @@ import { type Extractor } from '../cutover.types';
  * repository substitutes `reasons: []` / `comments: null` when absent), so a row
  * with neither is a real state and is carried as the same empty defaults the
  * Postgres column already declares.
+ *
+ * ## There is no timestamp anywhere in the source
+ *
+ * `created_at` / `updated_at` are NOT NULL here, and nothing in Neo4j can fill
+ * them. Measured on the production copy 2026-08-20: all 5,729 explanation nodes
+ * carry ZERO properties — `keys(node)` is empty, so no `createdAt`, no
+ * `modifiedAt`, not even an `id` — and the `varianceExplanation` relationship
+ * carries only `active`.
+ *
+ * So this falls back to the PARENT REPORT's `createdAt`, which every report has
+ * (0 of 5,729 are missing it). It is not the moment the explanation was written,
+ * but it is a real date, it orders correctly relative to other reports, and it
+ * cannot be later than the explanation's own creation.
+ *
+ * It previously fell back to `new Date()`, which stamped every row in the table
+ * with the same load time. That is worse than imprecise: it silently destroyed
+ * ordering, and because it applied to 100% of rows there was no surviving signal
+ * to notice it by.
  */
 export const progressReportVarianceExplanationExtractor: Extractor = {
   name: 'progress-report-variance-explanation',
@@ -47,6 +65,7 @@ export const progressReportVarianceExplanationExtractor: Extractor = {
       comments: unknown;
       createdAt: string | null;
       modifiedAt: string | null;
+      reportCreatedAt: string | null;
     }>(
       ctx,
       `MATCH (report:ProgressReport)-[:varianceExplanation { active: true }]->(node:ProgressReportVarianceExplanation)
@@ -56,7 +75,8 @@ export const progressReportVarianceExplanationExtractor: Extractor = {
               reasons.value AS reasons,
               comments.value AS comments,
               toString(node.createdAt) AS createdAt,
-              toString(node.modifiedAt) AS modifiedAt`,
+              toString(node.modifiedAt) AS modifiedAt,
+              toString(report.createdAt) AS reportCreatedAt`,
     );
     if (rows.length === 0) {
       await warnIfRelTypeUnknown(ctx, 'varianceExplanation');
@@ -83,15 +103,21 @@ export const progressReportVarianceExplanationExtractor: Extractor = {
     // is worth knowing on its own.
     const seen = new Set<string>();
     const duplicated: string[] = [];
-    const undated: string[] = [];
+    const borrowedFromReport: string[] = [];
+    const stampedNow: string[] = [];
     const values = kept.kept.flatMap((row) => {
       if (seen.has(row.reportId)) {
         duplicated.push(row.reportId);
         return [];
       }
       seen.add(row.reportId);
-      if (!row.createdAt) undated.push(row.reportId);
-      const created = ts(row.createdAt) ?? new Date();
+      if (!row.createdAt) {
+        (row.reportCreatedAt ? borrowedFromReport : stampedNow).push(
+          row.reportId,
+        );
+      }
+      const created =
+        ts(row.createdAt) ?? ts(row.reportCreatedAt) ?? new Date();
       return [
         {
           reportId: row.reportId,
@@ -118,10 +144,20 @@ export const progressReportVarianceExplanationExtractor: Extractor = {
           `Kept the first of each; investigate the source rows.`,
       );
     }
-    if (undated.length > 0) {
+    if (borrowedFromReport.length > 0) {
       ctx.log(
-        `    ⚠ ${undated.length} variance explanation(s) had no createdAt under a NOT ` +
-          `NULL column — stamped now()`,
+        `    ℹ ${borrowedFromReport.length} of ${values.length} variance ` +
+          `explanation(s) carry no createdAt of their own — the source stores no ` +
+          `timestamp for them anywhere, so created_at/updated_at come from the ` +
+          `parent report. Expect this to be ALL of them; see the docblock.`,
+      );
+    }
+    if (stampedNow.length > 0) {
+      ctx.log(
+        `    ⚠ ${stampedNow.length} variance explanation(s) had no createdAt AND ` +
+          `their report has none either — stamped now(), which is a load-time date ` +
+          `with no meaning. Every report in the 2026-08-20 production copy had one, ` +
+          `so a non-zero count here is a new finding worth chasing.`,
       );
     }
 

--- a/src/core/cutover/extractors/progress-report-variance-explanation.extractor.ts
+++ b/src/core/cutover/extractors/progress-report-variance-explanation.extractor.ts
@@ -10,6 +10,7 @@ import {
   liveTargetIds,
   one,
   richText,
+  ts,
   warnIfRelTypeUnknown,
 } from '../cutover.helpers';
 import { type Extractor } from '../cutover.types';
@@ -90,7 +91,7 @@ export const progressReportVarianceExplanationExtractor: Extractor = {
       }
       seen.add(row.reportId);
       if (!row.createdAt) undated.push(row.reportId);
-      const created = row.createdAt ? new Date(row.createdAt) : new Date();
+      const created = ts(row.createdAt) ?? new Date();
       return [
         {
           reportId: row.reportId,
@@ -105,7 +106,7 @@ export const progressReportVarianceExplanationExtractor: Extractor = {
           // it from createdAt matches what the other extractors do for the same
           // NOT NULL column, and is truthful: never edited means unchanged since
           // creation.
-          updatedAt: row.modifiedAt ? new Date(row.modifiedAt) : created,
+          updatedAt: ts(row.modifiedAt) ?? created,
         },
       ];
     });

--- a/src/core/cutover/extractors/progress-report-variance-explanation.extractor.ts
+++ b/src/core/cutover/extractors/progress-report-variance-explanation.extractor.ts
@@ -1,0 +1,134 @@
+import { type ID } from '~/common';
+import {
+  periodicReports,
+  progressReportVarianceExplanations,
+} from '~/core/drizzle/schema';
+import {
+  bulkInsert,
+  cypher,
+  keepLanded,
+  liveTargetIds,
+  one,
+  richText,
+  warnIfRelTypeUnknown,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * Progress report variance explanations — why a report's progress differs from
+ * plan: a set of canned reasons plus free prose.
+ *
+ * One row per report, and the Postgres table says so structurally: `report_id` IS
+ * the primary key, there is no id column of its own, and the Neo4j node's id is
+ * deliberately discarded. Neo4j enforces the same thing a different way — the
+ * repository `merge`s the `varianceExplanation` relationship, so a report can
+ * never accumulate two.
+ *
+ * Unlike its workflow-event sibling, `reasons` and `comments` are NOT stored on the
+ * node. The repository reads them with `matchProps`, meaning each is a separate
+ * `Property` node behind an active relationship, so the Cypher below walks to them
+ * explicitly. Reading these off the node would return nulls for every row and
+ * still reconcile as a clean run.
+ *
+ * Both properties are optional in Neo4j (`matchProps({ optional: true })`, and the
+ * repository substitutes `reasons: []` / `comments: null` when absent), so a row
+ * with neither is a real state and is carried as the same empty defaults the
+ * Postgres column already declares.
+ */
+export const progressReportVarianceExplanationExtractor: Extractor = {
+  name: 'progress-report-variance-explanation',
+  targetTables: ['progress_report_variance_explanations'],
+  dependsOn: ['periodic-report'],
+  async run(ctx) {
+    const rows = await cypher<{
+      reportId: ID<'ProgressReport'>;
+      reasons: string[] | null;
+      comments: unknown;
+      createdAt: string | null;
+      modifiedAt: string | null;
+    }>(
+      ctx,
+      `MATCH (report:ProgressReport)-[:varianceExplanation { active: true }]->(node:ProgressReportVarianceExplanation)
+       OPTIONAL MATCH (node)-[:reasons { active: true }]->(reasons:Property)
+       OPTIONAL MATCH (node)-[:comments { active: true }]->(comments:Property)
+       RETURN report.id AS reportId,
+              reasons.value AS reasons,
+              comments.value AS comments,
+              toString(node.createdAt) AS createdAt,
+              toString(node.modifiedAt) AS modifiedAt`,
+    );
+    if (rows.length === 0) {
+      await warnIfRelTypeUnknown(ctx, 'varianceExplanation');
+    }
+
+    const landedReports = await liveTargetIds(
+      ctx,
+      'ProgressReport',
+      periodicReports,
+    );
+    const kept = keepLanded(rows, [[landedReports, (row) => row.reportId]]);
+    if (kept.skipped > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${kept.skipped} variance explanation(s) whose report never ` +
+          `landed (report_id is both the PK and a real FK). A soft-deleted report is ` +
+          `the expected cause — the ETL is live-only.`,
+      );
+    }
+
+    // The relationship is merged, so two active explanations for one report should
+    // be impossible. Guard anyway: `report_id` is the primary key, so a duplicate
+    // would abort the load, and deduping here reports it instead of failing. A
+    // second active row would also mean the merge invariant has been broken, which
+    // is worth knowing on its own.
+    const seen = new Set<string>();
+    const duplicated: string[] = [];
+    const undated: string[] = [];
+    const values = kept.kept.flatMap((row) => {
+      if (seen.has(row.reportId)) {
+        duplicated.push(row.reportId);
+        return [];
+      }
+      seen.add(row.reportId);
+      if (!row.createdAt) undated.push(row.reportId);
+      const created = row.createdAt ? new Date(row.createdAt) : new Date();
+      return [
+        {
+          reportId: row.reportId,
+          // Deliberately kept as text[] rather than an enum: the reason vocabulary
+          // carries an explicit deprecated list whose whole purpose is keeping old
+          // values readable while blocking them for new writes. So an unrecognised
+          // reason here is data to preserve, not data to drop — nothing is filtered.
+          reasons: row.reasons ?? [],
+          comments: richText(row.comments) ?? null,
+          createdAt: created,
+          // Neo4j only stamps modifiedAt once a property has been updated. Seeding
+          // it from createdAt matches what the other extractors do for the same
+          // NOT NULL column, and is truthful: never edited means unchanged since
+          // creation.
+          updatedAt: row.modifiedAt ? new Date(row.modifiedAt) : created,
+        },
+      ];
+    });
+    if (duplicated.length > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${duplicated.length} duplicate variance explanation(s) — a ` +
+          `report held more than one active explanation, which the merge in ` +
+          `ProgressReportVarianceExplanationRepository.update is supposed to prevent. ` +
+          `Kept the first of each; investigate the source rows.`,
+      );
+    }
+    if (undated.length > 0) {
+      ctx.log(
+        `    ⚠ ${undated.length} variance explanation(s) had no createdAt under a NOT ` +
+          `NULL column — stamped now()`,
+      );
+    }
+
+    const inserted = await bulkInsert(
+      ctx,
+      progressReportVarianceExplanations,
+      values,
+    );
+    return one('progress_report_variance_explanations', rows.length, inserted);
+  },
+};

--- a/src/core/cutover/extractors/progress-report-workflow-event.extractor.ts
+++ b/src/core/cutover/extractors/progress-report-workflow-event.extractor.ts
@@ -12,6 +12,7 @@ import {
   liveTargetIds,
   one,
   richText,
+  ts,
   warnIfRelTypeUnknown,
 } from '../cutover.helpers';
 import { type Extractor } from '../cutover.types';
@@ -128,7 +129,7 @@ export const progressReportWorkflowEventExtractor: Extractor = {
           // which is a legitimate state rather than missing data.
           transitionKey: row.transitionKey ?? null,
           notes: richText(row.notes) ?? null,
-          at: row.at ? new Date(row.at) : new Date(),
+          at: ts(row.at) ?? new Date(),
         },
       ];
     });

--- a/src/core/cutover/extractors/progress-report-workflow-event.extractor.ts
+++ b/src/core/cutover/extractors/progress-report-workflow-event.extractor.ts
@@ -8,9 +8,11 @@ import { type ProgressReportStatus } from '../../../components/progress-report/d
 import {
   bulkInsert,
   cypher,
+  fetchIds,
   keepLanded,
   liveTargetIds,
   one,
+  recordReadLoss,
   richText,
   ts,
   warnIfRelTypeUnknown,
@@ -69,6 +71,22 @@ export const progressReportWorkflowEventExtractor: Extractor = {
       // so out loud rather than reporting a clean empty run.
       await warnIfRelTypeUnknown(ctx, 'workflowEvent');
     }
+    // `report:ProgressReport` is a required match, so events whose report was
+    // soft-deleted (every label relabelled `Deleted_`) never enter `rows` at all.
+    // Dropping them is the live-only policy working as intended; the problem is
+    // that they would leave NO trace — unlike the keepLanded drops below, they
+    // are gone before `read` counts them, so this table would reconcile ✓ and the
+    // footer would claim zero rows lost. Every sibling in this cluster
+    // (progress-summary, PVR, post, comment) enumerates and compares for exactly
+    // this reason; this one did not.
+    const allEventIds = await fetchIds(ctx, 'ProgressReportWorkflowEvent');
+    recordReadLoss(
+      ctx,
+      'ProgressReportWorkflowEvent',
+      allEventIds.length - rows.length,
+      `${rows.length} of ${allEventIds.length} hang off a live report, ` +
+        `the rest are under a soft-deleted one`,
+    );
 
     // Both are real foreign keys, so a row referencing something that never landed
     // cannot be carried. `who` is NOT NULL as well, which makes the actor guard a

--- a/src/core/cutover/extractors/progress-report-workflow-event.extractor.ts
+++ b/src/core/cutover/extractors/progress-report-workflow-event.extractor.ts
@@ -1,0 +1,157 @@
+import { type ID } from '~/common';
+import {
+  periodicReports,
+  progressReportWorkflowEvents,
+  users,
+} from '~/core/drizzle/schema';
+import { type ProgressReportStatus } from '../../../components/progress-report/dto';
+import {
+  bulkInsert,
+  cypher,
+  keepLanded,
+  liveTargetIds,
+  one,
+  richText,
+  warnIfRelTypeUnknown,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * Progress report workflow events — the transition history behind every report's
+ * status.
+ *
+ * Without this extractor a report's CURRENT status carries over (it is a column on
+ * `periodic_reports`, filled by the periodic-report extractor) while the record of
+ * how it got there does not. This is the largest of the four tables by row count,
+ * and the loss would be silent: the status field looks right, and only the history
+ * panel is empty.
+ *
+ * Read with raw Cypher rather than through the repository, on purpose. The repo's
+ * `matchEvent()` is a required walk up through `:ProgressReport` → `:Engagement` →
+ * `:Project` and then applies `filterToReadable()`, so reading through it would
+ * silently shed events whose ancestors are soft-deleted AND everything the running
+ * session cannot see. An extractor wants every row, and the ancestor filtering is
+ * handled below by the landed-parent guard instead — which is the same answer for
+ * the right reason.
+ *
+ * `status`, `transition` and `notes` are baseNodeProps, stored directly on the node
+ * (see `recordEvent`'s `createNode(WorkflowEvent, { baseNodeProps: props })`), so
+ * they read straight off it with no Property-node walk.
+ */
+export const progressReportWorkflowEventExtractor: Extractor = {
+  name: 'progress-report-workflow-event',
+  targetTables: ['progress_report_workflow_events'],
+  dependsOn: ['periodic-report', 'user'],
+  async run(ctx) {
+    const rows = await cypher<{
+      id: ID<'ProgressReportWorkflowEvent'>;
+      reportId: ID<'ProgressReport'>;
+      who: ID<'User'> | null;
+      status: string | null;
+      transitionKey: string | null;
+      notes: unknown;
+      at: string | null;
+    }>(
+      ctx,
+      `MATCH (report:ProgressReport)-[:workflowEvent { active: true }]->(node:ProgressReportWorkflowEvent)
+       OPTIONAL MATCH (node)-[:who]->(who:User)
+       RETURN node.id AS id,
+              report.id AS reportId,
+              who.id AS who,
+              node.status AS status,
+              node.transition AS transitionKey,
+              node.notes AS notes,
+              toString(node.createdAt) AS at`,
+    );
+    if (rows.length === 0) {
+      // A misspelled relationship type returns zero rows and reconciles ✓, so say
+      // so out loud rather than reporting a clean empty run.
+      await warnIfRelTypeUnknown(ctx, 'workflowEvent');
+    }
+
+    // Both are real foreign keys, so a row referencing something that never landed
+    // cannot be carried. `who` is NOT NULL as well, which makes the actor guard a
+    // requirement rather than a choice.
+    const landedReports = await liveTargetIds(
+      ctx,
+      'ProgressReport',
+      periodicReports,
+    );
+    const landedUsers = await liveTargetIds(ctx, 'User', users);
+
+    const actorless = rows.filter((row) => !row.who).length;
+    if (actorless > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${actorless} workflow event(s) with no \`who\` edge at all ` +
+          `(who is NOT NULL). Neo4j's hydrate() requires that edge too, so these ` +
+          `events are already invisible in the app today.`,
+      );
+    }
+
+    const kept = keepLanded(
+      rows.filter((row) => row.who),
+      [
+        [landedReports, (row) => row.reportId],
+        [landedUsers, (row) => row.who!],
+      ],
+    );
+    if (kept.skipped > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${kept.skipped} workflow event(s) whose report or actor never ` +
+          `landed (both are real FKs). A soft-deleted report is the expected cause — ` +
+          `the ETL is live-only, so its events go with it.`,
+      );
+    }
+
+    // Taken from the column itself rather than re-listed here, so this cannot
+    // drift from what Postgres will actually accept.
+    const allowedStatuses = new Set<string>(
+      progressReportWorkflowEvents.status.enumValues,
+    );
+
+    const undated: string[] = [];
+    const values = kept.kept.flatMap((row) => {
+      // `status` is NOT NULL and an enum. An event predating the status property,
+      // or carrying a value the enum no longer lists, would abort the entire load
+      // on a cast error — drop it and say how many, the posture the other enum
+      // columns take.
+      if (!row.status || !allowedStatuses.has(row.status)) return [];
+      const status = row.status as ProgressReportStatus;
+      if (!row.at) undated.push(row.id);
+      return [
+        {
+          id: row.id,
+          reportId: row.reportId,
+          who: row.who!,
+          status,
+          // Nullable here: a bypassed or dynamically resolved transition has no key,
+          // which is a legitimate state rather than missing data.
+          transitionKey: row.transitionKey ?? null,
+          notes: richText(row.notes) ?? null,
+          at: row.at ? new Date(row.at) : new Date(),
+        },
+      ];
+    });
+
+    const droppedStatus = kept.kept.length - values.length;
+    if (droppedStatus > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${droppedStatus} workflow event(s) whose status is missing or ` +
+          `not a value the \`progress_report_status\` enum lists (NOT NULL enum column)`,
+      );
+    }
+    if (undated.length > 0) {
+      ctx.log(
+        `    ⚠ ${undated.length} workflow event(s) had no createdAt under a NOT NULL ` +
+          `column — stamped now(). These will sort last in the history panel.`,
+      );
+    }
+
+    const inserted = await bulkInsert(
+      ctx,
+      progressReportWorkflowEvents,
+      values,
+    );
+    return one('progress_report_workflow_events', rows.length, inserted);
+  },
+};

--- a/src/core/cutover/extractors/progress-summary.extractor.ts
+++ b/src/core/cutover/extractors/progress-summary.extractor.ts
@@ -1,0 +1,126 @@
+import { type ID } from '~/common';
+import {
+  periodicReports,
+  progressSummaries,
+  summaryPeriodEnum,
+} from '~/core/drizzle/schema';
+import {
+  bulkInsert,
+  cypher,
+  fetchIds,
+  keepLanded,
+  liveTargetIds,
+  one,
+  orDefault,
+  sanitizeEnum,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * ProgressSummary — the planned/actual figures the PnP extractor writes per
+ * (progress report, period).
+ *
+ * The smallest mapping in the harness, and the only one where the source node has
+ * no identity of its own: a Neo4j ProgressSummary carries just
+ * {period, planned, actual} — no id, no createdAt. It is addressed entirely by its
+ * report + period, which is what the target's unique index encodes, and why the
+ * target id is a bigserial. Insert order therefore assigns the ids, so the rows
+ * are sorted before insert to keep them stable across re-runs.
+ */
+export const progressSummaryExtractor: Extractor = {
+  name: 'progress-summary',
+  targetTables: ['progress_summaries'],
+  dependsOn: ['periodic-report'],
+  async run(ctx) {
+    const rows = await cypher<{
+      reportId: ID;
+      period: string;
+      planned: number | null;
+      actual: number | null;
+    }>(
+      ctx,
+      `MATCH (report:PeriodicReport)-[:summary { active: true }]->(summary:ProgressSummary)
+       RETURN report.id AS reportId, summary.period AS period,
+              summary.planned AS planned, summary.actual AS actual`,
+    );
+    // The report edge is required, so summaries under a soft-deleted report drop
+    // out of the match entirely — 3 of 48 locally. Enumerate to say so.
+    const allIds = await fetchIds(ctx, 'ProgressSummary');
+    if (allIds.length !== rows.length) {
+      ctx.log(
+        `    ⚠ ProgressSummary: ${allIds.length} node(s) enumerated but ${rows.length} had a live ` +
+          `report — ${allIds.length - rows.length} hang off a soft-deleted one`,
+      );
+    }
+
+    const landedReports = await liveTargetIds(
+      ctx,
+      'PeriodicReport',
+      periodicReports,
+    );
+    const kept = keepLanded(rows, [[landedReports, (row) => row.reportId]]);
+    if (kept.skipped > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${kept.skipped} summary row(s) whose report never landed`,
+      );
+    }
+
+    const seen = new Set<string>();
+    const droppedPeriods = new Set<string>();
+    const defaulted: string[] = [];
+    const values = [...kept.kept]
+      // Stable bigserial assignment — see the docblock.
+      .sort(
+        (a, b) =>
+          a.reportId.localeCompare(b.reportId) ||
+          a.period.localeCompare(b.period),
+      )
+      .flatMap((row) => {
+        const period = sanitizeEnum([row.period], summaryPeriodEnum.enumValues);
+        if (!period.kept[0]) {
+          droppedPeriods.add(row.period);
+          return [];
+        }
+        // The unique index would absorb a duplicate silently; skip it here so
+        // the count is attributable instead.
+        const key = `${row.reportId}::${period.kept[0]}`;
+        if (seen.has(key)) return [];
+        seen.add(key);
+        if (row.planned == null || row.actual == null) {
+          defaulted.push(row.reportId);
+        }
+        return [
+          {
+            reportId: row.reportId,
+            period: period.kept[0],
+            planned: orDefault(row.planned, 0),
+            actual: orDefault(row.actual, 0),
+          },
+        ];
+      });
+    if (droppedPeriods.size > 0) {
+      ctx.log(
+        `    ⚠ DROPPED summary row(s) naming a period outside the summary_period enum: ` +
+          `${[...droppedPeriods].join(', ')} — migration-todo: map, don't drop`,
+      );
+    }
+    if (defaulted.length > 0) {
+      ctx.log(
+        `    ⚠ ${defaulted.length} summary row(s) had a null planned/actual under NOT NULL columns — ` +
+          `zeroed: ${defaulted.slice(0, 10).join(', ')}`,
+      );
+    }
+    if (values.length !== kept.kept.length) {
+      ctx.log(
+        `    ⚠ skipped ${kept.kept.length - values.length} summary row(s) — unknown period or a ` +
+          `(report, period) duplicate`,
+      );
+    }
+
+    return one(
+      'progress_summaries',
+      rows.length,
+      await bulkInsert(ctx, progressSummaries, values),
+    );
+  },
+};

--- a/src/core/cutover/extractors/progress-summary.extractor.ts
+++ b/src/core/cutover/extractors/progress-summary.extractor.ts
@@ -12,6 +12,7 @@ import {
   liveTargetIds,
   one,
   orDefault,
+  recordReadLoss,
   sanitizeEnum,
 } from '../cutover.helpers';
 import { type Extractor } from '../cutover.types';
@@ -46,12 +47,12 @@ export const progressSummaryExtractor: Extractor = {
     // The report edge is required, so summaries under a soft-deleted report drop
     // out of the match entirely — 3 of 48 locally. Enumerate to say so.
     const allIds = await fetchIds(ctx, 'ProgressSummary');
-    if (allIds.length !== rows.length) {
-      ctx.log(
-        `    ⚠ ProgressSummary: ${allIds.length} node(s) enumerated but ${rows.length} had a live ` +
-          `report — ${allIds.length - rows.length} hang off a soft-deleted one`,
-      );
-    }
+    recordReadLoss(
+      ctx,
+      'ProgressSummary',
+      allIds.length - rows.length,
+      `${rows.length} of ${allIds.length} had a live report, the rest hang off a soft-deleted one`,
+    );
 
     const landedReports = await liveTargetIds(
       ctx,

--- a/src/core/cutover/extractors/project-member.extractor.ts
+++ b/src/core/cutover/extractors/project-member.extractor.ts
@@ -1,0 +1,88 @@
+import {
+  projectMembers,
+  projects,
+  roleEnum,
+  users,
+} from '~/core/drizzle/schema';
+import { type ProjectMember } from '../../../components/project/project-member/dto';
+import { ProjectMemberRepository } from '../../../components/project/project-member/project-member.repository';
+import {
+  bulkInsert,
+  linkId,
+  liveTargetIds,
+  one,
+  readAllViaRepo,
+  sanitizeEnum,
+  ts,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * ProjectMember — the DTO's `user` is the full unsecured user, so the FK is a
+ * plain `.id`. `inactiveAt` carries over as-is (member replacement history —
+ * the Drizzle read filters exclude inactive members, deliberately tighter
+ * than Neo4j; see the pre-cutover audit ledger).
+ */
+export const projectMemberExtractor: Extractor = {
+  name: 'projectMember',
+  targetTables: ['project_members'],
+  dependsOn: ['project', 'user'],
+  async run(ctx) {
+    const dtos = await readAllViaRepo<ProjectMember>(
+      ctx,
+      'ProjectMember',
+      ProjectMemberRepository,
+    );
+
+    // Prod-finding #2 guard: both FKs are NOT NULL, so rows referencing
+    // soft-deleted projects/users can't be nulled — drop + log.
+    const liveProjects = await liveTargetIds(ctx, 'Project', projects);
+    const liveUsers = await liveTargetIds(ctx, 'User', users);
+    let droppedDangling = 0;
+
+    const droppedRoles = new Set<string>();
+    const rows = dtos.flatMap((m) => {
+      const projectId = linkId(m.project);
+      const userId = m.user?.id;
+      if (
+        !projectId ||
+        !liveProjects.has(projectId) ||
+        !userId ||
+        !liveUsers.has(userId)
+      ) {
+        droppedDangling++;
+        return [];
+      }
+      const roles = sanitizeEnum([...m.roles], roleEnum.enumValues);
+      roles.dropped.forEach((role) => droppedRoles.add(role));
+      return [
+        {
+          id: m.id,
+          projectId,
+          userId,
+          roles: roles.kept,
+          inactiveAt: ts(m.inactiveAt),
+          createdAt: tsReq(m.createdAt),
+          updatedAt: tsReq(m.modifiedAt),
+          deletedAt: null,
+        },
+      ];
+    });
+    if (droppedRoles.size) {
+      ctx.log(
+        `    ⚠ dropped unknown member role(s): ${[...droppedRoles].join(', ')} — migration-todo: map, don't drop`,
+      );
+    }
+    if (droppedDangling) {
+      ctx.log(
+        `    ⚠ dropped ${droppedDangling} member(s) of soft-deleted projects/users (NOT NULL FKs — prod-finding #2)`,
+      );
+    }
+    return one(
+      'project_members',
+      dtos.length,
+      await bulkInsert(ctx, projectMembers, rows),
+    );
+  },
+};

--- a/src/core/cutover/extractors/project-member.extractor.ts
+++ b/src/core/cutover/extractors/project-member.extractor.ts
@@ -11,6 +11,7 @@ import {
   linkId,
   liveTargetIds,
   one,
+  orDefault,
   readAllViaRepo,
   sanitizeEnum,
   ts,
@@ -54,7 +55,13 @@ export const projectMemberExtractor: Extractor = {
         droppedDangling++;
         return [];
       }
-      const roles = sanitizeEnum([...m.roles], roleEnum.enumValues);
+      // orDefault, not a bare spread — see the organization extractor: a member
+      // whose roles were never written arrives undefined despite the DTO's array
+      // type, and spreading it ends the whole run rather than dropping this row.
+      const roles = sanitizeEnum(
+        [...orDefault(m.roles, [])],
+        roleEnum.enumValues,
+      );
       roles.dropped.forEach((role) => droppedRoles.add(role));
       return [
         {

--- a/src/core/cutover/extractors/project-member.extractor.ts
+++ b/src/core/cutover/extractors/project-member.extractor.ts
@@ -24,6 +24,33 @@ import { type Extractor } from '../cutover.types';
  * plain `.id`. `inactiveAt` carries over as-is (member replacement history —
  * the Drizzle read filters exclude inactive members, deliberately tighter
  * than Neo4j; see the pre-cutover audit ledger).
+ *
+ * ## One person can be a member of one project TWICE
+ *
+ * Neo4j puts no uniqueness on `(project, user)` and the service never checks, so
+ * production carries 8 pairs where the same user holds two live memberships of
+ * the same project — some created minutes apart (a double submit), some years
+ * apart (re-added by someone who did not know). None are inactive; both are
+ * fully live.
+ *
+ * Postgres models this differently: roles are an ARRAY on a single membership
+ * row, under a partial unique index on `(project_id, user_id) WHERE deleted_at
+ * IS NULL`. So the second row cannot exist, and until 2026-08-20 it was silently
+ * refused by `onConflictDoNothing` — keeping whichever row reached Postgres
+ * first, which is arbitrary.
+ *
+ * That is not a duplicate being tidied away, it is **a permission being
+ * revoked**. `matchProjectScopedRoles` (match-project-based-props.ts) matches
+ * EVERY membership node for the user on that project and `collect`s the roles
+ * across all of them, so Neo4j grants the UNION. Three of the eight differ:
+ * `FinancialAnalyst` vs none, `ProjectManager` vs none, and
+ * `BibleTranslationLiaison` vs `ConsultantManager`. Dropping the wrong row of
+ * those pairs removes access the person has today.
+ *
+ * So duplicates are MERGED rather than dropped: union of roles, earliest
+ * `createdAt`, latest `updatedAt`, and still active if any membership is. That
+ * reproduces exactly what Neo4j grants, and the merged row keeps the earliest
+ * membership's id so a rerun picks the same one.
  */
 export const projectMemberExtractor: Extractor = {
   name: 'projectMember',
@@ -86,10 +113,66 @@ export const projectMemberExtractor: Extractor = {
         `    ⚠ dropped ${droppedDangling} member(s) of soft-deleted projects/users (NOT NULL FKs — prod-finding #2)`,
       );
     }
+
+    // Merge duplicate (project, user) memberships — see the docblock. Ordered by
+    // createdAt so the surviving id and the merged dates do not depend on the
+    // order readMany happened to return.
+    const byPair = new Map<string, Array<(typeof rows)[number]>>();
+    for (const row of rows) {
+      const key = `${row.projectId}\u0000${row.userId}`;
+      const held = byPair.get(key);
+      if (held) held.push(row);
+      else byPair.set(key, [row]);
+    }
+    const mergedPairs: string[] = [];
+    const roleChanges: string[] = [];
+    const merged = [...byPair.values()].map((group) => {
+      if (group.length === 1) return group[0]!;
+      const ordered = [...group].sort(
+        (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+      );
+      const keep = ordered[0]!;
+      const roles = [...new Set(ordered.flatMap((row) => row.roles))].sort(
+        (a, b) => a.localeCompare(b),
+      );
+      // Only worth a line when the merge actually changes someone's access —
+      // identical roles on both memberships is a true duplicate and boring.
+      if (ordered.some((row) => row.roles.length !== roles.length)) {
+        roleChanges.push(
+          `${keep.projectId}/${keep.userId} → ${roles.join('+')}`,
+        );
+      }
+      mergedPairs.push(keep.id);
+      return {
+        ...keep,
+        roles,
+        // Live if ANY membership is live; Neo4j reads them together.
+        inactiveAt: ordered.some((row) => row.inactiveAt == null)
+          ? null
+          : ordered[ordered.length - 1]!.inactiveAt,
+        updatedAt: ordered.reduce(
+          (latest, row) => (row.updatedAt > latest ? row.updatedAt : latest),
+          ordered[0]!.updatedAt,
+        ),
+      };
+    });
+    if (mergedPairs.length > 0) {
+      ctx.log(
+        `    ℹ merged ${rows.length - merged.length} duplicate project ` +
+          `membership(s) into ${mergedPairs.length} row(s) — the same user held ` +
+          `more than one live membership of the same project, which Postgres's ` +
+          `partial unique index cannot represent. Roles are UNIONED because ` +
+          `Neo4j grants the union; dropping a row would revoke access.` +
+          (roleChanges.length > 0
+            ? ` ${roleChanges.length} of them changed someone's role set: ${roleChanges.join(', ')}`
+            : ''),
+      );
+    }
+
     return one(
       'project_members',
       dtos.length,
-      await bulkInsert(ctx, projectMembers, rows),
+      await bulkInsert(ctx, projectMembers, merged),
     );
   },
 };

--- a/src/core/cutover/extractors/project.extractor.ts
+++ b/src/core/cutover/extractors/project.extractor.ts
@@ -5,6 +5,7 @@ import {
   fileNodes,
   locations,
   organizations,
+  projectOtherLocations,
   projects,
   projectStepEnum,
   projectWorkflowEvents,
@@ -21,6 +22,7 @@ import {
   bulkInsert,
   cypher,
   dateStr,
+  keepLanded,
   linkId,
   liveTargetIds,
   orDefault,
@@ -51,7 +53,11 @@ import { type Extractor, type TableStat } from '../cutover.types';
  */
 export const projectExtractor: Extractor = {
   name: 'project',
-  targetTables: ['projects', 'project_workflow_events'],
+  targetTables: [
+    'projects',
+    'project_workflow_events',
+    'project_other_locations',
+  ],
   dependsOn: [
     'user',
     'location',
@@ -325,6 +331,34 @@ export const projectExtractor: Extractor = {
         );
       }
     }
+
+    // ── project_other_locations ────────────────────────────────────────────
+    // The plural `otherLocations` edge — distinct from the singular
+    // primaryLocation/marketingLocation FKs mapped above. Mirrors
+    // organization.extractor.ts's `organization_locations` junction, same
+    // landed-both-sides guard. Reads Postgres truth for `Project` (not the
+    // `dtos`/`rows` read set) since onConflictDoNothing can drop a project
+    // this wave otherwise assumed landed — same reasoning as `landedUsers` in
+    // user.extractor.ts.
+    const otherLocPairs = await cypher<{ projectId: ID; locationId: ID }>(
+      ctx,
+      `MATCH (p:Project)-[:otherLocations { active: true }]->(l:Location)
+       RETURN p.id AS projectId, l.id AS locationId`,
+    );
+    const landedProjects = await liveTargetIds(ctx, 'Project', projects);
+    const otherLocRows = keepLanded(otherLocPairs, [
+      [landedProjects, (row) => row.projectId],
+      [liveLocations, (row) => row.locationId],
+    ]);
+    if (otherLocRows.skipped > 0) {
+      ctx.log(
+        `    ⚠ skipped ${otherLocRows.skipped} project_other_locations row(s) — project or location never landed`,
+      );
+    }
+    out.project_other_locations = stat(
+      otherLocPairs.length,
+      await bulkInsert(ctx, projectOtherLocations, otherLocRows.kept),
+    );
 
     return out;
   },

--- a/src/core/cutover/extractors/project.extractor.ts
+++ b/src/core/cutover/extractors/project.extractor.ts
@@ -202,7 +202,13 @@ export const projectExtractor: Extractor = {
     );
 
     const knownSteps = new Set<string>(projectStepEnum.enumValues);
-    const projectIds = new Set(rows.map((row) => row.id));
+    // Postgres truth rather than the mapped `rows`, for the same reason the
+    // other_locations junction below reads it: a project that mapped fine can
+    // still have been dropped by onConflictDoNothing, and its events would then
+    // FK-abort. `rows` only catches the hydrate-drop half of that.
+    const projectIds = ctx.dryRun
+      ? new Set(rows.map((row) => row.id))
+      : await liveTargetIds(ctx, 'Project', projects);
     let droppedActors = 0;
     let agentActors = 0;
     let droppedSteps = 0;
@@ -308,26 +314,66 @@ export const projectExtractor: Extractor = {
       await bulkInsert(ctx, projectWorkflowEvents, eventRows),
     );
 
-    // ── Step re-assert ─────────────────────────────────────────────────────
-    // The step-sync trigger set `projects.step` to each project's last event.
-    // Where Neo4j's current step disagrees with its own event history (steps
-    // taken outside the workflow), Neo4j wins — it's the live value.
+    // ── Step + modifiedAt re-assert ────────────────────────────────────────
+    // Inserting the events fired the step-sync trigger, which sets BOTH
+    // `projects.step` AND `projects.modified_at` from the newest event
+    // (`sync_project_step_from_event`, 0010_add_projects.sql). Two distinct
+    // corrections are needed, and the second is easy to miss:
+    //
+    //   step — where Neo4j's current step disagrees with its own event history
+    //     (steps taken outside the workflow), Neo4j wins, it is the live value.
+    //
+    //   modified_at — the trigger REGRESSES it to the last transition's
+    //     timestamp, discarding the Neo4j value this extractor deliberately
+    //     carries (S7). A project last transitioned in 2023 but edited in 2026
+    //     would land claiming it had not been touched since 2023, and the
+    //     Postgres read side both returns and sorts/filters on this column.
+    //     Every project with at least one event is affected, so this is not an
+    //     edge case. `updated_at` keeps the carried value either way, which is
+    //     the cheapest way to spot the divergence if it ever regresses again.
     if (!ctx.dryRun) {
-      const stepById = new Map(rows.map((row) => [row.id, row.step]));
+      const wantById = new Map(
+        rows.map((row) => [
+          row.id,
+          { step: row.step, modifiedAt: row.modifiedAt },
+        ]),
+      );
       const live = await ctx.db
-        .select({ id: projects.id, step: projects.step })
+        .select({
+          id: projects.id,
+          step: projects.step,
+          modifiedAt: projects.modifiedAt,
+        })
         .from(projects)
-        .where(inArray(projects.id, [...stepById.keys()]));
-      const drifted = live.filter((row) => stepById.get(row.id) !== row.step);
+        .where(inArray(projects.id, [...wantById.keys()]));
+
+      let stepDrift = 0;
+      let modifiedDrift = 0;
+      const drifted = live.filter((row) => {
+        const want = wantById.get(row.id);
+        if (!want) return false;
+        const stepOff = want.step !== row.step;
+        const modifiedOff =
+          want.modifiedAt.getTime() !== row.modifiedAt.getTime();
+        if (stepOff) stepDrift++;
+        if (modifiedOff) modifiedDrift++;
+        return stepOff || modifiedOff;
+      });
       for (const row of drifted) {
+        const want = wantById.get(row.id)!;
         await ctx.db
           .update(projects)
-          .set({ step: stepById.get(row.id)! })
+          .set({ step: want.step, modifiedAt: want.modifiedAt })
           .where(inArray(projects.id, [row.id]));
       }
-      if (drifted.length) {
+      if (stepDrift) {
         ctx.log(
-          `    ⚠ re-asserted step on ${drifted.length} project(s) where event history disagreed with the live Neo4j step`,
+          `    ⚠ re-asserted step on ${stepDrift} project(s) where event history disagreed with the live Neo4j step`,
+        );
+      }
+      if (modifiedDrift) {
+        ctx.log(
+          `    ⚠ restored modifiedAt on ${modifiedDrift} project(s) that the step-sync trigger had set to their last transition time`,
         );
       }
     }

--- a/src/core/cutover/extractors/project.extractor.ts
+++ b/src/core/cutover/extractors/project.extractor.ts
@@ -180,6 +180,23 @@ export const projectExtractor: Extractor = {
     let droppedSteps = 0;
     const lastStepByProject = new Map<ID, string>();
     const eventRows = events.flatMap((event) => {
+      // Advance the per-project step chain over EVERY Neo4j event, in order,
+      // BEFORE any drop check — `from_step` is DERIVED here (Neo4j doesn't store
+      // it), so a dropped event must still contribute its `to`.
+      //
+      // Otherwise the corruption is worse than the drop: with B→C dropped, the
+      // next surviving event reported `from: B` and claimed a B→D transition
+      // that never happened. Advancing unconditionally yields `from: C` — the
+      // missing event becomes a visible discontinuity between consecutive rows
+      // instead of invented history. A gap you can see beats a lie you can't.
+      //
+      // Only KNOWN steps advance it: an unrecognized value would flow into a
+      // later row's enum-typed `from_step` and fail the insert, so the chain
+      // holds at the last known step, which is the best available truth.
+      const fromStep = lastStepByProject.get(event.projectId) ?? null;
+      if (knownSteps.has(event.toStep)) {
+        lastStepByProject.set(event.projectId, event.toStep);
+      }
       if (!event.who || !userIds.has(event.who)) {
         droppedActors++;
         return [];
@@ -188,8 +205,6 @@ export const projectExtractor: Extractor = {
         droppedSteps++;
         return [];
       }
-      const fromStep = lastStepByProject.get(event.projectId) ?? null;
-      lastStepByProject.set(event.projectId, event.toStep);
       let notes: unknown = null;
       if (event.notes) {
         try {

--- a/src/core/cutover/extractors/project.extractor.ts
+++ b/src/core/cutover/extractors/project.extractor.ts
@@ -8,6 +8,7 @@ import {
   projectStepEnum,
   projectWorkflowEvents,
   reportPeriodEnum,
+  systemAgents,
   users,
 } from '~/core/drizzle/schema';
 import {
@@ -152,10 +153,18 @@ export const projectExtractor: Extractor = {
     out.projects = stat(dtos.length, await bulkInsert(ctx, projects, rows));
 
     // ── Workflow events ────────────────────────────────────────────────────
-    // `who` is FK → users; Neo4j actors can be SystemAgents, which have no
-    // users row. Those events are dropped + logged — migration-todo(cutover):
-    // decide mapping (relax FK vs attribute to root) before prod.
+    // Neo4j's `who` edge points at an :Actor, which is a User OR a SystemAgent —
+    // and in production the agents are the MAJORITY: 18,054 of 27,244 events.
+    // Migration 0031 gave the table one column per kind with a CHECK that
+    // exactly one is set, so each actor is routed to the column matching what it
+    // actually is. Before that, `who` was a NOT NULL FK to users and every
+    // agent-driven event was dropped — two thirds of each project's step
+    // history, silently, since a dropped row raises nothing.
+    //
+    // `system_agents` is loaded by the `user` extractor, which is already a
+    // declared dependency, so both id sets are populated by the time we read.
     const userIds = await liveTargetIds(ctx, 'User', users);
+    const agentIds = await liveTargetIds(ctx, 'SystemAgent', systemAgents);
 
     const events = await cypher<{
       projectId: ID;
@@ -181,8 +190,27 @@ export const projectExtractor: Extractor = {
     const knownSteps = new Set<string>(projectStepEnum.enumValues);
     const projectIds = new Set(rows.map((row) => row.id));
     let droppedActors = 0;
+    let agentActors = 0;
     let droppedSteps = 0;
     let unusableNotes = 0;
+    /**
+     * Which actor column this event belongs in, or null if the actor cannot be
+     * placed at all.
+     *
+     * Both sets are read from the *Postgres* tables in a real run, so an actor
+     * whose own row was dropped upstream (a soft-deleted user, say) is caught
+     * here rather than failing the insert. Production has none of either — 0
+     * absent actors, 0 that resolve to neither table — so this returning null is
+     * itself worth logging rather than passing over.
+     */
+    const resolveActor = (
+      who: ID | null,
+    ): { who: ID | null; whoSystemAgentId: ID | null } | null => {
+      if (!who) return null;
+      if (userIds.has(who)) return { who, whoSystemAgentId: null };
+      if (agentIds.has(who)) return { who: null, whoSystemAgentId: who };
+      return null;
+    };
     const lastStepByProject = new Map<ID, string>();
     const eventRows = events.flatMap((event) => {
       // Advance the per-project step chain over EVERY Neo4j event, in order,
@@ -202,10 +230,12 @@ export const projectExtractor: Extractor = {
       if (knownSteps.has(event.toStep)) {
         lastStepByProject.set(event.projectId, event.toStep);
       }
-      if (!event.who || !userIds.has(event.who)) {
+      const actor = resolveActor(event.who);
+      if (!actor) {
         droppedActors++;
         return [];
       }
+      if (actor.whoSystemAgentId) agentActors++;
       if (!knownSteps.has(event.toStep) || !projectIds.has(event.projectId)) {
         droppedSteps++;
         return [];
@@ -229,7 +259,7 @@ export const projectExtractor: Extractor = {
         {
           id: event.id,
           projectId: event.projectId,
-          who: event.who,
+          ...actor,
           // Runtime-validated against projectStepEnum above.
           fromStep: fromStep as ProjectStep | null,
           toStep: event.toStep as ProjectStep,
@@ -239,9 +269,14 @@ export const projectExtractor: Extractor = {
         },
       ];
     });
+    if (agentActors) {
+      ctx.log(
+        `    attributed ${agentActors} workflow event(s) to system agents (who_system_agent_id)`,
+      );
+    }
     if (droppedActors) {
       ctx.log(
-        `    ⚠ dropped ${droppedActors} workflow event(s) with SystemAgent/absent actors (who FK → users) — migration-todo(cutover): decide mapping`,
+        `    ⚠ dropped ${droppedActors} workflow event(s) whose actor is neither a live user nor a live system agent`,
       );
     }
     if (droppedSteps) {

--- a/src/core/cutover/extractors/project.extractor.ts
+++ b/src/core/cutover/extractors/project.extractor.ts
@@ -2,6 +2,7 @@ import { inArray } from 'drizzle-orm';
 import { type ID } from '~/common';
 import {
   fieldRegions,
+  fileNodes,
   locations,
   organizations,
   projects,
@@ -41,9 +42,12 @@ import { type Extractor, type TableStat } from '../cutover.types';
  *    should equal the row's step. A post-pass re-asserts the Neo4j step where
  *    history disagrees (legacy projects stepped outside the workflow).
  *
- * `root_directory_id` stays NULL — file_nodes isn't ETL'd yet; the File wave
- * backfills it (same IDs carry over). `department_id_block_id` has no Neo4j
- * source (the PG handler doesn't write it either) — NULL.
+ * `root_directory_id` is backfilled from the same `rootDirectory` relationship
+ * the live repo hydrates — the File wave landed `file_nodes` with identical ids
+ * carried over from Neo4j, so no second pass is needed: `file` just has to run
+ * before `project` (added to `dependsOn` below) and the id is already sitting
+ * on the DTO. `department_id_block_id` has no Neo4j source (the PG handler
+ * doesn't write it either) — NULL.
  */
 export const projectExtractor: Extractor = {
   name: 'project',
@@ -54,6 +58,7 @@ export const projectExtractor: Extractor = {
     'fieldRegion',
     'organization',
     'departmentIdBlock',
+    'file',
   ],
   async run(ctx) {
     const out: Record<string, TableStat> = {};
@@ -70,6 +75,10 @@ export const projectExtractor: Extractor = {
     const liveLocations = await liveTargetIds(ctx, 'Location', locations);
     const liveRegions = await liveTargetIds(ctx, 'FieldRegion', fieldRegions);
     const liveOrgs = await liveTargetIds(ctx, 'Organization', organizations);
+    // 'FileNode' matches Directory/File/FileVersion alike, same as file.extractor.ts's
+    // own read — a rootDirectory only ever points at a Directory, but checking the
+    // shared label is what the `file` extractor's landed set actually supports.
+    const liveFileNodes = await liveTargetIds(ctx, 'FileNode', fileNodes);
     let danglingRefs = 0;
     const liveOrNull = <T extends string>(
       id: T | null,
@@ -124,8 +133,7 @@ export const projectExtractor: Extractor = {
           linkId(p.owningOrganization),
           liveOrgs,
         ),
-        // migration-todo(cutover): backfill from file_nodes in the File wave.
-        rootDirectoryId: null,
+        rootDirectoryId: liveOrNull(linkId(p.rootDirectory), liveFileNodes),
         mouStart: dateStr(p.mouStart),
         mouEnd: dateStr(p.mouEnd),
         initialMouEnd: dateStr(p.initialMouEnd),
@@ -147,7 +155,7 @@ export const projectExtractor: Extractor = {
     }
     if (danglingRefs) {
       ctx.log(
-        `    ⚠ nulled ${danglingRefs} dangling project ref(s) to soft-deleted locations/regions/orgs (prod-finding #2)`,
+        `    ⚠ nulled ${danglingRefs} dangling project ref(s) to soft-deleted/dropped locations/regions/orgs/root-directories (prod-finding #2)`,
       );
     }
     out.projects = stat(dtos.length, await bulkInsert(ctx, projects, rows));
@@ -182,7 +190,7 @@ export const projectExtractor: Extractor = {
       `MATCH (p:Project)-[:workflowEvent { active: true }]->(e:ProjectWorkflowEvent)
        OPTIONAL MATCH (e)-[:who]->(w)
        RETURN p.id AS projectId, e.id AS id, toString(e.createdAt) AS at,
-              e.transitionKey AS transitionKey, e.to AS toStep,
+              e.transition AS transitionKey, e.to AS toStep,
               e.notes AS notes, w.id AS who
        ORDER BY p.id, e.createdAt ASC`,
     );

--- a/src/core/cutover/extractors/project.extractor.ts
+++ b/src/core/cutover/extractors/project.extractor.ts
@@ -23,6 +23,7 @@ import {
   liveTargetIds,
   orDefault,
   readAllViaRepo,
+  richText,
   stat,
   ts,
   tsReq,
@@ -162,7 +163,10 @@ export const projectExtractor: Extractor = {
       at: string;
       transitionKey: string | null;
       toStep: string;
-      notes: string | null;
+      // NOT `string`: the read transformer turns the stored `'\0RichText\0'`
+      // form into a RichTextDocument object. Typing it as a string is what
+      // invited JSON.parse and silently emptied every note.
+      notes: unknown;
       who: ID | null;
     }>(
       ctx,
@@ -178,6 +182,7 @@ export const projectExtractor: Extractor = {
     const projectIds = new Set(rows.map((row) => row.id));
     let droppedActors = 0;
     let droppedSteps = 0;
+    let unusableNotes = 0;
     const lastStepByProject = new Map<ID, string>();
     const eventRows = events.flatMap((event) => {
       // Advance the per-project step chain over EVERY Neo4j event, in order,
@@ -205,14 +210,21 @@ export const projectExtractor: Extractor = {
         droppedSteps++;
         return [];
       }
-      let notes: unknown = null;
-      if (event.notes) {
-        try {
-          notes = JSON.parse(event.notes);
-        } catch {
-          notes = null;
-        }
-      }
+      // `notes` is RichText. It must go through `richText()`, NOT JSON.parse:
+      // the Neo4j connection installs a read transformer (`cypher.factory.ts`
+      // sets `conn.transformer = new MyTransformer()`), which recognizes the
+      // `'\0RichText\0'` prefix and hands back a RichTextDocument OBJECT. Calling
+      // JSON.parse on an object stringifies it to '[object Object]' and throws,
+      // and the catch turned that into null — so EVERY note was silently
+      // discarded. Nothing failed; the column just came out empty.
+      //
+      // `richText()` also covers the case the transformer misses (a value nested
+      // inside a map still arrives serialized), which matters because Postgres
+      // jsonb cannot hold a NUL byte at all — passing the serialized form
+      // through is a hard insert failure, not a cosmetic one.
+      const parsedNotes = richText(event.notes);
+      if (parsedNotes === undefined) unusableNotes++;
+      const notes = parsedNotes ?? null;
       return [
         {
           id: event.id,
@@ -235,6 +247,11 @@ export const projectExtractor: Extractor = {
     if (droppedSteps) {
       ctx.log(
         `    ⚠ dropped ${droppedSteps} workflow event(s) with unknown steps or absent projects`,
+      );
+    }
+    if (unusableNotes) {
+      ctx.log(
+        `    ⚠ nulled ${unusableNotes} unparseable workflow-event note(s) — row kept, notes empty`,
       );
     }
     out.project_workflow_events = stat(

--- a/src/core/cutover/extractors/project.extractor.ts
+++ b/src/core/cutover/extractors/project.extractor.ts
@@ -265,7 +265,7 @@ export const projectExtractor: Extractor = {
           toStep: event.toStep as ProjectStep,
           transitionKey: event.transitionKey ?? null,
           notes,
-          at: new Date(event.at),
+          at: tsReq(event.at),
         },
       ];
     });

--- a/src/core/cutover/extractors/project.extractor.ts
+++ b/src/core/cutover/extractors/project.extractor.ts
@@ -1,0 +1,256 @@
+import { inArray } from 'drizzle-orm';
+import { type ID } from '~/common';
+import {
+  fieldRegions,
+  locations,
+  organizations,
+  projects,
+  projectStepEnum,
+  projectWorkflowEvents,
+  reportPeriodEnum,
+  users,
+} from '~/core/drizzle/schema';
+import {
+  type Project,
+  type ProjectStep,
+} from '../../../components/project/dto';
+import { ProjectRepository } from '../../../components/project/project.repository';
+import {
+  bulkInsert,
+  cypher,
+  dateStr,
+  linkId,
+  liveTargetIds,
+  orDefault,
+  readAllViaRepo,
+  stat,
+  ts,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor, type TableStat } from '../cutover.types';
+
+/**
+ * Project + its workflow-event stream.
+ *
+ * Order matters twice over:
+ *  - `projects` rows carry their current `step` (status is GENERATED from it).
+ *  - `project_workflow_events` INSERTs fire the step-sync trigger, so events
+ *    are inserted in chronological order per project; the last event's `to`
+ *    should equal the row's step. A post-pass re-asserts the Neo4j step where
+ *    history disagrees (legacy projects stepped outside the workflow).
+ *
+ * `root_directory_id` stays NULL — file_nodes isn't ETL'd yet; the File wave
+ * backfills it (same IDs carry over). `department_id_block_id` has no Neo4j
+ * source (the PG handler doesn't write it either) — NULL.
+ */
+export const projectExtractor: Extractor = {
+  name: 'project',
+  targetTables: ['projects', 'project_workflow_events'],
+  dependsOn: [
+    'user',
+    'location',
+    'fieldRegion',
+    'organization',
+    'departmentIdBlock',
+  ],
+  async run(ctx) {
+    const out: Record<string, TableStat> = {};
+
+    const dtos = await readAllViaRepo<Project>(
+      ctx,
+      'Project',
+      ProjectRepository,
+    );
+
+    // Prod-finding #2 guard (dangling live→deleted refs): a live project can
+    // reference a location/region/org that Neo4j soft-deleted (relabelled), so
+    // the target row never migrates. Nullable FKs → null + log.
+    const liveLocations = await liveTargetIds(ctx, 'Location', locations);
+    const liveRegions = await liveTargetIds(ctx, 'FieldRegion', fieldRegions);
+    const liveOrgs = await liveTargetIds(ctx, 'Organization', organizations);
+    let danglingRefs = 0;
+    const liveOrNull = <T extends string>(
+      id: T | null,
+      live: ReadonlySet<string>,
+    ): T | null => {
+      if (id && !live.has(id)) {
+        danglingRefs++;
+        return null;
+      }
+      return id;
+    };
+
+    const droppedValues = new Set<string>();
+    const rows = dtos.map((p) => {
+      const financialReportPeriod =
+        p.financialReportPeriod &&
+        (reportPeriodEnum.enumValues as readonly string[]).includes(
+          p.financialReportPeriod,
+        )
+          ? p.financialReportPeriod
+          : null;
+      if (p.financialReportPeriod && !financialReportPeriod) {
+        droppedValues.add(p.financialReportPeriod);
+      }
+      return {
+        id: p.id,
+        type: p.type,
+        name: p.name,
+        step: p.step,
+        // Effective sensitivity from Neo4j is the real (engagement-derived)
+        // value for translation projects — better than the schema default.
+        sensitivity: orDefault(p.sensitivity, 'High' as const),
+        // Writable only for Internship; translation rows derive theirs.
+        ownSensitivity:
+          p.type === 'Internship' ? (p.sensitivity ?? null) : null,
+        rev79ProjectId: p.rev79ProjectId ?? null,
+        departmentId: p.departmentId ?? null,
+        // No Neo4j source; the PG SetDepartmentId path resolves blocks via
+        // funding accounts, not this column.
+        departmentIdBlockId: null,
+        primaryLocationId: liveOrNull(linkId(p.primaryLocation), liveLocations),
+        marketingLocationId: liveOrNull(
+          linkId(p.marketingLocation),
+          liveLocations,
+        ),
+        marketingRegionOverrideId: liveOrNull(
+          linkId(p.marketingRegionOverride),
+          liveLocations,
+        ),
+        fieldRegionId: liveOrNull(linkId(p.fieldRegion), liveRegions),
+        owningOrganizationId: liveOrNull(
+          linkId(p.owningOrganization),
+          liveOrgs,
+        ),
+        // migration-todo(cutover): backfill from file_nodes in the File wave.
+        rootDirectoryId: null,
+        mouStart: dateStr(p.mouStart),
+        mouEnd: dateStr(p.mouEnd),
+        initialMouEnd: dateStr(p.initialMouEnd),
+        estimatedSubmission: dateStr(p.estimatedSubmission),
+        financialReportReceivedAt: ts(p.financialReportReceivedAt),
+        financialReportPeriod,
+        tags: [...orDefault(p.tags, [])],
+        presetInventory: orDefault(p.presetInventory, false),
+        createdAt: tsReq(p.createdAt),
+        modifiedAt: tsReq(p.modifiedAt),
+        updatedAt: tsReq(p.modifiedAt),
+        deletedAt: null,
+      };
+    });
+    if (droppedValues.size) {
+      ctx.log(
+        `    ⚠ dropped unknown project enum value(s): ${[...droppedValues].join(', ')} — migration-todo: map, don't drop`,
+      );
+    }
+    if (danglingRefs) {
+      ctx.log(
+        `    ⚠ nulled ${danglingRefs} dangling project ref(s) to soft-deleted locations/regions/orgs (prod-finding #2)`,
+      );
+    }
+    out.projects = stat(dtos.length, await bulkInsert(ctx, projects, rows));
+
+    // ── Workflow events ────────────────────────────────────────────────────
+    // `who` is FK → users; Neo4j actors can be SystemAgents, which have no
+    // users row. Those events are dropped + logged — migration-todo(cutover):
+    // decide mapping (relax FK vs attribute to root) before prod.
+    const userIds = await liveTargetIds(ctx, 'User', users);
+
+    const events = await cypher<{
+      projectId: ID;
+      id: ID;
+      at: string;
+      transitionKey: string | null;
+      toStep: string;
+      notes: string | null;
+      who: ID | null;
+    }>(
+      ctx,
+      `MATCH (p:Project)-[:workflowEvent { active: true }]->(e:ProjectWorkflowEvent)
+       OPTIONAL MATCH (e)-[:who]->(w)
+       RETURN p.id AS projectId, e.id AS id, toString(e.createdAt) AS at,
+              e.transitionKey AS transitionKey, e.to AS toStep,
+              e.notes AS notes, w.id AS who
+       ORDER BY p.id, e.createdAt ASC`,
+    );
+
+    const knownSteps = new Set<string>(projectStepEnum.enumValues);
+    const projectIds = new Set(rows.map((row) => row.id));
+    let droppedActors = 0;
+    let droppedSteps = 0;
+    const lastStepByProject = new Map<ID, string>();
+    const eventRows = events.flatMap((event) => {
+      if (!event.who || !userIds.has(event.who)) {
+        droppedActors++;
+        return [];
+      }
+      if (!knownSteps.has(event.toStep) || !projectIds.has(event.projectId)) {
+        droppedSteps++;
+        return [];
+      }
+      const fromStep = lastStepByProject.get(event.projectId) ?? null;
+      lastStepByProject.set(event.projectId, event.toStep);
+      let notes: unknown = null;
+      if (event.notes) {
+        try {
+          notes = JSON.parse(event.notes);
+        } catch {
+          notes = null;
+        }
+      }
+      return [
+        {
+          id: event.id,
+          projectId: event.projectId,
+          who: event.who,
+          // Runtime-validated against projectStepEnum above.
+          fromStep: fromStep as ProjectStep | null,
+          toStep: event.toStep as ProjectStep,
+          transitionKey: event.transitionKey ?? null,
+          notes,
+          at: new Date(event.at),
+        },
+      ];
+    });
+    if (droppedActors) {
+      ctx.log(
+        `    ⚠ dropped ${droppedActors} workflow event(s) with SystemAgent/absent actors (who FK → users) — migration-todo(cutover): decide mapping`,
+      );
+    }
+    if (droppedSteps) {
+      ctx.log(
+        `    ⚠ dropped ${droppedSteps} workflow event(s) with unknown steps or absent projects`,
+      );
+    }
+    out.project_workflow_events = stat(
+      events.length,
+      await bulkInsert(ctx, projectWorkflowEvents, eventRows),
+    );
+
+    // ── Step re-assert ─────────────────────────────────────────────────────
+    // The step-sync trigger set `projects.step` to each project's last event.
+    // Where Neo4j's current step disagrees with its own event history (steps
+    // taken outside the workflow), Neo4j wins — it's the live value.
+    if (!ctx.dryRun) {
+      const stepById = new Map(rows.map((row) => [row.id, row.step]));
+      const live = await ctx.db
+        .select({ id: projects.id, step: projects.step })
+        .from(projects)
+        .where(inArray(projects.id, [...stepById.keys()]));
+      const drifted = live.filter((row) => stepById.get(row.id) !== row.step);
+      for (const row of drifted) {
+        await ctx.db
+          .update(projects)
+          .set({ step: stepById.get(row.id)! })
+          .where(inArray(projects.id, [row.id]));
+      }
+      if (drifted.length) {
+        ctx.log(
+          `    ⚠ re-asserted step on ${drifted.length} project(s) where event history disagreed with the live Neo4j step`,
+        );
+      }
+    }
+
+    return out;
+  },
+};

--- a/src/core/cutover/extractors/prompt-variant-response.extractor.ts
+++ b/src/core/cutover/extractors/prompt-variant-response.extractor.ts
@@ -1,0 +1,241 @@
+import { type ID, RichTextDocument } from '~/common';
+import {
+  periodicReports,
+  promptVariantResponseEntries,
+  promptVariantResponses,
+  users,
+} from '~/core/drizzle/schema';
+import { ProgressReportCommunityStory } from '../../../components/progress-report/dto/community-stories.dto';
+import { ProgressReportHighlight } from '../../../components/progress-report/dto/highlights.dto';
+import { ProgressReportTeamNews } from '../../../components/progress-report/dto/team-news.dto';
+import {
+  bulkInsert,
+  cypher,
+  fetchIds,
+  keepLanded,
+  liveTargetIds,
+  stat,
+} from '../cutover.helpers';
+import { type Extractor, type TableStat } from '../cutover.types';
+
+/**
+ * PromptVariantResponse — the prompt/answer pairs on progress reports
+ * (ProgressReportTeamNews / …Highlight / …CommunityStory), plus their per-variant
+ * answers. Both live in one table pair discriminated by `resource_type`.
+ *
+ * The concrete DTO classes drive BOTH sides of the mapping: `type.name` is
+ * simultaneously the Neo4j label and the `resource_type` value the drizzle repo
+ * filters on, so there is no place for the two to drift apart. There is no
+ * enumerable base label to use instead — `:PromptVariantResponse` exists but
+ * carries no discriminator, and the whole point of `resource_type` is to keep
+ * the subtypes apart.
+ *
+ * Two things about the entry (VariantResponse) rows:
+ *
+ * · The response history is carried, not just the current answer. Neo4j keeps
+ *   superseded answers as `Deleted_VariantResponse` nodes whose `child` edge is
+ *   still `active: true` — so the edge cannot be used to tell live from retired,
+ *   only the LABEL can (109 nodes locally: 69 live, 40 retired). The partial
+ *   unique index on (response_id, variant) is likewise scoped WHERE deleted_at
+ *   IS NULL, which is exactly what makes carrying the history legal.
+ *
+ * · `response` needs a real conversion, not a copy. Neo4j stores rich text as a
+ *   NUL-delimited tagged string (`\0RichText\0{…}` — see RichTextDocument), while
+ *   the column is jsonb. Passing the stored form through would not merely be
+ *   wrong, it would be rejected: Postgres text/jsonb cannot hold a NUL byte. The
+ *   read transformer normally parses this on the way out, so richText() below is
+ *   the belt to that braces.
+ */
+const PVR_TYPES = [
+  ProgressReportTeamNews,
+  ProgressReportHighlight,
+  ProgressReportCommunityStory,
+] as const;
+
+interface PvrRow {
+  id: ID;
+  parentId: ID;
+  creatorId: ID<'User'>;
+  prompt: string;
+  createdAt: string;
+  modifiedAt: string | null;
+}
+
+interface EntryRow {
+  responseId: ID;
+  variant: string;
+  response: unknown;
+  creatorId: ID<'User'>;
+  createdAt: string;
+  modifiedAt: string | null;
+  deletedAt: string | null;
+}
+
+export const promptVariantResponseExtractor: Extractor = {
+  name: 'prompt-variant-response',
+  targetTables: ['prompt_variant_responses', 'prompt_variant_response_entries'],
+  dependsOn: ['periodic-report', 'user'],
+  async run(ctx) {
+    const out: Record<string, TableStat> = {};
+
+    const landedReports = await liveTargetIds(
+      ctx,
+      'PeriodicReport',
+      periodicReports,
+    );
+    const landedUsers = await liveTargetIds(ctx, 'User', users);
+
+    // ── prompt_variant_responses ──────────────────────────────────────────────
+    const read: Array<PvrRow & { resourceType: string }> = [];
+    for (const type of PVR_TYPES) {
+      const rows = await cypher<PvrRow>(
+        ctx,
+        `MATCH (parent:BaseNode)-[:child { active: true }]->(n:\`${type.name}\`)
+         MATCH (n)-[:creator]->(creator:User)
+         MATCH (n)-[:prompt { active: true }]->(prompt:Property)
+         RETURN n.id AS id, parent.id AS parentId, creator.id AS creatorId,
+                prompt.value AS prompt, toString(n.createdAt) AS createdAt,
+                toString(n.modifiedAt) AS modifiedAt`,
+      );
+      // Enumerate independently so an unknown label warns (the ethnologue trap)
+      // and so a node lost to a missing creator / active prompt is visible —
+      // the joins above are all required, and a silent inner-join loss would
+      // otherwise reconcile ✓.
+      const ids = await fetchIds(ctx, type.name);
+      if (ids.length !== rows.length) {
+        ctx.log(
+          `    ⚠ ${type.name}: ${ids.length} node(s) enumerated but ${rows.length} matched the ` +
+            `parent + creator + active-prompt joins — ${ids.length - rows.length} lost to a broken required rel`,
+        );
+      }
+      for (const row of rows) {
+        read.push({ ...row, resourceType: type.name });
+      }
+    }
+
+    const pvrKept = keepLanded(read, [
+      [landedReports, (row) => row.parentId],
+      [landedUsers, (row) => row.creatorId],
+    ]);
+    if (pvrKept.skipped > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${pvrKept.skipped} prompt response(s) whose parent report or creator never landed`,
+      );
+    }
+
+    out.prompt_variant_responses = stat(
+      read.length,
+      await bulkInsert(
+        ctx,
+        promptVariantResponses,
+        pvrKept.kept.map((row) => ({
+          id: row.id,
+          resourceType: row.resourceType,
+          parentId: row.parentId,
+          prompt: row.prompt,
+          creatorId: row.creatorId,
+          createdAt: new Date(row.createdAt),
+          // NOT NULL here, optional in Neo4j — coalesce to createdAt, which is
+          // what the Neo4j hydrate does for the entry rows.
+          modifiedAt: new Date(row.modifiedAt ?? row.createdAt),
+          updatedAt: new Date(row.modifiedAt ?? row.createdAt),
+          // No soft-deleted state to carry: Neo4j relabels a deleted PVR, so
+          // `MATCH (n:ProgressReportTeamNews)` never returns one, and the read
+          // path filters deleted_at IS NULL anyway. Same visibility either way.
+          deletedAt: null,
+        })),
+      ),
+    );
+
+    // ── prompt_variant_response_entries ───────────────────────────────────────
+    // Live AND retired answers — see the docblock on why the label, not the edge,
+    // is the liveness test.
+    const entryRows = await cypher<EntryRow>(
+      ctx,
+      `MATCH (n:PromptVariantResponse)-[:child]->(entry)
+       WHERE entry:VariantResponse OR entry:Deleted_VariantResponse
+       MATCH (entry)-[:creator]->(creator:User)
+       RETURN n.id AS responseId, entry.variant AS variant, entry.response AS response,
+              creator.id AS creatorId, toString(entry.createdAt) AS createdAt,
+              toString(entry.modifiedAt) AS modifiedAt, toString(entry.deletedAt) AS deletedAt`,
+    );
+
+    const landedPvrs = new Set<string>(pvrKept.kept.map((row) => row.id));
+    const entriesKept = keepLanded(entryRows, [
+      [landedPvrs, (row) => row.responseId],
+      [landedUsers, (row) => row.creatorId],
+    ]);
+    if (entriesKept.skipped > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${entriesKept.skipped} answer(s) whose prompt response or creator never landed`,
+      );
+    }
+
+    const unparsedResponses: string[] = [];
+    out.prompt_variant_response_entries = stat(
+      entryRows.length,
+      await bulkInsert(
+        ctx,
+        promptVariantResponseEntries,
+        // `id` is a bigserial, so insert order assigns it. Sort so a re-run
+        // hands out the same ids rather than reshuffling every row.
+        [...entriesKept.kept]
+          .sort(
+            (a, b) =>
+              a.responseId.localeCompare(b.responseId) ||
+              a.createdAt.localeCompare(b.createdAt) ||
+              a.variant.localeCompare(b.variant),
+          )
+          .map((row) => {
+            const response = richText(row.response);
+            if (response === undefined) {
+              unparsedResponses.push(`${row.responseId}/${row.variant}`);
+            }
+            return {
+              responseId: row.responseId,
+              variant: row.variant,
+              response: response ?? null,
+              creatorId: row.creatorId,
+              createdAt: new Date(row.createdAt),
+              modifiedAt: new Date(row.modifiedAt ?? row.createdAt),
+              deletedAt: row.deletedAt ? new Date(row.deletedAt) : null,
+            };
+          }),
+      ),
+    );
+    if (unparsedResponses.length > 0) {
+      ctx.log(
+        `    ⚠ ${unparsedResponses.length} answer(s) had a rich-text body that could not be parsed ` +
+          `into jsonb — stored as null: ${unparsedResponses.slice(0, 10).join(', ')}`,
+      );
+    }
+
+    return out;
+  },
+};
+
+/**
+ * The stored rich-text value → the plain object the jsonb column takes.
+ *
+ * The Neo4j read transformer already turns `\0RichText\0{…}` into a
+ * RichTextDocument, so the first branch is the normal path; the serialized branch
+ * covers a value the transformer did not reach (nested in a map, say). Handling it
+ * is not optional politeness — the serialized form contains NUL bytes, which
+ * Postgres jsonb cannot store at all, so a miss here is a hard insert failure
+ * rather than a cosmetic one.
+ *
+ * `undefined` means "was present but unusable" (caller warns); `null` means the
+ * source was genuinely empty, which 10 of 109 answers are locally.
+ */
+const richText = (value: unknown): object | null | undefined => {
+  if (value == null) return null;
+  if (RichTextDocument.isSerialized(value)) {
+    try {
+      return { ...RichTextDocument.fromSerialized(value) };
+    } catch {
+      return undefined;
+    }
+  }
+  if (typeof value === 'object') return { ...value };
+  return undefined;
+};

--- a/src/core/cutover/extractors/prompt-variant-response.extractor.ts
+++ b/src/core/cutover/extractors/prompt-variant-response.extractor.ts
@@ -50,6 +50,13 @@ import { type Extractor, type TableStat } from '../cutover.types';
  *   wrong, it would be rejected: Postgres text/jsonb cannot hold a NUL byte. The
  *   read transformer normally parses this on the way out, so the shared
  *   `richText()` helper is the belt to that braces (comments need it too).
+ *
+ * · The creator comes from the [:creator] edge OR the `creator` node property.
+ *   5,368 of the 9,995 retired answers predate the edge and store the creator
+ *   id as a property; requiring the edge silently dropped 54% of the history
+ *   this carry exists to keep (found by cutover-coverage 2026-08-24 — a
+ *   500-node sample of the property values all resolve to live users). The
+ *   edge wins when both exist, matching what the app reads today.
  */
 const PVR_TYPES = [
   ProgressReportTeamNews,
@@ -72,7 +79,9 @@ interface EntryRow {
   responseId: ID;
   variant: string;
   response: unknown;
-  creatorId: ID<'User'>;
+  // Null when the entry has neither a [:creator] edge nor a creator property —
+  // see the docblock; those rows cannot satisfy the NOT NULL column.
+  creatorId: ID<'User'> | null;
   createdAt: string;
   modifiedAt: string | null;
   deletedAt: string | null;
@@ -162,17 +171,32 @@ export const promptVariantResponseExtractor: Extractor = {
       ctx,
       `MATCH (n:PromptVariantResponse)-[:child]->(entry)
        WHERE entry:VariantResponse OR entry:Deleted_VariantResponse
-       MATCH (entry)-[:creator]->(creator:User)
+       OPTIONAL MATCH (entry)-[:creator]->(creator:User)
        RETURN n.id AS responseId, entry.variant AS variant, entry.response AS response,
-              creator.id AS creatorId, toString(entry.createdAt) AS createdAt,
+              coalesce(creator.id, entry.creator) AS creatorId,
+              toString(entry.createdAt) AS createdAt,
               toString(entry.modifiedAt) AS modifiedAt, toString(entry.deletedAt) AS deletedAt`,
     );
 
+    const creatorless = entryRows.filter((row) => row.creatorId == null).length;
+    if (creatorless > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${creatorless} answer(s) with neither a [:creator] edge nor a ` +
+          `creator property — creator_id is NOT NULL and there is nothing to resolve`,
+      );
+    }
+
     const landedPvrs = new Set<string>(pvrKept.kept.map((row) => row.id));
-    const entriesKept = keepLanded(entryRows, [
-      [landedPvrs, (row) => row.responseId],
-      [landedUsers, (row) => row.creatorId],
-    ]);
+    const entriesKept = keepLanded(
+      entryRows.filter(
+        (row): row is EntryRow & { creatorId: ID<'User'> } =>
+          row.creatorId != null,
+      ),
+      [
+        [landedPvrs, (row) => row.responseId],
+        [landedUsers, (row) => row.creatorId],
+      ],
+    );
     if (entriesKept.skipped > 0) {
       ctx.log(
         `    ⚠ DROPPED ${entriesKept.skipped} answer(s) whose prompt response or creator never landed`,

--- a/src/core/cutover/extractors/prompt-variant-response.extractor.ts
+++ b/src/core/cutover/extractors/prompt-variant-response.extractor.ts
@@ -16,6 +16,8 @@ import {
   liveTargetIds,
   richText,
   stat,
+  ts,
+  tsReq,
 } from '../cutover.helpers';
 import { type Extractor, type TableStat } from '../cutover.types';
 
@@ -135,11 +137,11 @@ export const promptVariantResponseExtractor: Extractor = {
           parentId: row.parentId,
           prompt: row.prompt,
           creatorId: row.creatorId,
-          createdAt: new Date(row.createdAt),
+          createdAt: tsReq(row.createdAt),
           // NOT NULL here, optional in Neo4j — coalesce to createdAt, which is
           // what the Neo4j hydrate does for the entry rows.
-          modifiedAt: new Date(row.modifiedAt ?? row.createdAt),
-          updatedAt: new Date(row.modifiedAt ?? row.createdAt),
+          modifiedAt: tsReq(row.modifiedAt ?? row.createdAt),
+          updatedAt: tsReq(row.modifiedAt ?? row.createdAt),
           // No soft-deleted state to carry: Neo4j relabels a deleted PVR, so
           // `MATCH (n:ProgressReportTeamNews)` never returns one, and the read
           // path filters deleted_at IS NULL anyway. Same visibility either way.
@@ -197,9 +199,9 @@ export const promptVariantResponseExtractor: Extractor = {
               variant: row.variant,
               response: response ?? null,
               creatorId: row.creatorId,
-              createdAt: new Date(row.createdAt),
-              modifiedAt: new Date(row.modifiedAt ?? row.createdAt),
-              deletedAt: row.deletedAt ? new Date(row.deletedAt) : null,
+              createdAt: tsReq(row.createdAt),
+              modifiedAt: tsReq(row.modifiedAt ?? row.createdAt),
+              deletedAt: ts(row.deletedAt),
             };
           }),
       ),

--- a/src/core/cutover/extractors/prompt-variant-response.extractor.ts
+++ b/src/core/cutover/extractors/prompt-variant-response.extractor.ts
@@ -8,6 +8,7 @@ import {
 import { ProgressReportCommunityStory } from '../../../components/progress-report/dto/community-stories.dto';
 import { ProgressReportHighlight } from '../../../components/progress-report/dto/highlights.dto';
 import { ProgressReportTeamNews } from '../../../components/progress-report/dto/team-news.dto';
+import { type Prompt } from '../../../components/prompts/dto/prompt.dto';
 import {
   bulkInsert,
   cypher,
@@ -59,7 +60,9 @@ interface PvrRow {
   id: ID;
   parentId: ID;
   creatorId: ID<'User'>;
-  prompt: string;
+  // The Cypher property already holds a Prompt id, not its text — see the
+  // schema comment on `promptVariantResponses.prompt`.
+  prompt: ID<Prompt>;
   createdAt: string;
   modifiedAt: string | null;
 }

--- a/src/core/cutover/extractors/prompt-variant-response.extractor.ts
+++ b/src/core/cutover/extractors/prompt-variant-response.extractor.ts
@@ -179,6 +179,55 @@ export const promptVariantResponseExtractor: Extractor = {
       );
     }
 
+    // Only ONE answer per (response, variant) may be live — the unique index is
+    // `(response_id, variant) WHERE deleted_at IS NULL`. The source already
+    // models a superseded answer by stamping `deletedAt`, and does so 4,301
+    // times, so the shape is well established. Exactly one pair never got
+    // stamped: response UW2vHYXF0hV / variant `fpm`, two answers by the same
+    // person 7ms apart, both reading "NA" — a double submit.
+    //
+    // Retiring the older one is strictly better than letting the insert refuse
+    // it. `onConflictDoNothing` discarded a row silently and kept whichever
+    // arrived first; this keeps BOTH rows, with the loser shaped exactly like
+    // every other superseded answer in the table. Nothing is lost and the index
+    // is satisfied.
+    //
+    // Retired at the winner's createdAt — "superseded when the newer answer was
+    // written" — rather than now(), which would be a load-time date with no
+    // meaning. Ordered by real timestamps, not the ISO strings: Neo4j hands some
+    // of these back with a `[UTC]` suffix and some without, so a lexical compare
+    // is not reliable across formats.
+    const liveByPair = new Map<string, EntryRow[]>();
+    for (const row of entriesKept.kept) {
+      if (row.deletedAt != null) continue;
+      const key = `${row.responseId}\u0000${row.variant}`;
+      const held = liveByPair.get(key);
+      if (held) held.push(row);
+      else liveByPair.set(key, [row]);
+    }
+    const retired: string[] = [];
+    for (const group of liveByPair.values()) {
+      if (group.length === 1) continue;
+      const ordered = [...group].sort(
+        (a, b) => tsReq(a.createdAt).getTime() - tsReq(b.createdAt).getTime(),
+      );
+      const keep = ordered[ordered.length - 1]!;
+      for (const row of ordered.slice(0, -1)) {
+        row.deletedAt = keep.createdAt;
+        retired.push(`${row.responseId}/${row.variant}`);
+      }
+    }
+    if (retired.length > 0) {
+      ctx.log(
+        `    ℹ retired ${retired.length} superseded answer(s) rather than letting ` +
+          `the unique index refuse them — more than one answer was live for the ` +
+          `same (response, variant), which the source normally records by ` +
+          `stamping deletedAt. Both rows are kept; the older is marked deleted at ` +
+          `the newer one's createdAt: ${retired.slice(0, 10).join(', ')}` +
+          `${retired.length > 10 ? ', …' : ''}`,
+      );
+    }
+
     const unparsedResponses: string[] = [];
     out.prompt_variant_response_entries = stat(
       entryRows.length,

--- a/src/core/cutover/extractors/prompt-variant-response.extractor.ts
+++ b/src/core/cutover/extractors/prompt-variant-response.extractor.ts
@@ -15,6 +15,7 @@ import {
   fetchIds,
   keepLanded,
   liveTargetIds,
+  recordReadLoss,
   richText,
   stat,
   ts,
@@ -108,12 +109,13 @@ export const promptVariantResponseExtractor: Extractor = {
       // the joins above are all required, and a silent inner-join loss would
       // otherwise reconcile ✓.
       const ids = await fetchIds(ctx, type.name);
-      if (ids.length !== rows.length) {
-        ctx.log(
-          `    ⚠ ${type.name}: ${ids.length} node(s) enumerated but ${rows.length} matched the ` +
-            `parent + creator + active-prompt joins — ${ids.length - rows.length} lost to a broken required rel`,
-        );
-      }
+      recordReadLoss(
+        ctx,
+        type.name,
+        ids.length - rows.length,
+        `${rows.length} of ${ids.length} matched the parent + creator + active-prompt joins, ` +
+          `the rest are lost to a broken required rel`,
+      );
       for (const row of rows) {
         read.push({ ...row, resourceType: type.name });
       }

--- a/src/core/cutover/extractors/prompt-variant-response.extractor.ts
+++ b/src/core/cutover/extractors/prompt-variant-response.extractor.ts
@@ -1,4 +1,4 @@
-import { type ID, RichTextDocument } from '~/common';
+import { type ID } from '~/common';
 import {
   periodicReports,
   promptVariantResponseEntries,
@@ -14,6 +14,7 @@ import {
   fetchIds,
   keepLanded,
   liveTargetIds,
+  richText,
   stat,
 } from '../cutover.helpers';
 import { type Extractor, type TableStat } from '../cutover.types';
@@ -43,8 +44,8 @@ import { type Extractor, type TableStat } from '../cutover.types';
  *   NUL-delimited tagged string (`\0RichText\0{…}` — see RichTextDocument), while
  *   the column is jsonb. Passing the stored form through would not merely be
  *   wrong, it would be rejected: Postgres text/jsonb cannot hold a NUL byte. The
- *   read transformer normally parses this on the way out, so richText() below is
- *   the belt to that braces.
+ *   read transformer normally parses this on the way out, so the shared
+ *   `richText()` helper is the belt to that braces (comments need it too).
  */
 const PVR_TYPES = [
   ProgressReportTeamNews,
@@ -212,30 +213,4 @@ export const promptVariantResponseExtractor: Extractor = {
 
     return out;
   },
-};
-
-/**
- * The stored rich-text value → the plain object the jsonb column takes.
- *
- * The Neo4j read transformer already turns `\0RichText\0{…}` into a
- * RichTextDocument, so the first branch is the normal path; the serialized branch
- * covers a value the transformer did not reach (nested in a map, say). Handling it
- * is not optional politeness — the serialized form contains NUL bytes, which
- * Postgres jsonb cannot store at all, so a miss here is a hard insert failure
- * rather than a cosmetic one.
- *
- * `undefined` means "was present but unusable" (caller warns); `null` means the
- * source was genuinely empty, which 10 of 109 answers are locally.
- */
-const richText = (value: unknown): object | null | undefined => {
-  if (value == null) return null;
-  if (RichTextDocument.isSerialized(value)) {
-    try {
-      return { ...RichTextDocument.fromSerialized(value) };
-    } catch {
-      return undefined;
-    }
-  }
-  if (typeof value === 'object') return { ...value };
-  return undefined;
 };

--- a/src/core/cutover/extractors/tool-usage.extractor.ts
+++ b/src/core/cutover/extractors/tool-usage.extractor.ts
@@ -1,0 +1,172 @@
+import { type ID } from '~/common';
+import { tools, toolUsages, users } from '~/core/drizzle/schema';
+import {
+  bulkInsert,
+  cypher,
+  keepLanded,
+  liveTargetIds,
+  one,
+  resolveParentTypes,
+  warnIfRelTypeUnknown,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * Tool usages — a record that some resource uses some tool, from some date.
+ *
+ * The container is polymorphic and deliberately unconstrained: Rob's scope call
+ * (2026-07-29) is that a usage may attach to ANY resource, which is how the domain
+ * was built. So `container_id` carries no foreign key and `container_type` stores
+ * the container's concrete `__typename` alongside it.
+ *
+ * That discriminator is why this extractor resolves types through
+ * {@link resolveParentTypes} rather than reading Neo4j labels. A Neo4j project node
+ * carries a stack of labels (`BaseNode`, `Project`, `TranslationProject`,
+ * `MomentumTranslationProject`) and picking the concrete one back out means
+ * reimplementing precedence rules that already exist — twice over, since the read
+ * path in the repository has its own copy keyed off this exact column. Asking
+ * Postgres which table holds the id gives the same answer from the source of truth,
+ * and it doubles as the landed-container guard, so the two can never disagree.
+ *
+ * A container that does not resolve is dropped rather than carried. Two reasons,
+ * and they agree: Neo4j's hydrate opens with a required `(container:BaseNode)` match
+ * and soft delete strips even the `BaseNode` label, so a usage under a removed
+ * container does not come back there either — and here a row with no
+ * `container_type` cannot be written at all, the column being NOT NULL. That is the
+ * opposite call from `pin`, whose FK-less `resource_id` has no discriminator to fill
+ * and so loses nothing by carrying an inert row.
+ *
+ * `tool_id` and `creator_id` are both real foreign keys AND both required matches in
+ * the Neo4j hydrate, so the guards below reproduce behaviour rather than inventing
+ * it.
+ */
+export const toolUsageExtractor: Extractor = {
+  name: 'tool-usage',
+  targetTables: ['tool_usages'],
+  // Every domain resolveParentTypes can name has to have landed first, or a usage
+  // on it looks like an unresolvable container and gets dropped.
+  dependsOn: [
+    'tool',
+    'user',
+    'language',
+    'partner',
+    'project',
+    'engagement',
+    'periodic-report',
+  ],
+  async run(ctx) {
+    const rows = await cypher<{
+      id: ID<'ToolUsage'>;
+      containerId: ID;
+      toolId: ID<'Tool'>;
+      creatorId: ID<'User'> | null;
+      startDate: string | null;
+      createdAt: string | null;
+      modifiedAt: string | null;
+    }>(
+      ctx,
+      `MATCH (container:BaseNode)-[:uses { active: true }]->(node:ToolUsage)
+       MATCH (node)-[:tool]->(tool:Tool)
+       OPTIONAL MATCH (node)-[:creator]->(creator:Actor)
+       OPTIONAL MATCH (node)-[:startDate { active: true }]->(startDate:Property)
+       RETURN node.id AS id,
+              container.id AS containerId,
+              tool.id AS toolId,
+              creator.id AS creatorId,
+              toString(startDate.value) AS startDate,
+              toString(node.createdAt) AS createdAt,
+              toString(node.modifiedAt) AS modifiedAt`,
+    );
+    if (rows.length === 0) {
+      await warnIfRelTypeUnknown(ctx, 'uses');
+    }
+
+    const landedTools = await liveTargetIds(ctx, 'Tool', tools);
+    const landedUsers = await liveTargetIds(ctx, 'User', users);
+
+    const creatorless = rows.filter((row) => !row.creatorId).length;
+    if (creatorless > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${creatorless} tool usage(s) with no \`creator\` edge at all ` +
+          `(creator_id is NOT NULL). Neo4j's hydrate requires that edge too, so these ` +
+          `are already invisible in the app.`,
+      );
+    }
+
+    const withRefs = keepLanded(
+      rows.filter((row) => row.creatorId),
+      [
+        [landedTools, (row) => row.toolId],
+        [landedUsers, (row) => row.creatorId!],
+      ],
+    );
+    if (withRefs.skipped > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${withRefs.skipped} tool usage(s) whose tool or creator never ` +
+          `landed (both are real FKs). Note the creator must be a live USER — a usage ` +
+          `attributed to a system agent would land here, and system agents live in a ` +
+          `different table, so it would be reported rather than written.`,
+      );
+    }
+
+    // Dry-run cannot do this: `resolveParentTypes` reads the Postgres tables, which
+    // are empty until a real run has filled them. Report the shortfall instead of
+    // silently treating every container as unresolvable.
+    if (ctx.dryRun) {
+      ctx.log(
+        `    ℹ dry-run: container types are resolved against the Postgres tables, ` +
+          `which are empty here, so ${withRefs.kept.length} usage(s) are counted as ` +
+          `read but their container_type is unverified. A real run is what exercises ` +
+          `this.`,
+      );
+      return one('tool_usages', rows.length, 0);
+    }
+
+    const containerTypes = await resolveParentTypes(
+      ctx,
+      withRefs.kept.map((row) => row.containerId),
+    );
+
+    const unresolved: string[] = [];
+    const values = withRefs.kept.flatMap((row) => {
+      const containerType = containerTypes.get(row.containerId);
+      if (!containerType) {
+        unresolved.push(row.containerId);
+        return [];
+      }
+      const created = row.createdAt ? new Date(row.createdAt) : new Date();
+      return [
+        {
+          id: row.id,
+          containerId: row.containerId,
+          containerType,
+          toolId: row.toolId,
+          creatorId: row.creatorId!,
+          // A plain `date` column, not a timestamp — the usage records when the tool
+          // started being used, with no time of day. Not `dateStr()`: that takes a
+          // Luxon value, and the Cypher above has already stringified this one.
+          // Neo4j renders both `date` and `datetime` ISO-first, so the leading ten
+          // characters are the calendar date either way.
+          startDate: row.startDate ? row.startDate.slice(0, 10) : null,
+          createdAt: created,
+          updatedAt: row.modifiedAt ? new Date(row.modifiedAt) : created,
+          // The ETL is live-only; nothing arrives already deleted.
+          deletedAt: null,
+        },
+      ];
+    });
+    if (unresolved.length > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${unresolved.length} tool usage(s) whose container did not ` +
+          `resolve to a live row in any of the tables resolveParentTypes covers ` +
+          `(progress report / engagement / project / partner / language / user). ` +
+          `Expected causes: a soft-deleted or hard-deleted container, or a container ` +
+          `on a resource type that map does not yet name. The second is worth ` +
+          `checking — container_type is NOT NULL, so an unnamed type loses the row.`,
+      );
+    }
+
+    const inserted = await bulkInsert(ctx, toolUsages, values);
+    return one('tool_usages', rows.length, inserted);
+  },
+};

--- a/src/core/cutover/extractors/tool-usage.extractor.ts
+++ b/src/core/cutover/extractors/tool-usage.extractor.ts
@@ -7,6 +7,7 @@ import {
   liveTargetIds,
   one,
   resolveParentTypes,
+  ts,
   warnIfRelTypeUnknown,
 } from '../cutover.helpers';
 import { type Extractor } from '../cutover.types';
@@ -134,7 +135,7 @@ export const toolUsageExtractor: Extractor = {
         unresolved.push(row.containerId);
         return [];
       }
-      const created = row.createdAt ? new Date(row.createdAt) : new Date();
+      const created = ts(row.createdAt) ?? new Date();
       return [
         {
           id: row.id,
@@ -149,7 +150,7 @@ export const toolUsageExtractor: Extractor = {
           // characters are the calendar date either way.
           startDate: row.startDate ? row.startDate.slice(0, 10) : null,
           createdAt: created,
-          updatedAt: row.modifiedAt ? new Date(row.modifiedAt) : created,
+          updatedAt: ts(row.modifiedAt) ?? created,
           // The ETL is live-only; nothing arrives already deleted.
           deletedAt: null,
         },

--- a/src/core/cutover/extractors/tool.extractor.ts
+++ b/src/core/cutover/extractors/tool.extractor.ts
@@ -1,0 +1,33 @@
+import { tools } from '~/core/drizzle/schema';
+import { type Tool } from '../../../components/tools/tool/dto';
+import { ToolRepository } from '../../../components/tools/tool/tool.neo4j.repository';
+import { bulkInsert, readAllViaRepo, stat, tsReq } from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * Tool — the reference extractor. Leaf domain, no FKs, no junctions. Read every
+ * `Tool` node via the Neo4j repo (hydrates name/description/aiBased/key from
+ * their Property nodes), map to the `tools` row shape, insert ID-preserving.
+ */
+export const toolExtractor: Extractor = {
+  name: 'tool',
+  targetTables: ['tools'],
+  async run(ctx) {
+    const dtos = await readAllViaRepo<Tool>(ctx, 'Tool', ToolRepository);
+    const rows = dtos.map((t) => ({
+      id: t.id,
+      name: t.name,
+      description: t.description ?? null,
+      aiBased: t.aiBased,
+      key: t.key ?? null,
+      createdAt: tsReq(t.createdAt),
+      // Neo4j Tool has no separate modifiedAt; seed updatedAt = createdAt.
+      updatedAt: tsReq(t.createdAt),
+      // migration-todo: readMany returns live rows only; deleted Tools (if the
+      // Neo4j model retains any) are not carried. Confirm before cutover.
+      deletedAt: null,
+    }));
+    const inserted = await bulkInsert(ctx, tools, rows);
+    return { tools: stat(dtos.length, inserted) };
+  },
+};

--- a/src/core/cutover/extractors/user-location.extractor.ts
+++ b/src/core/cutover/extractors/user-location.extractor.ts
@@ -1,0 +1,51 @@
+import { type ID } from '~/common';
+import { locations, userLocations, users } from '~/core/drizzle/schema';
+import {
+  bulkInsert,
+  cypher,
+  keepLanded,
+  liveTargetIds,
+  one,
+} from '../cutover.helpers';
+import { type Extractor } from '../cutover.types';
+
+/**
+ * user_locations — the (User)-[:locations]->(Location) junction, kept as its
+ * OWN extractor rather than folded into `user`. `user` sits UPSTREAM of
+ * `location` in the dependency graph (user → fieldZone → fieldRegion →
+ * location), so `user` itself cannot declare a dependency on `location`
+ * without creating a cycle. This extractor runs after both instead.
+ *
+ * Mirrors organization.extractor.ts's `organization_locations` junction —
+ * same relationship name (`locations`), same landed-both-sides guard.
+ */
+export const userLocationExtractor: Extractor = {
+  name: 'userLocation',
+  targetTables: ['user_locations'],
+  dependsOn: ['user', 'location'],
+  async run(ctx) {
+    const pairs = await cypher<{ userId: ID; locationId: ID }>(
+      ctx,
+      `MATCH (u:User)-[:locations { active: true }]->(l:Location)
+       RETURN u.id AS userId, l.id AS locationId`,
+    );
+
+    const landedUsers = await liveTargetIds(ctx, 'User', users);
+    const landedLocations = await liveTargetIds(ctx, 'Location', locations);
+    const { kept, skipped } = keepLanded(pairs, [
+      [landedUsers, (row) => row.userId],
+      [landedLocations, (row) => row.locationId],
+    ]);
+    if (skipped > 0) {
+      ctx.log(
+        `    ⚠ skipped ${skipped} user_locations row(s) — user or location never landed`,
+      );
+    }
+
+    return one(
+      'user_locations',
+      pairs.length,
+      await bulkInsert(ctx, userLocations, kept),
+    );
+  },
+};

--- a/src/core/cutover/extractors/user.extractor.ts
+++ b/src/core/cutover/extractors/user.extractor.ts
@@ -1,4 +1,5 @@
 import { type ID, type Role } from '~/common';
+import { ConfigService } from '~/core/config';
 import {
   authIdentities,
   educations,
@@ -47,12 +48,15 @@ export const userExtractor: Extractor = {
 
     // ── users ──────────────────────────────────────────────────────────────
     const userDtos = await readAllViaRepo<User>(ctx, 'User', UserRepository);
+    // Root must be flagged here: with is_root=false everywhere, the admin
+    // bootstrap's createRootUser conflicts with the migrated row and
+    // waitForRootUserId polls forever (first PG boot on an ETL'd DB hangs —
+    // shadow-diff maiden-run finding, ledger S5).
+    const rootEmail = ctx.moduleRef.get(ConfigService, { strict: false })
+      .rootUser.email;
     const userRows = userDtos.map((u) => ({
       id: u.id,
-      // migration-todo: root flag defaulted false. The admin bootstrap
-      // re-establishes root on first postgres boot; alternatively detect the
-      // Neo4j root by the configured root-admin email and set true here.
-      isRoot: false,
+      isRoot: u.email === rootEmail,
       // NOT NULL columns whose Property node may be missing in Neo4j — coalesce
       // to the schema default (real load surfaced null `status` on legacy rows).
       status: orDefault(u.status, 'Active'),

--- a/src/core/cutover/extractors/user.extractor.ts
+++ b/src/core/cutover/extractors/user.extractor.ts
@@ -53,11 +53,23 @@ export const userExtractor: Extractor = {
     // bootstrap's createRootUser conflicts with the migrated row and
     // waitForRootUserId polls forever (first PG boot on an ETL'd DB hangs —
     // shadow-diff maiden-run finding, ledger S5).
+    //
+    // The authoritative marker in Neo4j is the `:RootUser` LABEL (admin.repository
+    // sets it and reads it back), not the configured email — this box's ROOT_USER
+    // need not match the source graph's. The email is kept only as a fallback for
+    // a graph where the label was never applied.
     const rootEmail = ctx.moduleRef.get(ConfigService, { strict: false })
       .rootUser.email;
+    const labelledRoots = new Set(
+      (
+        await cypher<{ id: ID }>(ctx, `MATCH (n:RootUser) RETURN n.id AS id`)
+      ).map((row) => row.id),
+    );
+    const isRootUser = (u: { id: ID; email?: string | null }) =>
+      labelledRoots.size > 0 ? labelledRoots.has(u.id) : u.email === rootEmail;
     const userRows = userDtos.map((u) => ({
       id: u.id,
-      isRoot: u.email === rootEmail,
+      isRoot: isRootUser(u),
       // NOT NULL columns whose Property node may be missing in Neo4j — coalesce
       // to the schema default (real load surfaced null `status` on legacy rows).
       status: orDefault(u.status, 'Active'),
@@ -77,6 +89,23 @@ export const userExtractor: Extractor = {
       updatedAt: tsReq(u.createdAt),
       deletedAt: null,
     }));
+    // Assert the outcome rather than assuming it. Landing ZERO root users is the
+    // exact S5 failure this flag exists to prevent — the first Postgres boot on
+    // the loaded DB then tries to create a root user, conflicts with the migrated
+    // row on its primary key, and `waitForRootUserId` polls forever. Landing more
+    // than one is equally wrong and would be invisible. Neither shows up in any
+    // row count, so the run has to say it out loud.
+    const rootCount = userRows.filter((row) => row.isRoot).length;
+    if (rootCount !== 1) {
+      ctx.log(
+        `    ⚠⚠ ${rootCount} user(s) flagged is_root — expected exactly 1. ` +
+          (rootCount === 0
+            ? `Neither a :RootUser label nor a user with the configured ROOT_USER email ` +
+              `(${rootEmail}) was found in the source. The first Postgres boot on this ` +
+              `database will HANG in waitForRootUserId (ledger S5).`
+            : `More than one root will make the bootstrap's root lookup ambiguous.`),
+      );
+    }
     out.users = stat(userDtos.length, await bulkInsert(ctx, users, userRows));
 
     // Every table below FKs to users.id, and the three built from raw Cypher
@@ -132,8 +161,24 @@ export const userExtractor: Extractor = {
           ]
         : [];
     });
+    // `read` is the PRE-guard count, so a dropped row shows up as a read-vs-
+    // inserted gap. Counting `eduRows.length` here would make the guard's own
+    // drops invisible — read would equal inserted and the table would tick ✓.
+    const eduOrphans = eduDtos.filter((e) => !eduUser.get(e.id)).length;
+    const eduUnlanded = eduDtos.length - eduRows.length - eduOrphans;
+    if (eduOrphans > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${eduOrphans} education(s) with no active [:education] edge from any live user ` +
+          `(the owning user is soft-deleted, or the edge was deactivated)`,
+      );
+    }
+    if (eduUnlanded > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${eduUnlanded} education(s) whose user never landed in Postgres`,
+      );
+    }
     out.educations = stat(
-      eduRows.length,
+      eduDtos.length,
       await bulkInsert(ctx, educations, eduRows),
     );
 
@@ -166,8 +211,24 @@ export const userExtractor: Extractor = {
           ]
         : [];
     });
+    const unavailOrphans = unavailDtos.filter(
+      (x) => !unavailUser.get(x.id),
+    ).length;
+    const unavailUnlanded =
+      unavailDtos.length - unavailRows.length - unavailOrphans;
+    if (unavailOrphans > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${unavailOrphans} unavailability(s) with no active [:unavailability] edge from ` +
+          `any live user (the owning user is soft-deleted, or the edge was deactivated)`,
+      );
+    }
+    if (unavailUnlanded > 0) {
+      ctx.log(
+        `    ⚠ DROPPED ${unavailUnlanded} unavailability(s) whose user never landed in Postgres`,
+      );
+    }
     out.unavailabilities = stat(
-      unavailRows.length,
+      unavailDtos.length,
       await bulkInsert(ctx, unavailabilities, unavailRows),
     );
 

--- a/src/core/cutover/extractors/user.extractor.ts
+++ b/src/core/cutover/extractors/user.extractor.ts
@@ -1,0 +1,191 @@
+import { type ID, type Role } from '~/common';
+import {
+  authIdentities,
+  educations,
+  systemAgents,
+  unavailabilities,
+  userGlobalRoles,
+  users,
+} from '~/core/drizzle/schema';
+import { type User } from '../../../components/user/dto';
+import { type Education } from '../../../components/user/education/dto';
+import { EducationRepository } from '../../../components/user/education/education.repository';
+import { type Unavailability } from '../../../components/user/unavailability/dto';
+import { UnavailabilityRepository } from '../../../components/user/unavailability/unavailability.repository';
+import { UserRepository } from '../../../components/user/user.repository';
+import {
+  bulkInsert,
+  cypher,
+  linkId,
+  orDefault,
+  readAllViaRepo,
+  stat,
+  tsReq,
+} from '../cutover.helpers';
+import { type Extractor, type TableStat } from '../cutover.types';
+
+/**
+ * User cluster — users + user_global_roles + educations + unavailabilities +
+ * system_agents + auth_identities (password hashes). Inserts users first (the
+ * rest FK to it).
+ *
+ * Deliberately NOT migrated (transient): auth_sessions, auth_password_reset_tokens
+ * — users re-authenticate post-cutover (see README + the User-domain spec).
+ */
+export const userExtractor: Extractor = {
+  name: 'user',
+  targetTables: [
+    'users',
+    'user_global_roles',
+    'educations',
+    'unavailabilities',
+    'system_agents',
+    'auth_identities',
+  ],
+  async run(ctx) {
+    const out: Record<string, TableStat> = {};
+
+    // ── users ──────────────────────────────────────────────────────────────
+    const userDtos = await readAllViaRepo<User>(ctx, 'User', UserRepository);
+    const userRows = userDtos.map((u) => ({
+      id: u.id,
+      // migration-todo: root flag defaulted false. The admin bootstrap
+      // re-establishes root on first postgres boot; alternatively detect the
+      // Neo4j root by the configured root-admin email and set true here.
+      isRoot: false,
+      // NOT NULL columns whose Property node may be missing in Neo4j — coalesce
+      // to the schema default (real load surfaced null `status` on legacy rows).
+      status: orDefault(u.status, 'Active'),
+      email: u.email ?? null,
+      realFirstName: orDefault(u.realFirstName, ''),
+      realLastName: orDefault(u.realLastName, ''),
+      displayFirstName: orDefault(u.displayFirstName, ''),
+      displayLastName: orDefault(u.displayLastName, ''),
+      phone: u.phone ?? null,
+      timezone: orDefault(u.timezone, 'America/Chicago'),
+      about: u.about ?? null,
+      title: u.title ?? null,
+      gender: u.gender ?? null,
+      // Plain text (no FK); the referenced file_node lands in the file wave.
+      photoId: linkId(u.photo),
+      createdAt: tsReq(u.createdAt),
+      updatedAt: tsReq(u.createdAt),
+      deletedAt: null,
+    }));
+    out.users = stat(userDtos.length, await bulkInsert(ctx, users, userRows));
+
+    // ── user_global_roles ───────────────────────────────────────────────────
+    const roleRows = userDtos.flatMap((u) =>
+      (u.roles ?? []).map((role) => ({ userId: u.id, role })),
+    );
+    out.user_global_roles = stat(
+      roleRows.length,
+      await bulkInsert(ctx, userGlobalRoles, roleRows),
+    );
+
+    // ── educations (userId via the User→Education rel) ───────────────────────
+    // migration-todo: verify the rel name/direction against a live Neo4j — a
+    // mismatch silently drops rows (orphans skipped). Spec: (User)-[:education]->(Education).
+    const eduDtos = await readAllViaRepo<Education>(
+      ctx,
+      'Education',
+      EducationRepository,
+    );
+    const eduPairs = await cypher<{ eid: ID; uid: ID }>(
+      ctx,
+      `MATCH (u:User)-[:education { active: true }]->(e:Education)
+       RETURN e.id AS eid, u.id AS uid`,
+    );
+    const eduUser = new Map(eduPairs.map((p) => [p.eid, p.uid]));
+    const eduRows = eduDtos.flatMap((e) => {
+      const userId = eduUser.get(e.id);
+      return userId
+        ? [
+            {
+              id: e.id,
+              userId,
+              degree: e.degree,
+              major: e.major,
+              institution: e.institution,
+              createdAt: tsReq(e.createdAt),
+              updatedAt: tsReq(e.createdAt),
+              deletedAt: null,
+            },
+          ]
+        : [];
+    });
+    out.educations = stat(
+      eduRows.length,
+      await bulkInsert(ctx, educations, eduRows),
+    );
+
+    // ── unavailabilities ─────────────────────────────────────────────────────
+    const unavailDtos = await readAllViaRepo<Unavailability>(
+      ctx,
+      'Unavailability',
+      UnavailabilityRepository,
+    );
+    const unavailPairs = await cypher<{ xid: ID; uid: ID }>(
+      ctx,
+      `MATCH (u:User)-[:unavailability { active: true }]->(x:Unavailability)
+       RETURN x.id AS xid, u.id AS uid`,
+    );
+    const unavailUser = new Map(unavailPairs.map((p) => [p.xid, p.uid]));
+    const unavailRows = unavailDtos.flatMap((x) => {
+      const userId = unavailUser.get(x.id);
+      return userId
+        ? [
+            {
+              id: x.id,
+              userId,
+              description: x.description,
+              start: tsReq(x.start),
+              end: tsReq(x.end),
+              createdAt: tsReq(x.createdAt),
+              updatedAt: tsReq(x.createdAt),
+              deletedAt: null,
+            },
+          ]
+        : [];
+    });
+    out.unavailabilities = stat(
+      unavailRows.length,
+      await bulkInsert(ctx, unavailabilities, unavailRows),
+    );
+
+    // ── system_agents (roles stored directly on the node; createdAt defaulted) ─
+    const agentRows = await cypher<{ id: ID; name: string; roles: string[] }>(
+      ctx,
+      `MATCH (n:SystemAgent) RETURN n.id AS id, n.name AS name, n.roles AS roles`,
+    );
+    out.system_agents = stat(
+      agentRows.length,
+      await bulkInsert(
+        ctx,
+        systemAgents,
+        agentRows.map((a) => ({
+          id: a.id,
+          name: a.name,
+          roles: (a.roles ?? []) as Role[],
+        })),
+      ),
+    );
+
+    // ── auth_identities (password hashes — copied as-is; updatedAt defaulted) ──
+    const pwRows = await cypher<{ userId: ID; hash: string }>(
+      ctx,
+      `MATCH (u:User)-[:password { active: true }]->(p:Property)
+       RETURN u.id AS userId, p.value AS hash`,
+    );
+    out.auth_identities = stat(
+      pwRows.length,
+      await bulkInsert(
+        ctx,
+        authIdentities,
+        pwRows.map((p) => ({ userId: p.userId, passwordHash: p.hash })),
+      ),
+    );
+
+    return out;
+  },
+};

--- a/src/core/cutover/extractors/user.extractor.ts
+++ b/src/core/cutover/extractors/user.extractor.ts
@@ -18,6 +18,7 @@ import {
   bulkInsert,
   cypher,
   linkId,
+  liveTargetIds,
   orDefault,
   readAllViaRepo,
   stat,
@@ -78,6 +79,19 @@ export const userExtractor: Extractor = {
     }));
     out.users = stat(userDtos.length, await bulkInsert(ctx, users, userRows));
 
+    // Every table below FKs to users.id, and the three built from raw Cypher
+    // below enumerate ALL `:User` nodes — a superset of what actually LANDED.
+    // readMany silently drops nodes with broken required rels (49 locally), and
+    // onConflictDoNothing can drop more, so an unfiltered child insert dies on
+    // `*_user_id_fkey`. This is the truth source; skips are counted, not silent.
+    const landedUsers = await liveTargetIds(ctx, 'User', users);
+    let orphanedChildren = 0;
+    const userLanded = (userId: ID): boolean => {
+      if (landedUsers.has(userId)) return true;
+      orphanedChildren++;
+      return false;
+    };
+
     // ── user_global_roles ───────────────────────────────────────────────────
     const roleRows = userDtos.flatMap((u) =>
       (u.roles ?? []).map((role) => ({ userId: u.id, role })),
@@ -103,7 +117,7 @@ export const userExtractor: Extractor = {
     const eduUser = new Map(eduPairs.map((p) => [p.eid, p.uid]));
     const eduRows = eduDtos.flatMap((e) => {
       const userId = eduUser.get(e.id);
-      return userId
+      return userId && userLanded(userId)
         ? [
             {
               id: e.id,
@@ -137,7 +151,7 @@ export const userExtractor: Extractor = {
     const unavailUser = new Map(unavailPairs.map((p) => [p.xid, p.uid]));
     const unavailRows = unavailDtos.flatMap((x) => {
       const userId = unavailUser.get(x.id);
-      return userId
+      return userId && userLanded(userId)
         ? [
             {
               id: x.id,
@@ -181,14 +195,23 @@ export const userExtractor: Extractor = {
       `MATCH (u:User)-[:password { active: true }]->(p:Property)
        RETURN u.id AS userId, p.value AS hash`,
     );
+    const pwLanded = pwRows.filter((p) => userLanded(p.userId));
     out.auth_identities = stat(
       pwRows.length,
       await bulkInsert(
         ctx,
         authIdentities,
-        pwRows.map((p) => ({ userId: p.userId, passwordHash: p.hash })),
+        pwLanded.map((p) => ({ userId: p.userId, passwordHash: p.hash })),
       ),
     );
+
+    if (orphanedChildren > 0) {
+      ctx.log(
+        `    ⚠ skipped ${orphanedChildren} education/unavailability/auth-identity row(s) whose user never ` +
+          `landed in \`users\` (hydrate-drop or conflict-drop). Each skipped auth_identity is a user who ` +
+          `CANNOT log in post-cutover — reconcile the users hydrate-drop list before the real load.`,
+      );
+    }
 
     return out;
   },

--- a/src/core/cutover/preflight-enums.cypher
+++ b/src/core/cutover/preflight-enums.cypher
@@ -1,0 +1,307 @@
+// ═══════════════════════════════════════════════════════════════════════════════
+// CUTOVER PRE-FLIGHT — stored enum values against the Postgres enum that receives them
+//
+// READ-ONLY. Every leg returns exactly ONE row even when it matches nothing, so a
+// clean property and a broken pattern are never confused.
+//
+// Read the columns as:
+//   distinctValues  distinct live values seen. ZERO means the pattern matched
+//                   nothing — a BROKEN LEG, not a clean result. Check it.
+//   wouldDrop       values the Postgres enum does not declare. MUST be empty.
+//
+// Why this exists rather than a value dump: the answer has to be computed against
+// the enum, and reading a dump by eye (or through a parser) is where the mistakes
+// happen. The allowed lists below are generated FROM the schema, so they cannot
+// drift from it by hand-editing.
+//
+// TWO different failures hide here, and they look nothing alike:
+//   · A value dropped by sanitizeEnum — the ROW STILL LANDS, minus that value.
+//     Invisible to row-count reconciliation. This is what wouldDrop predicts.
+//   · A value on a column whose extractor does NOT sanitise — the CAST FAILS and
+//     the whole load stops. Louder, but the same root cause.
+//
+// Storage shape matters and is stated per leg: a sweep that only walks Property
+// nodes silently misses every enum held on the node itself or on a relationship.
+// That mistake was made once; hence the 'storedAs' column.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// Rows are ORDERED so anything needing attention is at the TOP:
+//   · a non-empty `wouldDrop` first  — a value the Postgres enum rejects
+//   · then any `distinctValues = 0`  — a leg that matched nothing, i.e. very
+//     likely a WRONG leg rather than an empty domain. One was found that way
+//     (media category, which is stored on the node, not as a Property node).
+// A fully clean run therefore starts with a row whose wouldDrop is [] and whose
+// distinctValues is > 0.
+
+CALL {
+  MATCH (n:Budget)-[r:status { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Budget.status' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Pending', 'Current', 'Superceded', 'Rejected']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Ceremony)-[r:type { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Ceremony.type' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Dedication', 'Certification']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Engagement)-[r:status { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Engagement.status' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['InDevelopment', 'DidNotDevelop', 'Rejected', 'Active', 'ActiveChangedPlan', 'DiscussingTermination', 'DiscussingReactivation', 'DiscussingChangeToPlan', 'DiscussingSuspension', 'Suspended', 'FinalizingCompletion', 'Terminated', 'Completed', 'Converted', 'Unapproved', 'Transferred', 'NotRenewed']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Engagement)-[r:methodologies { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Engagement.methodologies' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Paratext', 'OtherWritten', 'Render', 'Audacity', 'AdobeAudition', 'OtherOralTranslation', 'StoryTogether', 'SeedCompanyMethod', 'OneStory', 'Craft2Tell', 'OtherOralStories', 'Film', 'SignLanguage', 'OtherVisual']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Engagement)-[r:milestonePlanned { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Engagement.milestonePlanned' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Unknown', 'None', 'OldTestament', 'NewTestament', 'FullBible']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Location)-[r:type { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Location.type' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Country', 'City', 'County', 'Region', 'State', 'CrossBorderArea']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Organization)-[r:types { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Organization.types' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Church', 'Parachurch', 'Mission', 'Translation', 'Alliance']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Organization)-[r:reach { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Organization.reach' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Local', 'Regional', 'National', 'Global']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Partner)-[r:types { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Partner.types' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Managing', 'Funding', 'Impact', 'Technical', 'Resource']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Partner)-[r:financialReportingTypes { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Partner.financialReportingTypes' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Funded', 'FieldEngaged', 'Hybrid']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Partner)-[r:approvedPrograms { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Partner.approvedPrograms' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['MomentumTranslation', 'MultiplicationTranslation', 'Internship']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Partnership)-[r:types { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Partnership.types' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Managing', 'Funding', 'Impact', 'Technical', 'Resource']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Partnership)-[r:agreementStatus { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Partnership.agreementStatus' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['NotAttached', 'AwaitingSignature', 'Signed']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Partnership)-[r:mouStatus { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Partnership.mouStatus' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['NotAttached', 'AwaitingSignature', 'Signed']] AS wouldDrop
+  UNION ALL
+  MATCH (n:PeriodicReport)-[r:status { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'PeriodicReport.status' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['NotStarted', 'InProgress', 'PendingTranslation', 'InReview', 'Approved', 'Published']] AS wouldDrop
+  UNION ALL
+  MATCH (n:PeriodicReport)-[r:type { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'PeriodicReport.type' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Financial', 'Narrative', 'Progress']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Post)-[r:type { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Post.type' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Note', 'Story', 'Prayer']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Post)-[r:shareability { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Post.shareability' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Membership', 'ProjectTeam', 'Internal', 'AskToShareExternally', 'External']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Producible)-[r:mediums { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Producible.mediums' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Print', 'Web', 'EBook', 'App', 'TrainedStoryTellers', 'Audio', 'Video', 'Other']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Producible)-[r:purposes { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Producible.purposes' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['EvangelismChurchPlanting', 'ChurchLife', 'ChurchMaturity', 'SocialIssues', 'Discipleship']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Producible)-[r:steps { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Producible.steps' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['ExegesisAndFirstDraft', 'TeamCheck', 'CommunityTesting', 'BackTranslation', 'ConsultantCheck', 'InternalizationAndDrafting', 'PeerRevision', 'ConsistencyCheckAndFinalEdits', 'Craft', 'Test', 'Check', 'Record', 'Develop', 'Translate', 'Completed']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Product)-[r:mediums { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Product.mediums' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Print', 'Web', 'EBook', 'App', 'TrainedStoryTellers', 'Audio', 'Video', 'Other']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Product)-[r:purposes { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Product.purposes' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['EvangelismChurchPlanting', 'ChurchLife', 'ChurchMaturity', 'SocialIssues', 'Discipleship']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Product)-[r:steps { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Product.steps' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['ExegesisAndFirstDraft', 'TeamCheck', 'CommunityTesting', 'BackTranslation', 'ConsultantCheck', 'InternalizationAndDrafting', 'PeerRevision', 'ConsistencyCheckAndFinalEdits', 'Craft', 'Test', 'Check', 'Record', 'Develop', 'Translate', 'Completed']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Project)-[r:status { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Project.status' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['InDevelopment', 'Active', 'Terminated', 'Completed', 'DidNotDevelop']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Project)-[r:step { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Project.step' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['EarlyConversations', 'PendingConceptApproval', 'PrepForConsultantEndorsement', 'PendingConsultantEndorsement', 'PrepForFinancialEndorsement', 'PendingFinancialEndorsement', 'FinalizingProposal', 'PendingRegionalDirectorApproval', 'PendingZoneDirectorApproval', 'PendingFinanceConfirmation', 'OnHoldFinanceConfirmation', 'DidNotDevelop', 'Rejected', 'Active', 'ActiveChangedPlan', 'DiscussingChangeToPlan', 'PendingChangeToPlanApproval', 'PendingChangeToPlanConfirmation', 'DiscussingSuspension', 'PendingSuspensionApproval', 'Suspended', 'DiscussingReactivation', 'PendingReactivationApproval', 'DiscussingTermination', 'PendingTerminationApproval', 'FinalizingCompletion', 'Terminated', 'Completed']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Project)-[r:sensitivity { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Project.sensitivity' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Low', 'Medium', 'High']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Language)-[r:sensitivity { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Language.sensitivity' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Low', 'Medium', 'High']] AS wouldDrop
+  UNION ALL
+  MATCH (n:ProjectMember)-[r:roles { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'ProjectMember.roles' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Administrator', 'BetaTester', 'BibleTranslationLiaison', 'Consultant', 'ConsultantManager', 'Controller', 'ExperienceOperations', 'FieldOperationsDirector', 'FieldPartner', 'FieldServices', 'FinancialAnalyst', 'Fundraising', 'Intern', 'LeadFinancialAnalyst', 'Leadership', 'Liaison', 'Marketing', 'Mentor', 'MultiplicationFinanceApprover', 'ProjectManager', 'RegionalCommunicationsCoordinator', 'RegionalDirector', 'StaffMember', 'Translator']] AS wouldDrop
+  UNION ALL
+  MATCH (n:User)-[r:roles { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'User.roles' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Administrator', 'BetaTester', 'BibleTranslationLiaison', 'Consultant', 'ConsultantManager', 'Controller', 'ExperienceOperations', 'FieldOperationsDirector', 'FieldPartner', 'FieldServices', 'FinancialAnalyst', 'Fundraising', 'Intern', 'LeadFinancialAnalyst', 'Leadership', 'Liaison', 'Marketing', 'Mentor', 'MultiplicationFinanceApprover', 'ProjectManager', 'RegionalCommunicationsCoordinator', 'RegionalDirector', 'StaffMember', 'Translator']] AS wouldDrop
+  UNION ALL
+  MATCH (n:User)-[r:status { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'User.status' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Active', 'Disabled']] AS wouldDrop
+  UNION ALL
+  MATCH (n:User)-[r:gender { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'User.gender' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Male', 'Female']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Education)-[r:degree { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Education.degree' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Primary', 'Secondary', 'Associates', 'Bachelors', 'Masters', 'Doctorate']] AS wouldDrop
+  UNION ALL
+  MATCH (n:Tool)-[r:key { active: true }]->(p:Property)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Tool.key' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Rev79']] AS wouldDrop
+  UNION ALL
+  MATCH (n:ProgressSummary)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND n.period IS NOT NULL
+  WITH collect(DISTINCT toString(n.period)) AS vals
+  RETURN 'ProgressSummary.period' AS property, 'on the node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['ReportPeriod', 'FiscalYearSoFar', 'Cumulative']] AS wouldDrop
+  UNION ALL
+  MATCH (n:StepProgress)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND n.step IS NOT NULL
+  WITH collect(DISTINCT toString(n.step)) AS vals
+  RETURN 'StepProgress.step' AS property, 'on the node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['ExegesisAndFirstDraft', 'TeamCheck', 'CommunityTesting', 'BackTranslation', 'ConsultantCheck', 'InternalizationAndDrafting', 'PeerRevision', 'ConsistencyCheckAndFinalEdits', 'Craft', 'Test', 'Check', 'Record', 'Develop', 'Translate', 'Completed']] AS wouldDrop
+  UNION ALL
+  MATCH (n:ProgressReportWorkflowEvent)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND n.status IS NOT NULL
+  WITH collect(DISTINCT toString(n.status)) AS vals
+  RETURN 'ProgressReportWorkflowEvent.status' AS property, 'on the node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['NotStarted', 'InProgress', 'PendingTranslation', 'InReview', 'Approved', 'Published']] AS wouldDrop
+  UNION ALL
+  MATCH (n:ProgressReportMedia)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND n.category IS NOT NULL
+  WITH collect(DISTINCT toString(n.category)) AS vals
+  RETURN 'ProgressReportMedia.category' AS property, 'on the node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Team', 'WorkInProgress', 'CommunityEngagement', 'LifeInCommunity', 'Events', 'SceneryLandscape', 'Other']] AS wouldDrop
+  UNION ALL
+  MATCH (:User)-[r:knownLanguage { active: true }]->(:Language)
+  WHERE r.value IS NOT NULL
+  WITH collect(DISTINCT toString(r.value)) AS vals
+  RETURN 'KnownLanguage.proficiency' AS property, 'on the edge' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['Beginner', 'Conversational', 'Skilled', 'Fluent']] AS wouldDrop
+}
+WITH property, storedAs, distinctValues, wouldDrop
+RETURN property, storedAs, distinctValues, wouldDrop
+  ORDER BY size(wouldDrop) DESC, distinctValues ASC, property

--- a/src/core/cutover/preflight-enums.cypher
+++ b/src/core/cutover/preflight-enums.cypher
@@ -55,6 +55,17 @@ CALL {
   RETURN 'Engagement.status' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
          [x IN vals WHERE NOT x IN ['InDevelopment', 'DidNotDevelop', 'Rejected', 'Active', 'ActiveChangedPlan', 'DiscussingTermination', 'DiscussingReactivation', 'DiscussingChangeToPlan', 'DiscussingSuspension', 'Suspended', 'FinalizingCompletion', 'Terminated', 'Completed', 'Converted', 'Unapproved', 'Transferred', 'NotRenewed']] AS wouldDrop
   UNION ALL
+  // Superseded statuses feed engagement_status_history and are a SEPARATE value
+  // domain from the live one above -- a status retired years ago survives only
+  // here. No label filter on p, and active:false, exactly matching what the
+  // engagement extractor reads (a superseded property node is Deleted_Property).
+  MATCH (n:Engagement)-[r:status { active: false }]->(p)
+  WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
+  UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v
+  WITH collect(DISTINCT toString(v)) AS vals
+  RETURN 'Engagement.status (superseded/history)' AS property, 'Property node' AS storedAs, size(vals) AS distinctValues,
+         [x IN vals WHERE NOT x IN ['InDevelopment', 'DidNotDevelop', 'Rejected', 'Active', 'ActiveChangedPlan', 'DiscussingTermination', 'DiscussingReactivation', 'DiscussingChangeToPlan', 'DiscussingSuspension', 'Suspended', 'FinalizingCompletion', 'Terminated', 'Completed', 'Converted', 'Unapproved', 'Transferred', 'NotRenewed']] AS wouldDrop
+  UNION ALL
   MATCH (n:Engagement)-[r:methodologies { active: true }]->(p:Property)
   WHERE NOT any(l IN labels(n) WHERE l STARTS WITH 'Deleted_') AND p.value IS NOT NULL
   UNWIND (CASE WHEN p.value IS :: LIST<ANY> THEN p.value ELSE [p.value] END) AS v

--- a/src/core/cutover/preflight-uniques.cypher
+++ b/src/core/cutover/preflight-uniques.cypher
@@ -1,0 +1,135 @@
+// ═══════════════════════════════════════════════════════════════════════════════
+// CUTOVER PRE-FLIGHT — duplicate live values on every Postgres unique index
+//
+// READ-ONLY. Every leg returns exactly one row even when it matches nothing, so a
+// clean constraint and a broken pattern are never confused (the aggregation
+// collapses to a single row BEFORE the leg's label literal is attached).
+//
+// Read the columns as:
+//   scannedKeys    distinct live key values seen. ZERO here means the pattern
+//                  matched nothing — treat as a BROKEN LEG, not a clean result.
+//   dupGroups      key values held by more than one live row.
+//   rowsWouldDrop  rows the loader silently sheds to onConflictDoNothing.
+//
+// rowsWouldDrop is NOT a row count — for a root entity it is a SUBTREE count.
+// Measured example: 19 dropped languages cost ~1,400 rows downstream.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// ── TIER 1 — root entities: a drop here takes its whole subtree ───────────────
+
+MATCH (n:Project)-[:name {active:true}]->(p:Property)
+WITH p.value AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'projects.name' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (n:Project)-[:departmentId {active:true}]->(p:Property) WHERE p.value IS NOT NULL
+WITH p.value AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'projects.departmentId (non-null)' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (n:Location)-[:name {active:true}]->(p:Property)
+WITH p.value AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'locations.name' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (n:Location)-[:isoAlpha3 {active:true}]->(p:Property) WHERE p.value IS NOT NULL
+WITH p.value AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'locations.isoAlpha3 (non-null) <-- the real cause of the dev 9-row drop' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (n:Organization)-[:name {active:true}]->(p:Property)
+WITH p.value AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'organizations.name' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (n:FieldZone)-[:name {active:true}]->(p:Property)
+WITH p.value AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'field_zones.name' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (n:FieldRegion)-[:name {active:true}]->(p:Property)
+WITH p.value AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'field_regions.name' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (n:FundingAccount)-[:name {active:true}]->(p:Property)
+WITH p.value AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'funding_accounts.name' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (n:EthnologueLanguage)-[:code {active:true}]->(p:Property) WHERE p.value IS NOT NULL
+WITH p.value AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'ethnologue.code (non-null)' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (n:EthnologueLanguage)-[:provisionalCode {active:true}]->(p:Property) WHERE p.value IS NOT NULL
+WITH p.value AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'ethnologue.provisionalCode (non-null)' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (org:Organization)<-[:organization {active:true}]-(n:Partner)
+WITH org.id AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'partners.organization (one partner per org)' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (n)-[:name {active:true}]->(p:Property) WHERE n:Film OR n:Story OR n:EthnoArt
+// NOT labels(n)[0] — that is 'BaseNode' for every producible, which would fold
+// a Film and a Story sharing a name into one group and report a FALSE dup.
+WITH (CASE WHEN n:Film THEN 'Film' WHEN n:Story THEN 'Story' ELSE 'EthnoArt' END)
+     + '/' + p.value AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'producibles.(type,name)' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (proj:Project)-[:engagement {active:true}]->(n:LanguageEngagement)-[:language {active:true}]->(l:Language)
+WITH proj.id + '/' + l.id AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'engagements.(project,language)' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (proj:Project)-[:engagement {active:true}]->(n:InternshipEngagement)-[:intern {active:true}]->(u:User)
+WITH proj.id + '/' + u.id AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'engagements.(project,intern)' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+
+// ── TIER 2 — junctions and children: a drop here loses one row ───────────────
+
+UNION ALL
+MATCH (proj:Project)-[:member {active:true}]->(n:ProjectMember)-[:user {active:true}]->(u:User)
+WITH proj.id + '/' + u.id AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'project_members.(project,user)' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (proj:Project)-[:partnership {active:true}]->(n:Partnership)-[:partner {active:true}]->(pa:Partner)
+WITH proj.id + '/' + pa.id AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'partnerships.(project,partner)' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (proj:Project)-[:partnership {active:true}]->(n:Partnership)-[:primary {active:true}]->(p:Property {value:true})
+WITH proj.id AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'partnerships one PRIMARY per project' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (u:User)-[:primaryOrganization {active:true}]->(o:Organization)
+WITH u.id AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'user_organizations one PRIMARY per user' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (e:Engagement)-[:ceremony {active:true}]->(n:Ceremony)
+WITH e.id AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'ceremonies one per engagement' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (b:Budget)-[:record {active:true}]->(n:BudgetRecord)-[:organization {active:true}]->(o:Organization)
+MATCH (n)-[:fiscalYear {active:true}]->(fy:Property)
+WITH b.id + '/' + o.id + '/' + toString(fy.value) AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'budget_records.(budget,org,fy)' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (n:Tool)-[:name {active:true}]->(p:Property)
+WITH p.value AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'tools.name' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+MATCH (n:Tool)-[:key {active:true}]->(p:Property) WHERE p.value IS NOT NULL
+WITH p.value AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'tools.key (non-null)' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop;

--- a/src/core/cutover/preflight-uniques.cypher
+++ b/src/core/cutover/preflight-uniques.cypher
@@ -13,6 +13,13 @@
 //
 // rowsWouldDrop is NOT a row count — for a root entity it is a SUBTREE count.
 // Measured example: 19 dropped languages cost ~1,400 rows downstream.
+//
+// Legs marked "RELAXED 0030" no longer drop anything: that migration dropped the
+// unique indexes behind them (language name + displayName, ethnologue code +
+// provisionalCode, locations isoAlpha3) because the source never enforced them.
+// Their legs are kept because the duplicate COUNT is still worth knowing — it is
+// how the 37 production name groups were found — but read rowsWouldDrop as
+// "rows that used to be shed", not as a prediction.
 // ═══════════════════════════════════════════════════════════════════════════════
 
 // ── TIER 1 — root entities: a drop here takes its whole subtree ───────────────
@@ -35,7 +42,7 @@ UNION ALL
 MATCH (n:Location)-[:isoAlpha3 {active:true}]->(p:Property) WHERE p.value IS NOT NULL
 WITH p.value AS v, count(*) AS c
 WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
-RETURN 'locations.isoAlpha3 (non-null) <-- the real cause of the dev 9-row drop' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+RETURN 'locations.isoAlpha3 (non-null) — RELAXED 0030, informational' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
 UNION ALL
 MATCH (n:Organization)-[:name {active:true}]->(p:Property)
 WITH p.value AS v, count(*) AS c
@@ -60,12 +67,20 @@ UNION ALL
 MATCH (n:EthnologueLanguage)-[:code {active:true}]->(p:Property) WHERE p.value IS NOT NULL
 WITH p.value AS v, count(*) AS c
 WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
-RETURN 'ethnologue.code (non-null)' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+RETURN 'ethnologue.code (non-null) — RELAXED 0030, informational' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
 UNION ALL
 MATCH (n:EthnologueLanguage)-[:provisionalCode {active:true}]->(p:Property) WHERE p.value IS NOT NULL
 WITH p.value AS v, count(*) AS c
 WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
-RETURN 'ethnologue.provisionalCode (non-null)' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+RETURN 'ethnologue.provisionalCode (non-null) — RELAXED 0030, informational' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
+UNION ALL
+// The ROLV code is the ONE unique still enforced on a language, and it had no leg
+// here while the three relaxed above did — the instrument was measuring the
+// constraints that no longer drop and not the one that does.
+MATCH (n:Language)-[:registryOfLanguageVarietiesCode {active:true}]->(p:Property) WHERE p.value IS NOT NULL
+WITH p.value AS v, count(*) AS c
+WITH count(*) AS k, sum(CASE WHEN c>1 THEN 1 ELSE 0 END) AS g, sum(CASE WHEN c>1 THEN c-1 ELSE 0 END) AS d
+RETURN 'languages.rolvCode (non-null)' AS check, k AS scannedKeys, g AS dupGroups, d AS rowsWouldDrop
 UNION ALL
 MATCH (org:Organization)<-[:organization {active:true}]-(n:Partner)
 WITH org.id AS v, count(*) AS c

--- a/src/core/cutover/verify.ts
+++ b/src/core/cutover/verify.ts
@@ -1,0 +1,1163 @@
+import { getTableName, is, sql, type SQL } from 'drizzle-orm';
+import { getTableConfig, type PgTable } from 'drizzle-orm/pg-core';
+import { PgTable as PgTableClass } from 'drizzle-orm/pg-core';
+import { type DrizzleDb } from '~/core/drizzle/drizzle.service';
+import {
+  ENGAGEMENT_TYPENAMES,
+  PROJECT_TYPENAMES,
+} from '~/core/drizzle/resolve-resource-base-node';
+import * as schema from '~/core/drizzle/schema';
+
+/**
+ * The independent check that a cutover load HOLDS TOGETHER.
+ *
+ * ## What this is for, and what it is not for
+ *
+ * The harness already reconciles counts: rows read out of Neo4j against rows
+ * written to Postgres, per table. That answers "did everything arrive?" and
+ * nothing else. It cannot answer "is what arrived coherent?", because it never
+ * looks at the loaded database — only at its own bookkeeping. A load can
+ * reconcile perfectly and still hold a report pointing at a file that was never
+ * written, or a live membership of a project that is soft-deleted.
+ *
+ * So this reads ONLY Postgres, and only after the load. Deliberately not built
+ * from the ETL's own numbers — same reasoning as the scrub's verifier, and for
+ * the same reason: a check derived from the thing it is checking agrees with it
+ * by construction.
+ *
+ * ## It checks what the database cannot check for itself
+ *
+ * Postgres already enforces its own foreign keys, CHECKs and unique indexes, and
+ * re-testing those would only prove the server works. Every check here is one
+ * the schema deliberately cannot express:
+ *
+ * 1. **Unenforced references.** ~24 id-shaped columns carry no FK — some because
+ *    the row is inserted before its target exists (the `createDefinedFile`
+ *    ordering behind `mou_id`, `report_file_id`, …), some because the target is
+ *    polymorphic and there is no single table to point at. Postgres will accept
+ *    any string in those. See {@link UNENFORCED}.
+ * 2. **Live rows pointing at soft-deleted targets.** A soft-deleted row never
+ *    leaves the table, so a foreign key is satisfied by a dead parent exactly as
+ *    well as a live one. The FK proves the row EXISTS; nothing proves it is
+ *    still alive. This is the whole class of bug the ETL's `liveTargetIds`
+ *    guards exist to prevent, checked from the other end.
+ * 3. **Subtype agreement.** `media.file_version_id` has a real FK to
+ *    `file_nodes`, which cannot say "and it must be a FileVersion, not a
+ *    Directory". Same for every `*_type` discriminator: it is a plain text
+ *    column, free to disagree with the row it describes.
+ * 4. **Timestamp ordering** and **array hygiene**, both derived across the whole
+ *    schema rather than listed per table.
+ *
+ * ## Violations vs watchlist
+ *
+ * A violation means the LOAD is wrong: something Postgres accepted that the
+ * application's own rules say cannot happen. A watchlist entry means the SOURCE
+ * is odd and the load carried it faithfully — real, worth knowing, and not a
+ * cutover problem. Keeping them apart is what stops the report from being
+ * ignored: 6,395 timestamp inversions inherited verbatim from Neo4j would
+ * otherwise drown the handful of findings that mean something.
+ *
+ * ## Reports counts, never values
+ *
+ * Every finding is a name and a number. That makes the output safe to paste into
+ * a ticket or a CI log from a run over production data, which is exactly when it
+ * matters most — and it is everything triage needs, since the check itself says
+ * where to look.
+ */
+
+export interface Finding {
+  /** What was checked, e.g. `partnerships.mou_id -> file_nodes`. */
+  readonly check: string;
+  /** What is wrong with the rows counted, in plain words. */
+  readonly detail: string;
+  readonly count: number;
+}
+
+export interface VerifyReport {
+  /** The load is wrong. Non-empty means do not cut over on this data. */
+  readonly violations: readonly Finding[];
+  /** Faithfully carried source oddities. Worth reading, not worth blocking. */
+  readonly watchlist: readonly Finding[];
+  /**
+   * How many checks actually ran. A check set that quietly shrinks to nothing
+   * reports "clean" just like a healthy database — this is how that shows up as
+   * a number instead of as silence.
+   */
+  readonly checksRun: number;
+  /**
+   * Rows the checks ran over. Reported alongside the verdict because every check
+   * counts rows that break a rule, so "no violations" over an empty database is
+   * a meaningless pass that reads like a perfect one.
+   */
+  readonly rowsChecked: number;
+  readonly clean: boolean;
+}
+
+// ─── The schema, at runtime ──────────────────────────────────────────────────
+
+/**
+ * Every `pgTable` the schema module exports, by its SQL name.
+ *
+ * The `Record<string, unknown>` cast is not cosmetic. `Object.values(schema)`
+ * asks TypeScript to form a union of all ~200 schema exports, and a drizzle
+ * table's type is enormous — the compiler exhausts its heap and dies before it
+ * reports a single error. Erasing the value type first costs nothing here, since
+ * the guard below narrows each one anyway.
+ */
+const TABLES: ReadonlyMap<string, PgTable> = new Map(
+  Object.values(schema as Record<string, unknown>)
+    .filter((value): value is PgTable => is(value, PgTableClass))
+    .map((table) => [getTableName(table), table] as const),
+);
+
+const columnNames = (table: PgTable): ReadonlySet<string> =>
+  new Set(getTableConfig(table).columns.map((column) => column.name));
+
+const hasColumn = (table: PgTable, name: string) =>
+  columnNames(table).has(name);
+
+/** `"alias"."column"`, so generated SQL quotes identifiers rather than pasting. */
+const col = (alias: string, name: string) =>
+  sql`${sql.identifier(alias)}.${sql.identifier(name)}`;
+
+const from = (table: PgTable, alias: string) =>
+  sql`${sql.identifier(getTableName(table))} ${sql.identifier(alias)}`;
+
+/** `count(*)` arrives as a bigint (i.e. a string); no table here approaches 2^31. */
+const runCount = async (db: DrizzleDb, query: SQL): Promise<number> => {
+  const result = await db.execute<{ n: number }>(query);
+  return Number(result.rows[0]?.n ?? 0);
+};
+
+const countWhere = async (db: DrizzleDb, table: PgTable, where: SQL) =>
+  await runCount(
+    db,
+    sql`select count(*)::int as n from ${from(table, 'c')} where ${where}`,
+  );
+
+/** `c.<column>` has no row in `target`. */
+const noRowIn = (target: PgTable, childColumn: SQL, alias = 't') =>
+  sql`not exists (select 1 from ${from(target, alias)} where ${col(
+    alias,
+    'id',
+  )} = ${childColumn})`;
+
+// ─── 1. References Postgres does not enforce ─────────────────────────────────
+
+const { budgets, budgetRecords, ceremonies, comments, commentThreads } = schema;
+const { educations, engagements, fieldRegions, fieldZones, fileNodes } = schema;
+const { fundingAccounts, languages, locations, notifications } = schema;
+const { organizations, partners, partnerships, periodicReports } = schema;
+const { posts, producibles, products, projectMembers, projects } = schema;
+const { tools, toolUsages, unavailabilities, users } = schema;
+
+/**
+ * Concrete `__typename` → the table its rows live in.
+ *
+ * Mirrors `RESOURCE_TABLES` in resolve-resource-base-node.ts, which is the
+ * registry the running application uses for the same job. Not imported from it
+ * because that registry exposes query branches rather than tables — but the two
+ * subtype FAMILIES most likely to gain a member are imported, so adding a
+ * project or engagement type updates this map without anyone remembering to.
+ *
+ * A stored type this map does not claim is reported as a violation rather than
+ * skipped. That is the point: an unmapped type and a dangling id look identical
+ * from the outside, and only one of them is a data problem.
+ *
+ * Built entry by entry rather than as one array literal, for the same reason
+ * {@link TABLES} erases its value type: a single literal makes TypeScript infer
+ * a union of thirty-odd drizzle table types and run out of memory.
+ */
+const named = (
+  typenames: readonly string[],
+  table: PgTable,
+): ReadonlyArray<readonly [string, PgTable]> =>
+  typenames.map((typename) => [typename, table] as const);
+
+const TABLE_BY_TYPENAME: ReadonlyMap<string, PgTable> = new Map([
+  ...named(PROJECT_TYPENAMES, projects),
+  ...named(ENGAGEMENT_TYPENAMES, engagements),
+  ...named(['User'], users),
+  ...named(['Language'], languages),
+  ...named(['Partner'], partners),
+  ...named(['Organization'], organizations),
+  ...named(['Location'], locations),
+  ...named(['FieldRegion'], fieldRegions),
+  ...named(['FieldZone'], fieldZones),
+  ...named(['FundingAccount'], fundingAccounts),
+  ...named(['Partnership'], partnerships),
+  ...named(['Budget'], budgets),
+  ...named(['BudgetRecord'], budgetRecords),
+  ...named(['Ceremony'], ceremonies),
+  ...named(['ProjectMember'], projectMembers),
+  ...named(['Unavailability'], unavailabilities),
+  ...named(['Education'], educations),
+  ...named(['Tool'], tools),
+  ...named(['ToolUsage'], toolUsages),
+  ...named(['Comment'], comments),
+  ...named(['CommentThread'], commentThreads),
+  ...named(['Post'], posts),
+  ...named(
+    ['ProgressReport', 'FinancialReport', 'NarrativeReport'],
+    periodicReports,
+  ),
+  ...named(
+    ['DirectScriptureProduct', 'DerivativeScriptureProduct', 'OtherProduct'],
+    products,
+  ),
+  ...named(['Film', 'Story', 'EthnoArt'], producibles),
+  ...named(['Directory', 'File', 'FileVersion'], fileNodes),
+  ...named(
+    ['SystemNotification', 'CommentViaMentionNotification'],
+    notifications,
+  ),
+]);
+
+/** How a column with no foreign key behind it should be read. */
+type ReferenceKind =
+  /** Always points at one table. A dangling value is a violation. */
+  | { readonly kind: 'points-at'; readonly target: PgTable }
+  /** Points at whichever table a sibling `*_type` column names. */
+  | { readonly kind: 'polymorphic'; readonly typeColumn: string }
+  /** Points at one of several tables, with nothing stored to say which. */
+  | { readonly kind: 'any-of'; readonly targets: readonly PgTable[] }
+  /** Not a reference into this database at all — nothing to check. */
+  | { readonly kind: 'not-a-reference' };
+
+type UnenforcedReference = ReferenceKind & {
+  /** SQL names, because they are what the catalogue is compared against. */
+  readonly table: string;
+  readonly column: string;
+  readonly why: string;
+};
+
+/**
+ * Every id-shaped column carrying no foreign key, and what it actually means.
+ *
+ * Completeness is enforced, not assumed — {@link assertEveryUnenforcedColumnIsClassified}
+ * walks the schema and refuses to run if a column is missing here. Without that
+ * this list would rot the moment someone added a column, and rot INVISIBLY: the
+ * check set would quietly shrink and keep reporting clean.
+ *
+ * Written as a flat list rather than nested by table so that each entry names
+ * its own table and column. The keys would otherwise be snake_case object
+ * properties, and this way the SQL names stay values — which is what they are,
+ * since they are compared against `information_schema` rather than dereferenced.
+ */
+const UNENFORCED: readonly UnenforcedReference[] = [
+  {
+    table: 'users',
+    column: 'photo_id',
+    kind: 'points-at',
+    target: fileNodes,
+    why: 'DefinedFile placeholder — the row is written before the file node exists',
+  },
+  {
+    table: 'locations',
+    column: 'map_image_id',
+    kind: 'points-at',
+    target: fileNodes,
+    why: 'DefinedFile placeholder',
+  },
+  {
+    table: 'partners',
+    column: 'language_of_wider_communication_id',
+    kind: 'points-at',
+    target: languages,
+    why: 'deferred FK → languages(id); the real one lands when Language migrates',
+  },
+  {
+    table: 'partners',
+    column: 'language_of_reporting_id',
+    kind: 'points-at',
+    target: languages,
+    why: 'deferred FK → languages(id); the real one lands when Language migrates',
+  },
+  {
+    table: 'partner_languages_of_consulting',
+    column: 'language_id',
+    kind: 'points-at',
+    target: languages,
+    why: 'deferred FK → languages(id); one half of this junction is enforced, this half is not',
+  },
+  {
+    table: 'partnerships',
+    column: 'mou_id',
+    kind: 'points-at',
+    target: fileNodes,
+    why: 'DefinedFile placeholder — createDefinedFile runs after this insert',
+  },
+  {
+    table: 'partnerships',
+    column: 'agreement_id',
+    kind: 'points-at',
+    target: fileNodes,
+    why: 'DefinedFile placeholder — createDefinedFile runs after this insert',
+  },
+  {
+    table: 'budgets',
+    column: 'universal_template_file_id',
+    kind: 'points-at',
+    target: fileNodes,
+    why: 'DefinedFile placeholder — same ordering as partnerships.mou_id',
+  },
+  {
+    table: 'engagements',
+    column: 'pnp_id',
+    kind: 'points-at',
+    target: fileNodes,
+    why: 'DefinedFile placeholder',
+  },
+  {
+    table: 'engagements',
+    column: 'growth_plan_id',
+    kind: 'points-at',
+    target: fileNodes,
+    why: 'DefinedFile placeholder',
+  },
+  {
+    table: 'engagements',
+    column: 'paratext_registry_id',
+    kind: 'not-a-reference',
+    why: "Paratext's own registry id — another system's string",
+  },
+  {
+    table: 'engagements',
+    column: 'rev79_community_id',
+    kind: 'not-a-reference',
+    why: "Rev79's community id — another system's string",
+  },
+  {
+    table: 'engagements',
+    column: 'web_id',
+    kind: 'not-a-reference',
+    why: 'an id carried for outside reporting, not a row in this database',
+  },
+  {
+    table: 'projects',
+    column: 'rev79_project_id',
+    kind: 'not-a-reference',
+    why: "Rev79's project id — another system's string",
+  },
+  {
+    table: 'projects',
+    column: 'department_id',
+    kind: 'not-a-reference',
+    why: 'a finance department NUMBER allocated out of a department_id_block, not a row id',
+  },
+  {
+    table: 'periodic_reports',
+    column: 'report_file_id',
+    kind: 'points-at',
+    target: fileNodes,
+    why: 'DefinedFile placeholder — the report row precedes its file rows',
+  },
+  {
+    table: 'periodic_reports',
+    column: 'narrative_file_id',
+    kind: 'points-at',
+    target: fileNodes,
+    why: 'DefinedFile placeholder — the report row precedes its file rows',
+  },
+  {
+    table: 'progress_report_media',
+    column: 'file_id',
+    kind: 'points-at',
+    target: fileNodes,
+    why: 'DefinedFile placeholder — created by createDefinedFile after this row',
+  },
+  {
+    table: 'progress_report_media',
+    column: 'variant_group_id',
+    kind: 'not-a-reference',
+    why: 'a grouping key shared by the variants of one upload; no table holds it',
+  },
+  {
+    table: 'prompt_variant_responses',
+    column: 'parent_id',
+    kind: 'points-at',
+    target: periodicReports,
+    why: 'always a progress report — the Cypher matches any BaseNode, but only reports carry these',
+  },
+  {
+    table: 'comment_threads',
+    column: 'parent_id',
+    kind: 'polymorphic',
+    typeColumn: 'parent_type',
+    why: 'a thread hangs off any commentable resource',
+  },
+  {
+    table: 'posts',
+    column: 'parent_id',
+    kind: 'polymorphic',
+    typeColumn: 'parent_type',
+    why: 'a post hangs off a Language, Partner or Project',
+  },
+  {
+    table: 'tool_usages',
+    column: 'container_id',
+    kind: 'polymorphic',
+    typeColumn: 'container_type',
+    why: 'a tool is used on a Project, Engagement, Language or Product',
+  },
+  {
+    table: 'resource_mutations',
+    column: 'resource_id',
+    kind: 'not-a-reference',
+    // Classified as polymorphic at first, which was wrong, and a probe run
+    // against a database with real app traffic said so: 108 findings on the e2e
+    // database, every one of them correct behaviour. The trail holds 330 Comment
+    // Creates and 18 Comment Deletes against 3 surviving comments — comments and
+    // posts hard-delete, so an entry recording a deletion MUST outlive the row it
+    // names. Following it would turn the whole audit log into violations.
+    why:
+      'a historical snapshot, not a live pointer — the resource it names may ' +
+      'since have been hard-deleted, which is exactly what an append-only trail ' +
+      'is for. Same reasoning as the actor_system_agent column beside it.',
+  },
+  {
+    table: 'pins',
+    column: 'resource_id',
+    kind: 'any-of',
+    targets: [
+      projects,
+      languages,
+      partners,
+      engagements,
+      users,
+      organizations,
+      locations,
+      products,
+      periodicReports,
+      fileNodes,
+    ],
+    why: 'a user can pin any resource, and nothing is stored to say which kind',
+  },
+];
+
+/** `table.column` for every entry above — the guard compares against this. */
+const CLASSIFIED: ReadonlySet<string> = new Set(
+  UNENFORCED.map((reference) => `${reference.table}.${reference.column}`),
+);
+
+/**
+ * An id-shaped column with no foreign key must appear in {@link UNENFORCED}.
+ *
+ * The inverse guard, and the reason this file can be trusted a year from now.
+ * Every check below iterates the manifest, so a column nobody classified is not
+ * checked — and an unchecked column produces no finding, which reads exactly
+ * like a clean one. The same shape as the scrub's `assertFullyClassified`, and
+ * added for the same reason the ETL's own coverage gaps were only found by
+ * counting from both ends.
+ *
+ * Throws rather than warns: a run that cannot say what it covers should not
+ * print a verdict.
+ */
+export const assertEveryUnenforcedColumnIsClassified = () => {
+  const unclassified: string[] = [];
+  for (const [tableName, table] of TABLES) {
+    const config = getTableConfig(table);
+    const enforced = new Set(
+      config.foreignKeys.flatMap((key) =>
+        key.reference().columns.map((column) => column.name),
+      ),
+    );
+    for (const column of config.columns) {
+      if (!/_ids?$/.test(column.name)) continue;
+      if (enforced.has(column.name)) continue;
+      if (CLASSIFIED.has(`${tableName}.${column.name}`)) continue;
+      unclassified.push(`${tableName}.${column.name}`);
+    }
+  }
+  if (unclassified.length > 0) {
+    throw new Error(
+      `Refusing to verify: ${unclassified.length} id-shaped column(s) carry no ` +
+        `foreign key and are not classified in UNENFORCED — this check cannot ` +
+        `say whether they hold anything real. Classify them (points-at / ` +
+        `polymorphic / any-of / not-a-reference) and re-run: ` +
+        unclassified.join(', '),
+    );
+  }
+};
+
+const checkUnenforcedReferences = async (
+  db: DrizzleDb,
+): Promise<{ findings: Finding[]; checksRun: number }> => {
+  const findings: Finding[] = [];
+  let checksRun = 0;
+
+  for (const reference of UNENFORCED) {
+    if (reference.kind === 'not-a-reference') continue;
+    const { table: tableName, column: columnName } = reference;
+    const table = TABLES.get(tableName)!;
+    const value = col('c', columnName);
+    const present = sql`${value} is not null`;
+
+    if (reference.kind === 'points-at') {
+      checksRun++;
+      const count = await countWhere(
+        db,
+        table,
+        sql`${present} and ${noRowIn(reference.target, value)}`,
+      );
+      if (count > 0) {
+        findings.push({
+          check: `${tableName}.${columnName} → ${getTableName(
+            reference.target,
+          )}`,
+          detail: `points at a row that does not exist (${reference.why})`,
+          count,
+        });
+      }
+      continue;
+    }
+
+    if (reference.kind === 'any-of') {
+      checksRun++;
+      // Distinct aliases: these NOT EXISTS clauses sit side by side.
+      const clauses = reference.targets.map((target, index) =>
+        noRowIn(target, value, `t${index}`),
+      );
+      const count = await countWhere(
+        db,
+        table,
+        sql`${present} and ${sql.join(clauses, sql` and `)}`,
+      );
+      if (count > 0) {
+        findings.push({
+          check: `${tableName}.${columnName} → any resource`,
+          detail:
+            `points at a row in none of the ${reference.targets.length} tables ` +
+            `it could be in (${reference.why})`,
+          count,
+        });
+      }
+      continue;
+    }
+
+    // Polymorphic: ask the data which types are actually present, then check
+    // each against its own table. Driving off the STORED values rather than off
+    // the map is what lets an unmapped type be reported instead of skipped —
+    // the map cannot know what it is missing.
+    const typeColumn = col('c', reference.typeColumn);
+    const storedTypes = await db.execute<{ type: string; n: number }>(
+      sql`select ${typeColumn} as type, count(*)::int as n
+          from ${from(table, 'c')} where ${present} group by 1`,
+    );
+    for (const row of storedTypes.rows) {
+      checksRun++;
+      const target = TABLE_BY_TYPENAME.get(row.type);
+      if (!target) {
+        findings.push({
+          check: `${tableName}.${reference.typeColumn} = ${row.type}`,
+          detail:
+            'no table is registered for this type, so the rows carrying it ' +
+            'cannot be checked at all — either the stored type is wrong or ' +
+            'TABLE_BY_TYPENAME is behind the schema',
+          count: Number(row.n),
+        });
+        continue;
+      }
+      const count = await countWhere(
+        db,
+        table,
+        sql`${typeColumn} = ${row.type} and ${noRowIn(target, value)}`,
+      );
+      if (count > 0) {
+        findings.push({
+          check: `${tableName}.${columnName} (${row.type}) → ${getTableName(
+            target,
+          )}`,
+          detail: `points at a row that does not exist (${reference.why})`,
+          count,
+        });
+      }
+    }
+  }
+  return { findings, checksRun };
+};
+
+// ─── 2. Live rows pointing at soft-deleted targets ───────────────────────────
+
+/**
+ * A foreign key proves the target row EXISTS. It cannot prove the target is
+ * still alive, because Neo4j's soft delete became a `deleted_at` column here and
+ * the row never leaves the table.
+ *
+ * Derived from the catalogue rather than listed: every real FK whose target
+ * table soft-deletes, plus every `points-at` entry above. A child with no
+ * `deleted_at` of its own is always live, so it is checked too — a hard-deleted
+ * comment on a soft-deleted post is the same bug.
+ *
+ * Applied to every edge without exception, and that is a statement about the
+ * LOAD rather than about the application. The ETL drops any row whose target
+ * did not land alive (`liveTargetIds`), so a correct load contains none of these
+ * by construction — and the 2026-08-20 production-scale load indeed reports zero
+ * across all 102 edges. Anything here means a guard was missed.
+ *
+ * That is not the same rule a long-running application would want. Deactivating
+ * a user does not invalidate the files they created, so `file_nodes.created_by_id`
+ * pointing at a departed user is ordinary once the app is live. Read a finding
+ * here as "the load did not reproduce the source's liveness", not as "the app is
+ * broken".
+ */
+const checkDeadTargets = async (
+  db: DrizzleDb,
+): Promise<{ findings: Finding[]; checksRun: number }> => {
+  const findings: Finding[] = [];
+  let checksRun = 0;
+
+  const edges: Array<{
+    child: PgTable;
+    childColumn: string;
+    target: PgTable;
+    targetColumn: string;
+  }> = [];
+
+  for (const table of TABLES.values()) {
+    for (const key of getTableConfig(table).foreignKeys) {
+      const reference = key.reference();
+      // Composite foreign keys would need a composite anti-join; none of the
+      // schema's FKs are composite, and asserting that is cheaper than writing
+      // the general case for a shape that does not occur.
+      if (reference.columns.length !== 1) continue;
+      edges.push({
+        child: table,
+        childColumn: reference.columns[0]!.name,
+        target: reference.foreignTable,
+        targetColumn: reference.foreignColumns[0]!.name,
+      });
+    }
+  }
+  for (const reference of UNENFORCED) {
+    if (reference.kind !== 'points-at') continue;
+    edges.push({
+      child: TABLES.get(reference.table)!,
+      childColumn: reference.column,
+      target: reference.target,
+      targetColumn: 'id',
+    });
+  }
+
+  for (const edge of edges) {
+    if (!hasColumn(edge.target, 'deleted_at')) continue;
+    checksRun++;
+    const childLive = hasColumn(edge.child, 'deleted_at')
+      ? sql`${col('c', 'deleted_at')} is null and `
+      : sql``;
+    const count = await runCount(
+      db,
+      sql`select count(*)::int as n
+          from ${from(edge.child, 'c')}
+          join ${from(edge.target, 't')}
+            on ${col('t', edge.targetColumn)} = ${col('c', edge.childColumn)}
+          where ${childLive}${col('t', 'deleted_at')} is not null`,
+    );
+    if (count > 0) {
+      findings.push({
+        check: `${getTableName(edge.child)}.${edge.childColumn} → ${getTableName(
+          edge.target,
+        )}`,
+        detail:
+          'live row whose target is soft-deleted — the foreign key is satisfied ' +
+          'by a dead row, so nothing in the database catches this',
+        count,
+      });
+    }
+  }
+  return { findings, checksRun };
+};
+
+// ─── 3. Subtype agreement ────────────────────────────────────────────────────
+
+/**
+ * Where a foreign key points at the right TABLE but cannot say which KIND of row.
+ *
+ * These have to be written out: nothing in the schema records that a
+ * `progress_report_media` row belongs to a *Progress* report specifically, or
+ * that `media.file_version_id` must be a FileVersion rather than a Directory.
+ * The FK is satisfied either way, and the read path would simply return the
+ * wrong thing.
+ */
+const SUBTYPE_AGREEMENT: ReadonlyArray<{
+  check: string;
+  detail: string;
+  where: SQL;
+}> = [
+  {
+    check: 'media.file_version_id → file_nodes',
+    detail: 'points at a file node that is not a FileVersion',
+    where: sql`select count(*)::int as n from ${from(schema.media, 'c')}
+      join ${from(fileNodes, 't')} on ${col('t', 'id')} = ${col(
+        'c',
+        'file_version_id',
+      )}
+      where ${col('t', 'type')} <> 'FileVersion'`,
+  },
+  {
+    check: 'projects.root_directory_id → file_nodes',
+    detail:
+      "points at a file node that is not a Directory, so the project's tree has no root",
+    where: sql`select count(*)::int as n from ${from(projects, 'c')}
+      join ${from(fileNodes, 't')} on ${col('t', 'id')} = ${col(
+        'c',
+        'root_directory_id',
+      )}
+      where ${col('t', 'type')} <> 'Directory'`,
+  },
+  {
+    check: 'file_nodes.latest_version_id',
+    detail:
+      'points at a node that is not a FileVersion of THIS file — the self-FK only ' +
+      'requires some file node, so a file can advertise another file’s version',
+    where: sql`select count(*)::int as n from ${from(fileNodes, 'c')}
+      where ${col('c', 'latest_version_id')} is not null
+        and not exists (select 1 from ${from(fileNodes, 'v')}
+          where ${col('v', 'id')} = ${col('c', 'latest_version_id')}
+            and ${col('v', 'type')} = 'FileVersion'
+            and ${col('v', 'parent_id')} = ${col('c', 'id')})`,
+  },
+  {
+    check: 'file_nodes.parent_id',
+    detail:
+      'sits under the wrong kind of node — a File must hang off a Directory, a ' +
+      'FileVersion off a File, and a Directory off another Directory',
+    where: sql`select count(*)::int as n from ${from(fileNodes, 'c')}
+      join ${from(fileNodes, 'p')} on ${col('p', 'id')} = ${col(
+        'c',
+        'parent_id',
+      )}
+      where (${col('c', 'type')} = 'File' and ${col('p', 'type')} <> 'Directory')
+         or (${col('c', 'type')} = 'FileVersion' and ${col(
+           'p',
+           'type',
+         )} <> 'File')
+         or (${col('c', 'type')} = 'Directory' and ${col(
+           'p',
+           'type',
+         )} <> 'Directory')`,
+  },
+  {
+    check: 'progress_report_media.report_id → periodic_reports',
+    detail: 'hangs off a report that is not a Progress report',
+    where: sql`select count(*)::int as n from ${from(
+      schema.progressReportMedia,
+      'c',
+    )}
+      join ${from(periodicReports, 't')} on ${col('t', 'id')} = ${col(
+        'c',
+        'report_id',
+      )}
+      where ${col('t', 'type')} <> 'Progress'`,
+  },
+  {
+    check: 'progress_report_variance_explanations.report_id → periodic_reports',
+    detail: 'hangs off a report that is not a Progress report',
+    where: sql`select count(*)::int as n from ${from(
+      schema.progressReportVarianceExplanations,
+      'c',
+    )}
+      join ${from(periodicReports, 't')} on ${col('t', 'id')} = ${col(
+        'c',
+        'report_id',
+      )}
+      where ${col('t', 'type')} <> 'Progress'`,
+  },
+  {
+    check: 'progress_report_workflow_events.report_id → periodic_reports',
+    detail: 'hangs off a report that is not a Progress report',
+    where: sql`select count(*)::int as n from ${from(
+      schema.progressReportWorkflowEvents,
+      'c',
+    )}
+      join ${from(periodicReports, 't')} on ${col('t', 'id')} = ${col(
+        'c',
+        'report_id',
+      )}
+      where ${col('t', 'type')} <> 'Progress'`,
+  },
+  {
+    check: 'prompt_variant_responses.parent_id → periodic_reports',
+    detail: 'hangs off a report that is not a Progress report',
+    where: sql`select count(*)::int as n from ${from(
+      schema.promptVariantResponses,
+      'c',
+    )}
+      join ${from(periodicReports, 't')} on ${col('t', 'id')} = ${col(
+        'c',
+        'parent_id',
+      )}
+      where ${col('t', 'type')} <> 'Progress'`,
+  },
+  {
+    check: 'posts.parent_type vs projects.type',
+    detail:
+      'the stored type names a different project kind than the project row does, ' +
+      'so the resolver would look in the right table for the wrong subtype',
+    where: sql`select count(*)::int as n from ${from(posts, 'c')}
+      join ${from(projects, 'p')} on ${col('p', 'id')} = ${col('c', 'parent_id')}
+      where ${col('c', 'parent_type')} <> ${col('p', 'type')} || 'Project'`,
+  },
+  {
+    check: 'comment_threads.parent_type vs projects.type',
+    detail:
+      'the stored type names a different project kind than the project row does',
+    where: sql`select count(*)::int as n from ${from(commentThreads, 'c')}
+      join ${from(projects, 'p')} on ${col('p', 'id')} = ${col('c', 'parent_id')}
+      where ${col('c', 'parent_type')} <> ${col('p', 'type')} || 'Project'`,
+  },
+  {
+    check: 'tool_usages.container_type vs projects.type',
+    detail:
+      'the stored type names a different project kind than the project row does',
+    where: sql`select count(*)::int as n from ${from(toolUsages, 'c')}
+      join ${from(projects, 'p')} on ${col('p', 'id')} = ${col(
+        'c',
+        'container_id',
+      )}
+      where ${col('c', 'container_type')} <> ${col('p', 'type')} || 'Project'`,
+  },
+  {
+    check: 'tool_usages.container_type vs engagements.type',
+    detail:
+      'the stored type names a different engagement kind than the engagement row does',
+    where: sql`select count(*)::int as n from ${from(toolUsages, 'c')}
+      join ${from(engagements, 'e')} on ${col('e', 'id')} = ${col(
+        'c',
+        'container_id',
+      )}
+      where ${col('c', 'container_type')} <> ${col('e', 'type')} || 'Engagement'`,
+  },
+];
+
+const checkSubtypeAgreement = async (db: DrizzleDb) => {
+  const findings: Finding[] = [];
+  for (const check of SUBTYPE_AGREEMENT) {
+    const count = await runCount(db, check.where);
+    if (count > 0) {
+      findings.push({ check: check.check, detail: check.detail, count });
+    }
+  }
+  return { findings, checksRun: SUBTYPE_AGREEMENT.length };
+};
+
+// ─── 4. Array hygiene ────────────────────────────────────────────────────────
+
+/**
+ * Enum arrays stand in for Neo4j's repeated property edges — `roles`, `types`,
+ * `steps`. Nothing stops the same value being written twice, and a duplicate
+ * role is invisible until something counts them.
+ *
+ * A NULL inside the array is worse than a duplicate: `'Manager' = any(roles)`
+ * still works, but `not ('X' = any(roles))` becomes NULL rather than true, so a
+ * negative filter silently stops matching the row.
+ */
+const checkArrays = async (db: DrizzleDb) => {
+  const findings: Finding[] = [];
+  let checksRun = 0;
+  for (const [tableName, table] of TABLES) {
+    for (const column of getTableConfig(table).columns) {
+      if (column.dataType !== 'array') continue;
+      checksRun++;
+      const value = col('c', column.name);
+      const duplicates = await countWhere(
+        db,
+        table,
+        sql`cardinality(${value}) <> cardinality(array(select distinct unnest(${value})))`,
+      );
+      if (duplicates > 0) {
+        findings.push({
+          check: `${tableName}.${column.name}`,
+          detail: 'array holds the same value more than once',
+          count: duplicates,
+        });
+      }
+      const nulls = await countWhere(
+        db,
+        table,
+        sql`array_position(${value}, null) is not null`,
+      );
+      if (nulls > 0) {
+        findings.push({
+          check: `${tableName}.${column.name}`,
+          detail:
+            'array holds a NULL element, which turns every negative filter over ' +
+            'this column into NULL and silently stops matching the row',
+          count: nulls,
+        });
+      }
+    }
+  }
+  return { findings, checksRun };
+};
+
+// ─── 5. Timestamp ordering (watchlist) ───────────────────────────────────────
+
+/**
+ * A row modified or deleted BEFORE it was created.
+ *
+ * Watchlist, not violation, and the distinction was measured rather than
+ * assumed. On the 2026-08-20 production-scale load this reports 6,395 rows, and
+ * every one is inherited: Neo4j stores `createdAt` on the node but `modifiedAt`
+ * as a separate property record, and nothing has ever kept the two in order.
+ * The source graph holds 2,184 posts whose `modifiedAt` predates their
+ * `createdAt` by more than a day — the worst by 2,864 days — and Postgres holds
+ * exactly those same rows. The remainder differ by a millisecond or two, which
+ * is just two clock reads inside one transaction.
+ *
+ * So a non-zero count here is not a load defect and must not block a cutover. It
+ * is worth reporting because a count that MOVES means the ETL started inventing
+ * timestamps, which is a real failure mode — the variance-explanation extractor
+ * stamped all 5,729 of its rows with `new Date()` until 2026-08-19.
+ */
+const checkTimestampOrder = async (db: DrizzleDb) => {
+  const findings: Finding[] = [];
+  let checksRun = 0;
+  for (const [tableName, table] of TABLES) {
+    const columns = columnNames(table);
+    if (!columns.has('created_at')) continue;
+    for (const later of ['updated_at', 'modified_at', 'deleted_at']) {
+      if (!columns.has(later)) continue;
+      checksRun++;
+      const count = await countWhere(
+        db,
+        table,
+        sql`${col('c', later)} is not null and ${col('c', later)} < ${col(
+          'c',
+          'created_at',
+        )}`,
+      );
+      if (count > 0) {
+        findings.push({
+          check: `${tableName}.${later}`,
+          detail: `stamped before the row's own created_at`,
+          count,
+        });
+      }
+    }
+  }
+  return { findings, checksRun };
+};
+
+// ─── 6. Unreachable file nodes (watchlist) ───────────────────────────────────
+
+/**
+ * Files and versions with no parent, i.e. nothing above them in the tree.
+ *
+ * All faithful, and all measured against the source rather than assumed: Neo4j
+ * holds 783,810 `:File` nodes with no active `parent` edge and 9,645 such
+ * `:FileVersion` nodes, and the load carries the same population (783,722 /
+ * 9,645 — the gap is exactly the 88 nodes the extractor dropped for a missing
+ * creator).
+ *
+ * Split three ways, because one number covering all of them said something
+ * untrue. The first version of this reported both types with the same sentence,
+ * "mostly DefinedFile placeholders that were never uploaded to" — true of most
+ * Files and impossible for a FileVersion, which IS an upload. Worse, it buried
+ * the one population that means anything inside a total 500× its size.
+ *
+ * - **Reachable by a column.** A `DefinedFile` has no parent directory BY
+ *   DESIGN: `createDefinedFile` makes it for a specific field, and it is found
+ *   through `partnerships.mou_id` and friends rather than through the tree.
+ *   Working as intended; counted only to account for the bulk of the total.
+ * - **Holds uploads that nothing references.** No parent, no column pointing at
+ *   it, and yet real content beneath it: 1,541 files / 1,636 versions / 871 MB
+ *   on the 2026-08-20 load. Traced to source 2026-08-20 and it splits in two.
+ *   **1,082 are unreachable in Neo4j as well**, and they got that way through
+ *   `deleteBaseNode`, which deactivates every INBOUND relationship of the node
+ *   it deletes — a child's `parent` edge points AT its parent, so deleting a
+ *   directory severs every child's link and leaves the children fully alive,
+ *   labels intact. 176 deleted directories did this to 1,082 Files and 20
+ *   Directories, spread evenly over 2021–2026, most recently 2026-07-13.
+ *   Verified by applying the generated Cypher to throwaway nodes: the child
+ *   keeps its labels, carries no `deletedAt`, and its edge reads `active: false`.
+ *   **The Postgres arm already fixes this**, deliberately — `delete()` walks the
+ *   subtree with a recursive CTE (accepted 2026-07-14, pre-cutover audit F1) —
+ *   so the code stops producing these at cutover, but the historical rows come
+ *   across as-is and nothing will ever reattach them.
+ *   The other ~459 are reachable in Neo4j and not here, because the owner
+ *   holding the reference did not land: 435 have a soft-deleted owner
+ *   (`fileNode` 396, `pnpNode` 34, `growthPlanNode` 4, `reportFileNode` 1) and
+ *   the rest belong to the 7,011 reports lost to a dead project two levels up.
+ *   Those are consequences of drops already accounted for, not new damage.
+ * - **Versions of a deleted File.** Every one of the 9,645 has a `parent` edge
+ *   that was DEACTIVATED, and in all 9,645 cases the node on the other end is a
+ *   `Deleted_File`. So these are the version history of deleted files, kept
+ *   because the version's own label survives the parent's deletion. Unreachable
+ *   in Neo4j and Postgres alike.
+ *
+ * The referenced set is derived from {@link UNENFORCED} rather than written out,
+ * so a new `DefinedFile` column moves files out of the stranded count on its own.
+ */
+const checkOrphanFileNodes = async (db: DrizzleDb) => {
+  const findings: Finding[] = [];
+  const fileColumns = UNENFORCED.filter(
+    (reference) =>
+      reference.kind === 'points-at' && reference.target === fileNodes,
+  );
+  const referenced = sql.join(
+    fileColumns.map(
+      (reference) =>
+        sql`select ${sql.identifier(reference.column)} as id
+            from ${sql.identifier(reference.table)}
+            where ${sql.identifier(reference.column)} is not null`,
+    ),
+    sql` union `,
+  );
+
+  // Joins, and `as materialized`, both deliberate. Written first with correlated
+  // `exists (select 1 from referenced …)` per row, which is the natural way to
+  // say it and does not finish: a CTE used ONCE is inlined, so the whole union
+  // was re-evaluated for each of 783,722 rows and the run had to be killed at ten
+  // minutes. As three sets joined instead, it is 2 seconds. Left joins rather
+  // than NOT EXISTS so one pass answers all three counts.
+  const [counts] = (
+    await db.execute<{
+      stranded: number;
+      byColumn: number;
+      placeholder: number;
+    }>(
+      sql`with referenced(id) as materialized (${referenced}),
+          parentless as (
+            select ${col('f', 'id')} as id from ${from(fileNodes, 'f')}
+            where ${col('f', 'type')} = 'File' and ${col('f', 'parent_id')} is null
+          ),
+          uploaded(id) as materialized (
+            select distinct ${col('v', 'parent_id')} from ${from(fileNodes, 'v')}
+            where ${col('v', 'type')} = 'FileVersion'
+              and ${col('v', 'parent_id')} is not null
+          )
+          select
+            count(*) filter (where u.id is not null and r.id is null)::int as "stranded",
+            count(*) filter (where r.id is not null)::int as "byColumn",
+            count(*) filter (where u.id is null and r.id is null)::int as "placeholder"
+          from parentless p
+          left join referenced r on r.id = p.id
+          left join uploaded u on u.id = p.id`,
+    )
+  ).rows;
+
+  if (counts && Number(counts.stranded) > 0) {
+    findings.push({
+      check: 'file_nodes (File, stranded)',
+      detail:
+        'holds uploaded versions but has no parent folder AND no column pointing ' +
+        'at it, so nothing in the application can reach the content',
+      count: Number(counts.stranded),
+    });
+  }
+  if (counts && Number(counts.byColumn) > 0) {
+    findings.push({
+      check: 'file_nodes (File, by column)',
+      detail:
+        'no parent folder, which is how a DefinedFile is meant to sit — found ' +
+        'through mou_id / report_file_id / photo_id and the rest, not the tree',
+      count: Number(counts.byColumn),
+    });
+  }
+  if (counts && Number(counts.placeholder) > 0) {
+    findings.push({
+      check: 'file_nodes (File, empty)',
+      detail:
+        'no parent, no uploads, and nothing references it — an upload slot that ' +
+        'was created and never used',
+      count: Number(counts.placeholder),
+    });
+  }
+
+  const versions = await countWhere(
+    db,
+    fileNodes,
+    sql`${col('c', 'type')} = 'FileVersion' and ${col('c', 'parent_id')} is null`,
+  );
+  if (versions > 0) {
+    findings.push({
+      check: 'file_nodes (FileVersion, orphaned)',
+      detail:
+        "its File was deleted — the version outlives the parent because Neo4j's " +
+        'soft delete strips the parent’s label and retires the edge, leaving the ' +
+        'version itself intact',
+      count: versions,
+    });
+  }
+  return { findings, checksRun: 2 };
+};
+
+// ─── Runner ──────────────────────────────────────────────────────────────────
+
+/**
+ * How many rows are actually here, and how many tables hold any.
+ *
+ * Every check below counts rows that BREAK a rule, so an empty database breaks
+ * none of them and passes all 220 — the most dangerous possible result, because
+ * it looks exactly like a perfect load. That is the same failure the ETL itself
+ * shipped twice: a wrong Neo4j label matched nothing and reconciled `0 == 0 ✓`,
+ * and a run booted against the empty target loaded nothing and declared success.
+ *
+ * So the total is measured up front, printed as part of the verdict, and a
+ * database with no rows at all is refused rather than certified.
+ */
+const census = async (db: DrizzleDb) => {
+  let rows = 0;
+  let populated = 0;
+  for (const table of TABLES.values()) {
+    const count = await runCount(
+      db,
+      sql`select count(*)::int as n from ${from(table, 'c')}`,
+    );
+    rows += count;
+    if (count > 0) populated++;
+  }
+  return { rows, populated, tables: TABLES.size };
+};
+
+export const runCutoverVerify = async (
+  db: DrizzleDb,
+  log: (msg: string) => void,
+): Promise<VerifyReport> => {
+  assertEveryUnenforcedColumnIsClassified();
+
+  const counted = await census(db);
+  log(
+    `  ${counted.rows.toLocaleString()} row(s) across ${counted.populated} of ` +
+      `${counted.tables} tables\n`,
+  );
+  if (counted.rows === 0) {
+    throw new Error(
+      'Refusing to verify: this database holds no rows at all. Every check ' +
+        'here counts rows that break a rule, so an empty database passes all ' +
+        'of them — point this at a loaded target, not a freshly migrated one.',
+    );
+  }
+
+  const violations: Finding[] = [];
+  const watchlist: Finding[] = [];
+  let checksRun = 0;
+
+  const groups = [
+    ['unenforced references', checkUnenforcedReferences, violations],
+    ['soft-deleted targets', checkDeadTargets, violations],
+    ['subtype agreement', checkSubtypeAgreement, violations],
+    ['array hygiene', checkArrays, violations],
+    ['timestamp ordering', checkTimestampOrder, watchlist],
+    ['unreachable file nodes', checkOrphanFileNodes, watchlist],
+  ] as const;
+
+  for (const [name, run, into] of groups) {
+    const result = await run(db);
+    checksRun += result.checksRun;
+    into.push(...result.findings);
+    log(
+      `  ${result.findings.length === 0 ? '✓' : '·'} ${name}: ` +
+        `${result.checksRun} check(s), ${result.findings.length} finding(s)`,
+    );
+  }
+
+  return {
+    violations,
+    watchlist,
+    checksRun,
+    rowsChecked: counted.rows,
+    clean: violations.length === 0,
+  };
+};

--- a/src/core/drizzle/drizzle.module.ts
+++ b/src/core/drizzle/drizzle.module.ts
@@ -3,12 +3,14 @@ import { APP_INTERCEPTOR } from '@nestjs/core';
 import { DrizzleTransactionalMutationsInterceptor } from './drizzle-transactional-mutations.interceptor';
 import { DrizzleService } from './drizzle.service';
 import { DrizzleMigrator } from './migrator';
+import { PgRefreshCommand } from './refresh/pg-refresh.command';
 
 @Global()
 @Module({
   providers: [
     DrizzleService,
     DrizzleMigrator,
+    PgRefreshCommand,
     {
       provide: APP_INTERCEPTOR,
       useClass: DrizzleTransactionalMutationsInterceptor,

--- a/src/core/drizzle/live-query-invalidation.spec.ts
+++ b/src/core/drizzle/live-query-invalidation.spec.ts
@@ -59,6 +59,14 @@ const EXEMPT: Record<string, string> = {
   // --- parity: verified the Neo4j counterpart has no invalidation either ---
   'src/components/pin/pin.drizzle.repository.ts':
     'parity — pin.repository.ts extends no invalidating base and never invalidates',
+  'src/components/project/financial-approver/financial-approver.drizzle.repository.ts':
+    'parity — financial-approver-neo4j.repository.ts extends CommonRepository but ' +
+    'writes with hand-built queries (merge / setValues / detachDelete), never one of ' +
+    'its invalidating methods, so Neo4j does not announce an approver change either. ' +
+    'Note the canonical `financial-approver.repository.ts` in this folder is the GEL ' +
+    'arm, not the Neo4j one — the Neo4j arm carries the `-neo4j` infix here, unlike ' +
+    'most domains. Adding invalidation to the Postgres arm alone would introduce a ' +
+    'divergence rather than remove one',
   'src/components/product-progress/product-progress.drizzle.repository.ts':
     'parity — product-progress.repository.ts extends no invalidating base',
   'src/components/progress-summary/progress-summary.drizzle.repository.ts':

--- a/src/core/drizzle/migrations/0039_add_financial_approvers.sql
+++ b/src/core/drizzle/migrations/0039_add_financial_approvers.sql
@@ -1,0 +1,21 @@
+-- Financial approvers: "user X approves finances for project type Y" — read by
+-- the project workflow to notify approvers on five financial-plan transitions
+-- (the FinancialApprovers notifier). Ported, not retired, per Rob 2026-08-24:
+-- without this table those notifications silently stop at cutover. 3 rows in
+-- production.
+--
+-- Neo4j models this as a ProjectTypeFinancialApprover node holding ONLY a
+-- projectTypes array, linked -[:financialApprover]-> User and merged
+-- one-per-user (Gel likewise makes the link exclusive). The node has no id and
+-- no timestamps, so the user is the row identity — hence user_id as the
+-- primary key and no id/created_at columns to carry.
+
+CREATE TABLE "financial_approvers" (
+  "user_id"        text PRIMARY KEY REFERENCES "users"("id"),
+  "project_types"  "project_type"[] NOT NULL,
+  -- An approver with no project types is a delete, not a row — the write path
+  -- removes the row when the list empties (matching Neo4j's detachDelete), so
+  -- the empty state is meaningless and the database refuses it outright.
+  CONSTRAINT "financial_approvers_types_not_empty"
+    CHECK (cardinality("project_types") > 0)
+);

--- a/src/core/drizzle/migrations/0040_add_external_department_ids.sql
+++ b/src/core/drizzle/migrations/0040_add_external_department_ids.sql
@@ -1,0 +1,42 @@
+-- Migration: add external_department_ids — the department IDs that already exist
+-- in Intacct (the accounting system) and therefore must never be handed out to a
+-- CORD project.
+--
+-- This is a reservation list, not an entity. Nothing points at these rows and
+-- they point at nothing; their only job is to be subtracted from the pool of
+-- available department IDs in set-department-id.handler.ts. In Neo4j they are
+-- 565 fully disconnected `ExternalDepartmentId` nodes, which is why they read as
+-- droppable on a first pass — but the handler unions them into the "already
+-- used" set on every assignment, and has since 2025-09.
+--
+-- Measured against the 2026-08-24 production copy: 389 of the 565 codes fall
+-- inside blocks CORD assigns from, and two blocks would hand out a different ID
+-- with this list missing than with it present. A collision here is invisible to
+-- CORD — projects_department_id_active_unique catches CORD-internal duplicates,
+-- but nothing in this database knows what Intacct holds.
+
+CREATE TABLE "external_department_ids" (
+  -- The reservation IS the identity. The source nodes carry an apoc-generated
+  -- uuid that names nothing and is referenced by nothing, so it is not carried;
+  -- the department ID is what the handler looks up and what must be unique.
+  "department_id" text PRIMARY KEY,
+
+  -- The Intacct department name. Not unique, legitimately: one name covers three
+  -- codes in the current data. Carried because it is what a person needs when
+  -- reconciling a reservation against Intacct.
+  "name" text NOT NULL,
+
+  -- When the list was imported, carried from the source nodes. Kept because the
+  -- staleness of this list is the interesting thing about it: every current row
+  -- was loaded in a single manual run and nothing has refreshed it since.
+  "created_at" timestamptz NOT NULL DEFAULT now()
+);
+
+-- Deliberately no CHECK on the shape of department_id. The obvious one — five
+-- digits, matching how the handler pads block IDs — would reject a real row:
+-- 564 of the 565 codes are five digits and one is six. This table mirrors an
+-- external system, so it must accept whatever that system holds; a constraint
+-- that edits the mirror makes it stop being a mirror.
+--
+-- Deliberately no deleted_at either. These are not CORD records with a
+-- lifecycle; when Intacct changes, the list is re-imported.

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1753920000000,
       "tag": "0038_add_location_edges",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1754006400000,
+      "tag": "0039_add_financial_approvers",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1754006400000,
       "tag": "0039_add_financial_approvers",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1754092800000,
+      "tag": "0040_add_external_department_ids",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/migrator.ts
+++ b/src/core/drizzle/migrator.ts
@@ -16,7 +16,11 @@ export class DrizzleMigrator implements OnModuleInit {
 
   async onModuleInit() {
     if (this.config.databaseEngine !== 'postgres') return;
+    await this.run();
+  }
 
+  /** Apply all pending Drizzle migrations. Safe to call repeatedly. */
+  async run() {
     this.logger.info('Running PostgreSQL migrations');
     // NOTE: our migrations are hand-written, but drizzle's migrator only runs
     // files listed in `migrations/meta/_journal.json`. Adding a .sql file

--- a/src/core/drizzle/order-by.ts
+++ b/src/core/drizzle/order-by.ts
@@ -1,4 +1,4 @@
-import { asc, desc, sql, type SQL, type SQLWrapper } from 'drizzle-orm';
+import { asc, desc, is, SQL, sql, type SQLWrapper } from 'drizzle-orm';
 import { type AnyPgColumn } from 'drizzle-orm/pg-core';
 import { type Order } from '~/common';
 import {
@@ -17,10 +17,24 @@ import {
 } from './schema';
 
 /**
- * One sort entry: a single column, or a column list expressing tiebreakers
- * (e.g. `[lastName, firstName]`).
+ * One thing to order by: a column, or an expression built with {@link sql}.
+ *
+ * An expression is needed when Neo4j's matching sorter does not order by a
+ * single stored value — `User.fullName` is the case that forced this: Neo4j
+ * concatenates first and last name into ONE string and orders that, which is not
+ * the same as ordering by first name then last name (see the user repository).
+ *
+ * ⚠️ An expression is returned from {@link displayOrder} UNCOLLATED, because
+ * there is no column to look up in {@link NAME_COLUMNS}. Build name expressions
+ * with {@link collateDisplayOrder} so the collation cannot be forgotten.
  */
-export type SortColumns = AnyPgColumn | readonly AnyPgColumn[];
+export type SortEntry = AnyPgColumn | SQL;
+
+/**
+ * One sort entry: a single column or expression, or a list expressing
+ * tiebreakers (e.g. `[lastName, firstName]`).
+ */
+export type SortColumns = SortEntry | readonly SortEntry[];
 
 /**
  * Map of supported sort keys to columns, narrowed to the DTO's fields:
@@ -116,22 +130,38 @@ const NAME_COLUMNS: ReadonlySet<AnyPgColumn> = new Set<AnyPgColumn>([
  * being read off the primary key index, for any list that falls back to id sorting.
  *
  * ⚠️ This can only inspect a COLUMN. A sort written as a raw `sql` expression has
- * no column to look up, so it falls through here and comes back uncollated — with
- * no error and nothing failing. A name sort built as an expression has to write
- * `collate display_order` inline itself.
+ * no column to look up, so it is returned unchanged — with no error and nothing
+ * failing. That pass-through is deliberate rather than accidental: an expression
+ * is the only way to express a sort Neo4j builds from more than one stored value,
+ * and only its author knows whether the result is a name. Build those with
+ * {@link collateDisplayOrder} rather than by hand, so the collation travels with
+ * the expression instead of being something to remember.
  *
  * Use this at every name sort, including ones built by hand rather than through
  * {@link resolveOrderBy} — the three list queries that sort by a joined table's
  * name (partner, partnership, project) do exactly that, and would otherwise order
  * differently from every other list in the app.
  */
-export const displayOrder = (col: AnyPgColumn): SQLWrapper =>
-  NAME_COLUMNS.has(col) &&
-  COLLATABLE_COLUMN_TYPES.has(col.columnType) &&
-  !col.enumValues?.length &&
-  !col.primary
-    ? sql`${col} collate ${sql.identifier(DISPLAY_ORDER_COLLATION)}`
-    : col;
+export const displayOrder = (col: SortEntry): SQLWrapper =>
+  is(col, SQL)
+    ? col
+    : NAME_COLUMNS.has(col) &&
+        COLLATABLE_COLUMN_TYPES.has(col.columnType) &&
+        !col.enumValues?.length &&
+        !col.primary
+      ? sql`${col} collate ${sql.identifier(DISPLAY_ORDER_COLLATION)}`
+      : col;
+
+/**
+ * Collate a multi-column name EXPRESSION the way {@link displayOrder} collates a
+ * name column, so both order the same way.
+ *
+ * Postgres applies a collation to the result of the whole expression, so this
+ * wraps rather than collating each part — `(a || b) collate display_order`, not
+ * `(a collate display_order) || b`, which would not compile.
+ */
+export const collateDisplayOrder = (expr: SQL): SQL =>
+  sql`(${expr}) collate ${sql.identifier(DISPLAY_ORDER_COLLATION)}`;
 
 /**
  * Resolve a list-input's `sort` key to an ORDER BY clause. Unmatched keys

--- a/src/core/drizzle/refresh/is-pg-refresh-invocation.ts
+++ b/src/core/drizzle/refresh/is-pg-refresh-invocation.ts
@@ -1,0 +1,22 @@
+/**
+ * True when this process was launched as the `pg refresh` console command.
+ *
+ * That command drops the Postgres schema, re-applies the migrations and reloads
+ * the data itself, so anything that would write to Postgres during startup has
+ * to stay out of its way — specifically the root-object setup in
+ * AdminDrizzleService. A startup write that lands after the command has already
+ * rebuilt the schema collides with the rows being loaded.
+ *
+ * The arguments are read from `process.argv` rather than from the parsed
+ * command because Nest runs its startup hooks inside `app.init()`, which the
+ * console entry point calls before it parses anything.
+ *
+ * `refresh` is looked for anywhere after `pg` rather than immediately after it,
+ * because the option parser accepts a flag in between — `pg --fresh refresh`
+ * is a valid way to invoke this and must not be missed.
+ */
+export const isPgRefreshInvocation = () => {
+  const args = process.argv.slice(2);
+  const pg = args.indexOf('pg');
+  return pg !== -1 && args.includes('refresh', pg + 1);
+};

--- a/src/core/drizzle/refresh/pg-refresh.command.ts
+++ b/src/core/drizzle/refresh/pg-refresh.command.ts
@@ -1,0 +1,141 @@
+import { ModuleRef } from '@nestjs/core';
+import { Command, Option } from 'clipanion';
+import { sql } from 'drizzle-orm';
+import { InjectableCommand } from '~/core/cli';
+import { ConfigService } from '~/core/config';
+import { DatabaseService } from '~/core/neo4j';
+import { DrizzleService } from '../drizzle.service';
+import { DrizzleMigrator } from '../migrator';
+
+/**
+ * Ad-hoc refresh of the Postgres database from a Neo4j source.
+ *
+ * Intended for the PG-test cutover environment: tear down the data, rebuild
+ * the schema from migrations, then load a fresh copy of prod-shaped data via
+ * the cutover ETL harness. Invoked out-of-band as an ECS task, never on a
+ * schedule.
+ *
+ *   DATABASE=neo4j POSTGRES_URL=postgresql://... \
+ *     yarn console:prod pg refresh --fresh
+ *
+ * Requires DATABASE=neo4j so that splitDb resolves the Neo4j repositories as
+ * the readers. POSTGRES_URL is the write target — DrizzleService connects
+ * whenever it is set, regardless of engine.
+ *
+ * The source Neo4j is whatever NEO4J_URL / NEO4J_USERNAME / NEO4J_PASSWORD are
+ * configured to. Point them at a scrubbed production copy before running.
+ * The cutover harness enforces this via its scrub gate.
+ */
+@InjectableCommand()
+export class PgRefreshCommand extends Command {
+  static paths = [['pg', 'refresh']];
+  static usage = Command.Usage({
+    category: 'Postgres',
+    description: 'Tear down and reload the Postgres database from Neo4j',
+    details: `
+      Order of operations:
+        1. --fresh  drop the schema (all data + migration history)
+        2.          apply Drizzle migrations to rebuild the empty schema
+        3.          load all data from Neo4j into Postgres
+
+      Requires DATABASE=neo4j (so splitDb resolves the Neo4j repositories as
+      the readers) and POSTGRES_URL set to the target database.
+    `,
+  });
+
+  fresh = Option.Boolean('--fresh', false, {
+    description: 'Drop the schema (data + migration history) before migrating',
+  });
+  productionSource = Option.Boolean('--production-source', false, {
+    description:
+      'Allow loading from a production-scale Neo4j without a scrub marker. ' +
+      'Required for the real cutover. Omit for QA refreshes (scrubbed data only).',
+  });
+  only = Option.String('--only', {
+    description:
+      'Comma-separated extractor names to run, e.g. --only=tool,user',
+  });
+  batch = Option.String('--batch', {
+    description: 'Insert batch size (default 500)',
+  });
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly drizzle: DrizzleService,
+    private readonly migrator: DrizzleMigrator,
+    private readonly neo4j: DatabaseService,
+    private readonly moduleRef: ModuleRef,
+  ) {
+    super();
+  }
+
+  async execute() {
+    const write = (msg: string) => this.context.stdout.write(msg);
+
+    if (!this.config.postgres.url) {
+      write('Refusing to run: POSTGRES_URL is not set (the write target).\n');
+      return 1;
+    }
+    if (this.config.databaseEngine !== 'neo4j') {
+      write(
+        `Refusing to run: DATABASE is "${this.config.databaseEngine}", expected "neo4j".\n` +
+          'The cutover reads through Neo4j repositories — set DATABASE=neo4j.\n',
+      );
+      return 1;
+    }
+
+    if (this.fresh) {
+      write('Dropping schema (data + migration history)…\n');
+      try {
+        await this.drizzle.client.execute(
+          sql.raw(`drop schema if exists public cascade`),
+        );
+        await this.drizzle.client.execute(
+          sql.raw(`drop schema if exists drizzle cascade`),
+        );
+        await this.drizzle.client.execute(sql.raw(`create schema public`));
+      } catch (err: unknown) {
+        write(`Drop failed: ${String(err)}\n`);
+        if (err && typeof err === 'object' && 'cause' in err) {
+          write(`Cause: ${String((err as { cause: unknown }).cause)}\n`);
+        }
+        throw err;
+      }
+    }
+
+    write('Applying migrations…\n');
+    await this.migrator.run();
+
+    write('Loading data from Neo4j…\n');
+    const { runCutover } = await import('../../cutover/cutover.harness.js');
+    const { extractors } = await import('../../cutover/extractors/index.js');
+    const { SessionManager } =
+      await import('~/core/authentication/session/session.manager.js');
+
+    const batchSize = this.batch ? Number(this.batch) : 500;
+    const only = this.only?.split(',').filter(Boolean);
+    const log = (msg: string) => write(msg + '\n');
+
+    const sessions = this.moduleRef.get(SessionManager, { strict: false });
+    const rootSession = await sessions.lazySessionForRootUser();
+    await sessions.asUser(rootSession, async () => {
+      await runCutover(
+        {
+          neo4j: this.neo4j,
+          db: this.drizzle.client,
+          moduleRef: this.moduleRef,
+          dryRun: false,
+          batchSize,
+          allowProductionSource: this.productionSource,
+          notHydrated: new Map(),
+          log,
+        },
+        extractors,
+        { only },
+      );
+    });
+
+    write('Refresh complete.\n');
+    return 0;
+  }
+}

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -870,6 +870,50 @@ export const departmentIdBlocks = pgTable('department_id_blocks', {
     .default([]),
 });
 
+/**
+ * Finance-approver config: "user X approves finances for project type Y" —
+ * read by the project workflow to notify approvers on financial-plan
+ * transitions. Ported (not retired) per Rob 2026-08-24: without it those
+ * notifications silently stop at cutover.
+ *
+ * One row per user: Neo4j merges one ProjectTypeFinancialApprover node per
+ * [:financialApprover] user and Gel makes the link exclusive. The source node
+ * holds ONLY the projectTypes array — no id, no timestamps — so the user IS
+ * the row identity.
+ */
+export const financialApprovers = pgTable(
+  'financial_approvers',
+  {
+    userId: text('user_id')
+      .$type<ID<'User'>>()
+      .primaryKey()
+      .references(() => users.id),
+    projectTypes: projectTypeEnum('project_types')
+      .array()
+      .$type<readonly [ProjectType, ...ProjectType[]]>()
+      .notNull(),
+  },
+  (t) => [
+    // An approver with no project types is a delete, not a row — the write
+    // path removes the row when the list empties (matching Neo4j's
+    // detachDelete), and the DB refuses the meaningless state outright.
+    check(
+      'financial_approvers_types_not_empty',
+      sql`cardinality(${t.projectTypes}) > 0`,
+    ),
+  ],
+);
+
+export const financialApproversRelations = relations(
+  financialApprovers,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [financialApprovers.userId],
+      references: [users.id],
+    }),
+  }),
+);
+
 export const partners = pgTable(
   'partners',
   {

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -85,8 +85,8 @@ export const users = pgTable('users', {
   about: text('about'),
   title: text('title'),
   gender: genderEnum('gender').$type<Gender>(),
-  // migration-todo(cutover): deferred FK — see partnerships.mou_id for the
-  // decided plan (DEFERRABLE INITIALLY DEFERRED at cutover).
+  // migration-todo(cutover-cleanup): deferred FK — see partnerships.mou_id
+  // for the plan (reorder createDefinedFile → plain FK at cutover cleanup).
   photoId: text('photo_id').$type<ID<'File'>>(),
   createdAt: timestamp('created_at', { withTimezone: true })
     .notNull()
@@ -1500,15 +1500,18 @@ export const partnerships = pgTable(
       .$type<PartnershipAgreementStatus>()
       .notNull()
       .default('NotAttached'),
-    // migration-todo(cutover): plain text (not FK) because create() inserts
-    // this row before files.createDefinedFile() makes the file nodes — the
-    // ordering is pinned by Neo4j parity until the flip. DECIDED 2026-07-13:
-    // at cutover, add REFERENCES file_nodes(id) DEFERRABLE INITIALLY DEFERRED
-    // (drizzle can't express DEFERRABLE — hand-patch the genesis SQL). The
-    // creation order stays as-is; the FK checks at COMMIT, which is safe since
-    // mutations run in one transaction. Same decision applies to every
-    // insert-before-createDefinedFile column (users.photo_id,
-    // budgets.universal_template_file_id).
+    // migration-todo(cutover-cleanup): plain text (not FK) because create()
+    // inserts this row before files.createDefinedFile() makes the file nodes.
+    // The ordering can't flip while Neo4j lives — its createDefinedFile
+    // attaches the file to the parent node, so the parent must exist first;
+    // PG's FK direction wants the opposite. FINAL plan (2026-07-14): do
+    // nothing until cutover, then as a cutover-cleanup item reorder the
+    // createDefinedFile fan-out (file node FIRST, then the referencing row)
+    // and add plain immediate REFERENCES file_nodes(id) — the from-scratch
+    // relational design. (A DEFERRABLE interim was considered and dropped.)
+    // Same plan applies to every insert-before-createDefinedFile column
+    // (users.photo_id, budgets.universal_template_file_id, + Engagement's
+    // pnp_id / growth_plan_id when that lands).
     mouId: text('mou_id').$type<ID<'File'>>(),
     agreementId: text('agreement_id').$type<ID<'File'>>(),
     mouStartOverride: date('mou_start_override'),

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -85,6 +85,8 @@ export const users = pgTable('users', {
   about: text('about'),
   title: text('title'),
   gender: genderEnum('gender').$type<Gender>(),
+  // migration-todo(cutover): deferred FK — see partnerships.mou_id for the
+  // decided plan (DEFERRABLE INITIALLY DEFERRED at cutover).
   photoId: text('photo_id').$type<ID<'File'>>(),
   createdAt: timestamp('created_at', { withTimezone: true })
     .notNull()
@@ -1498,9 +1500,15 @@ export const partnerships = pgTable(
       .$type<PartnershipAgreementStatus>()
       .notNull()
       .default('NotAttached'),
-    // migration-todo: plain text (not FK) because create() inserts this row
-    // before files.createDefinedFile() makes the file nodes. Add REFERENCES
-    // file_nodes(id) only if create() is reordered to write the files first.
+    // migration-todo(cutover): plain text (not FK) because create() inserts
+    // this row before files.createDefinedFile() makes the file nodes — the
+    // ordering is pinned by Neo4j parity until the flip. DECIDED 2026-07-13:
+    // at cutover, add REFERENCES file_nodes(id) DEFERRABLE INITIALLY DEFERRED
+    // (drizzle can't express DEFERRABLE — hand-patch the genesis SQL). The
+    // creation order stays as-is; the FK checks at COMMIT, which is safe since
+    // mutations run in one transaction. Same decision applies to every
+    // insert-before-createDefinedFile column (users.photo_id,
+    // budgets.universal_template_file_id).
     mouId: text('mou_id').$type<ID<'File'>>(),
     agreementId: text('agreement_id').$type<ID<'File'>>(),
     mouStartOverride: date('mou_start_override'),

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -871,6 +871,27 @@ export const departmentIdBlocks = pgTable('department_id_blocks', {
 });
 
 /**
+ * Department IDs that already exist in Intacct, the accounting system, and so
+ * must never be assigned to a CORD project.
+ *
+ * A reservation list rather than an entity: nothing references these rows and
+ * they reference nothing. Their whole purpose is to be subtracted from the pool
+ * of available IDs when set-department-id.handler.ts picks the next one. The
+ * department ID is the primary key because the reservation is the identity —
+ * the source nodes carry an apoc-generated uuid that names nothing.
+ *
+ * See migration 0040 for why there is no CHECK on the code's shape and no
+ * deleted_at.
+ */
+export const externalDepartmentIds = pgTable('external_department_ids', {
+  departmentId: text('department_id').primaryKey(),
+  name: text('name').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+/**
  * Finance-approver config: "user X approves finances for project type Y" —
  * read by the project workflow to notify approvers on financial-plan
  * transitions. Ported (not retired) per Rob 2026-08-24: without it those

--- a/src/core/repair-post-bodies.run.ts
+++ b/src/core/repair-post-bodies.run.ts
@@ -1,0 +1,233 @@
+/**
+ * One-off repair: post bodies that were turned into rich-text documents.
+ *
+ * WHY THIS EXISTS. `body` is one link name covering two value types — rich text
+ * on a comment, a plain string on a post. An earlier classification sent both
+ * through the rich-text handler, so every post body in an already-scrubbed copy
+ * is a serialized single-block document where the column holds plain text. The
+ * API declares `Post.body` as a String, so GraphQL cannot serialize it and the
+ * whole post list fails.
+ *
+ * Re-scrubbing does NOT fix this: the converted value reads back as an object,
+ * so the corrected handler sees an object and faithfully keeps it a document.
+ * Hence a repair rather than another pass.
+ *
+ * WHAT IT RESTORES. The words inside those documents are already fake, generated
+ * from the originals, so flattening the blocks back to a plain string yields
+ * exactly what the corrected handler would have written. It does NOT recover
+ * production's real text — that is gone, and only a fresh restore brings it back.
+ * Since every value in a scrubbed copy is fake by design, the type is the only
+ * thing that matters here.
+ *
+ * SCOPE. Posts only. Comment bodies are legitimately documents and are left
+ * alone — the owning label is the whole distinction. Runs against a RESTORED
+ * COPY, never production, and boots with `DATABASE=neo4j` so the Neo4j
+ * connection is the one in play.
+ *
+ * Safe to re-run: a body already stored as a plain string is skipped, not
+ * rewritten.
+ *
+ * Usage:
+ *   # count what would change, write nothing
+ *   yarn start --entryFile core/repair-post-bodies.run -- --dry-run
+ *
+ *   # repair
+ *   yarn start --entryFile core/repair-post-bodies.run
+ *
+ * Flags: --dry-run | --batch=N
+ */
+import { NestFactory } from '@nestjs/core';
+import { exit } from 'node:process';
+import '../polyfills';
+
+const parseFlags = (argv: readonly string[]) => {
+  const get = (name: string) =>
+    argv.find((arg) => arg.startsWith(`--${name}=`))?.split('=')[1];
+  return {
+    dryRun: argv.includes('--dry-run'),
+    // Paging by internal id is quadratic — there is no index on those, so every
+    // page rescans. A small page size is what made the scrub look hung.
+    batchSize: get('batch') ? Number(get('batch')) : 25_000,
+  };
+};
+
+interface BodyRow {
+  nodeId: number;
+  value: unknown;
+}
+
+/** Strip inline markup and collapse whitespace; block text may carry HTML. */
+const plainText = (html: string) =>
+  html
+    .replace(/<[^>]*>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+/**
+ * Only the two static helpers this needs, described structurally so the module
+ * holding them stays a runtime import inside `bootstrap` — the entry file must
+ * not pull the app in before argv is set.
+ */
+interface SerializedDocReader {
+  isSerialized: (value: unknown) => value is string;
+  fromSerialized: (value: string) => unknown;
+}
+
+/**
+ * Pull the prose back out of a document. Returns null when the value is not a
+ * document at all, which is how an already-repaired row is skipped.
+ */
+const flattenToText = (
+  value: unknown,
+  richText: SerializedDocReader,
+): string | null => {
+  let doc: { blocks?: unknown[] } | undefined;
+  if (value !== null && typeof value === 'object') {
+    doc = value as { blocks?: unknown[] };
+  } else if (richText.isSerialized(value)) {
+    // Belt and braces: the connection's read transformer normally hands these
+    // back as objects, but a raw serialized string must not slip through.
+    try {
+      doc = richText.fromSerialized(value) as {
+        blocks?: unknown[];
+      };
+    } catch {
+      doc = undefined;
+    }
+  }
+  if (!doc || !Array.isArray(doc.blocks)) return null;
+
+  const parts: string[] = [];
+  for (const block of doc.blocks) {
+    if (block === null || typeof block !== 'object') continue;
+    const data = (block as { data?: unknown }).data;
+    if (data === null || typeof data !== 'object') continue;
+    const text = (data as { text?: unknown }).text;
+    if (typeof text === 'string') parts.push(plainText(text));
+    // List blocks keep their content in `items` rather than `text`.
+    const items = (data as { items?: unknown }).items;
+    if (Array.isArray(items)) {
+      for (const item of items) {
+        if (typeof item === 'string') parts.push(plainText(item));
+        else if (item !== null && typeof item === 'object') {
+          const content = (item as { content?: unknown }).content;
+          if (typeof content === 'string') parts.push(plainText(content));
+        }
+      }
+    }
+  }
+  return parts.filter((part) => part.length > 0).join(' ');
+};
+
+async function bootstrap() {
+  // Flags first, THEN push 'console' so ConfigService.isCli is true — same order
+  // as scrub.run.ts and cutover.run.ts.
+  const flags = parseFlags(process.argv.slice(2));
+  process.argv.push('console');
+
+  const pageSize = Math.trunc(flags.batchSize);
+  if (!Number.isSafeInteger(pageSize) || pageSize < 1) {
+    throw new Error(`Batch size must be a positive integer (got ${pageSize})`);
+  }
+
+  const { AppModule } = await import('../app.module');
+  const { DatabaseService } = await import('~/core/neo4j');
+  const { RichTextDocument } = await import('~/common');
+  const { sortValueFor } = await import('./scrub/fake');
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn'],
+  });
+  const neo4j = app.get(DatabaseService);
+
+  // eslint-disable-next-line no-console
+  const log = (msg: string) => console.log(msg);
+
+  log(
+    flags.dryRun
+      ? '\nDry run — counting only, nothing is written.\n'
+      : '\nRepairing post bodies in place.\n',
+  );
+
+  let examined = 0;
+  let repaired = 0;
+  let alreadyPlain = 0;
+  let emptyAfterFlatten = 0;
+
+  // Keyset on id(p), not SKIP: values change under us as we write, and ids never
+  // move, so a page can never step over an unprocessed row.
+  let after = -1;
+  let page = 0;
+  do {
+    const rows = [
+      ...(await neo4j
+        .query<BodyRow>(
+          `MATCH (owner)-[:body]->(p)
+           WHERE (owner:Post OR owner:Deleted_Post)
+             AND (p:Property OR p:Deleted_Property)
+             AND p.value IS NOT NULL
+             AND id(p) > $after
+           RETURN id(p) AS nodeId, p.value AS value
+           ORDER BY id(p) LIMIT ${pageSize}`,
+          { after },
+        )
+        .run()),
+    ];
+    page = rows.length;
+    if (page === 0) break;
+    examined += page;
+    after = rows[page - 1]!.nodeId;
+
+    const updates: Array<{ nodeId: number; value: string }> = [];
+    for (const row of rows) {
+      const text = flattenToText(row.value, RichTextDocument);
+      if (text === null) {
+        // Not a document — already a plain string, nothing to do.
+        alreadyPlain++;
+        continue;
+      }
+      if (text.length === 0) emptyAfterFlatten++;
+      updates.push({ nodeId: row.nodeId, value: text });
+    }
+
+    if (updates.length > 0 && !flags.dryRun) {
+      await neo4j
+        .query(
+          `UNWIND $batch AS row
+           MATCH (p) WHERE id(p) = row.nodeId
+           SET p.value = row.value,
+               p.sortValue = CASE WHEN p.sortValue IS NULL THEN NULL ELSE row.sortValue END`,
+          {
+            batch: updates.map((update) => ({
+              nodeId: update.nodeId,
+              value: update.value,
+              sortValue: sortValueFor(update.value),
+            })),
+          },
+        )
+        .run();
+    }
+    repaired += updates.length;
+  } while (page === pageSize);
+
+  log(`  examined:            ${examined}`);
+  log(`  ${flags.dryRun ? 'would repair' : 'repaired'}:        ${repaired}`);
+  log(`  already plain text:  ${alreadyPlain}`);
+  if (emptyAfterFlatten > 0) {
+    log(
+      `  ⚠ empty after flattening: ${emptyAfterFlatten} (document held no readable text; stored as an empty body)`,
+    );
+  }
+  log('');
+
+  await app.close();
+}
+
+await bootstrap().then(
+  () => exit(0),
+  (error: unknown) => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    exit(1);
+  },
+);

--- a/src/core/repair-scrubbed-enums.run.ts
+++ b/src/core/repair-scrubbed-enums.run.ts
@@ -1,0 +1,352 @@
+/**
+ * One-off repair: enum values that a text strategy overwrote with fake prose.
+ *
+ * WHY THIS EXISTS. The classification is supposed to leave enums alone, and for
+ * most of them it does (`status`, `step`, `sensitivity`, `methodology`, `medium`
+ * all say so explicitly). Two did not — `position` and `degree` were classified
+ * as prose — so the scrub replaced enum members with invented words, and the API
+ * then refuses to serialize them: `Enum "InternshipPosition" cannot represent
+ * value: "Utilis"`.
+ *
+ * HOW THE ORIGINALS COME BACK. The fakes are deterministic by design, so the
+ * same input always produces the same output. That makes the mapping invertible:
+ * compute the fake for every member of every enum the API declares, and any
+ * field whose stored values are all fakes of one enum is an over-scrubbed enum —
+ * with the true value recoverable for each. No guessing, and no fresh restore.
+ *
+ * This doubles as the DISCOVERY tool. It does not trust the field name or a
+ * hand-maintained list: it checks the data against the enums the schema actually
+ * declares, so it finds fields nobody thought to look at.
+ *
+ * A field is only touched when most of what it holds maps onto one enum, and only
+ * the values that map are rewritten. Values whose original is not a current member
+ * of that enum cannot be mapped back to anything, so they are left as they are and
+ * reported — never counted as repaired.
+ *
+ * The scrub is NOT idempotent for values, so a copy scrubbed twice holds a fake OF
+ * a fake and the original is two applications back. This searches successive
+ * generations; trying only one finds nothing and reads as "no enum was damaged".
+ *
+ * Enum members come from `schema.graphql`, which is generated from the API and
+ * is plain SDL — deliberately not from parsing TypeScript, which produced a
+ * false clearance the last time it was tried.
+ *
+ * Runs against a RESTORED COPY, never production. Boots with `DATABASE=neo4j`.
+ * Safe to re-run: a field already holding real enum members matches no fake set,
+ * so it is skipped.
+ *
+ * Usage:
+ *   # report what it would change, write nothing
+ *   yarn start --entryFile core/repair-scrubbed-enums.run -- --dry-run
+ *
+ *   # repair
+ *   yarn start --entryFile core/repair-scrubbed-enums.run
+ *
+ * Flags: --dry-run | --max-distinct=N (default 200; skips high-cardinality
+ *        fields like `name`, which cannot be enums)
+ */
+import { NestFactory } from '@nestjs/core';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { exit } from 'node:process';
+import '../polyfills';
+
+const parseFlags = (argv: readonly string[]) => {
+  const get = (name: string) =>
+    argv.find((arg) => arg.startsWith(`--${name}=`))?.split('=')[1];
+  return {
+    dryRun: argv.includes('--dry-run'),
+    maxDistinct: get('max-distinct') ? Number(get('max-distinct')) : 200,
+  };
+};
+
+/**
+ * Enum name → members, read from the generated GraphQL schema.
+ *
+ * SDL is regular enough to read directly: `enum Name {` then one member per line
+ * until the closing brace.
+ *
+ * ⚠ A member may carry a directive — the historic values look like
+ * `TranslationFacilitator @deprecated(reason: "...")`. Requiring a LONE identifier
+ * silently dropped every deprecated member, which read as "the original is not a
+ * current member of this enum" for exactly the legacy values. Match the leading
+ * identifier and allow anything after it.
+ */
+const readSchemaEnums = (sdl: string): Map<string, string[]> => {
+  const enums = new Map<string, string[]>();
+  const lines = sdl.split('\n');
+  let current: string | null = null;
+  let members: string[] = [];
+  for (const line of lines) {
+    const start = /^enum\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{/.exec(line);
+    if (start) {
+      current = start[1]!;
+      members = [];
+      continue;
+    }
+    if (current === null) continue;
+    if (/^\s*\}/.test(line)) {
+      if (members.length > 0) enums.set(current, members);
+      current = null;
+      continue;
+    }
+    // Skip descriptions ("""…""" or #) and blank lines; take the identifier and
+    // ignore any directive trailing it.
+    if (/^\s*(#|"|$)/.test(line)) continue;
+    const member = /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(@.*)?$/.exec(line);
+    if (member) members.push(member[1]!);
+  }
+  return enums;
+};
+
+/**
+ * How many times the scrub may have been applied. A copy scrubbed twice holds a
+ * fake of a fake; the original is that many applications back.
+ */
+const MAX_GENERATIONS = 5;
+/** A genuine enum match accounts for most of the field, not a stray collision. */
+const MIN_MATCHED_VALUES = 2;
+const MIN_COVERAGE = 0.5;
+
+interface Candidate {
+  /** Link name or node-property key. */
+  readonly name: string;
+  readonly kind: 'link' | 'field';
+  readonly strategy: string;
+  readonly total: number;
+  readonly distinct: readonly string[];
+}
+
+async function bootstrap() {
+  const flags = parseFlags(process.argv.slice(2));
+  process.argv.push('console');
+
+  const { AppModule } = await import('../app.module');
+  const { DatabaseService } = await import('~/core/neo4j');
+  const { fakeValue, sortValueFor } = await import('./scrub/fake');
+  const { links, properties } = await import('./scrub/classification');
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn'],
+  });
+  const neo4j = app.get(DatabaseService);
+  // eslint-disable-next-line no-console
+  const log = (msg: string) => console.log(msg);
+
+  const sdlPath = path.join(process.cwd(), 'schema.graphql');
+  const schemaEnums = readSchemaEnums(readFileSync(sdlPath, 'utf8'));
+  log(
+    flags.dryRun
+      ? '\nDry run — reporting only, nothing is written.\n'
+      : '\nRepairing over-scrubbed enum values in place.\n',
+  );
+  log(`Read ${schemaEnums.size} enums from schema.graphql.`);
+
+  // Every field the classification rewrites with a text strategy. Credentials are
+  // excluded: those are emptied on purpose and have no original to restore.
+  const scrubbed: Array<{
+    name: string;
+    kind: 'link' | 'field';
+    strategy: string;
+  }> = [];
+  for (const [name, action] of Object.entries(links)) {
+    if (action.kind === 'scrub' && action.as !== 'credential') {
+      scrubbed.push({ name, kind: 'link', strategy: action.as });
+    }
+  }
+  for (const [name, action] of Object.entries(properties)) {
+    if (action.kind === 'scrub' && action.as !== 'credential') {
+      scrubbed.push({ name, kind: 'field', strategy: action.as });
+    }
+  }
+  log(`Checking ${scrubbed.length} scrubbed field(s) against those enums.\n`);
+
+  // Gather distinct values, skipping anything too varied to be an enum.
+  const candidates: Candidate[] = [];
+  for (const entry of scrubbed) {
+    const cypher =
+      entry.kind === 'link'
+        ? `MATCH ()-[:\`${entry.name}\`]->(p)
+           WHERE (p:Property OR p:Deleted_Property) AND p.value IS NOT NULL
+           RETURN count(p) AS total, count(DISTINCT p.value) AS distinctCount`
+        : `MATCH (n) WHERE n.\`${entry.name}\` IS NOT NULL
+           RETURN count(n) AS total, count(DISTINCT n.\`${entry.name}\`) AS distinctCount`;
+    const [counts] = [
+      ...(await neo4j
+        .query<{ total: number; distinctCount: number }>(cypher)
+        .run()),
+    ];
+    const total = Number(counts?.total ?? 0);
+    const distinctCount = Number(counts?.distinctCount ?? 0);
+    if (total === 0 || distinctCount === 0) continue;
+    if (distinctCount > flags.maxDistinct) continue;
+
+    const valuesCypher =
+      entry.kind === 'link'
+        ? `MATCH ()-[:\`${entry.name}\`]->(p)
+           WHERE (p:Property OR p:Deleted_Property) AND p.value IS NOT NULL
+           RETURN DISTINCT p.value AS value`
+        : `MATCH (n) WHERE n.\`${entry.name}\` IS NOT NULL
+           RETURN DISTINCT n.\`${entry.name}\` AS value`;
+    const rows = [
+      ...(await neo4j.query<{ value: unknown }>(valuesCypher).run()),
+    ];
+    const distinct = rows
+      .map((row) => row.value)
+      .filter((value): value is string => typeof value === 'string');
+    if (distinct.length === 0) continue;
+    candidates.push({ ...entry, total, distinct });
+  }
+
+  // Match each candidate against every enum's fake set.
+  let repairedFields = 0;
+  let repairedValues = 0;
+  const partial: string[] = [];
+
+  for (const candidate of candidates) {
+    let matched: {
+      enumName: string;
+      map: Map<string, string>;
+      covered: readonly string[];
+    } | null = null;
+    let ambiguous = false;
+
+    for (const [enumName, members] of schemaEnums) {
+      // Search successive generations, because the scrub is not idempotent for
+      // values: scrubbing an already-fake value produces a different fake. A copy
+      // that has been through the scrub twice holds a fake OF a fake, so the
+      // original is two applications back, not one. Trying only one generation
+      // finds nothing and looks like "no enum was damaged".
+      let fakeToReal = new Map<string, string>();
+      let bestCovered = 0;
+      // One generation is one more application of the fake, so carry each
+      // member's value forward rather than re-deriving it from the member.
+      let valueByMember = new Map(members.map((member) => [member, member]));
+      let generation = 0;
+      while (generation < MAX_GENERATIONS) {
+        generation++;
+        const advanced = new Map<string, string>();
+        for (const [member, value] of valueByMember) {
+          const next = fakeValue(candidate.strategy as never, value);
+          // A strategy that does not return a string cannot be inverted, so
+          // that member simply drops out of the search.
+          if (typeof next === 'string') advanced.set(member, next);
+        }
+        valueByMember = advanced;
+
+        const attempt = new Map<string, string>();
+        let injective = true;
+        for (const [member, value] of valueByMember) {
+          if (attempt.has(value)) {
+            // Two members collapsing to one fake would make the inverse ambiguous.
+            injective = false;
+            break;
+          }
+          attempt.set(value, member);
+        }
+        if (!injective) continue;
+        const covered = candidate.distinct.filter((value) =>
+          attempt.has(value),
+        );
+        if (covered.length > bestCovered) {
+          bestCovered = covered.length;
+          fakeToReal = attempt;
+        }
+      }
+      if (fakeToReal.size === 0) continue;
+      const covered = candidate.distinct.filter((value) =>
+        fakeToReal.has(value),
+      );
+      if (covered.length === 0) continue;
+      // Values that are ALREADY valid members need no repair, so they must not
+      // count against coverage. Without this, a field that has been partly
+      // repaired looks mostly-clean and the remainder can never be finished.
+      const memberSet = new Set(members);
+      const needsRepair = candidate.distinct.filter(
+        (value) => !memberSet.has(value),
+      );
+      // A real match accounts for most of what the field holds. An unrelated prose
+      // field will collide with a stray enum fake now and then — those land in the
+      // low single-digit percentages, well under this bar.
+      const coverage =
+        needsRepair.length === 0 ? 0 : covered.length / needsRepair.length;
+      if (covered.length >= MIN_MATCHED_VALUES && coverage >= MIN_COVERAGE) {
+        if (matched) ambiguous = true;
+        matched = { enumName, map: fakeToReal, covered };
+      } else {
+        partial.push(
+          `  ? ${candidate.name} (${candidate.kind}): only ${covered.length} of ${needsRepair.length} unrecognised value(s) look like ${enumName} fakes — left alone, needs a human`,
+        );
+      }
+    }
+
+    if (!matched) continue;
+    if (ambiguous) {
+      partial.push(
+        `  ? ${candidate.name} (${candidate.kind}): matches more than one enum — left alone, needs a human`,
+      );
+      continue;
+    }
+
+    const unmapped = candidate.distinct.filter(
+      (value) => !matched.map.has(value),
+    );
+    log(
+      `  \u2717 ${candidate.name} (${candidate.kind}) was scrubbed as '${candidate.strategy}' but holds ${matched.enumName} \u2014 ${matched.covered.length} value(s) recoverable`,
+    );
+    if (unmapped.length > 0) {
+      // Values whose original is not a member of the enum the API declares now.
+      // Nothing to map them back to, so they are left as they are and named here
+      // rather than quietly counted as repaired.
+      log(
+        `      ${unmapped.length} not recoverable (original is not a current member of ${matched.enumName})`,
+      );
+    }
+    repairedFields++;
+    repairedValues += matched.covered.length;
+
+    if (flags.dryRun) continue;
+
+    const batch = matched.covered.map((fake) => ({
+      fake,
+      real: matched.map.get(fake)!,
+      sortValue: sortValueFor(matched.map.get(fake)!),
+    }));
+    const writeCypher =
+      candidate.kind === 'link'
+        ? `UNWIND $batch AS row
+           MATCH ()-[:\`${candidate.name}\`]->(p)
+           WHERE (p:Property OR p:Deleted_Property) AND p.value = row.fake
+           SET p.value = row.real,
+               p.sortValue = CASE WHEN p.sortValue IS NULL THEN NULL ELSE row.sortValue END`
+        : `UNWIND $batch AS row
+           MATCH (n) WHERE n.\`${candidate.name}\` = row.fake
+           SET n.\`${candidate.name}\` = row.real`;
+    await neo4j.query(writeCypher, { batch }).run();
+  }
+
+  if (partial.length > 0) {
+    log('\nInconclusive — reported, not changed:');
+    for (const line of partial) log(line);
+  }
+
+  log('');
+  log(
+    `  fields ${flags.dryRun ? 'that would be' : ''} repaired: ${repairedFields}`,
+  );
+  log(
+    `  distinct values ${flags.dryRun ? 'that would be' : ''} remapped: ${repairedValues}`,
+  );
+  log('');
+
+  await app.close();
+}
+
+await bootstrap().then(
+  () => exit(0),
+  (error: unknown) => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    exit(1);
+  },
+);

--- a/src/core/scrub-deep-deleted.run.ts
+++ b/src/core/scrub-deep-deleted.run.ts
@@ -1,0 +1,159 @@
+/**
+ * ONE-OFF repair: scrub the field records the old label predicate skipped.
+ *
+ * Background. Neo4j's soft delete prefixes labels rather than setting a flag, so
+ * a record deleted twice is `:Deleted_Deleted_Property`. Until 2026-08-20 both
+ * the scrubber and its verifier matched `(p:Property OR p:Deleted_Property)`,
+ * which stops at depth one — so a handful of records kept their original
+ * production values and the verifier reported clean throughout.
+ *
+ * The code fix (`isFieldRecord`) means a FRESH scrub handles these correctly.
+ * This script exists only because re-scrubbing an ALREADY-scrubbed copy is not
+ * a repair: `fakeValue` is deterministic on its input, so running it over
+ * existing fakes produces fakes-of-fakes and churns every value in the graph,
+ * invalidating any Postgres load taken from it. This touches only the records
+ * the old predicate missed and leaves everything else byte-identical.
+ *
+ * It reuses `fakeValue` with the strategy the classification already assigns to
+ * each link, so a repaired value is exactly what a full scrub would have
+ * written — which matters, because the same original may appear both live
+ * (already faked) and here.
+ *
+ * migration-todo(cleanup): delete this file once every scrubbed copy has been
+ * repaired or rebuilt. Kept rather than deleted on 2026-08-20 because the local
+ * copy is not necessarily the only one — any other environment scrubbed before
+ * that date carries the same leak, and a copy rebuilt from a fresh dump with the
+ * fixed scrubber does not need this at all. The code fix is the durable part;
+ * this only repairs data that was already written.
+ *
+ *   yarn start --entryFile core/scrub-deep-deleted.run -- --dry-run
+ *   yarn start --entryFile core/scrub-deep-deleted.run
+ */
+import { NestFactory } from '@nestjs/core';
+import { exit } from 'node:process';
+import '../polyfills';
+
+/** Depth two or deeper. Depth one is what the old predicate already covered. */
+const DEEP = `any(lbl IN labels(p) WHERE lbl STARTS WITH 'Deleted_Deleted_')`;
+
+interface DeepRow {
+  nodeId: number;
+  link: string;
+  value: unknown;
+}
+
+async function bootstrap() {
+  const dryRun = process.argv.includes('--dry-run');
+  process.argv.push('console');
+
+  // Booting the AppModule writes to the graph on its own — observed here as
+  // `[admin:service] Updating root user to match app configuration`, which
+  // rewrites the root user's email and password hash to match this box's config.
+  // A repair script should change the 16 records it came for and nothing else,
+  // and on a copy being used for read-parity work an unrelated write is noise
+  // that shows up later as an unexplained difference. Set before the AppModule
+  // import below, since ConfigService reads env once. Same guard, same reason,
+  // as shadow-diff.run.ts.
+  process.env.DB_ROOT_OBJECTS_SYNC = 'false';
+  process.env.DB_CREATE_INDEXES = 'false';
+
+  const { AppModule } = await import('../app.module');
+  const { DatabaseService } = await import('~/core/neo4j');
+  const { links } = await import('./scrub/classification');
+  const { fakeValue } = await import('./scrub/fake');
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn'],
+  });
+  const neo4j = app.get(DatabaseService);
+  // CLI script — its output IS the interface. Same as scrub.run.ts.
+  // eslint-disable-next-line no-console
+  const log = (msg: string) => console.log(msg);
+
+  try {
+    const rows = [
+      ...(await neo4j
+        .query<DeepRow>(
+          `MATCH ()-[r]->(p)
+           WHERE ${DEEP} AND p.value IS NOT NULL
+           RETURN id(p) AS nodeId, type(r) AS link, p.value AS value`,
+        )
+        .run()),
+    ];
+    log(
+      `Found ${rows.length} field record(s) at soft-delete depth 2 or deeper.`,
+    );
+    if (rows.length === 0) {
+      log('Nothing to repair.');
+      return;
+    }
+
+    const byLink = new Map<string, number>();
+    for (const row of rows) {
+      byLink.set(row.link, (byLink.get(row.link) ?? 0) + 1);
+    }
+    for (const [link, count] of byLink) {
+      log(`  ${link}: ${count}`);
+    }
+
+    // An unclassified or non-scrub link here is a real finding, not something to
+    // skip quietly — the whole point of the allowlist is that nothing slips past
+    // unexamined.
+    const updates: Array<{ nodeId: number; value: string | null }> = [];
+    const unclassified: string[] = [];
+    for (const row of rows) {
+      const action = links[row.link];
+      if (!action) {
+        unclassified.push(row.link);
+        continue;
+      }
+      if (action.kind !== 'scrub') continue;
+      updates.push({
+        nodeId: row.nodeId,
+        value: fakeValue(action.as, row.value),
+      });
+    }
+    if (unclassified.length > 0) {
+      throw new Error(
+        `Refusing to run: ${[...new Set(unclassified)].join(', ')} is not in the ` +
+          `classification. Classify it before repairing.`,
+      );
+    }
+
+    log(
+      `\n${dryRun ? 'Would replace' : 'Replacing'} ${updates.length} value(s).`,
+    );
+    if (dryRun) return;
+
+    await neo4j
+      .query(
+        `UNWIND $batch AS row
+         MATCH (p) WHERE id(p) = row.nodeId
+         SET p.value = row.value,
+             p.sortValue = CASE WHEN p.sortValue IS NULL THEN NULL ELSE row.value END`,
+        { batch: updates },
+      )
+      .run();
+
+    const left = [
+      ...(await neo4j
+        .query<{ total: number }>(
+          `MATCH ()-[]->(p) WHERE ${DEEP} AND p.value IS NOT NULL
+           RETURN count(p) AS total`,
+        )
+        .run()),
+    ];
+    log(
+      `Repaired. ${Number(left[0]?.total ?? 0)} record(s) now at that depth.`,
+    );
+  } finally {
+    await app.close();
+  }
+  exit();
+}
+
+void bootstrap().catch((err: unknown) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+});

--- a/src/core/scrub.run.ts
+++ b/src/core/scrub.run.ts
@@ -1,12 +1,11 @@
 /**
  * Scrub a restored production copy so it is safe to develop and rehearse against.
  *
- * WHY THIS EXISTS. The production pre-flight showed roughly 35,000 records flow
- * through migration code that has never executed once — 23,815 prompt answers,
- * 7,803 posts, 2,560 producibles, 903 status-history rows, all of which are zero
- * or near-zero locally. No amount of running against local test data changes that.
- * A scrubbed production copy exercises every one of those paths, and doubles as a
- * dev environment that resembles reality.
+ * WHY THIS EXISTS. Several domains — prompt answers, posts, producibles, status
+ * history — carry real volume in production and are empty or near-empty locally,
+ * so their migration code has never actually executed. No amount of running
+ * against local test data changes that. A scrubbed production copy exercises
+ * those paths, and doubles as a dev environment that resembles reality.
  *
  * Boots with `DATABASE=neo4j` so the Neo4j connection is the one in play. This
  * writes to that graph in place, so point it at a RESTORED COPY, never at
@@ -22,7 +21,13 @@
  *   # verify an already-scrubbed copy (safe to re-run any time)
  *   yarn start --entryFile core/scrub.run -- --verify-only
  *
- * Flags: --dry-run | --verify-only | --batch=N
+ * Flags: --dry-run | --verify-only | --restamp | --batch=N
+ *
+ * `--restamp` re-records the marker with the CURRENT classification hash, without
+ * touching any value. Only correct when the classification changed and the copy
+ * already satisfies the new version — e.g. a field was reclassified as an enum to
+ * leave alone, and its values were separately restored. It is not a way to silence
+ * a stale-copy refusal: if the data does not match the classification, re-scrub.
  */
 import { NestFactory } from '@nestjs/core';
 import { exit } from 'node:process';
@@ -35,6 +40,7 @@ const parseFlags = (argv: readonly string[]) => {
   return {
     dryRun: has('dry-run'),
     verifyOnly: has('verify-only'),
+    restamp: has('restamp'),
     batchSize: get('batch') ? Number(get('batch')) : 1000,
   };
 };
@@ -52,7 +58,8 @@ async function bootstrap() {
     await import('~/core/authentication/crypto.service');
   const { runScrub } = await import('./scrub/scrub');
   const { runVerify } = await import('./scrub/verify');
-  const { readProvenance } = await import('./scrub/provenance');
+  const { readProvenance, stampProvenance } =
+    await import('./scrub/provenance');
 
   const app = await NestFactory.createApplicationContext(AppModule, {
     logger: ['error', 'warn'],
@@ -63,7 +70,27 @@ async function bootstrap() {
   const log = (msg: string) => console.log(msg);
 
   try {
-    if (flags.verifyOnly) {
+    if (flags.restamp) {
+      const before = await readProvenance(neo4j);
+      if (!before) {
+        throw new Error(
+          'Refusing to restamp: this graph carries no scrub marker, so there is ' +
+            'nothing to re-record. Run the scrub.',
+        );
+      }
+      await stampProvenance(neo4j, {
+        scrubbedValues: before.scrubbedValues,
+        deletedKeys: before.deletedKeys,
+        at: new Date().toISOString(),
+      });
+      const after = await readProvenance(neo4j);
+      log(
+        `\nRe-recorded the marker: classification ${
+          before.classificationHash
+        } -> ${after?.classificationHash ?? '(marker unreadable)'}\n` +
+          'No values were touched.\n',
+      );
+    } else if (flags.verifyOnly) {
       const provenance = await readProvenance(neo4j);
       log(
         provenance

--- a/src/core/scrub.run.ts
+++ b/src/core/scrub.run.ts
@@ -1,0 +1,141 @@
+/**
+ * Scrub a restored production copy so it is safe to develop and rehearse against.
+ *
+ * WHY THIS EXISTS. The production pre-flight showed roughly 35,000 records flow
+ * through migration code that has never executed once — 23,815 prompt answers,
+ * 7,803 posts, 2,560 producibles, 903 status-history rows, all of which are zero
+ * or near-zero locally. No amount of running against local test data changes that.
+ * A scrubbed production copy exercises every one of those paths, and doubles as a
+ * dev environment that resembles reality.
+ *
+ * Boots with `DATABASE=neo4j` so the Neo4j connection is the one in play. This
+ * writes to that graph in place, so point it at a RESTORED COPY, never at
+ * production.
+ *
+ * Usage:
+ *   # count what would change, write nothing
+ *   yarn start --entryFile core/scrub.run -- --dry-run
+ *
+ *   # scrub, then verify
+ *   SCRUB_DEV_PASSWORD=localdev yarn start --entryFile core/scrub.run
+ *
+ *   # verify an already-scrubbed copy (safe to re-run any time)
+ *   yarn start --entryFile core/scrub.run -- --verify-only
+ *
+ * Flags: --dry-run | --verify-only | --batch=N
+ */
+import { NestFactory } from '@nestjs/core';
+import { exit } from 'node:process';
+import '../polyfills';
+
+const parseFlags = (argv: readonly string[]) => {
+  const get = (name: string) =>
+    argv.find((arg) => arg.startsWith(`--${name}=`))?.split('=')[1];
+  const has = (name: string) => argv.includes(`--${name}`);
+  return {
+    dryRun: has('dry-run'),
+    verifyOnly: has('verify-only'),
+    batchSize: get('batch') ? Number(get('batch')) : 1000,
+  };
+};
+
+async function bootstrap() {
+  // Flags first, THEN push 'console' so ConfigService.isCli is true (loaders
+  // resolve against the CLI context, scheduler off) — same order as
+  // cutover.run.ts and repl.ts.
+  const flags = parseFlags(process.argv.slice(2));
+  process.argv.push('console');
+
+  const { AppModule } = await import('../app.module');
+  const { DatabaseService } = await import('~/core/neo4j');
+  const { CryptoService } =
+    await import('~/core/authentication/crypto.service');
+  const { runScrub } = await import('./scrub/scrub');
+  const { runVerify } = await import('./scrub/verify');
+  const { readProvenance } = await import('./scrub/provenance');
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['error', 'warn'],
+  });
+  const neo4j = app.get(DatabaseService);
+  // Same as cutover.run.ts: this is a CLI script whose output IS the interface.
+  // eslint-disable-next-line no-console
+  const log = (msg: string) => console.log(msg);
+
+  try {
+    if (flags.verifyOnly) {
+      const provenance = await readProvenance(neo4j);
+      log(
+        provenance
+          ? `\nMarked scrubbed ${provenance.scrubbedAt} — ${provenance.scrubbedValues} values replaced, classification ${provenance.classificationHash}\n`
+          : '\n⚠ No scrub marker on this graph.\n',
+      );
+    } else {
+      const crypto = app.get(CryptoService);
+      const devPassword = process.env.SCRUB_DEV_PASSWORD;
+      if (!devPassword && !flags.dryRun) {
+        throw new Error(
+          'SCRUB_DEV_PASSWORD is required for a real run — every account in the ' +
+            'copy is set to it, and it is the only way to log in afterwards.',
+        );
+      }
+      const devPasswordHash = devPassword
+        ? await crypto.hash(devPassword)
+        : 'dry-run';
+
+      log(
+        flags.dryRun
+          ? '\nDRY RUN — counting only, nothing is written.\n'
+          : '\nScrubbing in place. This rewrites the graph it is pointed at.\n',
+      );
+
+      const report = await runScrub({
+        neo4j,
+        batchSize: flags.batchSize,
+        log,
+        devPasswordHash,
+        dryRun: flags.dryRun,
+      });
+
+      log(
+        `\n${flags.dryRun ? 'Would replace' : 'Replaced'} ${report.scrubbedValues} value(s), ` +
+          `${flags.dryRun ? 'clear' : 'cleared'} ${report.credentialsCleared} credential(s), ` +
+          `${flags.dryRun ? 'remove' : 'removed'} ${report.deletedKeys} dead key value(s).`,
+      );
+    }
+
+    // Verification always runs, including after a dry run — on an unscrubbed
+    // graph it reports what is currently exposed, which is a useful baseline and
+    // proves the probes actually fire rather than passing vacuously.
+    log('\nVerifying —');
+    const verify = await runVerify(neo4j);
+    if (verify.clean) {
+      log('  no violations.');
+    } else {
+      for (const violation of verify.violations) {
+        log(`  ✗ ${violation.field}: ${violation.count} — ${violation.probe}`);
+      }
+    }
+    for (const item of verify.watchlist) {
+      log(`  • ${item.field}: ${item.count} — ${item.probe}`);
+    }
+
+    if (!flags.dryRun && !flags.verifyOnly && !verify.clean) {
+      log(
+        '\n⚠ Scrub completed but verification found survivors. Treat this copy as ' +
+          'unscrubbed until the fields above are resolved.',
+      );
+      await app.close();
+      exit(1);
+    }
+
+    await app.close();
+    exit(0);
+  } catch (error) {
+    log(`\n✗ ${error instanceof Error ? error.message : String(error)}`);
+    await app.close();
+    exit(1);
+  }
+}
+
+await bootstrap();

--- a/src/core/scrub/classification.ts
+++ b/src/core/scrub/classification.ts
@@ -29,6 +29,35 @@
  *    bookmarks and screenshots still make sense) and two runs stay comparable.
  */
 
+/**
+ * Cypher predicate matching a field record at ANY soft-delete depth.
+ *
+ * Neo4j's soft delete does not set a flag, it PREFIXES every label — so a
+ * deleted field record is `:Deleted_Property`, and one deleted twice is
+ * `:Deleted_Deleted_Property`. Both the scrub and its verifier used to spell the
+ * set out as `(p:Property OR p:Deleted_Property)`, which silently stops at depth
+ * one.
+ *
+ * That cost real exposure. Found 2026-08-20 in the production copy: 16 field
+ * records sat at depth 2 and 3, every one of them a file name, and every one
+ * still holding its original production value — one is a fiscal-year report
+ * naming a specific minority language. The scrub skipped them because they
+ * matched neither label, and **the verifier reported `0 violations` because it
+ * carried the identical blind spot**, which is why a run could look clean for
+ * months. Two checks are only two checks if they disagree about something.
+ *
+ * Matching on the label SUFFIX makes the depth irrelevant, so a third or fourth
+ * prefix cannot reopen this. Nothing else in the schema mints a `*_Property`
+ * label, so the widened match cannot pull in anything unintended.
+ *
+ * Not part of {@link classificationHash} — that hashes classification DECISIONS,
+ * and this is how the graph is walked. Worth knowing, because it means a copy
+ * scrubbed before this fix and one scrubbed after are indistinguishable by their
+ * marker: the only way to tell is to re-scrub.
+ */
+export const isFieldRecord = (variable: string) =>
+  `any(lbl IN labels(${variable}) WHERE lbl = 'Property' OR lbl ENDS WITH '_Property')`;
+
 /** How a replacement value is generated. All are deterministic in the input. */
 export type Strategy =
   /** Person names — first/last/display, and the derived initials. */

--- a/src/core/scrub/classification.ts
+++ b/src/core/scrub/classification.ts
@@ -50,6 +50,17 @@ export type Strategy =
   /** A RichTextDocument. Structure preserved, block text replaced. */
   | 'richText'
   /**
+   * Either of the two above, chosen per value rather than per field.
+   *
+   * Needed because the classification keys on the LINK name and Neo4j reuses one
+   * link name across node types that disagree about the value's type. The known
+   * case is `description`: rich text on an engagement, a plain string on a
+   * product, a tool and an unavailability. A replacement has to match the shape
+   * it replaces — writing a document where a string was would break reading it
+   * back — so the choice can only be made from the value itself.
+   */
+  | 'proseOrRichText'
+  /**
    * Emptied, not faked. Fake credentials still read as credentials, and a
    * plausible-looking one invites someone to try it. See `credentialLinks`.
    */
@@ -90,8 +101,12 @@ export const links: Readonly<Record<string, Action>> = {
   phone: scrub('phone'),
   about: scrub('prose', 'User bio, free text'),
   title: scrub('prose', 'job title'),
-  position: scrub('prose'),
-  degree: scrub('prose', 'Education'),
+  // Enums, so LEAVE THEM — the same rule `status`/`step`/`sensitivity` follow.
+  // Classified as prose originally, which replaced enum members with invented
+  // words and made the API refuse to serialize them. Repaired by inverting the
+  // deterministic fake; see core/repair-scrubbed-enums.run.ts.
+  position: safe('enum — InternshipPosition'),
+  degree: safe('enum — Degree, on Education'),
   major: scrub('prose', 'Education'),
   institution: scrub('entityName', 'Education'),
   timezone: safe('IANA zone name, coarse and non-identifying'),
@@ -109,12 +124,15 @@ export const links: Readonly<Record<string, Action>> = {
   displayNamePronunciation: scrub('languageName'),
 
   // ── Free text people wrote ────────────────────────────────────────────────
-  body: scrub(
-    'richText',
-    'Comment body — Post.body is plain text, same handler',
-  ),
+  // Rich text on a comment, a plain string on a post — same link name, two
+  // value types, chosen per value. Using the rich-text handler for both turned
+  // every post body into a serialized document: no error, and not undone by
+  // re-scrubbing, since the replacement reads back as an object the second time.
+  body: scrub('proseOrRichText'),
   comments: scrub('richText', 'variance explanation'),
-  description: scrub('prose'),
+  // Rich text on an engagement, a plain string on a product, a tool and an
+  // unavailability — same link name, two value types. Chosen per value.
+  description: scrub('proseOrRichText'),
   describeCompletion: scrub('prose'),
   historicGoal: scrub('prose'),
   leastOfTheseReason: scrub('prose'),

--- a/src/core/scrub/classification.ts
+++ b/src/core/scrub/classification.ts
@@ -1,0 +1,593 @@
+/**
+ * Scrub classification — the single source of truth for what a production copy
+ * is allowed to expose.
+ *
+ * WHY THIS FILE IS AN ALLOWLIST. Neo4j stores each field as its own attached
+ * `:Property` record whose payload is *always* called `value`. The only thing
+ * distinguishing a name from an email from a password is the **relationship type
+ * pointing at it**. So classification is keyed on link name, not field name —
+ * `db.propertyKeys()` returns 81 keys but one of them (`value`) carries nearly
+ * all the real content.
+ *
+ * Everything the live graph contains must appear below. `assertFullyClassified`
+ * compares this file against `db.relationshipTypes()` and `db.propertyKeys()` and
+ * THROWS on anything unlisted, so the scrub refuses to run rather than silently
+ * skipping a field nobody classified. That inverted failure mode is the whole
+ * point: a blocklist leaks whatever you forgot and never tells you.
+ *
+ * `review` entries also block. An unanswered question is not a default to `safe`.
+ *
+ * Two further rules the scrub itself enforces, recorded here because they are
+ * easy to lose:
+ *  - Replace, never blank. Nulls break what the migration test measures —
+ *    project names carry a uniqueness constraint and a null one already aborted a
+ *    load. Fakes must be valid, unique where the original was unique, and of
+ *    comparable length. Rich text keeps its document structure; only the words
+ *    inside change.
+ *  - Deterministic, never random. The same input must always produce the same
+ *    fake, so monthly refreshes stay stable (a person keeps their fake name, so
+ *    bookmarks and screenshots still make sense) and two runs stay comparable.
+ */
+
+/** How a replacement value is generated. All are deterministic in the input. */
+export type Strategy =
+  /** Person names — first/last/display, and the derived initials. */
+  | 'personName'
+  /** Names of organizations, projects, places, tools, funding accounts. */
+  | 'entityName'
+  /**
+   * Language names and pronunciations. Separate from `entityName` because the
+   * protocol treats language data supplied by a community differently from an
+   * org's trading name, and because a reviewer should be able to see at a glance
+   * which fields are the community-data ones.
+   */
+  | 'languageName'
+  | 'email'
+  | 'phone'
+  | 'address'
+  /** Single-line free text a person wrote. Length-comparable. */
+  | 'prose'
+  /** A RichTextDocument. Structure preserved, block text replaced. */
+  | 'richText'
+  /**
+   * Emptied, not faked. Fake credentials still read as credentials, and a
+   * plausible-looking one invites someone to try it. See `credentialLinks`.
+   */
+  | 'credential';
+
+export type Action =
+  /** Points at another record. No stored value, nothing to scrub. */
+  | { kind: 'structural' }
+  /** Holds a value that carries nothing protected. `why` is required. */
+  | { kind: 'safe'; why: string }
+  | { kind: 'scrub'; as: Strategy; note?: string }
+  /** Removed outright. Better than scrubbing — absent data cannot leak. */
+  | { kind: 'delete'; why: string }
+  /** BLOCKS the scrub. Someone must decide before a copy can be made. */
+  | { kind: 'review'; question: string };
+
+const structural: Action = { kind: 'structural' };
+const safe = (why: string): Action => ({ kind: 'safe', why });
+const scrub = (as: Strategy, note?: string): Action => ({
+  kind: 'scrub',
+  as,
+  note,
+});
+
+/**
+ * Relationship types (207 in production as of 2026-07-31).
+ *
+ * Most are structural — the connections that make up the graph. Only the ones
+ * pointing at a `:Property` carry a value, and only some of those matter.
+ */
+export const links: Readonly<Record<string, Action>> = {
+  // ── People ────────────────────────────────────────────────────────────────
+  realFirstName: scrub('personName'),
+  realLastName: scrub('personName'),
+  displayFirstName: scrub('personName'),
+  displayLastName: scrub('personName'),
+  email: scrub('email'),
+  phone: scrub('phone'),
+  about: scrub('prose', 'User bio, free text'),
+  title: scrub('prose', 'job title'),
+  position: scrub('prose'),
+  degree: scrub('prose', 'Education'),
+  major: scrub('prose', 'Education'),
+  institution: scrub('entityName', 'Education'),
+  timezone: safe('IANA zone name, coarse and non-identifying'),
+
+  // ── Entity names ──────────────────────────────────────────────────────────
+  name: scrub(
+    'entityName',
+    'polymorphic — project, org, partner, location, tool, zone, region, funding account, producible',
+  ),
+  acronym: scrub('entityName'),
+  address: scrub('address', 'Organization postal address'),
+
+  // ── Language data ─────────────────────────────────────────────────────────
+  displayName: scrub('languageName', 'Language.displayName'),
+  displayNamePronunciation: scrub('languageName'),
+
+  // ── Free text people wrote ────────────────────────────────────────────────
+  body: scrub(
+    'richText',
+    'Comment body — Post.body is plain text, same handler',
+  ),
+  comments: scrub('richText', 'variance explanation'),
+  description: scrub('prose'),
+  describeCompletion: scrub('prose'),
+  historicGoal: scrub('prose'),
+  leastOfTheseReason: scrub('prose'),
+  placeholderDescription: scrub('prose'),
+  skippedReason: scrub('prose'),
+  prompt: safe('prompt text is app-authored, not user content'),
+  reasons: safe('fixed option set, app-level enum in all but type'),
+
+  // ── Credentials — emptied, and done in a separate first pass ──────────────
+  password: scrub(
+    'credential',
+    'reset to one known dev value, see credentialLinks',
+  ),
+  token: scrub(
+    'credential',
+    'session + password-reset tokens are LIVE in a dump',
+  ),
+
+  // ── Dead 2021 artifacts — delete, do not classify ─────────────────────────
+  // 87Six was the system Cord v3 replaced. Commits cc389c2a8 / 6143fc3e0
+  // (Aug 2021) imported its comments into Cord posts and left rollback markers
+  // behind. The rollback never happened. Nothing reads any of these.
+  // (`87SixId`, `v2User`, `finalReportMigration`, `postMigration` are direct
+  // node properties — see `properties` below.)
+
+  // ── Identifiers and codes ─────────────────────────────────────────────────
+  departmentId: safe(
+    'finance code, carries a uniqueness test the migration measures',
+  ),
+  pmcEntityCode: safe('internal entity code'),
+  webId: safe('internal reference'),
+  paratextRegistryId: safe('external tool reference, not personal'),
+  rev79ProjectId: safe('external system reference, not personal'),
+  rev79CommunityId: safe('external system reference, not personal'),
+  isoAlpha3: safe('published ISO country code'),
+  key: safe('Tool key, a slug'),
+
+  // ── Dates ─────────────────────────────────────────────────────────────────
+  start: safe('date'),
+  end: safe('date'),
+  startDate: safe('date'),
+  startDateOverride: safe('date'),
+  endDateOverride: safe('date'),
+  actualDate: safe('date'),
+  estimatedDate: safe('date'),
+  estimatedSubmission: safe('date'),
+  completeDate: safe('date'),
+  communicationsCompleteDate: safe('date'),
+  disbursementCompleteDate: safe('date'),
+  sentPrintingDate: safe('date'),
+  receivedDate: safe('date'),
+  narrativeReceivedDate: safe('date'),
+  initialEndDate: safe('date'),
+  sponsorEstimatedEndDate: safe('date'),
+  mouStart: safe('date'),
+  mouEnd: safe('date'),
+  mouStartOverride: safe('date'),
+  mouEndOverride: safe('date'),
+  initialMouEnd: safe('date'),
+  financialReportReceivedAt: safe('date'),
+  inactiveAt: safe('date'),
+  lastSuspendedAt: safe('date'),
+  lastReactivatedAt: safe('date'),
+  statusModifiedAt: safe('date'),
+  stepChangedAt: safe('date'),
+  modifiedAt: safe('date'),
+  fiscalYear: safe('year'),
+
+  // ── Statuses, enums, flags ────────────────────────────────────────────────
+  status: safe('enum'),
+  step: safe('enum'),
+  type: safe('enum'),
+  types: safe('enum list'),
+  sensitivity: safe('enum — and the migration test depends on it'),
+  shareability: safe('enum'),
+  methodology: safe('enum'),
+  methodologies: safe('enum list'),
+  mediums: safe('enum list'),
+  purposes: safe('enum list'),
+  roles: safe('enum list'),
+  agreementStatus: safe('enum'),
+  mouStatus: safe('enum'),
+  financialReportPeriod: safe('enum'),
+  financialReportingType: safe('enum'),
+  financialReportingTypes: safe('enum list'),
+  approvedPrograms: safe('enum list'),
+  progressStepMeasurement: safe('enum'),
+  reach: safe('enum'),
+  active: safe('boolean'),
+  primary: safe('boolean'),
+  public: safe('boolean'),
+  canDelete: safe('boolean'),
+  completed: safe('number or boolean'),
+  composite: safe('boolean'),
+  marketable: safe('boolean'),
+  presetInventory: safe('boolean'),
+  leastOfThese: safe('boolean'),
+  globalInnovationsClient: safe('boolean'),
+  openToInvestorVisit: safe('boolean'),
+  isDialect: safe('boolean'),
+  isSignLanguage: safe('boolean'),
+  isOverriding: safe('boolean'),
+  isAvailableForReporting: safe('boolean'),
+  hasExternalFirstScripture: safe('boolean'),
+  aiBased: safe('boolean'),
+  usingAIAssistedTranslation: safe('boolean'),
+  lukePartnership: safe('boolean'),
+  tags: safe('short app-level labels'),
+  mimeType: safe('media type'),
+  size: safe('byte count'),
+
+  // ── Numbers and measurements ──────────────────────────────────────────────
+  population: safe('language population estimate, aggregate'),
+  populationOverride: safe('aggregate'),
+  totalVerses: safe('count'),
+  totalVerseEquivalents: safe('count'),
+  unspecifiedScripture: safe('count'),
+  progressTarget: safe('number'),
+  planned: safe('number'),
+  milestonePlanned: safe('number'),
+  milestoneReached: safe('number'),
+
+  // ── Structural — connections to other records ─────────────────────────────
+  PartnershipProducingMedium: structural,
+  agreement: structural,
+  agreementNode: structural,
+  budget: structural,
+  ceremony: structural,
+  changeset: structural,
+  child: structural,
+  comment: structural,
+  commentThread: structural,
+  countries: structural,
+  countryOfOrigin: structural,
+  createdBy: structural,
+  creator: safe(
+    'either a User link or a Property holding a user id — an id either way',
+  ),
+  defaultFieldRegion: structural,
+  defaultMarketingRegion: structural,
+  departmentIdBlock: structural,
+  director: structural,
+  education: structural,
+  engagement: structural,
+  ethnologue: structural,
+  fieldRegion: structural,
+  fieldRegions: structural,
+  fileNode: structural,
+  financialApprover: structural,
+  firstScripture: structural,
+  fundingAccount: structural,
+  growthPlan: structural,
+  growthPlanNode: structural,
+  intern: structural,
+  language: structural,
+  locations: structural,
+  mapImage: structural,
+  mapImageNode: structural,
+  marketingLocation: structural,
+  media: structural,
+  member: structural,
+  mentor: structural,
+  mou: structural,
+  mouNode: structural,
+  narrativeFile: structural,
+  narrativeFileNode: structural,
+  organization: structural,
+  owningOrganization: structural,
+  parent: structural,
+  partner: structural,
+  partnership: structural,
+  photo: structural,
+  photoNode: structural,
+  pinned: structural,
+  pnp: structural,
+  pnpData: structural,
+  pnpExtractionResult: structural,
+  pnpNode: structural,
+  pointOfContact: structural,
+  post: structural,
+  primaryLocation: structural,
+  primaryOrganization: structural,
+  problem: structural,
+  produces: structural,
+  product: structural,
+  progress: structural,
+  record: structural,
+  report: structural,
+  reportFile: structural,
+  reportFileNode: structural,
+  rootDirectory: structural,
+  scriptureReferences: structural,
+  scriptureReferencesOverride: structural,
+  steps: structural,
+  summary: structural,
+  tool: structural,
+  unavailability: structural,
+  universalTemplateFile: structural,
+  universalTemplateFileNode: structural,
+  user: structural,
+  uses: structural,
+  varianceExplanation: structural,
+  who: structural,
+  workflowEvent: structural,
+  zone: structural,
+
+  // ── Present locally but NOT in production (added 2026-07-31) ──────────────
+  // The first dry run surfaced 30 names the production catalog does not contain.
+  // Two causes, and both mean a production snapshot was never a sufficient basis
+  // for this file:
+  //   * features that have not shipped yet (`marketingRegionOverride`)
+  //   * things production has none of, but dev exercises — notification
+  //     `recipient` edges being the case we already measured at zero in prod
+  //   * dead schema from removed features, still in a dev graph
+  // Each was probed for what it actually points at rather than guessed from its
+  // name — `fieldZoneId` is a LINK to a FieldZone despite reading like an id, and
+  // `strategicAlliances` points at BOTH a Property and a Partner.
+  producer: structural,
+  recipient: structural,
+  appliedBy: structural,
+  container: structural,
+  fieldZone: structural,
+  fieldZoneId: structural,
+  alliance: structural,
+  allianceMembers: structural,
+  marketingRegionOverride: structural,
+  languageOfWiderCommunication: structural,
+  languageOfReporting: structural,
+  languagesOfConsulting: structural,
+  isLanguageOfWiderCommunication: safe('boolean'),
+  isLanguageOfReporting: safe('boolean'),
+  isWiderComm: safe('boolean, legacy spelling of the above'),
+  applied: safe('changeset boolean'),
+  editable: safe('changeset boolean'),
+  appliedById: safe('holds an id'),
+  appliedDate: safe('date'),
+  joinedAt: safe('date'),
+  gtlId: safe('external reference, dead in the codebase'),
+  completedMilestone: safe('number'),
+  adjustedAmount: safe('budget figure — consistent with the `amount` decision'),
+  strategicAlliances: scrub(
+    'prose',
+    'dead in the codebase and absent from production, and it points at BOTH a Property and a Partner. Unknown content gets scrubbed rather than passed through: over-scrubbing a field nobody reads costs nothing, under-scrubbing leaks.',
+  ),
+
+  // ── Resolved 2026-07-31 (Rob): leave all of these ─────────────────────────
+  // These were raised as blocking questions and all eleven were decided the same
+  // day. Kept as their own group, with the reasoning, so a future reviewer sees a
+  // decision rather than an oversight.
+  gender: safe(
+    'DECIDED (Rob 2026-07-31): leave. Personal but a small enum — swapping one value for another protects little. I had recommended scrubbing; overruled, and the reasoning holds either way.',
+  ),
+  accountNumber: safe(
+    'DECIDED (Rob 2026-07-31): leave. A SecuredInt internal accounting code, NOT a bank account despite the name, and it carries a uniqueness test the migration measures.',
+  ),
+  amount: safe(
+    'DECIDED (Rob 2026-07-31): leave. Organizational budget figures, not donations, so outside the donor-amount rule.',
+  ),
+  initialAmount: safe('DECIDED (Rob 2026-07-31): leave. See `amount`.'),
+  preApprovedAmount: safe('DECIDED (Rob 2026-07-31): leave. See `amount`.'),
+  code: safe(
+    'DECIDED (Rob 2026-07-31): leave. ISO 639-3 and registry codes are published standards, and scrambling them would destroy the duplicate-code evidence behind the migration-0030 index drops. Applies to the four sibling code fields below.',
+  ),
+  provisionalCode: safe('DECIDED (Rob 2026-07-31): leave. See `code`.'),
+  registryOfDialectsCode: safe('DECIDED (Rob 2026-07-31): leave. See `code`.'),
+  registryOfLanguageVarietiesCode: safe(
+    'DECIDED (Rob 2026-07-31): leave. See `code`.',
+  ),
+  signLanguageCode: safe('DECIDED (Rob 2026-07-31): leave. See `code`.'),
+};
+
+/**
+ * Direct properties on nodes and relationships (81 keys in production).
+ *
+ * ⚠ `db.propertyKeys()` returns every key that has EVER existed, not what is in
+ * use. `commentDescription`, `commentPrayerNeeds` and `commentProposalComments`
+ * are listed there and exist on **0 of 5,264 projects** — the 2021 migration
+ * removed them. Verified, so they are `delete` rather than `scrub`. A key with no
+ * live values must not sit on this list demanding review forever.
+ */
+export const properties: Readonly<Record<string, Action>> = {
+  // ── Dead 2021 migration artifacts ─────────────────────────────────────────
+  '87SixId': {
+    kind: 'delete',
+    why: 'join key for the Aug-2021 import from 87Six, the system Cord v3 replaced. On 2,210 of 5,264 projects (only those existing at import), nothing has written it since, nothing reads it, and there is no live system on the other end.',
+  },
+  v2User: {
+    kind: 'delete',
+    why: 'old-system actor id on field-history records. 4,546 values, 106 distinct, fixed 24 chars, none contain "@" — opaque, not a name. Nothing reads it and the migration does not carry it.',
+  },
+  finalReportMigration: {
+    kind: 'delete',
+    why: 'rollback marker from the same 2021 effort. 7,738 reports, exactly ONE distinct value. Not data.',
+  },
+  postMigration: {
+    kind: 'delete',
+    why: 'rollback marker set by 87SixComments.migration.ts, "in case of reversion". Never reverted.',
+  },
+  commentDescription: {
+    kind: 'delete',
+    why: 'imported from 87Six, converted to posts and removed in 2021. Verified 0 of 5,264 projects.',
+  },
+  commentPrayerNeeds: {
+    kind: 'delete',
+    why: 'as commentDescription. Would be genuinely sensitive if any survived — none do.',
+  },
+  commentProposalComments: {
+    kind: 'delete',
+    why: 'as commentDescription.',
+  },
+  migrated: { kind: 'delete', why: 'migration marker' },
+  migration: { kind: 'delete', why: 'migration marker' },
+
+  // ── The polymorphic one — resolved through `links` above ───────────────────
+  value: safe('sensitivity is decided by the link pointing at it, see `links`'),
+  // Snake case because these are Neo4j's own property names, not ours — the keys
+  // in this object must match the graph exactly or the guard cannot find them.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  deleted_value: safe('as `value`, on a soft-deleted field record'),
+  sortValue: safe('a derived sort key — regenerated from the scrubbed value'),
+
+  // ── Free text held directly on a node ─────────────────────────────────────
+  notes: scrub('richText', 'workflow event notes — 0 in prod today, but wired'),
+  caption: scrub('prose', 'media caption'),
+  response: scrub(
+    'richText',
+    'prompt answers — 23,815 in prod, the largest set',
+  ),
+
+  // ── Credentials ───────────────────────────────────────────────────────────
+  secret: scrub('credential', 'webhook signing secret — live in a dump'),
+  token: scrub(
+    'credential',
+    'session and password-reset tokens — live in a dump',
+  ),
+
+  // ── Identifiers, dates, structure ─────────────────────────────────────────
+  id: safe('opaque nanoid'),
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  deleted_id: safe('opaque'),
+  originalParentId: safe('opaque'),
+  property: safe('internal field name'),
+  key: safe('slug'),
+  createdAt: safe('date'),
+  createdOn: safe('date'),
+  modifiedAt: safe('date'),
+  deletedAt: safe('date'),
+  lastUsedAt: safe('date'),
+  primarySchemaUpdateAt: safe('date'),
+  v2Timestamp: safe('date'),
+  read: safe('read-state date on a notification recipient link'),
+  active: safe('boolean'),
+  edit: safe('boolean'),
+  valid: safe('boolean'),
+  mimeType: safe('media type'),
+  departmentId: safe('finance code'),
+
+  // ── Numbers, enums, machine output ────────────────────────────────────────
+  actual: safe('number'),
+  planned: safe('number'),
+  progressActual: safe('number'),
+  progressPlanned: safe('number'),
+  variance: safe('number'),
+  totalVerses: safe('count'),
+  duration: safe('number'),
+  height: safe('pixels'),
+  width: safe('pixels'),
+  year: safe('year'),
+  quarter: safe('number'),
+  // Also link names — separate namespace. As direct properties these are the
+  // verse bounds on a ScriptureRange.
+  start: safe('scripture range start verse'),
+  end: safe('scripture range end verse'),
+  period: safe('enum'),
+  pnpIndex: safe('spreadsheet row index'),
+  book: safe('Bible book name — a published canon, not project data'),
+  medium: safe('enum'),
+  methodology: safe('enum'),
+  category: safe('enum'),
+  type: safe('enum'),
+  status: safe('enum'),
+  step: safe('enum'),
+  to: safe('enum — a workflow event target step'),
+  transition: safe('enum'),
+  variant: safe('enum'),
+  role: safe('enum'),
+  roles: safe('enum list'),
+  powers: safe('enum list'),
+  projectTypes: safe('enum list'),
+  programs: safe('enum list'),
+  source: safe('enum'),
+  severity: safe('enum'),
+  countError: safe('count'),
+  countNotice: safe('count'),
+  countWarning: safe('count'),
+  hasError: safe('boolean'),
+  hasNotice: safe('boolean'),
+  hasWarning: safe('boolean'),
+  hadNaN: safe('boolean'),
+  blocks: safe('JSON ranges of department-id numbers, no free text'),
+  subscription: safe('a GraphQL document, app-authored'),
+  url: safe('webhook target URL, app config not user content'),
+  creator: safe('holds a user id'),
+  name: scrub(
+    'entityName',
+    'direct on SystemAgent and on file nodes — a file name can carry a person’s name',
+  ),
+
+  // ── Present locally but NOT in production (added 2026-07-31) ──────────────
+  // Probed on the local graph rather than inferred from the names.
+  readAt: safe('date, carried on the notification recipient edge'),
+  photo: safe('holds a file id, on User'),
+  public: safe('boolean, on File'),
+  message: scrub(
+    'prose',
+    'SystemNotification text. App-authored, but these templates interpolate the thing they are about, so a name can ride along. Nothing depends on the wording.',
+  ),
+  createdBy: scrub(
+    'prose',
+    'on the department-id nodes, 10 values, no references anywhere in the codebase — so its content is genuinely unknown. Scrubbed on the when-in-doubt rule.',
+  ),
+  comment: scrub(
+    'prose',
+    'registry ghost — 0 live values locally and absent from production. Classified as scrub rather than safe so that if it ever gains values, free text under this name does not pass through unnoticed.',
+  ),
+
+  // ── Resolved 2026-07-31 (Rob): leave both ─────────────────────────────────
+  // ⚠ RESIDUAL RISK, recorded rather than re-argued. Both hold spreadsheet
+  // extraction output. It is machine-generated, which is why leaving it is
+  // reasonable — but templated messages interpolate the cells that triggered
+  // them, so if any planning spreadsheet carries narrative text, a fragment could
+  // survive here. Nobody has read the real values.
+  //
+  // Mitigation that needs no one to read anything: the verify pass counts long
+  // free-text runs inside these two blobs and reports the COUNT per field. Zero
+  // closes the question outright. Non-zero is a signal to revisit, without ever
+  // surfacing a value. Cheaper than an inspection and repeats on every refresh.
+  context: safe(
+    'DECIDED (Rob 2026-07-31): leave. Machine-generated extraction render context. Watched by the verify pass free-text probe.',
+  ),
+  problems: safe(
+    'DECIDED (Rob 2026-07-31): leave. Machine-generated extraction messages. Watched by the verify pass free-text probe.',
+  ),
+};
+
+/**
+ * Emptied in a dedicated pass that runs BEFORE the main scrub, so an interrupted
+ * run cannot leave working credentials behind. Passwords are set to one known dev
+ * value rather than emptied — it is the only way to log in to the copy.
+ */
+export const credentialLinks = ['password', 'token'] as const;
+export const credentialProperties = ['secret', 'token'] as const;
+
+export interface UnclassifiedReport {
+  readonly links: readonly string[];
+  readonly properties: readonly string[];
+  readonly unresolvedReviews: readonly string[];
+}
+
+/**
+ * The guard. Compare the live graph against this file; anything unlisted, or any
+ * `review` still unanswered, stops the scrub.
+ *
+ * Deliberately reports EVERYTHING wrong at once rather than failing on the first
+ * problem — whoever fixes this wants the whole list, not one entry per run.
+ */
+export const findUnclassified = (
+  liveLinkTypes: readonly string[],
+  livePropertyKeys: readonly string[],
+): UnclassifiedReport => ({
+  links: liveLinkTypes.filter((type) => !(type in links)),
+  properties: livePropertyKeys.filter((key) => !(key in properties)),
+  unresolvedReviews: [...Object.entries(links), ...Object.entries(properties)]
+    .filter(([, action]) => action.kind === 'review')
+    .map(([name]) => name),
+});

--- a/src/core/scrub/fake.spec.ts
+++ b/src/core/scrub/fake.spec.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from '@jest/globals';
+import { RichTextDocument } from '~/common';
+import { fakeValue } from './fake';
+
+/**
+ * The properties the scrub depends on, tested rather than assumed.
+ *
+ * Determinism and distinctness are not cosmetic here: determinism is what keeps a
+ * monthly refresh usable and what preserves the duplicate-name finding the
+ * migration test measures, and distinctness is what stops a unique constraint
+ * aborting a load. Both are easy to break with a small edit to `fake.ts`, and
+ * neither would be obvious from reading the output.
+ */
+describe('scrub fake values', () => {
+  describe('determinism', () => {
+    it('gives the same replacement for the same input, every time', () => {
+      const once = fakeValue('personName', 'Some Person');
+      const twice = fakeValue('personName', 'Some Person');
+      expect(once).toBe(twice);
+      expect(once).not.toBe('Some Person');
+    });
+
+    it('is stable across every strategy', () => {
+      const strategies = [
+        'personName',
+        'entityName',
+        'languageName',
+        'email',
+        'phone',
+        'address',
+        'prose',
+      ] as const;
+      for (const strategy of strategies) {
+        expect(fakeValue(strategy, 'input value')).toBe(
+          fakeValue(strategy, 'input value'),
+        );
+      }
+    });
+
+    it('does not let one call bleed into the next', () => {
+      // faker is seeded globally, so an interleaved call could shift the sequence
+      // and make results depend on call ORDER rather than input.
+      const isolated = fakeValue('personName', 'A');
+      fakeValue('entityName', 'unrelated');
+      fakeValue('prose', 'unrelated and longer text here');
+      expect(fakeValue('personName', 'A')).toBe(isolated);
+    });
+  });
+
+  describe('duplicate preservation', () => {
+    it('maps two records sharing a name to the same fake name', () => {
+      // Production has projects sharing a name. That duplication is a finding the
+      // migration measures, so the scrub must not quietly resolve it.
+      expect(fakeValue('entityName', 'Shared Name')).toBe(
+        fakeValue('entityName', 'Shared Name'),
+      );
+    });
+
+    it('keeps distinct inputs distinct, so unique constraints survive', () => {
+      const generated = new Set(
+        Array.from({ length: 2000 }, (_, i) =>
+          fakeValue('entityName', `project number ${i}`),
+        ),
+      );
+      expect(generated.size).toBe(2000);
+    });
+  });
+
+  describe('replacements are not mistakable for real data', () => {
+    it('puts emails on the reserved non-routable domain', () => {
+      const email = fakeValue('email', 'someone@real-domain.org');
+      expect(email).toMatch(/@example\.invalid$/);
+      expect(email).not.toContain('real-domain');
+    });
+
+    it('keeps emails unique — the column is uniquely indexed', () => {
+      const generated = new Set(
+        Array.from({ length: 2000 }, (_, i) =>
+          fakeValue('email', `person${i}@example.org`),
+        ),
+      );
+      expect(generated.size).toBe(2000);
+    });
+
+    it('puts phone numbers in the reserved fictional block', () => {
+      expect(fakeValue('phone', '+1 402 555 8721')).toContain('555 01');
+    });
+
+    it('empties credentials rather than inventing plausible ones', () => {
+      expect(
+        fakeValue('credential', '$argon2id$v=19$m=65536,t=3,p=4$abc'),
+      ).toBeNull();
+    });
+  });
+
+  describe('prose', () => {
+    it('stays close to the original length', () => {
+      const original = 'a'.repeat(240);
+      const scrubbed = fakeValue('prose', original)!;
+      expect(scrubbed).not.toContain('aaa');
+      expect(scrubbed.length).toBeGreaterThan(original.length * 0.8);
+      expect(scrubbed.length).toBeLessThanOrEqual(original.length);
+    });
+
+    it('leaves an empty value empty', () => {
+      expect(fakeValue('prose', '')).toBe('');
+    });
+  });
+
+  describe('rich text', () => {
+    const stored = RichTextDocument.serialize(
+      RichTextDocument.from({
+        version: '2.25.0',
+        time: 1700000000000,
+        blocks: [
+          {
+            id: 'one',
+            type: 'paragraph',
+            data: { text: 'Sensitive first line.' },
+          },
+          {
+            id: 'two',
+            type: 'paragraph',
+            data: { text: 'Sensitive second line.' },
+          },
+        ],
+      }),
+    );
+
+    it('keeps the document shape and drops the words', () => {
+      const scrubbed = fakeValue('richText', stored)!;
+      expect(RichTextDocument.isSerialized(scrubbed)).toBe(true);
+
+      const doc = RichTextDocument.fromSerialized(scrubbed) as unknown as {
+        version: string;
+        blocks: Array<{ id: string; type: string; data: { text: string } }>;
+      };
+      expect(doc.version).toBe('2.25.0');
+      expect(doc.blocks).toHaveLength(2);
+      expect(doc.blocks.map((block) => block.id)).toEqual(['one', 'two']);
+      expect(doc.blocks.map((block) => block.type)).toEqual([
+        'paragraph',
+        'paragraph',
+      ]);
+      expect(scrubbed).not.toContain('Sensitive');
+      expect(doc.blocks[0]!.data.text).not.toBe(doc.blocks[1]!.data.text);
+    });
+
+    it('re-serializes with the prefix the database expects', () => {
+      // Postgres jsonb cannot hold a NUL byte, so a value that keeps the stored
+      // form must keep it exactly — half-converted is a hard insert failure later.
+      expect(fakeValue('richText', stored)!.startsWith('\0RichText\0')).toBe(
+        true,
+      );
+    });
+
+    it('still replaces a value it cannot parse', () => {
+      // A field we cannot read is still a field we must not leave in place.
+      const notJson = '\0RichText\0{ this is not valid json';
+      const scrubbed = fakeValue('richText', notJson)!;
+      expect(scrubbed).not.toContain('not valid json');
+    });
+  });
+});

--- a/src/core/scrub/fake.spec.ts
+++ b/src/core/scrub/fake.spec.ts
@@ -154,6 +154,65 @@ describe('scrub fake values', () => {
       );
     });
 
+    it('handles the OBJECT form, which is what the database read actually yields', () => {
+      // The regression that mattered. The Neo4j read transformer converts a stored
+      // rich-text string into a RichTextDocument object, so this — not the string
+      // above — is the shape production data arrives in. The first version
+      // stringified it to the constant '[object RichText]', so every document in
+      // the graph collapsed to the same generated text and lost its blocks, and
+      // the ETL then dropped 30 of 32 comments as unparseable.
+      const asObject = RichTextDocument.fromSerialized(stored);
+      const scrubbed = fakeValue('richText', asObject)!;
+
+      expect(RichTextDocument.isSerialized(scrubbed)).toBe(true);
+      const doc = RichTextDocument.fromSerialized(scrubbed) as unknown as {
+        blocks: Array<{ id: string; data: { text: string } }>;
+      };
+      expect(doc.blocks).toHaveLength(2);
+      expect(doc.blocks.map((block) => block.id)).toEqual(['one', 'two']);
+      expect(scrubbed).not.toContain('Sensitive');
+      expect(scrubbed).not.toContain('object RichText');
+    });
+
+    it('gives two different documents two different results', () => {
+      // The symptom that would have caught the bug from the outside: every row
+      // collapsing to one value. Distinct inputs must stay distinct even as objects.
+      const first = RichTextDocument.fromSerialized(stored);
+      const second = RichTextDocument.fromSerialized(
+        RichTextDocument.serialize(
+          RichTextDocument.from({
+            version: '2.25.0',
+            time: 1700000000000,
+            blocks: [
+              {
+                id: 'x',
+                type: 'paragraph',
+                data: { text: 'Totally other text.' },
+              },
+            ],
+          }),
+        ),
+      );
+      expect(fakeValue('richText', first)).not.toBe(
+        fakeValue('richText', second),
+      );
+    });
+
+    it('turns a plain string into a VALID document, not bare text', () => {
+      // A rich-text column has to hold rich text. Emitting a plain string is what
+      // made the value unloadable, so the fallback repairs the shape.
+      const scrubbed = fakeValue('richText', 'just a plain string')!;
+      expect(RichTextDocument.isSerialized(scrubbed)).toBe(true);
+      expect(scrubbed).not.toContain('just a plain string');
+    });
+
+    it('refuses to stringify an object for a non-richText strategy', () => {
+      // The guard that stops this class of bug recurring on another field.
+      expect(() => fakeValue('prose', { some: 'object' })).toThrow(
+        /received an object/,
+      );
+    });
+
     it('still replaces a value it cannot parse', () => {
       // A field we cannot read is still a field we must not leave in place.
       const notJson = '\0RichText\0{ this is not valid json';

--- a/src/core/scrub/fake.spec.ts
+++ b/src/core/scrub/fake.spec.ts
@@ -219,5 +219,43 @@ describe('scrub fake values', () => {
       const scrubbed = fakeValue('richText', notJson)!;
       expect(scrubbed).not.toContain('not valid json');
     });
+
+    describe('one link name, two value types', () => {
+      // `description` is rich text on an engagement and a plain string on a
+      // product, a tool and an unavailability. The classification keys on the
+      // link name, so a single strategy serves all of them and has to decide from
+      // the value. Getting this wrong is not cosmetic: a document written where a
+      // string was, or the reverse, breaks every read of that field.
+      it('keeps the document shape when the value is rich text', () => {
+        const scrubbed = fakeValue(
+          'proseOrRichText',
+          RichTextDocument.fromSerialized(stored),
+        )!;
+
+        expect(RichTextDocument.isSerialized(scrubbed)).toBe(true);
+        const doc = RichTextDocument.fromSerialized(scrubbed) as unknown as {
+          blocks: Array<{ id: string; data: { text: string } }>;
+        };
+        expect(doc.blocks.map((block) => block.id)).toEqual(['one', 'two']);
+        expect(scrubbed).not.toContain('Sensitive');
+      });
+
+      it('returns a plain string when the value is a plain string', () => {
+        const scrubbed = fakeValue('proseOrRichText', 'A tool description.')!;
+
+        expect(typeof scrubbed).toBe('string');
+        expect(RichTextDocument.isSerialized(scrubbed)).toBe(false);
+        expect(scrubbed).not.toContain('tool description');
+      });
+
+      it('does not throw on the object form the plain strategy refuses', () => {
+        // The failure this strategy exists to fix: `prose` guards against objects
+        // on purpose, and pointing it at `description` stopped a full scrub run
+        // partway through.
+        expect(() =>
+          fakeValue('proseOrRichText', RichTextDocument.fromSerialized(stored)),
+        ).not.toThrow();
+      });
+    });
   });
 });

--- a/src/core/scrub/fake.ts
+++ b/src/core/scrub/fake.ts
@@ -1,0 +1,176 @@
+import { faker } from '@faker-js/faker';
+import { createHash } from 'node:crypto';
+import { RichTextDocument } from '~/common';
+import { type Strategy } from './classification';
+
+/**
+ * Deterministic replacement values.
+ *
+ * Every generator is a pure function of (strategy, original value). Two
+ * consequences, both load-bearing:
+ *
+ *  - **Refreshes are stable.** The same person keeps the same fake name across
+ *    monthly rebuilds, so a bookmark, screenshot or ticket from last month still
+ *    points at something recognizable.
+ *  - **Duplicates survive.** Production contains projects sharing a name, and
+ *    that duplication is a finding the migration test measures. Because identical
+ *    inputs produce identical outputs, the duplicate is preserved rather than
+ *    accidentally resolved by the scrub.
+ *
+ * The mirror of that: **distinct inputs produce distinct outputs**, guaranteed by
+ * appending a hash suffix wherever the real value carried a uniqueness
+ * constraint. A collision there would abort a load, so it is built in rather
+ * than left to luck — 40 bits over a few thousand values is a ~1-in-100,000 risk,
+ * against a birthday collision on plain generated names being near-certain.
+ */
+
+/** 48 bits of the digest — deterministic, and inside the safe integer range. */
+const seedOf = (strategy: string, value: string): number =>
+  parseInt(
+    createHash('sha256')
+      .update(`${strategy}\0${value}`)
+      .digest('hex')
+      .slice(0, 12),
+    16,
+  );
+
+/** Stable suffix that makes a generated value unique to its input. */
+const tagOf = (value: string): string =>
+  createHash('sha256').update(value).digest('hex').slice(0, 10);
+
+const seeded = <T>(strategy: string, value: string, make: () => T): T => {
+  faker.seed(seedOf(strategy, value));
+  return make();
+};
+
+/**
+ * Prose of comparable length — length matters because it drives rich-text
+ * structure and column sizing, which is part of what a migration rehearsal is
+ * measuring. Trimmed at a word boundary so the result reads as text.
+ */
+const proseLike = (value: string): string => {
+  const target = value.length;
+  return seeded('prose', value, () => {
+    let out = '';
+    while (out.length < target) {
+      out += (out ? ' ' : '') + faker.lorem.sentence();
+    }
+    if (out.length <= target) return out;
+    const cut = out.slice(0, target);
+    const lastSpace = cut.lastIndexOf(' ');
+    return (lastSpace > target * 0.6 ? cut.slice(0, lastSpace) : cut).trimEnd();
+  });
+};
+
+/**
+ * Rich text keeps its document shape — same block count, same block types, same
+ * ids — and only the words inside change. A reader of the copy sees a document
+ * that behaves like the original; nothing of what was written survives.
+ *
+ * Returns the re-serialized string (NUL-prefixed), because that is the form the
+ * database stores. Anything unparseable comes back as a plain prose replacement:
+ * a value we cannot read is still a value we must not leave in place.
+ */
+const richTextLike = (stored: string): string => {
+  if (!RichTextDocument.isSerialized(stored)) return proseLike(stored);
+  let doc: RichTextDocument;
+  try {
+    doc = RichTextDocument.fromSerialized(stored);
+  } catch {
+    return proseLike(stored);
+  }
+  const raw = doc as unknown as { blocks?: unknown[] };
+  const blocks = Array.isArray(raw.blocks) ? raw.blocks : [];
+  const scrubbedBlocks = blocks.map((block) => {
+    if (block === null || typeof block !== 'object') return block;
+    const data = (block as { data?: unknown }).data;
+    if (data === null || typeof data !== 'object') return block;
+    const text = (data as { text?: unknown }).text;
+    if (typeof text !== 'string') return block;
+    return {
+      ...block,
+      data: { ...data, text: proseLike(text) },
+    };
+  });
+  return RichTextDocument.serialize(
+    RichTextDocument.from({
+      ...(raw as object),
+      blocks: scrubbedBlocks,
+    } as any),
+  );
+};
+
+/**
+ * Replacement for one value.
+ *
+ * `credential` returns null — emptied rather than faked. A plausible-looking
+ * secret still reads as a secret and invites someone to try it. Passwords are the
+ * exception and are handled by the caller, which writes one known development
+ * hash so the copy can actually be logged into.
+ */
+export const fakeValue = (
+  strategy: Strategy,
+  original: unknown,
+): string | null => {
+  if (strategy === 'credential') return null;
+  const value =
+    typeof original === 'string' ? original : String(original ?? '');
+  if (value === '') return value;
+
+  switch (strategy) {
+    case 'personName':
+      // No uniqueness constraint on people's names, so no suffix — real name
+      // collisions exist and should be allowed to exist here too.
+      return seeded('personName', value, () => faker.person.fullName());
+
+    case 'entityName':
+      return `${seeded('entityName', value, () =>
+        faker.company.name(),
+      )} ${tagOf(value)}`;
+
+    case 'languageName':
+      // Deliberately not faker's language list: a real language name would be
+      // indistinguishable from unscrubbed data, and someone WILL eventually ask
+      // whether a copy was scrubbed. An invented word cannot be mistaken.
+      return `${seeded('languageName', value, () =>
+        faker.word.adjective(),
+      )}-${tagOf(value).slice(0, 6)}`;
+
+    case 'email':
+      // `.invalid` is reserved by RFC 2606 and cannot resolve, so a stray dev
+      // notification can never reach a real person.
+      return `${seeded('email', value, () =>
+        faker.internet
+          .username()
+          .toLowerCase()
+          .replace(/[^a-z0-9._-]/g, ''),
+      )}.${tagOf(value).slice(0, 8)}@example.invalid`;
+
+    case 'phone':
+      // 555-01xx is the reserved fictional block — not dialable.
+      return `+1 555 01${(seedOf('phone', value) % 100)
+        .toString()
+        .padStart(2, '0')}`;
+
+    case 'address':
+      return seeded(
+        'address',
+        value,
+        () => `${faker.location.streetAddress()}, ${faker.location.city()}`,
+      );
+
+    case 'prose':
+      return proseLike(value);
+
+    case 'richText':
+      return richTextLike(value);
+  }
+};
+
+/**
+ * `sortValue` on a field record is derived from its value, so it has to be
+ * regenerated alongside — otherwise the original leaks through the sort key,
+ * which is the kind of thing a field-by-field review misses.
+ */
+export const sortValueFor = (scrubbed: string | null): string | null =>
+  scrubbed === null ? null : scrubbed;

--- a/src/core/scrub/fake.ts
+++ b/src/core/scrub/fake.ts
@@ -71,15 +71,42 @@ const proseLike = (value: string): string => {
  * database stores. Anything unparseable comes back as a plain prose replacement:
  * a value we cannot read is still a value we must not leave in place.
  */
-const richTextLike = (stored: string): string => {
-  if (!RichTextDocument.isSerialized(stored)) return proseLike(stored);
-  let doc: RichTextDocument;
-  try {
-    doc = RichTextDocument.fromSerialized(stored);
-  } catch {
-    return proseLike(stored);
+const richTextLike = (original: unknown): string => {
+  // Resolve to a document object, from whichever of the three shapes arrived.
+  //
+  // THE OBJECT CASE IS THE NORMAL ONE, and missing it was a real bug: the Neo4j
+  // connection installs a read transformer, so a stored rich-text string arrives
+  // here as a RichTextDocument *object*. The first version only handled strings
+  // and fell through to `String(original)` — which, because the class sets a
+  // toStringTag, yields the constant '[object RichText]' for every row. Every
+  // body in the graph collapsed to the same generated text and lost its
+  // structure, and the ETL then dropped 30 of 32 comments because it could no
+  // longer parse them. Exactly the mistake the project extractor's notes field
+  // had, made again one layer down.
+  let raw: { blocks?: unknown[] } | undefined;
+  if (original !== null && typeof original === 'object') {
+    raw = original as { blocks?: unknown[] };
+  } else if (RichTextDocument.isSerialized(original)) {
+    try {
+      raw = RichTextDocument.fromSerialized(original) as unknown as {
+        blocks?: unknown[];
+      };
+    } catch {
+      raw = undefined;
+    }
   }
-  const raw = doc as unknown as { blocks?: unknown[] };
+
+  // Anything with no usable document — a plain string, or JSON we couldn't read —
+  // becomes a VALID single-block document rather than bare text. A rich-text
+  // column has to hold rich text: emitting a plain string is what made the value
+  // unloadable in the first place. This also repairs a field previously mangled
+  // by that bug, instead of leaving it permanently unparseable.
+  if (!raw || !Array.isArray(raw.blocks)) {
+    const text = typeof original === 'string' ? original : '';
+    return RichTextDocument.serialize(
+      RichTextDocument.fromText(proseLike(text || 'placeholder')),
+    );
+  }
   const blocks = Array.isArray(raw.blocks) ? raw.blocks : [];
   const scrubbedBlocks = blocks.map((block) => {
     if (block === null || typeof block !== 'object') return block;
@@ -113,9 +140,25 @@ export const fakeValue = (
   original: unknown,
 ): string | null => {
   if (strategy === 'credential') return null;
+  // richText BEFORE the string coercion below. It is the one strategy whose input
+  // legitimately arrives as an object, and `String()`-ing that object is what
+  // collapsed every document to one value and destroyed the structure.
+  if (strategy === 'richText') {
+    return original == null ? null : richTextLike(original);
+  }
   const value =
     typeof original === 'string' ? original : String(original ?? '');
   if (value === '') return value;
+  // A non-string that survives to here would be silently stringified — which is
+  // how the richText bug hid. Nothing else is expected to be an object, so say so
+  // loudly rather than generating from '[object Object]'.
+  if (typeof original === 'object') {
+    throw new Error(
+      `Strategy '${strategy}' received an object, not a string. Values arriving ` +
+        `as objects need explicit handling (see richText) — generating from a ` +
+        `stringified object silently collapses every row to one value.`,
+    );
+  }
 
   switch (strategy) {
     case 'personName':
@@ -161,10 +204,10 @@ export const fakeValue = (
 
     case 'prose':
       return proseLike(value);
-
-    case 'richText':
-      return richTextLike(value);
   }
+  // No `richText` case: it returns above, before the string coercion, because its
+  // input is legitimately an object. TypeScript enforces that this switch is
+  // exhaustive over what remains.
 };
 
 /**

--- a/src/core/scrub/fake.ts
+++ b/src/core/scrub/fake.ts
@@ -146,6 +146,16 @@ export const fakeValue = (
   if (strategy === 'richText') {
     return original == null ? null : richTextLike(original);
   }
+  // Also before the coercion, and for the same reason: this one's input may or
+  // may not be an object, so it decides from the value in hand. The replacement
+  // must keep the shape it replaces — a document written where a string was would
+  // break every read of that field.
+  if (strategy === 'proseOrRichText') {
+    if (original == null) return null;
+    return typeof original === 'object'
+      ? richTextLike(original)
+      : proseLike(String(original));
+  }
   const value =
     typeof original === 'string' ? original : String(original ?? '');
   if (value === '') return value;

--- a/src/core/scrub/provenance.ts
+++ b/src/core/scrub/provenance.ts
@@ -1,0 +1,189 @@
+import { createHash } from 'node:crypto';
+import { type DatabaseService } from '~/core/neo4j';
+import { links, properties } from './classification';
+
+/**
+ * Data provenance marker, and the gate that reads it.
+ *
+ * The point of this file is that "the copy was scrubbed" stops being a promise
+ * anybody has to remember and becomes something the tooling can check. Without
+ * it, the safety story depends on nobody ever restoring a dump and then getting
+ * distracted — which is exactly the failure that would matter most.
+ *
+ * TWO SIGNALS, because either one alone has a hole:
+ *
+ *  1. **The marker.** Written on a successful scrub. Precise, and records which
+ *     classification produced it.
+ *  2. **A size heuristic.** A graph far larger than any seeded local dataset is
+ *     production-derived by definition. This is the backstop for the case the
+ *     marker cannot cover: someone restores a dump and never runs anything, so
+ *     there is no marker to be missing-or-present — just an unmarked graph that
+ *     looks exactly like a fresh dev database.
+ *
+ * Heuristic first, then marker: a big graph with no marker is refused. A small
+ * graph is assumed to be local test data and allowed, because requiring a marker
+ * everywhere would mean retrofitting every existing dev workflow, and a gate
+ * people have to disable to get work done is a gate that gets disabled.
+ */
+
+const MARKER_LABEL = 'DataProvenance';
+
+/**
+ * The marker's own property names.
+ *
+ * These have to be excluded from the classification guard, and finding out why
+ * took a second run: stamping the marker introduces four new property names into
+ * the graph's registry, so the very next scrub refuses to start on fields it
+ * created itself. A graph could be scrubbed exactly once, ever.
+ *
+ * Kept here rather than added to the classification because that file is a review
+ * artifact about the application's data. Mixing this tool's own bookkeeping into
+ * it would mean a reviewer has to work out which entries are real.
+ */
+export const MARKER_PROPERTY_KEYS: readonly string[] = [
+  'scrubbedAt',
+  'classificationHash',
+  'scrubbedValues',
+  'deletedKeys',
+];
+
+/**
+ * Above this node count, a graph is treated as production-derived.
+ *
+ * Calibration: production has ~5,264 projects and millions of field records;
+ * local test data is a few dozen entities. Any threshold in between works, so
+ * this is deliberately far above realistic seeded data and far below real. Uses
+ * the count store, so it is O(1) regardless of graph size.
+ */
+const PROD_SCALE_NODE_COUNT = 100_000;
+
+export interface Provenance {
+  readonly scrubbedAt: string;
+  readonly classificationHash: string;
+  readonly scrubbedValues: number;
+  readonly deletedKeys: number;
+}
+
+/**
+ * Hash of the classification's DECISIONS. Recorded with the marker so a copy
+ * scrubbed under older rules is identifiable after the rules change — "was this
+ * scrubbed?" is a less useful question than "was it scrubbed under the rules we
+ * have now?".
+ *
+ * Hashes the data, not the source file. Two reasons, the first learned the hard
+ * way: reading the `.ts` alongside the module works in development and throws
+ * once the code is compiled, because the module then lives in `dist/` where no
+ * source file exists. The second is better semantics — reformatting or rewording
+ * a comment should not invalidate every existing copy, while genuinely
+ * reclassifying a field should.
+ *
+ * Sorted, so key order in the file cannot change the hash either.
+ */
+export const classificationHash = (): string => {
+  const canonical = [
+    ...Object.entries(links).map(([name, action]) => ['link', name, action]),
+    ...Object.entries(properties).map(([name, action]) => [
+      'field',
+      name,
+      action,
+    ]),
+  ]
+    .map(
+      ([scope, name, action]) =>
+        `${scope as string}:${name as string}:${JSON.stringify(action)}`,
+    )
+    .sort((a, b) => a.localeCompare(b))
+    .join('\n');
+  return createHash('sha256').update(canonical).digest('hex').slice(0, 16);
+};
+
+export const readProvenance = async (
+  neo4j: DatabaseService,
+): Promise<Provenance | undefined> => {
+  const rows = await neo4j
+    .query<{
+      marker: Provenance;
+    }>(`MATCH (n:\`${MARKER_LABEL}\`) RETURN properties(n) AS marker LIMIT 1`)
+    .run();
+  return rows[0]?.marker;
+};
+
+export const stampProvenance = async (
+  neo4j: DatabaseService,
+  stats: { scrubbedValues: number; deletedKeys: number; at: string },
+): Promise<void> => {
+  await neo4j
+    .query(
+      `MERGE (n:\`${MARKER_LABEL}\`)
+       SET n.scrubbedAt = $at,
+           n.classificationHash = $hash,
+           n.scrubbedValues = $scrubbedValues,
+           n.deletedKeys = $deletedKeys`,
+      {
+        at: stats.at,
+        hash: classificationHash(),
+        scrubbedValues: stats.scrubbedValues,
+        deletedKeys: stats.deletedKeys,
+      },
+    )
+    .run();
+};
+
+const nodeCount = async (neo4j: DatabaseService): Promise<number> => {
+  const rows = await neo4j
+    .query<{ total: number }>('MATCH (n) RETURN count(n) AS total')
+    .run();
+  return Number(rows[0]?.total ?? 0);
+};
+
+export interface GateResult {
+  readonly allowed: boolean;
+  readonly reason: string;
+}
+
+/**
+ * Call before anything reads the graph in bulk — the copy harness and the parity
+ * capture both qualify, because both persist what they read.
+ *
+ * Returns a result rather than throwing so the caller decides how loud to be, and
+ * so the reason can be logged verbatim. A refusal names what to do about it;
+ * a gate that only says "no" gets worked around.
+ */
+export const checkScrubGate = async (
+  neo4j: DatabaseService,
+): Promise<GateResult> => {
+  const provenance = await readProvenance(neo4j);
+  if (provenance) {
+    const current = classificationHash();
+    if (provenance.classificationHash !== current) {
+      return {
+        allowed: false,
+        reason:
+          `This graph was scrubbed under classification ${provenance.classificationHash}, ` +
+          `but the current classification is ${current}. Fields may have been ` +
+          `added or reclassified since. Re-run \`yarn scrub\` before using it.`,
+      };
+    }
+    return {
+      allowed: true,
+      reason: `Scrubbed ${provenance.scrubbedAt} (${provenance.scrubbedValues} values replaced).`,
+    };
+  }
+
+  const total = await nodeCount(neo4j);
+  if (total >= PROD_SCALE_NODE_COUNT) {
+    return {
+      allowed: false,
+      reason:
+        `Refusing to read: ${total.toLocaleString()} nodes is production scale and ` +
+        `there is no scrub marker. If this really is a production copy, run ` +
+        `\`yarn scrub\` first. If it is genuinely test data at this size, stamp it ` +
+        `deliberately rather than lowering this threshold.`,
+    };
+  }
+
+  return {
+    allowed: true,
+    reason: `No marker, ${total.toLocaleString()} nodes — treated as local test data.`,
+  };
+};

--- a/src/core/scrub/provenance.ts
+++ b/src/core/scrub/provenance.ts
@@ -50,12 +50,18 @@ export const MARKER_PROPERTY_KEYS: readonly string[] = [
 /**
  * Above this node count, a graph is treated as production-derived.
  *
- * Calibration: production has ~5,264 projects and millions of field records;
- * local test data is a few dozen entities. Any threshold in between works, so
- * this is deliberately far above realistic seeded data and far below real. Uses
- * the count store, so it is O(1) regardless of graph size.
+ * MEASURED, not guessed — the first version used 100,000 on the assumption that
+ * local test data is "a few dozen entities". It is not: a local graph measured
+ * **100,771 nodes**, because every field is its own node and every edit adds
+ * another version of it. That put the threshold exactly at local scale, so an
+ * ordinary dev database would have been refused — and a gate that blocks routine
+ * work is a gate someone turns off, which is worse than having none.
+ *
+ * 1,000,000 is ~10x that measurement, with production (5,264 projects, 2,353
+ * users, and the field records behind them) comfortably above it. Uses the count
+ * store, so it stays O(1) however large the graph is.
  */
-const PROD_SCALE_NODE_COUNT = 100_000;
+const PROD_SCALE_NODE_COUNT = 1_000_000;
 
 export interface Provenance {
   readonly scrubbedAt: string;

--- a/src/core/scrub/scrub.ts
+++ b/src/core/scrub/scrub.ts
@@ -3,6 +3,7 @@ import { type DatabaseService } from '~/core/neo4j';
 import {
   type Action,
   findUnclassified,
+  isFieldRecord,
   links,
   properties,
 } from './classification';
@@ -110,7 +111,7 @@ const eachFieldValuePage = async (
     ctx,
     (after, pageSize) => [
       `MATCH ()-[:\`${link}\`]->(p)
-       WHERE (p:Property OR p:Deleted_Property) AND p.value IS NOT NULL
+       WHERE ${isFieldRecord('p')} AND p.value IS NOT NULL
          AND id(p) > $after
        RETURN id(p) AS nodeId, p.value AS value
        ORDER BY id(p) LIMIT ${pageSize}`,

--- a/src/core/scrub/scrub.ts
+++ b/src/core/scrub/scrub.ts
@@ -1,0 +1,285 @@
+import { chunk } from 'lodash';
+import { type DatabaseService } from '~/core/neo4j';
+import {
+  type Action,
+  findUnclassified,
+  links,
+  properties,
+} from './classification';
+import { fakeValue, sortValueFor } from './fake';
+import { MARKER_PROPERTY_KEYS, stampProvenance } from './provenance';
+
+/**
+ * The scrub itself.
+ *
+ * Runs in three passes, in this order and for this reason:
+ *
+ *  1. **Credentials.** First, and separately, so an interrupted run cannot leave
+ *     working secrets behind. A dump contains live session tokens, live
+ *     password-reset tokens and live webhook signing secrets — the one category
+ *     where a half-finished scrub is worse than none, because the graph looks
+ *     partly cleaned.
+ *  2. **Dead keys.** Removed outright. Absent data cannot leak and does not need
+ *     re-reviewing every time the classification is revisited.
+ *  3. **Everything else.** Field records first (the `:Property` chain behind each
+ *     classified link), then direct node properties.
+ *
+ * Both live and soft-deleted field records are covered. That is not a detail:
+ * the version chain keeps every previous value, so scrubbing only the current one
+ * leaves the history of what a field used to say fully intact.
+ */
+
+export interface ScrubContext {
+  readonly neo4j: DatabaseService;
+  readonly batchSize: number;
+  readonly log: (msg: string) => void;
+  /**
+   * Hash to write into every password field — one known development value, so
+   * the copy can be logged into. Computed by the caller through the app's own
+   * crypto service rather than reimplemented here.
+   */
+  readonly devPasswordHash: string;
+  /** When true, count what would change and write nothing. */
+  readonly dryRun: boolean;
+}
+
+interface ValueRow {
+  readonly nodeId: number;
+  readonly value: unknown;
+}
+
+/** Field records reachable through one link name, live and soft-deleted alike. */
+const readFieldValues = async (
+  ctx: ScrubContext,
+  link: string,
+): Promise<ValueRow[]> =>
+  await ctx.neo4j
+    .query<ValueRow>(
+      `MATCH ()-[:\`${link}\`]->(p)
+       WHERE (p:Property OR p:Deleted_Property) AND p.value IS NOT NULL
+       RETURN id(p) AS nodeId, p.value AS value`,
+    )
+    .run()
+    .then((rows) => [...rows]);
+
+const writeFieldValues = async (
+  ctx: ScrubContext,
+  updates: ReadonlyArray<{ nodeId: number; value: string | null }>,
+): Promise<void> => {
+  for (const batch of chunk([...updates], ctx.batchSize)) {
+    await ctx.neo4j
+      .query(
+        `UNWIND $batch AS row
+         MATCH (p) WHERE id(p) = row.nodeId
+         SET p.value = row.value,
+             p.sortValue = CASE WHEN p.sortValue IS NULL THEN NULL ELSE row.value END`,
+        { batch: batch.map((row) => ({ ...row })) },
+      )
+      .run();
+  }
+};
+
+const readNodeProperty = async (
+  ctx: ScrubContext,
+  key: string,
+): Promise<ValueRow[]> =>
+  await ctx.neo4j
+    .query<ValueRow>(
+      `MATCH (n) WHERE n.\`${key}\` IS NOT NULL
+       RETURN id(n) AS nodeId, n.\`${key}\` AS value`,
+    )
+    .run()
+    .then((rows) => [...rows]);
+
+const writeNodeProperty = async (
+  ctx: ScrubContext,
+  key: string,
+  updates: ReadonlyArray<{ nodeId: number; value: string | null }>,
+): Promise<void> => {
+  for (const batch of chunk([...updates], ctx.batchSize)) {
+    await ctx.neo4j
+      .query(
+        `UNWIND $batch AS row
+         MATCH (n) WHERE id(n) = row.nodeId
+         SET n.\`${key}\` = row.value`,
+        { batch: batch.map((row) => ({ ...row })) },
+      )
+      .run();
+  }
+};
+
+/** Remove a key from every node and relationship carrying it. */
+const deleteKeyEverywhere = async (
+  ctx: ScrubContext,
+  key: string,
+): Promise<number> => {
+  const nodes = await ctx.neo4j
+    .query<{ affected: number }>(
+      `MATCH (n) WHERE n.\`${key}\` IS NOT NULL
+       ${ctx.dryRun ? '' : `REMOVE n.\`${key}\``}
+       RETURN count(n) AS affected`,
+    )
+    .run();
+  const rels = await ctx.neo4j
+    .query<{ affected: number }>(
+      `MATCH ()-[r]->() WHERE r.\`${key}\` IS NOT NULL
+       ${ctx.dryRun ? '' : `REMOVE r.\`${key}\``}
+       RETURN count(r) AS affected`,
+    )
+    .run();
+  return Number(nodes[0]?.affected ?? 0) + Number(rels[0]?.affected ?? 0);
+};
+
+const isScrub = (
+  action: Action,
+): action is Extract<Action, { kind: 'scrub' }> => action.kind === 'scrub';
+
+export interface ScrubReport {
+  readonly scrubbedValues: number;
+  readonly deletedKeys: number;
+  readonly credentialsCleared: number;
+  readonly perField: ReadonlyArray<{ field: string; replaced: number }>;
+}
+
+export const runScrub = async (ctx: ScrubContext): Promise<ScrubReport> => {
+  // ── Guard ────────────────────────────────────────────────────────────────
+  // Anything the live graph contains that this classification does not name is a
+  // hard stop. The whole design rests on that: a field nobody classified is a
+  // field nobody decided about, and defaulting it either way is wrong.
+  const [liveLinks, liveKeys] = await Promise.all([
+    ctx.neo4j
+      .query<{ relationshipType: string }>(
+        'CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType',
+      )
+      .run()
+      .then((rows) => rows.map((row) => row.relationshipType)),
+    ctx.neo4j
+      .query<{ propertyKey: string }>(
+        'CALL db.propertyKeys() YIELD propertyKey RETURN propertyKey',
+      )
+      .run()
+      .then((rows) => rows.map((row) => row.propertyKey)),
+  ]);
+
+  // The marker's own fields are excluded — otherwise a scrubbed graph can never
+  // be scrubbed again, because stamping it added keys nobody classified.
+  const unclassified = findUnclassified(
+    liveLinks,
+    liveKeys.filter((key) => !MARKER_PROPERTY_KEYS.includes(key)),
+  );
+  const problems = [
+    ...unclassified.links.map((name) => `link "${name}"`),
+    ...unclassified.properties.map((name) => `field "${name}"`),
+    ...unclassified.unresolvedReviews.map(
+      (name) => `"${name}" is still marked for review`,
+    ),
+  ];
+  if (problems.length > 0) {
+    throw new Error(
+      `Refusing to scrub — ${problems.length} unresolved item(s). Classify each ` +
+        `in src/core/scrub/classification.ts, then re-run:\n  ` +
+        problems.join('\n  '),
+    );
+  }
+  ctx.log(
+    `Classification covers all ${liveLinks.length} links and ${liveKeys.length} fields.\n`,
+  );
+
+  const perField: Array<{ field: string; replaced: number }> = [];
+  let scrubbedValues = 0;
+  let credentialsCleared = 0;
+
+  // ── Pass 1: credentials ──────────────────────────────────────────────────
+  ctx.log('Pass 1 — credentials');
+  for (const [link, action] of Object.entries(links)) {
+    if (!isScrub(action) || action.as !== 'credential') continue;
+    const rows = await readFieldValues(ctx, link);
+    // Passwords become one known dev hash so the copy is usable; every other
+    // credential is emptied.
+    const replacement = link === 'password' ? ctx.devPasswordHash : null;
+    if (!ctx.dryRun && rows.length > 0) {
+      await writeFieldValues(
+        ctx,
+        rows.map((row) => ({ nodeId: row.nodeId, value: replacement })),
+      );
+    }
+    credentialsCleared += rows.length;
+    perField.push({ field: `${link} (link)`, replaced: rows.length });
+    ctx.log(
+      `  ${link} (link): ${rows.length}${link === 'password' ? ' → dev password' : ' → emptied'}`,
+    );
+  }
+  for (const [key, action] of Object.entries(properties)) {
+    if (!isScrub(action) || action.as !== 'credential') continue;
+    const rows = await readNodeProperty(ctx, key);
+    if (!ctx.dryRun && rows.length > 0) {
+      await writeNodeProperty(
+        ctx,
+        key,
+        rows.map((row) => ({ nodeId: row.nodeId, value: null })),
+      );
+    }
+    credentialsCleared += rows.length;
+    perField.push({ field: `${key} (field)`, replaced: rows.length });
+    ctx.log(`  ${key} (field): ${rows.length} → emptied`);
+  }
+
+  // ── Pass 2: dead keys ────────────────────────────────────────────────────
+  ctx.log('\nPass 2 — dead keys removed');
+  let deletedKeys = 0;
+  for (const [key, action] of Object.entries(properties)) {
+    if (action.kind !== 'delete') continue;
+    const affected = await deleteKeyEverywhere(ctx, key);
+    if (affected > 0) deletedKeys += affected;
+    ctx.log(`  ${key} (field): ${affected}`);
+  }
+
+  // ── Pass 3: everything else ──────────────────────────────────────────────
+  ctx.log('\nPass 3 — values replaced');
+  for (const [link, action] of Object.entries(links)) {
+    if (!isScrub(action) || action.as === 'credential') continue;
+    const rows = await readFieldValues(ctx, link);
+    if (rows.length === 0) {
+      ctx.log(`  ${link} (link): 0`);
+      continue;
+    }
+    const updates = rows.map((row) => ({
+      nodeId: row.nodeId,
+      value: fakeValue(action.as, row.value),
+    }));
+    if (!ctx.dryRun) await writeFieldValues(ctx, updates);
+    scrubbedValues += updates.length;
+    perField.push({ field: `${link} (link)`, replaced: updates.length });
+    ctx.log(`  ${link} (link): ${updates.length} → ${action.as}`);
+  }
+  for (const [key, action] of Object.entries(properties)) {
+    if (!isScrub(action) || action.as === 'credential') continue;
+    const rows = await readNodeProperty(ctx, key);
+    if (rows.length === 0) {
+      ctx.log(`  ${key} (field): 0`);
+      continue;
+    }
+    const updates = rows.map((row) => ({
+      nodeId: row.nodeId,
+      value: fakeValue(action.as, row.value),
+    }));
+    if (!ctx.dryRun) await writeNodeProperty(ctx, key, updates);
+    scrubbedValues += updates.length;
+    perField.push({ field: `${key} (field)`, replaced: updates.length });
+    ctx.log(`  ${key} (field): ${updates.length} → ${action.as}`);
+  }
+
+  // `sortValueFor` is referenced so the derived-key rule stays visible to anyone
+  // editing the write helpers; the SET clause above applies it inline.
+  void sortValueFor;
+
+  if (!ctx.dryRun) {
+    await stampProvenance(ctx.neo4j, {
+      scrubbedValues,
+      deletedKeys,
+      at: new Date().toISOString(),
+    });
+  }
+
+  return { scrubbedValues, deletedKeys, credentialsCleared, perField };
+};

--- a/src/core/scrub/scrub.ts
+++ b/src/core/scrub/scrub.ts
@@ -48,19 +48,76 @@ interface ValueRow {
   readonly value: unknown;
 }
 
+/**
+ * Page through matching rows, handing each page to `handle` before reading the
+ * next. Returns the total number of rows processed.
+ *
+ * PAGINATED BY NODE ID, not SKIP/LIMIT, and the difference is correctness rather
+ * than taste. The match predicate includes `value IS NOT NULL`, and the credential
+ * pass sets values TO null — so rows leave the result set as we work, and every
+ * subsequent SKIP would step over rows that were never processed. Seeking on
+ * `id(p) > $after` is immune: ids don't change, so a page boundary means the same
+ * thing before and after a write.
+ *
+ * It also bounds memory to one page. The first version read a whole field's rows
+ * up front, which was fine against the 21,110 values a local graph holds and
+ * would not have been against the millions a production copy does — `name` alone
+ * spans every named record in the system.
+ */
+const forEachPage = async (
+  ctx: ScrubContext,
+  buildQuery: (
+    after: number,
+    pageSize: number,
+  ) => readonly [cypher: string, params: object],
+  handle: (rows: readonly ValueRow[]) => Promise<void>,
+): Promise<number> => {
+  // Inlined into the Cypher rather than bound as a parameter: LIMIT demands an
+  // integer, and the driver serializes a JS number as a float ('1000.0 is not a
+  // valid value'). Safe to interpolate because it is validated as an integer
+  // here and never comes from user input.
+  const pageSize = Math.trunc(ctx.batchSize);
+  if (!Number.isSafeInteger(pageSize) || pageSize < 1) {
+    throw new Error(
+      `Batch size must be a positive integer (got ${ctx.batchSize})`,
+    );
+  }
+  let after = -1;
+  let total = 0;
+  let page = 0;
+  // A short page means the end — so a field that fits in one page costs one query
+  // rather than two, which matters across 40-odd fields.
+  do {
+    const [cypher, params] = buildQuery(after, pageSize);
+    const rows = [...(await ctx.neo4j.query<ValueRow>(cypher, params).run())];
+    page = rows.length;
+    if (page > 0) {
+      await handle(rows);
+      total += page;
+      after = rows[page - 1]!.nodeId;
+    }
+  } while (page === pageSize);
+  return total;
+};
+
 /** Field records reachable through one link name, live and soft-deleted alike. */
-const readFieldValues = async (
+const eachFieldValuePage = async (
   ctx: ScrubContext,
   link: string,
-): Promise<ValueRow[]> =>
-  await ctx.neo4j
-    .query<ValueRow>(
+  handle: (rows: readonly ValueRow[]) => Promise<void>,
+): Promise<number> =>
+  await forEachPage(
+    ctx,
+    (after, pageSize) => [
       `MATCH ()-[:\`${link}\`]->(p)
        WHERE (p:Property OR p:Deleted_Property) AND p.value IS NOT NULL
-       RETURN id(p) AS nodeId, p.value AS value`,
-    )
-    .run()
-    .then((rows) => [...rows]);
+         AND id(p) > $after
+       RETURN id(p) AS nodeId, p.value AS value
+       ORDER BY id(p) LIMIT ${pageSize}`,
+      { after },
+    ],
+    handle,
+  );
 
 const writeFieldValues = async (
   ctx: ScrubContext,
@@ -79,17 +136,21 @@ const writeFieldValues = async (
   }
 };
 
-const readNodeProperty = async (
+const eachNodePropertyPage = async (
   ctx: ScrubContext,
   key: string,
-): Promise<ValueRow[]> =>
-  await ctx.neo4j
-    .query<ValueRow>(
-      `MATCH (n) WHERE n.\`${key}\` IS NOT NULL
-       RETURN id(n) AS nodeId, n.\`${key}\` AS value`,
-    )
-    .run()
-    .then((rows) => [...rows]);
+  handle: (rows: readonly ValueRow[]) => Promise<void>,
+): Promise<number> =>
+  await forEachPage(
+    ctx,
+    (after, pageSize) => [
+      `MATCH (n) WHERE n.\`${key}\` IS NOT NULL AND id(n) > $after
+       RETURN id(n) AS nodeId, n.\`${key}\` AS value
+       ORDER BY id(n) LIMIT ${pageSize}`,
+      { after },
+    ],
+    handle,
+  );
 
 const writeNodeProperty = async (
   ctx: ScrubContext,
@@ -193,35 +254,35 @@ export const runScrub = async (ctx: ScrubContext): Promise<ScrubReport> => {
   ctx.log('Pass 1 — credentials');
   for (const [link, action] of Object.entries(links)) {
     if (!isScrub(action) || action.as !== 'credential') continue;
-    const rows = await readFieldValues(ctx, link);
     // Passwords become one known dev hash so the copy is usable; every other
     // credential is emptied.
     const replacement = link === 'password' ? ctx.devPasswordHash : null;
-    if (!ctx.dryRun && rows.length > 0) {
+    const count = await eachFieldValuePage(ctx, link, async (rows) => {
+      if (ctx.dryRun) return;
       await writeFieldValues(
         ctx,
         rows.map((row) => ({ nodeId: row.nodeId, value: replacement })),
       );
-    }
-    credentialsCleared += rows.length;
-    perField.push({ field: `${link} (link)`, replaced: rows.length });
+    });
+    credentialsCleared += count;
+    perField.push({ field: `${link} (link)`, replaced: count });
     ctx.log(
-      `  ${link} (link): ${rows.length}${link === 'password' ? ' → dev password' : ' → emptied'}`,
+      `  ${link} (link): ${count}${link === 'password' ? ' → dev password' : ' → emptied'}`,
     );
   }
   for (const [key, action] of Object.entries(properties)) {
     if (!isScrub(action) || action.as !== 'credential') continue;
-    const rows = await readNodeProperty(ctx, key);
-    if (!ctx.dryRun && rows.length > 0) {
+    const count = await eachNodePropertyPage(ctx, key, async (rows) => {
+      if (ctx.dryRun) return;
       await writeNodeProperty(
         ctx,
         key,
         rows.map((row) => ({ nodeId: row.nodeId, value: null })),
       );
-    }
-    credentialsCleared += rows.length;
-    perField.push({ field: `${key} (field)`, replaced: rows.length });
-    ctx.log(`  ${key} (field): ${rows.length} → emptied`);
+    });
+    credentialsCleared += count;
+    perField.push({ field: `${key} (field)`, replaced: count });
+    ctx.log(`  ${key} (field): ${count} → emptied`);
   }
 
   // ── Pass 2: dead keys ────────────────────────────────────────────────────
@@ -238,35 +299,33 @@ export const runScrub = async (ctx: ScrubContext): Promise<ScrubReport> => {
   ctx.log('\nPass 3 — values replaced');
   for (const [link, action] of Object.entries(links)) {
     if (!isScrub(action) || action.as === 'credential') continue;
-    const rows = await readFieldValues(ctx, link);
-    if (rows.length === 0) {
-      ctx.log(`  ${link} (link): 0`);
-      continue;
+    const count = await eachFieldValuePage(ctx, link, async (rows) => {
+      const updates = rows.map((row) => ({
+        nodeId: row.nodeId,
+        value: fakeValue(action.as, row.value),
+      }));
+      if (!ctx.dryRun) await writeFieldValues(ctx, updates);
+    });
+    scrubbedValues += count;
+    if (count > 0) {
+      perField.push({ field: `${link} (link)`, replaced: count });
     }
-    const updates = rows.map((row) => ({
-      nodeId: row.nodeId,
-      value: fakeValue(action.as, row.value),
-    }));
-    if (!ctx.dryRun) await writeFieldValues(ctx, updates);
-    scrubbedValues += updates.length;
-    perField.push({ field: `${link} (link)`, replaced: updates.length });
-    ctx.log(`  ${link} (link): ${updates.length} → ${action.as}`);
+    ctx.log(`  ${link} (link): ${count}${count ? ` → ${action.as}` : ''}`);
   }
   for (const [key, action] of Object.entries(properties)) {
     if (!isScrub(action) || action.as === 'credential') continue;
-    const rows = await readNodeProperty(ctx, key);
-    if (rows.length === 0) {
-      ctx.log(`  ${key} (field): 0`);
-      continue;
+    const count = await eachNodePropertyPage(ctx, key, async (rows) => {
+      const updates = rows.map((row) => ({
+        nodeId: row.nodeId,
+        value: fakeValue(action.as, row.value),
+      }));
+      if (!ctx.dryRun) await writeNodeProperty(ctx, key, updates);
+    });
+    scrubbedValues += count;
+    if (count > 0) {
+      perField.push({ field: `${key} (field)`, replaced: count });
     }
-    const updates = rows.map((row) => ({
-      nodeId: row.nodeId,
-      value: fakeValue(action.as, row.value),
-    }));
-    if (!ctx.dryRun) await writeNodeProperty(ctx, key, updates);
-    scrubbedValues += updates.length;
-    perField.push({ field: `${key} (field)`, replaced: updates.length });
-    ctx.log(`  ${key} (field): ${updates.length} → ${action.as}`);
+    ctx.log(`  ${key} (field): ${count}${count ? ` → ${action.as}` : ''}`);
   }
 
   // `sortValueFor` is referenced so the derived-key rule stays visible to anyone

--- a/src/core/scrub/verify.ts
+++ b/src/core/scrub/verify.ts
@@ -1,5 +1,5 @@
 import { type DatabaseService } from '~/core/neo4j';
-import { links, properties } from './classification';
+import { isFieldRecord, links, properties } from './classification';
 
 /**
  * The independent check that the scrub worked.
@@ -65,7 +65,7 @@ const countFieldMatches = async (
   const rows = await neo4j
     .query<{ total: number }>(
       `MATCH ()-[:\`${link}\`]->(p)
-       WHERE (p:Property OR p:Deleted_Property)
+       WHERE ${isFieldRecord('p')}
          AND p.value IS NOT NULL AND ${where}
        RETURN count(p) AS total`,
     )

--- a/src/core/scrub/verify.ts
+++ b/src/core/scrub/verify.ts
@@ -37,10 +37,23 @@ const PROBES = {
     where: `p.value =~ '.*[0-9]{3}[^0-9]?[0-9]{4}.*' AND NOT p.value CONTAINS '555 01'`,
     describes: 'phone-shaped and not in the reserved block',
   },
-  /** The NUL-prefixed stored form leaking into a scrubbed field. */
-  serializedRichText: {
-    where: `p.value STARTS WITH '\\u0000RichText\\u0000'`,
-    describes: 'still serialized rich text',
+  /**
+   * A rich-text field NOT holding a serialized document.
+   *
+   * This probe started out inverted — it flagged the NUL-prefixed form as a
+   * violation, reasoning that a leftover serialized value meant unscrubbed data.
+   * Backwards: a correctly scrubbed rich-text field MUST still be a serialized
+   * document, because that is the only shape the column can hold. So the probe
+   * reported clean on genuinely broken data and would have failed on correct data.
+   *
+   * It now checks what actually goes wrong. When the scrub mishandled the object
+   * form, every body became a bare string, the structure was lost, and the ETL
+   * dropped 30 of 32 comments as unparseable — with verification reporting no
+   * violations throughout. This is the probe that catches that.
+   */
+  nonDocumentRichText: {
+    where: `NOT p.value STARTS WITH '\\u0000RichText\\u0000'`,
+    describes: 'rich-text field holding a bare string, not a document',
   },
 } as const;
 
@@ -108,7 +121,7 @@ export const runVerify = async (
     const applicable: Array<keyof typeof PROBES> = [];
     if (action.as === 'email') applicable.push('realEmail');
     if (action.as === 'phone') applicable.push('realPhone');
-    if (action.as === 'richText') applicable.push('serializedRichText');
+    if (action.as === 'richText') applicable.push('nonDocumentRichText');
 
     for (const probe of applicable) {
       const count = await countFieldMatches(neo4j, link, PROBES[probe].where);

--- a/src/core/scrub/verify.ts
+++ b/src/core/scrub/verify.ts
@@ -1,0 +1,156 @@
+import { type DatabaseService } from '~/core/neo4j';
+import { links, properties } from './classification';
+
+/**
+ * The independent check that the scrub worked.
+ *
+ * Deliberately **not** built from the scrub's own bookkeeping. A scrub that
+ * silently skipped a field would report success and its own counts would agree
+ * with it. This re-reads the graph and looks for values that still look real, so
+ * a missed field shows up as a number rather than as silence.
+ *
+ * REPORTS COUNTS, NEVER VALUES. That is what makes the result safe to paste into
+ * a conversation, a ticket, or a CI log: a violation names the field and how many,
+ * which is everything triage needs and nothing a reader shouldn't see.
+ */
+
+export interface Violation {
+  readonly field: string;
+  readonly probe: string;
+  readonly count: number;
+}
+
+/**
+ * Patterns that indicate an unscrubbed value survived.
+ *
+ * Each is written to catch the shape of *real* data, not to validate the shape of
+ * fake data — an inverted test would pass on an empty database.
+ */
+const PROBES = {
+  /** Any address not on the reserved non-routable domain. */
+  realEmail: {
+    where: `p.value =~ '(?i).*@.*\\\\..*' AND NOT p.value ENDS WITH '@example.invalid'`,
+    describes: 'email not on example.invalid',
+  },
+  /** Dialable numbers — the fakes all sit in the reserved 555-01xx block. */
+  realPhone: {
+    where: `p.value =~ '.*[0-9]{3}[^0-9]?[0-9]{4}.*' AND NOT p.value CONTAINS '555 01'`,
+    describes: 'phone-shaped and not in the reserved block',
+  },
+  /** The NUL-prefixed stored form leaking into a scrubbed field. */
+  serializedRichText: {
+    where: `p.value STARTS WITH '\\u0000RichText\\u0000'`,
+    describes: 'still serialized rich text',
+  },
+} as const;
+
+const countFieldMatches = async (
+  neo4j: DatabaseService,
+  link: string,
+  where: string,
+): Promise<number> => {
+  const rows = await neo4j
+    .query<{ total: number }>(
+      `MATCH ()-[:\`${link}\`]->(p)
+       WHERE (p:Property OR p:Deleted_Property)
+         AND p.value IS NOT NULL AND ${where}
+       RETURN count(p) AS total`,
+    )
+    .run();
+  return Number(rows[0]?.total ?? 0);
+};
+
+/**
+ * Long free-text runs inside the two extraction fields left unscrubbed by
+ * decision on 2026-07-31.
+ *
+ * Both hold machine-generated output, which is why leaving them was reasonable —
+ * but templated messages interpolate the spreadsheet cells that triggered them, so
+ * a fragment of real narrative could ride along. Nobody has read those values, and
+ * this is how that stays true: a count of suspiciously long text runs, repeated on
+ * every refresh. Zero closes the question. Non-zero is a prompt to look, without
+ * this check ever surfacing what it found.
+ */
+const FREE_TEXT_RUN = 200;
+
+const countLongTextRuns = async (
+  neo4j: DatabaseService,
+  key: string,
+): Promise<number> => {
+  const rows = await neo4j
+    .query<{ total: number }>(
+      `MATCH (n) WHERE n.\`${key}\` IS NOT NULL
+         AND size(toString(n.\`${key}\`)) > $threshold
+       RETURN count(n) AS total`,
+      { threshold: FREE_TEXT_RUN },
+    )
+    .run();
+  return Number(rows[0]?.total ?? 0);
+};
+
+export interface VerifyReport {
+  readonly violations: readonly Violation[];
+  readonly watchlist: readonly Violation[];
+  readonly clean: boolean;
+}
+
+export const runVerify = async (
+  neo4j: DatabaseService,
+): Promise<VerifyReport> => {
+  const violations: Violation[] = [];
+
+  for (const [link, action] of Object.entries(links)) {
+    if (action.kind !== 'scrub') continue;
+
+    // Match each probe to the fields it can actually judge. Running every probe
+    // against every field would generate noise that trains people to ignore the
+    // report, which is worse than not having one.
+    const applicable: Array<keyof typeof PROBES> = [];
+    if (action.as === 'email') applicable.push('realEmail');
+    if (action.as === 'phone') applicable.push('realPhone');
+    if (action.as === 'richText') applicable.push('serializedRichText');
+
+    for (const probe of applicable) {
+      const count = await countFieldMatches(neo4j, link, PROBES[probe].where);
+      if (count > 0) {
+        violations.push({
+          field: `${link} (link)`,
+          probe: PROBES[probe].describes,
+          count,
+        });
+      }
+    }
+  }
+
+  // Anything the classification says to delete must genuinely be gone.
+  for (const [key, action] of Object.entries(properties)) {
+    if (action.kind !== 'delete') continue;
+    const rows = await neo4j
+      .query<{
+        total: number;
+      }>(`MATCH (n) WHERE n.\`${key}\` IS NOT NULL RETURN count(n) AS total`)
+      .run();
+    const count = Number(rows[0]?.total ?? 0);
+    if (count > 0) {
+      violations.push({
+        field: `${key} (field)`,
+        probe: 'should have been deleted',
+        count,
+      });
+    }
+  }
+
+  const watchlist: Violation[] = [];
+  for (const key of ['context', 'problems']) {
+    const count = await countLongTextRuns(neo4j, key);
+    if (count > 0) {
+      watchlist.push({
+        field: `${key} (field)`,
+        probe: `left unscrubbed by decision — values longer than ${FREE_TEXT_RUN} chars`,
+        count,
+      });
+    }
+  }
+
+  return { violations, watchlist, clean: violations.length === 0 };
+};

--- a/src/core/shadow-diff.run.ts
+++ b/src/core/shadow-diff.run.ts
@@ -120,6 +120,24 @@ async function runCaptureMode(dir: string) {
       );
     }
 
+    // Scrub gate. Capture WRITES every response it reads to a file, so an
+    // unscrubbed source means protected values land on disk — which is the
+    // failure redact.ts exists to bound, and this is the layer that stops it
+    // happening at all.
+    //
+    // Only the neo4j capture is checked, because only it reads Neo4j directly.
+    // The postgres capture reads a database the ETL loaded, and the ETL is gated
+    // on the same check — so prod data cannot reach Postgres unmarked either.
+    if (engine === 'neo4j') {
+      const { DatabaseService } = await import('~/core/neo4j');
+      const { checkScrubGate } = await import('./scrub/provenance');
+      const gate = await checkScrubGate(app.get(DatabaseService));
+      if (!gate.allowed) {
+        throw new Error(`Capture refused — ${gate.reason}`);
+      }
+      log(`Source: ${gate.reason}`);
+    }
+
     // Warm the root session so CLI-mode loaders (ResourceLoader.readyForCli)
     // don't race the admin bootstrap.
     await app.get(SessionManager).lazySessionForRootUser();

--- a/src/core/shadow-diff.run.ts
+++ b/src/core/shadow-diff.run.ts
@@ -83,6 +83,25 @@ async function runCaptureMode(dir: string) {
   // loader caching is disabled. Same trick as cutover.run.ts / pg-seed.run.ts.
   process.argv.push('console');
 
+  // A capture must not WRITE to what it is measuring, and merely booting the
+  // AppModule does. Observed on 2026-08-19 while scrubbing the production copy:
+  // `[admin:service] Updating root user to match app configuration` — the
+  // background root-objects bootstrap had rewritten the root user's email and
+  // password hash to match this box's config. In a capture that is worse than
+  // untidy: the neo4j run is the ORACLE the postgres run is compared against, so
+  // a boot-time write means the two engines are no longer being asked about the
+  // same graph, and against a frozen source it is a write the runbook forbids.
+  // Index creation is DDL for the same reason. Both default ON outside a local
+  // development box, which is exactly the machine a rehearsal runs on.
+  //
+  // Set before the AppModule import below, since ConfigService reads env once.
+  // Consequence worth knowing: `lazySessionForRootUser()` further down no longer
+  // has a bootstrap to fall back on, so a capture against a database with no
+  // root user now FAILS instead of quietly creating one. That is the intended
+  // trade — an absent root user is a load defect the capture should surface.
+  process.env.DB_ROOT_OBJECTS_SYNC = 'false';
+  process.env.DB_CREATE_INDEXES = 'false';
+
   // AppModule FIRST, then dynamic imports (circular-dep ordering — same as
   // main.ts / cutover.run.ts / pg-seed.run.ts).
   const { AppModule } = await import('../app.module');

--- a/src/core/shadow-diff.run.ts
+++ b/src/core/shadow-diff.run.ts
@@ -1,0 +1,161 @@
+/**
+ * Shadow-diff harness — Neo4j ↔ Postgres read parity (cutover-only tooling).
+ *
+ * Capture mode boots the app under the current `DATABASE` engine, replays a
+ * read-only GraphQL corpus IN-PROCESS under several role personas, and writes
+ * `capture-<engine>.json`. Diff mode compares the two capture files
+ * (neo4j = oracle) with a known-deltas suppression registry and writes
+ * `report.md` + `report.json`. See src/core/shadow-diff/README.md.
+ *
+ * Usage (both engines must be loaded with the SAME dataset via the cutover
+ * ETL first — see the README runbook):
+ *
+ *   DATABASE=neo4j POSTGRES_URL=postgresql://... \
+ *     yarn start --entryFile core/shadow-diff.run -- --capture
+ *
+ *   DATABASE=postgres POSTGRES_URL=postgresql://... \
+ *     yarn start --entryFile core/shadow-diff.run -- --capture
+ *
+ *   yarn start --entryFile core/shadow-diff.run -- --diff
+ *
+ * Flags: --capture | --diff | --out=<dir> (capture) | --dir=<dir> (diff).
+ * Default dir: shadow-diff-output/ at the repo root.
+ * Diff exits 1 when any UNSUPPRESSED difference is found.
+ */
+import { NestFactory } from '@nestjs/core';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { exit } from 'node:process';
+import type { CaptureFile } from './shadow-diff/types';
+import '../polyfills';
+
+const parseFlags = (argv: readonly string[]) => {
+  const get = (name: string) =>
+    argv.find((a) => a.startsWith(`--${name}=`))?.split('=')[1];
+  const has = (name: string) => argv.includes(`--${name}`);
+  return {
+    capture: has('capture'),
+    diff: has('diff'),
+    dir:
+      get('out') ??
+      get('dir') ??
+      path.join(process.cwd(), 'shadow-diff-output'),
+  };
+};
+
+// eslint-disable-next-line no-console
+const log = (msg: string) => console.log(msg);
+
+/** Pure file processing — no app boot needed. */
+async function runDiff(dir: string) {
+  const { diffCaptures } = await import('./shadow-diff/diff');
+  const { renderMarkdown, summaryLines } = await import('./shadow-diff/report');
+
+  const read = (engine: string) => {
+    const file = path.join(dir, `capture-${engine}.json`);
+    if (!fs.existsSync(file)) {
+      throw new Error(
+        `Missing ${file} — run --capture under DATABASE=${engine} first.`,
+      );
+    }
+    // Captures are produced by this same tool; trust their shape.
+    return JSON.parse(fs.readFileSync(file, 'utf8')) as CaptureFile;
+  };
+  const neo4j = read('neo4j');
+  const postgres = read('postgres');
+
+  const report = diffCaptures(neo4j, postgres);
+
+  fs.writeFileSync(
+    path.join(dir, 'report.json'),
+    JSON.stringify(report, null, 2),
+  );
+  fs.writeFileSync(path.join(dir, 'report.md'), renderMarkdown(report));
+  for (const line of summaryLines(report)) log(line);
+  log(`\nWrote ${path.join(dir, 'report.md')} + report.json`);
+
+  process.exit(report.totals.withDiffs > 0 ? 1 : 0);
+}
+
+async function runCaptureMode(dir: string) {
+  // Push 'console' AFTER flag parsing so ConfigService.isCli is true —
+  // DataLoaders resolve against CLI_CONTEXT_ID, the scheduler stays off, and
+  // loader caching is disabled. Same trick as cutover.run.ts / pg-seed.run.ts.
+  process.argv.push('console');
+
+  // AppModule FIRST, then dynamic imports (circular-dep ordering — same as
+  // main.ts / cutover.run.ts / pg-seed.run.ts).
+  const { AppModule } = await import('../app.module');
+  const { GraphQLSchemaHost } = await import('@nestjs/graphql');
+  const { ConfigService } = await import('~/core/config');
+  const { Identity } = await import('~/core/authentication');
+  const { SessionManager } =
+    await import('~/core/authentication/session/session.manager');
+  const { DrizzleService } = await import('~/core/drizzle/drizzle.service');
+  const { GqlContextHostImpl } =
+    await import('~/core/graphql/gql-context.host');
+  const { HttpAdapter } = await import('~/core/http');
+  const { runCapture } = await import('./shadow-diff/capture');
+
+  // A FULL Nest app (not an application context): GraphQLModule only builds
+  // the schema when an HTTP adapter is present (same recipe as main.ts's
+  // --gen-schema path). We init but never listen.
+  const app = await NestFactory.create(AppModule, new HttpAdapter(), {
+    logger: ['error', 'warn'],
+  });
+  try {
+    await app.init();
+
+    const config = app.get(ConfigService);
+    if (!config.postgres.url) {
+      throw new Error(
+        'POSTGRES_URL is required — personas + id samples are resolved from ' +
+          'Postgres in both capture runs.',
+      );
+    }
+    const engine = config.databaseEngine;
+    if (engine !== 'neo4j' && engine !== 'postgres') {
+      throw new Error(
+        `DATABASE must be neo4j or postgres for a capture (got '${engine}').`,
+      );
+    }
+
+    // Warm the root session so CLI-mode loaders (ResourceLoader.readyForCli)
+    // don't race the admin bootstrap.
+    await app.get(SessionManager).lazySessionForRootUser();
+
+    await runCapture(
+      {
+        schema: app.get(GraphQLSchemaHost).schema,
+        identity: app.get(Identity),
+        gqlContextAls: app.get(GqlContextHostImpl).als,
+        db: app.get(DrizzleService).client,
+        engine,
+        log,
+      },
+      dir,
+    );
+  } finally {
+    await app.close();
+  }
+  exit();
+}
+
+async function bootstrap() {
+  const flags = parseFlags(process.argv.slice(2));
+  if (flags.diff === flags.capture) {
+    log('Usage: --capture [--out=<dir>] | --diff [--dir=<dir>]');
+    process.exit(1);
+  }
+  if (flags.diff) {
+    await runDiff(flags.dir);
+    return;
+  }
+  await runCaptureMode(flags.dir);
+}
+
+void bootstrap().catch((err: unknown) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+});

--- a/src/core/shadow-diff/README.md
+++ b/src/core/shadow-diff/README.md
@@ -160,7 +160,53 @@ live location names dropped by `onConflictDoNothing` — see
 (`total` mismatches etc.) until the ETL findings are resolved — that's the
 harness doing its job, not a harness bug.
 
-## Latest run — 2026-07-30, after the Language / Engagement / Product / report / leaves waves
+## Latest run — 2026-07-30, EXTENDED corpus (83 → 135 ops/persona, 810 pairs)
+
+**612 of 810 identical · 146 pairs with unsuppressed diffs · 52 suppressed-only.**
+The corpus now covers the five waves it previously ignored: languages (+ethnologue),
+engagements (both subtypes via the interface), products (all three fragments),
+periodic reports, progress reports (status, all three summaries, prompt responses,
+product progress), comment threads + comments, and posts. Pins are covered via
+`Language.pinned`.
+
+**The headline is that every new BY-ID document is clean.** Zero diffs on
+`language.byId`, `product.byId`, `periodicReport.byId`, `progressReport.byId`,
+`commentThread.byId` and `post.byId` across all six personas — so the report
+cluster and the leaves read identically field-for-field, including the summaries,
+prompt-response entries and step progress. That is the strongest parity evidence
+this harness has produced for the newly-migrated domains.
+
+The new-domain diffs are 14 ops / 674 entries and almost entirely **list** totals
+and item windows, i.e. the ETL's known row drops showing through (languages 69→50,
+engagements 117→80, products 363→275, periodic reports 2383→1869). Two exceptions
+matter:
+
+**🔴 NEW AND SERIOUS — a 2-row ethnologue drop breaks the whole language list.**
+Postgres throws where Neo4j answers:
+
+```
+Language iaJWie869fn has no attached EthnologueLanguage — create-flow invariant violated
+```
+
+This kills `languages.list.default`, `languages.list.sort-createdAt-asc`,
+`languages.list.filter-presetInventory` **entirely** (not one row — the whole query,
+for Administrator), plus `engagement.byId` for any engagement whose language is
+affected. Cause: the ETL drops 2 `ethnologue_languages` rows to the
+code/provisional_code unique indexes, leaving `iaJWie869fn` and `Dw5mcfubJUG` with
+no ethnologue row, and the Postgres language repo treats that as a hard invariant
+while Neo4j tolerates it. This is the **ETH1** concern with a concrete
+reproduction, and it escalates the unique-dup class: a dropped row is not only lost
+data, it can make an entire list query fail. Prod exposure is unmeasured — the
+`ethnologue.code` / `provisionalCode` legs of the cutover pre-flight are what size
+it.
+
+**`engagements.list.filter-status-active` (27 entries)** — differs by more than the
+row drops; worth separating from the drop noise on a dataset without them.
+
+The 23 pre-existing ops with diffs are unchanged from the run below, and none is a
+newly-broken repository.
+
+## Previous run — 2026-07-30, original 83-op corpus
 
 **350 of 498 identical · 96 op×persona pairs with unsuppressed diffs · 52
 suppressed-only.** Loaded into a dedicated `cord_shadow` database (NOT the dev

--- a/src/core/shadow-diff/README.md
+++ b/src/core/shadow-diff/README.md
@@ -145,6 +145,36 @@ Seeded rules: `S1` (inactive-membership visibility on project reads under
 member personas), `U14` (user.photo null shape), and a **disabled** collation
 placeholder for order-only diffs on name sorts (enable only after inspecting).
 
+## Value redaction — and the residual question (2026-07-31)
+
+Capture files previously held person names, email addresses, phone numbers,
+user-authored comment and post bodies, and language names, alongside **213 records
+marked `sensitivity: High`**. Under Seed Company's AI protocol, high-sensitivity
+project data and linguistic data held in confidence are **Restricted**, and PII is
+at least Confidential. Those files sat in plain text at the repo root.
+
+`redact.ts` now hashes every string under a sensitive field name before anything is
+written. **Hashing rather than dropping the field is deliberate:** parity is the
+point of this harness, so if the two engines disagree the run must fail — drop the
+field and that check goes with it, hash it and the check survives while nothing
+readable is stored. Verified on a fresh capture: 269 sensitive values, all hashed,
+zero readable, zero email-shaped strings. A diff shows `#a1b2c3…`, so triage looks
+the record up locally by id — which is all it needs, since the report still names
+which field of which record disagrees.
+
+⚠ **What redaction does NOT settle.** The captures still contain data *derived from*
+high-sensitivity records: ids, enums, dates, numeric fields, and the `sensitivity`
+marker itself (which must stay — it drives authorization and is exactly what parity
+should test). §4 defines Restricted as "all data from high-sensitivity
+projects/partners", so redacted-but-derived may still qualify, and §4 also warns
+that combined fields and indirect identifiers must not enable re-identification.
+**Do not treat a redacted capture as certified clean.**
+
+The stricter option, not taken because it costs real coverage: exclude
+`sensitivity = 'High'` records from `sampledTables` so no high-sensitivity data is
+captured at all. That removes the exposure but also removes parity testing for the
+records whose authorization behaviour matters most. Open decision.
+
 ## Reading the report
 
 - `report.md` — summary table (operation × persona: `✓` / `D<n>` unsuppressed

--- a/src/core/shadow-diff/README.md
+++ b/src/core/shadow-diff/README.md
@@ -200,8 +200,14 @@ data, it can make an entire list query fail. Prod exposure is unmeasured — the
 `ethnologue.code` / `provisionalCode` legs of the cutover pre-flight are what size
 it.
 
-**`engagements.list.filter-status-active` (27 entries)** — differs by more than the
-row drops; worth separating from the drop noise on a dataset without them.
+**`engagements.list.filter-status-active` — investigated and fully accounted for.**
+Neo4j total 8, Postgres 7, and the single missing engagement is `c6UpBhwNe4Q`,
+named explicitly in the ETL's own "DROPPED 32 engagement(s) … whose language never
+landed" warning. The arithmetic closes on the unfiltered list too: Neo4j 112 −
+32 = Postgres 80. So every engagement list diff is the language cascade showing
+through, with nothing left over. (An earlier draft of this section claimed it
+differed by *more* than the row drops — that was wrong, and measuring the sets
+rather than the diff count is what settled it.)
 
 The 23 pre-existing ops with diffs are unchanged from the run below, and none is a
 newly-broken repository.

--- a/src/core/shadow-diff/README.md
+++ b/src/core/shadow-diff/README.md
@@ -160,6 +160,57 @@ live location names dropped by `onConflictDoNothing` — see
 (`total` mismatches etc.) until the ETL findings are resolved — that's the
 harness doing its job, not a harness bug.
 
+## Latest run — 2026-07-30, after the Language / Engagement / Product / report / leaves waves
+
+**350 of 498 identical · 96 op×persona pairs with unsuppressed diffs · 52
+suppressed-only.** Loaded into a dedicated `cord_shadow` database (NOT the dev
+`cord` DB, which the ETL's TRUNCATE would otherwise wipe) from the same local
+Neo4j, 46 tables reconciling. Both captures exited 0 — no recurrence of the S5
+root-user hang.
+
+⚠ **Read this number with the corpus in mind.** `corpus.ts` is hand-enumerated and
+has not grown since 2026-07-14, while five domain waves have landed since. So this
+run is a **regression check over the old surface**, not coverage of the new one:
+periodic reports, progress reports, prompt responses, product progress, progress
+summaries, comments, posts and pins are all migrated and **not queried by a single
+operation here**. Treating 350/498 as a parity certificate would be a mistake —
+the gate cannot certify what it does not ask about.
+
+All 96 fall into five classes, none of them a newly-broken repository:
+
+1. **Order-only** (`tools`, `fieldRegions`, `fieldZones`, `projects`, and the
+   page-window shifts that follow in `organizations`/`users`) — identical SET and
+   identical `total`, different sequence. This is the inspection the `collation`
+   rule was waiting on, and for these ops it passes. Still left disabled, because
+   suppressing it would also mask the second sub-case: PG repos lacking an `id`
+   tie-break on equal sort keys is a real determinism defect, not a collation
+   difference, and the two are indistinguishable from the diff alone. **Open
+   question:** separate them before enabling.
+2. **`locations` — real ETL data loss.** total 26 → 17. This is the
+   `locations_iso_alpha3_active_unique` drop (cutover README finding #3, whose
+   attribution was corrected the same day — it was blamed on `name` for weeks).
+   It cascades: every `locations.list` page and total, plus
+   `location.byId.defaultMarketingRegion` going null because the referenced
+   location is one of the nine dropped.
+3. **`project.byId` ×5 — PG errors where Neo4j returns data:** *"Could not find
+   root directory associated to this project"*. Expected until File+Media loads
+   `root_directory_id`; it should clear entirely with that wave, and is worth
+   re-checking as a signal that the wave worked.
+4. **NEW — `users.list.filter-status-active` totals 32 (Neo4j) vs 48 (Postgres).**
+   Not a filter bug (`eq(users.status, filter.status)` is correct) — a data
+   consequence of the ETL's `orDefault(status, 'Active')`. Locally 32 users have an
+   Active status Property, **16 have none at all**, and 1 is Disabled; the ETL
+   coalesces those 16 to Active, so "Active users" becomes a 50% larger set. The S6
+   known-delta covers the status *value* but not a filtered list's *cardinality* —
+   see the `S6-cardinality` rule, deliberately disabled so this stays red pending
+   a call.
+5. **NEW (minor, Neo4j-side, self-resolving) — sorting by a Property a node lacks
+   drops that node from the result.** `sort-displayLastName` yields a Neo4j total of
+   48 against 49 elsewhere, because the AnonUser node carries only
+   gender/photo/status Properties and the sorter's match is required. Postgres
+   keeps the row (`ORDER BY` on a null column). **Postgres is the correct one** — a
+   sort must not change cardinality — so this needs no fix and dies at cutover.
+
 ## File map
 
 - `../shadow-diff.run.ts` — entry (flags, boot, capture/diff dispatch).

--- a/src/core/shadow-diff/README.md
+++ b/src/core/shadow-diff/README.md
@@ -1,0 +1,170 @@
+# Shadow-diff harness — Neo4j ↔ Postgres read parity
+
+**Cutover-only tooling — this dies with the migration.** It exists to validate
+that the Postgres repositories answer GraphQL reads identically to the proven
+Neo4j ones, over the same dataset, before the `DATABASE=postgres` flip. Once
+the cutover lands and Neo4j is torn down, delete this folder and
+`../shadow-diff.run.ts`. Don't over-invest here.
+
+## What it does
+
+1. **Capture** — boots the app under the current `DATABASE` engine, replays a
+   hand-enumerated **read-only** GraphQL corpus **in-process** (no HTTP) under
+   several role personas, and writes `capture-<engine>.json`.
+2. **Diff** — loads `capture-neo4j.json` (the oracle) + `capture-postgres.json`,
+   compares with a known-deltas suppression registry, and writes `report.md` +
+   `report.json`. Exits **1** if any UNSUPPRESSED difference exists.
+
+Both engines must be loaded with the **same dataset** by the cutover ETL
+(`src/core/cutover/`) — then responses should be identical except for real
+parity bugs and registered known deltas.
+
+## Runbook
+
+Prereqs: dev Neo4j + Postgres up (`docker compose up -d postgres db`), the
+Postgres DB loaded from that same Neo4j by the cutover ETL:
+
+```bash
+POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/cord \
+  yarn start --entryFile core/cutover.run
+```
+
+Then the three commands (output dir defaults to `shadow-diff-output/` at the
+repo root — keep it out of git via `.git/info/exclude`, e.g.
+`echo shadow-diff-output/ >> .git/info/exclude`; do not add it to `.gitignore`):
+
+```bash
+# 1. capture with Neo4j serving reads (the oracle)
+DATABASE=neo4j POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/cord \
+  yarn start --entryFile core/shadow-diff.run -- --capture
+
+# 2. capture with Postgres serving reads
+DATABASE=postgres POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/cord \
+  yarn start --entryFile core/shadow-diff.run -- --capture
+
+# 3. diff the two captures → report.md + report.json + stdout summary
+yarn start --entryFile core/shadow-diff.run -- --diff
+```
+
+Flags: `--capture` | `--diff` · `--out=<dir>` (capture) · `--dir=<dir>` (diff).
+
+Capture never mutates anything: the corpus is queries only, executed through
+the ordinary resolver → service → repository path. (Note: under
+`DATABASE=postgres` the app's boot path runs the Drizzle migrator; on a DB the
+ETL already loaded, all migrations are applied and it's a no-op.)
+
+**Gotcha — root user on a freshly ETL'd DB (fixed, ledger S5):** the ETL
+originally loaded `users.is_root` as `false` for every row, and the postgres
+admin bootstrap's `createRootUser` then PK-conflicted on the same configured
+id — the bootstrap died in the background and `waitForRootUserId` polled
+forever, so the capture (or ANY `DATABASE=postgres` boot) hung after schema
+generation. The user extractor now sets `is_root` by matching the configured
+root email, so fresh ETL loads boot fine. Only a DB loaded by a pre-fix ETL
+run needs the one-row manual unblock:
+
+```bash
+docker exec cord-api-v3-postgres-1 psql -U postgres -d cord \
+  -c "UPDATE users SET is_root=true WHERE email='devops@tsco.org';"
+```
+
+## Design
+
+- **Two sequential process runs + file captures** — no live dual server.
+- **In-process execution** via `graphql({ schema, ... })` with the schema from
+  `GraphQLSchemaHost`. The capture boots a full Nest app (custom
+  `HttpAdapter`) but never listens — the GraphQL module only builds the schema
+  when an HTTP adapter exists (same recipe as `main.ts --gen-schema`).
+- **Identity**: personas are arbitrary migrated users (no passwords), entered
+  via `identity.asUser(userId, fn)`. The GraphQL context deliberately has
+  **no `request`** — with one, the `SessionInterceptor` would resolve a session
+  from it and clobber the persona; without one it early-returns. Each
+  operation also runs inside `GqlContextHostImpl.als.run(context, ...)` since
+  in-process execution bypasses the Yoga plugin that normally populates it.
+  The process runs in CLI mode (`'console'` pushed into argv) so
+  `ResourceLoader` uses `CLI_CONTEXT_ID` and the scheduler stays off.
+- **Deterministic personas** (`personas.ts`): for each role in
+  Administrator, ProjectManager, Consultant, Intern, FieldPartner, Marketing,
+  StaffMember — the live user with the lowest id holding that global role,
+  resolved **from Postgres in both runs** (`POSTGRES_URL` is always set).
+  Roles with no user are skipped + logged. The diff asserts both captures
+  resolved identical personas.
+- **Deterministic id sampling**: by-id documents run against the first K=5
+  live ids (ordered by id) from the domain's PG table — same ids both runs,
+  asserted in the diff.
+- **Errors are data**: `{ data, errors }` is captured per operation (errors
+  normalized to message + code + path — no stacks). Deny-vs-allow or
+  error-shape differences between engines are exactly the signal we want.
+- **Normalization is minimal**: values that are both ISO instants for the
+  same moment but in different string forms are treated equal (and counted in
+  the report). Null-vs-missing-vs-empty-array is NEVER normalized — those are
+  real finding classes. List order is compared as-is — ordering drift IS
+  signal.
+
+## Corpus coverage (corpus.ts)
+
+12 queryable landed+ETL'd domains: users, tools, fundingAccounts, locations,
+fieldZones, fieldRegions, organizations, partners, projects, projectMembers,
+partnerships, notifications.
+
+- **projectMembers** have no top-level query — they are covered via the
+  `project.team` sub-selection on the project by-id document.
+- **Education/Unavailability** are covered as sub-selections on the user
+  by-id document.
+- **EthnologueLanguage is excluded** — it is only reachable through Language,
+  which hasn't landed on Postgres.
+- **notifications** are requester-scoped: per-persona results are expected and
+  must match across engines for the same persona.
+
+Per list: default sort, 1–2 real non-default sorts (name-ish + `createdAt`),
+ASC/DESC on the name sort, one obvious filter where the input has one — each
+selecting `total` + `hasMore` + item ids. Per by-id: full secured-field
+coverage of **migrated-backed fields only**. Every excluded field is commented
+in `corpus.ts` with the reason (PG stub, unmigrated boundary) so re-adding at
+each domain land is a grep for the domain name.
+
+### Adding a domain when its recut lands
+
+1. In `corpus.ts`: add a by-id document (full secured-field selection — crib
+   from `test/utility/fragments.ts`, do NOT import test files) + list variants
+   (default sort, name + createdAt sorts, an obvious filter). Check the
+   domain's `list-*.dto.ts` for real sort keys.
+2. If it should be id-sampled: add the domain to `SampledDomain` in `types.ts`
+   and its table to `sampledTables` in `capture.ts`.
+3. Grep `corpus.ts` for the domain name and re-add any field selections that
+   were excluded as "not landed".
+4. Re-run ETL + both captures + diff.
+
+### Adding a known-delta rule
+
+In `known-deltas.ts`, append a rule with `op`/`persona`/`path` regexes and a
+mandatory `reason` + `ref` (miss-ledger id). Suppressed diffs are counted and
+listed in the report — never silent. Only add a rule for a difference that has
+been investigated and accepted; everything else should stay red.
+
+Seeded rules: `S1` (inactive-membership visibility on project reads under
+member personas), `U14` (user.photo null shape), and a **disabled** collation
+placeholder for order-only diffs on name sorts (enable only after inspecting).
+
+## Reading the report
+
+- `report.md` — summary table (operation × persona: `✓` / `D<n>` unsuppressed
+  / `S<n>` suppressed / `E` errors-mismatch), then per-diff detail (op,
+  persona, JSON path, neo4j vs postgres values, truncated), then the
+  suppressed section grouped by rule ref.
+- `report.json` — the full machine-readable report.
+- Exit code 1 ⇔ any unsuppressed diff.
+
+Expected local-dev noise: the dev dataset has known ETL gaps (e.g. duplicate
+live location names dropped by `onConflictDoNothing` — see
+`src/core/cutover/README.md` findings). Those correctly show up as real diffs
+(`total` mismatches etc.) until the ETL findings are resolved — that's the
+harness doing its job, not a harness bug.
+
+## File map
+
+- `../shadow-diff.run.ts` — entry (flags, boot, capture/diff dispatch).
+- `types.ts` — shared types. `personas.ts` — persona resolution.
+- `corpus.ts` — the hand-enumerated operations (the only file that grows).
+- `capture.ts` — id sampling, in-process execution, capture writing.
+- `known-deltas.ts` — suppression registry. `diff.ts` — comparison.
+- `report.ts` — markdown/stdout rendering.

--- a/src/core/shadow-diff/capture.ts
+++ b/src/core/shadow-diff/capture.ts
@@ -32,6 +32,7 @@ import {
 import { isGqlContext } from '~/core/graphql/gql-context.host';
 import { corpus } from './corpus';
 import { resolvePersonas } from './personas';
+import { redactCaptured, redactMessage } from './redact';
 import {
   type CaptureFile,
   type CaptureRunContext,
@@ -170,7 +171,7 @@ const expandCorpus = (
 
 /** Strip GraphQL errors to a comparable shape — message + code + path only. */
 const normalizeError = (error: GraphQLError): NormalizedError => ({
-  message: error.message,
+  message: redactMessage(error.message),
   ...(typeof error.extensions.code === 'string'
     ? { code: error.extensions.code }
     : {}),
@@ -230,8 +231,12 @@ const executeAs = async (
           }),
       ),
   );
+  // Redact BEFORE anything is retained: capture files previously held names,
+  // emails, phone numbers, comment/post bodies and 213 sensitivity=High records
+  // in plain text. Hashing preserves the parity check (same value -> same digest
+  // on both engines) while storing nothing readable. See redact.ts.
   return {
-    data: result.data ?? null,
+    data: redactCaptured(result.data ?? null),
     errors: (result.errors ?? []).map(normalizeError),
   };
 };

--- a/src/core/shadow-diff/capture.ts
+++ b/src/core/shadow-diff/capture.ts
@@ -1,0 +1,254 @@
+import { asc, isNull } from 'drizzle-orm';
+import { type AnyPgColumn, type PgTable } from 'drizzle-orm/pg-core';
+import {
+  graphql,
+  type GraphQLError,
+  Kind,
+  type OperationDefinitionNode,
+  parse,
+} from 'graphql';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { type GqlContextType, type ID } from '~/common';
+import { type DrizzleDb } from '~/core/drizzle/drizzle.service';
+import {
+  fieldRegions,
+  fieldZones,
+  fundingAccounts,
+  locations,
+  organizations,
+  partners,
+  partnerships,
+  projects,
+  tools,
+  users,
+} from '~/core/drizzle/schema';
+import { isGqlContext } from '~/core/graphql/gql-context.host';
+import { corpus } from './corpus';
+import { resolvePersonas } from './personas';
+import {
+  type CaptureFile,
+  type CaptureRunContext,
+  type NormalizedError,
+  type OperationResult,
+  type PersonaRole,
+  type SampledDomain,
+} from './types';
+
+/** By-id documents run against the first K live ids (ordered by id) per domain. */
+const SAMPLE_SIZE = 5;
+
+interface SampledTable {
+  readonly table: PgTable;
+  readonly id: AnyPgColumn;
+  readonly deletedAt: AnyPgColumn;
+}
+
+/**
+ * Domain → Postgres table for deterministic id sampling. Sampled from PG in
+ * BOTH capture runs (POSTGRES_URL is always set), so the id sets are
+ * identical across engines — the diff asserts this via the capture meta.
+ */
+const sampledTables: Readonly<Record<SampledDomain, SampledTable>> = {
+  users: { table: users, id: users.id, deletedAt: users.deletedAt },
+  tools: { table: tools, id: tools.id, deletedAt: tools.deletedAt },
+  fundingAccounts: {
+    table: fundingAccounts,
+    id: fundingAccounts.id,
+    deletedAt: fundingAccounts.deletedAt,
+  },
+  locations: {
+    table: locations,
+    id: locations.id,
+    deletedAt: locations.deletedAt,
+  },
+  fieldZones: {
+    table: fieldZones,
+    id: fieldZones.id,
+    deletedAt: fieldZones.deletedAt,
+  },
+  fieldRegions: {
+    table: fieldRegions,
+    id: fieldRegions.id,
+    deletedAt: fieldRegions.deletedAt,
+  },
+  organizations: {
+    table: organizations,
+    id: organizations.id,
+    deletedAt: organizations.deletedAt,
+  },
+  partners: { table: partners, id: partners.id, deletedAt: partners.deletedAt },
+  projects: { table: projects, id: projects.id, deletedAt: projects.deletedAt },
+  partnerships: {
+    table: partnerships,
+    id: partnerships.id,
+    deletedAt: partnerships.deletedAt,
+  },
+};
+
+const sampleIds = async (
+  db: DrizzleDb,
+): Promise<Record<SampledDomain, readonly string[]>> => {
+  const out: Partial<Record<SampledDomain, readonly string[]>> = {};
+  for (const [domain, spec] of Object.entries(sampledTables) as Array<
+    [SampledDomain, SampledTable]
+  >) {
+    const rows = await db
+      .select({ id: spec.id })
+      .from(spec.table)
+      .where(isNull(spec.deletedAt))
+      .orderBy(asc(spec.id))
+      .limit(SAMPLE_SIZE);
+    out[domain] = rows.map((row) => String(row.id));
+  }
+  return out as Record<SampledDomain, readonly string[]>;
+};
+
+/** A corpus entry expanded to a concrete (single) execution. */
+interface ExpandedOp {
+  readonly key: string;
+  readonly document: string;
+  readonly variables?: Readonly<Record<string, unknown>>;
+}
+
+const expandCorpus = (
+  sampledIds: Record<SampledDomain, readonly string[]>,
+): ExpandedOp[] =>
+  corpus.flatMap((entry): ExpandedOp[] => {
+    if (!entry.idsFrom) {
+      return [
+        {
+          key: entry.key,
+          document: entry.document,
+          variables: entry.variables,
+        },
+      ];
+    }
+    return sampledIds[entry.idsFrom].map((id) => ({
+      key: `${entry.key}:${id}`,
+      document: entry.document,
+      variables: { ...entry.variables, id },
+    }));
+  });
+
+/** Strip GraphQL errors to a comparable shape — message + code + path only. */
+const normalizeError = (error: GraphQLError): NormalizedError => ({
+  message: error.message,
+  ...(typeof error.extensions.code === 'string'
+    ? { code: error.extensions.code }
+    : {}),
+  ...(error.path ? { path: [...error.path] } : {}),
+});
+
+const operationCache = new Map<string, OperationDefinitionNode>();
+const operationOf = (source: string): OperationDefinitionNode => {
+  const cached = operationCache.get(source);
+  if (cached) return cached;
+  const operation = parse(source).definitions.find(
+    (def): def is OperationDefinitionNode =>
+      def.kind === Kind.OPERATION_DEFINITION,
+  );
+  if (!operation) {
+    throw new Error('Corpus document has no operation definition');
+  }
+  operationCache.set(source, operation);
+  return operation;
+};
+
+/**
+ * Execute one corpus operation in-process as the given persona.
+ *
+ * Wiring notes (each piece is load-bearing — see README):
+ * - The context object carries `isGqlContext.KEY` + `operation` but NO
+ *   `request`: with a request present, the SessionInterceptor would resolve a
+ *   session from it and overwrite the persona session; without one it
+ *   early-returns and the `identity.asUser` session stands.
+ * - `gqlContextAls.run(...)` populates GqlContextHostImpl for anything that
+ *   reads `contextHost.context` (e.g. TransactionHooks) — in-process
+ *   execution bypasses the Yoga plugin that normally does this.
+ * - The process runs in CLI mode ('console' in argv), so ResourceLoader
+ *   resolves loaders against CLI_CONTEXT_ID and loader caching is off, while
+ *   `@Loader()` params still scope to the persona session via getLifetimeId.
+ */
+const executeAs = async (
+  ctx: CaptureRunContext,
+  userId: ID<'User'>,
+  op: ExpandedOp,
+): Promise<Pick<OperationResult, 'data' | 'errors'>> => {
+  const contextValue = Object.assign(Object.create(null) as GqlContextType, {
+    [isGqlContext.KEY]: true,
+    operation: operationOf(op.document),
+  });
+  const result = await ctx.gqlContextAls.run(
+    contextValue,
+    async () =>
+      await ctx.identity.asUser(
+        userId,
+        async () =>
+          await graphql({
+            schema: ctx.schema,
+            source: op.document,
+            variableValues: op.variables,
+            contextValue,
+          }),
+      ),
+  );
+  return {
+    data: result.data ?? null,
+    errors: (result.errors ?? []).map(normalizeError),
+  };
+};
+
+/**
+ * Replay the whole corpus under every resolvable persona and write
+ * `capture-<engine>.json` into `outDir`.
+ */
+export const runCapture = async (
+  ctx: CaptureRunContext,
+  outDir: string,
+): Promise<void> => {
+  const { personas, skipped } = await resolvePersonas(ctx.db, ctx.log);
+  const sampled = await sampleIds(ctx.db);
+  const ops = expandCorpus(sampled);
+
+  ctx.log(
+    `\nShadow-diff capture — engine=${ctx.engine}\n` +
+      `${ops.length} operations × ${personas.size} personas ` +
+      `(${skipped.length} roles skipped)\n`,
+  );
+
+  const results: OperationResult[] = [];
+  for (const [role, userId] of personas) {
+    const started = process.hrtime.bigint();
+    for (const op of ops) {
+      const { data, errors } = await executeAs(ctx, userId, op);
+      results.push({ op: op.key, persona: role, data, errors });
+    }
+    const ms = Number(process.hrtime.bigint() - started) / 1e6;
+    const errorCount = results.filter(
+      (r) => r.persona === role && r.errors.length > 0,
+    ).length;
+    ctx.log(
+      `  ${role} (${userId}): ${ops.length} ops, ` +
+        `${errorCount} with errors (${ms.toFixed(0)}ms)`,
+    );
+  }
+
+  const capture: CaptureFile = {
+    meta: {
+      engine: ctx.engine,
+      capturedAt: new Date().toISOString(),
+      personas: Object.fromEntries(personas) as Partial<
+        Record<PersonaRole, string>
+      >,
+      skippedPersonas: skipped,
+      sampledIds: sampled,
+    },
+    results,
+  };
+
+  fs.mkdirSync(outDir, { recursive: true });
+  const outFile = path.join(outDir, `capture-${ctx.engine}.json`);
+  fs.writeFileSync(outFile, JSON.stringify(capture, null, 2));
+  ctx.log(`\nWrote ${results.length} results to ${outFile}`);
+};

--- a/src/core/shadow-diff/capture.ts
+++ b/src/core/shadow-diff/capture.ts
@@ -1,4 +1,4 @@
-import { asc, isNull } from 'drizzle-orm';
+import { and, asc, eq, isNull, type SQL } from 'drizzle-orm';
 import { type AnyPgColumn, type PgTable } from 'drizzle-orm/pg-core';
 import {
   graphql,
@@ -12,13 +12,19 @@ import * as path from 'node:path';
 import { type GqlContextType, type ID } from '~/common';
 import { type DrizzleDb } from '~/core/drizzle/drizzle.service';
 import {
+  commentThreads,
+  engagements,
   fieldRegions,
   fieldZones,
   fundingAccounts,
+  languages,
   locations,
   organizations,
   partners,
   partnerships,
+  periodicReports,
+  posts,
+  products,
   projects,
   tools,
   users,
@@ -41,7 +47,14 @@ const SAMPLE_SIZE = 5;
 interface SampledTable {
   readonly table: PgTable;
   readonly id: AnyPgColumn;
-  readonly deletedAt: AnyPgColumn;
+  /**
+   * Optional because not every migrated table is soft-deleted: `periodic_reports`
+   * deliberately has NO `deleted_at` (deterministic ids + real deletes), so
+   * requiring one here would have forced a fake column to sample it.
+   */
+  readonly deletedAt?: AnyPgColumn;
+  /** Extra narrowing, e.g. progress reports = periodic_reports type='Progress'. */
+  readonly predicate?: SQL;
 }
 
 /**
@@ -84,6 +97,26 @@ const sampledTables: Readonly<Record<SampledDomain, SampledTable>> = {
     id: partnerships.id,
     deletedAt: partnerships.deletedAt,
   },
+  languages: {
+    table: languages,
+    id: languages.id,
+    deletedAt: languages.deletedAt,
+  },
+  engagements: {
+    table: engagements,
+    id: engagements.id,
+    deletedAt: engagements.deletedAt,
+  },
+  products: { table: products, id: products.id, deletedAt: products.deletedAt },
+  // No deletedAt — periodic_reports is real-delete by design.
+  periodicReports: { table: periodicReports, id: periodicReports.id },
+  progressReports: {
+    table: periodicReports,
+    id: periodicReports.id,
+    predicate: eq(periodicReports.type, 'Progress'),
+  },
+  commentThreads: { table: commentThreads, id: commentThreads.id },
+  posts: { table: posts, id: posts.id },
 };
 
 const sampleIds = async (
@@ -93,10 +126,14 @@ const sampleIds = async (
   for (const [domain, spec] of Object.entries(sampledTables) as Array<
     [SampledDomain, SampledTable]
   >) {
+    const conditions = [
+      ...(spec.deletedAt ? [isNull(spec.deletedAt)] : []),
+      ...(spec.predicate ? [spec.predicate] : []),
+    ];
     const rows = await db
       .select({ id: spec.id })
       .from(spec.table)
-      .where(isNull(spec.deletedAt))
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
       .orderBy(asc(spec.id))
       .limit(SAMPLE_SIZE);
     out[domain] = rows.map((row) => String(row.id));

--- a/src/core/shadow-diff/corpus.ts
+++ b/src/core/shadow-diff/corpus.ts
@@ -746,6 +746,635 @@ const notificationsList = /* GraphQL */ `
 
 // ─── the corpus ──────────────────────────────────────────────────────────────
 
+// ─── languages ───────────────────────────────────────────────────────────────
+// Added 2026-07-30. Excluded and why:
+//   tools           — ToolUsage has no table on this branch.
+//   history         — resource_mutations exists but the ETL does not load it, so
+//                     Postgres would be empty against a populated Neo4j.
+//   firstScripture  — union over engagement/product derivation; covered
+//                     indirectly by hasExternalFirstScripture (a stored bool).
+//   usesAIAssistance — derived, and carries a known Neo4j 42N07 shadowing fault
+//                     on the filter+sort combination (transition-only, won't fix).
+// pinned IS included — it is how this corpus covers the Pin domain at all.
+const languageFields = /* GraphQL */ `
+  id
+  createdAt
+  avatarLetters
+  sensitivity
+  pinned
+  name { value canRead canEdit }
+  displayName { value canRead canEdit }
+  displayNamePronunciation { value canRead canEdit }
+  isDialect { value canRead canEdit }
+  isSignLanguage { value canRead canEdit }
+  signLanguageCode { value canRead canEdit }
+  population { value canRead canEdit }
+  populationOverride { value canRead canEdit }
+  registryOfLanguageVarietiesCode { value canRead canEdit }
+  leastOfThese { value canRead canEdit }
+  leastOfTheseReason { value canRead canEdit }
+  sponsorStartDate { value canRead canEdit }
+  sponsorEstimatedEndDate { value canRead canEdit }
+  isAvailableForReporting { value canRead canEdit }
+  presetInventory { value canRead canEdit }
+  hasExternalFirstScripture { value canRead canEdit }
+  tags { value canRead canEdit }
+  ethnologue {
+    sensitivity
+    code { value canRead canEdit }
+    provisionalCode { value canRead canEdit }
+    name { value canRead canEdit }
+    population { value canRead canEdit }
+  }
+`;
+
+const languagesList = /* GraphQL */ `
+  query ShadowLanguages($input: LanguageListInput) {
+    languages(input: $input) {
+      total
+      hasMore
+      items {
+        id
+      }
+    }
+  }
+`;
+
+const languageById = /* GraphQL */ `
+  query ShadowLanguageById($id: ID!) {
+    language(id: $id) {
+      ${languageFields}
+      posts { total hasMore canRead canCreate items { id type shareability } }
+      commentThreads { total hasMore canRead canCreate items { id } }
+    }
+  }
+`;
+
+// ─── engagements ─────────────────────────────────────────────────────────────
+// Read through `engagement(id)` (the interface) rather than
+// `languageEngagement(id)`, so one document covers BOTH subtypes and the
+// sampled id set does not have to be split by type.
+// Excluded: pnp / pnpExtractionResult (File wave), partnershipsProducingMediums
+// (no table on this branch), changeset + changesetDiff (changesets are not
+// carried forward), tools, history, usingAIAssistedTranslation (tool-derived).
+const engagementsList = /* GraphQL */ `
+  query ShadowEngagements($input: EngagementListInput) {
+    engagements(input: $input) {
+      total
+      hasMore
+      items {
+        id
+      }
+    }
+  }
+`;
+
+const engagementById = /* GraphQL */ `
+  query ShadowEngagementById($id: ID!) {
+    engagement(id: $id) {
+      __typename
+      id
+      createdAt
+      modifiedAt
+      sensitivity
+      status {
+        value
+        canRead
+        canEdit
+      }
+      statusModifiedAt {
+        value
+        canRead
+        canEdit
+      }
+      lastSuspendedAt {
+        value
+        canRead
+        canEdit
+      }
+      lastReactivatedAt {
+        value
+        canRead
+        canEdit
+      }
+      completeDate {
+        value
+        canRead
+        canEdit
+      }
+      disbursementCompleteDate {
+        value
+        canRead
+        canEdit
+      }
+      startDate {
+        value
+        canRead
+        canEdit
+      }
+      endDate {
+        value
+        canRead
+        canEdit
+      }
+      startDateOverride {
+        value
+        canRead
+        canEdit
+      }
+      endDateOverride {
+        value
+        canRead
+        canEdit
+      }
+      initialEndDate {
+        value
+        canRead
+        canEdit
+      }
+      description {
+        value
+        canRead
+        canEdit
+      }
+      ceremony {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+      ... on LanguageEngagement {
+        historicGoal {
+          value
+          canRead
+          canEdit
+        }
+        lukePartnership {
+          value
+          canRead
+          canEdit
+        }
+        openToInvestorVisit {
+          value
+          canRead
+          canEdit
+        }
+        firstScripture {
+          value
+          canRead
+          canEdit
+        }
+        paratextRegistryId {
+          value
+          canRead
+          canEdit
+        }
+        milestonePlanned {
+          value
+          canRead
+          canEdit
+        }
+        milestoneReached {
+          value
+          canRead
+          canEdit
+        }
+        sentPrintingDate {
+          value
+          canRead
+          canEdit
+        }
+        rev79CommunityId {
+          value
+          canRead
+          canEdit
+        }
+        language {
+          canRead
+          canEdit
+          value {
+            id
+          }
+        }
+        products {
+          total
+          hasMore
+          canRead
+          canCreate
+          items {
+            id
+          }
+        }
+        progressReports {
+          total
+          hasMore
+          items {
+            id
+          }
+        }
+      }
+      ... on InternshipEngagement {
+        methodologies {
+          value
+          canRead
+          canEdit
+        }
+        position {
+          value
+          canRead
+          canEdit
+        }
+        intern {
+          canRead
+          canEdit
+          value {
+            id
+          }
+        }
+        mentor {
+          canRead
+          canEdit
+          value {
+            id
+          }
+        }
+        countryOfOrigin {
+          canRead
+          canEdit
+          value {
+            id
+          }
+        }
+      }
+    }
+  }
+`;
+
+// ─── products ────────────────────────────────────────────────────────────────
+// Product is an interface; the three concrete types carry the fields that the
+// single-table-inheritance CHECKs are built around, so each gets a fragment.
+// Excluded: tools, history, project/engagement back-refs (covered from the
+// engagement side), progressReport* (covered via the ProgressReport document).
+const productsList = /* GraphQL */ `
+  query ShadowProducts($input: ProductListInput) {
+    products(input: $input) {
+      total
+      hasMore
+      items {
+        id
+      }
+    }
+  }
+`;
+
+const productById = /* GraphQL */ `
+  query ShadowProductById($id: ID!) {
+    product(id: $id) {
+      __typename
+      id
+      createdAt
+      sensitivity
+      approach
+      category
+      availableSteps
+      mediums {
+        value
+        canRead
+        canEdit
+      }
+      purposes {
+        value
+        canRead
+        canEdit
+      }
+      methodology {
+        value
+        canRead
+        canEdit
+      }
+      steps {
+        value
+        canRead
+        canEdit
+      }
+      describeCompletion {
+        value
+        canRead
+        canEdit
+      }
+      placeholderDescription {
+        value
+        canRead
+        canEdit
+      }
+      progressStepMeasurement {
+        value
+        canRead
+        canEdit
+      }
+      progressTarget {
+        value
+        canRead
+        canEdit
+      }
+      scriptureReferences {
+        canRead
+        canEdit
+        value {
+          start {
+            book
+            chapter
+            verse
+          }
+          end {
+            book
+            chapter
+            verse
+          }
+        }
+      }
+      ... on DirectScriptureProduct {
+        unspecifiedScripture {
+          canRead
+          canEdit
+          value {
+            book
+            totalVerses
+          }
+        }
+        totalVerses
+        totalVerseEquivalents
+      }
+      ... on DerivativeScriptureProduct {
+        composite {
+          value
+          canRead
+          canEdit
+        }
+        totalVerses
+        totalVerseEquivalents
+        scriptureReferencesOverride {
+          canRead
+          canEdit
+          value {
+            start {
+              book
+              chapter
+              verse
+            }
+            end {
+              book
+              chapter
+              verse
+            }
+          }
+        }
+        produces {
+          canRead
+          canEdit
+          value {
+            id
+            __typename
+          }
+        }
+      }
+      ... on OtherProduct {
+        title {
+          value
+          canRead
+          canEdit
+        }
+        description {
+          value
+          canRead
+          canEdit
+        }
+      }
+    }
+  }
+`;
+
+// ─── periodic + progress reports ─────────────────────────────────────────────
+// Excluded: reportFile / narrativeFile (File wave — the ids are carried but the
+// file_nodes rows are not, so both engines would answer from different truths),
+// media / featuredMedia / pnpExtractionResult (File-keyed), varianceExplanation
+// and workflowEvents (NO Postgres table exists for either — a real gap, see
+// src/core/cutover/README.md), tools, history.
+const periodicReportsList = /* GraphQL */ `
+  query ShadowPeriodicReports($input: PeriodicReportListInput) {
+    periodicReports(input: $input) {
+      total
+      hasMore
+      items {
+        id
+        __typename
+        type
+        start
+        end
+        due
+      }
+    }
+  }
+`;
+
+const periodicReportById = /* GraphQL */ `
+  query ShadowPeriodicReportById($id: ID!) {
+    periodicReport(id: $id) {
+      __typename
+      id
+      createdAt
+      type
+      start
+      end
+      due
+      sensitivity
+      receivedDate {
+        value
+        canRead
+        canEdit
+      }
+      narrativeReceivedDate {
+        value
+        canRead
+        canEdit
+      }
+      skippedReason {
+        value
+        canRead
+        canEdit
+      }
+      parent {
+        id
+      }
+      ... on ProgressReport {
+        status {
+          value
+          canRead
+          canEdit
+          transitions {
+            id
+            label
+            to
+            type
+          }
+        }
+        cumulativeSummary {
+          planned
+          actual
+          variance
+          scheduleStatus
+        }
+        fiscalYearSummary {
+          planned
+          actual
+          variance
+          scheduleStatus
+        }
+        periodSummary {
+          planned
+          actual
+          variance
+          scheduleStatus
+        }
+        teamNews {
+          total
+          hasMore
+          canRead
+          canCreate
+          items {
+            id
+            prompt {
+              value {
+                id
+              }
+            }
+          }
+        }
+        highlights {
+          total
+          hasMore
+          canRead
+          canCreate
+          items {
+            id
+          }
+        }
+        communityStories {
+          total
+          hasMore
+          canRead
+          canCreate
+          items {
+            id
+          }
+        }
+        progress {
+          variant {
+            key
+          }
+          steps {
+            step
+            completed {
+              value
+              canRead
+              canEdit
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const progressReportsList = /* GraphQL */ `
+  query ShadowProgressReports($input: ProgressReportListInput) {
+    progressReports(input: $input) {
+      total
+      hasMore
+      canRead
+      canCreate
+      items {
+        id
+        start
+        end
+        status {
+          value
+        }
+      }
+    }
+  }
+`;
+
+// ─── comments + posts (the leaves) ───────────────────────────────────────────
+// `commentThreads(resource:)` needs a parent id, so threads are covered by-id
+// instead; the comments list hangs off the thread document.
+const commentThreadById = /* GraphQL */ `
+  query ShadowCommentThreadById($id: ID!) {
+    commentThread(id: $id) {
+      id
+      createdAt
+      creator {
+        id
+      }
+      parent {
+        id
+      }
+      firstComment {
+        id
+        createdAt
+      }
+      latestComment {
+        id
+        createdAt
+      }
+      comments {
+        total
+        hasMore
+        canRead
+        canCreate
+        items {
+          id
+          createdAt
+          modifiedAt
+          creator {
+            id
+          }
+          body {
+            value
+            canRead
+            canEdit
+          }
+        }
+      }
+    }
+  }
+`;
+
+const postById = /* GraphQL */ `
+  query ShadowPostById($id: ID!) {
+    post(id: $id) {
+      id
+      createdAt
+      modifiedAt
+      type
+      shareability
+      body {
+        value
+        canRead
+        canEdit
+      }
+      creator {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+    }
+  }
+`;
+
 export const corpus: readonly CorpusEntry[] = [
   // users — default sort is `id`
   { key: 'users.list.default', document: usersList },
@@ -934,4 +1563,100 @@ export const corpus: readonly CorpusEntry[] = [
     document: notificationsList,
     variables: { input: { filter: { unread: true } } },
   },
+  // ─── languages (added 2026-07-30) ──────────────────────────────────────────
+  { key: 'languages.list.default', document: languagesList },
+  {
+    key: 'languages.list.sort-name-desc',
+    document: languagesList,
+    variables: { input: { sort: 'name', order: 'DESC' } },
+  },
+  {
+    key: 'languages.list.sort-createdAt-asc',
+    document: languagesList,
+    variables: { input: { sort: 'createdAt', order: 'ASC' } },
+  },
+  {
+    key: 'languages.list.filter-isDialect',
+    document: languagesList,
+    variables: { input: { filter: { isDialect: true } } },
+  },
+  {
+    key: 'languages.list.filter-presetInventory',
+    document: languagesList,
+    variables: { input: { filter: { presetInventory: true } } },
+  },
+  { key: 'language.byId', document: languageById, idsFrom: 'languages' },
+
+  // ─── engagements ──────────────────────────────────────────────────────────
+  { key: 'engagements.list.default', document: engagementsList },
+  {
+    key: 'engagements.list.sort-createdAt-desc',
+    document: engagementsList,
+    variables: { input: { sort: 'createdAt', order: 'DESC' } },
+  },
+  {
+    key: 'engagements.list.filter-status-active',
+    document: engagementsList,
+    variables: { input: { filter: { status: ['Active'] } } },
+  },
+  {
+    key: 'engagements.list.filter-type-language',
+    document: engagementsList,
+    variables: { input: { filter: { type: 'language' } } },
+  },
+  { key: 'engagement.byId', document: engagementById, idsFrom: 'engagements' },
+
+  // ─── products ─────────────────────────────────────────────────────────────
+  { key: 'products.list.default', document: productsList },
+  {
+    key: 'products.list.sort-createdAt-desc',
+    document: productsList,
+    variables: { input: { sort: 'createdAt', order: 'DESC' } },
+  },
+  {
+    key: 'products.list.filter-methodology',
+    document: productsList,
+    variables: { input: { filter: { methodology: 'OtherWritten' } } },
+  },
+  { key: 'product.byId', document: productById, idsFrom: 'products' },
+
+  // ─── periodic + progress reports ──────────────────────────────────────────
+  { key: 'periodicReports.list.default', document: periodicReportsList },
+  {
+    key: 'periodicReports.list.filter-type-progress',
+    document: periodicReportsList,
+    variables: { input: { type: 'Progress' } },
+  },
+  {
+    key: 'periodicReports.list.sort-end-desc',
+    document: periodicReportsList,
+    variables: { input: { sort: 'end', order: 'DESC' } },
+  },
+  {
+    key: 'periodicReport.byId',
+    document: periodicReportById,
+    idsFrom: 'periodicReports',
+  },
+  // Same document, but over ids sampled from type='Progress' only — this is what
+  // actually exercises the ProgressReport fragment (status, the three summaries,
+  // prompt responses, product progress).
+  {
+    key: 'progressReport.byId',
+    document: periodicReportById,
+    idsFrom: 'progressReports',
+  },
+  { key: 'progressReports.list.default', document: progressReportsList },
+  {
+    key: 'progressReports.list.filter-status-notStarted',
+    document: progressReportsList,
+    variables: { input: { filter: { status: ['NotStarted'] } } },
+  },
+
+  // ─── comments + posts ─────────────────────────────────────────────────────
+  {
+    key: 'commentThread.byId',
+    document: commentThreadById,
+    idsFrom: 'commentThreads',
+  },
+  { key: 'post.byId', document: postById, idsFrom: 'posts' },
 ];

--- a/src/core/shadow-diff/corpus.ts
+++ b/src/core/shadow-diff/corpus.ts
@@ -1,0 +1,937 @@
+import { type CorpusEntry } from './types';
+
+/**
+ * The hand-enumerated read-only corpus, covering the 12 queryable domains
+ * that are landed on Postgres AND loaded by the cutover ETL:
+ *
+ *   users · tools · fundingAccounts · locations · fieldZones · fieldRegions
+ *   organizations · partners · projects · projectMembers · partnerships
+ *   notifications
+ *
+ * - projectMembers have no top-level query; they are read via `project.team`
+ *   (see the project by-id document).
+ * - Education + Unavailability are read via `user.education` /
+ *   `user.unavailabilities` sub-selections on the user by-id document.
+ * - EthnologueLanguage is only reachable through Language (not landed) and is
+ *   EXCLUDED (see README).
+ *
+ * Lists select `total` + `hasMore` + item IDS only — ordering, filtering, and
+ * row-visibility parity. Full secured-field coverage lives on the by-id
+ * documents (expanded over K=5 deterministically sampled ids per domain).
+ *
+ * Field selections cover MIGRATED-BACKED fields only. Every exclusion is
+ * commented with why, so re-adding at each domain land is a grep away.
+ */
+
+// ─── users ───────────────────────────────────────────────────────────────────
+// Excluded: isIntern (engagement-derived; PG stubs it — migration-todo in
+//   user.drizzle.repository.ts), pinned (Pin domain not migrated).
+// Excluded: knownLanguages (Language not landed).
+// photo IS included (File-domain boundary resolves via the Neo4j file repo on
+//   both engines); its null-shape difference is registered as known-delta U14.
+const userFields = /* GraphQL */ `
+  id
+  createdAt
+  fullName
+  firstName
+  avatarLetters
+  email { value canRead canEdit }
+  realFirstName { value canRead canEdit }
+  realLastName { value canRead canEdit }
+  displayFirstName { value canRead canEdit }
+  displayLastName { value canRead canEdit }
+  phone { value canRead canEdit }
+  timezone { canRead canEdit value { name } }
+  about { value canRead canEdit }
+  status { value canRead canEdit }
+  roles { value canRead canEdit }
+  title { value canRead canEdit }
+  photo { canRead canEdit value { id } }
+`;
+
+const userById = /* GraphQL */ `
+  query ShadowUserById($id: ID!) {
+    user(id: $id) {
+      ${userFields}
+      education {
+        canRead canCreate total hasMore
+        items {
+          id
+          createdAt
+          degree { value canRead canEdit }
+          major { value canRead canEdit }
+          institution { value canRead canEdit }
+        }
+      }
+      unavailabilities {
+        canRead canCreate total hasMore
+        items {
+          id
+          createdAt
+          description { value canRead canEdit }
+          start { value canRead canEdit }
+          end { value canRead canEdit }
+        }
+      }
+      # items excluded on the three lists below:
+      # - organizations/partners: userId-filtered from-user reads are not
+      #   validated on PG yet; can* perms are policy-driven (engine-agnostic).
+      # - locations: PG listLocationsFromNode is an EMPTY_PAGE stub
+      #   (migration-todo in location.drizzle.repository.ts).
+      organizations { canRead canCreate }
+      partners { canRead canCreate }
+      locations { canRead canCreate }
+    }
+  }
+`;
+
+const usersList = /* GraphQL */ `
+  query ShadowUsersList($input: UserListInput) {
+    users(input: $input) {
+      total
+      hasMore
+      items {
+        id
+      }
+    }
+  }
+`;
+
+// ─── tools ───────────────────────────────────────────────────────────────────
+const toolById = /* GraphQL */ `
+  query ShadowToolById($id: ID!) {
+    tool(id: $id) {
+      id
+      createdAt
+      name {
+        value
+        canRead
+        canEdit
+      }
+      description {
+        value
+        canRead
+        canEdit
+      }
+      aiBased {
+        value
+        canRead
+        canEdit
+      }
+      key {
+        value
+        canRead
+        canEdit
+      }
+    }
+  }
+`;
+
+const toolsList = /* GraphQL */ `
+  query ShadowToolsList($input: ToolListInput) {
+    tools(input: $input) {
+      total
+      hasMore
+      items {
+        id
+      }
+    }
+  }
+`;
+
+// ─── fundingAccounts ─────────────────────────────────────────────────────────
+const fundingAccountById = /* GraphQL */ `
+  query ShadowFundingAccountById($id: ID!) {
+    fundingAccount(id: $id) {
+      id
+      createdAt
+      name {
+        value
+        canRead
+        canEdit
+      }
+      accountNumber {
+        value
+        canRead
+        canEdit
+      }
+    }
+  }
+`;
+
+const fundingAccountsList = /* GraphQL */ `
+  query ShadowFundingAccountsList($input: FundingAccountListInput) {
+    fundingAccounts(input: $input) {
+      total
+      hasMore
+      items {
+        id
+      }
+    }
+  }
+`;
+
+// ─── locations ───────────────────────────────────────────────────────────────
+// Excluded: mapImage (File-domain boundary; not covered by the proven test
+//   fragments — revisit when the File domain lands).
+const locationById = /* GraphQL */ `
+  query ShadowLocationById($id: ID!) {
+    location(id: $id) {
+      id
+      createdAt
+      name {
+        value
+        canRead
+        canEdit
+      }
+      type {
+        value
+        canRead
+        canEdit
+      }
+      isoAlpha3 {
+        value
+        canRead
+        canEdit
+      }
+      fundingAccount {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+      defaultFieldRegion {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+      defaultMarketingRegion {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+    }
+  }
+`;
+
+const locationsList = /* GraphQL */ `
+  query ShadowLocationsList($input: LocationListInput) {
+    locations(input: $input) {
+      total
+      hasMore
+      items {
+        id
+      }
+    }
+  }
+`;
+
+// ─── fieldZones ──────────────────────────────────────────────────────────────
+const fieldZoneById = /* GraphQL */ `
+  query ShadowFieldZoneById($id: ID!) {
+    fieldZone(id: $id) {
+      id
+      createdAt
+      name {
+        value
+        canRead
+        canEdit
+      }
+      director {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+    }
+  }
+`;
+
+const fieldZonesList = /* GraphQL */ `
+  query ShadowFieldZonesList($input: FieldZoneListInput) {
+    fieldZones(input: $input) {
+      total
+      hasMore
+      items {
+        id
+      }
+    }
+  }
+`;
+
+// ─── fieldRegions ────────────────────────────────────────────────────────────
+const fieldRegionById = /* GraphQL */ `
+  query ShadowFieldRegionById($id: ID!) {
+    fieldRegion(id: $id) {
+      id
+      createdAt
+      name {
+        value
+        canRead
+        canEdit
+      }
+      fieldZone {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+      director {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+    }
+  }
+`;
+
+const fieldRegionsList = /* GraphQL */ `
+  query ShadowFieldRegionsList($input: FieldRegionListInput) {
+    fieldRegions(input: $input) {
+      total
+      hasMore
+      items {
+        id
+      }
+    }
+  }
+`;
+
+// ─── organizations ───────────────────────────────────────────────────────────
+// Excluded: locations sub-list (PG listLocationsFromNode is an EMPTY_PAGE
+//   stub — migration-todo in location.drizzle.repository.ts).
+const organizationById = /* GraphQL */ `
+  query ShadowOrganizationById($id: ID!) {
+    organization(id: $id) {
+      id
+      createdAt
+      sensitivity
+      name {
+        value
+        canRead
+        canEdit
+      }
+      acronym {
+        value
+        canRead
+        canEdit
+      }
+      address {
+        value
+        canRead
+        canEdit
+      }
+      types {
+        value
+        canRead
+        canEdit
+      }
+      reach {
+        value
+        canRead
+        canEdit
+      }
+    }
+  }
+`;
+
+const organizationsList = /* GraphQL */ `
+  query ShadowOrganizationsList($input: OrganizationListInput) {
+    organizations(input: $input) {
+      total
+      hasMore
+      items {
+        id
+      }
+    }
+  }
+`;
+
+// ─── partners ────────────────────────────────────────────────────────────────
+// Excluded: languageOfWiderCommunication / languageOfReporting /
+//   languagesOfConsulting (Language not landed on PG).
+// Excluded: pinned (Pin domain not migrated; PG stubs false).
+// Excluded: projects / languages / engagements / people sub-lists — cross-
+//   domain lists; projects has its own corpus entries, the rest aren't landed.
+const partnerById = /* GraphQL */ `
+  query ShadowPartnerById($id: ID!) {
+    partner(id: $id) {
+      id
+      createdAt
+      modifiedAt
+      sensitivity
+      organization {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+      pointOfContact {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+      types {
+        value
+        canRead
+        canEdit
+      }
+      financialReportingTypes {
+        value
+        canRead
+        canEdit
+      }
+      pmcEntityCode {
+        value
+        canRead
+        canEdit
+      }
+      globalInnovationsClient {
+        value
+        canRead
+        canEdit
+      }
+      active {
+        value
+        canRead
+        canEdit
+      }
+      address {
+        value
+        canRead
+        canEdit
+      }
+      startDate {
+        value
+        canRead
+        canEdit
+      }
+      approvedPrograms {
+        value
+        canRead
+        canEdit
+      }
+      departmentIdBlock {
+        canRead
+        canEdit
+        value {
+          id
+          blocks
+          programs
+        }
+      }
+      fieldRegions {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+      countries {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+    }
+  }
+`;
+
+const partnersList = /* GraphQL */ `
+  query ShadowPartnersList($input: PartnerListInput) {
+    partners(input: $input) {
+      total
+      hasMore
+      items {
+        id
+      }
+    }
+  }
+`;
+
+// ─── projects (+ projectMembers via team) ────────────────────────────────────
+// Excluded: pinned (Pin stub), engagementTotal (stubbed 0 until Engagement
+//   migrates), engagements (Engagement not landed), primaryPartnership (PG
+//   hydrates null — migration-todo in project.drizzle.repository.ts),
+//   budget/changeRequests (Budget/PCR not landed / excluded from migration).
+// rootDirectory value is id-only (File-domain boundary; column parity only).
+const projectById = /* GraphQL */ `
+  query ShadowProjectById($id: ID!) {
+    project(id: $id) {
+      id
+      createdAt
+      modifiedAt
+      type
+      sensitivity
+      status
+      name {
+        value
+        canRead
+        canEdit
+      }
+      departmentId {
+        value
+        canRead
+        canEdit
+      }
+      step {
+        value
+        canRead
+        canEdit
+      }
+      stepChangedAt {
+        value
+        canRead
+        canEdit
+      }
+      mouStart {
+        value
+        canRead
+        canEdit
+      }
+      mouEnd {
+        value
+        canRead
+        canEdit
+      }
+      initialMouEnd {
+        value
+        canRead
+        canEdit
+      }
+      estimatedSubmission {
+        value
+        canRead
+        canEdit
+      }
+      tags {
+        value
+        canRead
+        canEdit
+      }
+      financialReportReceivedAt {
+        value
+        canRead
+        canEdit
+      }
+      financialReportPeriod {
+        value
+        canRead
+        canEdit
+      }
+      primaryLocation {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+      marketingLocation {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+      marketingRegionOverride {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+      fieldRegion {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+      owningOrganization {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+      rootDirectory {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+      presetInventory {
+        value
+        canRead
+        canEdit
+      }
+      partnerships {
+        canRead
+        canCreate
+      }
+      team {
+        canRead
+        canCreate
+        total
+        hasMore
+        items {
+          id
+          createdAt
+          modifiedAt
+          sensitivity
+          active
+          inactiveAt {
+            value
+            canRead
+            canEdit
+          }
+          roles {
+            value
+            canRead
+            canEdit
+          }
+          user {
+            canRead
+            canEdit
+            value {
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const projectsList = /* GraphQL */ `
+  query ShadowProjectsList($input: ProjectListInput) {
+    projects(input: $input) {
+      total
+      hasMore
+      items {
+        id
+      }
+    }
+  }
+`;
+
+// ─── partnerships ────────────────────────────────────────────────────────────
+// mou/agreement values are id-only (File-domain boundary; column parity only).
+const partnershipById = /* GraphQL */ `
+  query ShadowPartnershipById($id: ID!) {
+    partnership(id: $id) {
+      id
+      createdAt
+      sensitivity
+      agreementStatus {
+        value
+        canRead
+        canEdit
+      }
+      mouStatus {
+        value
+        canRead
+        canEdit
+      }
+      mouStart {
+        value
+        canRead
+        canEdit
+      }
+      mouEnd {
+        value
+        canRead
+        canEdit
+      }
+      mouStartOverride {
+        value
+        canRead
+        canEdit
+      }
+      mouEndOverride {
+        value
+        canRead
+        canEdit
+      }
+      types {
+        value
+        canRead
+        canEdit
+      }
+      primary {
+        value
+        canRead
+        canEdit
+      }
+      financialReportingType {
+        value
+        canRead
+        canEdit
+      }
+      partner {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+      mou {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+      agreement {
+        canRead
+        canEdit
+        value {
+          id
+        }
+      }
+    }
+  }
+`;
+
+const partnershipsList = /* GraphQL */ `
+  query ShadowPartnershipsList($input: PartnershipListInput) {
+    partnerships(input: $input) {
+      total
+      hasMore
+      items {
+        id
+      }
+    }
+  }
+`;
+
+// ─── notifications ───────────────────────────────────────────────────────────
+// Requester-scoped: per-persona results are expected and must match across
+// engines for the same persona. No top-level by-id query exists.
+// Only the SystemNotification concrete selection is included; comment-mention
+// notifications hydrate through the Comments domain (not landed).
+const notificationsList = /* GraphQL */ `
+  query ShadowNotificationsList($input: NotificationListInput) {
+    notifications(input: $input) {
+      total
+      totalUnread
+      hasMore
+      items {
+        __typename
+        id
+        createdAt
+        unread
+        readAt
+        ... on SystemNotification {
+          message
+        }
+      }
+    }
+  }
+`;
+
+// ─── the corpus ──────────────────────────────────────────────────────────────
+
+export const corpus: readonly CorpusEntry[] = [
+  // users — default sort is `id`
+  { key: 'users.list.default', document: usersList },
+  {
+    key: 'users.list.sort-displayLastName-asc',
+    document: usersList,
+    variables: { input: { sort: 'displayLastName' } },
+  },
+  {
+    key: 'users.list.sort-displayLastName-desc',
+    document: usersList,
+    variables: { input: { sort: 'displayLastName', order: 'DESC' } },
+  },
+  {
+    key: 'users.list.sort-createdAt-asc',
+    document: usersList,
+    variables: { input: { sort: 'createdAt' } },
+  },
+  {
+    key: 'users.list.filter-status-active',
+    document: usersList,
+    variables: { input: { filter: { status: 'Active' } } },
+  },
+  { key: 'user.byId', document: userById, idsFrom: 'users' },
+
+  // tools — default sort is `name`
+  { key: 'tools.list.default', document: toolsList },
+  {
+    key: 'tools.list.sort-name-desc',
+    document: toolsList,
+    variables: { input: { sort: 'name', order: 'DESC' } },
+  },
+  {
+    key: 'tools.list.sort-createdAt-asc',
+    document: toolsList,
+    variables: { input: { sort: 'createdAt' } },
+  },
+  {
+    key: 'tools.list.filter-aiBased',
+    document: toolsList,
+    variables: { input: { filter: { aiBased: true } } },
+  },
+  { key: 'tool.byId', document: toolById, idsFrom: 'tools' },
+
+  // fundingAccounts — default sort is `name`; the input has no filter field
+  { key: 'fundingAccounts.list.default', document: fundingAccountsList },
+  {
+    key: 'fundingAccounts.list.sort-name-desc',
+    document: fundingAccountsList,
+    variables: { input: { sort: 'name', order: 'DESC' } },
+  },
+  {
+    key: 'fundingAccounts.list.sort-createdAt-asc',
+    document: fundingAccountsList,
+    variables: { input: { sort: 'createdAt' } },
+  },
+  {
+    key: 'fundingAccount.byId',
+    document: fundingAccountById,
+    idsFrom: 'fundingAccounts',
+  },
+
+  // locations — default sort is `name`
+  { key: 'locations.list.default', document: locationsList },
+  {
+    key: 'locations.list.sort-name-desc',
+    document: locationsList,
+    variables: { input: { sort: 'name', order: 'DESC' } },
+  },
+  {
+    key: 'locations.list.sort-createdAt-asc',
+    document: locationsList,
+    variables: { input: { sort: 'createdAt' } },
+  },
+  {
+    key: 'locations.list.filter-type-country',
+    document: locationsList,
+    variables: { input: { filter: { type: ['Country'] } } },
+  },
+  { key: 'location.byId', document: locationById, idsFrom: 'locations' },
+
+  // fieldZones — default sort is `name`; only nested (director) filters exist
+  { key: 'fieldZones.list.default', document: fieldZonesList },
+  {
+    key: 'fieldZones.list.sort-name-desc',
+    document: fieldZonesList,
+    variables: { input: { sort: 'name', order: 'DESC' } },
+  },
+  {
+    key: 'fieldZones.list.sort-createdAt-asc',
+    document: fieldZonesList,
+    variables: { input: { sort: 'createdAt' } },
+  },
+  { key: 'fieldZone.byId', document: fieldZoneById, idsFrom: 'fieldZones' },
+
+  // fieldRegions — default sort is `name`
+  { key: 'fieldRegions.list.default', document: fieldRegionsList },
+  {
+    key: 'fieldRegions.list.sort-name-desc',
+    document: fieldRegionsList,
+    variables: { input: { sort: 'name', order: 'DESC' } },
+  },
+  {
+    key: 'fieldRegions.list.sort-createdAt-asc',
+    document: fieldRegionsList,
+    variables: { input: { sort: 'createdAt' } },
+  },
+  {
+    key: 'fieldRegion.byId',
+    document: fieldRegionById,
+    idsFrom: 'fieldRegions',
+  },
+
+  // organizations — default sort is `name`; the filter arg is internal (not
+  // exposed in the schema — `@FilterField(..., { internal: true })`), so no
+  // filter variant
+  { key: 'organizations.list.default', document: organizationsList },
+  {
+    key: 'organizations.list.sort-name-desc',
+    document: organizationsList,
+    variables: { input: { sort: 'name', order: 'DESC' } },
+  },
+  {
+    key: 'organizations.list.sort-createdAt-asc',
+    document: organizationsList,
+    variables: { input: { sort: 'createdAt' } },
+  },
+  {
+    key: 'organization.byId',
+    document: organizationById,
+    idsFrom: 'organizations',
+  },
+
+  // partners — default sort is `createdAt`; Partner has no own name column
+  // (org-name sort is a cross-domain path — covered indirectly by orgs)
+  { key: 'partners.list.default', document: partnersList },
+  {
+    key: 'partners.list.sort-createdAt-desc',
+    document: partnersList,
+    variables: { input: { sort: 'createdAt', order: 'DESC' } },
+  },
+  {
+    key: 'partners.list.filter-globalInnovationsClient',
+    document: partnersList,
+    variables: { input: { filter: { globalInnovationsClient: true } } },
+  },
+  { key: 'partner.byId', document: partnerById, idsFrom: 'partners' },
+
+  // projects — default sort is `name`
+  { key: 'projects.list.default', document: projectsList },
+  {
+    key: 'projects.list.sort-name-desc',
+    document: projectsList,
+    variables: { input: { sort: 'name', order: 'DESC' } },
+  },
+  {
+    key: 'projects.list.sort-createdAt-asc',
+    document: projectsList,
+    variables: { input: { sort: 'createdAt' } },
+  },
+  {
+    key: 'projects.list.filter-type-momentum',
+    document: projectsList,
+    variables: { input: { filter: { type: ['MomentumTranslation'] } } },
+  },
+  { key: 'project.byId', document: projectById, idsFrom: 'projects' },
+
+  // partnerships — default sort is `createdAt`; the filter arg is internal
+  // (not exposed in the schema), so no filter variant
+  { key: 'partnerships.list.default', document: partnershipsList },
+  {
+    key: 'partnerships.list.sort-createdAt-desc',
+    document: partnershipsList,
+    variables: { input: { sort: 'createdAt', order: 'DESC' } },
+  },
+  {
+    key: 'partnership.byId',
+    document: partnershipById,
+    idsFrom: 'partnerships',
+  },
+
+  // notifications — requester-scoped; unsorted pagination input
+  { key: 'notifications.list.default', document: notificationsList },
+  {
+    key: 'notifications.list.filter-unread',
+    document: notificationsList,
+    variables: { input: { filter: { unread: true } } },
+  },
+];

--- a/src/core/shadow-diff/diff.ts
+++ b/src/core/shadow-diff/diff.ts
@@ -1,0 +1,213 @@
+import { matchKnownDelta } from './known-deltas';
+import {
+  type CaptureFile,
+  type DiffEntry,
+  type DiffReport,
+  type OperationResult,
+  type OpPersonaSummary,
+} from './types';
+
+/**
+ * Marker for a key/index present on one side but absent on the other.
+ * Deliberately distinct from `null` — null-vs-missing is a real finding class
+ * and is never normalized away.
+ */
+export const ABSENT = '«absent»';
+
+/**
+ * Datetime canonicalization is limited to values that are BOTH valid ISO
+ * instants AND represent the same moment — i.e. only string-form differences
+ * (offset spelling, milliseconds) are treated as equal, and counted. Anything
+ * else (different instants, date-only strings, null-vs-value) diffs as usual.
+ */
+const ISO_INSTANT =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+const equivalentInstants = (a: unknown, b: unknown): boolean =>
+  typeof a === 'string' &&
+  typeof b === 'string' &&
+  ISO_INSTANT.test(a) &&
+  ISO_INSTANT.test(b) &&
+  Date.parse(a) === Date.parse(b);
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/** Locale-independent, deterministic string ordering. */
+const compareStrings = (a: string, b: string): number =>
+  a < b ? -1 : a > b ? 1 : 0;
+
+interface RawDiff {
+  readonly path: string;
+  readonly neo4j: unknown;
+  readonly postgres: unknown;
+}
+
+interface WalkState {
+  readonly diffs: RawDiff[];
+  instantNormalized: number;
+}
+
+/**
+ * Structural walk of two JSON values, emitting leaf differences.
+ * List item ORDER matters: arrays are compared index-wise as-is —
+ * ordering drift IS signal (see the disabled collation known-delta).
+ */
+const walk = (a: unknown, b: unknown, path: string, state: WalkState): void => {
+  if (Object.is(a, b)) return;
+  if (equivalentInstants(a, b)) {
+    state.instantNormalized += 1;
+    return;
+  }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      state.diffs.push({
+        path: `${path}.length`,
+        neo4j: a.length,
+        postgres: b.length,
+      });
+    }
+    const len = Math.max(a.length, b.length);
+    for (const i of Array.from({ length: len }).keys()) {
+      walk(
+        i < a.length ? a[i] : ABSENT,
+        i < b.length ? b[i] : ABSENT,
+        `${path}[${i}]`,
+        state,
+      );
+    }
+    return;
+  }
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const keys = [...new Set([...Object.keys(a), ...Object.keys(b)])].sort(
+      compareStrings,
+    );
+    for (const key of keys) {
+      walk(
+        key in a ? a[key] : ABSENT,
+        key in b ? b[key] : ABSENT,
+        path ? `${path}.${key}` : key,
+        state,
+      );
+    }
+    return;
+  }
+  state.diffs.push({ path, neo4j: a, postgres: b });
+};
+
+const resultKey = (result: OperationResult) =>
+  `${result.op}\0${result.persona}`;
+
+/** Throws unless both captures resolved identical personas + sampled ids. */
+const assertComparable = (neo4j: CaptureFile, postgres: CaptureFile): void => {
+  const mismatches: string[] = [];
+  const personasA = JSON.stringify(neo4j.meta.personas);
+  const personasB = JSON.stringify(postgres.meta.personas);
+  if (personasA !== personasB) {
+    mismatches.push(
+      `personas differ:\n  neo4j: ${personasA}\n  pg: ${personasB}`,
+    );
+  }
+  const idsA = JSON.stringify(neo4j.meta.sampledIds);
+  const idsB = JSON.stringify(postgres.meta.sampledIds);
+  if (idsA !== idsB) {
+    mismatches.push(`sampled ids differ:\n  neo4j: ${idsA}\n  pg: ${idsB}`);
+  }
+  if (mismatches.length > 0) {
+    throw new Error(
+      'Captures are not comparable — they were taken against different ' +
+        'datasets (or the Postgres data changed between runs). Re-run both ' +
+        `captures against the same loaded DBs.\n${mismatches.join('\n')}`,
+    );
+  }
+};
+
+export const diffCaptures = (
+  neo4j: CaptureFile,
+  postgres: CaptureFile,
+): DiffReport => {
+  assertComparable(neo4j, postgres);
+
+  const neo4jByKey = new Map(neo4j.results.map((r) => [resultKey(r), r]));
+  const postgresByKey = new Map(postgres.results.map((r) => [resultKey(r), r]));
+  const allKeys = [
+    ...new Set([...neo4jByKey.keys(), ...postgresByKey.keys()]),
+  ].sort(compareStrings);
+
+  const summaries: OpPersonaSummary[] = [];
+  const diffs: DiffEntry[] = [];
+  const suppressed: DiffEntry[] = [];
+  let instantNormalized = 0;
+
+  for (const key of allKeys) {
+    const a = neo4jByKey.get(key);
+    const b = postgresByKey.get(key);
+    // Op/persona identity comes from whichever side has the result; a result
+    // missing on one side (corpus drift between runs) diffs at the root.
+    const known = (a ?? b)!;
+    const state: WalkState = { diffs: [], instantNormalized: 0 };
+    walk(
+      a ? { data: a.data, errors: a.errors } : ABSENT,
+      b ? { data: b.data, errors: b.errors } : ABSENT,
+      '',
+      state,
+    );
+    instantNormalized += state.instantNormalized;
+
+    let unsuppressedCount = 0;
+    let suppressedCount = 0;
+    let errorsMismatch = false;
+    for (const raw of state.diffs) {
+      const rule = matchKnownDelta(known.op, known.persona, raw.path);
+      const entry: DiffEntry = {
+        op: known.op,
+        persona: known.persona,
+        ...raw,
+        ...(rule ? { suppressedBy: rule.ref } : {}),
+      };
+      if (rule) {
+        suppressed.push(entry);
+        suppressedCount += 1;
+      } else {
+        diffs.push(entry);
+        unsuppressedCount += 1;
+        if (raw.path.startsWith('errors')) errorsMismatch = true;
+      }
+    }
+    summaries.push({
+      op: known.op,
+      persona: known.persona,
+      diffs: unsuppressedCount,
+      suppressed: suppressedCount,
+      errorsMismatch,
+    });
+  }
+
+  const identical = summaries.filter(
+    (s) => s.diffs === 0 && s.suppressed === 0,
+  ).length;
+  const withDiffs = summaries.filter((s) => s.diffs > 0).length;
+  const withSuppressedOnly = summaries.filter(
+    (s) => s.diffs === 0 && s.suppressed > 0,
+  ).length;
+
+  return {
+    meta: {
+      neo4j: neo4j.meta,
+      postgres: postgres.meta,
+      diffedAt: new Date().toISOString(),
+    },
+    summaries,
+    diffs,
+    suppressed,
+    totals: {
+      pairs: summaries.length,
+      identical,
+      withDiffs,
+      withSuppressedOnly,
+      diffCount: diffs.length,
+      suppressedCount: suppressed.length,
+      instantNormalized,
+    },
+  };
+};

--- a/src/core/shadow-diff/known-deltas.ts
+++ b/src/core/shadow-diff/known-deltas.ts
@@ -1,0 +1,74 @@
+/**
+ * Known-deltas suppression registry.
+ *
+ * A rule matches a diff by (operation key, persona, JSON path). Matched diffs
+ * are moved to the report's "suppressed" section — COUNTED and listed, never
+ * silent — and do not fail the run. Every rule carries a mandatory `reason`
+ * and `ref` (miss-ledger id) so each suppression is traceable.
+ *
+ * Add a rule only for a difference that has been investigated and accepted
+ * (or ledgered for a later fix). Anything else should stay red in the report.
+ */
+export interface KnownDeltaRule {
+  /** Ledger id (miss-ledger / finding reference). */
+  readonly ref: string;
+  readonly reason: string;
+  /** Matches the operation key, e.g. `^project`. */
+  readonly op: RegExp;
+  /** Matches the persona role name. */
+  readonly persona: RegExp;
+  /** Matches the diff's JSON path, e.g. `(^|\.)photo(\.|$)`. */
+  readonly path: RegExp;
+  /** Disabled rules never match; they document a candidate suppression. */
+  readonly disabled?: boolean;
+}
+
+const NON_ADMIN_PERSONAS =
+  /^(?:ProjectManager|Consultant|Intern|FieldPartner|Marketing|StaffMember)$/;
+
+export const knownDeltas: readonly KnownDeltaRule[] = [
+  {
+    ref: 'S1',
+    reason:
+      'Inactive-membership visibility: Neo4j read filters honor inactive ' +
+      'project memberships while Postgres scopes to active ones, so project/' +
+      'projectMember results under member personas can differ (~110 affected ' +
+      'memberships in prod).',
+    op: /^project/,
+    persona: NON_ADMIN_PERSONAS,
+    path: /./,
+  },
+  {
+    ref: 'U14',
+    reason:
+      'user.photo null shape: Neo4j hydrates a truthy secured object with a ' +
+      'null id where Postgres returns a null value.',
+    op: /^user/,
+    persona: /./,
+    path: /(^|\.)photo(\.|$)/,
+  },
+  {
+    ref: 'collation — enable only after inspecting',
+    reason:
+      'ORDER-only differences on name sorts can stem from Neo4j vs Postgres ' +
+      '(ICU/libc) collation rather than data. Disabled by default: inspect ' +
+      'the ordering diffs first, then enable deliberately if confirmed.',
+    op: /sort-(?:name|displayLastName)/,
+    persona: /./,
+    path: /^data\.[A-Za-z]+\.items\[\d+\]/,
+    disabled: true,
+  },
+];
+
+export const matchKnownDelta = (
+  op: string,
+  persona: string,
+  path: string,
+): KnownDeltaRule | undefined =>
+  knownDeltas.find(
+    (rule) =>
+      !rule.disabled &&
+      rule.op.test(op) &&
+      rule.persona.test(persona) &&
+      rule.path.test(path),
+  );

--- a/src/core/shadow-diff/known-deltas.ts
+++ b/src/core/shadow-diff/known-deltas.ts
@@ -82,6 +82,26 @@ export const knownDeltas: readonly KnownDeltaRule[] = [
     path: /(^|\.)(total|hasMore)$/,
   },
   {
+    ref: 'S6-cardinality — NOT a suppression, a decision to re-open',
+    reason:
+      'The S6 rule above suppresses the orDefault status VALUE, but not its ' +
+      'consequence on a FILTERED LIST TOTAL, and the two are different sizes of ' +
+      'decision. Measured 2026-07-30: users.list.filter-status-active returns ' +
+      'total 32 under Neo4j and 48 under Postgres, because 16 of 49 users carry ' +
+      'no status Property at all and the ETL coalesces them to Active. So ' +
+      '"Active users" becomes a 50% larger set — which is product meaning ' +
+      '(who appears in pickers, assignment lists, reports), not a null-shape ' +
+      'nicety. The 2026-07-14 decision was taken when the visible effect was a ' +
+      'field reading Active instead of null; nobody had measured the list ' +
+      'effect. Deliberately DISABLED so the diff stays red: it needs a call on ' +
+      'whether statusless legacy users should be Active, or a distinct value / ' +
+      'nullable column. Enable only after that call.',
+    op: /^users\.list\.filter-status/,
+    persona: /./,
+    path: /(^|\.)(total|hasMore)$|items\[\d+\]/,
+    disabled: true,
+  },
+  {
     ref: 'collation — enable only after inspecting',
     reason:
       'ORDER-only differences on name sorts can stem from Neo4j vs Postgres ' +

--- a/src/core/shadow-diff/known-deltas.ts
+++ b/src/core/shadow-diff/known-deltas.ts
@@ -112,6 +112,27 @@ export const knownDeltas: readonly KnownDeltaRule[] = [
     path: /^data\.[A-Za-z]+\.items\[\d+\]/,
     disabled: true,
   },
+  {
+    ref: 'U-fullName-fold',
+    reason:
+      'user list fullName ordering: both engines now compare the SAME string ' +
+      '(first and last concatenated — the two-column form was fixed 2026-08-19), ' +
+      'but they fold it differently and that part is deliberate. `fullName` is a ' +
+      'resolver field, not a @NameField, so DbSort finds no transformer and Neo4j ' +
+      'orders it by raw code points — capitals before lower case, accented ' +
+      'initials after `z`. Postgres keeps the display_order collation instead ' +
+      '(Rob, 2026-08-19) so the list reads the way people expect and agrees with ' +
+      'every other name sort in the app. Exact parity would mean `collate "C"`. ' +
+      '⚠ STILL DISABLED, and not because the delta is unconfirmed: the same ' +
+      'path also carries the anonymous-user difference (Postgres returns 2376 ' +
+      'users to Neo4j`s 2375 — `anonuserid` is labelled AnonUser and Neo4j drops ' +
+      'it, Postgres lists it). Enabling this now would hide that. Enable once the ' +
+      'user list excludes the anonymous user.',
+    op: /^users\.list\.default$/,
+    persona: /./,
+    path: /^data\.users\.items\[\d+\]/,
+    disabled: true,
+  },
 ];
 
 export const matchKnownDelta = (

--- a/src/core/shadow-diff/known-deltas.ts
+++ b/src/core/shadow-diff/known-deltas.ts
@@ -48,6 +48,40 @@ export const knownDeltas: readonly KnownDeltaRule[] = [
     path: /(^|\.)photo(\.|$)/,
   },
   {
+    ref: 'S6',
+    reason:
+      'ETL orDefault coalescing accepted as new truth (decided 2026-07-14): ' +
+      'legacy partners missing the active / globalInnovationsClient ' +
+      'properties load as false — the schema default the DTO contract ' +
+      'always declared non-null.',
+    op: /^partner/,
+    persona: /./,
+    path: /(^|\.)(active|globalInnovationsClient)(\.|$)/,
+  },
+  {
+    ref: 'S6',
+    reason:
+      'ETL orDefault coalescing accepted as new truth (decided 2026-07-14): ' +
+      'legacy users missing status / timezone properties load as Active / ' +
+      'America/Chicago — the schema defaults the DTO contract always ' +
+      'declared non-null.',
+    op: /^user/,
+    persona: /./,
+    path: /(^|\.)(status|timezone)(\.|$)/,
+  },
+  {
+    ref: 'S8',
+    reason:
+      'Orphaned-partnership phantom counts (decided 2026-07-14, drop-and-log): ' +
+      'partnerships whose Partner was soft-deleted are unreadable under Neo4j ' +
+      '(counted in list total, absent from items) and are dropped by the ETL, ' +
+      'so Postgres totals run lower by exactly the orphan count — and are the ' +
+      'consistent ones.',
+    op: /^partnerships\.list/,
+    persona: /./,
+    path: /(^|\.)(total|hasMore)$/,
+  },
+  {
     ref: 'collation — enable only after inspecting',
     reason:
       'ORDER-only differences on name sorts can stem from Neo4j vs Postgres ' +

--- a/src/core/shadow-diff/personas.ts
+++ b/src/core/shadow-diff/personas.ts
@@ -1,0 +1,51 @@
+import { and, asc, eq, isNull } from 'drizzle-orm';
+import type { ID } from '~/common';
+import { type DrizzleDb } from '~/core/drizzle/drizzle.service';
+import { userGlobalRoles, users } from '~/core/drizzle/schema';
+import { type PersonaRole } from './types';
+
+/**
+ * Personas are DETERMINISTIC: for each role, the live user with the lowest id
+ * holding that global role. Resolved from Postgres in BOTH capture runs (both
+ * runs set POSTGRES_URL), so the same user ids resolve for each engine — the
+ * diff asserts this via the capture meta.
+ */
+export const PERSONA_ROLES: readonly PersonaRole[] = [
+  'Administrator',
+  'ProjectManager',
+  'Consultant',
+  'Intern',
+  'FieldPartner',
+  'Marketing',
+  'StaffMember',
+];
+
+export interface ResolvedPersonas {
+  readonly personas: ReadonlyMap<PersonaRole, ID<'User'>>;
+  readonly skipped: readonly PersonaRole[];
+}
+
+export const resolvePersonas = async (
+  db: DrizzleDb,
+  log: (msg: string) => void,
+): Promise<ResolvedPersonas> => {
+  const personas = new Map<PersonaRole, ID<'User'>>();
+  const skipped: PersonaRole[] = [];
+  for (const role of PERSONA_ROLES) {
+    const rows = await db
+      .select({ id: users.id })
+      .from(users)
+      .innerJoin(userGlobalRoles, eq(userGlobalRoles.userId, users.id))
+      .where(and(eq(userGlobalRoles.role, role), isNull(users.deletedAt)))
+      .orderBy(asc(users.id))
+      .limit(1);
+    const row = rows[0];
+    if (row) {
+      personas.set(role, row.id);
+    } else {
+      skipped.push(role);
+      log(`  persona ${role}: no live user holds this role — skipping`);
+    }
+  }
+  return { personas, skipped };
+};

--- a/src/core/shadow-diff/redact.ts
+++ b/src/core/shadow-diff/redact.ts
@@ -1,0 +1,119 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Value redaction for capture files (added 2026-07-31).
+ *
+ * WHY THIS EXISTS. The corpus reads real records out of Neo4j, so a capture file
+ * held person names, email addresses, phone numbers, user-authored comment and
+ * post bodies, and language names — alongside 213 records marked
+ * `sensitivity: High`. Under Seed Company's AI protocol, high-sensitivity project
+ * data and linguistic data held in confidence are **Restricted**, and PII is at
+ * least Confidential. Those files sat in plain text at the repo root.
+ *
+ * WHY HASHING RATHER THAN DROPPING THE FIELDS. Parity is the whole point of this
+ * harness: if Neo4j answers "X" and Postgres answers "Y", the run must fail. Drop
+ * the field and that check disappears with it. Hash it and the check survives
+ * intact — the same input hashes to the same digest under both engines, so a
+ * mismatch still diffs, while nothing readable is stored. Full fidelity, no
+ * content.
+ *
+ * The cost is that a diff report shows `#a1b2c3…` instead of the value, so a
+ * human has to look the record up locally by id. That is the correct trade: the
+ * report says WHICH field of WHICH record disagrees, which is all triage needs.
+ *
+ * migration-todo: delete with the rest of this folder at cutover.
+ */
+
+/**
+ * Field names whose values are — or may be — classified data.
+ *
+ * Deliberately over-broad. Over-redacting costs only readability (parity still
+ * holds via the digest); under-redacting writes protected data to disk. So a
+ * field goes in here whenever it *could* carry a name or free text on any type,
+ * even if it is innocuous on most: `name` covers Tool and FieldZone as well as
+ * Language, and hashing those is harmless.
+ */
+const SENSITIVE_FIELDS: ReadonlySet<string> = new Set([
+  // person + contact
+  'fullName',
+  'firstName',
+  'lastName',
+  'realFirstName',
+  'realLastName',
+  'displayFirstName',
+  'displayLastName',
+  'avatarLetters',
+  'email',
+  'phone',
+  'about',
+  'title',
+  'position',
+  // entity names, incl. language + project names
+  'name',
+  'displayName',
+  'displayNamePronunciation',
+  'description',
+  // free text authored by people
+  'body',
+  'caption',
+  'altText',
+  'historicGoal',
+  'skippedReason',
+  'response',
+  // education / employment detail
+  'degree',
+  'major',
+  'institution',
+]);
+
+/**
+ * Keys that stay readable even inside a redacted subtree. Ids are opaque and are
+ * what makes a finding actionable — without them the report names no record.
+ */
+const NEVER_REDACT: ReadonlySet<string> = new Set(['id', '__typename']);
+
+const digest = (value: string): string =>
+  '#' + createHash('sha256').update(value).digest('hex').slice(0, 12);
+
+/**
+ * Walk a captured GraphQL response and hash every string inside a sensitive
+ * field. `inSensitive` propagates through the `Secured*` wrapper so
+ * `name { value }` is caught as well as a bare `name`.
+ */
+const walk = (node: unknown, inSensitive: boolean): unknown => {
+  if (typeof node === 'string') {
+    return inSensitive ? digest(node) : node;
+  }
+  if (Array.isArray(node)) {
+    return node.map((item) => walk(item, inSensitive));
+  }
+  if (node !== null && typeof node === 'object') {
+    return Object.fromEntries(
+      Object.entries(node as Record<string, unknown>).map(([key, value]) => [
+        key,
+        walk(
+          value,
+          NEVER_REDACT.has(key)
+            ? false
+            : inSensitive || SENSITIVE_FIELDS.has(key),
+        ),
+      ]),
+    );
+  }
+  // numbers / booleans / null — never identifying on their own.
+  return node;
+};
+
+/** Redact a captured operation's `data` before it is written to disk. */
+export const redactCaptured = (data: unknown): unknown => walk(data, false);
+
+/**
+ * GraphQL error messages can quote a value (`Could not find Language "X"`), so
+ * they are redacted too — but only the interpolated segments, since the message
+ * text itself is the signal a diff needs. Quoted runs and parenthesised ids are
+ * the two shapes the codebase actually produces.
+ */
+export const redactMessage = (message: string): string =>
+  message
+    .replace(/"([^"]{3,})"/g, (_, inner: string) => `"${digest(inner)}"`)
+    .replace(/'([^']{3,})'/g, (_, inner: string) => `'${digest(inner)}'`);

--- a/src/core/shadow-diff/report.ts
+++ b/src/core/shadow-diff/report.ts
@@ -1,0 +1,149 @@
+import { knownDeltas } from './known-deltas';
+import { type DiffEntry, type DiffReport } from './types';
+
+/** Cap for per-diff detail in the markdown; the JSON report is always full. */
+const MAX_DETAILED_DIFFS = 500;
+const MAX_SUPPRESSED_LISTED = 100;
+const MAX_VALUE_LENGTH = 160;
+
+const truncate = (value: unknown): string => {
+  const str = JSON.stringify(value) ?? 'undefined';
+  return str.length > MAX_VALUE_LENGTH
+    ? `${str.slice(0, MAX_VALUE_LENGTH)}… (${str.length} chars)`
+    : str;
+};
+
+const personaOrder = (report: DiffReport): string[] =>
+  Object.keys(report.meta.neo4j.personas);
+
+/**
+ * Cell glyphs: `✓` identical · `D<n>` unsuppressed diffs · `S<n>` suppressed
+ * · `E` errors-mismatch · `·` not executed for this persona.
+ */
+const summaryCell = (
+  summary:
+    | { diffs: number; suppressed: number; errorsMismatch: boolean }
+    | undefined,
+): string => {
+  if (!summary) return '·';
+  if (summary.diffs === 0 && summary.suppressed === 0) return '✓';
+  const parts = [
+    ...(summary.diffs > 0 ? [`D${summary.diffs}`] : []),
+    ...(summary.suppressed > 0 ? [`S${summary.suppressed}`] : []),
+    ...(summary.errorsMismatch ? ['E'] : []),
+  ];
+  return parts.join(' ');
+};
+
+const summaryTable = (report: DiffReport): string[] => {
+  const personas = personaOrder(report);
+  const ops = [...new Set(report.summaries.map((s) => s.op))].sort((a, b) =>
+    a < b ? -1 : a > b ? 1 : 0,
+  );
+  const byOpPersona = new Map(
+    report.summaries.map((s) => [`${s.op} ${s.persona}`, s]),
+  );
+  return [
+    `| operation | ${personas.join(' | ')} |`,
+    `|---|${personas.map(() => '---').join('|')}|`,
+    ...ops.map(
+      (op) =>
+        `| \`${op}\` | ${personas
+          .map((p) => summaryCell(byOpPersona.get(`${op} ${p}`)))
+          .join(' | ')} |`,
+    ),
+  ];
+};
+
+const diffDetails = (diffs: readonly DiffEntry[]): string[] => {
+  const lines: string[] = [];
+  let currentGroup = '';
+  for (const diff of diffs.slice(0, MAX_DETAILED_DIFFS)) {
+    const group = `${diff.op} — ${diff.persona}`;
+    if (group !== currentGroup) {
+      currentGroup = group;
+      lines.push('', `### \`${diff.op}\` — ${diff.persona}`, '');
+    }
+    lines.push(
+      `- \`${diff.path || '(root)'}\``,
+      `  - neo4j: \`${truncate(diff.neo4j)}\``,
+      `  - postgres: \`${truncate(diff.postgres)}\``,
+    );
+  }
+  if (diffs.length > MAX_DETAILED_DIFFS) {
+    lines.push(
+      '',
+      `…and ${diffs.length - MAX_DETAILED_DIFFS} more — see report.json.`,
+    );
+  }
+  return lines;
+};
+
+const suppressedSection = (report: DiffReport): string[] => {
+  if (report.suppressed.length === 0) {
+    return ['No diffs were suppressed.'];
+  }
+  const lines: string[] = [];
+  const byRef = Map.groupBy(report.suppressed, (entry) => entry.suppressedBy!);
+  for (const [ref, entries] of byRef) {
+    const rule = knownDeltas.find((r) => r.ref === ref);
+    lines.push('', `### ${ref} — ${entries.length} suppressed`, '');
+    if (rule) lines.push(`> ${rule.reason}`, '');
+    for (const entry of entries.slice(0, MAX_SUPPRESSED_LISTED)) {
+      lines.push(
+        `- \`${entry.op}\` · ${entry.persona} · \`${entry.path || '(root)'}\` — ` +
+          `neo4j \`${truncate(entry.neo4j)}\` vs postgres \`${truncate(
+            entry.postgres,
+          )}\``,
+      );
+    }
+    if (entries.length > MAX_SUPPRESSED_LISTED) {
+      lines.push(
+        `- …and ${entries.length - MAX_SUPPRESSED_LISTED} more — see report.json.`,
+      );
+    }
+  }
+  return lines;
+};
+
+/** The stdout summary (also the header of the markdown report). */
+export const summaryLines = (report: DiffReport): string[] => {
+  const { totals } = report;
+  return [
+    `Shadow-diff: neo4j (${report.meta.neo4j.capturedAt}) vs ` +
+      `postgres (${report.meta.postgres.capturedAt})`,
+    `  op × persona pairs:     ${totals.pairs}`,
+    `  identical:              ${totals.identical}`,
+    `  with UNSUPPRESSED diffs: ${totals.withDiffs} (${totals.diffCount} diff entries)`,
+    `  suppressed-only:        ${totals.withSuppressedOnly} (${totals.suppressedCount} suppressed entries)`,
+    `  instant-normalized values (same moment, different string form): ${totals.instantNormalized}`,
+    totals.withDiffs === 0
+      ? '  RESULT: PASS — no unsuppressed differences.'
+      : '  RESULT: FAIL — unsuppressed differences found.',
+  ];
+};
+
+export const renderMarkdown = (report: DiffReport): string => {
+  const lines: string[] = [
+    '# Shadow-diff report — Neo4j vs Postgres',
+    '',
+    ...summaryLines(report)
+      .map((line) => line.trimStart())
+      .map((line) => `- ${line}`),
+    '',
+    '## Summary (operation × persona)',
+    '',
+    'Legend: `✓` identical · `D<n>` unsuppressed diffs · `S<n>` suppressed ·',
+    '`E` errors-mismatch',
+    '',
+    ...summaryTable(report),
+    '',
+    '## Unsuppressed diffs',
+    ...(report.diffs.length === 0 ? ['', 'None.'] : diffDetails(report.diffs)),
+    '',
+    '## Suppressed (known deltas — counted, never silent)',
+    ...suppressedSection(report),
+    '',
+  ];
+  return lines.join('\n');
+};

--- a/src/core/shadow-diff/types.ts
+++ b/src/core/shadow-diff/types.ts
@@ -30,7 +30,19 @@ export type SampledDomain =
   | 'organizations'
   | 'partners'
   | 'projects'
-  | 'partnerships';
+  | 'partnerships'
+  // Added 2026-07-30 with the Language / Engagement / Product / report / leaves
+  // waves. `progressReports` is periodic_reports narrowed to type='Progress' —
+  // a separate domain rather than a filter, because the ProgressReport
+  // selection set (summaries, prompt responses, product progress) does not
+  // exist on the Financial/Narrative siblings.
+  | 'languages'
+  | 'engagements'
+  | 'products'
+  | 'periodicReports'
+  | 'progressReports'
+  | 'commentThreads'
+  | 'posts';
 
 /** One hand-enumerated corpus operation (see corpus.ts). */
 export interface CorpusEntry {

--- a/src/core/shadow-diff/types.ts
+++ b/src/core/shadow-diff/types.ts
@@ -1,0 +1,139 @@
+import type { GraphQLSchema } from 'graphql';
+import type { AsyncLocalStorage } from 'node:async_hooks';
+import type { GqlContextType } from '~/common';
+import type { Identity } from '~/core/authentication';
+import type { DrizzleDb } from '~/core/drizzle/drizzle.service';
+
+/**
+ * Shared types for the shadow-diff harness (cutover-only tooling).
+ * See README.md in this folder.
+ */
+
+/** The global roles replayed as personas, in a fixed order. */
+export type PersonaRole =
+  | 'Administrator'
+  | 'ProjectManager'
+  | 'Consultant'
+  | 'Intern'
+  | 'FieldPartner'
+  | 'Marketing'
+  | 'StaffMember';
+
+/** Domains whose Postgres tables are sampled for by-id reads. */
+export type SampledDomain =
+  | 'users'
+  | 'tools'
+  | 'fundingAccounts'
+  | 'locations'
+  | 'fieldZones'
+  | 'fieldRegions'
+  | 'organizations'
+  | 'partners'
+  | 'projects'
+  | 'partnerships';
+
+/** One hand-enumerated corpus operation (see corpus.ts). */
+export interface CorpusEntry {
+  /** Unique, stable key — diff matches captures on it. */
+  readonly key: string;
+  /** GraphQL source. By-id documents take a single `$id: ID!` variable. */
+  readonly document: string;
+  readonly variables?: Readonly<Record<string, unknown>>;
+  /**
+   * When set, the entry expands to one operation per deterministically
+   * sampled id of this domain, executed with `{ id }` variables.
+   */
+  readonly idsFrom?: SampledDomain;
+}
+
+/** GraphQL error stripped to a comparable shape (no stacks). */
+export interface NormalizedError {
+  readonly message: string;
+  readonly code?: string;
+  readonly path?: ReadonlyArray<string | number>;
+}
+
+/** One operation × persona execution result. Errors are data (§ README). */
+export interface OperationResult {
+  readonly op: string;
+  readonly persona: PersonaRole;
+  readonly data: unknown;
+  readonly errors: readonly NormalizedError[];
+}
+
+export interface CaptureMeta {
+  readonly engine: string;
+  readonly capturedAt: string;
+  /** role → user id — must match between the two captures being diffed. */
+  readonly personas: Readonly<Partial<Record<PersonaRole, string>>>;
+  readonly skippedPersonas: readonly PersonaRole[];
+  /** domain → sampled ids — must match between the two captures. */
+  readonly sampledIds: Readonly<Record<SampledDomain, readonly string[]>>;
+}
+
+export interface CaptureFile {
+  readonly meta: CaptureMeta;
+  readonly results: readonly OperationResult[];
+}
+
+/** Everything capture mode needs from the booted app. */
+export interface CaptureRunContext {
+  readonly schema: GraphQLSchema;
+  readonly identity: Identity;
+  /**
+   * `GqlContextHostImpl.als` — in-process execution bypasses the Yoga
+   * `onExecute` plugin that normally populates it, so capture wraps every
+   * operation in `als.run(contextValue, ...)` itself.
+   */
+  readonly gqlContextAls: AsyncLocalStorage<GqlContextType>;
+  /** Personas + id samples are resolved from Postgres in BOTH capture runs. */
+  readonly db: DrizzleDb;
+  readonly engine: string;
+  readonly log: (msg: string) => void;
+}
+
+/** A single leaf difference between the two captures. */
+export interface DiffEntry {
+  readonly op: string;
+  readonly persona: PersonaRole;
+  /** e.g. `data.users.items[3].id` or `errors[0].message`. */
+  readonly path: string;
+  readonly neo4j: unknown;
+  readonly postgres: unknown;
+  /** Ref of the known-delta rule that suppressed this diff, if any. */
+  readonly suppressedBy?: string;
+}
+
+/** Per (operation × persona) rollup for the summary table. */
+export interface OpPersonaSummary {
+  readonly op: string;
+  readonly persona: PersonaRole;
+  readonly diffs: number;
+  readonly suppressed: number;
+  /** True when any UNSUPPRESSED diff falls under the `errors` path. */
+  readonly errorsMismatch: boolean;
+}
+
+export interface DiffReport {
+  readonly meta: {
+    readonly neo4j: CaptureMeta;
+    readonly postgres: CaptureMeta;
+    readonly diffedAt: string;
+  };
+  readonly summaries: readonly OpPersonaSummary[];
+  readonly diffs: readonly DiffEntry[];
+  readonly suppressed: readonly DiffEntry[];
+  readonly totals: {
+    readonly pairs: number;
+    readonly identical: number;
+    readonly withDiffs: number;
+    readonly withSuppressedOnly: number;
+    readonly diffCount: number;
+    readonly suppressedCount: number;
+    /**
+     * Values that differed only in datetime string form while representing
+     * the same instant — treated as equal, but counted for transparency.
+     */
+    readonly instantNormalized: number;
+  };
+}

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -11,6 +11,9 @@ import {
   Role,
   Sensitivity,
 } from '~/common';
+import { DrizzleService } from '~/core/drizzle';
+import { externalDepartmentIds } from '~/core/drizzle/schema';
+import { DatabaseService } from '~/core/neo4j';
 import { graphql, type InputOf } from '~/graphql';
 import { BudgetStatus } from '../src/components/budget/dto';
 import { PartnerType } from '../src/components/partner/dto';
@@ -1619,6 +1622,67 @@ describe('Project e2e', () => {
       );
 
       expect(departmentId1).not.toBe(departmentId2);
+    });
+  });
+
+  it('skips a department id that Intacct already holds', async () => {
+    // Deliberately NOT gated to one engine. The bug this guards against is the
+    // two engines disagreeing: Neo4j has unioned the externally reserved ids
+    // into the unavailable set since 2025-09, and the Postgres path shipped
+    // without that arm. A Postgres-only test would pass on either behaviour of
+    // the Neo4j path and so could not have caught the divergence.
+    //
+    // The reservation is seeded directly because there is no API for it — it is
+    // a flat list loaded from an Intacct export, with no resolver, service or
+    // DTO on either engine.
+    const reserved = '500200';
+    await runAsAdmin(app, async () => {
+      const partner = await createPartner(app, {
+        // The reserved id is the FIRST in the block, so the allocator returns it
+        // unless it is excluded. Without the exclusion this test reads 500200.
+        departmentIdBlock: { blocks: '500200-500209' },
+      });
+
+      if (process.env.DATABASE === 'postgres') {
+        await app
+          .get(DrizzleService)
+          .client.insert(externalDepartmentIds)
+          .values({ departmentId: reserved, name: 'Reserved in Intacct' })
+          .onConflictDoNothing();
+      } else {
+        await app
+          .get(DatabaseService)
+          .query()
+          .raw(
+            `CREATE (:ExternalDepartmentId {
+               id: $id, departmentId: $departmentId,
+               name: $name, createdAt: datetime()
+             })`,
+            {
+              id: await generateId(),
+              departmentId: reserved,
+              name: 'Reserved in Intacct',
+            },
+          )
+          .run();
+      }
+
+      const project = await createProject(app, {
+        type: ProjectType.MultiplicationTranslation,
+        fieldRegion: fieldRegion.id,
+      });
+      await createPartnership(app, {
+        project: project.id,
+        partner: partner.id,
+      });
+
+      await forceProjectTo(app, project.id, 'PendingFinanceConfirmation');
+      const departmentId = await readDepartmentId(app, project.id);
+
+      expect(departmentId).not.toBe(reserved);
+      // Exactly the next one, not merely "something else" — that pins the
+      // allocator to skipping only the reserved id rather than the whole block.
+      expect(departmentId).toBe('500201');
     });
   });
 

--- a/test/setup/pg-setup.ts
+++ b/test/setup/pg-setup.ts
@@ -9,10 +9,77 @@ const TEST_DB_PREFIX = 'cord_e2e_';
  * Creates an empty, uniquely named database for the current spec file.
  * The app applies migrations (DrizzleMigrator) and root objects
  * (AdminDrizzleService) itself on boot, so no template/seeding is needed here.
+ *
+ * Unless {@link E2E_REUSE_DB} says otherwise — see below.
  */
+
+/**
+ * Run the specs against an EXISTING database instead of a fresh empty one.
+ *
+ * Set it to a database name and every spec in the run connects to that database
+ * and never drops it:
+ *
+ *   DATABASE=postgres POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/postgres \
+ *   E2E_REUSE_DB=cord_e2e_loaded yarn test:e2e --testPathPatterns 'project'
+ *
+ * (`--testPathPatterns` with the s — jest 30 renamed it, and the old spelling is
+ * rejected outright rather than ignored.)
+ *
+ * ⚠ Across the whole suite use `--maxWorkers=1 --workerIdleMemoryLimit=2GB`, NOT
+ * `--runInBand`: in-band puts all 49 spec files in one process, each booting a
+ * full app against millions of rows, and it exhausts an 8GB heap around the 34th.
+ * One worker is still sequential — which a shared database needs — but recycles.
+ *
+ * This exists to answer one question the cutover ETL cannot answer about itself:
+ * a load can pass `cutover-verify.run` — every reference resolves, nothing points
+ * at a deleted row — and the APPLICATION can still fail on it, because the
+ * verifier checks the shape of the data and not the queries that read it. Only
+ * running the real suite against real loaded rows tests that.
+ *
+ * ⚠ **The specs write.** They create, update and delete, and nothing here rolls
+ * that back. Point this at a THROWAWAY COPY, never at the load itself:
+ *
+ *   create database cord_e2e_loaded template cord_cutover_verify;
+ *
+ * ⚠ Also expect legitimate failures that are not defects. A spec that asserts on
+ * a whole list, or on a count, is written against a database holding only what it
+ * just created; against five million pre-existing rows it fails by design. Those
+ * are worth reading one at a time — the interesting ones are queries that BREAK
+ * (timeouts, wrong joins, unique collisions with real data), not assertions that
+ * merely counted something bigger than they expected.
+ *
+ * Deliberately a separate variable rather than "reuse whatever POSTGRES_URL
+ * names". POSTGRES_URL is already required here (and points at a server, with
+ * ephemeral databases created beside it), so overloading it would mean a stray
+ * export silently turns every e2e run into a run against a real database that it
+ * then mutates. This has to be asked for by name.
+ *
+ * migration-todo(cutover-cleanup): keep past cutover — it is how a rehearsal load
+ * gets exercised — but the Neo4j-shaped bits around it go with the rest.
+ */
+const REUSE_DB = process.env.E2E_REUSE_DB;
+
 export const ephemeralPg = async () => {
   if (process.env.DATABASE !== 'postgres') {
     return undefined;
+  }
+
+  if (REUSE_DB) {
+    if (!process.env.POSTGRES_URL) {
+      throw new Error(
+        'POSTGRES_URL is required alongside E2E_REUSE_DB (it supplies the ' +
+          'host and credentials; E2E_REUSE_DB supplies the database name)',
+      );
+    }
+    const reused = new URL(process.env.POSTGRES_URL);
+    reused.pathname = `/${REUSE_DB}`;
+    // No cleanup: dropping the database the caller asked us to reuse would
+    // destroy the thing under test, and on a shared run would do it while other
+    // spec files are still connected.
+    const keep = async () => {
+      // Intentionally nothing.
+    };
+    return { url: reused.toString(), cleanup: keep };
   }
 
   // Mirror the app's DrizzleService, which refuses to guess a connection when


### PR DESCRIPTION
### Why

When a project reaches Pending Finance Confirmation it is given the lowest
unused department ID from its block. Two kinds of ID are unavailable: those
already on a live project, and those that already exist in Intacct. The second
list was imported in September 2025 and the allocator has honoured it ever
since.

The Postgres allocator only ever had the first kind. The second was left out
with a note to restore it once that data moved over, and this restores it.

The gap is not theoretical. Measured against a current copy of production, 389
of the 565 reserved IDs sit inside blocks that projects are assigned from, and
two of the thirteen blocks would have handed out a different ID than the
existing behaviour on their very next project — both of them belonging to
partners that are actively creating work.

It is also the kind of mistake that would not announce itself. The unique index
on project department IDs only knows about other projects, and nothing in our
database knows what Intacct holds, so a clash would surface in accounting rather
than in the app.

### How

- New `external_department_ids` table holding the reserved code and its Intacct
  department name.
- The allocator's "already used" set now includes that table, matching the
  existing behaviour exactly.

Two things about the table worth knowing, since both look like omissions:

- The department ID is the primary key. The reservation is the identity — the
  imported records carry a generated uuid that names nothing and is referenced by
  nothing, so it is not carried over.
- There is deliberately no constraint on the shape of the code. The obvious one,
  five digits to match how block numbers are padded, would reject a real row:
  564 of the codes are five digits and one is six. A list that mirrors another
  system has to accept whatever that system holds.

### Testing

A new case in the project suite reserves the first ID in a block and asserts the
next project gets the following one, rather than merely "something else".

It deliberately runs on both engines rather than only Postgres. The defect here
was the two behaving differently, so a Postgres-only test would have passed
regardless and could not have found it. Run with the exclusion removed, it fails
by returning the reserved ID exactly, which reproduces the original problem
rather than only asserting the fixed behaviour.

### Not in scope

The reserved list is a one-time manual import with no refresh path — the
importer that created it was never merged, so only the code that reads it ships.
It is therefore about eleven months stale against Intacct. Worth a separate
conversation with whoever owns that side about whether to re-export periodically
or build a real integration; this PR restores the behaviour we already had
rather than changing how the list is maintained.
