### PR TITLE
Work out partner and organization sensitivity instead of storing it

### DIFF
--- a/src/components/authorization/policies/conditions/sensitivity.condition.ts
+++ b/src/components/authorization/policies/conditions/sensitivity.condition.ts
@@ -7,6 +7,10 @@ import {
   type ResourceShape,
   Sensitivity,
 } from '~/common';
+import {
+  organizationDerivedSensitivity,
+  partnerDerivedSensitivity,
+} from '~/core/drizzle/derived-sensitivity';
 import { matchProjectSens, rankSens } from '~/core/neo4j/query';
 import {
   type AsDrizzleParams,
@@ -195,13 +199,21 @@ const sensitivityRefForResource = (
         where "b"."id" = "budget_records"."budget_id"
       ) <= ${accessLiteral}`;
     case 'Partner':
-      // Own denormalized column. Statically 'High' on create until Language
-      // migrates and wires the real derivation — fail-closed in the interim
-      // (sens-gated roles see nothing rather than everything).
-      return sql`"partners"."sensitivity" <= ${accessLiteral}`;
+      // Derived from the connected projects, like every other case here. This
+      // used to read the denormalized `partners.sensitivity` column, which was
+      // meant to be a temporary fail-closed default until the surrounding
+      // domains migrated. They did; the derivation was never wired; and the
+      // column has since been holding whatever the data migration loaded,
+      // with nothing keeping it current. A stale value here is not cosmetic —
+      // this clause decides who can see the record.
+      return sql`${partnerDerivedSensitivity(
+        sql`"partners"."id"`,
+      )} <= ${accessLiteral}`;
     case 'Organization':
-      // Same interim story as Partner.
-      return sql`"organizations"."sensitivity" <= ${accessLiteral}`;
+      // Same as Partner, one hop further out through its partners.
+      return sql`${organizationDerivedSensitivity(
+        sql`"organizations"."id"`,
+      )} <= ${accessLiteral}`;
     case 'Engagement':
     case 'LanguageEngagement':
     case 'InternshipEngagement':

--- a/src/components/organization/organization.drizzle.repository.ts
+++ b/src/components/organization/organization.drizzle.repository.ts
@@ -1,18 +1,21 @@
 import { Injectable } from '@nestjs/common';
-import { and, eq, ilike, inArray, isNull, type SQL } from 'drizzle-orm';
+import { and, eq, ilike, inArray, isNull, type SQL, sql } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import {
   generateId,
   type ID,
   type PaginatedListType,
+  type Sensitivity,
   type UnsecuredDto,
 } from '~/common';
 import { Identity } from '~/core/authentication';
 import {
   catchUniqueViolation,
+  derivedSensitivityByOrganization,
   DrizzleDtoRepository,
   EMPTY_PAGE,
   escapeLikePattern,
+  organizationDerivedSensitivity,
   resolveOrderBy,
   type SortMap,
 } from '~/core/drizzle';
@@ -74,12 +77,27 @@ export class OrganizationDrizzleRepository extends DrizzleDtoRepository<
           isNull(organizations.deletedAt),
         ),
       );
-    const scopeByOrg = await requesterScopeByOrganization(
-      this.db,
-      this.identity.current.userId,
-      rows.map((row) => row.id),
+    const [scopeByOrg, sensitivityByOrg] = await Promise.all([
+      requesterScopeByOrganization(
+        this.db,
+        this.identity.current.userId,
+        rows.map((row) => row.id),
+      ),
+      // Computed from the projects reached through this organization's
+      // partners, rather than read off the row — the stored column is no
+      // longer the source of truth. See `derived-sensitivity.ts`.
+      derivedSensitivityByOrganization(
+        this.db,
+        rows.map((row) => row.id),
+      ),
+    ]);
+    return rows.map((row) =>
+      this.toDto(
+        row,
+        scopeByOrg.get(row.id) ?? [],
+        sensitivityByOrg.get(row.id) ?? 'High',
+      ),
     );
-    return rows.map((row) => this.toDto(row, scopeByOrg.get(row.id) ?? []));
   }
 
   async create(input: CreateOrganization): Promise<UnsecuredDto<Organization>> {
@@ -139,7 +157,9 @@ export class OrganizationDrizzleRepository extends DrizzleDtoRepository<
       name: organizations.name,
       acronym: organizations.acronym,
       address: organizations.address,
-      sensitivity: organizations.sensitivity,
+      // Derived, not the stored column — a list must order by the same
+      // sensitivity it displays and filters on.
+      sensitivity: organizationDerivedSensitivity(sql`${organizations.id}`),
       createdAt: organizations.createdAt,
     } satisfies SortMap<keyof Organization>;
 
@@ -162,6 +182,11 @@ export class OrganizationDrizzleRepository extends DrizzleDtoRepository<
   protected toDto(
     row: typeof organizations.$inferSelect,
     scope: ScopedRole[] = [],
+    // Passed in rather than taken from `row`: it is derived from the connected
+    // projects, so the row's own column is not the answer. Defaults to the
+    // most restrictive value, which is what an organization with no projects
+    // reads on either engine.
+    sensitivity: Sensitivity = 'High',
   ): UnsecuredDto<Organization> {
     const dto: unknown = {
       id: row.id,
@@ -172,7 +197,7 @@ export class OrganizationDrizzleRepository extends DrizzleDtoRepository<
       address: row.address ?? null,
       types: row.types,
       reach: row.reach,
-      sensitivity: row.sensitivity,
+      sensitivity,
       scope,
     };
     return dto as UnsecuredDto<Organization>;
@@ -219,6 +244,7 @@ export const organizationSortColumns = {
   name: organizations.name,
   acronym: organizations.acronym,
   address: organizations.address,
-  sensitivity: organizations.sensitivity,
+  // Derived, not the stored column — see the sibling map in `list`.
+  sensitivity: organizationDerivedSensitivity(sql`${organizations.id}`),
   createdAt: organizations.createdAt,
 } as const;

--- a/src/components/partner/partner.drizzle.repository.ts
+++ b/src/components/partner/partner.drizzle.repository.ts
@@ -14,6 +14,7 @@ import {
   lt,
   lte,
   type SQL,
+  sql,
 } from 'drizzle-orm';
 import { DateTime } from 'luxon';
 import {
@@ -29,9 +30,11 @@ import { Identity } from '~/core/authentication';
 import {
   catchForeignKeyViolation,
   catchUniqueViolation,
+  derivedSensitivityByPartner,
   displayOrder,
   DrizzleDtoRepository,
   EMPTY_PAGE,
+  partnerDerivedSensitivity,
   resolveOrderBy,
   type SortMap,
   subFilter,
@@ -277,27 +280,37 @@ export class PartnerDrizzleRepository extends DrizzleDtoRepository<
         departmentIdBlock: true,
       },
     });
-    const [pinnedSet, scopeByPartner] = await Promise.all([
-      pinnedByRequester(
-        this.db,
-        this.identity.current.userId,
-        rows.map((r) => r.id),
-      ),
-      // Attaches `scope` so `member`-gated policies (e.g. FinancialAnalyst
-      // reading a High-sensitivity partner) can evaluate membership instead
-      // of throwing `MissingContextException` — see the Organization repo's
-      // sibling override for the full rationale.
-      requesterScopeByPartner(
-        this.db,
-        this.identity.current.userId,
-        rows.map((r) => r.id),
-      ),
-    ]);
+    const [pinnedSet, scopeByPartner, sensitivityByPartner] = await Promise.all(
+      [
+        pinnedByRequester(
+          this.db,
+          this.identity.current.userId,
+          rows.map((r) => r.id),
+        ),
+        // Attaches `scope` so `member`-gated policies (e.g. FinancialAnalyst
+        // reading a High-sensitivity partner) can evaluate membership instead
+        // of throwing `MissingContextException` — see the Organization repo's
+        // sibling override for the full rationale.
+        requesterScopeByPartner(
+          this.db,
+          this.identity.current.userId,
+          rows.map((r) => r.id),
+        ),
+        // Computed from the partner's projects rather than read off the row —
+        // the stored column is no longer the source of truth. See
+        // `derived-sensitivity.ts`.
+        derivedSensitivityByPartner(
+          this.db,
+          rows.map((r) => r.id),
+        ),
+      ],
+    );
     return rows.map((row) =>
       this.toDto({
         ...row,
         pinned: pinnedSet.has(row.id),
         scope: scopeByPartner.get(row.id) ?? [],
+        sensitivity: sensitivityByPartner.get(row.id) ?? 'High',
       }),
     );
   }
@@ -650,7 +663,9 @@ export const partnerSortColumns = {
   globalInnovationsClient: partners.globalInnovationsClient,
   modifiedAt: partners.updatedAt,
   pmcEntityCode: partners.pmcEntityCode,
-  sensitivity: partners.sensitivity,
+  // The derived value, not the stored column, so a list orders by the same
+  // sensitivity it displays and filters on.
+  sensitivity: partnerDerivedSensitivity(sql`${partners.id}`),
   startDate: partners.startDate,
 } satisfies SortMap<keyof Partner>;
 

--- a/src/core/drizzle/derived-sensitivity.ts
+++ b/src/core/drizzle/derived-sensitivity.ts
@@ -1,0 +1,124 @@
+import { inArray, sql, type SQL } from 'drizzle-orm';
+import { type ID, type Sensitivity } from '~/common';
+import { type DrizzleDb } from './drizzle.service';
+import { organizations, partners } from './schema';
+
+/**
+ * A partner's or organization's sensitivity, computed from the projects it is
+ * connected to — the lowest of them, or `High` when there are none.
+ *
+ * Neo4j computes this on every read and stores nothing
+ * (`partner.repository.ts` / `organization.repository.ts`: collect the
+ * projects, `ORDER BY rankSens ASC LIMIT 1`, `UNION` a `'High'` branch for the
+ * no-project case). Postgres carried a denormalized `sensitivity` column
+ * instead, defaulted to `'High'`, on the understanding that the real
+ * derivation would be wired once the surrounding domains migrated. They have,
+ * and it was not — so the column has been holding whatever the data migration
+ * loaded into it, with nothing to keep it current.
+ *
+ * Deriving it in the query rather than maintaining a stored copy is a
+ * deliberate choice, for three reasons:
+ *
+ * 1. **It cannot go stale.** A stored copy has to be refreshed on partnership
+ *    create, delete and soft-delete, on every change to a project's own
+ *    sensitivity (itself derived), and again across the extra hop to the
+ *    organization. Missing any one of those arms reintroduces the same silent
+ *    drift, in a value that decides who can see the record.
+ * 2. **It is what every neighbouring resource already does.** Partnership,
+ *    Budget, BudgetRecord, Engagement, Ceremony, ProjectMember and
+ *    ProgressReport all reach their project's sensitivity through a correlated
+ *    subquery. Partner and Organization were the only two reading a column.
+ * 3. **It matches the other engine by construction** rather than by
+ *    maintenance, so the two agree for a structural reason.
+ *
+ * `min()` gives the lowest because the enum is declared `Low, Medium, High` —
+ * Postgres orders enum values by declaration, so the ordering the comparison
+ * `sensitivity <= 'access'` already relies on is the same one used here.
+ *
+ * Soft-deleted partnerships and projects are excluded: a partnership that has
+ * been removed should stop lowering the partner's sensitivity, which is the
+ * behaviour on the other engine, where a deleted node no longer matches.
+ */
+export const partnerDerivedSensitivity = (
+  partnerIdRef: SQL,
+): SQL<Sensitivity> => sql`coalesce(
+  (
+    select min("p"."sensitivity")
+    from "projects" "p"
+    join "partnerships" "pship" on "pship"."project_id" = "p"."id"
+    where "pship"."partner_id" = ${partnerIdRef}
+      and "pship"."deleted_at" is null
+      and "p"."deleted_at" is null
+  ),
+  'High'::"sensitivity"
+)`;
+
+/**
+ * The same value for an organization, which reaches projects one hop further
+ * out — through the partners that belong to it.
+ *
+ * Kept separate from {@link partnerDerivedSensitivity} rather than sharing a
+ * parameterized join: the two walk different paths, and collapsing them would
+ * hide that an organization's answer depends on its partners' partnerships
+ * while a partner's does not. See `organization.repository.ts`, whose Cypher
+ * spells out the longer path for the same reason.
+ */
+export const organizationDerivedSensitivity = (
+  organizationIdRef: SQL,
+): SQL<Sensitivity> => sql`coalesce(
+  (
+    select min("p"."sensitivity")
+    from "projects" "p"
+    join "partnerships" "pship" on "pship"."project_id" = "p"."id"
+    join "partners" "pt" on "pt"."id" = "pship"."partner_id"
+    where "pt"."organization_id" = ${organizationIdRef}
+      and "pt"."deleted_at" is null
+      and "pship"."deleted_at" is null
+      and "p"."deleted_at" is null
+  ),
+  'High'::"sensitivity"
+)`;
+
+/**
+ * The derived sensitivity for a page of partners, keyed by id.
+ *
+ * Hydration counterpart to the expressions above, in the same shape as
+ * `pinnedByRequester`: the read paths build their rows through Drizzle's
+ * relational query API, which returns table columns, so a value computed from
+ * other tables is looked up for the whole page and merged in.
+ *
+ * Both halves are deliberately built from the one expression. If they drifted,
+ * a record could be *filtered* by one sensitivity and *displayed* with
+ * another — worse than either being wrong alone, because nothing about the
+ * result would look inconsistent.
+ */
+export const derivedSensitivityByPartner = async (
+  db: DrizzleDb,
+  ids: readonly ID[],
+): Promise<Map<ID, Sensitivity>> => {
+  if (ids.length === 0) return new Map();
+  const rows = await db
+    .select({
+      id: partners.id,
+      sensitivity: partnerDerivedSensitivity(sql`${partners.id}`),
+    })
+    .from(partners)
+    .where(inArray(partners.id, [...ids]));
+  return new Map(rows.map((row) => [row.id, row.sensitivity]));
+};
+
+/** The same for a page of organizations. */
+export const derivedSensitivityByOrganization = async (
+  db: DrizzleDb,
+  ids: readonly ID[],
+): Promise<Map<ID, Sensitivity>> => {
+  if (ids.length === 0) return new Map();
+  const rows = await db
+    .select({
+      id: organizations.id,
+      sensitivity: organizationDerivedSensitivity(sql`${organizations.id}`),
+    })
+    .from(organizations)
+    .where(inArray(organizations.id, [...ids]));
+  return new Map(rows.map((row) => [row.id, row.sensitivity]));
+};

--- a/src/core/drizzle/index.ts
+++ b/src/core/drizzle/index.ts
@@ -1,3 +1,4 @@
+export * from './derived-sensitivity';
 export * from './drizzle-transactional-mutations.interceptor';
 export * from './drizzle.module';
 export * from './drizzle.service';

--- a/src/core/drizzle/order-by.ts
+++ b/src/core/drizzle/order-by.ts
@@ -1,4 +1,4 @@
-import { asc, desc, sql, type SQL, type SQLWrapper } from 'drizzle-orm';
+import { asc, desc, SQL, sql, type SQLWrapper } from 'drizzle-orm';
 import { type AnyPgColumn } from 'drizzle-orm/pg-core';
 import { type Order } from '~/common';
 import {
@@ -20,7 +20,7 @@ import {
  * One sort entry: a single column, or a column list expressing tiebreakers
  * (e.g. `[lastName, firstName]`).
  */
-export type SortColumns = AnyPgColumn | readonly AnyPgColumn[];
+export type SortColumns = AnyPgColumn | SQL | ReadonlyArray<AnyPgColumn | SQL>;
 
 /**
  * Map of supported sort keys to columns, narrowed to the DTO's fields:
@@ -125,13 +125,18 @@ const NAME_COLUMNS: ReadonlySet<AnyPgColumn> = new Set<AnyPgColumn>([
  * name (partner, partnership, project) do exactly that, and would otherwise order
  * differently from every other list in the app.
  */
-export const displayOrder = (col: AnyPgColumn): SQLWrapper =>
-  NAME_COLUMNS.has(col) &&
-  COLLATABLE_COLUMN_TYPES.has(col.columnType) &&
-  !col.enumValues?.length &&
-  !col.primary
-    ? sql`${col} collate ${sql.identifier(DISPLAY_ORDER_COLLATION)}`
-    : col;
+export const displayOrder = (col: AnyPgColumn | SQL): SQLWrapper =>
+  // An expression rather than a column — a value computed in the query, such
+  // as a partner's sensitivity derived from its projects. There is no column
+  // to look up in NAME_COLUMNS and nothing to collate, so it orders as-is.
+  col instanceof SQL
+    ? col
+    : NAME_COLUMNS.has(col) &&
+        COLLATABLE_COLUMN_TYPES.has(col.columnType) &&
+        !col.enumValues?.length &&
+        !col.primary
+      ? sql`${col} collate ${sql.identifier(DISPLAY_ORDER_COLLATION)}`
+      : col;
 
 /**
  * Resolve a list-input's `sort` key to an ORDER BY clause. Unmatched keys

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -411,8 +411,15 @@ export const organizations = pgTable(
       .$type<readonly OrganizationReach[]>()
       .notNull()
       .default([]),
-    // migration-todo: keep current via hooks once Project/Partnership migrate;
-    // currently always 'High' since no project linkage exists in PG yet.
+    // NO LONGER READ. The organization's sensitivity is derived in the query
+    // from the projects reached through its partners — see
+    // `derived-sensitivity.ts`. This column stayed defaulted to 'High' with
+    // nothing keeping it current, which is why it stopped being the answer.
+    // It is left in place only because the cutover ETL still writes it and
+    // removing it would invalidate a certified load.
+    // migration-todo(cutover-cleanup): drop this column and stop the partner
+    // extractor writing it. Nothing reads it now, so it can go with the rest
+    // of the transition-only schema rather than needing its own migration.
     sensitivity: sensitivityEnum('sensitivity').notNull().default('High'),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
@@ -980,9 +987,9 @@ export const partners = pgTable(
     departmentIdBlockId: text('department_id_block_id')
       .$type<ID>()
       .references(() => departmentIdBlocks.id),
-    // migration-todo: derived from the project's sensitivity; keep current via
-    // hook once Project/Partnership migrate. Always 'High' until then — same as
-    // organizations.sensitivity.
+    // NO LONGER READ — same story as organizations.sensitivity above. Derived
+    // in the query from the partner's projects (`derived-sensitivity.ts`).
+    // migration-todo(cutover-cleanup): drop with the organization one.
     sensitivity: sensitivityEnum('sensitivity').notNull().default('High'),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()

--- a/test/organization.e2e-spec.ts
+++ b/test/organization.e2e-spec.ts
@@ -6,6 +6,9 @@ import { graphql } from '~/graphql';
 import {
   createLocation,
   createOrganization,
+  createPartner,
+  createPartnership,
+  createProject,
   createSession,
   createTestApp,
   errors,
@@ -24,6 +27,48 @@ describe('Organization e2e', () => {
     await registerUser(app, {
       roles: [Role.Controller],
     });
+  });
+
+  // The organization's own version of the partner test in partner.e2e-spec.
+  // Worth having separately rather than trusting the partner one to cover it:
+  // an organization reaches projects one hop further out, through the partners
+  // that belong to it, so the two walk different paths and only share the
+  // shape of the answer.
+  it('derives sensitivity from its partners projects, and follows them', async () => {
+    const org = await runAsAdmin(app, () => createOrganization(app));
+
+    const readSensitivity = async () => {
+      const { organization } = await app.graphql.query(
+        graphql(`
+          query organization($id: ID!) {
+            organization(id: $id) {
+              sensitivity
+            }
+          }
+        `),
+        { id: org.id },
+      );
+      return organization.sensitivity;
+    };
+
+    // Nothing connected yet, so the most restrictive answer.
+    expect(await readSensitivity()).toBe('High');
+
+    // A partner belonging to this organization, on a Low project. Reading the
+    // stored column instead leaves this at High.
+    await runAsAdmin(app, async () => {
+      const partner = await createPartner(app, { organization: org.id });
+      const project = await createProject(app, {
+        type: 'Internship',
+        sensitivity: 'Low',
+      });
+      await createPartnership(app, {
+        project: project.id,
+        partner: partner.id,
+      });
+    });
+
+    expect(await readSensitivity()).toBe('Low');
   });
 
   it.skip('should have unique name', async () => {

--- a/test/partner.e2e-spec.ts
+++ b/test/partner.e2e-spec.ts
@@ -7,7 +7,9 @@ import { FinancialReportingType } from '../src/components/partnership/dto';
 import {
   createOrganization,
   createPartner,
+  createPartnership,
   createPerson,
+  createProject,
   createSession,
   createTestApp,
   errors,
@@ -24,6 +26,52 @@ describe('Partner e2e', () => {
     app = await createTestApp();
     await createSession(app);
     await registerUser(app, { roles: [Role.LeadFinancialAnalyst] });
+  });
+
+  // Sensitivity is derived from the projects a partner is connected to — the
+  // lowest of them, or High when there are none. Neo4j works this out on every
+  // read. Postgres kept a stored column that nothing updated, so a partner's
+  // sensitivity was frozen at whatever it was created or migrated with.
+  //
+  // The second half is what makes this test worth having. Reading a partner
+  // that already had the right value proves nothing, because the stored column
+  // was right at rest — it only went wrong once the connected projects changed,
+  // and no read-only comparison between the two databases could see that.
+  it('derives sensitivity from its projects, and follows them when they change', async () => {
+    const partner = await runAsAdmin(app, () => createPartner(app));
+
+    const readSensitivity = async () => {
+      const { partner: read } = await app.graphql.query(
+        graphql(`
+          query partner($id: ID!) {
+            partner(id: $id) {
+              sensitivity
+            }
+          }
+        `),
+        { id: partner.id },
+      );
+      return read.sensitivity;
+    };
+
+    // No projects yet, so the most restrictive answer.
+    expect(await readSensitivity()).toBe('High');
+
+    // Connecting a Low project has to lower it. This is the assertion that
+    // fails when sensitivity is read from the stored column: the partnership
+    // is created, nothing recomputes, and the partner stays High.
+    await runAsAdmin(app, async () => {
+      const project = await createProject(app, {
+        type: 'Internship',
+        sensitivity: 'Low',
+      });
+      await createPartnership(app, {
+        project: project.id,
+        partner: partner.id,
+      });
+    });
+
+    expect(await readSensitivity()).toBe('Low');
   });
 
   it('create & read partner by id', async () => {


### PR DESCRIPTION
### Why

A partner's sensitivity is the lowest of the sensitivities of the projects
it is connected to, or High when it has none. An organization's is the
same, one hop further out through its partners. Neo4j works this out on
every read. Postgres kept a stored column that nothing ever updated, so
the value was frozen at whatever the record was created or migrated with.

This was known and meant to be temporary — the column's own comment said
it would stay High until the surrounding domains migrated and the real
derivation was wired. They migrated. It was never wired.

Nothing caught it, and the reason is worth stating. At rest the value was
right: the data migration loaded what the other database computed, so
every comparison between the two agreed. It only went wrong once the
connected projects changed, which a read-only comparison cannot see. And
sensitivity is not a display field — it is the clause that decides who is
allowed to see the record.

### How

It is now worked out in the query, which is what every neighbouring
resource already does. Partnerships, budgets, engagements, ceremonies,
project members and progress reports all reach their project's
sensitivity through a subquery; partner and organization were the only
two reading a column.

A refresh hook was the alternative and is the more fragile one. It would
have to fire on partnership create, delete and soft-delete, on changes to
a project's own sensitivity, and again across the organization hop —
and missing any one of those brings the same silent drift back.

The permission check, the value shown, and the sort are all built from
one shared definition on purpose. If they disagreed, a record could be
filtered by one sensitivity and displayed with another, and nothing about
the result would look wrong. Sorting needed the sort map to accept an
expression rather than only a column, so a list orders by the same value
it shows.

The stored columns stay for now. The cutover data migration still writes
them, and removing them would invalidate a load that has already been
checked end to end. They are marked as no longer read and tagged to be
dropped with the rest of the transition-only schema.

### Testing

One test per side, run against both databases.

Both were checked with their own fix removed, and both fail without it.
That mattered here more than usual: reading a partner that already holds
the right value passes whether or not anything is derived, which is
exactly why this went unnoticed for so long. Each test therefore connects
a project afterwards and asserts the value follows.

The organization test is separate rather than assumed to be covered by
the partner one. An organization reaches projects through its partners,
so it walks a different path — and covering only the simpler path is the
shortcut that let this sit unnoticed in the first place.

Passing on both databases is also what shows the two now agree on what
happens after a write, rather than only on what was loaded.
