### PR TITLE
Keep the anonymous system user out of the people list

### DIFF
--- a/src/components/user/user.drizzle.repository.ts
+++ b/src/components/user/user.drizzle.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { and, eq, ilike, inArray, isNull, or, type SQL } from 'drizzle-orm';
+import { and, eq, ilike, inArray, isNull, ne, or, type SQL } from 'drizzle-orm';
 import { groupBy } from 'lodash';
 import { DateTime } from 'luxon';
 import {
@@ -11,6 +11,7 @@ import {
   type UnsecuredDto,
 } from '~/common';
 import { Identity } from '~/core/authentication';
+import { ConfigService } from '~/core/config';
 import {
   catchUniqueViolation,
   DrizzleDtoRepository,
@@ -64,6 +65,7 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
     private readonly executor: PolicyExecutor,
     private readonly files: FileService,
     private readonly identity: Identity,
+    private readonly config: ConfigService,
   ) {
     super(db, users, User);
   }
@@ -236,7 +238,21 @@ export class UserDrizzleRepository extends DrizzleDtoRepository<
   async list(
     input: UserListInput,
   ): Promise<PaginatedListType<UnsecuredDto<User>>> {
-    const conditions: SQL[] = [isNull(users.deletedAt)];
+    const conditions: SQL[] = [
+      isNull(users.deletedAt),
+      // The anonymous user is a system record, not a person, and has no place
+      // in a list of people. Neo4j leaves it out; without this the People page
+      // gains a nameless extra row at cutover (Postgres 2,376 vs Neo4j 2,375,
+      // measured by shadow-diff against the production copy).
+      //
+      // Excluded by its configured id rather than a column, because there is no
+      // marker to read: Neo4j distinguishes it with an `AnonUser` label, and
+      // unlike the root user — carried as `users.is_root` — that label has no
+      // counterpart here. `config.anonUser.id` is the same fixed constant the
+      // admin bootstrap uses to create the row, so it is the definition of
+      // which user this is, on both engines.
+      ne(users.id, this.config.anonUser.id),
+    ];
     if (!this.executor.applyReadFilter(this.resource, conditions)) {
       return EMPTY_PAGE;
     }

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -255,7 +255,10 @@ export const makeConfig = (env: EnvironmentService) =>
     };
 
     anonUser = {
-      id: 'anonuserid',
+      // Typed as a User id, not a bare string: it is compared against
+      // `users.id` (which carries `ID<'User'>`) to keep the anonymous system
+      // record out of people lists. Same treatment as defaultOrg.id above.
+      id: 'anonuserid' as ID<'User'>,
     };
 
     cors = (() => {

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -2,6 +2,9 @@ import { faker } from '@faker-js/faker';
 import { beforeAll, describe, expect, it } from '@jest/globals';
 import { times } from 'lodash';
 import { firstLettersOfWords, generateId, isValidId } from '~/common';
+import { ConfigService } from '~/core/config';
+import { DrizzleService } from '~/core/drizzle';
+import { users } from '~/core/drizzle/schema';
 import { graphql, type InputOf, type VariablesOf } from '~/graphql';
 import { UserStatus } from '../src/components/user/dto';
 import {
@@ -209,6 +212,50 @@ describe('User e2e', () => {
     );
 
     expect(users.items.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('leaves the anonymous system user out of the people list', async () => {
+    // Un-gated on purpose: the anonymous record exists on both engines in a
+    // real deployment, and the point is that they agree about hiding it.
+    // Postgres used to list it — shadow-diff caught it as a one-row total
+    // difference against the production copy (2,376 vs 2,375), easy to dismiss
+    // as rounding until you notice it is a nameless system account sitting on
+    // the People page.
+    const anonId = app.get(ConfigService).anonUser.id;
+
+    // Seeded here on Postgres, and this is the whole reason the test is worth
+    // writing carefully. Neo4j's admin bootstrap creates the anonymous user
+    // (AdminService.mergeAnonUser); the Drizzle one does not, so a fresh
+    // Postgres database has no such row and an assertion about it would pass
+    // no matter what the repository did. The first version of this test did
+    // exactly that — it still passed with the exclusion commented out. In a
+    // real cutover the row arrives via the ETL, so seeding it reproduces the
+    // deployed state rather than inventing one.
+    if (process.env.DATABASE === 'postgres') {
+      await app
+        .get(DrizzleService)
+        .client.insert(users)
+        .values({ id: anonId, status: 'Active' })
+        .onConflictDoNothing();
+    }
+
+    const { users: listed } = await app.graphql.query(
+      graphql(`
+        query {
+          users(input: { count: 100, page: 1 }) {
+            items {
+              id
+            }
+            total
+          }
+        }
+      `),
+    );
+
+    // Both halves matter. Without the second this passes just as happily on an
+    // empty list, which is the failure mode that made the first version useless.
+    expect(listed.items.map((user) => user.id)).not.toContain(anonId);
+    expect(listed.items.length).toBeGreaterThan(0);
   });
 
   it('adds and removes a location from a user', async () => {


### PR DESCRIPTION
### Why

The anonymous user is a system record, not a person. Neo4j leaves it out of
the people list; Postgres did not, so after the database switch the People
page would gain a nameless extra row.

It turned up as a one-row difference in the user list total during a read
comparison between the two databases over a copy of production — 2,376
against 2,375. That is the sort of number it is easy to read as rounding
until you look at which row it is.

### How

The list now excludes the anonymous user by its configured id, rather than by
a column, because there is no column to read. Neo4j marks the record with an
`AnonUser` label, and unlike the root user — which is stored as a real flag —
that label has no counterpart on the Postgres side. The configured id is the
same fixed constant the Neo4j bootstrap uses to create the record, so it is
what identifies it on either database. It is now typed as a user id instead of
a plain string, matching the default organisation id declared beside it.

### Testing

One new case, run against both databases.

Worth knowing how it got there, because the obvious version of this test does
not work. Written the straightforward way it passed — and went on passing with
the fix removed. The reason is that the Postgres bootstrap never creates the
anonymous user, only the default organisation and the root user, so a fresh
test database has no such record and an assertion about it holds no matter
what the code does.

The test therefore creates that record on Postgres before asserting, which is
the state a real deployment is in, since the record arrives with the migrated
data. With that in place, removing the exclusion fails the test by returning
the record — so it now tests what it claims to.

### Not in scope

That missing bootstrap is left as it is. Nothing reads the configured
anonymous id except the Neo4j bootstrap that writes it, so the record is a
leftover rather than something the application depends on, and creating one on
Postgres would add a row with no reader. Worth revisiting only if something
starts needing it.
