### PR TITLE
Preserve what the old database recorded instead of inventing a value

### DIFF
--- a/src/common/graphql/fields/name.field.ts
+++ b/src/common/graphql/fields/name.field.ts
@@ -17,11 +17,19 @@ type NameFieldParams = FieldOptions & {
    * If true, values can be omitted/undefined but not null.
    */
   optional?: true;
+  /**
+   * Explicit GraphQL type, overriding inference from the TS property type.
+   * For when the declared TS type and the emitted wire type deliberately
+   * differ — e.g. a property typed `SecuredStringNullable` (migrated rows can
+   * be blank) that keeps emitting the `SecuredString` wire type, whose
+   * `value` was always nullable, so the schema does not change.
+   */
+  type?: ReturnTypeFunc;
 };
 
-export const NameField = (options: NameFieldParams = {}) =>
+export const NameField = ({ type, ...options }: NameFieldParams = {}) =>
   applyDecorators(
-    InferredTypeOrStringField({
+    InferredTypeOrStringField(type, {
       ...options,
       nullable: options.optional ?? options.nullable,
     }),
@@ -50,7 +58,10 @@ export const NameField = (options: NameFieldParams = {}) =>
  * Useful for when the type is `string | null`.
  */
 const InferredTypeOrStringField =
-  (options: FieldOptions): PropertyDecorator | MethodDecorator =>
+  (
+    explicitType: ReturnTypeFunc | undefined,
+    options: FieldOptions,
+  ): PropertyDecorator | MethodDecorator =>
   (prototype, property, descriptorRaw) => {
     const propertyKey = property as string;
     const applyMetadataFn = () => {
@@ -70,7 +81,7 @@ const InferredTypeOrStringField =
         });
       let resolved;
       try {
-        resolved = resolveType();
+        resolved = resolveType(explicitType);
       } catch {
         resolved = resolveType(() => String);
       }

--- a/src/common/graphql/objects/mappers/as-update.type.ts
+++ b/src/common/graphql/objects/mappers/as-update.type.ts
@@ -30,11 +30,31 @@ export const AsUpdateType = <
     {
       Links: links,
       fromInput: makeFromInput<Omit<T, OmitKeys>, Output>(links),
-      pickPrevious: (prev: Output, changes: Omit<T, OmitKeys>): Output =>
+      pickPrevious: (
+        prev: AsStored<Output>,
+        changes: Omit<T, OmitKeys>,
+      ): Output =>
         omit(pick(prev, Object.keys(changes)), 'modifiedAt') as Output,
     },
   );
 };
+
+/**
+ * What `pickPrevious` reads from: the record as it is actually stored, rather
+ * than the update input's shape.
+ *
+ * The two differ on nullability, and the difference is real. An input field is
+ * optional (`planned?: boolean`) because a client may leave it out; a stored
+ * field can be genuinely blank (`planned: boolean | null`) because nobody ever
+ * set it — which several columns became in migration 0042, so that a Neo4j
+ * blank survives the cutover instead of arriving as a definite `false`. Only
+ * inputs that let a client *clear* a value carry `| null` themselves, and
+ * widening those to match here would say clients can blank any of these.
+ *
+ * The return stays `Output`: the previous value goes onto a subscription
+ * payload whose fields are all nullable already.
+ */
+type AsStored<T> = { [K in keyof T]: T[K] | null };
 
 // eslint-disable-next-line @seedcompany/no-unused-vars
 type LinksAsIDs<T, Links extends LiteralUnion<keyof T & string, string>> = {

--- a/src/components/ceremony/dto/ceremony.dto.ts
+++ b/src/components/ceremony/dto/ceremony.dto.ts
@@ -3,6 +3,7 @@ import {
   Calculated,
   Resource,
   SecuredBoolean,
+  SecuredBooleanNullable,
   SecuredDateNullable,
   SecuredProperty,
   Sensitivity,
@@ -26,8 +27,12 @@ export class Ceremony extends Resource {
   @Field(() => CeremonyType)
   readonly type: CeremonyType;
 
-  @Field()
-  readonly planned: SecuredBoolean;
+  // Nullable in TS (migration 0042): 7,386 migrated ceremonies carry a kept
+  // blank. The WIRE type stays `SecuredBoolean` on purpose — the schema is an
+  // API-compatibility promise, and its `value` was always nullable
+  // (`Boolean`, not `Boolean!`), so the blank needs no schema change.
+  @Field(() => SecuredBoolean)
+  readonly planned: SecuredBooleanNullable;
 
   @Field()
   readonly estimatedDate: SecuredDateNullable;

--- a/src/components/engagement/dto/engagement.dto.ts
+++ b/src/components/engagement/dto/engagement.dto.ts
@@ -256,8 +256,11 @@ export class InternshipEngagement extends Engagement {
   @DbLabel('ProductMethodology')
   readonly methodologies: SecuredMethodologies;
 
-  @Field()
-  readonly marketable: SecuredBoolean;
+  // Nullable in TS (migration 0042): 6,866 migrated rows carry a kept blank.
+  // The WIRE type stays `SecuredBoolean` — its `value` was always nullable,
+  // so the schema does not change (an API-compatibility promise).
+  @Field(() => SecuredBoolean)
+  readonly marketable: SecuredBooleanNullable;
 
   @Field()
   readonly webId: SecuredStringNullable;

--- a/src/components/partner/dto/partner.dto.ts
+++ b/src/components/partner/dto/partner.dto.ts
@@ -7,6 +7,7 @@ import {
   type ResourceRelationsShape,
   type Secured,
   SecuredBoolean,
+  SecuredBooleanNullable,
   SecuredDateNullable,
   SecuredProperty,
   SecuredStringNullable,
@@ -50,11 +51,14 @@ export class Partner extends Interfaces {
   @Field()
   readonly pmcEntityCode: SecuredStringNullable;
 
-  @Field()
-  readonly globalInnovationsClient: SecuredBoolean;
+  // Nullable in TS (migration 0042): 78 + 9 migrated rows carry kept blanks.
+  // The WIRE type stays `SecuredBoolean` — its `value` was always nullable,
+  // so the schema does not change (an API-compatibility promise).
+  @Field(() => SecuredBoolean)
+  readonly globalInnovationsClient: SecuredBooleanNullable;
 
-  @Field()
-  readonly active: SecuredBoolean;
+  @Field(() => SecuredBoolean)
+  readonly active: SecuredBooleanNullable;
 
   @Field()
   readonly address: SecuredStringNullable;

--- a/src/components/progress-report/workflow/emails/progress-report-status-changed.email.tsx
+++ b/src/components/progress-report/workflow/emails/progress-report-status-changed.email.tsx
@@ -89,9 +89,11 @@ export function ProgressReportStatusChanged({
             ) : null}
             <>
               for {languageName} in <a href={projectUrl}>{projectName}</a> on{' '}
+              {/* A recipient with no recorded timezone falls back to the
+                  component's own default, same as one who never set it. */}
               <FormattedDateTime
                 value={workflowEvent.at}
-                timezone={recipient.timezone.value}
+                timezone={recipient.timezone.value ?? undefined}
               />
             </>
           </Mjml.Text>

--- a/src/components/project/dto/project.dto.ts
+++ b/src/components/project/dto/project.dto.ts
@@ -20,6 +20,7 @@ import {
   type ResourceRelationsShape,
   type Secured,
   SecuredBoolean,
+  SecuredBooleanNullable,
   SecuredDateNullable,
   SecuredDateTime,
   SecuredDateTimeNullable,
@@ -164,9 +165,23 @@ class Project extends Interfaces {
   // this should match project mouEnd, until it becomes active, then this is final.
   readonly initialMouEnd: SecuredDateNullable;
 
-  @Field()
+  /**
+   * When the project last moved to a new step — blank when it never has.
+   *
+   * Typed nullable as of 2026-08-26. It always could be null: `SecuredDateTime`
+   * already emits `value: DateTime` (nullable) in the schema, and Neo4j returns
+   * nothing here for the ~470 legacy projects created before the field was
+   * written at creation time. The TypeScript type simply claimed otherwise, and
+   * nothing caught it because the Neo4j repository builds this DTO untyped.
+   *
+   * The WIRE type stays `SecuredDateTime` on purpose — the schema is an
+   * API-compatibility promise, and its `value` was always nullable
+   * (`DateTime`, not `DateTime!`), so the blank needs no schema change at
+   * all. `@Field` pins the emitted name; the TS type tells the truth.
+   */
+  @Field(() => SecuredDateTime)
   @Calculated()
-  readonly stepChangedAt: SecuredDateTime;
+  readonly stepChangedAt: SecuredDateTimeNullable;
 
   @Field()
   readonly estimatedSubmission: SecuredDateNullable;
@@ -194,7 +209,10 @@ class Project extends Interfaces {
         Pick<UnsecuredDto<ProjectMember>, 'roles' | 'inactiveAt'>)
     | null;
 
-  @Field({
+  // Nullable in TS (migration 0042): 2,185 migrated rows carry a kept blank.
+  // The WIRE type stays `SecuredBoolean` — its `value` was always nullable,
+  // so the schema does not change (an API-compatibility promise).
+  @Field(() => SecuredBoolean, {
     description: stripIndent`
       Whether or not this project and its associated languages (via engagements)
       are a part of our "Preset Inventory".
@@ -203,7 +221,7 @@ class Project extends Interfaces {
       It also means the project is committed to having quality, consistent reporting.
     `,
   })
-  readonly presetInventory: SecuredBoolean;
+  readonly presetInventory: SecuredBooleanNullable;
 
   /**
    * Optimization for {@link ProjectResolver.engagements}.

--- a/src/components/project/project.drizzle.repository.ts
+++ b/src/components/project/project.drizzle.repository.ts
@@ -12,7 +12,6 @@ import {
   isNull,
   lt,
   lte,
-  max,
   notInArray,
   sql,
   type SQL,
@@ -50,7 +49,6 @@ import {
   partnerships,
   projectMembers,
   projects,
-  projectWorkflowEvents,
   tools,
   toolUsages,
 } from '~/core/drizzle/schema';
@@ -98,8 +96,6 @@ const catchDepartmentIdUnique = catchUniqueViolation(
 type ProjectRow = typeof projects.$inferSelect & {
   engagementTotal?: number;
   pinned?: boolean;
-  /** Latest workflow-event `at`, if any — batched in `readMany`. */
-  stepChangedAt?: Date | null;
   /**
    * The marketing location's default region — batched in `readMany`. Feeds
    * `marketingRegion`, which falls back to this when there's no override.
@@ -207,21 +203,11 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
     const membershipByProject = new Map(
       memberships.map((m) => [m.projectId, m]),
     );
-    // Latest workflow-event timestamp per project — `stepChangedAt` derives
-    // from it at read time (toDto falls back to createdAt, matching Gel's
-    // `latestWorkflowEvent.at ?? createdAt`). Served by the
-    // (project_id, at DESC) index; events are append-only (no soft delete).
-    const latestEvents = await this.db
-      .select({
-        projectId: projectWorkflowEvents.projectId,
-        at: max(projectWorkflowEvents.at),
-      })
-      .from(projectWorkflowEvents)
-      .where(inArray(projectWorkflowEvents.projectId, [...ids]))
-      .groupBy(projectWorkflowEvents.projectId);
-    const stepChangedByProject = new Map(
-      latestEvents.map((e) => [e.projectId, e.at]),
-    );
+    // `stepChangedAt` is a stored column (migration 0041), not a lookup of the
+    // latest workflow event. It used to be derived here; that agreed for
+    // anything transitioned after the event trail began in Feb 2021 and was
+    // wrong by up to four years for the 1,560 projects that moved before it
+    // existed. History that was never recorded cannot be derived.
     const engagementCounts = await this.db
       .select({
         projectId: engagements.projectId,
@@ -358,7 +344,6 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
       const enriched: ProjectRow = {
         ...row,
         membership: membershipByProject.get(row.id) ?? null,
-        stepChangedAt: stepChangedByProject.get(row.id) ?? null,
         engagementTotal: engagementTotalByProject.get(row.id) ?? 0,
         pinned: pinnedSet.has(row.id),
         inheritedMarketingRegionId: row.marketingLocationId
@@ -632,9 +617,14 @@ export class ProjectDrizzleRepository extends DrizzleDtoRepository<
       presetInventory: row.presetInventory,
       createdAt: DateTime.fromJSDate(row.createdAt),
       modifiedAt: DateTime.fromJSDate(row.modifiedAt),
-      // Derived from the latest workflow event (batched in readMany), falling
-      // back to createdAt — Gel parity: `latestWorkflowEvent.at ?? createdAt`.
-      stepChangedAt: DateTime.fromJSDate(row.stepChangedAt ?? row.createdAt),
+      // Stored, not derived (migration 0041). Null stays null rather than
+      // falling back to createdAt: Neo4j reports blank for the ~470 legacy
+      // projects that never moved off their first step, and a creation date
+      // presented as a step-change date is a confident wrong answer where
+      // blank is an honest one.
+      stepChangedAt: row.stepChangedAt
+        ? DateTime.fromJSDate(row.stepChangedAt)
+        : null,
       primaryLocation: linkOrNull(row.primaryLocationId),
       marketingLocation: linkOrNull(row.marketingLocationId),
       marketingRegionOverride: linkOrNull(row.marketingRegionOverrideId),

--- a/src/components/project/workflow/emails/project-step-changed.email.tsx
+++ b/src/components/project/workflow/emails/project-step-changed.email.tsx
@@ -78,9 +78,11 @@ export function ProjectStepChanged({
               </>
             ) : null}
             at{' '}
+            {/* A recipient with no recorded timezone falls back to the
+                component's own default, same as one who never set it. */}
             <FormattedDateTime
               value={project.modifiedAt}
-              timezone={recipient.timezone.value}
+              timezone={recipient.timezone.value ?? undefined}
             />
           </Mjml.Text>
           <InHtml>

--- a/src/components/project/workflow/project-workflow.drizzle.repository.ts
+++ b/src/components/project/workflow/project-workflow.drizzle.repository.ts
@@ -37,8 +37,12 @@ import {
  * `status` is a `GENERATED ALWAYS AS (CASE step ... END) STORED` column, so it
  * follows step automatically — no extra write needed.
  *
- * `stepChangedAt` derives from the event's `at` timestamp at read time on the
- * Project resolver; nothing is stored on `projects` for it.
+ * `projects.step_changed_at` is set by that same trigger, from the event's
+ * `at`. It used to be derived at read time from the latest event; migration
+ * 0041 stores it instead, because the event trail only begins 2021-02-13 and
+ * 1,560 projects moved step before it existed. Nothing to do here either way —
+ * insert the event and the trigger handles step, modified_at and
+ * step_changed_at together, so they cannot drift apart.
  */
 // migration-todo: `PublicOf<ProjectWorkflowRepository>` widens to every
 // public/protected member of the Gel base (privileges, getActualChanges,

--- a/src/components/user/dto/user-status.enum.ts
+++ b/src/components/user/dto/user-status.enum.ts
@@ -12,7 +12,15 @@ export const UserStatus = makeEnum({
   values: ['Active', 'Disabled'],
 });
 
+/**
+ * `nullable` because 92 migrated people have no recorded status — Neo4j only
+ * ever wrote the Property when somebody set one. This changes the TypeScript
+ * type only: the emitted `SecuredUserStatus.value` was already `UserStatus`
+ * (nullable) either way, so `schema.graphql` does not move.
+ */
 @ObjectType({
   description: SecuredProperty.descriptionFor('a user status'),
 })
-export abstract class SecuredUserStatus extends SecuredEnum(UserStatus) {}
+export abstract class SecuredUserStatus extends SecuredEnum(UserStatus, {
+  nullable: true,
+}) {}

--- a/src/components/user/dto/user.dto.ts
+++ b/src/components/user/dto/user.dto.ts
@@ -54,26 +54,32 @@ export class User extends Interfaces {
   @DbUnique('EmailAddress')
   email: SecuredStringNullable;
 
-  @NameField()
+  // Nullable in TS (migration 0042): Neo4j stores a name Property only when
+  // one was written, and one migrated person has none. The WIRE type stays
+  // `SecuredString` on purpose — the schema is an API-compatibility promise,
+  // and its `value` was always nullable (`String`, not `String!`), so the
+  // blank needs no schema change at all. `type:` pins the emitted name;
+  // the TS type tells the truth.
+  @NameField({ type: () => SecuredString })
   @DbLabel('UserName')
-  realFirstName: SecuredString;
+  realFirstName: SecuredStringNullable;
 
-  @NameField()
+  @NameField({ type: () => SecuredString })
   @DbLabel('UserName')
-  realLastName: SecuredString;
+  realLastName: SecuredStringNullable;
 
-  @NameField()
+  @NameField({ type: () => SecuredString })
   @DbLabel('UserName')
-  displayFirstName: SecuredString;
+  displayFirstName: SecuredStringNullable;
 
-  @NameField()
+  @NameField({ type: () => SecuredString })
   @DbLabel('UserName')
-  displayLastName: SecuredString;
+  displayLastName: SecuredStringNullable;
 
   @Field()
   phone: SecuredStringNullable;
 
-  timezone: SecuredString;
+  timezone: SecuredStringNullable;
 
   @Field()
   about: SecuredStringNullable;

--- a/src/core/authentication/authentication.repository.ts
+++ b/src/core/authentication/authentication.repository.ts
@@ -124,7 +124,13 @@ export class AuthenticationRepository {
           node('status', 'Property'),
         ],
       ])
-      .return<{ passwordHash: string; status: UserStatus }>([
+      // `status` is nullable in Postgres (migration 0042) — 92 migrated people
+      // have none recorded. The only consumer asks `status === 'Disabled'`,
+      // which is already correct for a blank. Neo4j cannot actually produce one
+      // here: the match above REQUIRES the status Property, so a person without
+      // it matches nothing and is refused a login outright. That engine
+      // difference pre-dates this change and is not resolved by it.
+      .return<{ passwordHash: string; status: UserStatus | null }>([
         'password.value as passwordHash',
         'status.value as status',
       ])

--- a/src/core/drizzle/migrations/0041_store_project_step_changed_at.sql
+++ b/src/core/drizzle/migrations/0041_store_project_step_changed_at.sql
@@ -1,0 +1,83 @@
+-- Store `stepChangedAt` on the project instead of deriving it from the
+-- workflow-event trail.
+--
+-- WHY: Neo4j stores this as a plain property, written whenever the project
+-- moves to a new step. Postgres was deriving it at read time from the latest
+-- entry in `project_workflow_events`, falling back to `created_at` when a
+-- project had no events at all. Those agree for anything that transitioned
+-- after the workflow trail began — but the trail only starts 2021-02-13, and
+-- 1,560 of 5,284 production projects have no events at all:
+--
+--   * ~1,081 reached Completed / Terminated / DidNotDevelop BEFORE 2021, so
+--     Neo4j holds the real date and Postgres substituted the creation date —
+--     wrong by as much as four years, on 991 completed projects.
+--   * ~470 old projects still in EarlyConversations have nothing stored in
+--     Neo4j at all, so it reports blank while Postgres invented a date.
+--
+-- Roughly 29% of projects differed on this field. A downstream warehouse
+-- comparison found it (Projects.CompletionDate); our own read comparison did
+-- not, because it samples the first five projects by id and every legacy
+-- record sorts past position 217.
+--
+-- The derivation cannot be repaired by adjusting the fallback: the history it
+-- derives from does not exist for these rows and never will. So the column is
+-- carried across from Neo4j verbatim, values and nulls alike.
+--
+-- migration-todo(post-cutover): Rob's call 2026-08-26 was to match Neo4j now
+-- and revisit afterwards. The open question is whether a stored column or a
+-- derived value is the right long-term design once the pre-2021 rows are the
+-- only ones that need the column. Deriving is arguably cleaner and matches the
+-- Gel model (`latestWorkflowEvent.at ?? createdAt`); it just cannot represent
+-- history that was never recorded. If it stays stored, the `@Calculated()`
+-- decorator on the DTO field is worth revisiting too.
+-- ⚠ TWO STEPS ON PURPOSE — do not collapse into `ADD COLUMN ... DEFAULT now()`.
+-- Postgres backfills every existing row with the default when the column is
+-- added with one. On an already-loaded database that stamps all 1,560
+-- no-event projects with the moment the migration ran — every legacy project
+-- claiming it changed step today, which is worse than the fallback this
+-- replaces. Adding the column bare leaves them NULL, then the default attaches
+-- for rows inserted afterwards. Measured: collapsing these gave 1,560 rows a
+-- current timestamp.
+ALTER TABLE "projects" ADD COLUMN "step_changed_at" timestamp with time zone;
+--> statement-breakpoint
+
+-- Nullable on purpose: Neo4j has no value for the ~470 legacy projects that
+-- never transitioned, and reports blank for them. Matching that beats
+-- inventing a date. The default covers rows the application creates from here
+-- on, mirroring Neo4j's `stepChangedAt: now` at creation; an explicit NULL
+-- from the loader still overrides it.
+ALTER TABLE "projects" ALTER COLUMN "step_changed_at" SET DEFAULT now();
+--> statement-breakpoint
+
+-- Backfill anything already loaded, so a database that was migrated before the
+-- loader carried this column still reads consistently: latest event if there
+-- is one, otherwise leave it NULL rather than guessing.
+UPDATE "projects" p
+   SET "step_changed_at" = e."at"
+  FROM (
+    SELECT "project_id", max("at") AS "at"
+      FROM "project_workflow_events"
+     GROUP BY "project_id"
+  ) e
+ WHERE e."project_id" = p."id";
+--> statement-breakpoint
+
+-- Keep it current the same way `step` is kept current: the trigger that already
+-- syncs step from a new event. App code never writes `projects.step` directly
+-- and it should not write this either — one place, one rule, and it cannot
+-- drift from the event that caused it.
+CREATE OR REPLACE FUNCTION "sync_project_step_from_event"() RETURNS trigger AS $$
+BEGIN
+  UPDATE "projects"
+     SET "step"            = NEW."to_step",
+         "modified_at"     = NEW."at",
+         "step_changed_at" = NEW."at"
+   WHERE "id" = NEW."project_id"
+     AND NOT EXISTS (
+       SELECT 1 FROM "project_workflow_events" "e"
+       WHERE "e"."project_id" = NEW."project_id"
+         AND ("e"."at", "e"."id") > (NEW."at", NEW."id")
+     );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/core/drizzle/migrations/0042_allow_blanks_on_migrated_flags.sql
+++ b/src/core/drizzle/migrations/0042_allow_blanks_on_migrated_flags.sql
@@ -1,0 +1,68 @@
+-- Let a Neo4j blank stay blank.
+--
+-- Neo4j stores a field only when somebody sets it: `planned` on a ceremony is a
+-- separate Property node, and ~90% of ceremonies never got one. Postgres
+-- declared these columns NOT NULL DEFAULT <something>, so the cutover loader had
+-- to invent a value for every row that had never had one — turning "nobody ever
+-- recorded this" into a definite answer. A warehouse comparison caught it from
+-- the outside: ceremonies read 'N' on Postgres and blank on Neo4j.
+--
+-- Dropping NOT NULL costs nothing at the API. Every one of these fields is
+-- exposed through a `Secured*` wrapper, and every wrapper already emits a
+-- nullable `value` — clients have always had to handle a blank here, because
+-- Neo4j has always returned one.
+--
+-- ⚠ The DEFAULT goes with the NOT NULL, deliberately. Drizzle omits an
+-- `undefined` key from an INSERT, which hands the column back to its default —
+-- so a field merely *absent* in the source would be silently re-filled by the
+-- very default this migration exists to remove. Every create path writes these
+-- columns explicitly (`input.marketable ?? false`), so nothing new arrives
+-- blank and no application insert depends on the default.
+--
+-- ⚠ This migration does NOT convert existing `false`/'Active'/'' rows to NULL,
+-- and cannot: once the value has been written there is no way to tell an
+-- invented one from a real one. Any database already populated by the cutover
+-- ETL must be RELOADED to pick up the preserved blanks.
+
+ALTER TABLE "ceremonies" ALTER COLUMN "planned" DROP DEFAULT;
+--> statement-breakpoint
+ALTER TABLE "ceremonies" ALTER COLUMN "planned" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "engagements" ALTER COLUMN "marketable" DROP DEFAULT;
+--> statement-breakpoint
+ALTER TABLE "engagements" ALTER COLUMN "marketable" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "projects" ALTER COLUMN "preset_inventory" DROP DEFAULT;
+--> statement-breakpoint
+ALTER TABLE "projects" ALTER COLUMN "preset_inventory" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "partners" ALTER COLUMN "global_innovations_client" DROP DEFAULT;
+--> statement-breakpoint
+ALTER TABLE "partners" ALTER COLUMN "global_innovations_client" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "partners" ALTER COLUMN "active" DROP DEFAULT;
+--> statement-breakpoint
+ALTER TABLE "partners" ALTER COLUMN "active" DROP NOT NULL;
+--> statement-breakpoint
+-- users.status has no DEFAULT to drop; the loader always supplied one.
+ALTER TABLE "users" ALTER COLUMN "status" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "timezone" DROP DEFAULT;
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "timezone" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "real_first_name" DROP DEFAULT;
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "real_first_name" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "real_last_name" DROP DEFAULT;
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "real_last_name" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "display_first_name" DROP DEFAULT;
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "display_first_name" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "display_last_name" DROP DEFAULT;
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "display_last_name" DROP NOT NULL;

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -288,6 +288,20 @@
       "when": 1754092800000,
       "tag": "0040_add_external_department_ids",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1754179200000,
+      "tag": "0041_store_project_step_changed_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1754265600000,
+      "tag": "0042_allow_blanks_on_migrated_flags",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -74,14 +74,17 @@ export const degreeEnum = pgEnum('degree', [
 export const users = pgTable('users', {
   id: text('id').$type<ID<'User'>>().primaryKey(),
   isRoot: boolean('is_root').notNull().default(false),
-  status: userStatusEnum('status').notNull(),
+  // Nullable (migration 0042): Neo4j stores each of these only when somebody
+  // set it, so NOT NULL forced the loader to invent one. The create paths all
+  // write these columns explicitly, so nothing new arrives blank.
+  status: userStatusEnum('status'),
   email: text('email').unique(),
-  realFirstName: text('real_first_name').notNull().default(''),
-  realLastName: text('real_last_name').notNull().default(''),
-  displayFirstName: text('display_first_name').notNull().default(''),
-  displayLastName: text('display_last_name').notNull().default(''),
+  realFirstName: text('real_first_name'),
+  realLastName: text('real_last_name'),
+  displayFirstName: text('display_first_name'),
+  displayLastName: text('display_last_name'),
   phone: text('phone'),
-  timezone: text('timezone').notNull().default('America/Chicago'),
+  timezone: text('timezone'),
   about: text('about'),
   title: text('title'),
   gender: genderEnum('gender').$type<Gender>(),
@@ -964,10 +967,9 @@ export const partners = pgTable(
       .notNull()
       .default([]),
     pmcEntityCode: text('pmc_entity_code'),
-    globalInnovationsClient: boolean('global_innovations_client')
-      .notNull()
-      .default(false),
-    active: boolean('active').notNull().default(false),
+    // Nullable (migration 0042) — an unmarked partner is blank, not a "no".
+    globalInnovationsClient: boolean('global_innovations_client'),
+    active: boolean('active'),
     address: text('address'),
     // migration-todo: deferred FK → languages(id); add REFERENCES when Language
     // migrates. Plain text until then (same pattern as locations.funding_account_id).
@@ -1222,6 +1224,24 @@ export const projects = pgTable(
       .$type<ProjectStep>()
       .notNull()
       .default('EarlyConversations'),
+    /**
+     * When the project last moved to a new step.
+     *
+     * Stored rather than derived from `project_workflow_events`, because the
+     * event trail only begins 2021-02-13 and 1,560 production projects
+     * transitioned before it existed — see migration 0041. Nullable on
+     * purpose: Neo4j reports blank for the ~470 legacy projects that never
+     * moved, and matching that beats inventing a date.
+     *
+     * Written by the `sync_project_step_from_event` trigger, never by app
+     * code — same rule as `step` itself.
+     *
+     * migration-todo(post-cutover): revisit stored vs derived once the
+     * pre-2021 rows are the only ones needing it (Rob's call 2026-08-26).
+     */
+    stepChangedAt: timestamp('step_changed_at', {
+      withTimezone: true,
+    }).default(sql`now()`),
     status: projectStatusEnum('status')
       .$type<ProjectStatus>()
       .generatedAlwaysAs(
@@ -1302,7 +1322,10 @@ export const projects = pgTable(
       'financial_report_period',
     ).$type<ReportPeriod>(),
     tags: text('tags').array().notNull().default([]),
-    presetInventory: boolean('preset_inventory').notNull().default(false),
+    // Nullable (migration 0042). Also fixes the list filter: `eq(..., false)`
+    // used to sweep in every unmarked project, where Neo4j's `filter.propVal()`
+    // matches neither true nor false when the property was never written.
+    presetInventory: boolean('preset_inventory'),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -2089,7 +2112,8 @@ export const engagements = pgTable(
       .references(() => locations.id),
     // migration-todo: deferred FK → files(id); Phase 7.
     growthPlanId: text('growth_plan_id').$type<ID<'File'>>(),
-    marketable: boolean('marketable').notNull().default(false),
+    // Nullable (migration 0042) — same filter reasoning as preset_inventory.
+    marketable: boolean('marketable'),
     webId: text('web_id'),
 
     createdAt: timestamp('created_at', { withTimezone: true })
@@ -2191,7 +2215,9 @@ export const ceremonies = pgTable(
       .notNull()
       .references(() => engagements.id, { onDelete: 'cascade' }),
     type: ceremonyTypeEnum('type').$type<CeremonyType>().notNull(),
-    planned: boolean('planned').notNull().default(false),
+    // Nullable (migration 0042) — the column a warehouse comparison caught
+    // reading 'N' on Postgres where Neo4j returned a blank.
+    planned: boolean('planned'),
     estimatedDate: date('estimated_date'),
     actualDate: date('actual_date'),
     createdAt: timestamp('created_at', { withTimezone: true })


### PR DESCRIPTION
### Why

Neo4j stores a field only when somebody sets it. `planned` on a ceremony is a
separate node, and about 90% of ceremonies never got one — so reading it back
gives a blank, not a "no".

Postgres declared those columns NOT NULL with a default, so the migration had to
supply a value for every record that had never had one. "Nobody ever recorded
this" became a definite answer. A warehouse comparison found it from the outside:
ceremonies read "N" on Postgres and blank on Neo4j, and the same thing was
happening to 6,866 of 8,224 language engagements without anyone noticing.

A second version of the same problem: a project's step-change date was being
derived from its most recent workflow event, falling back to its creation date
when there were none. The workflow trail only begins February 2021, so 1,560
projects reported the day they were created as the day they last changed step.

### What changes

Eleven columns become nullable, so a blank stays blank: a ceremony's planned
flag, a language engagement's marketable flag, a project's preset-inventory
flag, a person's status and timezone and four name fields, and a partner's
active and global-innovations-client flags.

A project's step-change date is now stored rather than derived, backfilled from
the workflow history and kept current by the same trigger that maintains the
step itself.

Nothing changes for records created from here on. Every create path already
writes these fields explicitly, so a new ceremony still gets a real planned
value.

### What this does not change

The API shape is identical. Each of these fields is returned in a wrapper that
already allowed a blank, because Neo4j has always returned one — the field types
are being corrected to say what was already true, not loosened. A query asking
for one of these values gets exactly the same thing back.

### Worth knowing

Databases already populated by the data migration are not repaired by this and
cannot be: once a "no" has been written there is no way to tell an invented one
from a real one. Those need reloading.

Two list filters change meaning as a result, and both move toward the old
system's behavior rather than away from it. Asking for engagements where
marketable is false, or projects where preset-inventory is false, previously
returned every unmarked record as well. Now it returns only the ones actually
marked false — which is what the old system has always done.
