### PR TITLE
Stop Postgres handing out department IDs that Intacct already holds

### DIFF
--- a/src/components/project/handlers/set-department-id.handler.ts
+++ b/src/components/project/handlers/set-department-id.handler.ts
@@ -106,9 +106,10 @@ export class SetDepartmentId {
    * generate_series` over the `int4multirange` don't have a clean
    * query-builder form.
    *
-   * `external_department_ids` exclusion is dropped — that table is part of an
-   * unmigrated domain. migration-todo: re-add the exclusion when that domain
-   * ports (probably with the broader Finance/Admin work).
+   * `external_department_ids` — the IDs Intacct already holds — is unioned into
+   * the used set exactly as the Neo4j path does. It is a flat reservation list
+   * with no owner and no lifecycle, so it needs no domain of its own; see
+   * migration 0040.
    */
   private async assignDepartmentIdPg(project: UnsecuredDto<Project>) {
     const isMultiplication = project.type === 'MultiplicationTranslation';
@@ -186,8 +187,12 @@ export class SetDepartmentId {
           used as (
             select department_id from projects
             where department_id is not null and deleted_at is null
-            -- migration-todo: also exclude external_department_ids when that
-            -- table migrates (likely Admin domain).
+            -- Same union the Neo4j path builds: an ID Intacct already holds is
+            -- as unavailable as one a project already has. Dropping this arm is
+            -- silent — CORD cannot see an Intacct collision, and the unique
+            -- index on projects.department_id will not catch one either.
+            union
+            select department_id from external_department_ids
           )
           select dept_id as "nextId" from enumerated
           where dept_id not in (select department_id from used)

--- a/src/core/drizzle/migrations/0040_add_external_department_ids.sql
+++ b/src/core/drizzle/migrations/0040_add_external_department_ids.sql
@@ -1,0 +1,42 @@
+-- Migration: add external_department_ids — the department IDs that already exist
+-- in Intacct (the accounting system) and therefore must never be handed out to a
+-- CORD project.
+--
+-- This is a reservation list, not an entity. Nothing points at these rows and
+-- they point at nothing; their only job is to be subtracted from the pool of
+-- available department IDs in set-department-id.handler.ts. In Neo4j they are
+-- 565 fully disconnected `ExternalDepartmentId` nodes, which is why they read as
+-- droppable on a first pass — but the handler unions them into the "already
+-- used" set on every assignment, and has since 2025-09.
+--
+-- Measured against the 2026-08-24 production copy: 389 of the 565 codes fall
+-- inside blocks CORD assigns from, and two blocks would hand out a different ID
+-- with this list missing than with it present. A collision here is invisible to
+-- CORD — projects_department_id_active_unique catches CORD-internal duplicates,
+-- but nothing in this database knows what Intacct holds.
+
+CREATE TABLE "external_department_ids" (
+  -- The reservation IS the identity. The source nodes carry an apoc-generated
+  -- uuid that names nothing and is referenced by nothing, so it is not carried;
+  -- the department ID is what the handler looks up and what must be unique.
+  "department_id" text PRIMARY KEY,
+
+  -- The Intacct department name. Not unique, legitimately: one name covers three
+  -- codes in the current data. Carried because it is what a person needs when
+  -- reconciling a reservation against Intacct.
+  "name" text NOT NULL,
+
+  -- When the list was imported, carried from the source nodes. Kept because the
+  -- staleness of this list is the interesting thing about it: every current row
+  -- was loaded in a single manual run and nothing has refreshed it since.
+  "created_at" timestamptz NOT NULL DEFAULT now()
+);
+
+-- Deliberately no CHECK on the shape of department_id. The obvious one — five
+-- digits, matching how the handler pads block IDs — would reject a real row:
+-- 564 of the 565 codes are five digits and one is six. This table mirrors an
+-- external system, so it must accept whatever that system holds; a constraint
+-- that edits the mirror makes it stop being a mirror.
+--
+-- Deliberately no deleted_at either. These are not CORD records with a
+-- lifecycle; when Intacct changes, the list is re-imported.

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1754006400000,
       "tag": "0039_add_financial_approvers",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1754092800000,
+      "tag": "0040_add_external_department_ids",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -869,6 +869,27 @@ export const departmentIdBlocks = pgTable('department_id_blocks', {
 });
 
 /**
+ * Department IDs that already exist in Intacct, the accounting system, and so
+ * must never be assigned to a CORD project.
+ *
+ * A reservation list rather than an entity: nothing references these rows and
+ * they reference nothing. Their whole purpose is to be subtracted from the pool
+ * of available IDs when set-department-id.handler.ts picks the next one. The
+ * department ID is the primary key because the reservation is the identity —
+ * the source nodes carry an apoc-generated uuid that names nothing.
+ *
+ * See migration 0040 for why there is no CHECK on the code's shape and no
+ * deleted_at.
+ */
+export const externalDepartmentIds = pgTable('external_department_ids', {
+  departmentId: text('department_id').primaryKey(),
+  name: text('name').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+/**
  * Finance-approver config: "user X approves finances for project type Y" —
  * read by the project workflow to notify approvers on financial-plan
  * transitions. Ported (not retired) per Rob 2026-08-24: without it those

--- a/test/project.e2e-spec.ts
+++ b/test/project.e2e-spec.ts
@@ -11,6 +11,9 @@ import {
   Role,
   Sensitivity,
 } from '~/common';
+import { DrizzleService } from '~/core/drizzle';
+import { externalDepartmentIds } from '~/core/drizzle/schema';
+import { DatabaseService } from '~/core/neo4j';
 import { graphql, type InputOf } from '~/graphql';
 import { BudgetStatus } from '../src/components/budget/dto';
 import { PartnerType } from '../src/components/partner/dto';
@@ -1619,6 +1622,67 @@ describe('Project e2e', () => {
       );
 
       expect(departmentId1).not.toBe(departmentId2);
+    });
+  });
+
+  it('skips a department id that Intacct already holds', async () => {
+    // Deliberately NOT gated to one engine. The bug this guards against is the
+    // two engines disagreeing: Neo4j has unioned the externally reserved ids
+    // into the unavailable set since 2025-09, and the Postgres path shipped
+    // without that arm. A Postgres-only test would pass on either behaviour of
+    // the Neo4j path and so could not have caught the divergence.
+    //
+    // The reservation is seeded directly because there is no API for it — it is
+    // a flat list loaded from an Intacct export, with no resolver, service or
+    // DTO on either engine.
+    const reserved = '500200';
+    await runAsAdmin(app, async () => {
+      const partner = await createPartner(app, {
+        // The reserved id is the FIRST in the block, so the allocator returns it
+        // unless it is excluded. Without the exclusion this test reads 500200.
+        departmentIdBlock: { blocks: '500200-500209' },
+      });
+
+      if (process.env.DATABASE === 'postgres') {
+        await app
+          .get(DrizzleService)
+          .client.insert(externalDepartmentIds)
+          .values({ departmentId: reserved, name: 'Reserved in Intacct' })
+          .onConflictDoNothing();
+      } else {
+        await app
+          .get(DatabaseService)
+          .query()
+          .raw(
+            `CREATE (:ExternalDepartmentId {
+               id: $id, departmentId: $departmentId,
+               name: $name, createdAt: datetime()
+             })`,
+            {
+              id: await generateId(),
+              departmentId: reserved,
+              name: 'Reserved in Intacct',
+            },
+          )
+          .run();
+      }
+
+      const project = await createProject(app, {
+        type: ProjectType.MultiplicationTranslation,
+        fieldRegion: fieldRegion.id,
+      });
+      await createPartnership(app, {
+        project: project.id,
+        partner: partner.id,
+      });
+
+      await forceProjectTo(app, project.id, 'PendingFinanceConfirmation');
+      const departmentId = await readDepartmentId(app, project.id);
+
+      expect(departmentId).not.toBe(reserved);
+      // Exactly the next one, not merely "something else" — that pins the
+      // allocator to skipping only the reserved id rather than the whole block.
+      expect(departmentId).toBe('500201');
     });
   });
 


### PR DESCRIPTION
### Why

When a project reaches Pending Finance Confirmation it is given the lowest
unused department ID from its block. Two kinds of ID are unavailable: those
already on a live project, and those that already exist in Intacct. The second
list was imported in September 2025 and the allocator has honoured it ever
since.

The Postgres allocator only ever had the first kind. The second was left out
with a note to restore it once that data moved over, and this restores it.

The gap is not theoretical. Measured against a current copy of production, 389
of the 565 reserved IDs sit inside blocks that projects are assigned from, and
two of the thirteen blocks would have handed out a different ID than the
existing behaviour on their very next project — both of them belonging to
partners that are actively creating work.

It is also the kind of mistake that would not announce itself. The unique index
on project department IDs only knows about other projects, and nothing in our
database knows what Intacct holds, so a clash would surface in accounting rather
than in the app.

### How

- New `external_department_ids` table holding the reserved code and its Intacct
  department name.
- The allocator's "already used" set now includes that table, matching the
  existing behaviour exactly.

Two things about the table worth knowing, since both look like omissions:

- The department ID is the primary key. The reservation is the identity — the
  imported records carry a generated uuid that names nothing and is referenced by
  nothing, so it is not carried over.
- There is deliberately no constraint on the shape of the code. The obvious one,
  five digits to match how block numbers are padded, would reject a real row:
  564 of the codes are five digits and one is six. A list that mirrors another
  system has to accept whatever that system holds.

### Testing

A new case in the project suite reserves the first ID in a block and asserts the
next project gets the following one, rather than merely "something else".

It deliberately runs on both engines rather than only Postgres. The defect here
was the two behaving differently, so a Postgres-only test would have passed
regardless and could not have found it. Run with the exclusion removed, it fails
by returning the reserved ID exactly, which reproduces the original problem
rather than only asserting the fixed behaviour.

### Not in scope

The reserved list is a one-time manual import with no refresh path — the
importer that created it was never merged, so only the code that reads it ships.
It is therefore about eleven months stale against Intacct. Worth a separate
conversation with whoever owns that side about whether to re-export periodically
or build a real integration; this PR restores the behaviour we already had
rather than changing how the list is maintained.
