### PR TITLE
Keep CI green through Gel package-CDN outages

### DIFF
--- a/.github/actions/gel-setup/action.yml
+++ b/.github/actions/gel-setup/action.yml
@@ -1,22 +1,28 @@
 name: Setup Gel
 description: 'Setup Gel server, migrate schema, generate TS files'
+inputs:
+  server:
+    description: >
+      Whether this job needs a live Gel instance. Jobs that only compile,
+      lint, or run unit tests need just the generated TS client, which the
+      cache below serves without Gel installed at all — declare 'false' so
+      an outage of Gel's package CDN (packages.geldata.com) cannot fail
+      them. Jobs that boot ephemeral Gel databases keep the default.
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
-    - name: Install Gel CLI
-      uses: geldata/setup-gel@v1
-      with:
-        server-version: none
-
-    - name: Initialize Gel Project
-      shell: bash
-      run: gel project init --no-migrations --non-interactive
-
     # The migrated (empty) database and the generated TS client are pure
     # functions of dbschema/ + the generator deps, but rebuilding them takes
     # ~15-20 min per job. Cache a dump of the migrated DB + the generated
     # files; on a hit, `gel restore` (seconds) replaces `gel migrate` and the
     # restored files skip `yarn gel:gen` entirely.
+    #
+    # Restored FIRST, before anything downloads from Gel's CDN: on a hit, a
+    # files-only job (server: 'false') is complete right here, so a CDN
+    # outage only blocks jobs that truly need Gel — or a genuinely cold
+    # cache, where building the files needs the real toolchain.
     - name: Restore migrated-DB dump & generated client
       id: gel-cache
       uses: actions/cache@v4
@@ -27,6 +33,47 @@ runs:
           src/core/gel/schema.ts
           src/**/*.edgeql.ts
         key: gel-setup-${{ runner.os }}-${{ hashFiles('dbschema/**', 'gel.toml', 'yarn.lock') }}
