### PR TITLE
Auto-advance quarterly reports when Rev79 delivers data

### DIFF
--- a/src/components/progress-report/workflow/emails/progress-report-status-changed.email.tsx
+++ b/src/components/progress-report/workflow/emails/progress-report-status-changed.email.tsx
@@ -16,7 +16,8 @@ import { ProgressReportStatus } from '../../dto';
 import { type ProgressReportWorkflowEvent } from '../dto/workflow-event.dto';
 
 export interface ProgressReportStatusChangedProps {
-  changedBy: UserRefProps;
+  /** Absent when the actor cannot be shown. */
+  changedBy?: UserRefProps;
   recipient: Pick<
     User,
     'email' | 'displayFirstName' | 'displayLastName' | 'timezone'
@@ -75,8 +76,16 @@ export function ProgressReportStatusChanged({
       <Mjml.Section>
         <Mjml.Column>
           <Mjml.Text paddingBottom={16}>
-            <UserRef {...changedBy} /> has changed{' '}
-            <a href={reportUrl}>{reportLabel}</a>{' '}
+            {changedBy ? (
+              <>
+                <UserRef {...changedBy} /> has changed{' '}
+                <a href={reportUrl}>{reportLabel}</a>{' '}
+              </>
+            ) : (
+              <>
+                <a href={reportUrl}>{reportLabel}</a> changed{' '}
+              </>
+            )}
             {newStatus ? (
               <>
                 {oldStatus ? (

--- a/src/components/progress-report/workflow/emails/progress-report-status-changed.email.tsx
+++ b/src/components/progress-report/workflow/emails/progress-report-status-changed.email.tsx
@@ -16,7 +16,10 @@ import { ProgressReportStatus } from '../../dto';
 import { type ProgressReportWorkflowEvent } from '../dto/workflow-event.dto';
 
 export interface ProgressReportStatusChangedProps {
-  /** Absent when the actor cannot be shown. */
+  /**
+   * Absent for automated changes (the automation sentence carries the
+   * attribution) and when the actor cannot be shown.
+   */
   changedBy?: UserRefProps;
   recipient: Pick<
     User,
@@ -28,6 +31,12 @@ export interface ProgressReportStatusChangedProps {
   newStatusVal?: ProgressReportStatus;
   previousStatusVal?: ProgressReportStatus;
   workflowEvent: ProgressReportWorkflowEvent;
+  /**
+   * When an automated process (not a person) executed the transition,
+   * a human-readable phrase for why, e.g.
+   * "report data was received from Rev79".
+   */
+  automatedReason?: string;
 }
 
 export function ProgressReportStatusChanged({
@@ -39,6 +48,7 @@ export function ProgressReportStatusChanged({
   newStatusVal,
   previousStatusVal,
   workflowEvent,
+  automatedReason,
 }: ProgressReportStatusChangedProps) {
   const projectUrl = useFrontendUrl(`/projects/${project.id}`);
   const projectName = project.name.value || '';
@@ -76,14 +86,17 @@ export function ProgressReportStatusChanged({
       <Mjml.Section>
         <Mjml.Column>
           <Mjml.Text paddingBottom={16}>
-            {changedBy ? (
+            {automatedReason || !changedBy ? (
+              // No actor lead for automated changes — the sentence below
+              // carries the attribution, and "Rev79 has changed ... because
+              // data was received from Rev79" read as a confusing double.
               <>
-                <UserRef {...changedBy} /> has changed{' '}
-                <a href={reportUrl}>{reportLabel}</a>{' '}
+                <a href={reportUrl}>{reportLabel}</a> changed{' '}
               </>
             ) : (
               <>
-                <a href={reportUrl}>{reportLabel}</a> changed{' '}
+                <UserRef {...changedBy} /> has changed{' '}
+                <a href={reportUrl}>{reportLabel}</a>{' '}
               </>
             )}
             {newStatus ? (
@@ -104,6 +117,11 @@ export function ProgressReportStatusChanged({
               />
             </>
           </Mjml.Text>
+          {automatedReason ? (
+            <Mjml.Text paddingBottom={16}>
+              This change was made automatically because {automatedReason}.
+            </Mjml.Text>
+          ) : null}
           <Mjml.Button href={reportUrl} paddingTop={16}>
             View {reportLabel}
           </Mjml.Button>

--- a/src/components/progress-report/workflow/handlers/index.ts
+++ b/src/components/progress-report/workflow/handlers/index.ts
@@ -1,1 +1,2 @@
+export * from './progress-report-ingest-auto-advance.handler';
 export * from './progress-report-workflow-notification.handler';

--- a/src/components/progress-report/workflow/handlers/progress-report-ingest-auto-advance.handler.ts
+++ b/src/components/progress-report/workflow/handlers/progress-report-ingest-auto-advance.handler.ts
@@ -1,0 +1,91 @@
+import { RichTextDocument, ServerException } from '~/common';
+import { Identity } from '~/core/authentication';
+import { ConfigService } from '~/core/config';
+import { OnHook } from '~/core/hooks';
+import { ILogger, Logger } from '~/core/logger';
+import { SystemAgentRepository } from '../../../user/system-agent.repository';
+import {
+  IngestTriggers,
+  ProgressReportIngestTriggerHook,
+} from '../hooks/ingest-trigger.hook';
+import { ProgressReportWorkflowService } from '../progress-report-workflow.service';
+import { Transitions } from '../transitions';
+
+/**
+ * Advances a progress report's status when an ingest trigger fires —
+ * e.g. NotStarted -> InProgress when Rev79 delivers report data.
+ *
+ * Never regresses: the transition only fires when it is available from the
+ * report's current status, and ingest triggers may only map to transitions
+ * with a `from` status — so a report that is already further along is never
+ * touched, and a repeated delivery changes nothing.
+ *
+ * The transition executes as the "Rev79" system agent, which is the recorded
+ * actor on the workflow event and in the notification email. The delivery
+ * itself is the authorization — the caller already needed write access to the
+ * report to get here.
+ */
+@OnHook(ProgressReportIngestTriggerHook)
+export class ProgressReportIngestAutoAdvanceHandler {
+  constructor(
+    private readonly workflow: ProgressReportWorkflowService,
+    private readonly agents: SystemAgentRepository,
+    private readonly identity: Identity,
+    private readonly config: ConfigService,
+    @Logger('progress-report:auto-advance') private readonly logger: ILogger,
+  ) {}
+
+  async handle({ reportId, trigger, source }: ProgressReportIngestTriggerHook) {
+    if (this.config.databaseEngine === 'gel') {
+      // migration-todo: the Gel schema types workflow-event `who` as a User,
+      // so an agent-actored event cannot be recorded there — skip rather than
+      // fail the whole ingest. Drop with the Gel arm at Phase 7 cutover.
+      this.logger.info(
+        'Skipping auto-advance; Gel cannot record agent actors',
+        { report: reportId, trigger },
+      );
+      return;
+    }
+
+    const { transition: transitionName, description } = IngestTriggers[trigger];
+    const transition = Transitions[transitionName];
+    if (!transition.from) {
+      // A from-less transition is available from EVERY status, so a repeated
+      // delivery would re-execute it and could regress a later status.
+      throw new ServerException(
+        `Ingest trigger "${trigger}" must map to a transition with a "from" status`,
+      );
+    }
+
+    const reason = `${description} from ${source}`;
+    // The actor is the Rev79 agent for every trigger that exists today; a
+    // future non-Rev79 source needs its own agent decided here deliberately.
+    const agent = await this.agents.getRev79();
+    const advanced = await this.identity.asSystemAgent(
+      agent,
+      async () =>
+        await this.workflow.executeTransitionIfAvailable(
+          {
+            report: reportId,
+            transition: transition.id,
+            notes: RichTextDocument.fromText(`Automated: ${reason}.`),
+          },
+          reason,
+        ),
+    );
+
+    if (!advanced) {
+      this.logger.debug('Report is already past this trigger', {
+        report: reportId,
+        trigger,
+      });
+      return;
+    }
+    this.logger.info('Auto-advanced progress report', {
+      report: reportId,
+      trigger,
+      transition: transition.name,
+      to: transition.to,
+    });
+  }
+}

--- a/src/components/progress-report/workflow/handlers/progress-report-workflow-notification.handler.tsx
+++ b/src/components/progress-report/workflow/handlers/progress-report-workflow-notification.handler.tsx
@@ -50,6 +50,7 @@ export class ProgressReportWorkflowNotificationHandler {
     previousStatus,
     next,
     workflowEvent,
+    automatedReason,
   }: WorkflowUpdatedHook) {
     const { enabled } = this.configService.progressReportStatusChange;
     if (!enabled) {
@@ -77,10 +78,11 @@ export class ProgressReportWorkflowNotificationHandler {
               workflowEvent,
               projectId,
               languageId,
+              automatedReason,
             );
           } catch (exception) {
             // Hooks run inside the transaction — losing one recipient's email
-            // must not roll back the status change.
+            // must not roll back the status change (or the whole ingest).
             this.logger.error('Failed to prepare status change notification', {
               recipient: email,
               reportId,
@@ -135,6 +137,7 @@ export class ProgressReportWorkflowNotificationHandler {
     unsecuredEvent: UnsecuredDto<ProgressReportWorkflowEvent>,
     projectId: ID,
     languageId: ID,
+    automatedReason?: string,
   ): Promise<EmailReportStatusNotification> {
     const recipientId = receiver.userId ?? this.configService.rootUser.id;
     return await this.identity.asUser(recipientId, async () => {
@@ -145,11 +148,12 @@ export class ProgressReportWorkflowNotificationHandler {
       const project = await this.projectService.readOne(projectId);
       const language = await this.languageService.readOne(languageId);
       const report = await this.reportService.readOne(reportId);
-      // The actor may be a User or a SystemAgent; an agent or unloadable actor
-      // degrades to the actor-less sentence in the template.
-      const changedByActor = (
-        await this.userService.readManyActors([unsecuredEvent.who.id])
-      )[0];
+      // The template only names the actor for human changes — automated ones
+      // carry the reason sentence instead — so skip the read entirely there.
+      // An agent or unloadable actor degrades to the actor-less sentence.
+      const changedByActor = automatedReason
+        ? undefined
+        : (await this.userService.readManyActors([unsecuredEvent.who.id]))[0];
       const changedBy =
         changedByActor?.__typename === 'User' ? changedByActor : undefined;
       const workflowEvent = this.workflowService.secure(unsecuredEvent);
@@ -163,6 +167,7 @@ export class ProgressReportWorkflowNotificationHandler {
         newStatusVal: report.status?.value,
         previousStatusVal: report.status?.value ? previousStatus : undefined,
         workflowEvent: workflowEvent,
+        automatedReason,
       };
     });
   }

--- a/src/components/progress-report/workflow/handlers/progress-report-workflow-notification.handler.tsx
+++ b/src/components/progress-report/workflow/handlers/progress-report-workflow-notification.handler.tsx
@@ -145,7 +145,13 @@ export class ProgressReportWorkflowNotificationHandler {
       const project = await this.projectService.readOne(projectId);
       const language = await this.languageService.readOne(languageId);
       const report = await this.reportService.readOne(reportId);
-      const changedBy = await this.userService.readOne(unsecuredEvent.who.id);
+      // The actor may be a User or a SystemAgent; an agent or unloadable actor
+      // degrades to the actor-less sentence in the template.
+      const changedByActor = (
+        await this.userService.readManyActors([unsecuredEvent.who.id])
+      )[0];
+      const changedBy =
+        changedByActor?.__typename === 'User' ? changedByActor : undefined;
       const workflowEvent = this.workflowService.secure(unsecuredEvent);
 
       return {

--- a/src/components/progress-report/workflow/handlers/progress-report-workflow-notification.handler.tsx
+++ b/src/components/progress-report/workflow/handlers/progress-report-workflow-notification.handler.tsx
@@ -3,6 +3,7 @@ import { type RequireExactlyOne } from 'type-fest';
 import { type ID, Role, type UnsecuredDto } from '~/common';
 import { Identity } from '~/core/authentication';
 import { ConfigService } from '~/core/config';
+import { TransactionHooks } from '~/core/database';
 import { MailerService } from '~/core/email';
 import { OnHook } from '~/core/hooks';
 import { ILogger, Logger } from '~/core/logger';
@@ -39,6 +40,7 @@ export class ProgressReportWorkflowNotificationHandler {
     private readonly reportService: PeriodicReportService,
     private readonly mailer: MailerService,
     private readonly workflowService: ProgressReportWorkflowService,
+    private readonly txHooks: TransactionHooks,
     @Logger('progress-report:status-change-notifier')
     private readonly logger: ILogger,
   ) {}
@@ -64,18 +66,31 @@ export class ProgressReportWorkflowNotificationHandler {
       ({ id, email }) => [email, id],
     ).asMap;
 
-    const notifications = await Promise.all(
-      entries(userIdByEmail).map(([email, userId]) =>
-        this.prepareNotificationObject(
-          reportId,
-          previousStatus,
-          userId ? { userId } : { email },
-          workflowEvent,
-          projectId,
-          languageId,
-        ),
-      ),
-    );
+    const notifications = (
+      await Promise.all(
+        entries(userIdByEmail).map(async ([email, userId]) => {
+          try {
+            return await this.prepareNotificationObject(
+              reportId,
+              previousStatus,
+              userId ? { userId } : { email },
+              workflowEvent,
+              projectId,
+              languageId,
+            );
+          } catch (exception) {
+            // Hooks run inside the transaction — losing one recipient's email
+            // must not roll back the status change.
+            this.logger.error('Failed to prepare status change notification', {
+              recipient: email,
+              reportId,
+              exception,
+            });
+            return null;
+          }
+        }),
+      )
+    ).flatMap((notification) => (notification ? [notification] : []));
 
     this.logger.info('Notifying', {
       emails: notifications.map((r) => r.recipient.email.value),
@@ -86,16 +101,31 @@ export class ProgressReportWorkflowNotificationHandler {
       previousStatusVal: notifications[0]?.previousStatusVal ?? undefined,
     });
 
-    for (const notification of notifications) {
-      if (notification.recipient.email.value) {
-        await this.mailer
-          .compose(
-            notification.recipient.email.value,
-            <ProgressReportStatusChanged {...notification} />,
-          )
-          .send();
+    const send = async () => {
+      for (const notification of notifications) {
+        const email = notification.recipient.email.value;
+        if (!email) {
+          continue;
+        }
+        try {
+          await this.mailer
+            .compose(email, <ProgressReportStatusChanged {...notification} />)
+            .send();
+        } catch (exception) {
+          // A failed send must not fail (or roll back) the status change.
+          this.logger.error('Failed to send status change notification', {
+            recipient: email,
+            reportId,
+            exception,
+          });
+        }
       }
-    }
+    };
+
+    // Emails are outbound side effects — hold them until the mutation's
+    // transaction commits, so a rolled-back attempt cannot send and a retry
+    // cannot re-send emails for writes that never persisted.
+    await this.txHooks.afterCommitOrNow(send);
   }
 
   private async prepareNotificationObject(

--- a/src/components/progress-report/workflow/hooks/ingest-trigger.hook.ts
+++ b/src/components/progress-report/workflow/hooks/ingest-trigger.hook.ts
@@ -1,0 +1,39 @@
+import type { ID } from '~/common';
+import type { TransitionName } from '../transitions';
+
+/**
+ * Everything the workflow does with each ingest trigger: the transition it
+ * attempts, and the phrase explaining why — used in the workflow event's note
+ * and the notification email.
+ *
+ * Future ingest triggers (auto-translation complete, AI draft complete — see
+ * #3767) each become one entry here once the system producing them exists.
+ * Entries must map to transitions with a `from` status — the auto-advance
+ * handler enforces this to guarantee a report is never moved backwards or
+ * re-advanced by a repeated delivery.
+ */
+export const IngestTriggers = {
+  DataReceived: {
+    transition: 'Start',
+    description: 'report data was received',
+  },
+} satisfies Record<string, { transition: TransitionName; description: string }>;
+
+export type ProgressReportIngestTrigger = keyof typeof IngestTriggers;
+
+/**
+ * An automated source (currently Rev79) delivered data for a progress report.
+ * Fired by ingest paths, inside their transaction, so the workflow can react —
+ * e.g. auto-advance the report's status.
+ */
+export class ProgressReportIngestTriggerHook {
+  constructor(
+    readonly reportId: ID<'ProgressReport'>,
+    readonly trigger: ProgressReportIngestTrigger,
+    /**
+     * Human-readable name of the system that delivered the data, e.g. "Rev79".
+     * Surfaces in the workflow event's notes and the notification email.
+     */
+    readonly source: string,
+  ) {}
+}

--- a/src/components/progress-report/workflow/hooks/workflow-updated.hook.ts
+++ b/src/components/progress-report/workflow/hooks/workflow-updated.hook.ts
@@ -9,5 +9,11 @@ export class WorkflowUpdatedHook {
     readonly previousStatus: Status,
     readonly next: InternalTransition | Status,
     readonly workflowEvent: UnsecuredDto<WorkflowEvent>,
+    /**
+     * When an automated process (not a person) executed the transition,
+     * a human-readable phrase for why, e.g.
+     * "report data was received from Rev79".
+     */
+    readonly automatedReason?: string,
   ) {}
 }

--- a/src/components/progress-report/workflow/progress-report-workflow.drizzle.repository.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.drizzle.repository.ts
@@ -117,17 +117,24 @@ export class ProgressReportWorkflowDrizzleRepository {
     }
     // Select the event's own columns so the row stays flat and `toDto` takes it
     // unchanged; a bare `.select()` over joins nests each table under its name.
-    return this.db
-      .select(getTableColumns(workflowEvents))
-      .from(workflowEvents)
-      .innerJoin(
-        periodicReports,
-        eq(periodicReports.id, workflowEvents.reportId),
-      )
-      .innerJoin(engagements, eq(engagements.id, periodicReports.engagementId))
-      .innerJoin(projects, eq(projects.id, engagements.projectId))
-      .innerJoin(users, eq(users.id, workflowEvents.who))
-      .where(and(...conditions));
+    return (
+      this.db
+        .select(getTableColumns(workflowEvents))
+        .from(workflowEvents)
+        .innerJoin(
+          periodicReports,
+          eq(periodicReports.id, workflowEvents.reportId),
+        )
+        .innerJoin(
+          engagements,
+          eq(engagements.id, periodicReports.engagementId),
+        )
+        .innerJoin(projects, eq(projects.id, engagements.projectId))
+        // LEFT, not INNER: agent-actored events (e.g. Rev79 auto-advance) have
+        // no `who` user row, and must still be readable.
+        .leftJoin(users, eq(users.id, workflowEvents.who))
+        .where(and(...conditions))
+    );
   }
 
   async readMany(
@@ -161,13 +168,13 @@ export class ProgressReportWorkflowDrizzleRepository {
     UnsecuredDto<WorkflowEvent>
   > {
     const id = await generateId<ID<'ProgressReportWorkflowEvent'>>();
-    const who = this.identity.current.userId;
+    const actor = this.resolveActor();
     const at = new Date();
 
     const row = {
       id,
       reportId: report as ID<'ProgressReport'>,
-      who,
+      ...actor,
       status: props.status,
       transitionKey: props.transition ?? null,
       notes: props.notes ?? null,
@@ -175,6 +182,23 @@ export class ProgressReportWorkflowDrizzleRepository {
     };
     await this.db.insert(workflowEvents).values(row);
     return this.toDto(row);
+  }
+
+  /**
+   * Which actor column this event belongs in. `Session.actor` owns the
+   * user-vs-agent discrimination (and documents the session shapes that defeat
+   * it); this only maps that to this table's columns. Exactly one column is
+   * non-null, satisfying `progress_report_workflow_events_actor_shape_chk`
+   * (migration 0043).
+   */
+  private resolveActor(): {
+    who: ID<'User'> | null;
+    whoSystemAgentId: ID<'SystemAgent'> | null;
+  } {
+    const actor = this.identity.current.actor;
+    return actor.type === 'agent'
+      ? { who: null, whoSystemAgentId: actor.id }
+      : { who: actor.id, whoSystemAgentId: null };
   }
 
   async currentStatus(reportId: ID): Promise<Status> {
@@ -308,7 +332,9 @@ export class ProgressReportWorkflowDrizzleRepository {
       __typename: 'ProgressReportWorkflowEvent',
       createdAt: DateTime.fromJSDate(row.at),
       at: DateTime.fromJSDate(row.at),
-      who: { id: row.who },
+      // ActorLoader hydrates users and system agents alike, so downstream only
+      // needs the one id — whichever column holds it.
+      who: { id: (row.who ?? row.whoSystemAgentId)! },
       // The transition *key*; the service resolves it to a WorkflowTransition
       // object. Null means the workflow was bypassed.
       transition: row.transitionKey ?? null,

--- a/src/components/progress-report/workflow/progress-report-workflow.gel.repository.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.gel.repository.ts
@@ -26,6 +26,10 @@ export class ProgressReportWorkflowGelRepository
     return await this.db.run(query);
   }
 
+  // migration-todo: the Gel schema types `who` as `default::User` (defaulted
+  // from `global currentUser`), so an agent-actored event (Rev79 auto-advance)
+  // is unsupported here — same lag as the project workflow's Gel arm. Moot at
+  // Phase 7 cutover.
   async recordEvent({
     report,
     ...props

--- a/src/components/progress-report/workflow/progress-report-workflow.repository.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.repository.ts
@@ -1,5 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { inArray, node, type Query, relation } from 'cypher-query-builder';
+import {
+  inArray,
+  isNull,
+  node,
+  type Query,
+  relation,
+} from 'cypher-query-builder';
 import { type SetRequired } from 'type-fest';
 import {
   type ID,
@@ -16,7 +22,6 @@ import {
   createRelationships,
   currentUser,
   merge,
-  path,
   sorting,
 } from '~/core/neo4j/query';
 import { ProgressReport, type ProgressReportStatus as Status } from '../dto';
@@ -144,13 +149,15 @@ export class ProgressReportWorkflowRepository extends DtoRepository(
         relation('out', '', 'user', ACTIVE),
         node('user', 'User'),
       ])
-      .where(
-        path([
-          node('member'),
-          relation('out', '', 'inactiveAt', ACTIVE),
-          node('', 'Property', { value: null }),
-        ]),
-      )
+      .match([
+        node('member'),
+        relation('out', '', 'inactiveAt', ACTIVE),
+        node('inactiveAt', 'Property'),
+      ])
+      // A map pattern `{ value: null }` never matches in Cypher — null only
+      // compares with IS NULL, so the property node has to be matched into a
+      // variable and filtered here.
+      .where({ inactiveAt: { value: isNull() } })
       .match([
         node('user'),
         relation('out', '', 'email', ACTIVE),

--- a/src/components/progress-report/workflow/progress-report-workflow.repository.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.repository.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import {
   inArray,
   isNull,
@@ -15,12 +15,12 @@ import {
   ServerException,
   type UnsecuredDto,
 } from '~/common';
+import { Identity } from '~/core/authentication';
 import { DtoRepository } from '~/core/neo4j';
 import {
   ACTIVE,
   createNode,
   createRelationships,
-  currentUser,
   merge,
   sorting,
 } from '~/core/neo4j/query';
@@ -32,6 +32,8 @@ import { ProgressReportWorkflowEvent as WorkflowEvent } from './dto/workflow-eve
 export class ProgressReportWorkflowRepository extends DtoRepository(
   WorkflowEvent,
 ) {
+  @Inject() private readonly identity: Identity;
+
   async readMany(ids: readonly ID[]) {
     return await this.db
       .query()
@@ -75,7 +77,9 @@ export class ProgressReportWorkflowRepository extends DtoRepository(
         .match([
           node('node'),
           relation('out', undefined, 'who'),
-          node('who', 'User'),
+          // Actor, not User — automated transitions are attributed to a
+          // SystemAgent (e.g. Rev79), same as project workflow events.
+          node('who', 'Actor'),
         ])
         .return<{ dto: UnsecuredDto<WorkflowEvent> }>(
           merge('node', {
@@ -99,7 +103,9 @@ export class ProgressReportWorkflowRepository extends DtoRepository(
       .apply(
         createRelationships(WorkflowEvent, {
           in: { workflowEvent: ['ProgressReport', report] },
-          out: { who: currentUser },
+          // By Actor rather than `currentUser` (a User-labeled match) so a
+          // session running as a SystemAgent can be the recorded actor.
+          out: { who: ['Actor', this.identity.current.userId] },
         }),
       )
       .apply(this.hydrate())

--- a/src/components/progress-report/workflow/progress-report-workflow.service.ts
+++ b/src/components/progress-report/workflow/progress-report-workflow.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { type SetRequired } from 'type-fest';
 import {
   type ID,
   many,
@@ -63,11 +64,51 @@ export class ProgressReportWorkflowService {
     return this.privileges.for(WorkflowEvent).can('create');
   }
 
-  async executeTransition(input: ExecuteProgressReportTransition) {
-    const { report: reportId, notes } = input;
-
-    const currentStatus = await this.repo.currentStatus(reportId);
+  async executeTransition(
+    input: ExecuteProgressReportTransition,
+    automatedReason?: string,
+  ) {
+    const currentStatus = await this.repo.currentStatus(input.report);
     const next = this.validateExecutionInput(input, currentStatus);
+    await this.commitTransition(input, currentStatus, next, automatedReason);
+  }
+
+  /**
+   * Execute the transition when it is available from the report's current
+   * status to the current session; otherwise do nothing and return false.
+   *
+   * The no-throw variant automation wants: where {@link executeTransition}
+   * treats an unavailable transition as an error, a repeated ingest trigger is
+   * simply a no-op. One status read serves both the availability check and the
+   * commit.
+   */
+  async executeTransitionIfAvailable(
+    input: SetRequired<ExecuteProgressReportTransition, 'transition'>,
+    automatedReason?: string,
+  ): Promise<boolean> {
+    const currentStatus = await this.repo.currentStatus(input.report);
+    const transition = this.getAvailableTransitions(currentStatus).find(
+      (t) => t.id === input.transition,
+    );
+    if (!transition) {
+      return false;
+    }
+    await this.commitTransition(
+      input,
+      currentStatus,
+      transition,
+      automatedReason,
+    );
+    return true;
+  }
+
+  private async commitTransition(
+    input: ExecuteProgressReportTransition,
+    currentStatus: Status,
+    next: InternalTransition | Status,
+    automatedReason?: string,
+  ) {
+    const { report: reportId, notes } = input;
     const isTransition = typeof next !== 'string';
 
     const [unsecuredEvent] = await Promise.all([
@@ -82,6 +123,7 @@ export class ProgressReportWorkflowService {
       currentStatus,
       next,
       unsecuredEvent,
+      automatedReason,
     );
     await this.hooks.run(event);
 

--- a/src/components/progress-report/workflow/resolvers/progress-report-workflow-event.resolver.ts
+++ b/src/components/progress-report/workflow/resolvers/progress-report-workflow-event.resolver.ts
@@ -1,17 +1,17 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { mapSecuredValue } from '~/common';
 import { Loader, type LoaderOf } from '~/core/data-loader';
-import { UserLoader } from '../../../user';
-import { SecuredUser } from '../../../user/dto';
+import { ActorLoader } from '../../../user/actor.loader';
+import { SecuredActor } from '../../../user/dto';
 import { ProgressReportWorkflowEvent as WorkflowEvent } from '../dto/workflow-event.dto';
 
 @Resolver(WorkflowEvent)
 export class ProgressReportWorkflowEventResolver {
-  @ResolveField(() => SecuredUser)
+  @ResolveField(() => SecuredActor)
   async who(
     @Parent() event: WorkflowEvent,
-    @Loader(UserLoader) users: LoaderOf<UserLoader>,
-  ): Promise<SecuredUser> {
-    return await mapSecuredValue(event.who, ({ id }) => users.load(id));
+    @Loader(ActorLoader) actors: LoaderOf<ActorLoader>,
+  ): Promise<SecuredActor> {
+    return await mapSecuredValue(event.who, ({ id }) => actors.load(id));
   }
 }

--- a/src/components/project/workflow/project-workflow.drizzle.repository.ts
+++ b/src/components/project/workflow/project-workflow.drizzle.repository.ts
@@ -191,13 +191,10 @@ export class ProjectWorkflowDrizzleRepository {
   }
 
   /**
-   * Which actor column this event belongs in.
-   *
-   * `identity.current.userId` holds a SystemAgent's id whenever the session
-   * resolved to an agent rather than a person: an anonymous session (the Anonymous
-   * agent) or Ghost impersonation. Both set `systemAgentName` in
-   * `SessionManager.resumeSession`, which is what makes the discriminator below
-   * work, and the audit writer discriminates on the same field.
+   * Which actor column this event belongs in. `Session.actor` owns the
+   * user-vs-agent discrimination — including the migration-todo documenting the
+   * two session shapes that defeat it (whose failure is the `users` FK, never
+   * the actor-shape CHECK) — this only maps that to this table's columns.
    *
    * Do NOT read a population claim from this method. The agent-actored events
    * already in the data did not arrive through here — they came from the
@@ -208,43 +205,15 @@ export class ProjectWorkflowDrizzleRepository {
    *
    * Exactly one column is returned non-null, satisfying
    * `project_workflow_events_actor_shape_chk` (migration 0031).
-   *
-   * migration-todo: TWO session shapes slip past the discriminator, and in both the
-   * failure is the foreign key to `users` — never the actor-shape CHECK, so that
-   * constraint is not what protects this.
-   *
-   * 1. REACHABLE TODAY, over a request header. `resumeSession` resolves the Ghost
-   *    agent only when the impersonatee id is the literal `'ghost'`; any other id
-   *    passes straight through, and `systemAgentName` is set from `ghost?.name`.
-   *    So a requester who sends a SystemAgent's REAL id as the impersonatee gets a
-   *    session whose `userId` is that agent while `systemAgentName` stays
-   *    undefined. The branch below reads it as a person, writes the agent id into
-   *    `who`, fails the FK, and rolls the whole transition back. Nothing validates
-   *    that the impersonatee is a live user. The underlying gap is pre-existing,
-   *    engine-independent, and mirrored in the audit writer, so it is not this
-   *    migration's to fix — but it is not hypothetical either.
-   * 2. Unreachable today. `SessionManager.asRole` builds a session with the literal
-   *    placeholder `userId: 'anonymous'`, `anonymous: false`, and no
-   *    `systemAgentName`. Both call sites are read-only permission serializers
-   *    (`policy-dumper.ts`, `permission.serializer.ts`), and `executeTransition`
-   *    does no identity switching around `recordEvent`. The fix belongs in
-   *    `asRole`.
-   *
-   * A safer shape for this method would be to treat an id that is not a live user
-   * as an agent, or to fail with a domain error naming the session shape, rather
-   * than handing an unresolvable id to the FK. Note this copy also omits the audit
-   * writer's `session.anonymous ||` half — equivalent today, and it would catch
-   * neither shape above (shape 2 sets `anonymous: false`; shape 1 has a real
-   * logged-in requester).
    */
   private resolveActor(): {
     who: ID<'User'> | null;
     whoSystemAgentId: ID<'SystemAgent'> | null;
   } {
-    const session = this.identity.current;
-    return session.systemAgentName
-      ? { who: null, whoSystemAgentId: session.userId as ID<'SystemAgent'> }
-      : { who: session.userId as ID<'User'>, whoSystemAgentId: null };
+    const actor = this.identity.current.actor;
+    return actor.type === 'agent'
+      ? { who: null, whoSystemAgentId: actor.id }
+      : { who: actor.id, whoSystemAgentId: null };
   }
 
   /**

--- a/src/components/rev79/rev79.service.spec.ts
+++ b/src/components/rev79/rev79.service.spec.ts
@@ -121,6 +121,7 @@ describe('Rev79Service — applyMedia', () => {
       {} as any, // communityStoryService
       productProgressService,
       mediaService,
+      { run: jest.fn() } as any, // hooks
       { debug: jest.fn() } as any,
     );
 

--- a/src/components/rev79/rev79.service.ts
+++ b/src/components/rev79/rev79.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { File } from '@whatwg-node/fetch';
 import { type ID, NotFoundException } from '~/common';
 import { fullFiscalQuarter } from '~/common/temporal/fiscal-year';
+import { Hooks } from '~/core/hooks';
 import { ILogger, Logger } from '~/core/logger';
 import { PeriodicReportService } from '../periodic-report/periodic-report.service';
 import { ProgressReportVariantProgress } from '../product-progress/dto';
@@ -10,6 +11,7 @@ import { ProgressReportCommunityStoryService } from '../progress-report/communit
 import { ProgressReportMedia } from '../progress-report/media/dto';
 import { ProgressReportMediaService } from '../progress-report/media/progress-report-media.service';
 import { ProgressReportTeamNewsService } from '../progress-report/team-news/progress-report-team-news.service';
+import { ProgressReportIngestTriggerHook } from '../progress-report/workflow/hooks/ingest-trigger.hook';
 import { ProjectService } from '../project/project.service';
 import type {
   Rev79BulkUploadProgressReportsInput,
@@ -45,6 +47,7 @@ export class Rev79Service {
     private readonly communityStoryService: ProgressReportCommunityStoryService,
     private readonly productProgressService: ProductProgressService,
     private readonly mediaService: ProgressReportMediaService,
+    private readonly hooks: Hooks,
     @Logger('rev79') private readonly logger: ILogger,
   ) {}
 
@@ -200,14 +203,18 @@ export class Rev79Service {
     }
     const reportId = report.id as ID<'ProgressReport'>;
 
+    let receivedData = false;
+
     if (item.teamNews) {
       await this.applyTeamNews(report, reportId, item.teamNews);
+      receivedData = true;
     }
 
     if (item.communityStories?.length) {
       for (const story of item.communityStories) {
         await this.applyCommunityStory(report, reportId, story);
       }
+      receivedData = true;
     }
 
     if (item.productProgress?.length) {
@@ -218,12 +225,22 @@ export class Rev79Service {
           variant: ProgressReportVariantProgress.Variants.byKey('partner'),
         });
       }
+      receivedData = true;
     }
 
     if (item.media?.length) {
       for (const m of item.media) {
         await this.applyMedia(reportId, m);
       }
+      receivedData = true;
+    }
+
+    if (receivedData) {
+      // Let the workflow react to the delivery, e.g. auto-advance the report
+      // from NotStarted to InProgress (#3767).
+      await this.hooks.run(
+        new ProgressReportIngestTriggerHook(reportId, 'DataReceived', 'Rev79'),
+      );
     }
 
     return { rev79CommunityId, progressReport: reportId };

--- a/src/components/user/system-agent.neo4j.repository.ts
+++ b/src/components/user/system-agent.neo4j.repository.ts
@@ -20,10 +20,10 @@ export class SystemAgentNeo4jRepository extends SystemAgentRepository {
         variables: {
           'agent.id': 'apoc.create.uuid()',
         },
-        values: {
-          'agent.roles': roles ?? [],
-        },
       })
+      // On match too — the Drizzle arm updates roles on conflict, and a roles
+      // change in a getter must land the same way on both engines.
+      .setValues({ 'agent.roles': roles ?? [] })
       .return<{ agent: SystemAgent }>(
         merge('agent', { __typename: '"SystemAgent"' }).as('agent'),
       )

--- a/src/components/user/system-agent.repository.ts
+++ b/src/components/user/system-agent.repository.ts
@@ -25,6 +25,17 @@ export abstract class SystemAgentRepository {
     return await this.upsertAgent('External Mailing Group', ['Leadership']);
   }
 
+  /**
+   * Deliberately NOT `@CachedByArg` like its siblings: the first call happens
+   * inside an ingest mutation's transaction, and a process-wide cache of a row
+   * that transaction may roll back would leave every later caller referencing
+   * a phantom agent id until restart. The upsert is one cheap query per
+   * auto-advance.
+   */
+  async getRev79() {
+    return await this.upsertAgent('Rev79', ['Administrator']);
+  }
+
   protected abstract upsertAgent(
     name: string,
     roles?: readonly Role[],

--- a/src/core/authentication/identity.service.ts
+++ b/src/core/authentication/identity.service.ts
@@ -1,5 +1,6 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { type ID, type Role } from '~/common';
+import { type SystemAgent } from '../../components/user/dto';
 import { type IRequest } from '../http/types';
 import { SessionHost } from './session/session.host';
 import type { SessionInitiator } from './session/session.initiator';
@@ -81,6 +82,13 @@ export class Identity {
 
   async asUser<R>(user: ID<'User'>, fn: () => Promise<R>): Promise<R> {
     return await this.sessionManager.asUser(user, fn);
+  }
+
+  /**
+   * Run this function as the given system agent, with the agent's roles.
+   */
+  async asSystemAgent<R>(agent: SystemAgent, fn: () => Promise<R>): Promise<R> {
+    return await this.sessionManager.asSystemAgent(agent, fn);
   }
 
   /**

--- a/src/core/authentication/session/session.dto.ts
+++ b/src/core/authentication/session/session.dto.ts
@@ -60,6 +60,37 @@ export class Session extends RawSession {
     }
   }
 
+  /**
+   * Which kind of actor this session runs as — for writers that record one.
+   *
+   * `userId` holds a SystemAgent's id whenever the session resolved to an
+   * agent rather than a person: an anonymous session (the Anonymous agent),
+   * Ghost impersonation, or `Identity.asSystemAgent`. All of those set
+   * `systemAgentName`, which is what makes this discriminator work; the audit
+   * writer discriminates on the same field.
+   *
+   * migration-todo: two session shapes slip past this discriminator, and in
+   * both the failure lands on whatever consumes the id (e.g. a `users` FK):
+   * 1. REACHABLE TODAY, over a request header: `resumeSession` resolves the
+   *    Ghost agent only for the literal impersonatee id 'ghost'; a requester
+   *    who sends a SystemAgent's REAL id gets `userId` = that agent with
+   *    `systemAgentName` unset, so it reads as a person here. Nothing
+   *    validates that the impersonatee is a live user.
+   * 2. Unreachable today: `SessionManager.asRole` fabricates
+   *    `userId: 'anonymous'` with no `systemAgentName`; both call sites are
+   *    read-only permission serializers.
+   * The fix belongs in session creation — validate or classify there (treat an
+   * id that is not a live user as an agent, or fail with a domain error naming
+   * the session shape) — not in each consumer.
+   */
+  get actor():
+    | { type: 'user'; id: ID<'User'> }
+    | { type: 'agent'; id: ID<'SystemAgent'> } {
+    return this.systemAgentName
+      ? { type: 'agent', id: this.userId as ID<'SystemAgent'> }
+      : { type: 'user', id: this.userId as ID<'User'> };
+  }
+
   get isAdmin() {
     return this.roles.has('Administrator');
   }

--- a/src/core/authentication/session/session.manager.ts
+++ b/src/core/authentication/session/session.manager.ts
@@ -11,6 +11,7 @@ import {
 } from '~/common';
 import { Hooks } from '~/core/hooks';
 import { ILogger, Logger } from '~/core/logger';
+import { type SystemAgent } from '../../../components/user/dto';
 import { SystemAgentRepository } from '../../../components/user/system-agent.repository';
 import { AuthenticationRepository } from '../authentication.repository';
 import { CanImpersonateHook } from '../hooks/can-impersonate.hook';
@@ -184,6 +185,21 @@ export class SessionManager {
     const session =
       typeof user === 'string' ? await this.sessionForUser(user) : user;
     return await this.sessionHost.withSession(session, () => fn(session));
+  }
+
+  /**
+   * Run this function as the given system agent, with the agent's roles.
+   */
+  async asSystemAgent<R>(agent: SystemAgent, fn: () => Promise<R>): Promise<R> {
+    const session = Session.from({
+      token: 'system',
+      issuedAt: DateTime.now(),
+      userId: agent.id,
+      anonymous: false,
+      roles: agent.roles,
+      systemAgentName: agent.name,
+    });
+    return await this.asUser(session, fn);
   }
 
   asRole<R>(role: Role, fn: () => R): R {

--- a/src/core/database/transaction-hooks.ts
+++ b/src/core/database/transaction-hooks.ts
@@ -19,6 +19,25 @@ export class TransactionHooks {
     return this.managerFor('afterCommit');
   }
 
+  /**
+   * Run `fn` after the current mutation's transaction commits, or immediately
+   * when not inside one.
+   *
+   * Inside a GraphQL mutation the work is queued to {@link afterCommit}, which
+   * the TransactionalMutationsInterceptor drains on commit and CLEARS on
+   * rollback — so a rolled-back attempt cannot leak its side effects, and a
+   * retried attempt cannot re-run them. Outside a mutation nothing drains that
+   * queue, so the work runs right away instead of never.
+   */
+  async afterCommitOrNow(fn: Callback) {
+    const op = this.contextHost.contextMaybe?.operation;
+    if (op && op.operation === 'mutation') {
+      this.afterCommit.add(fn);
+      return;
+    }
+    await fn();
+  }
+
   private managerFor(event: string) {
     const contextId = this.contextHost.context;
     return cached(

--- a/src/core/drizzle/migrations/0043_progress_report_workflow_event_actor.sql
+++ b/src/core/drizzle/migrations/0043_progress_report_workflow_event_actor.sql
@@ -1,0 +1,25 @@
+-- Let a progress report workflow event be attributed to a SystemAgent, not just
+-- a User — the Rev79 auto-advance (#3767) records the "Rev79" agent as the
+-- actor when report data arriving starts a report.
+--
+-- Same shape and reasoning as 0031 (`project_workflow_events`): two nullable
+-- columns with a `= 1` CHECK, agent stored as a real FK because the actor is
+-- read back as a hydrated object through `ActorLoader`. See 0031's header for
+-- the full argument, including why this diverges from the audit log's
+-- name-snapshot approach (0027).
+--
+-- Unlike 0031 there is no pre-existing agent-actored data to admit here — every
+-- existing row is user-actored — so this is purely forward-looking.
+
+ALTER TABLE "progress_report_workflow_events"
+  ALTER COLUMN "who" DROP NOT NULL;
+
+ALTER TABLE "progress_report_workflow_events"
+  ADD COLUMN "who_system_agent_id" text REFERENCES "system_agents"("id");
+
+ALTER TABLE "progress_report_workflow_events"
+  ADD CONSTRAINT "progress_report_workflow_events_actor_shape_chk"
+  CHECK (num_nonnulls("who", "who_system_agent_id") = 1);
+
+CREATE INDEX "progress_report_workflow_events_who_system_agent_id_idx"
+  ON "progress_report_workflow_events" ("who_system_agent_id");

--- a/src/core/drizzle/migrations/meta/_journal.json
+++ b/src/core/drizzle/migrations/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1754092800000,
       "tag": "0040_add_external_department_ids",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1787950800000,
+      "tag": "0043_progress_report_workflow_event_actor",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/drizzle/schema/index.ts
+++ b/src/core/drizzle/schema/index.ts
@@ -3187,10 +3187,15 @@ export const progressReportWorkflowEvents = pgTable(
       .$type<ID<'ProgressReport'>>()
       .notNull()
       .references(() => periodicReports.id, { onDelete: 'cascade' }),
+    // Exactly one of `who` / `who_system_agent_id` is set — the actor is a
+    // User or a SystemAgent (e.g. Rev79 auto-advance). Same shape as
+    // `project_workflow_events`; reasoning in migration 0031's header.
     who: text('who')
       .$type<ID<'User'>>()
-      .notNull()
       .references(() => users.id),
+    whoSystemAgentId: text('who_system_agent_id')
+      .$type<ID<'SystemAgent'>>()
+      .references(() => systemAgents.id),
     status: progressReportStatusEnum('status')
       .$type<ProgressReportStatus>()
       .notNull(),
@@ -3205,6 +3210,13 @@ export const progressReportWorkflowEvents = pgTable(
       t.at,
     ),
     index('progress_report_workflow_events_who_idx').on(t.who),
+    index('progress_report_workflow_events_who_system_agent_id_idx').on(
+      t.whoSystemAgentId,
+    ),
+    check(
+      'progress_report_workflow_events_actor_shape_chk',
+      sql`num_nonnulls(${t.who}, ${t.whoSystemAgentId}) = 1`,
+    ),
   ],
 );
 

--- a/test/rev79.e2e-spec.ts
+++ b/test/rev79.e2e-spec.ts
@@ -215,6 +215,125 @@ describe('Rev79 e2e', () => {
       ).rejects.toThrowGqlError(errors.notFound());
     });
   });
+
+  describe('auto-advance on data received (#3767)', () => {
+    // Each test uses its own quarter within the MOU window so it observes a
+    // fresh report at NotStarted, unaffected by the upload tests above (Q2).
+    const reportIdFor = async (period: { year: number; quarter: number }) => {
+      const result = await app.graphql.query(Rev79QuarterlyReportContextDoc, {
+        input: {
+          rev79ProjectId: REV79_PROJECT_ID,
+          rev79CommunityId: REV79_COMMUNITY_ID,
+          period,
+        },
+      });
+      return result.rev79QuarterlyReportContext.progressReport;
+    };
+
+    const readReport = async (id: ID) =>
+      await runAsAdmin(app, async () => {
+        const result = await app.graphql.query(ProgressReportStatusDoc, {
+          id,
+        });
+        const report = result.periodicReport;
+        if (!('status' in report)) {
+          throw new Error('Expected a progress report');
+        }
+        return report;
+      });
+
+    const uploadTeamNews = async (period: { year: number; quarter: number }) =>
+      await app.graphql.mutate(UploadRev79ProgressReportsDoc, {
+        input: {
+          rev79ProjectId: REV79_PROJECT_ID,
+          reports: [
+            {
+              rev79CommunityId: REV79_COMMUNITY_ID,
+              period,
+              teamNews: {
+                response: {
+                  type: 'doc',
+                  content: [
+                    {
+                      type: 'paragraph',
+                      content: [{ type: 'text', text: 'Data arrived!' }],
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      });
+
+    it('advances NotStarted -> InProgress when data arrives, exactly once', async () => {
+      const period = { year: 2024, quarter: 1 };
+      const reportId = await reportIdFor(period);
+
+      let report = await readReport(reportId);
+      expect(report.status.value).toBe('NotStarted');
+      expect(report.workflowEvents).toHaveLength(0);
+
+      await uploadTeamNews(period);
+
+      report = await readReport(reportId);
+      expect(report.status.value).toBe('InProgress');
+      expect(report.workflowEvents).toHaveLength(1);
+      expect(report.workflowEvents[0]!.transition?.label).toBe('Start');
+      // The event records why it happened, and the email says the same.
+      expect(JSON.stringify(report.workflowEvents[0]!.notes.value)).toContain(
+        'report data was received from Rev79',
+      );
+      // Attributed to the Rev79 system agent, not the calling account.
+      expect(report.workflowEvents[0]!.who.value).toMatchObject({
+        __typename: 'SystemAgent',
+        name: 'Rev79',
+      });
+
+      // A repeated delivery changes nothing.
+      await uploadTeamNews(period);
+
+      report = await readReport(reportId);
+      expect(report.status.value).toBe('InProgress');
+      expect(report.workflowEvents).toHaveLength(1);
+    });
+
+    it('never regresses a report that is already further along', async () => {
+      const period = { year: 2024, quarter: 4 };
+      const reportId = await reportIdFor(period);
+
+      await runAsAdmin(app, () =>
+        app.graphql.mutate(TransitionProgressReportDoc, {
+          input: { report: reportId, status: 'InReview' },
+        }),
+      );
+
+      await uploadTeamNews(period);
+
+      const report = await readReport(reportId);
+      expect(report.status.value).toBe('InReview');
+      // Only the admin bypass event; the delivery added none.
+      expect(report.workflowEvents).toHaveLength(1);
+      // A human transition still records the person, not an agent.
+      expect(report.workflowEvents[0]!.who.value?.__typename).toBe('User');
+    });
+
+    it('does not advance when the upload carries no report data', async () => {
+      const period = { year: 2024, quarter: 3 };
+      const reportId = await reportIdFor(period);
+
+      await app.graphql.mutate(UploadRev79ProgressReportsDoc, {
+        input: {
+          rev79ProjectId: REV79_PROJECT_ID,
+          reports: [{ rev79CommunityId: REV79_COMMUNITY_ID, period }],
+        },
+      });
+
+      const report = await readReport(reportId);
+      expect(report.status.value).toBe('NotStarted');
+      expect(report.workflowEvents).toHaveLength(0);
+    });
+  });
 });
 
 const Rev79QuarterlyReportContextDoc = graphql(`
@@ -237,6 +356,47 @@ const UploadRev79ProgressReportsDoc = graphql(`
       results {
         rev79CommunityId
         progressReport
+      }
+    }
+  }
+`);
+
+const ProgressReportStatusDoc = graphql(`
+  query ProgressReportStatus($id: ID!) {
+    periodicReport(id: $id) {
+      ... on ProgressReport {
+        id
+        status {
+          value
+        }
+        workflowEvents {
+          id
+          transition {
+            label
+          }
+          notes {
+            value
+          }
+          who {
+            value {
+              __typename
+              ... on SystemAgent {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`);
+
+const TransitionProgressReportDoc = graphql(`
+  mutation TransitionProgressReport($input: ExecuteProgressReportTransition!) {
+    transitionProgressReport(input: $input) {
+      id
+      status {
+        value
       }
     }
   }


### PR DESCRIPTION
Closes #3767

> [!IMPORTANT]
> Quarterly reports now start themselves. When Rev79 delivers report data, the report advances from **Not Started** to **In Progress** on its own, attributed to a **"Rev79" system agent**, and the project's FPM gets an email saying what happened and why. No more manual gatekeeping step, no more reports sitting untouched because nobody knew data had arrived.

```mermaid
flowchart LR
  NS(["Not Started"]) ==>|"automated:<br/>Rev79 data received"| IP(["In Progress"])
  IP -.->|"future trigger"| PT(["Pending Translation"])
  PT -.->|"future trigger"| IR(["In Review"])
  IR --> AP(["Approved"]) --> PB(["Published"])
  style NS stroke-dasharray: 0
```

*The solid edge is what this PR automates. The dashed edges are the ticket's future triggers (auto-translation, AI drafting) — each becomes a one-line registry entry once its system exists.*

### How the auto-advance works

- Rev79's bulk upload fires an internal `ProgressReportIngestTriggerHook` after it applies data to a report — event-driven, no polling, same transaction.
- A workflow handler executes the existing `Start` transition only when the report sits exactly at **Not Started**. A report that is already further along is never touched, and a repeated delivery changes nothing — so integration retries are harmless.
- The workflow event records **why**: a note reading `Automated: report data was received from Rev79.` shows in the report's status history, and the email carries the same sentence.

### Workflow events now have a User-or-agent actor

- The transition runs as a **"Rev79" system agent** (Administrator role, upserted on demand), so attribution never depends on which account the integration authenticates with. This adopts the exact actor pattern `project_workflow_events` already uses (see migration 0031's header for the full reasoning).
- On the wire, `ProgressReportWorkflowEvent.who` changes from `SecuredUser!` to `SecuredActor!`, resolved through the existing `ActorLoader`.
- Automated emails drop the actor lead entirely — "Quarterly Report - Q1 FY2024 changed from *Not Started* to *In Progress*… This change was made automatically because report data was received from Rev79." Human transitions still read "«Person» has changed…".

### Two production fixes ride along

> [!WARNING]
> **The project-member recipients of progress-report status emails have been silently dropped since the June 2025 "only notify active members" change.** That filter used a Cypher map pattern `{value: null}`, which never matches — null only compares with `IS NULL`. Verified against a production copy: the old predicate matches **0 of 30,204** project members, while the fixed query reaches the **19,311** active members with email addresses on progress-report projects. Recipients configured directly via the `PROGRESS_REPORT_EMAILS_FOR_*` env vars come from a separate path and kept receiving these emails the whole time — which is why the breakage was not obvious. (The Postgres port already filtered correctly.)
>
> **Rollout consequence:** on deploy, progress-report status changes start emailing the project's active PM/RD/FOD members again — worth a heads-up to the field before it ships.

- Workflow notification emails now send **after the transaction commits**, via the after-commit queue from #3848. A rolled-back attempt clears the queue, so a retried failed mutation can no longer re-send emails for writes that never persisted — the exact shape of the 2026-07-09 notification storm. A failed send now logs instead of rolling back the status change.

### Schema

```sql
ALTER TABLE "progress_report_workflow_events" ALTER COLUMN "who" DROP NOT NULL;
ALTER TABLE "progress_report_workflow_events" ADD COLUMN "who_system_agent_id" text REFERENCES "system_agents"("id");
ALTER TABLE "progress_report_workflow_events" ADD CONSTRAINT "progress_report_workflow_events_actor_shape_chk" CHECK (num_nonnulls("who", "who_system_agent_id") = 1);
```

- Migration `0043` is numbered past the pending `pg-preserve-migrated-values` branch (0041/0042); whichever merges second does a trivial journal reorder.
- Neo4j needs no schema change — the actor edge now matches the `Actor` label, which User nodes already carry.
- The Gel arm cannot represent agent actors (its schema types `who` as `User`); tagged `migration-todo`, moot at cutover.

> [!WARNING]
> **Deploy in lockstep with the companion cord-field change.** The old UI against this API fails GraphQL validation on report pages (`Cannot query field "fullName" on type "Actor"`); the new UI against the old API fails the same way in reverse.

<details>
<summary><strong>Validation</strong></summary>

- e2e `rev79.e2e-spec`: **13/13 on Neo4j and 13/13 on Postgres**, including three new scenarios: data arrival advances exactly once with the Rev79 agent as the recorded actor and the automation note on the event; a report bypassed to In Review stays put; an upload carrying no data does not advance.
- Unit 7/7 · lint 0 warnings · type-check 0 errors (both repos).
- Verified live against a dev stack: the email opens with the automated wording, the status history renders "Rev79", and the upload was deliberately run as root to prove attribution no longer follows the caller.

</details>

<details>
<summary><strong>Accepted limitations and follow-ups</strong></summary>

- Two *concurrent* deliveries for the same report (a client retry racing an in-flight request) can both pass the availability check and record two `Start` events. Sequential retries are fully idempotent; closing the concurrent window would need row locking that isn't expressible on both engines today.
- The other two email handlers (`ProjectWorkflowNotificationHandler`, `DblUploadNotificationHandler`) still send mid-transaction — the same class as the 2026-07-09 storm. `TransactionHooks.afterCommitOrNow()` now exists for exactly this; adopting it there is a small follow-up PR.
- `Session.actor` carries a migration-todo documenting two session shapes that defeat user-vs-agent discrimination (notably: impersonating a SystemAgent's real id). Pre-existing, engine-independent; the fix belongs in session creation.

</details>

<details>
<summary><strong>What the FPM email says now</strong></summary>

> **Quarterly Report - Q1 FY2024 is now _In Progress_**
>
> Quarterly Report - Q1 FY2024 changed from _Not Started_ to _In Progress_ for Rev79 Test Language in Rev79 Manual Test on August 28, 2026 at 4:12 PM EDT
>
> This change was made automatically because report data was received from Rev79.
>
> [ View Quarterly Report - Q1 FY2024 ]

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
