### PR TITLE
Add a read-only maintenance mode

### DIFF
--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -8,6 +8,7 @@ export * from './not-implemented.exception';
 export * from './unauthenticated.exception';
 export * from './unauthorized.exception';
 export * from './service-unavailable.exception';
+export * from './read-only-mode.exception';
 export * from './invalid-id-for-type.exception';
 export * from './creation-failed.exception';
 export * from './date-override-conflict.exception';

--- a/src/common/exceptions/read-only-mode.exception.ts
+++ b/src/common/exceptions/read-only-mode.exception.ts
@@ -1,0 +1,17 @@
+import { ServiceUnavailableException } from './service-unavailable.exception';
+
+/**
+ * A write was attempted while the API is in read-only maintenance mode.
+ * @see ReadOnlyModePlugin in ~/core/graphql for what enforces this.
+ */
+export class ReadOnlyModeException extends ServiceUnavailableException {
+  constructor(message?: string, previous?: Error) {
+    super(
+      message ??
+        'CORD is temporarily read-only while maintenance is underway. ' +
+          'Viewing data still works, but changes cannot be saved right now. ' +
+          'Please try again later.',
+      previous,
+    );
+  }
+}

--- a/src/components/admin/admin.drizzle.service.ts
+++ b/src/components/admin/admin.drizzle.service.ts
@@ -25,6 +25,9 @@ export class AdminDrizzleService implements OnApplicationBootstrap {
   }
 
   async onApplicationBootstrap(): Promise<void> {
+    // Same switch the Neo4j AdminService honors — also how read-only
+    // maintenance mode keeps boot from writing.
+    if (!this.config.dbRootObjectsSync) return;
     const finishing = this.repo.finishing(async () => {
       await this.setupRootUser();
       await this.setupDefaultOrg();

--- a/src/components/admin/admin.gel.service.ts
+++ b/src/components/admin/admin.gel.service.ts
@@ -25,6 +25,9 @@ export class AdminGelService implements OnApplicationBootstrap {
   }
 
   async onApplicationBootstrap(): Promise<void> {
+    // Same switch its Neo4j/Drizzle siblings honor — also how read-only
+    // maintenance mode keeps boot from writing.
+    if (!this.config.dbRootObjectsSync) return;
     const finishing = this.repo.finishing(() => this.setupRootUser());
     // Wait for root object setup when running tests, else just let it run in
     // the background and allow webserver to start.

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -1,5 +1,5 @@
 import { type Provider } from '@nestjs/common';
-import { csv } from '@seedcompany/common';
+import { csv, simpleSwitch } from '@seedcompany/common';
 import type { EmailModuleOptions as EmailOptions } from '@seedcompany/nestjs-email';
 import type { Server as HttpServer } from 'http';
 import { type LRUCache } from 'lru-cache';
@@ -202,22 +202,73 @@ export const makeConfig = (env: EnvironmentService) =>
       };
     })();
 
-    postgres = {
-      url: env.string('POSTGRES_URL').optional(),
-    };
+    postgres = (() => {
+      const url = env.string('POSTGRES_URL').optional();
+      let hostname;
+      try {
+        hostname = url ? new URL(url).hostname : undefined;
+      } catch {
+        hostname = undefined;
+      }
+      return {
+        url,
+        // Mirrors neo4j.isLocal. An absent or unparseable URL counts as
+        // local, preserving always-run behavior for setups without one.
+        isLocal: !hostname || hostname === 'localhost',
+      };
+    })();
 
     // Control which database is prioritized, while we migrate.
     databaseEngine = env.string('DATABASE').optional('neo4j').toLowerCase();
 
-    dbIndexesCreate = env
-      .boolean('DB_CREATE_INDEXES')
-      .optional(isDev ? this.neo4j.isLocal : true);
-    dbAutoMigrate = env
-      .boolean('DB_AUTO_MIGRATE')
-      .optional(isDev && this.neo4j.isLocal && !this.jest);
-    dbRootObjectsSync = env
-      .boolean('DB_ROOT_OBJECTS_SYNC')
-      .optional(isDev ? this.neo4j.isLocal : true);
+    /**
+     * Puts the API in read-only maintenance mode.
+     * Every mutation is refused, except signing in & out — sessions are not
+     * part of the frozen data. Boot-time writes (index creation, migrations,
+     * root object sync) are also skipped, regardless of their own flags.
+     * Queued background jobs (BullMQ) are NOT covered — anything already in
+     * the queue when the freeze starts can still run and write; let the
+     * queue drain before counting on the freeze.
+     * This keeps the app up for reading while the data underneath must not
+     * change — i.e. while the cutover ETL copies the database.
+     */
+    maintenance = {
+      readOnly: env.boolean('READ_ONLY').optional(false),
+    };
+
+    dbIndexesCreate =
+      !this.maintenance.readOnly &&
+      env
+        .boolean('DB_CREATE_INDEXES')
+        .optional(isDev ? this.neo4j.isLocal : true);
+    dbAutoMigrate =
+      !this.maintenance.readOnly &&
+      env
+        .boolean('DB_AUTO_MIGRATE')
+        .optional(isDev && this.neo4j.isLocal && !this.jest);
+    dbRootObjectsSync =
+      !this.maintenance.readOnly &&
+      env.boolean('DB_ROOT_OBJECTS_SYNC').optional(
+        isDev
+          ? // In dev, don't write root objects into a shared/remote database —
+            // judged by the ACTIVE engine's own URL, not always Neo4j's.
+            (simpleSwitch(this.databaseEngine, {
+              postgres: this.postgres.isLocal,
+              neo4j: this.neo4j.isLocal,
+              // Gel instances here are CLI-managed local ones.
+              gel: true,
+            }) ?? this.neo4j.isLocal)
+          : true,
+      );
+    /**
+     * Whether the Drizzle boot migrator applies pending migrations.
+     * Off during read-only maintenance — a schema change is still a write.
+     * Derived from the environment here, like the flags above, rather than
+     * read off `maintenance` at runtime: a test overriding
+     * `maintenance.readOnly` freezes the GraphQL layer without leaving its
+     * ephemeral database schemaless.
+     */
+    pgAutoMigrate = !this.maintenance.readOnly;
 
     files = (() => {
       const sources = env

--- a/src/core/drizzle/migrator.ts
+++ b/src/core/drizzle/migrator.ts
@@ -16,6 +16,12 @@ export class DrizzleMigrator implements OnModuleInit {
 
   async onModuleInit() {
     if (this.config.databaseEngine !== 'postgres') return;
+    if (!this.config.pgAutoMigrate) {
+      this.logger.info(
+        'Skipping migrations — the API is in read-only maintenance mode',
+      );
+      return;
+    }
 
     this.logger.info('Running PostgreSQL migrations');
     // NOTE: our migrations are hand-written, but drizzle's migrator only runs

--- a/src/core/graphql/graphql.module.ts
+++ b/src/core/graphql/graphql.module.ts
@@ -14,6 +14,7 @@ import { GraphqlErrorFormatter } from './graphql-error-formatter';
 import { GraphqlLoggingPlugin } from './graphql-logging.plugin';
 import { GraphqlTracingPlugin } from './graphql-tracing.plugin';
 import { GraphqlOptions } from './graphql.options';
+import { ReadOnlyModePlugin } from './read-only-mode.plugin';
 import { Yoga } from './yoga.facade';
 
 import './normalize-subscription-output';
@@ -38,6 +39,7 @@ class SharedPluginsModule {}
     GraphqlLoggingPlugin,
     GraphqlTracingPlugin,
     DataLoadersInSubscriptionPlugin,
+    ReadOnlyModePlugin,
   ],
   exports: [GraphqlOptions],
 })

--- a/src/core/graphql/read-only-mode.plugin.test.ts
+++ b/src/core/graphql/read-only-mode.plugin.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from '@jest/globals';
+import { buildSchema, type ExecutionResult, parse } from 'graphql';
+import { ReadOnlyModeException } from '~/common';
+import { type ConfigService } from '~/core/config';
+import { type Plugin } from './plugin.decorator';
+import { ReadOnlyModePlugin } from './read-only-mode.plugin';
+
+const makePlugin = (readOnly: boolean) =>
+  new ReadOnlyModePlugin({
+    maintenance: { readOnly },
+  } as unknown as ConfigService);
+
+type OnExecuteParams = Parameters<NonNullable<Plugin['onExecute']>>[0];
+
+/**
+ * Field collection only reads the ROOT selection set and the root types'
+ * names, so the documents below don't need schema-valid sub-selections.
+ */
+const schema = buildSchema(`
+  type Query { ok: Boolean }
+  type Mutation { ok: Boolean }
+  type Subscription { ok: Boolean }
+`);
+
+/**
+ * Runs the hook against a parsed operation.
+ * Returns the refusal result when the plugin replaced execution,
+ * or null when it left execution alone.
+ */
+const execute = (
+  plugin: ReadOnlyModePlugin,
+  query: string,
+  options: {
+    operationName?: string;
+    variables?: Record<string, unknown>;
+  } = {},
+): ExecutionResult | null => {
+  let refusal: ExecutionResult | null = null;
+  const params = {
+    args: {
+      schema,
+      document: parse(query),
+      operationName: options.operationName,
+      variableValues: options.variables,
+    },
+    setExecuteFn: (fn: () => ExecutionResult) => {
+      refusal = fn();
+    },
+  } as unknown as OnExecuteParams;
+  // The hook body is synchronous; the promise in its signature is envelop's.
+  void plugin.onExecute!(params);
+  return refusal;
+};
+
+const expectRefused = (refusal: ExecutionResult | null) => {
+  expect(refusal).not.toBeNull();
+  const error = refusal!.errors![0]!;
+  expect(error.originalError).toBeInstanceOf(ReadOnlyModeException);
+};
+
+describe('ReadOnlyModePlugin', () => {
+  it('leaves everything alone when the mode is off', () => {
+    const plugin = makePlugin(false);
+    const refusal = execute(
+      plugin,
+      'mutation { createOrganization { organization { id } } }',
+    );
+    expect(refusal).toBeNull();
+  });
+
+  describe('when the mode is on', () => {
+    const plugin = makePlugin(true);
+
+    it('leaves queries alone', () => {
+      const refusal = execute(plugin, 'query { session { token } }');
+      expect(refusal).toBeNull();
+    });
+
+    it('leaves subscriptions alone', () => {
+      const refusal = execute(plugin, 'subscription { notifications { id } }');
+      expect(refusal).toBeNull();
+    });
+
+    it('refuses a mutation', () => {
+      const refusal = execute(
+        plugin,
+        'mutation { createOrganization { organization { id } } }',
+      );
+      expectRefused(refusal);
+    });
+
+    it('allows signing in & out', () => {
+      const login = execute(plugin, 'mutation { login { user { id } } }');
+      expect(login).toBeNull();
+      const logout = execute(plugin, 'mutation { logout { __typename } }');
+      expect(logout).toBeNull();
+    });
+
+    it('refuses a mutation mixed in beside an allowed one', () => {
+      const refusal = execute(
+        plugin,
+        'mutation { login { user { id } } createOrganization { organization { id } } }',
+      );
+      expectRefused(refusal);
+    });
+
+    it('refuses a mutation hidden behind a fragment spread', () => {
+      const refusal = execute(
+        plugin,
+        `
+          mutation Sneaky { ...writes }
+          fragment writes on Mutation {
+            createOrganization { organization { id } }
+          }
+        `,
+      );
+      expectRefused(refusal);
+    });
+
+    it('refuses a mutation hidden behind an inline fragment', () => {
+      const refusal = execute(
+        plugin,
+        `
+          mutation Sneaky {
+            ... on Mutation {
+              createOrganization { organization { id } }
+            }
+          }
+        `,
+      );
+      expectRefused(refusal);
+    });
+
+    it('only judges the operation actually being executed', () => {
+      const document = `
+        query Reads { session { token } }
+        mutation Writes { createOrganization { organization { id } } }
+      `;
+      expect(execute(plugin, document, { operationName: 'Reads' })).toBeNull();
+      expectRefused(execute(plugin, document, { operationName: 'Writes' }));
+    });
+
+    it('allows a mutation selecting only meta fields', () => {
+      const refusal = execute(plugin, 'mutation { __typename }');
+      expect(refusal).toBeNull();
+    });
+
+    it('ignores a write field disabled by @skip', () => {
+      const refusal = execute(
+        plugin,
+        `
+          mutation {
+            login { user { id } }
+            createOrganization @skip(if: true) { organization { id } }
+          }
+        `,
+      );
+      expect(refusal).toBeNull();
+    });
+
+    it('judges a variable-driven @include by its actual value', () => {
+      const document = `
+        mutation ($doWrite: Boolean!) {
+          login { user { id } }
+          createOrganization @include(if: $doWrite) { organization { id } }
+        }
+      `;
+      expect(
+        execute(plugin, document, { variables: { doWrite: false } }),
+      ).toBeNull();
+      expectRefused(
+        execute(plugin, document, { variables: { doWrite: true } }),
+      );
+    });
+
+    it('ignores a whole fragment disabled by @skip', () => {
+      const refusal = execute(
+        plugin,
+        `
+          mutation {
+            login { user { id } }
+            ...writes @skip(if: true)
+          }
+          fragment writes on Mutation {
+            createOrganization { organization { id } }
+          }
+        `,
+      );
+      expect(refusal).toBeNull();
+    });
+  });
+});

--- a/src/core/graphql/read-only-mode.plugin.ts
+++ b/src/core/graphql/read-only-mode.plugin.ts
@@ -1,0 +1,119 @@
+import { collectFields } from '@graphql-tools/utils';
+import { Injectable, type OnModuleInit } from '@nestjs/common';
+import {
+  type ExecutionArgs,
+  type FragmentDefinitionNode,
+  getOperationAST,
+  GraphQLError,
+  Kind,
+  type OperationDefinitionNode,
+} from 'graphql';
+import { ReadOnlyModeException } from '~/common';
+import { ConfigService } from '~/core/config';
+import { ILogger, Logger } from '~/core/logger';
+import { Plugin } from './plugin.decorator';
+
+/**
+ * Refuses every mutation while the API is in read-only maintenance mode
+ * ({@link ConfigService.maintenance}), so the app stays up for reading while
+ * the data underneath is frozen — i.e. while the cutover ETL copies the
+ * database.
+ *
+ * Signing in & out stays available: sessions are deliberately outside the
+ * freeze (they are excluded from the cutover and do not survive it), and
+ * people need to sign in before they can read anything.
+ *
+ * Both transports funnel through here — HTTP requests and WebSocket
+ * operations share the same envelop execute pipeline.
+ */
+@Plugin()
+@Injectable()
+export class ReadOnlyModePlugin implements OnModuleInit {
+  /**
+   * Mutations that only touch session state, which is not part of the freeze.
+   * Password mutations are NOT here on purpose: they write real user data,
+   * which would be silently lost when the frozen source is replaced.
+   */
+  static readonly sessionOnlyMutations: ReadonlySet<string> = new Set([
+    'login',
+    'logout',
+  ]);
+
+  @Logger('graphql:read-only-mode') private readonly logger: ILogger;
+
+  constructor(private readonly config: ConfigService) {}
+
+  onModuleInit() {
+    if (this.config.maintenance.readOnly) {
+      this.logger.warning(
+        'Read-only maintenance mode is ON — refusing every mutation except login/logout',
+      );
+    }
+  }
+
+  onExecute: Plugin['onExecute'] = ({ args, setExecuteFn }) => {
+    if (!this.config.maintenance.readOnly) {
+      return;
+    }
+    const operation = getOperationAST(args.document, args.operationName);
+    if (operation?.operation !== 'mutation') {
+      return;
+    }
+    const fields = executedRootFields(args, operation);
+    if (
+      fields.every((field) =>
+        ReadOnlyModePlugin.sessionOnlyMutations.has(field),
+      )
+    ) {
+      return;
+    }
+    setExecuteFn(() => {
+      const exception = new ReadOnlyModeException();
+      return {
+        errors: [
+          new GraphQLError(exception.message, { originalError: exception }),
+        ],
+      };
+    });
+  };
+}
+
+/**
+ * The root field names the operation will actually execute.
+ *
+ * `collectFields` is the executor's own field collection: it flattens
+ * fragment spreads / inline fragments and honors `@skip`/`@include`, so a
+ * write field disabled by a directive doesn't count against the operation
+ * (a login mixed with a skipped write stays a login). `@defer`red selections
+ * still execute — just delivered later — so their fields count too.
+ * Meta fields (`__typename`) read the schema, not data, and are dropped.
+ */
+const executedRootFields = (
+  args: Pick<ExecutionArgs, 'schema' | 'document' | 'variableValues'>,
+  operation: OperationDefinitionNode,
+): string[] => {
+  const mutationType = args.schema.getMutationType();
+  if (!mutationType) {
+    // Unreachable for an executing mutation; judge nothing rather than crash.
+    return [];
+  }
+  const fragments = Object.fromEntries(
+    args.document.definitions
+      .filter(
+        (def): def is FragmentDefinitionNode =>
+          def.kind === Kind.FRAGMENT_DEFINITION,
+      )
+      .map((fragment) => [fragment.name.value, fragment]),
+  );
+  const { fields, patches } = collectFields(
+    args.schema,
+    fragments,
+    args.variableValues ?? {},
+    mutationType,
+    operation.selectionSet,
+  );
+  return [fields, ...patches.map((patch) => patch.fields)]
+    .flatMap((fieldMap) => [...fieldMap.values()].flat())
+    .map((field) => field.name.value)
+    .filter((name) => !name.startsWith('__'));
+};

--- a/test/read-only-mode.e2e-spec.ts
+++ b/test/read-only-mode.e2e-spec.ts
@@ -1,0 +1,73 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { graphql } from '~/graphql';
+import {
+  createOrganization,
+  createSession,
+  createTestApp,
+  loginAsAdmin,
+  type TestApp,
+} from './utility';
+
+/**
+ * Read-only maintenance mode — the freeze for cutover day.
+ *
+ * With `READ_ONLY=true` (here: the `maintenance.readOnly` config override),
+ * the API stays up so people can sign in and look at data, but every mutation
+ * that would change data is refused with a `ReadOnlyMode` error. Signing in
+ * and out keeps working: sessions are excluded from the cutover, so those
+ * writes are outside the freeze — and reading requires being signed in.
+ *
+ * Run on both engines:
+ *   yarn test:e2e --testPathPatterns read-only-mode
+ *   DATABASE=postgres POSTGRES_URL=... yarn test:e2e --testPathPatterns read-only-mode
+ */
+describe('Read-only maintenance mode', () => {
+  let app: TestApp;
+
+  beforeAll(async () => {
+    app = await createTestApp({
+      config: { maintenance: { readOnly: true } },
+    });
+    // The session query writes a token — deliberately not frozen.
+    await createSession(app);
+    // Signing in is a mutation that must keep working during the freeze;
+    // if the mode caught it, this would throw and fail the suite right here.
+    await loginAsAdmin(app);
+  });
+
+  it('still answers queries', async () => {
+    const result = await app.graphql.query(
+      graphql(`
+        query WhoAmIDuringReadOnly {
+          session {
+            user {
+              id
+            }
+          }
+        }
+      `),
+    );
+    expect(result.session.user?.id).toBeTruthy();
+  });
+
+  it('refuses a mutation that would change data', async () => {
+    await expect(createOrganization(app)).rejects.toThrowGqlError({
+      code: 'ReadOnlyMode',
+      message: expect.stringContaining('read-only'),
+    });
+  });
+
+  it('still allows signing out and back in', async () => {
+    const result = await app.graphql.mutate(
+      graphql(`
+        mutation LogoutDuringReadOnly {
+          logout {
+            __typename
+          }
+        }
+      `),
+    );
+    expect(result.logout.__typename).toBe('LoggedOut');
+    await loginAsAdmin(app);
+  });
+});


### PR DESCRIPTION
> [!IMPORTANT]
> Setting **`READ_ONLY=true`** freezes the data while keeping the API up. People can still **sign in and read everything**, but anything that would change data — from any account, including admins — is refused with a clear *"CORD is temporarily read-only while maintenance is underway. Viewing data still works, but changes cannot be saved right now."* error (code `ReadOnlyMode`, HTTP 200). Built for the database cutover's freeze window; reusable for any future maintenance window. Merging this changes nothing on its own — the flag defaults off.

```mermaid
flowchart LR
  OP(["GraphQL operation"]) --> KIND{"kind?"}
  KIND -->|"query /<br/>subscription"| RUN(["runs normally"])
  KIND -->|mutation| WHO{"only login /<br/>logout fields?"}
  WHO -->|yes| RUN
  WHO ==>|"anything else"| REF(["refused with<br/>ReadOnlyMode"])
```

*Every operation — HTTP and WebSocket share the same pipeline — passes this decision while the flag is on. With the flag off, the check steps aside entirely.*

### How the request freeze works

- One plugin sits ahead of GraphQL execution and judges the fields an operation would **actually execute**, using the executor's own field-collection logic. A write hidden behind a fragment spread is caught; a write field disabled by `@skip`/`@include` doesn't count against the request, so a login that carries directive-disabled fields still goes through.
- **Signing in and out stays available on purpose.** Sessions are not part of the frozen data — they don't survive the maintenance the freeze exists for — and nobody can read anything without signing in. Password changes, resets, and registration are *not* exempt: those write real user data, which would be silently lost when the frozen database is replaced.
- The refusal is a normal GraphQL error (`codes: [ReadOnlyMode, ServiceUnavailable, Transient, Server]`) with a user-facing message, so existing clients surface it wherever they already show mutation errors — no client change required.

### Boot-time writes are frozen too

- The app normally writes at startup: Neo4j index creation and migrations, root user / default organization sync, and Postgres migrations at boot. With `READ_ONLY=true` all of these are skipped, regardless of their individual flags — so restarting the frozen instance cannot drift the database underneath a maintenance operation reading it.
- All three engine variants of the root-object sync now honor the same `DB_ROOT_OBJECTS_SYNC` switch; previously only the Neo4j one checked it.
- Dev-machine nicety that fell out of this: whether root objects sync at boot in development is now judged by the **active engine's own URL locality** (Postgres checks the Postgres URL) instead of always Neo4j's — so developing against Postgres with a remote Neo4j URL configured no longer skips local Postgres bootstrap.

<details>
<summary><strong>Validation</strong></summary>

- e2e `read-only-mode.e2e-spec`: **3/3 on Neo4j and 3/3 on Postgres** — queries answer, a data mutation is refused with `ReadOnlyMode`, signing out and back in works while frozen.
- Unit **13/13** on the plugin: allowlist, mixed operations, fragment spreads, inline fragments, multi-operation documents, `__typename`-only mutations, and the three directive cases (`@skip`, variable-driven `@include`, a whole fragment disabled by `@skip`).
- Lint 0 warnings · type-check 0 errors.
- Verified live against a real Neo4j with the actual env var (not a test override): boot logs the warning, login as the root admin works, the same root admin's `createOrganization` is refused, and a full before/after node count reconciles exactly — the only new rows are the session tokens the freeze deliberately allows, proving the boot itself wrote nothing.
- The refusal's HTTP status was measured (200 with the error in the GraphQL response), so uptime monitoring won't page during an intentional maintenance window.

</details>

<details>
<summary><strong>Accepted limitations and follow-ups</strong></summary>

- **Queued background jobs are outside the freeze.** A BullMQ job already in Redis when the flag flips can still run and write. The only queue user today is webhook delivery, and production has zero registered webhooks (measured), so this is currently unreachable; the config doc carries the "let the queue drain first" guidance for when webhooks gain a consumer.
- **No UI banner.** Clients learn about the freeze when a save fails with the friendly message. A maintenance flag the UI could read up front (e.g. on the `session` query) is a possible follow-up if the freeze window wants better UX.
- The WebSocket transport shares the enforced pipeline (verified by code trace and covered at the unit level) but isn't exercised by the e2e suite.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