+
+    # Everything below installs or starts Gel. It is skipped entirely when
+    # the generated files were restored and the job declared server: 'false'.
+
+    # The CLI + portable server binaries, cached so a CDN outage can't block
+    # jobs once any prior run has warmed them. Keyed on gel.toml because it
+    # pins the exact server version; bump that pin (or the key) to pick up a
+    # newer CLI, since a cache key is immutable once saved.
+    - name: Restore Gel CLI & server binaries
+      id: gel-binaries
+      if: inputs.server == 'true' || steps.gel-cache.outputs.cache-hit != 'true'
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ runner.tool_cache }}/gel-cli
+          ~/.local/share/gel/portable
+        key: gel-binaries-${{ runner.os }}-${{ hashFiles('gel.toml') }}
+
+    # setup-gel installs via @actions/tool-cache into
+    # $RUNNER_TOOL_CACHE/gel-cli/<version>/<arch> and puts that dir on PATH;
+    # restoring the cache restores the files but not the PATH entry.
+    - name: Add cached Gel CLI to PATH
+      if: steps.gel-binaries.outputs.cache-hit == 'true'
+      shell: bash
+      run: ls -d "$RUNNER_TOOL_CACHE"/gel-cli/*/* >> "$GITHUB_PATH"
+
+    # Even with warm binaries, setup-gel would still resolve "stable" against
+    # the package index (a CDN call) — so on a binaries hit it is skipped
+    # outright rather than re-run.
+    - name: Install Gel CLI
+      if: |
+        (inputs.server == 'true' || steps.gel-cache.outputs.cache-hit != 'true')
+          && steps.gel-binaries.outputs.cache-hit != 'true'
+      uses: geldata/setup-gel@v1
+      with:
+        server-version: none
+
+    - name: Initialize Gel Project
+      if: inputs.server == 'true' || steps.gel-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: gel project init --no-migrations --non-interactive
 
     - name: Migrate Gel Schema
       if: steps.gel-cache.outputs.cache-hit != 'true'
@@ -46,6 +93,6 @@ runs:
         gel dump .gel-cache/main.dump
 
     - name: Restore migrated DB from cache
-      if: steps.gel-cache.outputs.cache-hit == 'true'
+      if: inputs.server == 'true' && steps.gel-cache.outputs.cache-hit == 'true'
       shell: bash
       run: gel restore .gel-cache/main.dump

--- a/.github/workflows/api-schema.yml
+++ b/.github/workflows/api-schema.yml
@@ -34,6 +34,10 @@ jobs:
 
       - name: Gel Setup
         uses: ./.github/actions/gel-setup
+        with:
+          # Schema generation never opens a Gel connection; the generated
+          # TS client (cached) is all it needs.
+          server: 'false'
 
       - name: Generate GraphQL Schema
         run: yarn start -- --gen-schema

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,10 @@ jobs:
 
       - name: Gel Setup
         uses: ./.github/actions/gel-setup
+        with:
+          # Only the generated TS client is needed to type-check & lint —
+          # proven by generating the schema against an unreachable DSN.
+          server: 'false'
 
       - name: Check for no duplicate dependencies
         run: yarn dedupe --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,10 @@ jobs:
 
       - name: Gel Setup
         uses: ./.github/actions/gel-setup
+        with:
+          # Unit tests never open a Gel connection (this job has no Neo4j
+          # service either); only the generated TS client is needed.
+          server: 'false'
 
       - name: Generate GQL Schema
         run: yarn start -- --gen-schema && yarn gql-tada generate output

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,6 +139,13 @@ jobs:
 
       - name: Gel Setup
         uses: ./.github/actions/gel-setup
+        with:
+          # Only the gel matrix entry runs tests against Gel; on neo4j and
+          # postgres, ephemeralGel() is a no-op (test/setup/gel-setup.ts) and
+          # nothing connects — proven by full suites passing on both engines
+          # with GEL_DSN pointed at an unreachable port. The generated TS
+          # client (cached) is all those entries need.
+          server: ${{ matrix.database == 'gel' }}
 
       - name: Generate GQL Schema
         run: yarn start -- --gen-schema && yarn gql-tada generate output


### PR DESCRIPTION
> [!IMPORTANT]
> Today's outage of **`packages.geldata.com`** (Gel's package CDN) failed **every** CI job in every workflow at the "Gel Setup" step — including lint and unit tests, which never talk to Gel. The CLI download ran before the cache of generated files was even consulted. After this change, a Gel CDN outage can only block jobs that genuinely need Gel *and* have nothing cached: most PRs keep their lint, type-check, schema, and unit signal through an outage, and previously-seen toolchains survive for the rest.

```mermaid
flowchart LR
  S(["Gel Setup"]) --> C{"generated-client<br/>cache hit?"}
  C -->|"hit + server: 'false'"| DONE(["done — Gel never installed"])
  C -->|"hit + needs server"| B{"CLI/server<br/>binaries cached?"}
  C -->|miss| B
  B -->|hit| LOCAL(["restore binaries,<br/>init instance"])
  B ==>|miss| CDN(["download from<br/>packages.geldata.com"])
```

*Only the double-miss path (bold) touches Gel's CDN. Before this change, every job started there unconditionally.*

### What changed

- The composite action now restores the **generated-client / migrated-DB cache first**. That cache is keyed on `dbschema/**`, `gel.toml`, and `yarn.lock` — so any PR that doesn't touch the Gel schema hits it.
- Jobs declare whether they actually need a live Gel instance. **Lint, API Schema, and Unit** pass `server: 'false'`: on a cache hit their setup is complete immediately, with no Gel CLI installed at all. Verified safe by generating the GraphQL schema against an unreachable DSN (`gel://127.0.0.1:1`) — it completes, proving schema generation and type-checking only need the generated TS files.
- For jobs that do need an instance (e2e, the Gel workflow), the **CLI and portable server binaries are now cached** (keyed on `gel.toml`, which pins the exact server version). `setup-gel` is skipped outright on a binaries hit, since even with warm binaries it would still resolve "stable" against the package index — a CDN call.

> [!WARNING]
> The binaries cache cannot warm itself **during** the current outage — nothing can download. So on this PR, expect Lint / API Schema / Unit to go green immediately (their file cache is already warm from develop), while the e2e shards and the Gel workflow stay red until `packages.geldata.com` recovers. The first successful run after recovery warms the binaries cache; from then on, outages only hurt PRs that change the Gel schema itself.

<details>
<summary><strong>Validation</strong></summary>

- All four YAML files parse (checked with the `yaml` package).
- `yarn start -- --gen-schema` with `GEL_DSN=gel://127.0.0.1:1/nope`: completes and writes `schema.graphql` — the evidence behind `server: 'false'` on the three files-only jobs.
- The failure mode being fixed was measured, not guessed: every failed job on the triggering PR died at `geldata/setup-gel@v1` with *"Client network socket disconnected before secure TLS connection was established"*, reproduced independently against the same URL.
- This PR is its own live test: it changes none of the cache-key inputs, so the files-only jobs should pass while the outage is still ongoing.

</details>

<details>
<summary><strong>Accepted limitations</strong></summary>

- A genuinely cold cache (first run after a `dbschema/`, `gel.toml`, or `yarn.lock` change) still needs the CDN — the generated client has to be built by the real toolchain at least once per key.
- On a binaries-cache hit, `gel project init` runs against the restored portable server. If the CLI still consults the package index despite an exact version pin and a present portable, e2e jobs would remain CDN-dependent — observable the first time this path runs during an outage, and fixable then; the files-only path is unaffected either way.
- Multiple CLI versions accumulating under one cache key would all be appended to `PATH`; the key is derived from `gel.toml`, so in practice one version lives per key.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
