### PR TITLE
Give a project its primary partnership on Postgres

### DIFF
--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -92,8 +92,8 @@ const catchDepartmentIdUnique = catchUniqueViolation(
 /**
  * Hydrated Project row: the projects table row + the current user's membership
  * (id, roles, inactive_at) if any. Pulled together in a single SELECT for
- * `readMany`. Cross-domain stubs (usesRev79, primaryPartnership,
- * rootDirectory) live in `toDto`.
+ * `readMany`. Cross-domain stubs (usesRev79, rootDirectory) live in `toDto`.
+ * `primaryPartnership` used to be one of them and is now batched like the rest.
  */
 type ProjectRow = typeof projects.$inferSelect & {
   engagementTotal?: number;
@@ -107,6 +107,8 @@ type ProjectRow = typeof projects.$inferSelect & {
   inheritedMarketingRegionId?: ID<'Location'> | null;
   /** Has a live ToolUsage for the Rev79 tool — batched in `readMany`. */
   usesRev79?: boolean;
+  /** The live primary partnership's id, if the project has one — batched in `readMany`. */
+  primaryPartnershipId?: ID<'Partnership'> | null;
   membership?: {
     id: ID<'ProjectMember'>;
     // `Role`, not `string` — the column is a role enum array, and the DTO's
@@ -329,6 +331,29 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
     const usesRev79ByProject = new Set(
       rev79Usages.map((r) => r.projectId as ID<'Project'>),
     );
+    // The project's primary partnership. Neo4j finds it by walking to each
+    // partnership and checking its `primary` property; here it is a column,
+    // and `partnerships_project_primary_active_unique` already guarantees at
+    // most one live primary row per project, so this cannot return two.
+    const primaryPartnerships = await this.db
+      .select({
+        projectId: partnerships.projectId,
+        id: partnerships.id,
+      })
+      .from(partnerships)
+      .where(
+        and(
+          inArray(
+            partnerships.projectId,
+            rows.map((r) => r.id),
+          ),
+          eq(partnerships.primary, true),
+          isNull(partnerships.deletedAt),
+        ),
+      );
+    const primaryPartnershipByProject = new Map(
+      primaryPartnerships.map((row) => [row.projectId, row.id]),
+    );
     return rows.map((row): UnsecuredDto<Project> => {
       const enriched: ProjectRow = {
         ...row,
@@ -340,6 +365,7 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
           ? (inheritedRegionByLocation.get(row.marketingLocationId) ?? null)
           : null,
         usesRev79: usesRev79ByProject.has(row.id),
+        primaryPartnershipId: primaryPartnershipByProject.get(row.id) ?? null,
       };
       return this.toDto(enriched);
     });
@@ -620,10 +646,7 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
       fieldRegion: linkOrNull(row.fieldRegionId),
       owningOrganization: linkOrNull(row.owningOrganizationId),
       rootDirectory: linkOrNull(row.rootDirectoryId),
-      // migration-todo: Partnership is on develop, but per-project
-      // primaryPartnership hydration is not yet wired (mono stubs it null too).
-      // Wire via a `partnerships` subquery (primary = true) as a follow-up.
-      primaryPartnership: null,
+      primaryPartnership: linkOrNull(row.primaryPartnershipId ?? null),
       engagementTotal: row.engagementTotal ?? 0,
       // Batched in readMany — whether the project has a live ToolUsage
       // against the Rev79 tool.

--- a/test/partnership.e2e-spec.ts
+++ b/test/partnership.e2e-spec.ts
@@ -34,6 +34,55 @@ describe('Partnership e2e', () => {
     project = await createProject(app);
   });
 
+  // A project's `primaryPartnership` is whichever of its partnerships is
+  // flagged primary. Postgres returned a hardcoded null here — the field had
+  // no coverage on either engine, and it was left out of the read comparison
+  // between the two databases, so nothing was in a position to notice.
+  //
+  // Note the first partnership on a project is made primary automatically
+  // whatever the input says (partnership.service.ts), so this walks the two
+  // states that actually exist: no partnerships at all, and a later one taking
+  // over as primary.
+  it('exposes the primary partnership on its project', async () => {
+    const own = await createProject(app);
+
+    const readPrimary = async () => {
+      const { project: read } = await app.graphql.query(
+        graphql(`
+          query project($id: ID!) {
+            project(id: $id) {
+              primaryPartnership {
+                canRead
+                value {
+                  id
+                }
+              }
+            }
+          }
+        `),
+        { id: own.id },
+      );
+      return read.primaryPartnership;
+    };
+
+    // No partnerships at all.
+    expect((await readPrimary()).value).toBeNull();
+
+    // The first one is primary whether or not it asked to be.
+    const first = await createPartnership(app, { project: own.id });
+    const afterFirst = await readPrimary();
+    expect(afterFirst.canRead).toBe(true);
+    expect(afterFirst.value?.id).toBe(first.id);
+
+    // A later one flagged primary takes over. This is the assertion that
+    // fails while the field is stubbed: the project answers null throughout.
+    const second = await createPartnership(app, {
+      project: own.id,
+      primary: true,
+    });
+    expect((await readPrimary()).value?.id).toBe(second.id);
+  });
+
   it('create & read partnership by id', async () => {
     const partnership = await createPartnership(app, { project: project.id });
 


### PR DESCRIPTION
### Why

A project's primary partnership came back as null on Postgres, always.
The other database walks to whichever of the project's partnerships is
flagged primary and returns it, and can filter projects by it.

Partnership moved across a while ago, so nothing was blocking this — the
wiring was simply never done. What kept it out of sight is more
interesting than the bug: the field had no test on either database, and
it was one of the fields left out of the read comparison we run between
the two, on the grounds that Postgres was known to stub it. So the one
check that would have caught it had been told not to look.

### How

It now reads the flag directly, gathered for the whole page alongside the
other per-project values rather than queried one project at a time. There
is already a unique index allowing at most one live primary partnership
per project, so the lookup cannot come back with two.

### Testing

One new test, run against both databases, and checked with the fix
reverted so it fails without it.

Worth knowing before reading it: the first partnership added to a project
becomes the primary automatically, whatever the request asks for. My
first attempt at this test assumed otherwise and failed on its opening
assertion — the code was right and the assumption was wrong. The test now
walks the states that actually occur: a project with no partnerships, the
first one arriving, and a later one taking over as primary. That covers
the handover as well, which the original version did not.

Separately, the field has been added back to the read comparison between
the two databases, which is where a difference like this should have
surfaced. Against a loaded copy of production it now returns a value on
all twenty-five sampled reads on both sides, with matching ids and no new
differences.
